### PR TITLE
Prevent race conditions in agents connected using TCP

### DIFF
--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -15,9 +15,8 @@
 int send_msg(const char *msg, ssize_t msg_length)
 {
     ssize_t msg_size;
-    uint32_t length;
     char crypt_msg[OS_MAXSTR + 1];
-    int recv_b;
+    int retval;
 
     msg_size = CreateSecMSG(&keys, msg, msg_length < 0 ? strlen(msg) : (size_t)msg_length, crypt_msg, 0);
     if (msg_size == 0) {
@@ -27,19 +26,17 @@ int send_msg(const char *msg, ssize_t msg_length)
 
     /* Send msg_size of crypt_msg */
     if (agt->server[agt->rip_id].protocol == UDP_PROTO) {
-        recv_b = OS_SendUDPbySize(agt->sock, msg_size, crypt_msg);
+        retval = OS_SendUDPbySize(agt->sock, msg_size, crypt_msg);
     } else {
-        length = wnet_order(msg_size);
-        OS_SendTCPbySize(agt->sock, sizeof(length), (char *)&length);
-        recv_b = OS_SendTCPbySize(agt->sock, msg_size, crypt_msg);
+        retval = OS_SendSecureTCP(agt->sock, msg_size, crypt_msg);
     }
 
-    if (recv_b < 0) {
+    if (!retval) {
+        agent_state.msg_sent++;
+    } else {
         merror(SEND_ERROR, "server", strerror(errno));
         sleep(1);
-        return (-1);
     }
 
-    agent_state.msg_sent++;
-    return (0);
+    return retval;
 }

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -11,6 +11,8 @@
 #include "agentd.h"
 #include "os_net/os_net.h"
 
+static pthread_mutex_t send_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 /* Send a message to the server */
 int send_msg(const char *msg, ssize_t msg_length)
 {
@@ -28,7 +30,9 @@ int send_msg(const char *msg, ssize_t msg_length)
     if (agt->server[agt->rip_id].protocol == UDP_PROTO) {
         retval = OS_SendUDPbySize(agt->sock, msg_size, crypt_msg);
     } else {
+        w_mutex_lock(&send_mutex);
         retval = OS_SendSecureTCP(agt->sock, msg_size, crypt_msg);
+        w_mutex_unlock(&send_mutex);
     }
 
     if (!retval) {

--- a/src/headers/pthreads_op.h
+++ b/src/headers/pthreads_op.h
@@ -17,6 +17,9 @@
 #define w_mutex_unlock(x) { int error = pthread_mutex_unlock(x); if (error) merror_exit("At pthread_mutex_unlock(): %s", strerror(error)); }
 #define w_cond_wait(x, y) { int error = pthread_cond_wait(x, y); if (error) merror_exit("At pthread_cond_wait(): %s", strerror(error)); }
 #define w_cond_signal(x) { int error = pthread_cond_signal(x); if (error) merror_exit("At pthread_cond_signal(): %s", strerror(error)); }
+#define w_rwlock_rdlock(x) { int error = pthread_rwlock_rdlock(x); if (error) merror_exit("At pthread_rwlock_rdlock(): %s", strerror(error)); }
+#define w_rwlock_wrlock(x) { int error = pthread_rwlock_wrlock(x); if (error) merror_exit("At pthread_rdlock_wrlock(): %s", strerror(error)); }
+#define w_rwlock_unlock(x) { int error = pthread_rwlock_unlock(x); if (error) merror_exit("At pthread_rwlock_unlock(): %s", strerror(error)); }
 
 #ifndef WIN32
 int CreateThread(void * (*function_pointer)(void *), void * data) __attribute__((nonnull(1)));

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -11,6 +11,7 @@
 #define __SEC_H
 
 #include <time.h>
+#include <pthread.h>
 
 typedef struct keystore_flags_t {
     unsigned int rehash_keys:1;     // Flag: rehash keys on adding
@@ -30,6 +31,7 @@ typedef struct _keyentry {
 
     os_ip *ip;
     int sock;
+    pthread_mutex_t mutex;
     struct sockaddr_in peer_info;
     FILE *fp;
 } keyentry;

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -96,6 +96,7 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
     keys->keyentries[keys->keysize]->global = 0;
     keys->keyentries[keys->keysize]->fp = NULL;
     keys->keyentries[keys->keysize]->sock = -1;
+    w_mutex_init(&keys->keyentries[keys->keysize]->mutex, NULL);
 
     if (keys->flags.rehash_keys) {
         /** Generate final symmetric key **/
@@ -340,6 +341,7 @@ void OS_FreeKey(keyentry *key) {
         fclose(key->fp);
     }
 
+    pthread_mutex_destroy(&key->mutex);
     free(key);
 }
 
@@ -603,6 +605,7 @@ keystore* OS_DupKeys(const keystore *keys) {
         }
 
         copy->keyentries[i]->sock = keys->keyentries[i]->sock;
+        copy->keyentries[i]->mutex = keys->keyentries[i]->mutex;
         copy->keyentries[i]->peer_info = keys->keyentries[i]->peer_info;
     }
 

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -514,6 +514,24 @@ int OS_SetRecvTimeout(int socket, int seconds)
     return setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const void *)&tv, sizeof(tv));
 }
 
+/* Send secure TCP message
+ * This function prepends a header containing message size as 4-byte little-endian unsigned integer.
+ * Return 0 on success or OS_SOCKTERR on error.
+ */
+int OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
+    int retval;
+    void * buffer;
+    size_t bufsz = size + sizeof(uint32_t);
+
+    os_malloc(bufsz, buffer);
+    *(uint32_t *)buffer = wnet_order(size);
+    memcpy(buffer + sizeof(uint32_t), msg, size);
+    retval = send(sock, buffer, bufsz, 0) == (ssize_t)bufsz ? 0 : OS_SOCKTERR;
+
+    free(buffer);
+    return retval;
+}
+
 // Byte ordering
 
 uint32_t wnet_order(uint32_t value) {

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -80,6 +80,12 @@ int OS_CloseSocket(int socket);
  */
 int OS_SetRecvTimeout(int socket, int seconds);
 
+/* Send secure TCP message
+ * This function prepends a header containing message size as 4-byte little-endian unsigned integer.
+ * Return 0 on success or OS_SOCKTERR on error.
+ */
+int OS_SendSecureTCP(int sock, uint32_t size, const void * msg);
+
 // Byte ordering
 
 uint32_t wnet_order(uint32_t value);

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -119,14 +119,14 @@ void *AR_Forward(__attribute__((unused)) void *arg)
                 unsigned int i;
 
                 /* Lock use of keys */
-                key_lock();
+                key_lock_read();
 
                 for (i = 0; i < keys.keysize; i++) {
                     if (keys.keyentries[i]->rcvd >= (time(0) - DISCON_TIME)) {
                         strncpy(agent_id, keys.keyentries[i]->id, KEYSIZE);
                         key_unlock();
                         send_msg(agent_id, msg_to_send, -1);
-                        key_lock();
+                        key_lock_read();
                     }
                 }
 
@@ -135,7 +135,7 @@ void *AR_Forward(__attribute__((unused)) void *arg)
 
             /* Send to the remote agent that generated the event */
             else if ((ar_location & REMOTE_AGENT) && (location != NULL)) {
-                key_lock();
+                key_lock_read();
                 key_id = OS_IsAllowedName(&keys, location);
 
                 if (key_id < 0) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -659,7 +659,6 @@ void *wait_for_msgs(__attribute__((unused)) void *none)
         if ((data = OSHash_Get(pending_data, pending_queue[queue_j]))) {
             strncpy(agent_id, pending_queue[queue_j], 8);
             strncpy(msg, data->message, OS_SIZE_1024);
-            data->changed = 0;
         } else {
             merror("Couldn't get pending data from hash table for agent ID '%s'.", pending_queue[queue_j]);
             *agent_id = '\0';
@@ -674,6 +673,11 @@ void *wait_for_msgs(__attribute__((unused)) void *none)
         if (*agent_id) {
             read_controlmsg(agent_id, msg);
         }
+
+        // Mark message as dispatched
+        w_mutex_lock(&lastmsg_mutex);
+        data->changed = 0;
+        w_mutex_unlock(&lastmsg_mutex);
     }
 
     return (NULL);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -76,11 +76,11 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length);
 
 int check_keyupdate(void);
 
-void key_lock(void);
+void key_lock_read(void);
+
+void key_lock_write(void);
 
 void key_unlock(void);
-
-void keyupdate_init(void);
 
 /** Global variables **/
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -48,9 +48,6 @@ void HandleSecure()
     struct epoll_event *events = NULL;
 #endif /* __MACH__ || __FreeBSD__ || __OpenBSD__ */
 
-    /* Initialize key mutex */
-    keyupdate_init();
-
     /* Initialize manager */
     manager_init();
 

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -111,6 +111,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
         retval = OS_SendSecureTCP(sock, msg_size, crypt_msg);
     } else {
         mdebug1("Send operation cancelled due to closed socket.");
+        return -1;
     }
 
     if (retval < 0) {

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -67,8 +67,6 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
     int key_id;
     int sock = -1;
     ssize_t msg_size;
-    ssize_t send_b = 0;
-    uint32_t length;
     char crypt_msg[OS_MAXSTR + 1];
     struct sockaddr_in peer_info;
     int retval = 0;
@@ -106,18 +104,16 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
 
     /* Send initial message */
     if (logr.proto[logr.position] == UDP_PROTO) {
-        send_b = sendto(logr.sock, crypt_msg, msg_size, 0,
+        retval = sendto(logr.sock, crypt_msg, msg_size, 0,
                (struct sockaddr *)&peer_info,
                logr.peer_size);
     } else if (sock >= 0) {
-        length = wnet_order(msg_size);
-        send(sock, (char*)&length, sizeof(length), 0);
-        send_b = send(sock, crypt_msg, msg_size, 0);
+        retval = OS_SendSecureTCP(sock, msg_size, crypt_msg);
     } else {
         mdebug1("Send operation cancelled due to closed socket.");
     }
 
-    if (send_b < 0) {
+    if (retval < 0) {
         switch (errno) {
         case EPIPE:
         case EBADF:

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -14,28 +14,21 @@
 #include "os_net/os_net.h"
 
 /* pthread key update mutex */
-static pthread_mutex_t keyupdate_mutex;
+static pthread_rwlock_t keyupdate_rwlock = PTHREAD_RWLOCK_INITIALIZER;
 
-
-/* Initializes mutex */
-void keyupdate_init()
+void key_lock_read()
 {
-    /* Initialize mutex */
-    pthread_mutex_init(&keyupdate_mutex, NULL);
+    w_rwlock_rdlock(&keyupdate_rwlock);
 }
 
-void key_lock()
+void key_lock_write()
 {
-    if (pthread_mutex_lock(&keyupdate_mutex) != 0) {
-        merror(MUTEX_ERROR);
-    }
+    w_rwlock_wrlock(&keyupdate_rwlock);
 }
 
 void key_unlock()
 {
-    if (pthread_mutex_unlock(&keyupdate_mutex) != 0) {
-        merror(MUTEX_ERROR);
-    }
+    w_rwlock_unlock(&keyupdate_rwlock);
 }
 
 /* Check for key updates */
@@ -48,7 +41,7 @@ int check_keyupdate()
         return (0);
     }
 
-    key_lock();
+    key_lock_write();
 
     if (OS_UpdateKeys(&keys)) {
         retval = 1;
@@ -65,13 +58,11 @@ int check_keyupdate()
 int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
 {
     int key_id;
-    int sock = -1;
     ssize_t msg_size;
     char crypt_msg[OS_MAXSTR + 1];
-    struct sockaddr_in peer_info;
     int retval = 0;
 
-    key_lock();
+    key_lock_read();
     key_id = OS_IsAllowedID(&keys, agent_id);
 
     if (key_id < 0) {
@@ -89,30 +80,26 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
 
     msg_size = CreateSecMSG(&keys, msg, msg_length < 0 ? strlen(msg) : (size_t)msg_length, crypt_msg, key_id);
 
-    if (logr.proto[logr.position] == UDP_PROTO) {
-        memcpy(&peer_info, &keys.keyentries[key_id]->peer_info, sizeof(peer_info));
-    } else {
-        sock = keys.keyentries[key_id]->sock;
-    }
-
-    key_unlock();
-
     if (msg_size == 0) {
+        key_unlock();
         merror(SEC_ERROR);
         return (-1);
     }
 
     /* Send initial message */
     if (logr.proto[logr.position] == UDP_PROTO) {
-        retval = sendto(logr.sock, crypt_msg, msg_size, 0,
-               (struct sockaddr *)&peer_info,
-               logr.peer_size);
-    } else if (sock >= 0) {
-        retval = OS_SendSecureTCP(sock, msg_size, crypt_msg);
+        retval = sendto(logr.sock, crypt_msg, msg_size, 0, (struct sockaddr *)&keys.keyentries[key_id]->peer_info, logr.peer_size);
+    } else if (keys.keyentries[key_id]->sock >= 0) {
+        w_mutex_lock(&keys.keyentries[key_id]->mutex);
+        retval = OS_SendSecureTCP(keys.keyentries[key_id]->sock, msg_size, crypt_msg);
+        w_mutex_unlock(&keys.keyentries[key_id]->mutex);
     } else {
+        key_unlock();
         mdebug1("Send operation cancelled due to closed socket.");
         return -1;
     }
+
+    key_unlock();
 
     if (retval < 0) {
         switch (errno) {

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -470,13 +470,10 @@ int StartMQ(__attribute__((unused)) const char *path, __attribute__((unused)) sh
 /* Send win32 info to server */
 void send_win32_info(time_t curr_time)
 {
-    int msg_size;
     char tmp_msg[OS_MAXSTR - OS_HEADER_SIZE + 2];
-    char crypt_msg[OS_MAXSTR + 2];
     char tmp_labels[OS_MAXSTR - OS_HEADER_SIZE] = { '\0' };
 
     tmp_msg[OS_MAXSTR - OS_HEADER_SIZE + 1] = '\0';
-    crypt_msg[OS_MAXSTR + 1] = '\0';
 
     mdebug1("Sending keep alive message.");
 
@@ -535,24 +532,8 @@ void send_win32_info(time_t curr_time)
 
     /* Create message */
     mdebug2("Sending keep alive: %s", tmp_msg);
+    send_msg(tmp_msg, -1);
 
-    msg_size = CreateSecMSG(&keys, tmp_msg, strlen(tmp_msg), crypt_msg, 0);
-
-    if (msg_size == 0) {
-        merror(SEC_ERROR);
-        return;
-    }
-
-    /* Send UDP message */
-    if (agt->server[agt->rip_id].protocol == UDP_PROTO) {
-        if (OS_SendUDPbySize(agt->sock, msg_size, crypt_msg) < 0) {
-            merror(SEND_ERROR, "server", strerror(errno));
-            sleep(1);
-        }
-    } else if (OS_SendSecureTCP(agt->sock, msg_size, crypt_msg) < 0) {
-        merror(SEND_ERROR, "server", strerror(errno));
-        sleep(1);
-    }
 
     update_keepalive(curr_time);
 

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -549,16 +549,9 @@ void send_win32_info(time_t curr_time)
             merror(SEND_ERROR, "server", strerror(errno));
             sleep(1);
         }
-    } else {
-        uint32_t length = msg_size;
-
-        if (OS_SendTCPbySize(agt->sock, sizeof(length), (void*)&length) < 0) {
-            merror(SEND_ERROR, "server", strerror(errno));
-            sleep(1);
-        } else if (OS_SendTCPbySize(agt->sock, msg_size, crypt_msg) < 0) {
-            merror(SEND_ERROR, "server", strerror(errno));
-            sleep(1);
-        }
+    } else if (OS_SendSecureTCP(agt->sock, msg_size, crypt_msg) < 0) {
+        merror(SEND_ERROR, "server", strerror(errno));
+        sleep(1);
     }
 
     update_keepalive(curr_time);


### PR DESCRIPTION
Secure TCP messages are sent in two phases:
1. Message size as 4-byte little-endian unsigned integer.
2. Payload.

When delivering a message the second packet is sent no matter if the first failed, and if the second packet fails we can't undo the first operation.

This commit will pack the full content into a single buffer before sending, so the TCP buffer will keep consistent against sending errors.

On the other hand, TCP sockets will be protected with a mutex to prevent them from being used by more than one thread at the same time.

This should fix data corruption in the TCP stream.