### PR TITLE
adhere to CES_White_Paper_20100722.pdf from Arcsight.  I have chosen …

### DIFF
--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -126,7 +126,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  al_data->comment,
                  (al_data->level > 10) ? 10 : al_data->level,
                  hostname, al_data->location);
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=%s", al_data->group );
+        field_add_string(syslog_msg, OS_SIZE_2048, " cat=%s", al_data->group );
         field_add_string(syslog_msg, OS_SIZE_2048, " src=%s", al_data->srcip );
         field_add_int(syslog_msg, OS_SIZE_2048, " dpt=%d", al_data->dstport );
         field_add_int(syslog_msg, OS_SIZE_2048, " spt=%d", al_data->srcport );

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -228,6 +228,10 @@ alert_data *GetAlertData(int flag, FILE *fp)
             p = strchr(p, '-');
             if (p) {
                 p++;
+                /* Skip leading spaces */
+		while (*p == ' ') {
+                        p++;
+                }
                 free(group);
                 os_strdup(p, group);
 

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -229,7 +229,7 @@ alert_data *GetAlertData(int flag, FILE *fp)
             if (p) {
                 p++;
                 /* Skip leading spaces */
-		while (*p == ' ') {
+                while (*p == ' ') {
                         p++;
                 }
                 free(group);


### PR DESCRIPTION
…to map our group/classification key to the default 'cat' key.  According to the white paper

cat: Represents the category assigned by the originating device. Devices oftentimes use their own categorization schema to classify events.

I have also made a change to strip leading spaces in the value assigned to the 'cat' key.  Other formats are less picky about the leading spaces but some CEF parsers care.  This fixes the Graylog CEF plugin and properly pulls in the kvp.

Before:
Feb  3 10:33:41 CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.8|103501|spamdyke abuse attempt.|5|dvc=syslog2 cs2=(bamma2.booksamillion.com) 192.168.21.134->/var/log/maillog cs2Label=Location cat= local,syslog, src=212.8.248.198 shost=212.8.248.198 msg=Feb  3 10:33:39 bamma2 spamdyke[1022]: DENIED_RBL_MATCH from: rewardcheck@qinspe.stream to: suzie_arney@booksamillion.com origin_ip: 212.8.248.198 origin_rdns: (unknown) auth: (unknown) encryption: (none) reason: b.barracudacentral.org

After:
Feb  3 10:33:41 CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.8|103501|spamdyke abuse attempt.|5|dvc=syslog2 cs2=(bamma2.booksamillion.com) 192.168.21.134->/var/log/maillog cs2Label=Location cat=local,syslog, src=212.8.248.198 shost=212.8.248.198 msg=Feb  3 10:33:39 bamma2 spamdyke[1022]: DENIED_RBL_MATCH from: rewardcheck@qinspe.stream to: suzie_arney@booksamillion.com origin_ip: 212.8.248.198 origin_rdns: (unknown) auth: (unknown) encryption: (none) reason: b.barracudacentral.org