### PR TITLE
Synchronize custom rules and decoders in cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.2.0]
 
+### Added
+
+- [Added support to synchronize custom rules and decoders in the cluster.](https://github.com/wazuh/wazuh/pull/344)
+
 ### Fixed
 
 - [Fixed oscap.py to support new versions of OpenSCAP scanner.](https://github.com/wazuh/wazuh/pull/331)

--- a/framework/wazuh/cluster.json
+++ b/framework/wazuh/cluster.json
@@ -43,6 +43,28 @@
         "description": "agents group configuration"
     },
 
+    "/etc/rules": {
+        "umask": "0o137",
+        "format": "plain",
+        "source": "master",
+        "write_mode": "atomic",
+        "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
+        "files": ["all"],
+        "recursive": true,
+        "description": "user rules"
+    },
+
+    "/etc/decoders": {
+        "umask": "0o137",
+        "format": "plain",
+        "source": "master",
+        "write_mode": "atomic",
+        "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
+        "files": ["all"],
+        "recursive": true,
+        "description": "user decoders"
+    },
+
     "excluded_files": [
         "ar.conf",
         "merged.mg",

--- a/framework/wazuh/cluster.json
+++ b/framework/wazuh/cluster.json
@@ -7,6 +7,7 @@
         "flags": ["IN_MOVED_TO"],
         "files": ["client.keys"],
         "recursive": false,
+        "restart": false,
         "description": "client keys file database"
     },
 
@@ -18,6 +19,7 @@
         "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
         "files": ["all"],
         "recursive": true,
+        "restart": false,
         "description": "shared configuration files"
     },
 
@@ -29,6 +31,7 @@
         "flags": ["IN_CLOSE_WRITE", "IN_ATTRIB", "IN_MOVED_TO", "IN_DELETE"],
         "files": ["all"],
         "recursive": false,
+        "restart": false,
         "description": "agent status"
     },
 
@@ -40,10 +43,11 @@
         "flags": ["IN_CLOSE_WRITE", "IN_MOVED_TO", "IN_DELETE"],
         "files": ["all"],
         "recursive": false,
+        "restart": false,
         "description": "agents group configuration"
     },
 
-    "/etc/rules": {
+    "/etc/rules/": {
         "umask": "0o137",
         "format": "plain",
         "source": "master",
@@ -51,10 +55,11 @@
         "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
         "files": ["all"],
         "recursive": true,
+        "restart": true,
         "description": "user rules"
     },
 
-    "/etc/decoders": {
+    "/etc/decoders/": {
         "umask": "0o137",
         "format": "plain",
         "source": "master",
@@ -62,6 +67,7 @@
         "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
         "files": ["all"],
         "recursive": true,
+        "restart": true,
         "description": "user decoders"
     },
 

--- a/framework/wazuh/cluster.json
+++ b/framework/wazuh/cluster.json
@@ -54,7 +54,7 @@
         "write_mode": "atomic",
         "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
         "files": ["all"],
-        "recursive": true,
+        "recursive": false,
         "restart": true,
         "description": "user rules"
     },
@@ -66,9 +66,21 @@
         "write_mode": "atomic",
         "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
         "files": ["all"],
-        "recursive": true,
+        "recursive": false,
         "restart": true,
         "description": "user decoders"
+    },
+
+    "/etc/lists/": {
+        "umask": "0o137",
+        "format": "plain",
+        "source": "master",
+        "write_mode": "atomic",
+        "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
+        "files": ["all"],
+        "recursive": true,
+        "restart": true,
+        "description": "user CDB lists"
     },
 
     "excluded_files": [

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -594,8 +594,15 @@ def clear_file_status():
         query = "update1 "
         new_items = {}
         for files_slice in divide_list(own_items.items()):
-            local_items = dict(filter(lambda x: db_items[x[0]]['md5'] != x[1]['md5'] 
-                            or int(db_items[x[0]]['timestamp']) < int(x[1]['timestamp']), files_slice))
+            try:
+                local_items = dict(filter(lambda x: db_items[x[0]]['md5'] != x[1]['md5'] 
+                                or int(db_items[x[0]]['timestamp']) < int(x[1]['timestamp']), files_slice))
+            except KeyError as e:
+                new_items[e.args[0]] = {'md5': own_items[e.args[0]]['md5'], 
+                                        'timestamp': own_items[e.args[0]]['timestamp']}
+                logging.warning("File not found in database: {0}".format(e.args[0]))
+                continue
+
             query += ' '.join(local_items.keys())
             send_to_socket(cluster_socket, query)
             received = receive_data_from_db_socket(cluster_socket)

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -31,6 +31,7 @@ import re
 import socket
 import asyncore
 import asynchat
+import errno
 
 # import the C accelerated API of ElementTree
 try:
@@ -774,11 +775,14 @@ def _update_file(fullpath, new_content, umask_int=None, mtime=None, w_mode=None,
 
     try:
         dest_file = open(f_temp, "w")
-    except IOError:
-        dirpath = path.dirname(fullpath)
-        mkdir(dirpath)
-        chmod(dirpath, S_IRWXU | S_IRWXG)
-        dest_file = open(f_temp, "a+")
+    except IOError as e:
+        if e.errno == errno.ENOENT:
+            dirpath = path.dirname(fullpath)
+            mkdir(dirpath)
+            chmod(dirpath, S_IRWXU | S_IRWXG)
+            dest_file = open(f_temp, "a+")
+        else:
+            raise e
 
     dest_file.write(new_content)
 
@@ -839,15 +843,14 @@ def receive_zip(zip_file):
                 remote_write_mode = cluster_items[dir_name]['write_mode']
                 restart.append(cluster_items[dir_name]['restart'])
             except KeyError:
-                if '/etc/' in file_path:
-                    remote_umask = int(cluster_items['/etc/']['umask'], base=0)
-                    remote_write_mode = cluster_items['/etc/']['write_mode']
-                    restart.append(cluster_items['/etc/']['restart'])
-                elif '/etc/rules/' in file_path or '/etc/decoders/' in file_path:
-                    remote_umask = int(cluster_items['/etc/rules/']['umask'], base=0)
-                    remote_write_mode = cluster_items['/etc/rules/']['write_mode']
-                    restart.append(cluster_items['/etc/rules/']['restart'])
-            
+                # cluster_items entries with the flag recursive = true will make
+                # some paths to not match directly in this loop.
+                key = path.split(dir_name[:-1])[0] + '/'
+
+                remote_umask = int(cluster_items[key]['umask'], base=0)
+                remote_write_mode = cluster_items[key]['write_mode']
+                restart.append(cluster_items[key]['restart'])
+
             _update_file(file_path, new_content=content['data'],
                             umask_int=remote_umask,
                             mtime=content['time'],

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -812,6 +812,7 @@ def receive_zip(zip_file):
     logging.info("Receiving package with {0} files".format(len(zip_file)))
 
     final_dict = {'error':[], 'updated': [], 'invalid': []}
+    restart = False
 
     if 'remote_groups.txt' in zip_file.keys():
         check_groups(set(zip_file['remote_groups.txt']['data'].split('\n')))
@@ -835,12 +836,17 @@ def receive_zip(zip_file):
                             w_mode=remote_write_mode,
                             node_type=config['node_type'])
 
+            if 'rules' in file_path or 'decoders' in file_path:
+                restart = True
+
         except Exception as e:
             logging.error("Error extracting zip file: {0}".format(str(e)))
             final_dict['error'].append({'item': name, 'reason': str(e)})
             continue
 
         final_dict['updated'].append(name)
+
+    final_dict['restart'] = restart
 
     return final_dict
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -751,10 +751,10 @@ InstallLocal(){
         ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} -b ../etc/local_rules.xml ${PREFIX}/etc/rules/local_rules.xml
     fi
     if [ ! -f ${PREFIX}/etc/lists ]; then
-        ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc/lists
+        ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc/lists
     fi
     if [ ! -f ${PREFIX}/etc/lists/amazon ]; then
-        ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc/lists/amazon
+        ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc/lists/amazon
         ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} -b ../etc/lists/amazon/* ${PREFIX}/etc/lists/amazon/
     fi
     if [ ! -f ${PREFIX}/etc/lists/audit-keys ]; then


### PR DESCRIPTION
Hello team,

I've added functionality in the cluster to synchronize custom rules and decoders (`/var/ossec/etc/rules` and `/var/ossec/etc/decoders`). **When custom rules or decoders are synchronized, the node that receives them is restarted**. Before restarting, the rules/decoders are checked with `ossec-logtest`.

Also, I've added a new field in `cluster.json` file to decide which files need to restart the manager after synchronizing and which ones do not.

### Testing
When receiving rules or decoders, the log should look like the  following one:
```
2018-01-08 18:00:17,443 INFO: Accepted connection from host 192.168.56.102
2018-01-08 18:00:17,652 INFO: Accepted connection from host 192.168.56.102
2018-01-08 18:00:17,672 INFO: Receiving package with 16 files
2018-01-08 18:00:17,853 INFO: Restarting manager...
2018-01-08 18:00:17,854 INFO: Accepted connection from host 192.168.56.102
2018-01-08 18:00:17,879 INFO: Accepted connection from host 192.168.56.102
2018-01-08 18:00:18,286 INFO: Signal [15-Terminated] received. Exit cleaning...
2018-01-08 18:00:18,312 INFO: Signal [15-Terminated] received. Exit cleaning...
2018-01-08 18:00:19,961 INFO: Cleaning database before starting service...
2018-01-08 18:00:20,047 INFO: Starting cluster wazuh
2018-01-08 18:00:20,049 INFO: Listening on port 1516.
2018-01-08 18:00:20,053 INFO: 3 nodes found in configuration
2018-01-08 18:00:20,055 INFO: Synchronization interval: 2m
```

After receiving a decoder like the following one:
```xml
<decoder name="test">
    <program_name>^test</program_name>
</decoder>
```

and executing the following command:
```shellsession
# logger -t test "pam_unix(sshd:session): session opened for user root by TEST WAZUH 1"
```

The following should be seen in `alerts.log` file:
```shellsession
# tail /var/ossec/logs/alerts/alerts.log
2018 Jan 08 18:00:31 node03->ossec-monitord
Rule: 502 (level 3) -> 'Ossec server started.'
ossec: Ossec started.

** Alert 1515430873.332027: - pam,syslog,authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9
2018 Jan 08 18:01:13 node03->/var/log/messages
Rule: 5501 (level 3) -> 'PAM: Login session opened.'
User: root
Jan  8 18:01:12 node03 test: pam_unix(sshd:session): session opened for user root by TEST WAZUH 1
```

Best regards,
Marta