### PR TITLE
Fix defects

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -103,9 +103,10 @@ void *receiver_thread(__attribute__((unused)) void *none)
                     os_delwait();
                     update_status(GA_STATUS_ACTIVE);
                     break;
-                }
-
-                if (length > OS_MAXSTR) {
+                }else if (length == 0) {
+                    merror("Empty message from manager");
+                    break;
+                }else if (length > OS_MAXSTR) {
                     merror("Too big message size from manager.");
                     break;
                 }

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -51,29 +51,30 @@ int receive_msg()
 
             // Manager disconnected or error
 
-            if (recv_b <= 0 || length > OS_MAXSTR) {
-                switch (recv_b) {
-                case -1:
-                    if (errno == ENOTCONN) {
-                        mdebug1("Manager disconnected (ENOTCONN).");
-                    } else {
-                        merror("Connection socket: %s (%d)", strerror(errno), errno);
-                    }
-
-                    return -1;
-
-                case 0:
-                    mdebug1("Manager disconnected.");
-                    return -1;
-
-                default:
-                    // length > OS_MAXSTR
-                    merror("Too big message size from manager.");
+            switch (recv_b) {
+            case -1:
+                if (errno == ENOTCONN) {
+                    mdebug1("Manager disconnected (ENOTCONN).");
+                } else {
+                    merror("Connection socket: %s (%d)", strerror(errno), errno);
                 }
+                return -1;
 
-                break;
+            case 0:
+                mdebug1("Manager disconnected.");
+                return -1;
+
+            default:
+                // length > OS_MAXSTR
+                if(length == 0){
+                	merror("Empty message from manager");
+                	return 0;
+                }else if(length > OS_MAXSTR){
+                	merror("Too big message size from manager.");
+                	return 0;
+                }    
             }
-
+            
             recv_b = recv(agt->sock, buffer, length, MSG_WAITALL);
 
             if (recv_b != (ssize_t)length) {


### PR DESCRIPTION
* Fix "Out-of-bounds access (OVERRUN)10. overrun-buffer-arg: Overrunning array cleartext of 6145 bytes by passing it to a function which accesses it at byte offset 4294967295 using argument recv_b - 1L (which evaluates to 4294967295)".

* Fix "Insecure temporary file (SECURE_TEMP)5. secure_temp: Calling mkstemp without securely setting umask first" .