### PR TITLE
Fix cluster control response error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - [Fixed oscap.py to support new versions of OpenSCAP scanner.](https://github.com/wazuh/wazuh/pull/331)
+- [Fixed bug in cluster when receive an error response from client.](https://github.com/wazuh/wazuh/pull/346)
 
 ## [v3.1.0]
 
@@ -20,7 +21,7 @@ All notable changes to this project will be documented in this file.
 - Added alert and archive output files rotation capabilities.
 - Added rule option to discard field "firedtimes".
 - Added VULS integration for running vulnerability assessments.
-- CIS-CAT Wazuh Module to scan CIS policies. 
+- CIS-CAT Wazuh Module to scan CIS policies.
 
 ### Changed
 

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -305,12 +305,13 @@ def get_nodes(updateDBname=False):
         if not url in localhost_ips:
             error, response = send_request(host=url, port=config_cluster["port"], key=config_cluster['key'],
                                 data="node {0}".format('a'*(common.cluster_protocol_plain_size - len("node "))))
-            if response['error'] == 1:
-                logging.warning("Error bad response with {0}: {1}".format(url, response))
-                data.append({'error': response, 'node':'unknown', 'status':'disconnected', 'url':url})
-                continue
-            elif error == 0:
-                 reponse = response['data']
+            if error == 0:
+                if response['error'] == 0:
+                    reponse = response['data']
+                else:
+                    logging.warning("Error bad response with {0}: {1}".format(url, response))
+                    data.append({'error': response, 'node':'unknown', 'status':'disconnected', 'url':url})
+                    continue
         else:
             error = 0
             url = "localhost"

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -309,7 +309,7 @@ def get_nodes(updateDBname=False):
                 if response['error'] == 0:
                     reponse = response['data']
                 else:
-                    logging.warning("Error bad response with {0}: {1}".format(url, response))
+                    logging.warning("Received an error response from {0}: {1}".format(url, response))
                     data.append({'error': response, 'node':'unknown', 'status':'disconnected', 'url':url})
                     continue
         else:

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -300,6 +300,7 @@ def get_nodes(updateDBname=False):
     # list with all the ips the localhost has
     localhost_ips = get_localhost_ips()
     data = []
+    error_response = False
 
     for url in config_cluster["nodes"]:
         if not url in localhost_ips:
@@ -310,8 +311,7 @@ def get_nodes(updateDBname=False):
                     reponse = response['data']
                 else:
                     logging.warning("Received an error response from {0}: {1}".format(url, response))
-                    data.append({'error': response, 'node':'unknown', 'status':'disconnected', 'url':url})
-                    continue
+                    error_response = True
         else:
             error = 0
             url = "localhost"
@@ -319,7 +319,11 @@ def get_nodes(updateDBname=False):
 
         if error == 1:
             logging.warning("Error connecting with {0}: {1}".format(url, response))
+            error_response = True
+
+        if error_response:
             data.append({'error': response, 'node':'unknown', 'status':'disconnected', 'url':url})
+            error_response = False
             continue
 
         if config_cluster['node_type'] == 'master' or \


### PR DESCRIPTION
This PR solves:

In the function get_nodes we don't control that the response has error 1. For example, given the following response:

```{u'data': u'Received invalid cluster command node', u'error': 1}```

The function get_nodes doesn't have the case where response['error'] is 1.

Best regards,
Javier.