### PR TITLE
Fix byte-order incompatibility in agents on SPARC when connecting via TCP

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -78,6 +78,7 @@ void *receiver_thread(__attribute__((unused)) void *none)
                 }
 
                 recv_b = recv(agt->sock, (char*)&length, sizeof(length), MSG_WAITALL);
+                length = wnet_order(length);
 
                 if (recv_b <= 0) {
                     merror(LOST_ERROR);

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -43,6 +43,7 @@ int receive_msg()
             }
 
             recv_b = recv(agt->sock, (char*)&length, sizeof(length), MSG_WAITALL);
+            length = wnet_order(length);
 
             /* Manager disconnected */
             if (recv_b <= 0) {

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -30,7 +30,7 @@ int send_msg(int agentid, const char *msg)
     if (agt->protocol == UDP_PROTO) {
         recv_b = OS_SendUDPbySize(agt->sock, msg_size, crypt_msg);
     } else {
-        length = msg_size;
+        length = wnet_order(msg_size);
         OS_SendTCPbySize(agt->sock, sizeof(length), (char *)&length);
         recv_b = OS_SendTCPbySize(agt->sock, msg_size, crypt_msg);
     }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -160,6 +160,7 @@ void start_agent(int is_startup)
         while (attempts <= 5) {
             if (agt->protocol == TCP_PROTO) {
                 recv_b = recv(agt->sock, (char*)&length, sizeof(length), MSG_WAITALL);
+                length = wnet_order(length);
 
                 if (recv_b > 0) {
                     recv_b = recv(agt->sock, buffer, length, MSG_WAITALL);

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -107,8 +107,6 @@
 
 /* Global portability code */
 
-typedef int32_t netsize_t;
-
 #ifdef SOLARIS
 #include <limits.h>
 typedef uint32_t u_int32_t;

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -510,3 +510,13 @@ int OS_SetRecvTimeout(int socket, int seconds)
     struct timeval tv = { seconds, 0 };
     return setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const void *)&tv, sizeof(tv));
 }
+
+// Byte ordering
+
+netsize_t wnet_order(netsize_t value) {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    return (value >> 24) | (value << 24) | ((value & 0xFF0000) >> 8) | ((value & 0xFF00) << 8);
+#else
+    return value;
+#endif
+}

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -20,6 +20,10 @@ typedef uint8_t u_int8_t;
 typedef uint16_t u_int16_t;
 typedef uint32_t u_int32_t;
 #endif
+
+typedef int32_t netsize_t;
+
+
 /* OS_Bindport*
  * Bind a specific port (protocol and a ip).
  * If the IP is not set, it is going to use ADDR_ANY
@@ -84,5 +88,9 @@ int OS_CloseSocket(int socket);
  * Returns 0 on succes, else -1
  */
 int OS_SetRecvTimeout(int socket, int seconds);
+
+// Byte ordering
+
+netsize_t wnet_order(netsize_t value);
 
 #endif /* __OS_NET_H */

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -149,6 +149,7 @@ void HandleSecure()
                 } else {
                     sock_client = fd;
                     recv_b = recv(sock_client, (char*)&length, sizeof(length), MSG_WAITALL);
+                    length = wnet_order(length);
 
                     if (getpeername(sock_client, (struct sockaddr *)&peer_info, &logr.peer_size) < 0) {
                         merror("Couldn't get the remote peer information: %s", strerror(errno));

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -115,7 +115,7 @@ int send_msg(unsigned int agentid, const char *msg)
                (struct sockaddr *)&keys.keyentries[agentid]->peer_info,
                logr.peer_size);
     } else {
-        length = msg_size;
+        length = wnet_order(msg_size);
         send(keys.keyentries[agentid]->sock, (char*)&length, sizeof(length), 0);
         send_b = send(keys.keyentries[agentid]->sock, crypt_msg, msg_size, 0);
     }


### PR DESCRIPTION
Messages on TCP protocol include a 4-byte little-endian header with the size of the actual message.
SPARC is big-endian architecture so it must reorder those bytes.