### PR TITLE
Fix JSON alert file reloading

### DIFF
--- a/src/headers/json-queue.h
+++ b/src/headers/json-queue.h
@@ -20,7 +20,7 @@ void jqueue_init(file_queue * queue);
  * Open queue with the JSON alerts log file.
  * Returns 0 on success or -1 on error.
  */
-int jqueue_open(file_queue * queue);
+int jqueue_open(file_queue * queue, int tail);
 
 /*
  * Return next JSON object from the queue, or NULL if it is not available.

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -61,7 +61,7 @@ void OS_CSyslogD(SyslogConfig **syslog_config)
     if (sources.alert_json) {
         jqueue_init(&jfileq);
 
-        for (tries = 1; tries < OS_CSYSLOGD_MAX_TRIES && jqueue_open(&jfileq) < 0; tries++) {
+        for (tries = 1; tries < OS_CSYSLOGD_MAX_TRIES && jqueue_open(&jfileq, 1) < 0; tries++) {
             sleep(1);
         }
 

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -32,7 +32,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
     cJSON *json_field;
     cJSON *location;
     cJSON *rule;
-    
+
     integration_path[2048] = 0;
     exec_tmp_file[2048] = 0;
     exec_full_cmd[4096] = 0;
@@ -40,7 +40,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
     /* Initing file queue JSON - to read the alerts */
     jqueue_init(&jfileq);
 
-    for (tries = 1; tries < 100 && jqueue_open(&jfileq) < 0; tries++) {
+    for (tries = 1; tries < 100 && jqueue_open(&jfileq, 1) < 0; tries++) {
         sleep(1);
     }
 
@@ -49,7 +49,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
     } else {
         mdebug1("JSON file queue connected.");
     }
-    
+
     /* Connecting to syslog. */
     while(integrator_config[s])
     {
@@ -152,7 +152,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             /* Looking if location is set */
             if(integrator_config[s]->location)
             {
-              
+
                 if (location = cJSON_GetObjectItem(al_json, "location"), !location) {
                     s++; continue;
                 }
@@ -244,7 +244,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 }
                 else
                 {
-                    
+
                     fprintf(fp, "%s", cJSON_PrintUnformatted(al_json));
                     temp_file_created = 1;
                     mdebug2("file %s was written.", exec_tmp_file);
@@ -271,8 +271,8 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
         /* Clearing the memory */
         if(temp_file_created == 1)
             unlink(exec_tmp_file);
-            
-        
+
+
         if (al_json) {
             cJSON_Delete(al_json);
         }

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -230,7 +230,7 @@ static void OS_Run(MailConfig *mail)
         minfo("Getting alerts in JSON format.");
         jqueue_init(fileq);
 
-        if (jqueue_open(fileq) < 0) {
+        if (jqueue_open(fileq, 1) < 0) {
             merror("Could not open JSON alerts file.");
         }
 


### PR DESCRIPTION
This PR aims to solve two problems:

1. If any process that monitors the JSON alerts file reloads it due to midnight rotation before Analysisd rotates it, the reload is not valid but it won't retry it until the next day.
2. When the file is opened or reloaded, the pointer is moved to the file end. This is necessary on opening but shouldn't be done when reloading, since alerts could be lost.