### PR TITLE
Fix /manager/info output

### DIFF
--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -7,6 +7,7 @@ from wazuh import common
 from wazuh.utils import execute
 from wazuh.database import Connection
 from time import strftime
+from wazuh.exception import WazuhException
 import re
 
 
@@ -66,7 +67,7 @@ class Wazuh:
         return str(self.to_dict())
 
     def to_dict(self):
-        return {'path': self.path, 'version': self.version, 'installation_date': self.installation_date, 'type': self.type, 'max_agents': self.max_agents, 'openssl_support': self.openssl_support, 'ruleset_version': self.ruleset_version, 'tz_offset': self.tz_offset, 'tz_name': self.tz_name}
+        return {'path': self.path, 'version': self.version, 'compilation_date': self.installation_date, 'type': self.type, 'max_agents': self.max_agents, 'openssl_support': self.openssl_support, 'ruleset_version': self.ruleset_version, 'tz_offset': self.tz_offset, 'tz_name': self.tz_name}
 
     def get_ossec_init(self):
         """
@@ -93,7 +94,10 @@ class Wazuh:
                         elif key == "date":
                             self.installation_date = match.group(2)
                         elif key == "type":
-                            self.type = match.group(2)
+                            if (str(match.group(2)) == "server"):
+                                self.type = "manager"
+                            else:
+                                self.type = match.group(2)
         except:
             raise WazuhException(1005, self.OSSEC_INIT)
 

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -941,12 +941,8 @@ def push_updates_single_node(all_files, node_dest, config_cluster, removed, resu
     if len(pending_files) > 0 or removed or len(tobedeleted_files) > 0:
         logging.info("Sending {0} {1} files".format(node_dest, len(pending_files)))
         zip_file = compress_files(list_path=set(map(itemgetter(0), pending_files)),
-<<<<<<< HEAD
-                                  node_type=config_cluster['node_type'])
-=======
                                   node_type=config_cluster['node_type'],
                                   tobedeleted_files=map(itemgetter(0), tobedeleted_files))
->>>>>>> 3.1
 
         error, response = send_request(host=node_dest, port=config_cluster['port'],
                                        data="zip {0}".format(str(len(zip_file)).


### PR DESCRIPTION
This PR improves the output of GET /manager/info

Before:
```
{
   "error": 0,
   "data": {
      "installation_date": "Thu Feb  1 12:46:01 CET 2018",
      "version": "v3.2.0-alpha1",
      "openssl_support": "yes",
      "max_agents": "8000",
      "ruleset_version": "1005",
      "path": "/var/ossec",
      "tz_name": "CET",
      "type": "server",
      "tz_offset": "+0100"
   }
}
```

Now:
```
{
   "error": 0,
   "data": {
      "compilation_date": "Thu Feb  1 13:13:09 CET 2018",
      "version": "v3.2.0-alpha1",
      "openssl_support": "yes",
      "max_agents": "8000",
      "ruleset_version": "1005",
      "path": "/var/ossec",
      "tz_name": "CET",
      "type": "manager",
      "tz_offset": "+0100"
   }
}
```