### PR TITLE
Return key when adding new agents in framework

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -264,6 +264,11 @@ class Agent:
 
         return info
 
+    def compute_key(self):
+        str_key = "{0} {1} {2} {3}".format(self.id, self.name, self.ip, self.internal_key)
+        return b64encode(str_key.encode()).decode()
+        
+
     def get_key(self):
         """
         Gets agent key.
@@ -273,8 +278,7 @@ class Agent:
 
         self._load_info_from_DB()
         if self.id != "000":
-            str_key = "{0} {1} {2} {3}".format(self.id, self.name, self.ip, self.internal_key)
-            self.key = b64encode(str_key.encode()).decode()
+            self.key = self.compute_key()
         else:
             self.key = ""
 
@@ -490,7 +494,8 @@ class Agent:
         authd_socket.close()
 
         self.id  = data['id']
-        self.key = data['key']
+        self.internal_key = data['key']
+        self.key = self.compute_key()
 
     def _add_manual(self, name, ip, id=None, key=None, force=-1):
         """
@@ -606,7 +611,8 @@ class Agent:
         chmod(common.client_keys, 0o640)
 
         self.id = agent_id
-        self.key = agent_key
+        self.internal_key = agent_key
+        self.key = self.compute_key()
 
     def _remove_single_group(self, group_id):
         """

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -489,7 +489,8 @@ class Agent:
         data = authd_socket.receive()
         authd_socket.close()
 
-        self.id = data['id']
+        self.id  = data['id']
+        self.key = data['key']
 
     def _add_manual(self, name, ip, id=None, key=None, force=-1):
         """
@@ -605,6 +606,7 @@ class Agent:
         chmod(common.client_keys, 0o640)
 
         self.id = agent_id
+        self.key = agent_key
 
     def _remove_single_group(self, group_id):
         """
@@ -1030,7 +1032,8 @@ class Agent:
         :return: Agent ID.
         """
 
-        return Agent(name=name, ip=ip, force=force).id
+        new_agent = Agent(name=name, ip=ip, force=force)
+        return {'id': new_agent.id, 'key': new_agent.key}
 
     @staticmethod
     def insert_agent(name, id, key, ip='any', force=-1):
@@ -1045,7 +1048,8 @@ class Agent:
         :return: Agent ID.
         """
 
-        return Agent(name=name, ip=ip, id=id, key=key, force=force).id
+        new_agent = Agent(name=name, ip=ip, id=id, key=key, force=force)
+        return {'id': new_agent.id, 'key': key}
 
     @staticmethod
     def check_if_delete_agent(id, seconds):


### PR DESCRIPTION
Hello,

This PR implements functionality requested in https://github.com/wazuh/wazuh-api/issues/39. Now, the key will be returned when adding a new agent, with and without authd:

```shellsession
# curl -u foo:bar -k -X POST -d '{"name":"NewHost","ip":"11.0.10.10","id":"150","key":"1akcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64"}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/agents/insert?pretty"
{
   "error": 0,
   "data": {
      "id": "128",
      "key": "1akcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64"
   }
}
# curl -u foo:bar -XPUT "localhost:55000/agents/myAgent5?pretty"
{
   "error": 0,
   "data": {
      "id": "127",
      "key": "f07c91b8135caff0be1d26e76e256cb0c607c45300fba6b07a8c2b619a9f981f"
   }
}
```

Best regards,
Marta