### PR TITLE
fix netstat command in localfile-commands.template

### DIFF
--- a/etc/templates/config/generic/localfile-commands.template
+++ b/etc/templates/config/generic/localfile-commands.template
@@ -6,7 +6,8 @@
 
   <localfile>
     <log_format>full_command</log_format>
-    <command>netstat -tln | grep -v 127.0.0.1 | sort</command>
+    <command>netstat -tulpen | sort</command>
+    <alias>netstat listening ports</alias>
     <frequency>360</frequency>
   </localfile>
 


### PR DESCRIPTION
this PR:
* adds an alias to the command
* also checks udp ports