### PR TITLE
fixed solaris 10

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -61,7 +61,6 @@ ifeq (${uname_S},SunOS)
 		DEFINES+=-DSOLARIS
 		DEFINES+=-DHIGHFIRST
 		DEFINES+=-std=gnu99
-		OSSEC_LDFLAGS+=-z relax=secadj
 		OSSEC_LDFLAGS+=-lsocket -lnsl -lresolv
 		LUA_PLAT=solaris
 		PATH:=${PATH}:/usr/ccs/bin:/usr/xpg4/bin:/opt/csw/gcc3/bin:/opt/csw/bin:/usr/sfw/bin


### PR DESCRIPTION
Removed relax=secadj for correct compiling on Solaris 10