### PR TITLE
Add option to hide cluster information on JSON alerts.

### DIFF
--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -62,6 +62,7 @@ int GlobalConf(const char *cfgfile)
 
     Config.cluster_name = NULL;
     Config.node_name = NULL;
+    Config.hide_cluster_info = 0;
 
     os_calloc(1, sizeof(wlabel_t), Config.labels);
 

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -39,7 +39,6 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     cJSON_AddItemToObject(root, "rule", rule = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "agent", agent = cJSON_CreateObject());
     cJSON_AddItemToObject(root, "manager", manager = cJSON_CreateObject());
-    cJSON_AddItemToObject(root, "cluster", cluster = cJSON_CreateObject());
     data = cJSON_CreateObject();
 
     if ( lf->time ) {
@@ -54,11 +53,16 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     }
 
     // Cluster information
-    if(Config.cluster_name)
-        cJSON_AddStringToObject(cluster, "name", Config.cluster_name);
+    if (!Config.hide_cluster_info) {
+        cJSON_AddItemToObject(root, "cluster", cluster = cJSON_CreateObject());
+        if(Config.cluster_name)
+            cJSON_AddStringToObject(cluster, "name", Config.cluster_name);
+        else
+            cJSON_AddStringToObject(cluster, "name", "wazuh");
 
-    if(Config.node_name)
-        cJSON_AddStringToObject(cluster, "node", Config.node_name);
+        if(Config.node_name)
+            cJSON_AddStringToObject(cluster, "node", Config.node_name);
+    }
 
 	/* Get manager hostname */
     memset(manager_name, '\0', 512);

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -20,6 +20,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     static const char *key = "key";
     static const char *interval = "interval";
     static const char *nodes = "nodes";
+    static const char *hidden = "hidden";
 
     _Config *Config;
     Config = (_Config *)d1;
@@ -37,6 +38,8 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
          } else if (!strcmp(node[i]->element, node_name)) {
              os_strdup(node[i]->content, Config->node_name);
          } else if (!strcmp(node[i]->element, key)) {
+         } else if (!strcmp(node[i]->element, hidden)) {
+             Config->hide_cluster_info = 1;
          } else if (!strcmp(node[i]->element, interval)) {
          } else if (!strcmp(node[i]->element, nodes)) {
          } else {

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -101,7 +101,7 @@ typedef struct __Config {
     // Cluster configuration
     char *cluster_name;
     char *node_name;
-    u_int8_t hide_cluster_info;
+    unsigned char hide_cluster_info;
 
 } _Config;
 

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -101,6 +101,7 @@ typedef struct __Config {
     // Cluster configuration
     char *cluster_name;
     char *node_name;
+    u_int8_t hide_cluster_info;
 
 } _Config;
 


### PR DESCRIPTION
When the cluster configuration is not found in the _ossec.conf_ file, the object `"cluster":{"name":"wazuh"}` is added by default.

The new tag `<hidden>` allows to hide the cluster object on JSON alerts. No values are required, only the tag: `<hidden />`.