### PR TITLE
Added generic integrations array

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -53,6 +53,10 @@ conf_sections = {
     'auth': {
         'type': 'simple',
         'list_options': []
+    },
+    'integration': {
+        'type': 'duplicate',
+        'list_options': []
     }
 }
 


### PR DESCRIPTION
Hi folks, this PR adds support for integrations declared under `<integration></integration>` tag. Now we can call the api route `/manager/configuration` and see these integrations. Assuming the following integration in the `ossec.conf` file:

```
<integration>
  <name>virustotal</name>
  <api_key>foobarfoobarfoobarfoobar</api_key>
  <group>syscheck</group>
  <alert_format>json</alert_format>
</integration>
```

```json
GET /manager/configuration

{
"error": 0,
"data": {
   ...,
   "integration": [
     {
       "alert_format": "json",
       "api_key": "foobarfoobarfoobarfoobar",
       "group": "syscheck",
       "name": "virustotal" 
     }
   ],
   ...
  }
}
```