### PR TITLE
New Condition none #119

### DIFF
--- a/src/rootcheck/common_rcl.c
+++ b/src/rootcheck/common_rcl.c
@@ -27,9 +27,8 @@ static char *_rkcl_get_value(char *buf, int *type);
 #define RKCL_COND_ALL       0x001
 #define RKCL_COND_ANY       0x002
 #define RKCL_COND_REQ       0x004
-#define RKCL_COND_INV       0x010
-
-
+#define RKCL_COND_NON       0x008
+#define RKCL_COND_INV       0x016
 #ifdef WIN32
 char *_rkcl_getrootdir(char *root_dir, int dir_size)
 {
@@ -172,6 +171,8 @@ static char *_rkcl_get_name(char *buf, char *ref, int *condition)
         *condition |= RKCL_COND_ALL;
     } else if (strcmp(tmp_location, "any") == 0) {
         *condition |= RKCL_COND_ANY;
+    } else if (strcmp(tmp_location, "none") == 0) {
+        *condition |= RKCL_COND_NON;
     } else if (strcmp(tmp_location, "any required") == 0) {
         *condition |= RKCL_COND_ANY;
         *condition |= RKCL_COND_REQ;
@@ -502,6 +503,11 @@ int rkcl_get_entry(FILE *fp, const char *msg, OSList *p_list)
                 if (found) {
                     g_found = 1;
                 }
+            } else if (condition & RKCL_COND_NON) {
+                debug2("%s: DEBUG: Condition NON.", ARGV0);
+                if (!found) {
+                    g_found = 1;
+                }
             } else {
                 /* Condition for ALL */
                 debug2("%s: DEBUG: Condition ALL.", ARGV0);
@@ -589,4 +595,3 @@ clean_return:
 
     return (1);
 }
-

--- a/src/rootcheck/common_rcl.c
+++ b/src/rootcheck/common_rcl.c
@@ -317,7 +317,8 @@ int rkcl_get_entry(FILE *fp, const char *msg, OSList *p_list)
     /* Get the real entries */
     do {
         int g_found = 0;
-
+        int not_found = 0;
+        
         debug2("%s: DEBUG: Checking entry: '%s'.", ARGV0, name);
 
         /* Get each value */
@@ -505,8 +506,11 @@ int rkcl_get_entry(FILE *fp, const char *msg, OSList *p_list)
                 }
             } else if (condition & RKCL_COND_NON) {
                 debug2("%s: DEBUG: Condition NON.", ARGV0);
-                if (!found) {
-                    g_found = 1;
+                if (!found && (not_found != -1)) {
+                    debug2("%s: DEBUG: Condition NON setze not_found=1.", ARGV0);
+                    not_found = 1;
+                } else {
+                    not_found = -1;
                 }
             } else {
                 /* Condition for ALL */
@@ -518,6 +522,10 @@ int rkcl_get_entry(FILE *fp, const char *msg, OSList *p_list)
                 }
             }
         } while (value != NULL);
+
+        if (condition & RKCL_COND_NON) {
+           if (not_found == -1){ g_found = 0;} else {g_found = 1;}
+        }
 
         /* Alert if necessary */
         if (g_found == 1) {


### PR DESCRIPTION
Add the condition none so you can search that an entry is realy not defind:
Example:
```
# 1.1.1.4 Ensure mounting of hfs filesystems is disabled (Scored)
[CIS - SLES11 - 1.1.1.4 - Initial Setup - Filesystem Configuration - Disable unused filesystems - Ensure mounting of hfs filesystems is disabled (Scored) {CIS: 1.1.1.4 SLES11}] [none] [https://benchmarks.cisecurity.org/tools2/linux/CIS_SUSE_Linux_Enterprise_Server_11_Benchmark_v2.0.0.pdf]
f:/etc/modprobe.conf.local -> !r:^# && r:\.*install\.+hfs\.+/bin/true;
d:/etc/modprobe.d -> .conf$ -> !r:^# && r:\.*install\.+hfs\.+/bin/true;
```
#119 