### PR TITLE
Update ssh.exp to support different case from password prompt

### DIFF
--- a/src/agentlessd/scripts/ssh.exp
+++ b/src/agentlessd/scripts/ssh.exp
@@ -22,7 +22,7 @@ expect {
     }
     "*sure you want to continue connecting*" {
         send "yes\r"
-        expect "* password:*" {
+        expect "*assword:*" {
             send "$pass\r"
             source $sshloginsrc
         }
@@ -43,7 +43,7 @@ expect {
         send_user "\nERROR: Unable to connect to remote host: $hostname .\n"
         exit 1;
     }
-    "* password:*" {
+    "*assword:*" {
         send "$pass\r"
         source $sshloginsrc
     }


### PR DESCRIPTION
Updating the ssh.exp file to support an uppercase P for password (Password) being returned by F5 BigIP devices. By removing the p, it will match on either Password or password.
The first example in this link does it this way: https://www.pantz.org/software/expect/expect_examples_and_tips.html