### PR TITLE
RPM Build fix for SUSE init script

### DIFF
--- a/src/init/ossec-hids-suse.init
+++ b/src/init/ossec-hids-suse.init
@@ -7,7 +7,7 @@
 ### BEGIN INIT INFO
 # Provides:       ossec
 # Required-Start: $syslog
-# Required-Stop:
+# Required-Stop:  $null
 # Default-Start:  2 3 5
 # Default-Stop:
 # Description:    Start the ossec HIDS daemon

--- a/src/init/ossec-hids-suse.init
+++ b/src/init/ossec-hids-suse.init
@@ -9,7 +9,7 @@
 # Required-Start: $syslog
 # Required-Stop:  $null
 # Default-Start:  2 3 5
-# Default-Stop:   0 1 2 6
+# Default-Stop:   0 1 6
 # Description:    Start the ossec HIDS daemon
 ### END INIT INFO
 

--- a/src/init/ossec-hids-suse.init
+++ b/src/init/ossec-hids-suse.init
@@ -9,7 +9,7 @@
 # Required-Start: $syslog
 # Required-Stop:  $null
 # Default-Start:  2 3 5
-# Default-Stop:
+# Default-Stop:   0 1 2 6
 # Description:    Start the ossec HIDS daemon
 ### END INIT INFO
 


### PR DESCRIPTION
When building an RPM on SUSE SLES 11 these init-script needs these infos.