### PR TITLE
Extract timestamp data from Syslog events by predecoder

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -131,6 +131,10 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
         )
 
     ) {
+
+        lf->dec_timestamp = lf->full_log + loglen;
+        lf->log[-1] = '\0';
+
         /* Check for an extra space in here */
         if (*lf->log == ' ') {
             lf->log++;
@@ -327,7 +331,9 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
              (pieces[24] == ' ') &&
              (pieces[26] == ' ')) {
         /* Move log to the beginning of the message */
-        lf->log += 24;
+        lf->log += 25;
+        lf->dec_timestamp = lf->full_log + loglen;
+        lf->log[-1] = '\0';
     }
 
     /* Check for snort date format
@@ -341,6 +347,8 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
               (pieces[14] == '.') &&
               (pieces[21] == ' ') ) {
         lf->log += 23;
+        lf->dec_timestamp = lf->full_log + loglen;
+        lf->log[-2] = '\0';
     }
 
     /* Check for suricata (new) date format
@@ -355,6 +363,8 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
               (pieces[19] == '.') &&
               (pieces[26] == ' ') ) {
         lf->log += 28;
+        lf->dec_timestamp = lf->full_log + loglen;
+        lf->log[-2] = '\0';
     }
 
 
@@ -370,6 +380,8 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
               (pieces[20] == ' ') &&
               (pieces[25] == ']') ) {
         lf->log += 27;
+        lf->dec_timestamp = lf->full_log + loglen + 1;
+        lf->log[-2] = '\0';
     }
 
     /* Check for the osx asl log format.
@@ -484,6 +496,9 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
         while (*lf->log == ' ') {
             lf->log++;
         }
+
+        lf->dec_timestamp = lf->full_log + loglen;
+        lf->log[-1] = '\0';
     }
 
     /* Every message must be in the format
@@ -538,6 +553,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     if (!alert_only) {
         print_out("**Phase 1: Completed pre-decoding.");
         print_out("       full event: '%s'", lf->full_log);
+        print_out("       timestamp: '%s'", lf->dec_timestamp);
         print_out("       hostname: '%s'", lf->hostname);
         print_out("       program_name: '%s'", lf->program_name);
         print_out("       log: '%s'", lf->log);

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -462,6 +462,7 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->program_name = NULL;
     lf->location = NULL;
     lf->comment = NULL;
+    lf->dec_timestamp = NULL;
 
     lf->srcip = NULL;
     lf->srcgeoip = NULL;

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -30,6 +30,7 @@ typedef struct _Eventinfo {
     char *hostname;
     char *program_name;
     char *comment;
+    char *dec_timestamp;
 
     /* Extracted from the decoders */
     char *srcip;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -237,9 +237,16 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         }
     }
 
-    if(lf->program_name) {
+    if (lf->program_name || lf->dec_timestamp) {
         cJSON_AddItemToObject(root, "predecoder", predecoder = cJSON_CreateObject());
-        cJSON_AddStringToObject(predecoder, "program_name", lf->program_name);
+
+        if (lf->program_name) {
+            cJSON_AddStringToObject(predecoder, "program_name", lf->program_name);
+        }
+
+        if (lf->dec_timestamp) {
+            cJSON_AddStringToObject(predecoder, "timestamp", lf->dec_timestamp);
+        }
     }
 
     if(lf->id)


### PR DESCRIPTION
As explained in this comment: https://github.com/wazuh/wazuh/issues/257#issuecomment-344156058

This feature adds a new predecoder field, `timestamp`, that extracts the date-time part from standard logs.

For example, for the log `Nov 13 21:52:00 localhost salute: Hello world`, this is an example alert:

```
{
  "timestamp": "2017-11-13T21:52:55-0800",
  "rule": {
    "level": 5,
    "description": "Salute alert.",
    "id": "100001",
    "firedtimes": 1,
    "mail": false,
    "groups": [
      "local",
      "syslog",
      "sshd"
    ]
  },
  "agent": {
    "id": "000",
    "name": "ubuntu"
  },
  "manager": {
    "name": "ubuntu"
  },
  "id": "1510638775.28698",
  "cluster": {
    "name": "wazuh",
    "node": "node01"
  },
  "full_log": "Nov 13 21:52:00 localhost salute: Hello world",
  "predecoder": {
    "program_name": "salute",
    "event_timestamp": "Nov 13 21:52:00",
    "hostname": "localhost"
  },
  "decoder": {},
  "location": "/var/log/myapp.log"
}
```