### PR TITLE
Unification of the name convention

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -14,7 +14,7 @@
 
   <client_buffer>
     <!-- Agent buffer options -->
-    <disable>no</disable>
+    <disabled>no</disabled>
     <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>

--- a/etc/templates/config/README.md
+++ b/etc/templates/config/README.md
@@ -50,7 +50,7 @@
         </client>
         <client_buffer>
           <!-- Agent buffer options -->
-          <disable>no</disable>
+          <disabled>no</disabled>
           <queue_size>5000</queue_size>
           <events_per_second>500</events_per_second>
         </client_buffer>

--- a/src/config/buffer-config.c
+++ b/src/config/buffer-config.c
@@ -18,7 +18,7 @@ int Read_ClientBuffer(XML_NODE node, __attribute__((unused)) void *d1, void *d2)
     int i = 0;
 
     /* XML definitions */
-    const char *xml_buffer_disabled = "disable";
+    const char *xml_buffer_disabled = "disabled";
     const char *xml_buffer_queue_size = "queue_size";
     const char *xml_events_per_second = "events_per_second";
 

--- a/src/config/buffer-config.c
+++ b/src/config/buffer-config.c
@@ -24,7 +24,7 @@ int Read_ClientBuffer(XML_NODE node, __attribute__((unused)) void *d1, void *d2)
 
     /* Old XML definition */
     const char *xml_buffer_length = "length";
-    const char *xml_buffer_disabled = "disable";
+    const char *xml_buffer_disable = "disable";
 
     agent *logr;
 

--- a/src/config/buffer-config.c
+++ b/src/config/buffer-config.c
@@ -18,12 +18,13 @@ int Read_ClientBuffer(XML_NODE node, __attribute__((unused)) void *d1, void *d2)
     int i = 0;
 
     /* XML definitions */
-    const char *xml_buffer_disabled = "disabled";
+    const char *xml_buffer_disable = "disable";
     const char *xml_buffer_queue_size = "queue_size";
     const char *xml_events_per_second = "events_per_second";
 
     /* Old XML definition */
     const char *xml_buffer_length = "length";
+    const char *xml_buffer_disabled = "disabled";
 
     agent *logr;
 
@@ -36,7 +37,7 @@ int Read_ClientBuffer(XML_NODE node, __attribute__((unused)) void *d1, void *d2)
         } else if (!node[i]->content) {
             merror(XML_VALUENULL, node[i]->element);
             return (OS_INVALID);
-        } else if (strcmp(node[i]->element, xml_buffer_disabled) == 0) {
+        } else if (strcmp(node[i]->element, xml_buffer_disabled) == 0) || (strcmp(node[i]->element, xml_buffer_disable) == 0) {
             if (strcmp(node[i]->content, "yes") == 0) {
                 logr->buffer = 0;
             } else if (strcmp(node[i]->content, "no") == 0) {

--- a/src/config/buffer-config.c
+++ b/src/config/buffer-config.c
@@ -18,13 +18,12 @@ int Read_ClientBuffer(XML_NODE node, __attribute__((unused)) void *d1, void *d2)
     int i = 0;
 
     /* XML definitions */
-    const char *xml_buffer_disable = "disable";
+    const char *xml_buffer_disabled = "disabled";
     const char *xml_buffer_queue_size = "queue_size";
     const char *xml_events_per_second = "events_per_second";
 
     /* Old XML definition */
     const char *xml_buffer_length = "length";
-    const char *xml_buffer_disabled = "disabled";
 
     agent *logr;
 
@@ -37,7 +36,7 @@ int Read_ClientBuffer(XML_NODE node, __attribute__((unused)) void *d1, void *d2)
         } else if (!node[i]->content) {
             merror(XML_VALUENULL, node[i]->element);
             return (OS_INVALID);
-        } else if (strcmp(node[i]->element, xml_buffer_disabled) == 0) || (strcmp(node[i]->element, xml_buffer_disable) == 0) {
+        } else if (strcmp(node[i]->element, xml_buffer_disabled) == 0) {
             if (strcmp(node[i]->content, "yes") == 0) {
                 logr->buffer = 0;
             } else if (strcmp(node[i]->content, "no") == 0) {

--- a/src/config/buffer-config.c
+++ b/src/config/buffer-config.c
@@ -24,6 +24,7 @@ int Read_ClientBuffer(XML_NODE node, __attribute__((unused)) void *d1, void *d2)
 
     /* Old XML definition */
     const char *xml_buffer_length = "length";
+    const char *xml_buffer_disabled = "disable";
 
     agent *logr;
 
@@ -36,7 +37,7 @@ int Read_ClientBuffer(XML_NODE node, __attribute__((unused)) void *d1, void *d2)
         } else if (!node[i]->content) {
             merror(XML_VALUENULL, node[i]->element);
             return (OS_INVALID);
-        } else if (strcmp(node[i]->element, xml_buffer_disabled) == 0) {
+        } else if (strcmp(node[i]->element, xml_buffer_disabled) == 0 || strcmp(node[i]->element, xml_buffer_disable) == 0) {
             if (strcmp(node[i]->content, "yes") == 0) {
                 logr->buffer = 0;
             } else if (strcmp(node[i]->content, "no") == 0) {

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -276,7 +276,7 @@ WriteAgent()
 
     echo "  <client_buffer>" >> $NEWCONFIG
     echo "    <!-- Agent buffer options -->" >> $NEWCONFIG
-    echo "    <disable>no</disable>" >> $NEWCONFIG
+    echo "    <disabled>no</disabled>" >> $NEWCONFIG
     echo "    <queue_size>5000</queue_size>" >> $NEWCONFIG
     echo "    <events_per_second>500</events_per_second>" >> $NEWCONFIG
     echo "  </client_buffer>" >> $NEWCONFIG

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -16,7 +16,7 @@
 
   <client_buffer>
     <!-- Agent buffer options -->
-    <disable>no</disable>
+    <disabled>no</disabled>
     <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>


### PR DESCRIPTION
I spent lots of time while I want disable client buffer in configuration. Later on that day I found my problem...Wazuh using `<disable>` tag for this specific setting.
I'm used to the ossec configuration, where is something like this:
```
<active-response>
    <disabled>no</disabled>
  </active-response>
```
```
 <syscheck>
    <disabled>no</disabled>
.....
  </syscheck>
```
```
 <rootcheck>
    <disabled>no</disabled>
......
  </rootcheck>
```

From my point of view, it would be nice to unify naming of those tags.