### PR TITLE
Search only for group name in GET/agents/groups API call

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1330,7 +1330,7 @@ class Agent:
 
 
         if search:
-            data = search_array(data, search['value'], search['negation'])
+            data = search_array(data, search['value'], search['negation'], fields=['name'])
 
         if sort:
             data = sort_array(data, sort['fields'], sort['order'])

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -147,10 +147,11 @@ def sort_array(array, sort_by=None, order='asc', allowed_sort_fields=None):
             raise WazuhException(1404)
 
 
-def get_values(o):
+def get_values(o, fields=None):
     """
     Converts the values of an object to an array of strings.
     :param o: Object.
+    :param fields: fields to get values of (only for dictionaries)
     :return: Array of strings.
     """
     strings = []
@@ -165,20 +166,22 @@ def get_values(o):
             strings.extend(get_values(o))
     elif type(obj) is dict:
         for key in obj:
-            strings.extend(get_values(obj[key]))
+            if not fields or key in fields:
+                strings.extend(get_values(obj[key]))
     else:
         strings.append(str(obj).lower())
 
     return strings
 
 
-def search_array(array, text, negation=False):
+def search_array(array, text, negation=False, fields=None):
     """
     Looks for the string 'text' in the elements of the array.
 
     :param array: Array.
     :param text: Text to search.
     :param negation: the text must not be in the array.
+    :param fields: fields of the array to search in
     :return: True or False.
     """
 
@@ -186,7 +189,7 @@ def search_array(array, text, negation=False):
 
     for item in array:
 
-        values = get_values(item)
+        values = get_values(o=item, fields=fields)
 
         # print("'{0}' in '{1}'?".format(text, values))
 


### PR DESCRIPTION
Hello team,

When searching for groups in the `GET/agents/groups` API call, it also searches in the `config_sum` and `merged_sum` fields:
```shellsession
# curl -u foo:bar -k "http://127.0.0.1:55000/agents/groups?pretty&search=default"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "count": 0,
            "conf_sum": "ab73af41699f13fdd81903b5f23d8d00",
            "merged_sum": "1a444ca7d27c3ecffaf04b0a04f425c4",
            "name": "default"
         }
      ]
   }
}
# curl -u foo:bar -k "http://127.0.0.1:55000/agents/groups?pretty&search=5"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "count": 0,
            "conf_sum": "ab73af41699f13fdd81903b5f23d8d00",
            "merged_sum": "1a444ca7d27c3ecffaf04b0a04f425c4",
            "name": "default"
         }
      ]
   }
}
```

In this PR, I've made a solution that only searches by the `name` field:
```shellsession
# curl -u foo:bar -k "http://127.0.0.1:55000/agents/groups?pretty&search=5"
{
   "error": 0,
   "data": {
      "totalItems": 0,
      "items": []
   }
}
# curl -u foo:bar -k "http://127.0.0.1:55000/agents/groups?pretty&search=default"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "count": 0,
            "conf_sum": "ab73af41699f13fdd81903b5f23d8d00",
            "merged_sum": "1a444ca7d27c3ecffaf04b0a04f425c4",
            "name": "default"
         }
      ]
   }
}
```

Best regards,
Marta
