### PR TITLE
Added attributes to GET /agents

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -766,9 +766,14 @@ class Agent:
         query = "SELECT {0} FROM agent"
         fields = {'id': 'id', 'name': 'name', 'ip': 'ip', 'status': 'last_keepalive',
                   'os.name': 'os_name', 'os.version': 'os_version', 'os.platform': 'os_platform',
-                  'version': 'version', 'manager_host': 'manager_host', 'date_add': 'date_add'}
+                  'version': 'version', 'manager_host': 'manager_host', 'date_add': 'date_add',
+                   'group': 'group', 'merged_sum': 'merged_sum', 'config_sum': 'config_sum',
+                   'os.codename': 'os_codename','os.major': 'os_major','os.uname': 'os_uname',
+                  'last_keepalive': 'last_keepalive','os.arch': 'os_arch'}
         valid_select_fields = {"id", "name", "ip", "last_keepalive", "os_name", "os_version", "node_name",
-                               "os_platform", "version", "manager_host", "date_add", 'status'}
+                               "os_platform", "version", "manager_host", "date_add", 'status',
+                               'group', 'merged_sum', 'config_sum','os_codename', 'os_major', 'os_uname',
+                               'last_keepalive', 'os_arch'}
         select_fields = {'id', 'version', 'last_keepalive'}
         search_fields = {"id", "name", "ip", "os_name", "os_version", "os_platform", "manager_host", "version"}
         request = {}
@@ -858,6 +863,18 @@ class Agent:
             request['offset'] = offset
             request['limit'] = limit
 
+        if 'group' in select_fields:
+            select_fields.remove('group')
+            select_fields.add('`group`')
+
+        select_os_arch = 'os_arch' in select_fields
+        select_os_uname = 'os_uname' in select_fields
+        if select_os_arch:
+            select_fields.remove('os_arch')
+            if not select_os_uname:
+                select_fields.add('os_uname')
+                set_select_fields.add('os_uname')
+
         conn.execute(query.format(','.join(select_fields)), request)
 
         data['items'] = []
@@ -868,7 +885,6 @@ class Agent:
             pending = True
             os = {}
             for field, value in zip(select_fields, tuple):
-
                 if value != None and field == 'id':
                     data_tuple['id'] = str(value).zfill(3)
                 if value != None and field == 'name' and field in set_select_fields:
@@ -885,6 +901,34 @@ class Agent:
                     os['version'] = value
                 if value != None and field == 'os_platform' and field in set_select_fields:
                     os['platform'] = value
+                if value != None and field == 'os_codename' and field in set_select_fields:
+                    os['codename'] = value
+                if value != None and field == 'os_build' and field in set_select_fields:
+                    os['arch'] = value
+                if value != None and field == 'os_uname' and field in set_select_fields:
+                    if select_os_uname:
+                        os['uname'] = value
+                    if select_os_arch:
+                        if "x86_64" in value:
+                            os['arch'] = "x86_64"
+                        elif "i386" in value:
+                            os['arch'] = "i386"
+                        elif "i686" in value:
+                            os['arch'] = "i686"
+                        elif "sparc" in value:
+                            os['arch'] = "sparc"
+                        elif "amd64" in value:
+                            os['arch'] = "amd64"
+                        elif "ia64" in value:
+                            os['arch'] = "ia64"
+                        elif "AIX" in value:
+                            os['arch'] = "AIX"
+                        elif "armv6" in value:
+                            os['arch'] = "armv6"
+                        elif "armv7" in value:
+                            os['arch'] = "armv7"
+                if value != None and field == 'os_major' and field in set_select_fields:
+                    os['major'] = value
 
                 if value != None and field == 'version':
                     pending = False if value != "" else True
@@ -899,6 +943,18 @@ class Agent:
 
                 if value != None and field == 'node_name' and field in set_select_fields:
                     data_tuple['node_name'] = value
+
+                if value != None and field == '`group`' and 'group' in set_select_fields:
+                    data_tuple['group'] = value
+
+                if value != None and field == 'merged_sum' and field in set_select_fields:
+                    data_tuple['mergedSum'] = value
+
+                if value != None and field == 'config_sum' and field in set_select_fields:
+                    data_tuple['configSum'] = value
+
+                if value != None and field == 'last_keepalive' and field in set_select_fields:
+                    data_tuple['lastKeepAlive'] = value
 
             if os:
                 os_no_empty = dict((k, v) for k, v in os.items() if v)


### PR DESCRIPTION
This PR adds attributes to the output of GET /agents.
Now, it is more similar to /agents/:agent_id.

## Sample 
Before:
```
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "status": "Active",
            "name": "manager",
            "ip": "127.0.0.1",
            "dateAdd": "2018-02-01 17:25:24",
            "version": "Wazuh v3.2.0-alpha1",
            "manager_host": "manager",
            "os": {
               "platform": "centos",
               "version": "7",
               "name": "CentOS Linux"
            },
            "id": "000"
         },
         {
            "status": "Active",
            "name": "agent001",
            "ip": "192.168.56.103",
            "dateAdd": "2018-02-01 17:25:24",
            "version": "Wazuh v3.1.0",
            "manager_host": "manager",
            "os": {
               "platform": "centos",
               "version": "7",
               "name": "CentOS Linux"
            },
            "id": "001"
         }
      ]
   }
}
```

Now:
```
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "status": "Active",
            "name": "manager",
            "ip": "127.0.0.1",
            "dateAdd": "2018-02-02 17:01:18",
            "version": "Wazuh v3.2.0-alpha1",
            "manager_host": "manager",
            "lastKeepAlive": "9999-12-31 23:59:59",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux manager 3.10.0-693.11.1.el7.x86_64 #1 SMP Mon Dec 4 23:52:40 UTC 2017 x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "000"
         },
         {
            "status": "Active",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": "test_group",
            "name": "agent001",
            "mergedSum": "65da65dfda62f71213d109182ef9a077",
            "ip": "192.168.56.103",
            "dateAdd": "2018-02-02 17:01:18",
            "version": "Wazuh v3.1.0",
            "manager_host": "manager",
            "lastKeepAlive": "2018-02-02 17:03:26",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux manager 3.10.0-693.11.1.el7.x86_64 #1 SMP Mon Dec 4 23:52:40 UTC 2017 x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "001"
         }
      ]
   }
}
```
