### PR TITLE
Added Vuls integration

### DIFF
--- a/etc/rules/0505-vuls_rules.xml
+++ b/etc/rules/0505-vuls_rules.xml
@@ -35,13 +35,13 @@
       <description>Medium vulnerability $(ScannedCVE) detected in scanning launched on $(ScanDate) with $(Assurance) reliability ($(DetectionMethod)). Score: $(Score) ($(Source)). Affected packages: $(AffectedPackages)</description>
   </rule>
 
-  <rule id="22405" level="9">
+  <rule id="22405" level="10">
       <if_sid>22403</if_sid>
       <field name="Score">^7|^8</field>
       <description>High vulnerability $(ScannedCVE) detected in scanning launched on $(ScanDate) with $(Assurance) reliability ($(DetectionMethod)). Score: $(Score) ($(Source)). Affected packages: $(AffectedPackages)</description>
   </rule>
 
-  <rule id="22406" level="11">
+  <rule id="22406" level="13">
       <if_sid>22403</if_sid>
       <field name="Score">^9|^10</field>
       <description>Critical vulnerability $(ScannedCVE) detected in scanning launched on $(ScanDate) with $(Assurance) reliability ($(DetectionMethod)). Score: $(Score) ($(Source)). Affected packages: $(AffectedPackages)</description>

--- a/etc/rules/0505-vuls_rules.xml
+++ b/etc/rules/0505-vuls_rules.xml
@@ -1,0 +1,56 @@
+<!--
+  -  Vuls integration rules
+  -  Created by Wazuh, Inc. <support@wazuh.com>.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+{"KernelVersion": "3.10.0-693.el7.x86_64", "Source": "National Vulnerability Database", "LastModified": "2017-12-06 21:29:12", "integration": "vuls", "ScannedCVE": "CVE-2017-11176", "AffectedPackages": "kernel (Fixable), kernel-tools (Fixable), kernel-tools-libs (Fixable), python-perf (Fixable)", "DetectionMethod": "OvalMatch", "Score": 10.9431234567891024, "Link": "https://nvd.nist.gov/vuln/detail/CVE-2017-11176", "OSversion": "centos-7.4.1708", "Assurance": "100%", "ScanDate": "2017-12-19 14:53:25"}
+-->
+
+<group name="vuls,">
+
+  <rule id="22401" level="0">
+    <decoded_as>json</decoded_as>
+    <field name="integration">vuls</field>
+    <description>Vuls integration event.</description>
+  </rule>
+
+  <rule id="22402" level="7">
+      <if_sid>22401</if_sid>
+      <field name="event">\.+</field>
+      <match>has a update date lower</match>
+      <description>$(CveID) has a update date lower than $(Days) days.</description>
+  </rule>
+
+  <rule id="22403" level="5">
+      <if_sid>22401</if_sid>
+      <field name="AffectedPackages">\.+</field>
+      <description>Low vulnerability $(ScannedCVE) detected in scanning launched on $(ScanDate) with $(Assurance) reliability ($(DetectionMethod)). Score: $(Score) ($(Source)). Affected packages: $(AffectedPackages)</description>
+  </rule>
+
+  <rule id="22404" level="7">
+      <if_sid>22403</if_sid>
+      <field name="Score">^4|^5|^6</field>
+      <description>Medium vulnerability $(ScannedCVE) detected in scanning launched on $(ScanDate) with $(Assurance) reliability ($(DetectionMethod)). Score: $(Score) ($(Source)). Affected packages: $(AffectedPackages)</description>
+  </rule>
+
+  <rule id="22405" level="9">
+      <if_sid>22403</if_sid>
+      <field name="Score">^7|^8</field>
+      <description>High vulnerability $(ScannedCVE) detected in scanning launched on $(ScanDate) with $(Assurance) reliability ($(DetectionMethod)). Score: $(Score) ($(Source)). Affected packages: $(AffectedPackages)</description>
+  </rule>
+
+  <rule id="22406" level="11">
+      <if_sid>22403</if_sid>
+      <field name="Score">^9|^10</field>
+      <description>Critical vulnerability $(ScannedCVE) detected in scanning launched on $(ScanDate) with $(Assurance) reliability ($(DetectionMethod)). Score: $(Score) ($(Source)). Affected packages: $(AffectedPackages)</description>
+  </rule>
+
+  <rule id="22407" level="7">
+      <if_sid>22401</if_sid>
+      <field name="AffectedPackages">kernel</field>
+      <description>Vulnerability $(ScannedCVE) affects critical parts of the system.</description>
+  </rule>
+
+</group>

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -619,6 +619,12 @@ InstallCommon(){
 	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/oscap/oscap.py ${PREFIX}/wodles/oscap
 	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/oscap/template_*.xsl ${PREFIX}/wodles/oscap
 
+	${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/logs/vuls
+	${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/wodles/vuls
+	${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/wodles/vuls/go
+	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/vuls/vuls.py ${PREFIX}/wodles/vuls
+	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/vuls/deploy_vuls.sh ${PREFIX}/wodles/vuls
+
 	InstallOpenSCAPFiles
 
 	${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/etc

--- a/wodles/vuls/deploy_vuls.sh
+++ b/wodles/vuls/deploy_vuls.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+# December 12, 2017
+
+# ./deploy   <SO>   <version>
+
+# Allowed values:
+# redhat/7, redhat/6, readhat/5,
+# centos/7, centos/6, centos/5
+# ubuntu/16, ubuntu/14, ubuntu/12
+# debian/10, debian/9, debian/8, debian/7
+# oracle/7, oracle/6, oracle/5
+
+if [ $# != 2 ]; then
+    echo "  Use: ./deploy   <SO>   <version>"
+    exit 1
+fi
+
+
+OS_NAME=$1
+OS_VER=$2
+WAZUH=`cat /etc/ossec-init.conf | head -1 | cut -d '"' -f 2`
+INSTALL_PATH=$WAZUH"/wodles/vuls"
+LOG_PATH=$WAZUH"/logs/vuls"
+VULS_AGENT=$INSTALL_PATH"/vuls.py"
+PYTHON_PATH="/usr/bin/python"
+
+echo "  OS NAME: $OS_NAME"
+echo "  OS VERSION: $OS_VER"
+
+
+################################################################################
+
+THREADS=$(grep processor /proc/cpuinfo | wc -l)
+
+echo
+echo "********** Step2. Install requirements **********"
+echo
+
+if [ "$OS_NAME" = "redhat" ] || [ "$OS_NAME" = "centos" ] || [ "$OS_NAME" = "oracle" ]; then
+    if [ "$OS_NAME" = "centos" ]; then
+        OS_NAME="redhat"
+    fi
+    sudo yum -y install sqlite git gcc make wget yum-utils
+elif [ "$OS_NAME" = "ubuntu" ] || [ "$OS_NAME" = "debian" ]; then
+    sudo apt -y install sqlite git gcc make wget
+else
+    echo "  Enter a valid OS"
+    exit 1
+fi
+
+wget -O go1.8.3.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.8.3.linux-amd64.tar.gz
+
+export GOROOT=/usr/local/go
+export GOPATH=$INSTALL_PATH/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+echo
+echo "********** Step3. Deploy CVE dictionary **********"
+echo
+
+mkdir -p $GOPATH/src/github.com/kotakanbe
+cd $GOPATH/src/github.com/kotakanbe
+rm -rf go-cve-dictionary
+git clone https://github.com/kotakanbe/go-cve-dictionary.git
+cd go-cve-dictionary
+make -j$THREADS install
+
+$PYTHON_PATH $VULS_AGENT --updatenvd --onlyupdate --nvd-year 2002
+
+echo
+echo "********** Step4. Deploy goval-dictionary **********"
+echo
+
+mkdir -p $GOPATH/src/github.com/kotakanbe
+cd $GOPATH/src/github.com/kotakanbe
+rm -rf goval-dictionary
+git clone https://github.com/kotakanbe/goval-dictionary.git
+cd goval-dictionary
+make -j$THREADS install
+
+if [ "$OS_NAME" = "redhat" ]; then
+    $PYTHON_PATH $VULS_AGENT --updaterh --os-version $OS_VER --onlyupdate
+elif [ "$OS_NAME" = "ubuntu" ]; then
+    $PYTHON_PATH $VULS_AGENT --updateub --os-version $OS_VER --onlyupdate
+elif [ "$OS_NAME" = "debian" ]; then
+    $PYTHON_PATH $VULS_AGENT --updatedeb --os-version $OS_VER --onlyupdate
+elif [ "$OS_NAME" = "oracle" ]; then
+    $PYTHON_PATH $VULS_AGENT --updateorac --os-version $OS_VER --onlyupdate
+fi
+
+echo
+echo "********** Step5. Deploy Vuls *********"
+echo
+
+mkdir -p $GOPATH/src/github.com/future-architect
+rm -rf $GOPATH/pkg/linux_amd64/github.com/future-architect/vuls/
+rm -rf $GOPATH/src/github.com/future-architect/vuls/
+cd $GOPATH/src/github.com/future-architect
+git clone https://github.com/future-architect/vuls.git
+cd vuls
+make -j$THREADS install
+
+echo
+echo "********** Step6. Configuration *********"
+
+cd $INSTALL_PATH
+cat > config.toml <<\EOF
+[servers]
+
+[servers.localhost]
+host = "localhost"
+port = "local"
+EOF
+
+echo
+echo "********** Step7. Check config.toml and settings on the server before scanning *********"
+echo
+
+vuls configtest -log-dir $LOG_PATH

--- a/wodles/vuls/vuls.py
+++ b/wodles/vuls/vuls.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+################################################################################
+# Wazuh wrapper for Vuls
+# Wazuh Inc.
+# Dec 19, 2017
+################################################################################
+
+
+from datetime import datetime
+from socket import socket, AF_UNIX, SOCK_DGRAM
+from subprocess import call
+import json
+import sys
+import getopt
+
+# Enable/disable debug mode
+enable_debug = 0
+# Wazuh installation path
+wazuh_path = open('/etc/ossec-init.conf').readline().split('"')[1]
+# Vuls installation path
+vuls_path = '{0}/wodles/vuls'.format(wazuh_path)
+# Wazuh queue
+wazuh_queue = '{0}/queue/ossec/queue'.format(wazuh_path)
+# Path to VULS logs
+vuls_log = '{0}/logs/vuls/'.format(wazuh_path)
+# Path to VULS binary
+vuls_bin = '{0}/go/bin/vuls'.format(vuls_path)
+# Path to CVE fetcher
+cve_db_fetcher = '{0}/go/bin/go-cve-dictionary'.format(vuls_path)
+# Path to OVAL fetcher
+oval_db_fetcher = '{0}/go/bin/goval-dictionary'.format(vuls_path)
+# Path to VULS config
+vuls_config = '{0}/config.toml'.format(vuls_path)
+# Path to CVE database
+cve_db = '{0}/cve.sqlite3'.format(vuls_path)
+# Path to OVAL database
+oval_db = '{0}/oval.sqlite3'.format(vuls_path)
+
+def help():
+    print('wazuh-vuls \n' \
+    '           [--mincvss 5]               Minimum score to report.\n' \
+    '           [--updatenvd]               Update NVD database.\n' \
+    '           [--nvd-year 2002]                Year from which the CVE database will be downloaded'
+    '           [--updaterh]                Update Redhat OVAL database.\n' \
+    '           [--updateub]                Update Ubuntu OVAL database.\n' \
+    '           [--updatedeb]               Update Debian OVAL database.\n' \
+    '           [--updateorac]              Update Oracle OVAL database.\n' \
+    '           [--autoupdate]              Oval database auto-update.\n' \
+    '           [--os-version]              OS version for downloading the OVAL database'
+    '           [--onlyupdate]              Only update databases.\n' \
+    '           [--source <nvd|oval>]       CVE database preferred. The default will be the one that takes the highest CVSS.\n' \
+    '           [--antiquity-limit 30]      Warn if vulnerability update date is less than X days.\n' \
+    '           [--disable-package-info]    Disable packages info.\n' \
+    '           [--debug]                   Debug mode.\n')
+
+def extract_CVEinfo(cve, type):
+    if type == 'nvd':
+        source = 'National Vulnerability Database'
+    elif type == 'redhat' or type == 'centos':
+        source = 'RedHat OVAL'
+    elif type == 'ubuntu':
+            source = 'Ubuntu OVAL'
+    elif type == 'debian':
+            source = 'Debian OVAL'
+    elif type == 'oracle':
+            source = 'Oracle OVAL'
+    else:
+        print('Error: Invalid {0} type.'.format(type))
+        sys.exit(1)
+
+    link = cve['CveContents'][type]['SourceLink']
+    last_modified = cve['CveContents'][type]['LastModified']
+    return source, link, last_modified
+
+def extract_CVEscore(cve, type):
+    cvss2 = cve['CveContents'][type]['Cvss2Score']
+    cvss3 = cve['CveContents'][type]['Cvss3Score']
+    score = cvss2 if cvss2 > cvss3 else cvss3
+    return score
+
+def has_vector(cve, type):
+    return type in cve['CveContents']
+
+def change_vector(type, family):
+    return family if type == 'nvd' else 'nvd'
+
+def send_msg(wazuh_queue, header, msg):
+    msg['integration'] = 'vuls'
+    debug(json.dumps(msg, indent=4))
+    msg = '{0}{1}'.format(header, json.dumps(msg))
+    s = socket(AF_UNIX, SOCK_DGRAM)
+    s.connect(wazuh_queue)
+    s.send(msg.encode())
+    s.close()
+
+def debug(msg):
+    if enable_debug:
+        print(msg)
+
+def update_oval(OS, update_os_version):
+    global oval_db_fetcher
+    global vuls_log
+    global vuls_path
+
+    if not update_os_version:
+        print('Error: To update the OVAL database, the OS version must be attached with --os-version. You can do it automatically with --autoupdate.')
+        sys.exit(1)
+    debug('Updating {0} {1} OVAL database...'.format(OS, update_os_version))
+    call([oval_db_fetcher, 'fetch-{0}'.format(OS), '-dbpath={0}/oval.sqlite3'.format(vuls_path), '-log-dir={0}'.format(vuls_log), update_os_version])
+
+def update(update_nvd, update_rh, update_ub, update_deb, update_orac, os_name, update_os_version):
+    if update_nvd:
+        debug('Updating NVD database...')
+        for i in range(nvd_year, (int(str(datetime.now()).split('-')[0]) + 1)):
+            call([cve_db_fetcher, 'fetchnvd', '-dbpath={0}/cve.sqlite3'.format(vuls_path), '-log-dir={0}'.format(vuls_log), '-years', str(i)])
+
+    if update_rh or os_name == 'redhat':
+        debug('Updating Redhat OVAL database...')
+        update_oval('redhat', update_os_version) #5 6 7
+    elif update_ub or os_name == 'ubuntu':
+        debug('Updating Ubuntu OVAL database...')
+        update_oval('ubuntu', update_os_version) #12 14 16
+    elif update_deb or os_name == 'debian':
+        debug('Updating Debian OVAL database...')
+        update_oval('debian', update_os_version) #7 8 9 10
+    elif update_orac or os_name == 'oracle':
+        debug('Updating Oracle OVAL database...')
+        update_oval('oracle', update_os_version) #5 6 7
+
+def main(argv):
+
+    # Minimum CVSS for reporting
+    cvss_min = 0
+    # CVSS source
+    cvss_source=''
+    # Message header
+    header = '1:Wazuh-VULS:'
+    # Notify message header
+    notify_header = '9:Wazuh-VULS:'
+    # Show packages info
+    package_info = 1
+    # Minimum antiquity
+    antiquity_limit = 0
+    # Update databases
+    nvd_year = 2002
+    update_nvd = 0
+    update_rh = 0
+    update_ub = 0
+    update_deb = 0
+    update_orac = 0
+    autoupdate = 0
+    update_os_version = ''
+    only_update = 0
+
+    try:
+        opts, args = getopt.getopt(argv,'h',["mincvss=","updatenvd", "nvd-year=", "updaterh", "updateub", "updatedeb", "updateorac", "autoupdate", "os-version=", "disable-package-info", "antiquity-limit=", "debug", "source=", "onlyupdate"])
+    except getopt.GetoptError:
+        help()
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == '--updatenvd':
+            update_nvd = 1
+        elif opt == '--nvd-year':
+            nvd_year = int(arg)
+        elif opt == '--updaterh':
+            update_rh = 1
+        elif opt == '--updateub':
+            update_ub = 1
+        elif opt == '--updatedeb':
+            update_deb = 1
+        elif opt == '--updateorac':
+            update_orac = 1
+        elif opt == '--autoupdate':
+            autoupdate = 1
+        elif opt == '--onlyupdate':
+            only_update = 1
+        elif opt == '--os-version':
+            update_os_version = arg
+        elif opt == '--disable-package-info':
+            package_info = 0
+        elif opt == '--antiquity-limit':
+            antiquity_limit = int(arg)
+        elif opt == '--mincvss':
+            cvss_min = float(arg)
+        elif opt == '--source':
+            if arg == 'nvd' or arg == 'oval':
+                cvss_source = arg
+            else:
+                help()
+                sys.exit()
+        elif opt == '--debug':
+            global enable_debug
+            enable_debug = 1
+        elif opt == '-h':
+            help()
+            sys.exit()
+        else:
+            print('Error: Invalid parameter')
+            help()
+            sys.exit(1)
+
+    update(update_nvd, update_rh, update_ub, update_deb, update_orac, '', update_os_version)
+
+    if only_update:
+        sys.exit(0)
+
+    msg = {}
+    msg['event'] = 'Starting vulnerability scan.'
+    send_msg(wazuh_queue, notify_header, msg)
+
+    call([vuls_bin, 'scan', '-results-dir={0}'.format(vuls_log), '-config={0}'.format(vuls_config), '-log-dir={0}'.format(vuls_log)])
+
+    # Extracts the log header
+    data = json.load(open('{0}/current/localhost.json'.format(vuls_log)))
+
+    date = data['ScannedAt'].split('.')[0].replace('T', ' ')
+    os_family = data['Family']
+    family = os_family if os_family is not 'centos' else 'redhat'
+    os_release = data['Release']
+    kernel = data['RunningKernel']['Release']
+
+    if autoupdate:
+        update(0, 0, 0, 0, 0, family, os_release.split('.')[0].split('-')[0])
+
+    call([vuls_bin, 'report', '-format-json', '-ignore-unscored-cves', '-results-dir={0}'.format(vuls_log), '-cvedb-path={0}'.format(cve_db), '-ovaldb-path={0}'.format(oval_db), '-config={0}'.format(vuls_config), '-log-dir={0}'.format(vuls_log)])
+
+    # Send scanned CVEs
+    for c, cve in data['ScannedCves'].iteritems():
+        if cvss_source:
+            source = cvss_source if has_vector(cve, cvss_source) else change_vector(cvss_source, family)
+            score = extract_CVEscore(cve, source)
+            source, link, last_modified = extract_CVEinfo(cve, source)
+        else:
+            # Higher
+            nvd_score = extract_CVEscore(cve, 'nvd') if has_vector(cve, 'nvd') else -1
+            nat_score = extract_CVEscore(cve, family) if has_vector(cve, family) else -1
+
+            if nvd_score > nat_score:
+                score = nvd_score
+                source, link, last_modified = extract_CVEinfo(cve, 'nvd')
+            else:
+                score = nat_score
+                source, link, last_modified = extract_CVEinfo(cve, family)
+
+        if score < cvss_min:
+            debug('\n{0} has a score lower than {1}. Skipping.'.format(cve['CveID'], cvss_min))
+            continue
+
+        msg = {}
+        msg['ScanDate'] = date
+        msg['OSversion'] = '{0} {1}'.format(os_family, os_release)
+        msg['KernelVersion'] = kernel
+        msg['ScannedCVE'] = cve['CveID']
+        msg['Assurance'] = '{0}%'.format(cve['Confidence']['Score'])
+        msg['DetectionMethod'] = cve['Confidence']['DetectionMethod']
+        msg['Score'] = score
+        msg['Source'] = source
+        msg['Link'] = link
+        msg['LastModified'] = last_modified.split('.')[0].replace('T', ' ')[0:19]
+        msg['AffectedPackages'] = ''
+
+        diff = (datetime.now() - datetime.strptime(msg['LastModified'], '%Y-%m-%d %H:%M:%S')).days
+        if diff < antiquity_limit:
+            msg = {}
+            msg['Days'] = antiquity_limit
+            msg['event'] = '{0} has a update date lower than {1} days.'.format(cve['CveID'], antiquity_limit)
+            send_msg(wazuh_queue, header, msg)
+
+        if package_info:
+            msg['AffectedPackagesInfo'] = {}
+        # Look for affected packages
+        for p in cve['AffectedPackages']:
+            name = p['Name']
+            package = data['Packages'][name]
+            if package_info:
+                msg['AffectedPackagesInfo'][name] = {}
+                msg['AffectedPackagesInfo'][name]['Version'] = package['Version']
+                msg['AffectedPackagesInfo'][name]['Release'] = package ['Release']
+                msg['AffectedPackagesInfo'][name]['NewVersion'] = package ['NewVersion']
+                msg['AffectedPackagesInfo'][name]['NewRelease'] = package ['NewRelease']
+                msg['AffectedPackagesInfo'][name]['Arch'] = package ['Arch']
+                msg['AffectedPackagesInfo'][name]['Repository'] = package ['Repository']
+                msg['AffectedPackagesInfo'][name]['Fixable'] = 'Yes' if p['NotFixedYet'] == False else 'No'
+            msg['AffectedPackages'] = '{0}{1} ({2}), '.format(msg['AffectedPackages'], name,  'Fixable' if p['NotFixedYet'] == False else 'Not fixable')
+
+        msg['AffectedPackages'] = msg['AffectedPackages'][0:-2]
+
+        send_msg(wazuh_queue, header, msg)
+
+    msg = {}
+    msg['event'] = 'Ending vulnerability scan.'
+    send_msg(wazuh_queue, notify_header, msg)
+
+if __name__ == "__main__":
+   main(sys.argv[1:])


### PR DESCRIPTION
This pull request adds the integration of Vuls with Wazuh. To activate it we will have to place the next block in ossec.conf:

```
<wodle name="command">
  <tag>test</tag>
  <command>/usr/bin/python /var/ossec/wodles/vuls/vuls.py</command>
  <interval>1d</interval>
  <ignore_output>yes</ignore_output>
  <run_on_start>yes</run_on_start>
</wodle>
```

The following options can be added to the command section script:

- **[--mincvss 5]**  Will not report vulnerabilities with a CVSS of less than 5. Default is 0.
- **[--updatenvd]** Update NVD database. 
- **[--nvd-year 2005]** It will update the CVE database since 2005. Default starts 10 years ago.
- **[--updaterh]** Update Redhat OVAL database.
- **[--updateub]** Update Ubuntu OVAL database.
- **[--updatedeb]** Update Debian OVAL database.
- **[--updateorac]** Update Oracle OVAL database.
- **[--os-version]** OS version for downloading the OVAL database.
> If we decide to attach one of these options to update the OVAL of an operating system, we must also use the **--os-version** option to indicate the specific version.
- **[--os-version]** OS version for downloading the OVAL database.
- **[--autoupdate]** Detects the operating system, version, and updates its OVAL database.
- **[--onlyupdate]** The script will only update.
- **[--source <nvd|oval>]** We can choose to extract information from the NVD or from the system OVAL. By default it will take the font that gives a higher score.
- **[--antiquity-limit 30]** Will report those vulnerabilities with an update in less than 30 days.
- **[--disable-package-info]** It will not report detailed information on the affected packages.
- **[--debug]** Debug mode.

Examples alerts:

Vulnerability affects at least one package that has the word kernel in its name.
> 'Vulnerability CVE-2017-11176 affects critical parts of the system.'

A medium-level vulnerability has been detected and affects the packages displayed. All packages have been fixed in later versions to which we have installed.
> 'Medium vulnerability CVE-2016-2775 detected in scanning launched on 2017-12-20 02:52:18 with 100% reliability (OvalMatch). Score: 4.300000 (National Vulnerability Database). Affected packages: bind9-host (Fixable), dnsutils (Fixable), libbind9-140 (Fixable), libdns-export162 (Fixable), libdns162 (Fixable), libisc-export160 (Fixable), libisc160 (Fixable), libisccc140 (Fixable), libisccfg140 (Fixable), liblwres141 (Fixable)'

