### PR TITLE
CIS-CAT wodle for Linux

### DIFF
--- a/etc/rules/0505-ciscat_rules.xml
+++ b/etc/rules/0505-ciscat_rules.xml
@@ -1,0 +1,70 @@
+<!--
+  -  CIS-CAT scanner rules
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!-- ID: 87400 - 87500 -->
+
+<!-- Example JSON event
+{"type":"scan_result","scan_id":1670424437,"cis-data":{"rule_id":"6.2.20","rule_title":"Ensure shadow group is empty","group":"Additional Process Hardening","description":"The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group.","rationale":"Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.","remediation":"Remove all users from the shadow group, and change the primary group of any users with shadow as their primary group.","result":"pass"}}
+-->
+
+<!-- CIS-CAT rules -->
+<group name="ciscat,">
+
+  <rule id="87401" level="3">
+    <decoded_as>json</decoded_as>
+    <field name="type">\.+</field>
+    <field name="scan_id">\.+</field>
+    <description>CIS-CAT events.</description>
+  </rule>
+
+  <rule id="87402" level="3">
+      <if_sid>87401</if_sid>
+      <field name="type">^scan_start$</field>
+      <description>CIS-CAT: assessment information for scan $(scan_id)</description>
+  </rule>
+
+  <rule id="87403" level="5">
+      <if_sid>87401</if_sid>
+      <field name="type">^scan_result$</field>
+      <field name="cis-data.result">^pass$</field>
+      <description>CIS-CAT: $(cis-data.description) (passed)</description>
+  </rule>
+
+  <rule id="87404" level="7">
+      <if_sid>87401</if_sid>
+      <field name="type">^scan_result$</field>
+      <field name="cis-data.result">^notchecked$</field>
+      <description>CIS-CAT: $(cis-data.description) (not checked)</description>
+  </rule>
+
+  <rule id="87405" level="7">
+      <if_sid>87401</if_sid>
+      <field name="type">^scan_result$</field>
+      <field name="cis-data.result">^notselected$</field>
+      <description>CIS-CAT: $(cis-data.description) (not selected)</description>
+  </rule>
+
+  <rule id="87406" level="7">
+      <if_sid>87401</if_sid>
+      <field name="type">^scan_result$</field>
+      <field name="cis-data.result">^unknown$</field>
+      <description>CIS-CAT: $(cis-data.description) (unknown)</description>
+  </rule>
+
+  <rule id="87407" level="7">
+      <if_sid>87401</if_sid>
+      <field name="type">^scan_result$</field>
+      <field name="cis-data.result">^informational$</field>
+      <description>CIS-CAT: $(cis-data.description) (informational)</description>
+  </rule>
+
+  <rule id="87408" level="9">
+      <if_sid>87401</if_sid>
+      <field name="type">^scan_result$</field>
+      <field name="cis-data.result">^fail$</field>
+      <description>CIS-CAT: $(cis-data.description) (not passed)</description>
+  </rule>
+
+</group>

--- a/etc/rules/0510-ciscat_rules.xml
+++ b/etc/rules/0510-ciscat_rules.xml
@@ -12,7 +12,7 @@
 <!-- CIS-CAT rules -->
 <group name="ciscat,">
 
-  <rule id="87401" level="3">
+  <rule id="87401" level="0">
     <decoded_as>json</decoded_as>
     <field name="type">\.+</field>
     <field name="scan_id">\.+</field>
@@ -21,50 +21,85 @@
 
   <rule id="87402" level="3">
       <if_sid>87401</if_sid>
-      <field name="type">^scan_start$</field>
+      <field name="type">^scan_info$</field>
       <description>CIS-CAT: assessment information for scan $(scan_id)</description>
   </rule>
 
-  <rule id="87403" level="5">
+  <rule id="87403" level="0">
       <if_sid>87401</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^pass$</field>
       <description>CIS-CAT: $(cis-data.description) (passed)</description>
   </rule>
 
-  <rule id="87404" level="7">
+  <rule id="87404" level="0">
       <if_sid>87401</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^notchecked$</field>
       <description>CIS-CAT: $(cis-data.description) (not checked)</description>
   </rule>
 
-  <rule id="87405" level="7">
+  <rule id="87405" level="0">
       <if_sid>87401</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^notselected$</field>
       <description>CIS-CAT: $(cis-data.description) (not selected)</description>
   </rule>
 
-  <rule id="87406" level="7">
+  <rule id="87406" level="3">
+      <if_sid>87401</if_sid>
+      <field name="type">^scan_result$</field>
+      <field name="cis-data.result">^error$</field>
+      <description>CIS-CAT: $(cis-data.description) (error)</description>
+  </rule>
+
+  <rule id="87407" level="3">
       <if_sid>87401</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^unknown$</field>
       <description>CIS-CAT: $(cis-data.description) (unknown)</description>
   </rule>
 
-  <rule id="87407" level="7">
+  <rule id="87408" level="1">
       <if_sid>87401</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^informational$</field>
       <description>CIS-CAT: $(cis-data.description) (informational)</description>
   </rule>
 
-  <rule id="87408" level="9">
+  <rule id="87409" level="7">
       <if_sid>87401</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^fail$</field>
       <description>CIS-CAT: $(cis-data.description) (not passed)</description>
+  </rule>
+
+<!-- Example JSON event
+{"type":"scan_info","scan_id":75459013,"cis-data":{"benchmark":"CIS Ubuntu Linux 16.04 LTS Benchmark","hostname":"ubuntu","timestamp":"2017-12-21T03:16:54.431-08:00","score":76}}
+-->
+
+  <rule id="87410" level="4">
+    <if_sid>87402</if_sid>
+    <field name="cis-data.score">^8\d</field>
+    <description>CIS-CAT Report overview: Score less than 90 % ($(cis-data.score) %)</description>
+  </rule>
+
+  <rule id="87411" level="5">
+    <if_sid>87402</if_sid>
+    <field name="cis-data.score">^7\d|^6\d|^5\d</field>
+    <description>CIS-CAT Report overview: Score less than 80 % ($(cis-data.score) %)</description>
+  </rule>
+
+  <rule id="87412" level="7">
+    <if_sid>87402</if_sid>
+    <field name="cis-data.score">^4\d|^3\d</field>
+    <description>CIS-CAT Report overview: Score less than 50 % ($(cis-data.score) %)</description>
+  </rule>
+
+  <rule id="87413" level="9">
+    <if_sid>87402</if_sid>
+    <field name="cis-data.score">^2\d|^1\d|^\d$</field>
+    <description>CIS-CAT Report overview: Score less than 30 % ($(cis-data.score) %)</description>
   </rule>
 
 </group>

--- a/etc/templates/config/generic/wodle-ciscat.template
+++ b/etc/templates/config/generic/wodle-ciscat.template
@@ -6,8 +6,4 @@
 
     <java_path>/mnt/jre</java_path>
     <ciscat_path>/var/ossec/wodles/ciscat</ciscat_path>
-
-    <content type="xccdf" path="benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml">
-      <profile>xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Workstation</profile>
-    </content>
   </wodle>

--- a/etc/templates/config/generic/wodle-ciscat.template
+++ b/etc/templates/config/generic/wodle-ciscat.template
@@ -1,0 +1,13 @@
+  <wodle name="cis-cat">
+    <disabled>yes</disabled>
+    <timeout>1800</timeout>
+    <interval>1d</interval>
+    <scan-on-start>yes</scan-on-start>
+
+    <java_path>/mnt/jre</java_path>
+    <ciscat_path>/var/ossec/wodles/ciscat</ciscat_path>
+
+    <content type="xccdf" path="benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml">
+      <profile>xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Workstation</profile>
+    </content>
+  </wodle>

--- a/src/config/wmodules-ciscat.c
+++ b/src/config/wmodules-ciscat.c
@@ -1,7 +1,7 @@
 /*
  * Wazuh Module Configuration
  * Copyright (C) 2016 Wazuh Inc.
- * April 27, 2016.
+ * December, 2017.
  *
  * This program is a free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -9,6 +9,7 @@
  * Foundation.
  */
 
+#ifndef WIN32
 #include "wazuh_modules/wmodules.h"
 
 static const char *XML_CONTENT = "content";
@@ -20,10 +21,6 @@ static const char *XML_TIMEOUT = "timeout";
 static const char *XML_INTERVAL = "interval";
 static const char *XML_SCAN_ON_START = "scan-on-start";
 static const char *XML_PROFILE = "profile";
-static const char *XML_XCCDF_ID = "xccdf-id";
-static const char *XML_DS_ID = "datastream-id";
-static const char *XML_CPE = "cpe";
-static const char *XML_OVAL_ID = "oval-id";
 static const char *XML_JAVA_PATH = "java_path";
 static const char *XML_CISCAT_PATH = "ciscat_path";
 static const char *XML_DISABLED = "disabled";
@@ -131,64 +128,6 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }
-                } else if (!strcmp(children[j]->element, XML_XCCDF_ID)) {
-                    if (cur_eval->type != WM_CISCAT_XCCDF) {
-                        merror("Tag '%s' on incorrect content type at module '%s'", children[j]->element, WM_CISCAT_CONTEXT.name);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    }
-
-                    free(cur_eval->xccdf_id);
-
-                    if (!strlen(children[j]->content)) {
-                        merror("Invalid content for tag '%s' at module '%s'.", XML_XCCDF_ID, WM_CISCAT_CONTEXT.name);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    }
-
-                    cur_eval->xccdf_id = strdup(children[j]->content);
-                } else if (!strcmp(children[j]->element, XML_OVAL_ID)) {
-                    if (cur_eval->type != WM_CISCAT_OVAL) {
-                        merror("Tag '%s' on incorrect content type at module '%s'", children[j]->element, WM_CISCAT_CONTEXT.name);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    }
-
-                    free(cur_eval->oval_id);
-
-                    if (!strlen(children[j]->content)) {
-                        merror("Invalid content for tag '%s' at module '%s'.", XML_XCCDF_ID, WM_CISCAT_CONTEXT.name);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    }
-
-                    cur_eval->oval_id = strdup(children[j]->content);
-                } else if (!strcmp(children[j]->element, XML_DS_ID)) {
-                    free(cur_eval->ds_id);
-
-                    if (!strlen(children[j]->content)) {
-                        merror("Invalid content for tag '%s' at module '%s'.", XML_DS_ID, WM_CISCAT_CONTEXT.name);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    }
-
-                    cur_eval->ds_id = strdup(children[j]->content);
-                } else if (!strcmp(children[j]->element, XML_CPE)) {
-                    if (cur_eval->type != WM_CISCAT_XCCDF) {
-                        merror("Tag '%s' on incorrect content type at module '%s'", children[j]->element, WM_CISCAT_CONTEXT.name);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    }
-
-                    free(cur_eval->cpe);
-
-                    if (!strlen(children[j]->content)) {
-                        merror("Invalid content for tag '%s' at module '%s'.", XML_CPE, WM_CISCAT_CONTEXT.name);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    }
-
-                    cur_eval->cpe = strdup(children[j]->content);
                 } else {
                     merror("No such tag '%s' at module '%s'.", children[j]->element, WM_CISCAT_CONTEXT.name);
                     OS_ClearNode(children);
@@ -257,3 +196,5 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
 
     return 0;
 }
+
+#endif

--- a/src/config/wmodules-ciscat.c
+++ b/src/config/wmodules-ciscat.c
@@ -1,0 +1,259 @@
+/*
+ * Wazuh Module Configuration
+ * Copyright (C) 2016 Wazuh Inc.
+ * April 27, 2016.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wazuh_modules/wmodules.h"
+
+static const char *XML_CONTENT = "content";
+static const char *XML_CONTENT_TYPE = "type";
+static const char *XML_XCCDF = "xccdf";
+static const char *XML_OVAL = "oval";
+static const char *XML_PATH = "path";
+static const char *XML_TIMEOUT = "timeout";
+static const char *XML_INTERVAL = "interval";
+static const char *XML_SCAN_ON_START = "scan-on-start";
+static const char *XML_PROFILE = "profile";
+static const char *XML_XCCDF_ID = "xccdf-id";
+static const char *XML_DS_ID = "datastream-id";
+static const char *XML_CPE = "cpe";
+static const char *XML_OVAL_ID = "oval-id";
+static const char *XML_JAVA_PATH = "java_path";
+static const char *XML_CISCAT_PATH = "ciscat_path";
+static const char *XML_DISABLED = "disabled";
+
+// Parse XML
+
+int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
+{
+    int i = 0;
+    int j = 0;
+    xml_node **children = NULL;
+    wm_ciscat *ciscat;
+    wm_ciscat_eval *cur_eval = NULL;
+
+    // Create module
+
+    os_calloc(1, sizeof(wm_ciscat), ciscat);
+    ciscat->flags.enabled = 1;
+    ciscat->flags.scan_on_start = 1;
+    module->context = &WM_CISCAT_CONTEXT;
+    module->data = ciscat;
+
+    // Iterate over module subelements
+
+    for (i = 0; nodes[i]; i++){
+        if (!nodes[i]->element) {
+            merror(XML_ELEMNULL);
+            return OS_INVALID;
+        } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
+            ciscat->timeout = strtoul(nodes[i]->content, NULL, 0);
+
+            if (ciscat->timeout == 0 || ciscat->timeout == UINT_MAX) {
+                merror("Invalid timeout at module '%s'", WM_CISCAT_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_CONTENT)) {
+
+            // Create policy node
+
+            if (cur_eval) {
+                os_calloc(1, sizeof(wm_ciscat_eval), cur_eval->next);
+                cur_eval = cur_eval->next;
+            } else {
+                // First policy
+                os_calloc(1, sizeof(wm_ciscat_eval), cur_eval);
+                ciscat->evals = cur_eval;
+            }
+
+            // Parse policy attributes
+
+            for (j = 0; nodes[i]->attributes[j]; j++) {
+                if (!strcmp(nodes[i]->attributes[j], XML_PATH))
+                    cur_eval->path = strdup(nodes[i]->values[j]);
+                else if (!strcmp(nodes[i]->attributes[j], XML_CONTENT_TYPE)) {
+                    if (!strcmp(nodes[i]->values[j], XML_XCCDF))
+                        cur_eval->type = WM_CISCAT_XCCDF;
+                    else if (!strcmp(nodes[i]->values[j], XML_OVAL))
+                        cur_eval->type = WM_CISCAT_OVAL;
+                    else {
+                        merror("Invalid content for attribute '%s' at module '%s'.", XML_CONTENT_TYPE, WM_CISCAT_CONTEXT.name);
+                        return OS_INVALID;
+                    }
+                } else {
+                    merror("Invalid attribute '%s' at module '%s'.", nodes[i]->attributes[0], WM_CISCAT_CONTEXT.name);
+                    return OS_INVALID;
+                }
+            }
+
+            if (!cur_eval->path) {
+                merror("No such attribute '%s' at module '%s'.", XML_PATH, WM_CISCAT_CONTEXT.name);
+                return OS_INVALID;
+            }
+
+            if (!cur_eval->type) {
+                merror("No such attribute '%s' at module '%s'.", XML_CONTENT_TYPE, WM_CISCAT_CONTEXT.name);
+                return OS_INVALID;
+            }
+
+            // Expand policy children (optional)
+
+            if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
+                continue;
+            }
+
+            for (j = 0; children[j]; j++) {
+                if (!children[j]->element) {
+                    merror(XML_ELEMNULL);
+                    OS_ClearNode(children);
+                    return OS_INVALID;
+                }
+
+                if (!strcmp(children[j]->element, XML_PROFILE)) {
+                    if (cur_eval->type != WM_CISCAT_XCCDF) {
+                        merror("Tag '%s' on incorrect content type at module '%s'", children[j]->element, WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    cur_eval->profile = strdup(children[j]->content);
+                } else if (!strcmp(children[j]->element, XML_TIMEOUT)) {
+                    cur_eval->timeout = strtoul(children[j]->content, NULL, 0);
+
+                    if (cur_eval->timeout == 0 || cur_eval->timeout == UINT_MAX) {
+                        merror("Invalid timeout at module '%s'", WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+                } else if (!strcmp(children[j]->element, XML_XCCDF_ID)) {
+                    if (cur_eval->type != WM_CISCAT_XCCDF) {
+                        merror("Tag '%s' on incorrect content type at module '%s'", children[j]->element, WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    free(cur_eval->xccdf_id);
+
+                    if (!strlen(children[j]->content)) {
+                        merror("Invalid content for tag '%s' at module '%s'.", XML_XCCDF_ID, WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    cur_eval->xccdf_id = strdup(children[j]->content);
+                } else if (!strcmp(children[j]->element, XML_OVAL_ID)) {
+                    if (cur_eval->type != WM_CISCAT_OVAL) {
+                        merror("Tag '%s' on incorrect content type at module '%s'", children[j]->element, WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    free(cur_eval->oval_id);
+
+                    if (!strlen(children[j]->content)) {
+                        merror("Invalid content for tag '%s' at module '%s'.", XML_XCCDF_ID, WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    cur_eval->oval_id = strdup(children[j]->content);
+                } else if (!strcmp(children[j]->element, XML_DS_ID)) {
+                    free(cur_eval->ds_id);
+
+                    if (!strlen(children[j]->content)) {
+                        merror("Invalid content for tag '%s' at module '%s'.", XML_DS_ID, WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    cur_eval->ds_id = strdup(children[j]->content);
+                } else if (!strcmp(children[j]->element, XML_CPE)) {
+                    if (cur_eval->type != WM_CISCAT_XCCDF) {
+                        merror("Tag '%s' on incorrect content type at module '%s'", children[j]->element, WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    free(cur_eval->cpe);
+
+                    if (!strlen(children[j]->content)) {
+                        merror("Invalid content for tag '%s' at module '%s'.", XML_CPE, WM_CISCAT_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    cur_eval->cpe = strdup(children[j]->content);
+                } else {
+                    merror("No such tag '%s' at module '%s'.", children[j]->element, WM_CISCAT_CONTEXT.name);
+                    OS_ClearNode(children);
+                    return OS_INVALID;
+                }
+            }
+
+            OS_ClearNode(children);
+
+        } else if (!strcmp(nodes[i]->element, XML_INTERVAL)) {
+            char *endptr;
+            ciscat->interval = strtoul(nodes[i]->content, &endptr, 0);
+
+            if (ciscat->interval == 0 || ciscat->interval == UINT_MAX) {
+                merror("Invalid interval at module '%s'", WM_CISCAT_CONTEXT.name);
+                return OS_INVALID;
+            }
+
+            switch (*endptr) {
+            case 'd':
+                ciscat->interval *= 86400;
+                break;
+            case 'h':
+                ciscat->interval *= 3600;
+                break;
+            case 'm':
+                ciscat->interval *= 60;
+                break;
+            case 's':
+            case '\0':
+                break;
+            default:
+                merror("Invalid interval at module '%s'", WM_CISCAT_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_SCAN_ON_START)) {
+            if (!strcmp(nodes[i]->content, "yes"))
+                ciscat->flags.scan_on_start = 1;
+            else if (!strcmp(nodes[i]->content, "no"))
+                ciscat->flags.scan_on_start = 0;
+            else {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_SCAN_ON_START, WM_CISCAT_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_DISABLED)) {
+            if (!strcmp(nodes[i]->content, "yes"))
+                ciscat->flags.enabled = 0;
+            else if (!strcmp(nodes[i]->content, "no"))
+                ciscat->flags.enabled = 1;
+            else {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_DISABLED, WM_CISCAT_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_JAVA_PATH)) {
+            ciscat->java_path = strdup(nodes[i]->content);
+        } else if (!strcmp(nodes[i]->element, XML_CISCAT_PATH)) {
+            ciscat->ciscat_path = strdup(nodes[i]->content);
+        } else {
+            merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_CISCAT_CONTEXT.name);
+            return OS_INVALID;
+        }
+    }
+
+    if (!ciscat->interval)
+        ciscat->interval = WM_DEF_INTERVAL;
+
+    return 0;
+}

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -67,6 +67,11 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
             OS_ClearNode(children);
             return OS_INVALID;
         }
+    } else if (!strcmp(node->values[0], WM_CISCAT_CONTEXT.name)){
+        if (wm_ciscat_read(xml, children, cur_wmodule) < 0) {
+            OS_ClearNode(children);
+            return OS_INVALID;
+        }
     } else {
         merror("Unknown module '%s'", node->values[0]);
     }

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -67,11 +67,13 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
             OS_ClearNode(children);
             return OS_INVALID;
         }
+#ifndef WIN32
     } else if (!strcmp(node->values[0], WM_CISCAT_CONTEXT.name)){
         if (wm_ciscat_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }
+#endif
     } else {
         merror("Unknown module '%s'", node->values[0]);
     }

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -33,6 +33,8 @@ LOCALFILES_TEMPLATE="./etc/templates/config/generic/localfile-logs/*.template"
 AUTH_TEMPLATE="./etc/templates/config/generic/auth.template"
 CLUSTER_TEMPLATE="./etc/templates/config/generic/cluster.template"
 
+CISCAT_TEMPLATE="./etc/templates/config/generic/wodle-ciscat.template"
+
 ##########
 # WriteSyscheck()
 ##########
@@ -288,6 +290,11 @@ WriteAgent()
     # OpenSCAP
     WriteOpenSCAP "agent"
 
+
+    # CIS-CAT configuration
+    cat ${CISCAT_TEMPLATE} >> $NEWCONFIG
+    echo "" >> $NEWCONFIG
+
     # Syscheck
     WriteSyscheck "agent"
 
@@ -381,6 +388,10 @@ WriteManager()
 
     # Write OpenSCAP
     WriteOpenSCAP "manager"
+
+    # CIS-CAT configuration
+    cat ${CISCAT_TEMPLATE} >> $NEWCONFIG
+    echo "" >> $NEWCONFIG
 
     # Write syscheck
     WriteSyscheck "manager"
@@ -624,6 +635,7 @@ InstallCommon(){
 	${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/wodles/vuls/go
 	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/vuls/vuls.py ${PREFIX}/wodles/vuls
 	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/vuls/deploy_vuls.sh ${PREFIX}/wodles/vuls
+	${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/wodles/ciscat
 
 	InstallOpenSCAPFiles
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -636,6 +636,7 @@ InstallCommon(){
 	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/vuls/vuls.py ${PREFIX}/wodles/vuls
 	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/vuls/deploy_vuls.sh ${PREFIX}/wodles/vuls
 	${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/wodles/ciscat
+	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/ciscat/template_*.xsl ${PREFIX}/wodles/ciscat
 
 	InstallOpenSCAPFiles
 

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -40,13 +40,18 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
     time_t time_start = 0;
     time_t time_sleep = 0;
     char *cis_path;
+    char *jre_path;
+    char *env_var;
 
     os_calloc(OS_MAXSTR, sizeof(char), cis_path);
 
-    // Check if Java path is defined
+    // Check if Java path is defined and include it in "PATH" variable
 
     if (ciscat->java_path){
-        if(setenv("JAVA_HOME", ciscat->java_path, 1) < 0)
+        os_calloc(OS_MAXSTR, sizeof(char), jre_path);
+        env_var = getenv("PATH");
+        snprintf(jre_path, OS_MAXSTR - 1, "%s:%s", env_var, ciscat->java_path);
+        if(setenv("PATH", jre_path, 1) < 0)
             mtwarn(WM_CISCAT_LOGTAG, "Unable to define JRE location: %s", strerror(errno));
     }
 
@@ -105,9 +110,6 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
         // If time_sleep=0, yield CPU
         sleep(time_sleep);
     }
-
-    if (ciscat->java_path)
-        unsetenv("JAVA_HOME");
 
     return NULL;
 }
@@ -601,9 +603,6 @@ void wm_ciscat_destroy(wm_ciscat *ciscat) {
 
     wm_ciscat_eval *cur_eval;
     wm_ciscat_eval *next_eval;
-
-    if (ciscat->java_path)
-        unsetenv("JAVA_HOME");
 
     // Delete evals
 

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -1,0 +1,392 @@
+/*
+ * Wazuh Module for CIS-CAT
+ * Copyright (C) 2016 Wazuh Inc.
+ * April 25, 2016.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wmodules.h"
+
+static wm_ciscat *ciscat;                             // Pointer to configuration
+static int queue_fd;                                // Output queue file descriptor
+
+static void* wm_ciscat_main(wm_ciscat *ciscat);        // Module main function. It won't return
+static void wm_ciscat_setup(wm_ciscat *_ciscat);       // Setup module
+static void wm_ciscat_cleanup();                     // Cleanup function, doesn't overwrite wm_cleanup
+static void wm_ciscat_check();                       // Check configuration, disable flag
+static void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int *first);      // Run a CIS-CAT policy
+static void wm_ciscat_info();                        // Show module info
+static void wm_ciscat_destroy(wm_ciscat *ciscat);      // Destroy data
+
+const char *WM_CISCAT_LOCATION = "wodle_cis-cat";  // Location field for event sending
+
+// CIS-CAT module context definition
+
+const wm_context WM_CISCAT_CONTEXT = {
+    "cis-cat",
+    (wm_routine)wm_ciscat_main,
+    (wm_routine)wm_ciscat_destroy
+};
+
+// CIS-CAT module main function. It won't return.
+
+void* wm_ciscat_main(wm_ciscat *ciscat) {
+    wm_ciscat_eval *eval;
+    time_t time_start = 0;
+    time_t time_sleep = 0;
+    int first = 1;
+    char *cis_path;
+
+    os_calloc(OS_MAXSTR, sizeof(char), cis_path);
+
+    // Check if Java path is defined
+
+    if (ciscat->java_path){
+        if(setenv("JAVA_HOME", ciscat->java_path, 1) < 0)
+            mtwarn(WM_CISCAT_LOGTAG, "Unable to define JRE location: %s", strerror(errno));
+    }
+
+    // Define path where CIS-CAT is installed
+
+    if (ciscat->ciscat_path){
+        snprintf(cis_path, OS_MAXSTR - 1, "%s", ciscat->ciscat_path);
+    } else {
+        snprintf(cis_path, OS_MAXSTR - 1, "%s", WM_CISCAT_DEFAULT_DIR);
+    }
+
+    // Check configuration and show debug information
+
+    wm_ciscat_setup(ciscat);
+    mtinfo(WM_CISCAT_LOGTAG, "Module started.");
+
+    // First sleeping
+
+    if (!ciscat->flags.scan_on_start) {
+        time_start = time(NULL);
+
+        if (ciscat->state.next_time > time_start) {
+            mtinfo(WM_CISCAT_LOGTAG, "Waiting for turn to evaluate.");
+            sleep(ciscat->state.next_time - time_start);
+        }
+    }
+
+    // Main loop
+
+    while (1) {
+
+        mtinfo(WM_CISCAT_LOGTAG, "Starting evaluation.");
+
+        // Get time and execute
+        time_start = time(NULL);
+
+        for (eval = ciscat->evals; eval; eval = eval->next)
+            if (!eval->flags.error)
+                wm_ciscat_run(eval, cis_path, &first);
+
+        time_sleep = time(NULL) - time_start;
+
+        mtinfo(WM_CISCAT_LOGTAG, "Evaluation finished.");
+
+        if ((time_t)ciscat->interval >= time_sleep) {
+            time_sleep = ciscat->interval - time_sleep;
+            ciscat->state.next_time = ciscat->interval + time_start;
+        } else {
+            mterror(WM_CISCAT_LOGTAG, "Interval overtaken.");
+            time_sleep = ciscat->state.next_time = 0;
+        }
+
+        if (wm_state_io(&WM_CISCAT_CONTEXT, WM_IO_WRITE, &ciscat->state, sizeof(ciscat->state)) < 0)
+            mterror(WM_CISCAT_LOGTAG, "Couldn't save running state.");
+
+        // If time_sleep=0, yield CPU
+        sleep(time_sleep);
+    }
+
+    if (ciscat->java_path)
+        unsetenv("JAVA_HOME");
+
+    return NULL;
+}
+
+// Setup module
+
+void wm_ciscat_setup(wm_ciscat *_ciscat) {
+    int i;
+
+    ciscat = _ciscat;
+    wm_ciscat_check();
+
+    // Read running state
+
+    if (wm_state_io(&WM_CISCAT_CONTEXT, WM_IO_READ, &ciscat->state, sizeof(ciscat->state)) < 0)
+        memset(&ciscat->state, 0, sizeof(ciscat->state));
+
+    if (isDebug())
+        wm_ciscat_info();
+
+    // Connect to socket
+
+    for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
+        sleep(WM_MAX_WAIT);
+
+    if (i == WM_MAX_ATTEMPTS) {
+        mterror(WM_CISCAT_LOGTAG, "Can't connect to queue.");
+        pthread_exit(NULL);
+    }
+
+    // Cleanup exiting
+
+    atexit(wm_ciscat_cleanup);
+}
+
+// Cleanup function, doesn't overwrite wm_cleanup
+
+void wm_ciscat_cleanup() {
+    close(queue_fd);
+    mtinfo(WM_CISCAT_LOGTAG, "Module finished.");
+}
+
+// Run a CIS-CAT policy
+
+void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int *first) {
+    char *command = NULL;
+    int status, child_status;
+    char *output = NULL;
+    char msg[OS_MAXSTR];
+    char *ciscat_script = "./CIS-CAT.sh";
+    char *reports_location;
+
+    os_calloc(OS_MAXSTR, sizeof(char), reports_location);
+
+
+    // Define path to store reports
+
+    snprintf(reports_location, OS_MAXSTR - 1, "%s", WM_CISCAT_REPORTS);
+
+    // Define time to sleep between messages sent
+
+    int usec = 1000000 / wm_max_eps;
+    struct timeval timeout = {0, usec};
+
+    // Create arguments
+
+    wm_strcat(&command, ciscat_script, '\0');
+
+    // Accepting Terms of Use in first call
+    if (*first){
+        wm_strcat(&command, "-a", ' ');
+        *first = 0;
+    }
+
+    switch (eval->type) {
+    case WM_CISCAT_XCCDF:
+        wm_strcat(&command, "-b", ' ');
+        wm_strcat(&command, eval->path, ' ');
+
+        if (eval->profile) {
+            wm_strcat(&command, "-p", ' ');
+            wm_strcat(&command, eval->profile, ' ');
+        }
+        break;
+    case WM_CISCAT_OVAL:
+        wm_strcat(&command, "-od", ' ');
+        wm_strcat(&command, eval->path, ' ');
+        break;
+    default:
+        mterror(WM_CISCAT_LOGTAG, "Unspecified content type for file '%s'. This shouldn't happen.", eval->path);
+        pthread_exit(NULL);
+    }
+
+    if (eval->xccdf_id) {
+        wm_strcat(&command, "--xccdf-id", ' ');
+        wm_strcat(&command, eval->xccdf_id, ' ');
+    }
+
+    if (eval->oval_id) {
+        wm_strcat(&command, "--oval-id", ' ');
+        wm_strcat(&command, eval->oval_id, ' ');
+    }
+
+    if (eval->ds_id) {
+        wm_strcat(&command, "--ds-id", ' ');
+        wm_strcat(&command, eval->ds_id, ' ');
+    }
+
+    if (eval->cpe) {
+        wm_strcat(&command, "--cpe", ' ');
+        wm_strcat(&command, eval->cpe, ' ');
+    }
+
+    // Specify directory where saving reports
+
+    wm_strcat(&command, "-r", ' ');
+    wm_strcat(&command, reports_location, ' ');
+
+    // Set reports file name
+
+    wm_strcat(&command, "-rn", ' ');
+    wm_strcat(&command, "ciscat-report", ' ');
+
+    // Get CSV reports
+
+    wm_strcat(&command, "-csv", ' ');
+
+    // Not to create HTML report
+
+    wm_strcat(&command, "-n", ' ');
+
+    // Send rootcheck message
+
+    snprintf(msg, OS_MAXSTR, "Starting CIS-CAT scan. File: %s. ", eval->path);
+    SendMSG(queue_fd, msg, "rootcheck", ROOTCHECK_MQ);
+
+    // Execute the scan
+
+    pid_t pid;
+
+    pid = fork();
+
+    if (CreatePID(ARGV0, getpid()) < 0)
+        mterror_exit(WM_CISCAT_LOGTAG, "Couldn't create PID file for child process: (%s)", strerror(errno));
+
+    if (pid < 0){
+        mterror(WM_CISCAT_LOGTAG, FORK_ERROR, errno, strerror(errno));
+        pthread_exit(NULL);
+    } else if (pid == 0){
+
+        if (chdir(path) < 0) {
+            mterror(WM_CISCAT_LOGTAG, "Unable to change working directory: %s", strerror(errno));
+            pthread_exit(NULL);
+        } else
+            mtdebug2(WM_CISCAT_LOGTAG, "Changing working directory to %s", path);
+
+        mtdebug1(WM_CISCAT_LOGTAG, "Launching command: %s", command);
+
+        switch (wm_exec(command, &output, &status, eval->timeout)) {
+        case 0:
+            if (status > 0) {
+                mtwarn(WM_CISCAT_LOGTAG, "Ignoring content '%s' due to error (%d).", eval->path, status);
+                mtdebug2(WM_CISCAT_LOGTAG, "OUTPUT: %s", output);
+                exit(1);
+            }
+
+            mtinfo(WM_CISCAT_LOGTAG, "Scan finished successfully. File: %s", eval->path);
+
+            break;
+
+        case WM_ERROR_TIMEOUT:
+            free(output);
+            output = NULL;
+            wm_strcat(&output, "ciscat: ERROR: Timeout expired.", '\0');
+            mterror(WM_CISCAT_LOGTAG, "Timeout expired executing '%s'.", eval->path);
+            break;
+
+        default:
+            mterror(WM_CISCAT_LOGTAG, "Internal calling. Exiting...");
+            exit(0);
+            pthread_exit(NULL);
+        }
+
+        exit(0);
+    }
+
+    switch(waitpid(-1, &child_status, 0)) {
+        case -1:
+            mterror(WM_CISCAT_LOGTAG, WAITPID_ERROR, errno, strerror(errno));
+            break;
+        default:
+            if (WEXITSTATUS(child_status) == 1)
+                eval->flags.error = 1;
+    }
+
+    snprintf(msg, OS_MAXSTR, "Ending CIS-CAT scan. File: %s. ", eval->path);
+    timeout.tv_usec = usec;
+    select(0 , NULL, NULL, NULL, &timeout);
+    SendMSG(queue_fd, msg, "rootcheck", ROOTCHECK_MQ);
+
+    free(output);
+    free(command);
+}
+
+// Check configuration
+
+void wm_ciscat_check() {
+    wm_ciscat_eval *eval;
+
+    // Check if disabled
+
+    if (!ciscat->flags.enabled) {
+        mtinfo(WM_CISCAT_LOGTAG, "Module disabled. Exiting...");
+        pthread_exit(NULL);
+    }
+
+    // Check if evals
+
+    if (!ciscat->evals) {
+        mtwarn(WM_CISCAT_LOGTAG, "No evals defined. Exiting...");
+        pthread_exit(NULL);
+    }
+
+    // Check if interval
+
+    if (!ciscat->interval)
+        ciscat->interval = WM_DEF_INTERVAL;
+
+    // Check timeout and flags for evals
+
+    for (eval = ciscat->evals; eval; eval = eval->next) {
+        if (!eval->timeout)
+            if (!(eval->timeout = ciscat->timeout))
+                eval->timeout = WM_DEF_TIMEOUT;
+    }
+}
+
+// Show module info
+
+void wm_ciscat_info() {
+    wm_ciscat_eval *eval;
+
+    mtinfo(WM_CISCAT_LOGTAG, "SHOW_MODULE_CISCAT: ----");
+    mtinfo(WM_CISCAT_LOGTAG, "Timeout: %d", ciscat->timeout);
+    mtinfo(WM_CISCAT_LOGTAG, "Benchmarks:");
+
+    for (eval = (wm_ciscat_eval*)ciscat->evals; eval; eval = eval->next){
+        mtinfo(WM_CISCAT_LOGTAG, "[%s]", eval->path);
+        if (eval->profile) {
+            mtinfo(WM_CISCAT_LOGTAG, "\tProfile: %s", eval->profile);
+        }
+    }
+
+    mtinfo(WM_CISCAT_LOGTAG, "SHOW_MODULE_CISCAT: ----");
+}
+
+// Destroy data
+
+void wm_ciscat_destroy(wm_ciscat *ciscat) {
+
+    wm_ciscat_eval *cur_eval;
+    wm_ciscat_eval *next_eval;
+
+    if (ciscat->java_path)
+        unsetenv("JAVA_HOME");
+
+    // Delete evals
+
+    for (cur_eval = ciscat->evals; cur_eval; cur_eval = next_eval) {
+
+        next_eval = cur_eval->next;
+        free(cur_eval->path);
+        free(cur_eval->profile);
+        free(cur_eval->xccdf_id);
+        free(cur_eval->oval_id);
+        free(cur_eval->ds_id);
+        free(cur_eval->cpe);
+        free(cur_eval);
+    }
+
+    free(ciscat);
+}

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -106,7 +106,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
             time_sleep = ciscat->state.next_time = 0;
         }
 
-        if (wm_state_io(&WM_CISCAT_CONTEXT, WM_IO_WRITE, &ciscat->state, sizeof(ciscat->state)) < 0)
+        if (wm_state_io(WM_CISCAT_CONTEXT.name, WM_IO_WRITE, &ciscat->state, sizeof(ciscat->state)) < 0)
             mterror(WM_CISCAT_LOGTAG, "Couldn't save running state.");
 
         // If time_sleep=0, yield CPU
@@ -126,7 +126,7 @@ void wm_ciscat_setup(wm_ciscat *_ciscat) {
 
     // Read running state
 
-    if (wm_state_io(&WM_CISCAT_CONTEXT, WM_IO_READ, &ciscat->state, sizeof(ciscat->state)) < 0)
+    if (wm_state_io(WM_CISCAT_CONTEXT.name, WM_IO_READ, &ciscat->state, sizeof(ciscat->state)) < 0)
         memset(&ciscat->state, 0, sizeof(ciscat->state));
 
     if (isDebug())
@@ -276,7 +276,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path) {
 
         default:
             // Parent process
-            switch(waitpid(-1, &child_status, 0)) {
+            switch(waitpid(pid, &child_status, 0)) {
                 case -1:
                     mterror(WM_CISCAT_LOGTAG, WAITPID_ERROR, errno, strerror(errno));
                     break;

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -225,7 +225,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path) {
 
     wm_strcat(&command, "-t", ' ');
 
-    // Not to create HTML report
+    // Do not create HTML report
 
     wm_strcat(&command, "-n", ' ');
 
@@ -352,7 +352,7 @@ void wm_ciscat_parser(wm_ciscat_eval *eval){
                 data = cJSON_CreateObject();
                 cJSON_AddStringToObject(object, "type", "scan_start");
                 cJSON_AddNumberToObject(object, "scan_id", ID);
-                cJSON_AddItemToObject(object, "data", data);
+                cJSON_AddItemToObject(object, "cis-data", data);
                 char benchmark[OS_MAXSTR];
                 snprintf(benchmark, OS_MAXSTR - 1, "%s", string);
                 cJSON_AddStringToObject(data, "benchmark", benchmark);
@@ -402,7 +402,7 @@ void wm_ciscat_parser(wm_ciscat_eval *eval){
                 data = cJSON_CreateObject();
                 cJSON_AddStringToObject(object, "type", "scan_end");
                 cJSON_AddNumberToObject(object, "scan_id", ID);
-                cJSON_AddItemToObject(object, "data", data);
+                cJSON_AddItemToObject(object, "cis-data", data);
 
             } else if (line == 6 && final){
 
@@ -509,7 +509,7 @@ void wm_ciscat_parser(wm_ciscat_eval *eval){
                 data = cJSON_CreateObject();
                 cJSON_AddStringToObject(object, "type", "scan_result");
                 cJSON_AddNumberToObject(object, "scan_id", ID);
-                cJSON_AddItemToObject(object, "data", data);
+                cJSON_AddItemToObject(object, "cis-data", data);
 
                 char ** parts = NULL;
 

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -1,0 +1,62 @@
+/*
+ * Wazuh Module for CIS-CAT scanner
+ * Copyright (C) 2016 Wazuh Inc.
+ * April 25, 2016.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef WM_CISCAT
+#define WM_CISCAT
+
+#define WM_DEF_TIMEOUT      1800            // Default runtime limit (30 minutes)
+#define WM_DEF_INTERVAL     86400           // Default cycle interval (1 day)
+
+#define WM_CISCAT_LOGTAG ARGV0 ":ciscat"
+#define WM_CISCAT_DEFAULT_DIR WM_DEFAULT_DIR "/ciscat"
+#define WM_CISCAT_REPORTS DEFAULTDIR "/tmp"
+
+typedef enum wm_ciscat_eval_t { WM_CISCAT_XCCDF = 1, WM_CISCAT_OVAL } wm_ciscat_eval_t;
+
+typedef struct wm_ciscat_flags {
+    unsigned int enabled:1;
+    unsigned int scan_on_start:1;
+    unsigned int error:1;
+} wm_ciscat_flags;
+
+typedef struct wm_ciscat_eval {
+    wm_ciscat_eval_t type;           // Type of evaluation file
+    char *path;                     // File path (string)
+    char *xccdf_id;                 // XCCDF id
+    char *ds_id;                    // Datastream id
+    char *oval_id;                  // OVAL id
+    char *cpe;                      // CPE dictionary
+    char *profile;                  // Profile
+    wm_ciscat_flags flags;           // Flags
+    unsigned int timeout;           // Execution time limit (seconds)
+    struct wm_ciscat_eval *next;     // Pointer to next
+} wm_ciscat_eval;
+
+typedef struct wm_ciscat_state {
+    time_t next_time;               // Absolute time for next scan
+} wm_ciscat_state;
+
+typedef struct wm_ciscat {
+    unsigned int interval;          // Default time interval between cycles
+    unsigned int timeout;           // Default execution time limit (seconds)
+    char *java_path;                // Path to Java Runtime Environment
+    char *ciscat_path;              // Path to CIS-CAT scanner tool
+    wm_ciscat_flags flags;          // Default flags
+    wm_ciscat_state state;          // Running state
+    wm_ciscat_eval *evals;          // Evaluations (linked list)
+} wm_ciscat;
+
+extern const wm_context WM_CISCAT_CONTEXT;   // Context
+
+// Parse XML
+int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module);
+
+#endif // WM_OSCAP

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -1,7 +1,7 @@
 /*
  * Wazuh Module for CIS-CAT scanner
  * Copyright (C) 2016 Wazuh Inc.
- * April 25, 2016.
+ * December, 2017.
  *
  * This program is a free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -30,10 +30,6 @@ typedef struct wm_ciscat_flags {
 typedef struct wm_ciscat_eval {
     wm_ciscat_eval_t type;           // Type of evaluation file
     char *path;                     // File path (string)
-    char *xccdf_id;                 // XCCDF id
-    char *ds_id;                    // Datastream id
-    char *oval_id;                  // OVAL id
-    char *cpe;                      // CPE dictionary
     char *profile;                  // Profile
     wm_ciscat_flags flags;           // Flags
     unsigned int timeout;           // Execution time limit (seconds)

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -179,7 +179,6 @@ static pthread_mutex_t wm_children_mutex = PTHREAD_MUTEX_INITIALIZER;   // Mutex
 
 int wm_exec(char *command, char **output, int *exitcode, int secs)
 {
-    static char* const envp[] = { NULL };
     char **argv;
     pid_t pid;
     int pipe_fd[2];
@@ -227,7 +226,7 @@ int wm_exec(char *command, char **output, int *exitcode, int secs)
         setsid();
         if (nice(wm_task_nice)) {}
 
-        if (execve(argv[0], argv, envp) < 0)
+        if (execve(argv[0], argv, environ) < 0)
             exit(EXECVE_ERROR);
 
         break;

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -55,6 +55,7 @@ typedef struct wmodule {
 #include "wm_oscap.h"
 #include "wm_database.h"
 #include "wm_command.h"
+#include "wm_ciscat.h"
 
 extern wmodule *wmodules;       // Loaded modules.
 extern int wm_task_nice;        // Nice value for tasks.

--- a/wodles/ciscat/template_xccdf.xsl
+++ b/wodles/ciscat/template_xccdf.xsl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<stylesheet version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform">
+    <output method="text" omit-xml-declaration="yes" indent="no"/>
+    <template match="/">
+benchmark:<value-of select="/*[local-name()='Benchmark']/*[local-name()='TestResult']/*[local-name()='title']"/>
+    <variable name="profile-id" select="/*[local-name()='Benchmark']/*[local-name()='TestResult']/*[local-name()='profile']/@idref"/>
+profile_title:<value-of select="/*[local-name()='Benchmark']/*[local-name()='Profile'][@id=$profile-id]/*[local-name()='title']"/>
+hostname:<value-of select="/*[local-name()='Benchmark']/*[local-name()='TestResult']/*[local-name()='target']"/>
+timestamp:<value-of select="/*[local-name()='Benchmark']/*[local-name()='TestResult']/@end-time"/>
+score:<value-of select="/*[local-name()='Benchmark']/*[local-name()='TestResult']/*[local-name()='score']"/>
+      <for-each select="*[local-name()='Benchmark']//*[local-name()='Group']">
+          <variable name="group-title" select="*[local-name()='title']" />
+          <for-each select="//*[local-name()='Rule']">
+<variable name="rule-id" select="@id"/>
+<variable name="rule-title" select="*[local-name()='title']"/>
+********
+rule_id:<value-of select="$rule-id"/>
+rule_title:<value-of select="$rule-title"/>
+group:<value-of select="$group-title"/>
+description:<for-each select="*[local-name()='description']"><value-of select="normalize-space(*[local-name()='p'])"/></for-each>
+rationale:<for-each select="*[local-name()='rationale']"><value-of select="normalize-space(*[local-name()='p'])"/></for-each>
+remediation:<for-each select="*[local-name()='fixtext']"><value-of select="normalize-space(*[local-name()='div']/*[local-name()='p'])"/></for-each>
+result:<value-of select="//*[local-name()='rule-result'][@idref=$rule-id]/*[local-name()='result']"/></for-each></for-each>
+********
+</template>
+</stylesheet>


### PR DESCRIPTION
It has been included a CIS-CAT module to schedule CIS-CAT scans in Linux agents.

For running this module, a section like the following one has to be included in `ossec.conf`:

```
  <wodle name="cis-cat">
    <disabled>no</disabled>
    <timeout>1800</timeout>
    <interval>1d</interval>
    <scan-on-start>yes</scan-on-start>

    <java_path>/usr/bin</java_path>
    <ciscat_path>/root/cis-cat-full</ciscat_path>

    <content type="xccdf" path="benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml">
      <profile>xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Workstation</profile>
    </content>
  </wodle>
```

You can specify the fields described below:
 

- `Disabled, timeout, interval, scan-on-start` as performance options.
- `java_path, ciscat_path` to set where are located the necessary tools for running the scans.
- `content` section for specifying what benchmark is going to be assessed.

When a scan has finished, alerts will be generated including the scan results.