### PR TITLE
Fix incorrect Active response timeout

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -47,15 +47,15 @@ void *receiver_thread(__attribute__((unused)) void *none)
     memset(file_sum, '\0', 34);
 
     while (1) {
+        /* Run timeout commands */
+        if (agt->execdq >= 0) {
+            WinTimeoutRun();
+        }
+
         /* sock must be set */
         if (agt->sock == -1) {
             sleep(5);
             continue;
-        }
-
-        /* Run timeout commands */
-        if (agt->execdq >= 0) {
-            WinTimeoutRun(available_server);
         }
 
         FD_ZERO(&fdset);

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -53,11 +53,16 @@ void *receiver_thread(__attribute__((unused)) void *none)
             continue;
         }
 
+        /* Run timeout commands */
+        if (agt->execdq >= 0) {
+            WinTimeoutRun(available_server);
+        }
+
         FD_ZERO(&fdset);
         FD_SET(agt->sock, &fdset);
 
-        /* Wait for 30 seconds */
-        selecttime.tv_sec = 30;
+        /* Wait for 1 second */
+        selecttime.tv_sec = 1;
         selecttime.tv_usec = 0;
 
         /* Wait with a timeout for any descriptor */
@@ -132,11 +137,6 @@ void *receiver_thread(__attribute__((unused)) void *none)
                 /* This is the only thread that modifies it */
                 available_server = (int)time(NULL);
                 update_ack(available_server);
-
-                /* Run timeout commands */
-                if (agt->execdq >= 0) {
-                    WinTimeoutRun(available_server);
-                }
 
                 /* If it is an active response message */
                 if (strncmp(tmp_msg, EXECD_HEADER, strlen(EXECD_HEADER)) == 0) {

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -108,7 +108,7 @@ int receive_msg()
 #ifdef WIN32
             /* Run timeout commands */
             if (agt->execdq >= 0) {
-                WinTimeoutRun(available_server);
+                WinTimeoutRun();
             }
 #endif
 

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -40,7 +40,7 @@ void ExecCmd(char *const *cmd) __attribute__((nonnull));
 void ExecCmd_Win32(char *cmd);
 int ExecdConfig(const char *cfgfile) __attribute__((nonnull));
 int WinExecd_Start(void);
-void WinTimeoutRun(int timeout);
+void WinTimeoutRun(void);
 
 size_t wcom_open(const char *file_path, const char *mode, char *output);
 size_t wcom_write(const char *file_path, char *buffer, size_t length, char *output);

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -25,7 +25,7 @@
 #define MAX_ARGS    32
 
 /* Execd select timeout -- in seconds */
-#define EXECD_TIMEOUT   90
+#define EXECD_TIMEOUT   1
 
 extern int repeated_offenders_timeout[];
 extern char ** wcom_ca_store;

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -60,8 +60,10 @@ int WinExecd_Start()
     return (1);
 }
 
-void WinTimeoutRun(int curr_time)
+void WinTimeoutRun()
 {
+    time_t curr_time = time(NULL);
+
     /* Check if there is any timed out command to execute */
     timeout_node = OSList_GetFirstNode(timeout_list);
     while (timeout_node) {


### PR DESCRIPTION
Active response timeout is not accurate:

- In UNIX agents, pending delete commands by timeout are checked every 90 seconds.
- In Windows agents, they are checked only when the manager sends any message to the agent.

Now pending commands should be checked every second.