### PR TITLE
3.0 improve aws integration

### DIFF
--- a/extensions/logstash/01-wazuh.conf
+++ b/extensions/logstash/01-wazuh.conf
@@ -31,7 +31,7 @@ filter {
 }
 filter {
     geoip {
-        source => "[data][srcip]"
+        source => "@src_ip"
         target => "GeoLocation"
         fields => ["city_name", "continent_code", "country_code2", "country_name", "region_name", "location"]
     }

--- a/extensions/logstash/01-wazuh.conf
+++ b/extensions/logstash/01-wazuh.conf
@@ -18,6 +18,18 @@ input {
 #   }
 #}
 filter {
+    if [data][srcip] {
+        mutate {
+            add_field => [ "@src_ip", "%{[data][srcip]}" ]
+        }
+    }
+    if [data][aws][sourceIPAddress] {
+        mutate {
+            add_field => [ "@src_ip", "%{[data][aws][sourceIPAddress]}" ]
+        }
+    }
+}
+filter {
     geoip {
         source => "[data][srcip]"
         target => "GeoLocation"
@@ -28,7 +40,7 @@ filter {
         target => "@timestamp"
     }
     mutate {
-        remove_field => [ "timestamp", "beat", "input_type", "tags", "count", "@version", "log", "offset", "type"]
+        remove_field => [ "timestamp", "beat", "input_type", "tags", "count", "@version", "log", "offset", "type","@src_ip"]
         add_field => { "cluster.name" => "wazuh" }
     }
 }


### PR DESCRIPTION
Now, the file `01-wazuh.conf` can geolocate the alerts generated by AWS. This can be achieved adding a new field called `src_ip`. This field will store the source IP of the alert, no matter if the source IP comes from AWS events or any other alert. 

To do this, it is necessary to add a new `mutate` filter before the `geoip` filter like the following one:

```
filter {
    if [data][srcip] {
        mutate {
            add_field => [ "@src_ip", "%{[data][srcip]}" ]
        }
    }
    if [data][aws][sourceIPAddress] {
        mutate {
            add_field => [ "@src_ip", "%{[data][aws][sourceIPAddress]}" ]
        }
    }
}
```

After that, it is necessary to change the `geoip` filter and change source field in `geoip` filter from `[data][srcip]` to `@srcip` and finally, eliminate the field `src_ip`. 

```
filter {
    geoip {
        source => "@src_ip"
        target => "GeoLocation"
        fields => ["city_name", "continent_code", "country_code2", "country_name", "region_name", "location"]
    }
    ...
    mutate {
        remove_field => [ "timestamp", "beat", "input_type", "tags", "count", "@version", "log", "offset", "type","@src_ip"]
        add_field => { "cluster.name" => "wazuh" }
    }
}
```