### PR TITLE
Wodle to run commands asynchronously

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -171,8 +171,12 @@ dbd.reconnect_attempts=10
 # Wazuh modules - nice value for tasks. Lower value means higher priority
 wazuh_modules.task_nice=10
 
-# Wazuh modules - maximum number of events per second sent by OpenSCAP Wazuh Module
+# Wazuh modules - maximum number of events per second sent by each module
 wazuh_modules.max_eps=1000
+
+# Wazuh modules - time for a process to quit before killing it [0..3600]
+# 0: Kill immediately
+wazuh_modules.kill_timeout=10
 
 # Wazuh database module settings
 

--- a/src/config/wmodules-command.c
+++ b/src/config/wmodules-command.c
@@ -1,0 +1,117 @@
+/*
+ * Wazuh Module Configuration
+ * Copyright (C) 2017 Wazuh Inc.
+ * October 26, 2017.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wazuh_modules/wmodules.h"
+
+static const char *XML_TAG = "tag";
+static const char *XML_COMMAND = "command";
+static const char *XML_INTERVAL = "interval";
+static const char *XML_IGNORE_OUTPUT = "ignore_output";
+static const char *XML_RUN_ON_START = "run_on_start";
+
+// Parse XML
+
+int wm_command_read(xml_node **nodes, wmodule *module)
+{
+    int i;
+    wm_command_t * command;
+
+    // Create module
+
+    os_calloc(1, sizeof(wm_command_t), command);
+    command->run_on_start = 1;
+    module->context = &WM_COMMAND_CONTEXT;
+    module->data = command;
+
+    // Iterate over module subelements
+
+    for (i = 0; nodes[i]; i++){
+        if (!nodes[i]->element) {
+            merror(XML_ELEMNULL);
+            return OS_INVALID;
+        } else if (!strcmp(nodes[i]->element, XML_TAG)) {
+            if (strlen(nodes[i]->content) == 0) {
+                merror("Empty content for tag '%s' at module '%s'.", XML_TAG, WM_COMMAND_CONTEXT.name);
+                return OS_INVALID;
+            }
+
+            free(command->tag);
+            os_strdup(nodes[i]->content, command->tag);
+        } else if (!strcmp(nodes[i]->element, XML_COMMAND)) {
+            if (strlen(nodes[i]->content) == 0) {
+                merror("Empty content for tag '%s' at module '%s'.", XML_COMMAND, WM_COMMAND_CONTEXT.name);
+                return OS_INVALID;
+            }
+
+            free(command->command);
+            os_strdup(nodes[i]->content, command->command);
+        } else if (!strcmp(nodes[i]->element, XML_INTERVAL)) {
+            char *endptr;
+            command->interval = strtoul(nodes[i]->content, &endptr, 0);
+
+            if (command->interval == 0 || command->interval == UINT_MAX) {
+                merror("Invalid interval at module '%s'", WM_COMMAND_CONTEXT.name);
+                return OS_INVALID;
+            }
+
+            switch (*endptr) {
+            case 'd':
+                command->interval *= 86400;
+                break;
+            case 'h':
+                command->interval *= 3600;
+                break;
+            case 'm':
+                command->interval *= 60;
+                break;
+            case 's':
+            case '\0':
+                break;
+            default:
+                merror("Invalid interval at module '%s'", WM_COMMAND_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_RUN_ON_START)) {
+            if (!strcmp(nodes[i]->content, "yes"))
+                command->run_on_start = 1;
+            else if (!strcmp(nodes[i]->content, "no"))
+                command->run_on_start = 0;
+            else {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_RUN_ON_START, WM_COMMAND_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_IGNORE_OUTPUT)) {
+            if (!strcmp(nodes[i]->content, "yes"))
+                command->ignore_output = 1;
+            else if (!strcmp(nodes[i]->content, "no"))
+                command->ignore_output = 0;
+            else {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_IGNORE_OUTPUT, WM_COMMAND_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else {
+            merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_COMMAND_CONTEXT.name);
+            return OS_INVALID;
+        }
+    }
+
+    if (!command->tag) {
+        mwarn("Option <%s> not found at module '%s'.", XML_TAG, WM_COMMAND_CONTEXT.name);
+        os_strdup("", command->tag);
+    }
+
+    if (!command->command) {
+        mwarn("Tag <%s> not found at module '%s'.", XML_COMMAND, WM_COMMAND_CONTEXT.name);
+        return OS_INVALID;
+    }
+
+    return 0;
+}

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -61,8 +61,14 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, __attribute__((unu
             OS_ClearNode(children);
             return OS_INVALID;
         }
-    } else
+    } else if (!strcmp(node->values[0], WM_COMMAND_CONTEXT.name)){
+        if (wm_command_read(children, cur_wmodule) < 0) {
+            OS_ClearNode(children);
+            return OS_INVALID;
+        }
+    } else {
         merror("Unknown module '%s'", node->values[0]);
+    }
 
     OS_ClearNode(children);
     return 0;

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -118,8 +118,8 @@ void wm_setup()
     // Get defined values from internal_options
 
     wm_task_nice = getDefine_Int("wazuh_modules", "task_nice", -20, 19);
-
     wm_max_eps = getDefine_Int("wazuh_modules", "max_eps", 100, 1000);
+    wm_kill_timeout = getDefine_Int("wazuh_modules", "kill_timeout", 0, 3600);
 
     // Read configuration: ossec.conf
 

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -1,0 +1,142 @@
+/*
+ * Wazuh Module for custom command execution
+ * Copyright (C) 2017 Wazuh Inc.
+ * October 26, 2017.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wmodules.h"
+
+static void * wm_command_main(wm_command_t * command);    // Module main function. It won't return
+static void wm_command_destroy(wm_command_t * command);   // Destroy data
+
+// Command module context definition
+
+const wm_context WM_COMMAND_CONTEXT = {
+    "command",
+    (wm_routine)wm_command_main,
+    (wm_routine)wm_command_destroy
+};
+
+// Module module main function. It won't return.
+
+void * wm_command_main(wm_command_t * command) {
+    time_t time_start;
+    time_t time_sleep = 0;
+    size_t extag_len;
+    char * extag;
+    int usec = 1000000 / wm_max_eps;
+    struct timeval timeout = { 0, usec };
+
+    mtinfo(WM_COMMAND_LOGTAG, "Module command:%s started", command->tag);
+
+    // Set extended tag
+
+    extag_len = strlen(WM_COMMAND_CONTEXT.name) + strlen(command->tag) + 2;
+    os_malloc(extag_len * sizeof(char), extag);
+    snprintf(extag, extag_len, "%s_%s", WM_COMMAND_CONTEXT.name, command->tag);
+
+    if (wm_state_io(extag, WM_IO_READ, &command->state, sizeof(command->state)) < 0) {
+        memset(&command->state, 0, sizeof(command->state));
+    }
+
+    // Connect to socket
+
+    if (!command->ignore_output) {
+        int i;
+
+        for (i = 0; command->queue_fd = StartMQ(DEFAULTQPATH, WRITE), command->queue_fd < 0 && i < WM_MAX_ATTEMPTS; i++) {
+            sleep(WM_MAX_WAIT);
+        }
+
+        if (i == WM_MAX_ATTEMPTS) {
+            mterror(WM_COMMAND_LOGTAG, "Can't connect to queue.");
+            pthread_exit(NULL);
+        }
+    }
+
+    // First sleeping
+
+    if (!command->run_on_start) {
+        time_start = time(NULL);
+
+        if (command->state.next_time > time_start) {
+            mtinfo(WM_COMMAND_LOGTAG, "%s: Waiting for turn to evaluate.", command->tag);
+            sleep(command->state.next_time - time_start);
+        }
+    }
+
+    while (1) {
+        int status;
+        char * output = NULL;
+
+        mtdebug1(WM_COMMAND_LOGTAG, "Starting command '%s'.", command->tag);
+
+        // Get time and execute
+        time_start = time(NULL);
+
+        switch (wm_exec(command->command, command->ignore_output ? NULL : &output, &status, 0)) {
+        case 0:
+            if (status > 0) {
+                mtwarn(WM_COMMAND_LOGTAG, "Command '%s' returned exit code %d.", command->tag, status);
+
+                if (!command->ignore_output) {
+                    mtdebug2(WM_COMMAND_LOGTAG, "OUTPUT: %s", output);
+                }
+            }
+
+            break;
+
+        default:
+            mterror(WM_COMMAND_LOGTAG, "%s: Internal calling. Exiting...", command->tag);
+            pthread_exit(NULL);
+        }
+
+        if (!command->ignore_output) {
+            char * line;
+
+            for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
+                timeout.tv_usec = usec;
+                select(0 , NULL, NULL, NULL, &timeout);
+                SendMSG(command->queue_fd, line, extag, LOCALFILE_MQ);
+            }
+
+            free(output);
+        }
+
+
+        mtdebug1(WM_COMMAND_LOGTAG, "Command '%s' finished.", command->tag);
+
+        if (command->interval) {
+            time_sleep = time(NULL) - time_start;
+
+            if ((time_t)command->interval >= time_sleep) {
+                time_sleep = command->interval - time_sleep;
+                command->state.next_time = command->interval + time_start;
+            } else {
+                mtwarn(WM_COMMAND_LOGTAG, "%s: Interval overtaken.", command->tag);
+                time_sleep = command->state.next_time = 0;
+            }
+
+            if (wm_state_io(extag, WM_IO_WRITE, &command->state, sizeof(command->state)) < 0)
+                mterror(WM_COMMAND_LOGTAG, "%s: Couldn't save running state.", command->tag);
+        }
+
+        // If time_sleep=0, yield CPU
+        sleep(time_sleep);
+    }
+
+    return NULL;
+}
+
+// Destroy data
+
+void wm_command_destroy(wm_command_t * command) {
+    free(command->tag);
+    free(command->command);
+    free(command);
+}

--- a/src/wazuh_modules/wm_command.h
+++ b/src/wazuh_modules/wm_command.h
@@ -1,0 +1,36 @@
+/*
+ * Wazuh Module for custom command execution
+ * Copyright (C) 2017 Wazuh Inc.
+ * October 26, 2017.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef WM_COMMAND_H
+#define WM_COMMAND_H
+
+#define WM_COMMAND_LOGTAG ARGV0 ":command"
+
+typedef struct wm_command_state_t {
+    time_t next_time;               // Absolute time for next scan
+} wm_command_state_t;
+
+typedef struct wm_command_t {
+    char * tag;
+    char * command;
+    unsigned int interval;
+    int queue_fd;
+    wm_command_state_t state;
+    unsigned int run_on_start:1;
+    unsigned int ignore_output:1;
+} wm_command_t;
+
+extern const wm_context WM_COMMAND_CONTEXT;   // Context
+
+// Parse XML
+int wm_command_read(xml_node **nodes, wmodule *module);
+
+#endif // WM_COMMAND_H

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -39,7 +39,7 @@ static DWORD WINAPI Reader(LPVOID args);    // Reading thread's start point
 // Execute command with timeout of secs
 
 int wm_exec(char *command, char **output, int *status, int secs) {
-    HANDLE hThread;
+    HANDLE hThread = NULL;
     DWORD dwCreationFlags;
     STARTUPINFO sinfo = { 0 };
     PROCESS_INFORMATION pinfo = { 0 };
@@ -47,20 +47,23 @@ int wm_exec(char *command, char **output, int *status, int secs) {
     int retval = 0;
 
     sinfo.cb = sizeof(STARTUPINFO);
-    sinfo.dwFlags = STARTF_USESTDHANDLES;
 
-    // Create stdout pipe and make it inheritable
+    if (output) {
+        sinfo.dwFlags = STARTF_USESTDHANDLES;
 
-    if (!CreatePipe(&tinfo.pipe, &sinfo.hStdOutput, NULL, 0)) {
-        merror("CreatePipe()");
-        return -1;
-    }
+        // Create stdout pipe and make it inheritable
 
-    sinfo.hStdError = sinfo.hStdOutput;
+        if (!CreatePipe(&tinfo.pipe, &sinfo.hStdOutput, NULL, 0)) {
+            merror("CreatePipe()");
+            return -1;
+        }
 
-    if (!SetHandleInformation(sinfo.hStdOutput, HANDLE_FLAG_INHERIT, 1)) {
-        merror("SetHandleInformation()");
-        return -1;
+        sinfo.hStdError = sinfo.hStdOutput;
+
+        if (!SetHandleInformation(sinfo.hStdOutput, HANDLE_FLAG_INHERIT, 1)) {
+            merror("SetHandleInformation()");
+            return -1;
+        }
     }
 
     // Create child process and close inherited pipes
@@ -76,18 +79,18 @@ int wm_exec(char *command, char **output, int *status, int secs) {
         return -1;
     }
 
-    CloseHandle(sinfo.hStdOutput);
+    if (output) {
+        CloseHandle(sinfo.hStdOutput);
 
-    // Create reading thread
+        // Create reading thread
 
-    hThread = CreateThread(NULL, 0, Reader, &tinfo, 0, NULL);
+        hThread = CreateThread(NULL, 0, Reader, &tinfo, 0, NULL);
 
-    if (!hThread) {
-        merror("CreateThread(): %ld", GetLastError());
-        return -1;
+        if (!hThread) {
+            merror("CreateThread(): %ld", GetLastError());
+            return -1;
+        }
     }
-
-    // Get output
 
     switch (WaitForSingleObject(pinfo.hProcess, secs * 1000)) {
     case 0:
@@ -110,22 +113,25 @@ int wm_exec(char *command, char **output, int *status, int secs) {
         retval = -1;
     }
 
-    // Output
+    if (output) {
+        // Output
 
-    if (WaitForSingleObject(hThread, 1000) == WAIT_TIMEOUT) {
-		TerminateThread(hThread, 1);
-		WaitForSingleObject(hThread, INFINITE);
-	}
+        if (WaitForSingleObject(hThread, 1000) == WAIT_TIMEOUT) {
+            TerminateThread(hThread, 1);
+            WaitForSingleObject(hThread, INFINITE);
+        }
 
-    if (retval >= 0)
-        *output = tinfo.output ? tinfo.output : strdup("");
-    else
-        free(tinfo.output);
+        if (retval >= 0)
+            *output = tinfo.output ? tinfo.output : strdup("");
+        else
+            free(tinfo.output);
+
+        CloseHandle(hThread);
+        CloseHandle(tinfo.pipe);
+    }
 
     // Cleanup
 
-    CloseHandle(hThread);
-	CloseHandle(tinfo.pipe);
     CloseHandle(pinfo.hProcess);
     CloseHandle(pinfo.hThread);
 
@@ -141,17 +147,17 @@ DWORD WINAPI Reader(LPVOID args) {
     DWORD nbytes;
 
     while (ReadFile(tinfo->pipe, buffer, 1024, &nbytes, NULL), nbytes > 0) {
-		int nextsize = length + nbytes;
+        int nextsize = length + nbytes;
 
-		if (nextsize <= WM_STRING_MAX) {
-			tinfo->output = (char*)realloc(tinfo->output, nextsize + 1);
-			memcpy(tinfo->output + length, buffer, nbytes);
-			length = nextsize;
-			tinfo->output[length] = '\0';
-		} else {
-			mwarn("String limit reached.");
-			break;
-		}
+        if (nextsize <= WM_STRING_MAX) {
+            tinfo->output = (char*)realloc(tinfo->output, nextsize + 1);
+            memcpy(tinfo->output + length, buffer, nbytes);
+            length = nextsize;
+            tinfo->output[length] = '\0';
+        } else {
+            mwarn("String limit reached.");
+            break;
+        }
     }
 
     return 0;
@@ -185,7 +191,7 @@ int wm_exec(char *command, char **output, int *exitcode, int secs)
 
     // Create pipe for child's stdout
 
-    if (pipe(pipe_fd) < 0) {
+    if (output && pipe(pipe_fd) < 0) {
         merror("At wm_exec(): pipe(): %s", strerror(errno));
         return -1;
     }
@@ -206,10 +212,17 @@ int wm_exec(char *command, char **output, int *exitcode, int secs)
 
         argv = wm_strtok(command);
 
-        close(pipe_fd[0]);
-        dup2(pipe_fd[1], STDOUT_FILENO);
-        dup2(pipe_fd[1], STDERR_FILENO);
-        close(pipe_fd[1]);
+        if (output) {
+            close(pipe_fd[0]);
+            dup2(pipe_fd[1], STDOUT_FILENO);
+            dup2(pipe_fd[1], STDERR_FILENO);
+            close(pipe_fd[1]);
+        } else {
+            close(STDOUT_FILENO);
+            close(STDERR_FILENO);
+        }
+
+        close(STDIN_FILENO);
 
         setsid();
         if (nice(wm_task_nice)) {}
@@ -223,46 +236,55 @@ int wm_exec(char *command, char **output, int *exitcode, int secs)
 
         // Parent
 
-        close(pipe_fd[1]);
-        tinfo.pipe = pipe_fd[0];
         wm_append_sid(pid);
 
-        // Launch thread
+        if (output) {
+            close(pipe_fd[1]);
+            tinfo.pipe = pipe_fd[0];
 
-        pthread_mutex_lock(&tinfo.mutex);
+            // Launch thread
 
-        if (pthread_create(&thread, NULL, reader, &tinfo)) {
-            merror("Couldn't create reading thread.");
+            pthread_mutex_lock(&tinfo.mutex);
+
+            if (pthread_create(&thread, NULL, reader, &tinfo)) {
+                merror("Couldn't create reading thread.");
+                pthread_mutex_unlock(&tinfo.mutex);
+                return -1;
+            }
+
+            gettime(&timeout);
+            timeout.tv_sec += secs;
+
+            // Wait for reading termination
+
+            switch (secs ? pthread_cond_timedwait(&tinfo.finished, &tinfo.mutex, &timeout) : pthread_cond_wait(&tinfo.finished, &tinfo.mutex)) {
+            case 0:
+                retval = 0;
+                break;
+
+            case ETIMEDOUT:
+                retval = WM_ERROR_TIMEOUT;
+                kill(-pid, SIGTERM);
+                pthread_cancel(thread);
+                break;
+
+            default:
+                kill(-pid, SIGTERM);
+                pthread_cancel(thread);
+            }
+
+            // Wait for thread
+
             pthread_mutex_unlock(&tinfo.mutex);
-            return -1;
-        }
+            pthread_join(thread, NULL);
 
-        gettime(&timeout);
-        timeout.tv_sec += secs;
+            // Cleanup
 
-        // Wait for reading termination
-
-        switch (pthread_cond_timedwait(&tinfo.finished, &tinfo.mutex, &timeout)) {
-        case 0:
+            pthread_mutex_destroy(&tinfo.mutex);
+            pthread_cond_destroy(&tinfo.finished);
+        } else {
             retval = 0;
-            break;
-
-        case ETIMEDOUT:
-            retval = WM_ERROR_TIMEOUT;
-            kill(-pid, SIGTERM);
-            pthread_cancel(thread);
-            break;
-
-        default:
-            kill(-pid, SIGTERM);
-            pthread_cancel(thread);
         }
-
-        // Wait for thread
-
-        pthread_mutex_unlock(&tinfo.mutex);
-        pthread_join(thread, NULL);
-        wm_remove_sid(pid);
 
         // Wait for child process
 
@@ -273,23 +295,24 @@ int wm_exec(char *command, char **output, int *exitcode, int secs)
             break;
 
         default:
-            if (WEXITSTATUS(status) == EXECVE_ERROR)
+            if (WEXITSTATUS(status) == EXECVE_ERROR) {
+                merror("Invalid command: '%s': (%d) %s", command, errno, strerror(errno));
                 retval = -1;
-            else if (exitcode)
+            } else if (exitcode)
                 *exitcode = WEXITSTATUS(status);
         }
 
-        // Setup output
+        wm_remove_sid(pid);
 
-        if (retval >= 0)
-            *output = tinfo.output ? tinfo.output : strdup("");
-        else
-            free(tinfo.output);
+        if (output) {
+            // Setup output
 
-        // Cleanup
-
-        pthread_mutex_destroy(&tinfo.mutex);
-        pthread_cond_destroy(&tinfo.finished);
+            if (retval >= 0) {
+                *output = tinfo.output ? tinfo.output : strdup("");
+            } else {
+                free(tinfo.output);
+            }
+        }
     }
 
     return retval;

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -80,7 +80,7 @@ void* wm_oscap_main(wm_oscap *oscap) {
             time_sleep = oscap->state.next_time = 0;
         }
 
-        if (wm_state_io(&WM_OSCAP_CONTEXT, WM_IO_WRITE, &oscap->state, sizeof(oscap->state)) < 0)
+        if (wm_state_io(WM_OSCAP_CONTEXT.name, WM_IO_WRITE, &oscap->state, sizeof(oscap->state)) < 0)
             mterror(WM_OSCAP_LOGTAG, "Couldn't save running state.");
 
         // If time_sleep=0, yield CPU
@@ -100,7 +100,7 @@ void wm_oscap_setup(wm_oscap *_oscap) {
 
     // Read running state
 
-    if (wm_state_io(&WM_OSCAP_CONTEXT, WM_IO_READ, &oscap->state, sizeof(oscap->state)) < 0)
+    if (wm_state_io(WM_OSCAP_CONTEXT.name, WM_IO_READ, &oscap->state, sizeof(oscap->state)) < 0)
         memset(&oscap->state, 0, sizeof(oscap->state));
 
     if (isDebug())

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -158,12 +158,12 @@ char** wm_strtok(char *string) {
 
 // Load or save the running state
 
-int wm_state_io(const wm_context *context, int op, void *state, size_t size) {
+int wm_state_io(const char * tag, int op, void *state, size_t size) {
     char path[PATH_MAX] = { '\0' };
     size_t nmemb;
     FILE *file;
 
-    snprintf(path, PATH_MAX, "%s/%s", WM_STATE_DIR, context->name);
+    snprintf(path, PATH_MAX, "%s/%s", WM_STATE_DIR, tag);
 
     if (!(file = fopen(path, op == WM_IO_WRITE ? "w" : "r")))
         return -1;

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -13,7 +13,8 @@
 
 wmodule *wmodules = NULL;   // Config: linked list of all modules.
 int wm_task_nice = 0;       // Nice value for tasks.
-int wm_max_eps;
+int wm_max_eps;             // Maximum events per second sent by OpenScap Wazuh Module
+int wm_kill_timeout;        // Time for a process to quit before killing it
 
 // Add module to the global list
 

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -54,6 +54,7 @@ typedef struct wmodule {
 
 #include "wm_oscap.h"
 #include "wm_database.h"
+#include "wm_command.h"
 
 extern wmodule *wmodules;       // Loaded modules.
 extern int wm_task_nice;        // Nice value for tasks.
@@ -101,7 +102,7 @@ char** wm_strtok(char *string);
  * op: WM_IO_READ | WM_IO_WRITE
  * Returns 0 if success, or 1 if fail.
  */
-int wm_state_io(const wm_context *context, int op, void *state, size_t size);
+int wm_state_io(const char * tag, int op, void *state, size_t size);
 
 // Frees the wmodule struct
 void wm_free(wmodule * c);

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -59,6 +59,7 @@ typedef struct wmodule {
 extern wmodule *wmodules;       // Loaded modules.
 extern int wm_task_nice;        // Nice value for tasks.
 extern int wm_max_eps;          // Maximum events per second sent by OpenScap Wazuh Module
+extern int wm_kill_timeout;     // Time for a process to quit before killing it
 
 // Add module to the global list
 void wm_add(wmodule *module);


### PR DESCRIPTION
This PR adds the feature requested at issue https://github.com/wazuh/wazuh/issues/237.

Configuration example:

```xml
<wodle name="command">
  <tag>myapp</tag>
  <command>/usr/local/bin/myapp --config /var/ossec/etc/shared/myapp.conf</command>
  <interval>60</interval>
  <ignore_output>no</ignore_output>
  <run_on_start>yes</run_on_start>
</wodle>
```

**Default values for parameters**
- `interval`: `60` (seconds).
- `ignore_output`: `no`
- `run_on_start`: `yes`

**Ignoring output**

The function `wm_exec()` has been optimized to discard the child process output by closing the standard file descriptors (_stdout_ and _stderr_).

**Child processes termination**

We introduce a new reliable mechanism to kill child Modulesd processes without delaying the daemon stop procedure: every termination will fork into a new auxiliar process that will kill the child application. In case of timeout, the auxiliar program will kill the child process with `SIGKILL`. However Modulesd will stop and delete quickly the PID file so `ossec-control` could restart the daemons rapidly.

New internal option:
```
wazuh_modules.kill_timeout=10
```
