### PR TITLE
Add support for multiple masters in cluster

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -72,6 +72,7 @@ path.append(dirname(argv[0]) + '/../framework')  # It is necessary to import Waz
 try:
     from wazuh import Wazuh
     from wazuh.cluster.management import *
+    from wazuh.cluster.handler import *
     from wazuh.agent import Agent
     from wazuh.exception import WazuhException
 except Exception as e:

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -392,12 +392,14 @@ def crontab_sync_master(interval):
 
         sleep(interval_number if interval_measure == 's' else interval_number*60)
 
+
 def crontab_sync_client():
     def sync_handler(n_signal, frame):
-        master_ip, _, master_name = get_remote_nodes()[0]
+        master_ip, _, master_name = get_remote_nodes(updateDBname=True)[0]
         sync_one_node(False, master_ip, master_name)
 
     signal(SIGUSR1, sync_handler)
+
     while True:
         sleep(30)
 

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -187,10 +187,12 @@ def crontab_sync_master(interval):
                 # send the synchronization results to the rest of masters
                 message = "data {0}".format('a'*(common.cluster_protocol_plain_size - len('data ')))
                 file = json.dumps(sync_results).encode()
-            else:
+            elif node[1] == 'client':
                 # ask clients to send updates
                 message = "ready {0}".format('a'*(common.cluster_protocol_plain_size - len("ready ")))
                 file = None
+            else:
+                continue
             
             error, response = send_request(host=node[0], port=config_cluster["port"], key=config_cluster['key'],
                                 data=message, file=file)

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -424,7 +424,8 @@ def crontab_sync_client():
         sync_one_node(False, master_ip, master_name)
 
     signal(SIGUSR1, sync_handler)
-
+    # send a keep alive to the rest of nodes
+    get_remote_nodes(connected=True, updateDBname=True)
     while True:
         sleep(30)
 

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -371,7 +371,8 @@ class WazuhClusterServer(asyncore.dispatcher):
         logging.info("Starting cluster '{0}'".format(cluster_info['name']))
         logging.info("Listening on port {0}.".format(port))
         logging.info("{0} nodes found in configuration".format(len(cluster_info['nodes'])))
-        logging.info("Synchronization interval: {0}".format(cluster_info['interval']))
+        if cluster_info['node_type'] == 'master':
+            logging.info("Synchronization interval: {0}".format(cluster_info['interval']))
 
 
     def handle_accept(self):

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -323,8 +323,14 @@ def insert_actual_master(node_name, csocket=None):
 
 def select_actual_master(nodes, cluster_socket=None):
     # check if there's already one actual master
-    if len(list(filter(lambda x: x == 'master(*)', map(itemgetter('type'), nodes)))) > 0:
+    number_of_masters = len(list(filter(lambda x: x['type'] == 'master(*)', nodes)))
+    if number_of_masters == 1:
         return nodes
+    elif number_of_masters > 1:
+        logging.info("Found {} elected masters. Restarting lection process...".format(number_of_masters))
+        for node in nodes:
+            if node['type'] == 'master(*)':
+                node['type'] = 'master'
 
     # if there's no actual master, select one
     for node in nodes:

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -325,6 +325,7 @@ def select_actual_master(nodes, cluster_socket=None):
     # check if there's already one actual master
     number_of_masters = len(list(filter(lambda x: x['type'] == 'master(*)', nodes)))
     if number_of_masters == 1:
+        insert_actual_master(next (x['node'] for x in nodes if x['type'] == 'master(*)'), cluster_socket)
         return nodes
     elif number_of_masters > 1:
         logging.info("Found {} elected masters. Restarting lection process...".format(number_of_masters))

--- a/framework/wazuh/cluster/handler.py
+++ b/framework/wazuh/cluster/handler.py
@@ -637,7 +637,8 @@ def sync(debug, force=False):
     remote_nodes = get_remote_nodes(True, True)
 
     cluster_socket = connect_to_db_socket()
-    if config_cluster['node_type'] == 'master' and config_cluster['node_name'] != get_actual_master(cluster_socket):
+    my_data = get_node(cluster_socket)
+    if my_data['type'] == 'master' and my_data['node'] != get_actual_master(cluster_socket):
         config_cluster['node_type'] = 'client'
 
     # Get own items status

--- a/framework/wazuh/cluster/handler.py
+++ b/framework/wazuh/cluster/handler.py
@@ -290,11 +290,11 @@ def _check_removed_agents(new_client_keys):
                 logging.error("Error deleting agent {0}: {1}".format(agent_id, str(e)))
 
 
-def _update_file(fullpath, new_content, umask_int=None, mtime=None, w_mode=None, node_type='master', node_name=''):
+def _update_file(fullpath, new_content, umask_int=None, mtime=None, w_mode=None, node_type='master'):
     if path.basename(fullpath) == 'client.keys':
         if node_type=='client':
             _check_removed_agents(new_content.split('\n'))
-        elif node_name == get_actual_master()['name']:
+        elif get_actual_master()['url'] in get_localhost_ips():
             logging.warning("Client.keys file received in a elected master node.")
             raise WazuhException(3007)
 
@@ -389,8 +389,7 @@ def receive_zip(zip_file):
                             umask_int=remote_umask,
                             mtime=content['time'],
                             w_mode=remote_write_mode,
-                            node_type=config['node_type'],
-                            node_name=config['name'])
+                            node_type=config['node_type'])
 
         except Exception as e:
             logging.error("Error extracting zip file: {0}".format(str(e)))

--- a/framework/wazuh/cluster/management.py
+++ b/framework/wazuh/cluster/management.py
@@ -188,7 +188,7 @@ def check_cluster_config(config):
 
     if config['node_type'] != 'master' and config['node_type'] != 'client':
         raise WazuhException(3004, 'Invalid node type {0}. Correct values are master and client'.format(config['node_type']))
-    if not re.compile("\d+[m|s]").match(config['interval']):
+    if config['node_type'] == 'master' and not re.compile("\d+[m|s]").match(config['interval']):
         raise WazuhException(3004, 'Invalid interval specification. Please, specify it with format <number>s or <number>m')
     if config['nodes'][0] == 'localhost' and len(config['nodes']) == 1:
         raise WazuhException(3004, 'Please specify IPs of all cluster nodes')

--- a/framework/wazuh/wazuh-clusterd-internal.c
+++ b/framework/wazuh/wazuh-clusterd-internal.c
@@ -590,7 +590,8 @@ unsigned int get_files_to_watch(char * node_type, inotify_watch_file ** _files, 
         cJSON *source_item = cJSON_GetObjectItemCaseSensitive(subitem, "source");
 
         if (strcmp(source_item->valuestring, node_type) == 0 ||
-            strcmp(source_item->valuestring, "all") == 0) {
+            strcmp(source_item->valuestring, "all") == 0 ||
+            strcmp(node_type, "master") == 0) { // master nodes monitor all files
 
             char aux_path[PATH_MAX];
             if (snprintf(aux_path, PATH_MAX, "%s%s", DEFAULTDIR, subitem->string) >= PATH_MAX)


### PR DESCRIPTION
Hello,

This PR adds support for multiple masters in the cluster, improving its high availability. 

## How it works
Multiple nodes can be masters but there'll be only one "active" master, the rest will only check if the "active" master is alive and store a copy of its files.

Every 2 minutes (or the interval set in the cluster configuration) all nodes in the cluster send some kind of "keep alive message" to each other. The reply of that message is the node information (name, type of node, status, etc). Once all active nodes are known, their IPs are sorted and the first item on IP the list with type _master_ is selected as "actual master".

When the synchronization with all nodes in the cluster is done, the "actual master" sends its result to the rest of masters. This way, if the "actual master" is down, the new "actual master" won't send all data again to the clients.

## CLI example
Now, the node type is added in both API call `GET /cluster/nodes` and `cluster_control --nodes`:

```shellsession
# curl -u foo:bar "localhost:55000/cluster/nodes?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 3,
      "items": [
         {
            "url": "192.168.56.102",
            "node": "node01",
            "status": "connected",
            "type": "master(*)",
            "cluster": "wazuh"
         },
         {
            "url": "192.168.56.104",
            "node": "node02",
            "status": "connected",
            "type": "master",
            "cluster": "wazuh"
         },
         {
            "url": "192.168.56.105",
            "node": "node03",
            "status": "connected",
            "type": "client",
            "cluster": "wazuh"
         }
      ]
   }
}

# /var/ossec/bin/cluster_control --nodes
--------------------------------------------
Node    Address         Type       Status
--------------------------------------------
node01  192.168.56.102  master(*)  connected
node02  192.168.56.104  master     connected
node03  192.168.56.105  client     connected
--------------------------------------------
```

## Logs sample
### Actual master
```
2018-01-11 18:40:28,257 INFO: Cleaning database before starting service...
2018-01-11 18:40:29,486 INFO: Starting cluster 'wazuh'
2018-01-11 18:40:29,487 INFO: Listening on port 1516.
2018-01-11 18:40:29,487 INFO: 3 nodes found in configuration
2018-01-11 18:40:29,487 INFO: Synchronization interval: 2m
2018-01-11 18:40:29,937 INFO: Accepted connection from host 192.168.56.104
2018-01-11 18:40:30,204 INFO: The new elected master is node01.
2018-01-11 18:40:30,214 INFO: Starting synchronization process...
2018-01-11 18:40:30,215 INFO: Found 2 connected nodes
2018-01-11 18:40:30,219 INFO: New manager found: 192.168.56.104
2018-01-11 18:40:30,233 INFO: New manager found: 192.168.56.105
2018-01-11 18:40:30,242 INFO: Sending node02 (192.168.56.104) 17 files
2018-01-11 18:40:30,248 INFO: Accepted connection from host 192.168.56.104
2018-01-11 18:40:30,314 INFO: Sending node03 (192.168.56.105) 16 files
2018-01-11 18:40:30,351 INFO: Updating node03's (192.168.56.105) file status in DB
2018-01-11 18:40:30,360 INFO: Updating node02's (192.168.56.104) file status in DB
2018-01-11 18:40:30,798 INFO: Accepted connection from host 192.168.56.105
2018-01-11 18:40:30,858 INFO: Accepted connection from host 192.168.56.105
2018-01-11 18:40:30,865 INFO: Receiving package with 1 files
```

The actual master sends both the client (`192.168.56.104`) and the other master (`192.168.56.105`) its files. Since there an agent registered, the actual master sends its agent-info to the rest of masters.

### Master
```
2018-01-11 18:40:28,259 INFO: Cleaning database before starting service...
2018-01-11 18:40:29,512 INFO: Starting cluster 'wazuh'
2018-01-11 18:40:29,514 INFO: Listening on port 1516.
2018-01-11 18:40:29,515 INFO: 3 nodes found in configuration
2018-01-11 18:40:29,515 INFO: Synchronization interval: 2m
2018-01-11 18:40:29,846 INFO: Accepted connection from host 192.168.56.102
2018-01-11 18:40:30,219 INFO: The new elected master is node01.
2018-01-11 18:40:30,264 INFO: Accepted connection from host 192.168.56.102
2018-01-11 18:40:30,280 INFO: Receiving package with 18 files
2018-01-11 18:40:30,421 INFO: Accepted connection from host 192.168.56.102
2018-01-11 18:40:30,447 INFO: Accepted connection from host 192.168.56.102
2018-01-11 18:40:30,448 INFO: Updating database with information received from elected master.
2018-01-11 18:40:30,542 INFO: New manager found: 192.168.56.105
2018-01-11 18:40:30,551 INFO: Updating node03's (192.168.56.105) file status in DB
2018-01-11 18:40:30,650 INFO: New manager found: 192.168.56.102
2018-01-11 18:40:30,659 INFO: Updating node01's (192.168.56.102) file status in DB
2018-01-11 18:40:30,811 INFO: Accepted connection from host 192.168.56.105
```

The non-actual master only receives files from the actual master and updates on its `cluster.db` the result of the synchronization. Why does the non-actual master find 0 connected nodes? Because, since it doesn't send any message to any node, its "nodes to communicate with list" is empty.

### Client
```
2018-01-11 18:40:26,075 INFO: Cleaning database before starting service...
2018-01-11 18:40:27,163 INFO: Starting cluster 'wazuh'
2018-01-11 18:40:27,164 INFO: Listening on port 1516.
2018-01-11 18:40:27,164 INFO: 3 nodes found in configuration
2018-01-11 18:40:27,164 INFO: Synchronization interval: 2m
2018-01-11 18:40:30,063 INFO: Accepted connection from host 192.168.56.102
2018-01-11 18:40:30,181 INFO: Accepted connection from host 192.168.56.104
2018-01-11 18:40:30,326 INFO: Accepted connection from host 192.168.56.102
2018-01-11 18:40:30,340 INFO: Receiving package with 17 files
2018-01-11 18:40:30,404 INFO: Accepted connection from host 192.168.56.104
2018-01-11 18:40:30,432 INFO: Accepted connection from host 192.168.56.102
2018-01-11 18:40:30,671 INFO: Accepted connection from host 192.168.56.102
2018-01-11 18:40:30,847 INFO: New manager found: 192.168.56.102
2018-01-11 18:40:30,857 INFO: Sending node01 (192.168.56.102) 1 files
2018-01-11 18:40:30,870 INFO: Updating node01's (192.168.56.102) file status in DB
```

The client hasn't changed.

## Tests
- **The actual master goes down**: the following master (sorted by IP) is promoted as actual master. The new actual master doesn't send all files to the clients again.
- **An agent is registered when one of the masters is down**: The client sends the agent-info to the new actual master. 
- **The old actual master is active again**: The new actual master keeps being the actual master. The new actual master sends the old one all new files.

Best regards,
Marta
