### PR TITLE
Changes to strip leading spaces from classification field and rename classification to cat to match CEF standard

### DIFF
--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -132,7 +132,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  al_data->comment,
                  (al_data->level > 10) ? 10 : al_data->level,
                  hostname, al_data->location);
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=%s", al_data->group );
+        field_add_string(syslog_msg, OS_SIZE_2048, " cat=%s", al_data->group );
         field_add_string(syslog_msg, OS_SIZE_2048, " src=%s", al_data->srcip );
         field_add_int(syslog_msg, OS_SIZE_2048, " dpt=%d", al_data->dstport );
         field_add_int(syslog_msg, OS_SIZE_2048, " spt=%d", al_data->srcport );

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -272,6 +272,10 @@ alert_data *GetAlertData(int flag, FILE *fp)
             p = strchr(p, '-');
             if (p) {
                 p++;
+                /* Skip leading spaces */
+                while (*p == ' ') {
+                        p++;
+                }
                 free(group);
                 os_strdup(p, group);
 


### PR DESCRIPTION
Resubmit this pull request against master not a stable branch.

Two changes proposed:
1) strip leading spaces in alert processor.  Those leading spaces generate tuples like

classification= local,syslog

The space after the = sign can be interpreted as a field separator by some parsers (e.g. the Graylog CEF parser).

After my patch the tuple looks like:

classification=local,syslog

2) map ossec classification field to CEF cat filed which seems to match purpose.  IMHO, the whole purpose of using CEF is to use a data model that allows the consumer of the data to treat data from different sources devices in a consistent fashion.  I do understand that his is not backward compatible for existing CEF users relying on the classification key name.  

This is described in the CEF Event Format guide as category assigned by the originating device.  Devices oftentimes use their own categorization schema to classify events. 

The CEF Event Format guide is linked below.
https://www.protect724.hpe.com/docs/DOC-1072

Before the patch the tuple looks like:

classification=local,syslog

After my patch the tuple looks like:

cat=local,syslog
