### PR TITLE
OpenWRT decoders as the normal rules doesn't match

### DIFF
--- a/etc/decoders/kernel-iptables_apparmor_decoders.xml
+++ b/etc/decoders/kernel-iptables_apparmor_decoders.xml
@@ -103,6 +103,27 @@
   <order>action,srcip,dstip,protocol</order>
 </decoder>
 
+<!-- OpenWRT firewall
+Tested on OpenWRT with Chaos Calmer 15.05 with firewall logging to syslog.
+
+Example:
+ - Nov 18 13:39:49 OpenWRT kernel: [10051.313745] DROP(src wan)IN=eth0 OUT= MAC=c2:56:27:73:33:cf:c4:f0:81:b0:93:24:08:00 SRC=205.205.205.205 DST=192.168.8.100 LEN=44 TOS=0x00 PREC=0x00 TTL=31 ID=8549 PROTO=TCP SPT=40952 DPT=23 WINDOW=64144 RES=0x00 SYN URGP=0 MARK=0xff00
+-->
+
+<decoder name="iptables-OpenWRT">
+   <parent>iptables</parent>
+   <type>firewall</type>
+   <prematch>^[\d+.\d+] \S+\.*IN=</prematch>
+   <regex>^[\d+.\d+] (\S*)\(\.*\)\.+ SRC=(\S+) DST=(\S+)\.+ PROTO=(\w+) \.*$</rege$
+   <order>action,srcip,dstip,protocol</order>
+</decoder>
+
+<decoder name="iptables-OpenWRT">
+   <parent>iptables</parent>
+   <type>firewall</type>
+   <regex offset="after_regex">^SPT=(\d+) DPT=(\d+) </regex>
+   <order>srcport,dstport</order>
+</decoder>
 
 <!-- apparmor
   - Jun 24 10:35:29 hostname kernel: [49787.970285] audit: type=1400 audit(1403598929.839:88986): apparmor="ALLOWED" operation="getattr" profile="/usr/sbin/dovecot//null-1//null-2//null-4a6" name="/home/admin/mails/new/" pid=19973 comm="imap" requested_mask="r" denied_mask="r" fsuid=1003 ouid=1003


### PR DESCRIPTION
Current decoder for iptables doesn't work with OpenWRT logs I have add a modified version that works with those.