### PR TITLE
Fix queue_t struct

### DIFF
--- a/src/headers/queue_op.h
+++ b/src/headers/queue_op.h
@@ -17,13 +17,13 @@ typedef struct queue_t {
     size_t begin;
     size_t end;
     size_t size;
-} queue_t;
+} w_queue_t;
 
-queue_t * queue_init(size_t n);
-void queue_free(queue_t * queue);
-int queue_full(const queue_t * queue);
-int queue_empty(const queue_t * queue);
-int queue_push(queue_t * queue, void * data);
-void * queue_pop(queue_t * queue);
+w_queue_t * queue_init(size_t n);
+void queue_free(w_queue_t * queue);
+int queue_full(const w_queue_t * queue);
+int queue_empty(const w_queue_t * queue);
+int queue_push(w_queue_t * queue, void * data);
+void * queue_pop(w_queue_t * queue);
 
 #endif // QUEUE_OP_H

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -11,30 +11,30 @@
 
 #include <shared.h>
 
-queue_t * queue_init(size_t size) {
-    queue_t * queue;
-    os_calloc(1, sizeof(queue_t), queue);
+w_queue_t * queue_init(size_t size) {
+    w_queue_t * queue;
+    os_calloc(1, sizeof(w_queue_t), queue);
     os_malloc(size * sizeof(void *), queue->data);
     queue->size = size;
     return queue;
 }
 
-void queue_free(queue_t * queue) {
+void queue_free(w_queue_t * queue) {
     if (queue) {
         free(queue->data);
         free(queue);
     }
 }
 
-int queue_full(const queue_t * queue) {
+int queue_full(const w_queue_t * queue) {
     return (queue->begin + 1) % queue->size == queue->end;
 }
 
-int queue_empty(const queue_t * queue) {
+int queue_empty(const w_queue_t * queue) {
     return queue->begin == queue->end;
 }
 
-int queue_push(queue_t * queue, void * data) {
+int queue_push(w_queue_t * queue, void * data) {
     if (queue_full(queue)) {
         return -1;
     } else {
@@ -44,7 +44,7 @@ int queue_push(queue_t * queue, void * data) {
     }
 }
 
-void * queue_pop(queue_t * queue) {
+void * queue_pop(w_queue_t * queue) {
     void * data;
 
     if (queue_empty(queue)) {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -23,7 +23,7 @@
 
 static volatile unsigned int queue_i;
 static volatile unsigned int queue_j;
-static queue_t * queue;                 // Queue for pending files
+static w_queue_t * queue;                 // Queue for pending files
 static OSHash * ptable;                 // Table for pending paths
 static pthread_mutex_t mutex_queue = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t cond_pending = PTHREAD_COND_INITIALIZER;


### PR DESCRIPTION
The type queue_t was overlapping the original queue_t structure, the new one will be called w_queue_t