### PR TITLE
Fixed update by WPK

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -100,7 +100,7 @@ remoted.recv_timeout=1
 execd.request_timeout=60
 
 # Max timeout to lock the restart [0..3600]
-execd.max_restart_lock=60
+execd.max_restart_lock=600
 
 # Maild strict checking (0=disabled, 1=enabled)
 maild.strict_checking=1

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -99,6 +99,8 @@ remoted.recv_timeout=1
 # Timeout to execute remote requests [1..3600]
 execd.request_timeout=60
 
+# Max timeout to lock the restart [0..3600]
+execd.max_restart_lock=60
 
 # Maild strict checking (0=disabled, 1=enabled)
 maild.strict_checking=1

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -72,7 +72,7 @@ def main():
     # Custom WPK file
     if args.file:
         if args.execute:
-            upgrade_command_result = agent.upgrade_custom(file_path=args.file, installer=args.execute, debug=args.debug, show_progress=print_progress if not args.silent else None, chunk_size=args.chunk_size)
+            upgrade_command_result = agent.upgrade_custom(file_path=args.file, installer=args.execute, debug=args.debug, show_progress=print_progress if not args.silent else None, chunk_size=args.chunk_size, rl_timeout=args.timeout)
             if not args.silent:
                 if not args.debug:
                     print("\n{0}... Please wait.".format(upgrade_command_result))
@@ -99,7 +99,7 @@ def main():
     # WPK upgrade file
     else:
         prev_ver = agent.version
-        upgrade_command_result = agent.upgrade(wpk_repo=args.repository, debug=args.debug, version=args.version, force=args.force, show_progress=print_progress if not args.silent else None, chunk_size=args.chunk_size)
+        upgrade_command_result = agent.upgrade(wpk_repo=args.repository, debug=args.debug, version=args.version, force=args.force, show_progress=print_progress if not args.silent else None, chunk_size=args.chunk_size, rl_timeout=args.timeout)
         if not args.silent:
             if not args.debug:
                 print("\n{0}... Please wait.".format(upgrade_command_result))
@@ -138,6 +138,7 @@ if __name__ == "__main__":
     arg_parser.add_argument("-d", "--debug", action="store_true", help="Debug mode.")
     arg_parser.add_argument("-l", "--list_outdated", action="store_true", help="Generates a list with all outdated agents.")
     arg_parser.add_argument("-c", "--chunk_size", type=int, help="Chunk size sending WPK file.")
+    arg_parser.add_argument("-t", "--timeout", type=int, help="Timeout until agent restart is unlocked.")
     arg_parser.add_argument("-f", "--file", type=str, help="Custom WPK filename.")
     arg_parser.add_argument("-x", "--execute", type=str, help="Executable filename in the WPK custom file.")
     args = arg_parser.parse_args()

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1678,7 +1678,7 @@ class Agent:
         return [wpk_file, sha1hash]
 
 
-    def _send_wpk_file(self, wpk_repo=common.wpk_repo_url, debug=False, version=None, force=False, show_progress=None, chunk_size=None, rl_timeout=0):
+    def _send_wpk_file(self, wpk_repo=common.wpk_repo_url, debug=False, version=None, force=False, show_progress=None, chunk_size=None, rl_timeout=-1):
         """
         Sends WPK file to agent.
         """
@@ -1708,7 +1708,7 @@ class Agent:
         # Sending reset lock timeout
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.connect(common.ossec_path + "/queue/ossec/request")
-        msg = "{0} com rlock {1}".format(str(self.id).zfill(3), str(rl_timeout))
+        msg = "{0} com lock_restart {1}".format(str(self.id).zfill(3), str(rl_timeout))
         s.send(msg.encode())
         if debug:
             print("MSG SENT: {0}".format(str(msg)))
@@ -1716,6 +1716,8 @@ class Agent:
         s.close()
         if debug:
             print("RESPONSE: {0}".format(data))
+        if data != 'ok':
+            raise WazuhException(1715, data.replace("err ",""))
 
 
         # Sending file to agent
@@ -1781,7 +1783,7 @@ class Agent:
             raise WazuhException(1715, data.replace("err ",""))
 
 
-    def upgrade(self, wpk_repo=None, debug=False, version=None, force=False, show_progress=None, chunk_size=None, rl_timeout=0):
+    def upgrade(self, wpk_repo=None, debug=False, version=None, force=False, show_progress=None, chunk_size=None, rl_timeout=-1):
         """
         Upgrade agent using a WPK file.
         """
@@ -1907,7 +1909,7 @@ class Agent:
         return Agent(agent_id).upgrade_result(timeout=int(timeout))
 
 
-    def _send_custom_wpk_file(self, file_path, debug=False, show_progress=None, chunk_size=None, rl_timeout=0):
+    def _send_custom_wpk_file(self, file_path, debug=False, show_progress=None, chunk_size=None, rl_timeout=-1):
         """
         Sends custom WPK file to agent.
         """
@@ -1940,7 +1942,7 @@ class Agent:
         # Sending reset lock timeout
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.connect(common.ossec_path + "/queue/ossec/request")
-        msg = "{0} com rlock {1}".format(str(self.id).zfill(3), str(rl_timeout))
+        msg = "{0} com lock_restart {1}".format(str(self.id).zfill(3), str(rl_timeout))
         s.send(msg.encode())
         if debug:
             print("MSG SENT: {0}".format(str(msg)))
@@ -1948,6 +1950,8 @@ class Agent:
         s.close()
         if debug:
             print("RESPONSE: {0}".format(data))
+        if data != 'ok':
+            raise WazuhException(1715, data.replace("err ",""))
 
         # Sending file to agent
         if debug:
@@ -2013,7 +2017,7 @@ class Agent:
             raise WazuhException(1715, data.replace("err ",""))
 
 
-    def upgrade_custom(self, file_path, installer, debug=False, show_progress=None, chunk_size=None, rl_timeout=0):
+    def upgrade_custom(self, file_path, installer, debug=False, show_progress=None, chunk_size=None, rl_timeout=-1):
         """
         Upgrade agent using a custom WPK file.
         """

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1678,7 +1678,7 @@ class Agent:
         return [wpk_file, sha1hash]
 
 
-    def _send_wpk_file(self, wpk_repo=common.wpk_repo_url, debug=False, version=None, force=False, show_progress=None, chunk_size=None):
+    def _send_wpk_file(self, wpk_repo=common.wpk_repo_url, debug=False, version=None, force=False, show_progress=None, chunk_size=None, rl_timeout=0):
         """
         Sends WPK file to agent.
         """
@@ -1704,6 +1704,19 @@ class Agent:
             print("RESPONSE: {0}".format(data))
         if data != 'ok':
             raise WazuhException(1715, data.replace("err ",""))
+
+        # Sending reset lock timeout
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(common.ossec_path + "/queue/ossec/request")
+        msg = "{0} com rlock {1}".format(str(self.id).zfill(3), str(rl_timeout))
+        s.send(msg.encode())
+        if debug:
+            print("MSG SENT: {0}".format(str(msg)))
+        data = s.recv(1024).decode()
+        s.close()
+        if debug:
+            print("RESPONSE: {0}".format(data))
+
 
         # Sending file to agent
         if debug:
@@ -1768,7 +1781,7 @@ class Agent:
             raise WazuhException(1715, data.replace("err ",""))
 
 
-    def upgrade(self, wpk_repo=None, debug=False, version=None, force=False, show_progress=None, chunk_size=None):
+    def upgrade(self, wpk_repo=None, debug=False, version=None, force=False, show_progress=None, chunk_size=None, rl_timeout=0):
         """
         Upgrade agent using a WPK file.
         """
@@ -1799,7 +1812,7 @@ class Agent:
             raise WazuhException(1720)
 
         # Send file to agent
-        sending_result = self._send_wpk_file(wpk_repo, debug, version, force, show_progress, chunk_size)
+        sending_result = self._send_wpk_file(wpk_repo, debug, version, force, show_progress, chunk_size, rl_timeout)
         if debug:
             print(sending_result[0])
 
@@ -1894,7 +1907,7 @@ class Agent:
         return Agent(agent_id).upgrade_result(timeout=int(timeout))
 
 
-    def _send_custom_wpk_file(self, file_path, debug=False, show_progress=None, chunk_size=None):
+    def _send_custom_wpk_file(self, file_path, debug=False, show_progress=None, chunk_size=None, rl_timeout=0):
         """
         Sends custom WPK file to agent.
         """
@@ -1923,6 +1936,18 @@ class Agent:
             print("RESPONSE: {0}".format(data))
         if data != 'ok':
             raise WazuhException(1715, data.replace("err ",""))
+
+        # Sending reset lock timeout
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(common.ossec_path + "/queue/ossec/request")
+        msg = "{0} com rlock {1}".format(str(self.id).zfill(3), str(rl_timeout))
+        s.send(msg.encode())
+        if debug:
+            print("MSG SENT: {0}".format(str(msg)))
+        data = s.recv(1024).decode()
+        s.close()
+        if debug:
+            print("RESPONSE: {0}".format(data))
 
         # Sending file to agent
         if debug:
@@ -1988,7 +2013,7 @@ class Agent:
             raise WazuhException(1715, data.replace("err ",""))
 
 
-    def upgrade_custom(self, file_path, installer, debug=False, show_progress=None, chunk_size=None):
+    def upgrade_custom(self, file_path, installer, debug=False, show_progress=None, chunk_size=None, rl_timeout=0):
         """
         Upgrade agent using a custom WPK file.
         """
@@ -1999,7 +2024,7 @@ class Agent:
             raise WazuhException(1720)
 
         # Send file to agent
-        sending_result = self._send_custom_wpk_file(file_path, debug, show_progress, chunk_size)
+        sending_result = self._send_custom_wpk_file(file_path, debug, show_progress, chunk_size, rl_timeout)
         if debug:
             print(sending_result[0])
 

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -293,7 +293,7 @@
 #define WAITING_FREE    "Lock free. Continuing..."
 #define SERVER_UNAV     "Server unavailable. Setting lock."
 #define SERVER_UP       "Server responded. Releasing lock."
-#define LOCK_RES        "Locked restart for %d seconds."
+#define LOCK_RES        "Agent auto-restart locked for %d seconds."
 
 /* Buffer alerts */
 #define DISABLED_BUFFER "Agent buffer disabled."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -293,6 +293,7 @@
 #define WAITING_FREE    "Lock free. Continuing..."
 #define SERVER_UNAV     "Server unavailable. Setting lock."
 #define SERVER_UP       "Server responded. Releasing lock."
+#define LOCK_RES        "Locked restart for %d seconds."
 
 /* Buffer alerts */
 #define DISABLED_BUFFER "Agent buffer disabled."

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -14,6 +14,7 @@
 #include "execd.h"
 
 int repeated_offenders_timeout[] = {0, 0, 0, 0, 0, 0, 0};
+time_t pending_upg = 0;
 
 #ifndef WIN32
 

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -29,6 +29,7 @@
 
 extern int repeated_offenders_timeout[];
 extern char ** wcom_ca_store;
+extern time_t pending_upg;
 
 /** Function prototypes **/
 
@@ -49,8 +50,9 @@ size_t wcom_unmerge(const char *file_path, char *output);
 size_t wcom_uncompress(const char * source, const char * target, char * output);
 size_t wcom_upgrade(const char * package, const char * installer, char * output);
 size_t wcom_upgrade_result(char *output);
-size_t wcom_restart(char *output); 
+size_t wcom_restart(char *output);
 size_t wcom_dispatch(char *command, size_t length, char *output);
+size_t lock_restart(int timeout);
 
 #ifndef WIN32
 // Com request thread dispatcher

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -168,6 +168,24 @@ size_t wcom_dispatch(char *command, size_t length, char *output){
         }
     } else if (strcmp(rcv_comm, "restart") == 0) {
         return wcom_restart(output);
+    } else if (strcmp(rcv_comm, "rlock") == 0) {
+        static int max_restart_lock = 0;
+        int timeout;
+
+        if (!max_restart_lock) {
+                max_restart_lock = getDefine_Int("execd", "max_restart_lock", 0, 3600);
+        };
+        timeout = atoi(rcv_args);
+
+        if (timeout < 0 || timeout > max_restart_lock) {
+            timeout = max_restart_lock;
+            strcpy(output, "err Invalid timeout");
+        } else {
+            strcpy(output, "ok");
+        }
+        lock_restart(timeout);
+
+        return strlen(output);
     } else {
         merror("WCOM Unrecognized command '%s'.", rcv_comm);
         strcpy(output, "err Unrecognized command");
@@ -473,35 +491,37 @@ size_t wcom_upgrade_result(char *output){
 }
 
 size_t wcom_restart(char *output) {
-    #ifndef WIN32
+    time_t lock = pending_upg - time(NULL);
 
-    char *exec_cmd[3] = { DEFAULTDIR "/bin/ossec-control", "restart", NULL};
-    if (isChroot()) {
-        strcpy(exec_cmd[0], "/bin/ossec-control");
+    if (lock <= 0) {
+#ifndef WIN32
+        char *exec_cmd[3] = { DEFAULTDIR "/bin/ossec-control", "restart", NULL};
+        if (isChroot()) {
+            strcpy(exec_cmd[0], "/bin/ossec-control");
+        }
+
+        switch (fork()) {
+            case -1:
+                merror("At WCOM upgrade_result: Cannot fork");
+            break;
+            case 0:
+                sleep(1);
+                if (execv(exec_cmd[0], exec_cmd) < 0) {
+                    merror(EXEC_CMDERROR, *exec_cmd, strerror(errno));
+                    return strlen(output);
+                }
+            break;
+            default:
+                strcpy(output, "ok");
+            break;
+        }
+#else
+        char exec_cm[] = {"\"" AR_BINDIR "/restart-ossec.cmd\" add \"-\" \"null\" \"(from_the_server) (no_rule_id)\""};
+        ExecCmd_Win32(exec_cm);
+#endif
+    } else {
+        mwarn(LOCK_RES, (int)lock);
     }
-
-    switch (fork()) {
-        case -1:
-            merror("At WCOM upgrade_result: Cannot fork");
-        break;
-        case 0:
-            sleep(1);
-            if (execv(exec_cmd[0], exec_cmd) < 0) {
-                merror(EXEC_CMDERROR, *exec_cmd, strerror(errno));
-                return strlen(output);
-            }
-        break;
-        default:
-            strcpy(output, "ok");
-        break;
-    }
-
-    #else
-
-    char exec_cm[] = {"\"" AR_BINDIR "/restart-ossec.cmd\" add \"-\" \"null\" \"(from_the_server) (no_rule_id)\""};
-    ExecCmd_Win32(exec_cm);
-
-    #endif
 
     return strlen(output);
 }
@@ -696,5 +716,11 @@ int _uncompress(const char * source, const char *package, char dest[PATH_MAX + 1
     }
 
     unlink(source);
+    return 0;
+}
+
+size_t lock_restart(int timeout) {
+    minfo(LOCK_RES, timeout);
+    pending_upg = time(NULL) + (time_t) timeout;
     return 0;
 }


### PR DESCRIPTION
WPK updates were failing because the agent was restarting when merge.mg was changed.

A lock time has been implemented for these restarts, which can be declared from agent_upgrade with -t option.