### PR TITLE
Add predecoder and cluster objects to JSON alerts.

### DIFF
--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -60,11 +60,15 @@ int GlobalConf(const char *cfgfile)
     Config.label_cache_maxage = 0;
     Config.show_hidden_labels = 0;
 
+    Config.cluster_name = NULL;
+    Config.node_name = NULL;
+
     os_calloc(1, sizeof(wlabel_t), Config.labels);
 
     modules |= CGLOBAL;
     modules |= CRULES;
     modules |= CALERTS;
+    modules |= CCLUSTER;
 
     /* Read config */
     if (ReadConfig(modules, cfgfile, &Config, NULL) < 0 ||

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -235,9 +235,11 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
 {
     cJSON* agent;
     cJSON* manager;
+    cJSON* predecoder;
     cJSON * name;
     agent = cJSON_GetObjectItem(root, "agent");
     manager = cJSON_GetObjectItem(root, "manager");
+    predecoder = cJSON_GetObjectItem(root, "predecoder");
     if(lf->hostname[0] == '(') {
         char* search;
         char string[MAX_STRING] = "";
@@ -257,9 +259,9 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
             cJSON_AddItemReferenceToObject(agent, "name", name);
         }
 
-        cJSON_AddStringToObject(root, "hostname", lf->hostname);
+        cJSON_AddStringToObject(predecoder, "hostname", lf->hostname);
     }else{
-        cJSON_AddStringToObject(root, "hostname", lf->hostname);
+        cJSON_AddStringToObject(predecoder, "hostname", lf->hostname);
     }
 }
 // Parse timestamp

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -6,6 +6,7 @@
 #include "json_extended.h"
 #include <stddef.h>
 #include "config.h"
+#include <regex.h>
 
 #define MAX_MATCHES 10
 #define MAX_STRING 1024
@@ -239,11 +240,15 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
     cJSON * name;
     agent = cJSON_GetObjectItem(root, "agent");
     manager = cJSON_GetObjectItem(root, "manager");
-    predecoder = cJSON_GetObjectItem(root, "predecoder");
+
     if(lf->hostname[0] == '(') {
         char* search;
+        char* agent_hostname = NULL;
         char string[MAX_STRING] = "";
         int index;
+        regex_t regexCompiled;
+        regmatch_t match[2];
+        int match_size;
 
         strncpy(string, lf->hostname, MAX_STRING - 1);
         search = strchr(string, ')');
@@ -252,16 +257,46 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
             index = (int)(search - string);
             str_cut(string, index, -1);
             str_cut(string, 0, 1);
-            cJSON_AddStringToObject(agent, "name", string);
-        }
-    } else if(lf->agent_id && !strcmp(lf->agent_id, "000")){
-        if (name = cJSON_GetObjectItem(manager,"name"), name) {
-            cJSON_AddItemReferenceToObject(agent, "name", name);
         }
 
-        cJSON_AddStringToObject(predecoder, "hostname", lf->hostname);
-    }else{
-        cJSON_AddStringToObject(predecoder, "hostname", lf->hostname);
+        // Get agent hostname
+        static const char *pattern = " [0-9][0-9]:[0-9][0-9]:[0-9][0-9] (.+) .+\\[";
+        if (regcomp(&regexCompiled, pattern, REG_EXTENDED)) {
+            merror_exit("Can not compile regular expression.");
+        }
+        if(regexec(&regexCompiled, lf->full_log, 2, match, 0) == 0){
+            match_size = match[1].rm_eo - match[1].rm_so;
+            agent_hostname = malloc(match_size + 1);
+            snprintf (agent_hostname, match_size + 1, "%.*s", match_size, lf->full_log + match[1].rm_so);
+
+            if (!cJSON_HasObjectItem(root, "predecoder")) {
+                cJSON_AddItemToObject(root, "predecoder", predecoder = cJSON_CreateObject());
+            } else {
+                predecoder = cJSON_GetObjectItem(root, "predecoder");
+            }
+
+            cJSON_AddStringToObject(predecoder, "hostname", agent_hostname);
+            free(agent_hostname);
+        }
+        regfree(&regexCompiled);
+
+    } else {
+
+        if (!cJSON_HasObjectItem(root, "predecoder")) {
+            cJSON_AddItemToObject(root, "predecoder", predecoder = cJSON_CreateObject());
+        } else {
+            predecoder = cJSON_GetObjectItem(root, "predecoder");
+        }
+
+        if(lf->agent_id && !strcmp(lf->agent_id, "000")){
+            if (name = cJSON_GetObjectItem(manager,"name"), name) {
+                cJSON_AddItemReferenceToObject(agent, "name", name);
+            }
+
+            cJSON_AddStringToObject(predecoder, "hostname", lf->hostname);
+        }else{
+            cJSON_AddStringToObject(predecoder, "hostname", lf->hostname);
+        }
     }
 }
 // Parse timestamp

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -36,7 +36,6 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     // Parse timestamp
     W_JSON_AddTimestamp(root, lf);
 
-    cJSON_AddItemToObject(root, "predecoder", predecoder = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "rule", rule = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "agent", agent = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "manager", manager = cJSON_CreateObject());
@@ -234,8 +233,10 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         }
     }
 
-    if(lf->program_name)
+    if(lf->program_name) {
+        cJSON_AddItemToObject(root, "predecoder", predecoder = cJSON_CreateObject());
         cJSON_AddStringToObject(predecoder, "program_name", lf->program_name);
+    }
 
     if(lf->id)
         cJSON_AddStringToObject(data, "id", lf->id);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -22,6 +22,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     cJSON* file_diff;
     cJSON* manager;
 	cJSON* agent;
+    cJSON* predecoder;
     cJSON* data;
 	char manager_name[512];
     char* out;
@@ -34,6 +35,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     // Parse timestamp
     W_JSON_AddTimestamp(root, lf);
 
+    cJSON_AddItemToObject(root, "predecoder", predecoder = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "rule", rule = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "agent", agent = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "manager", manager = cJSON_CreateObject());
@@ -225,7 +227,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     }
 
     if(lf->program_name)
-        cJSON_AddStringToObject(root, "program_name", lf->program_name);
+        cJSON_AddStringToObject(predecoder, "program_name", lf->program_name);
 
     if(lf->id)
         cJSON_AddStringToObject(data, "id", lf->id);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -24,6 +24,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
 	cJSON* agent;
     cJSON* predecoder;
     cJSON* data;
+    cJSON* cluster;
 	char manager_name[512];
     char* out;
     int i;
@@ -39,6 +40,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     cJSON_AddItemToObject(root, "rule", rule = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "agent", agent = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "manager", manager = cJSON_CreateObject());
+    cJSON_AddItemToObject(root, "cluster", cluster = cJSON_CreateObject());
     data = cJSON_CreateObject();
 
     if ( lf->time ) {
@@ -52,6 +54,12 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         cJSON_AddStringToObject(root, "id", alert_id);
     }
 
+    // Cluster information
+    if(Config.cluster_name)
+        cJSON_AddStringToObject(cluster, "name", Config.cluster_name);
+
+    if(Config.node_name)
+        cJSON_AddStringToObject(cluster, "node", Config.node_name);
 
 	/* Get manager hostname */
     memset(manager_name, '\0', 512);

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -1,0 +1,49 @@
+/*
+ * Cluster settings manager
+ * Copyright (C) 2017 Wazuh Inc.
+ * Oct 16, 2017.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "shared.h"
+#include "config.h"
+#include "global-config.h"
+
+int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
+
+    static const char *cluster_name = "name";
+    static const char *node_name = "node_name";
+    static const char *key = "key";
+    static const char *interval = "interval";
+    static const char *nodes = "nodes";
+
+    _Config *Config;
+    Config = (_Config *)d1;
+    int i;
+
+     for (i = 0; node[i]; i++) {
+         if (!node[i]->element) {
+             merror(XML_ELEMNULL);
+             return OS_INVALID;
+         } else if (!node[i]->content) {
+             merror(XML_VALUENULL, node[i]->element);
+             return OS_INVALID;
+         } else if (!strcmp(node[i]->element, cluster_name)) {
+             os_strdup(node[i]->content, Config->cluster_name);
+         } else if (!strcmp(node[i]->element, node_name)) {
+             os_strdup(node[i]->content, Config->node_name);
+         } else if (!strcmp(node[i]->element, key)) {
+         } else if (!strcmp(node[i]->element, interval)) {
+         } else if (!strcmp(node[i]->element, nodes)) {
+         } else {
+             merror(XML_INVELEM, node[i]->element);
+             return OS_INVALID;
+         }
+     }
+
+     return 0;
+ }

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -48,6 +48,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
     const char *oslabels = "labels";                    /* Labels Config */
     const char *osauthd = "auth";                       /* Authd Config */
     const char *oslogging = "logging";                  /* Logging Config */
+    const char *oscluster = "cluster";                  /* Cluster Config */
 
     while (node[i]) {
         XML_NODE chld_node = NULL;
@@ -143,6 +144,10 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
         } else if (strcmp(node[i]->element, oslogging) == 0) {
+        } else if (strcmp(node[i]->element, oscluster) == 0) {
+            if ((modules & CCLUSTER) && (Read_Cluster(chld_node, d1, d2) < 0)) {
+                goto fail;
+            }
         } else {
             merror(XML_INVELEM, node[i]->element);
             goto fail;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -30,6 +30,7 @@
 #define CLABELS       00400000
 #define CAUTHD        01000000
 #define CBUFFER       02000000
+#define CCLUSTER      04000000
 
 #define UDP_PROTO   6
 #define TCP_PROTO   17
@@ -60,6 +61,7 @@ int Read_CReports(XML_NODE node, void *config1, void *config2);
 int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 int Read_Labels(XML_NODE node, void *d1, void *d2);
 int Read_Authd(XML_NODE node, void *d1, void *d2);
+int Read_Cluster(XML_NODE node, void *d1, void *d2);
 
 /* Verifies that the configuration for Syscheck is correct. Return 0 on success or -1 on error.  */
 int Test_Syscheck(const char * path);

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -98,6 +98,10 @@ typedef struct __Config {
     int label_cache_maxage;
     int show_hidden_labels;
 
+    // Cluster configuration
+    char *cluster_name;
+    char *node_name;
+
 } _Config;
 
 #endif /* _CCONFIG__H */


### PR DESCRIPTION
{"timestamp":"2017-10-16T19:13:46+0200",**"predecoder":{"hostname":"ubuntu"}**,"rule":{"level":3,"description":"Ossec server started.","id":"502","firedtimes":1,"mail":true,"groups":["ossec"],"pci_dss":["10.6.1"]},"agent":{"id":"000","name":"ubuntu"},"manager":{"name":"ubuntu"},**"cluster":{"name":"wazuh","node":"node01"}**,"id":"1508174026.25193","full_log":"ossec: Ossec started.","decoder":{"name":"ossec"},"location":"ossec-monitord"}