### PR TITLE
Add wazuh-db wrapper for the framework

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -8,6 +8,7 @@ from wazuh.exception import WazuhException
 from wazuh.ossec_queue import OssecQueue
 from wazuh.ossec_socket import OssecSocket
 from wazuh.database import Connection
+from wazuh.wdb import WazuhDBConnection
 from wazuh.InputValidator import InputValidator
 from wazuh import manager
 from wazuh import common
@@ -261,6 +262,25 @@ class Agent:
 
         if no_result:
             raise WazuhException(1701, self.id)
+
+
+    def _load_info_from_agent_db(self, table, select, filters=[]):
+        """
+        Make a request to agent's database using Wazuh DB
+        """
+        wdb_conn = WazuhDBConnection()
+        
+        query = "agent {} sql select {} from {}".format(self.id, ','.join(select), table)
+        
+        if filters:
+            query += " where"
+            for key, value in filters:
+                query += " {} = {} AND".format(key, value)
+            query = query[:-3] # remove last AND
+
+        response = wdb_conn.execute(query)
+
+        return response
 
 
     def get_basic_information(self, select=None):

--- a/framework/wazuh/common.py
+++ b/framework/wazuh/common.py
@@ -46,6 +46,9 @@ def set_paths_based_on_ossec(o_path='/var/ossec'):
     global database_path_global
     database_path_global = database_path + '/global.db'
 
+    global wdb_socket_path
+    wdb_socket_path = '{}/queue/db/wdb'.format(ossec_path)
+
     global api_config_path
     api_config_path = "{0}/api/configuration/config.js".format(ossec_path)
 

--- a/framework/wazuh/database.py
+++ b/framework/wazuh/database.py
@@ -5,7 +5,6 @@
 
 from wazuh import common
 from wazuh.exception import WazuhException
-from wazuh import common
 from os.path import isfile
 from distutils.version import LooseVersion
 import sqlite3

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -100,6 +100,8 @@ class WazuhException(Exception):
         2001: 'Incompatible version of SQLite',
         2002: 'Maximum attempts exceeded for sqlite3 execute',
         2003: 'Error in database request',
+        2004: 'Database query not valid',
+        2005: 'Could not connect to wdb socket',
 
         # Cluster
         3000: 'Cluster',

--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from wazuh import common
+from wazuh.exception import WazuhException
+from os.path import isfile
+from os import strerror
+import socket
+from sys import exc_info
+from traceback import extract_tb
+import re
+import json
+
+class WazuhDBConnection():
+    """
+    Represents a connection to the wdb socket
+    """
+
+    def __init__(self, socket_path=common.wdb_socket_path, request_slice=20, max_size=6144):
+        """
+        Constructor
+        """
+        self.socket_path = socket_path
+        self.request_slice = request_slice
+        self.max_size = max_size
+        self.__conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            self.__conn.connect(self.socket_path)
+        except socket.error as e:
+            raise WazuhException(2005, strerror(e[0]))
+
+
+    def __query_input_validation(self, query):
+        """
+        Checks input queries have the correct format
+        """
+        query_elements = query.split(" ")
+        sql_first_index = 2 if query_elements[0] == 'agent' else 1
+
+        try:
+            assert query_elements[sql_first_index] == 'sql'
+
+            assert query_elements[0] == 'agent' or \
+                   query_elements[0] == 'global'
+
+            if query_elements[0] == 'agent':
+                assert query_elements[1].isdigit()
+
+            assert query_elements[sql_first_index+1] == 'select'
+        except AssertionError as e:
+            _, _, tb = exc_info()
+            tb_info = extract_tb(tb)
+            filename, line, func, text = tb_info[-1]
+            raise WazuhException(2004, text)
+
+
+    def __send(self, msg):
+        """
+        Sends a message to the wdb socket
+        """
+        self.__conn.send(msg)
+        # Wazuh db can't send more than 6KB of data
+        data = self.__conn.recv(self.max_size).split(" ", 1)
+
+        if data[0] == "err":
+            raise WazuhException(2003, data[1])
+        else:
+            return json.loads(data[1])
+
+    def execute(self, query):
+        """
+        Sends a sql query to wdb socket
+        """
+        query_lower = query.lower()
+
+        self.__query_input_validation(query_lower)
+
+        # if the query has already a parameter limit / offset, divide using it
+        offset = 0
+        if 'offset' in query_lower:
+            offset = int(re.compile(r".* offset (\d)+").match(query_lower).group(1))
+            query_lower = query_lower.replace("offset {}".format(offset), "")
+
+        if 'count' not in query_lower:
+            lim = 0
+            if'limit' in query_lower:
+                lim  = int(re.compile(r".* limit (\d)+").match(query_lower).group(1))
+                query_lower = query_lower.replace("limit {}".format(lim), "")
+
+            regex  = re.compile(r"\w+ \d+? sql select ([a-z0-9,* ]+) from")
+            select = regex.match(query_lower).group(1)
+            countq = query_lower.replace(select, "count({})".format(select))
+            total  = self.__send(countq)[0].values()[0]
+
+            limit = total if lim == 0  else lim
+
+            response = []
+            step = limit if limit < self.request_slice  else self.request_slice
+            for off in range(offset, limit+1, step):
+                request = "{} limit {} offset {}".format(query_lower, step, off)
+                response.extend(self.__send(request))
+            return response
+        else:
+            return self.__send(query_lower)[0].values()[0]

--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -42,7 +42,8 @@ class WazuhDBConnection():
             (query_elements[sql_first_index] == 'sql', "Incorrect WDB request type."),
             (query_elements[0] == 'agent' or query_elements[0] == 'global', "The {} database is not valid".format(query_elements[0])),
             (query_elements[1].isdigit() if query_elements[0] == 'agent' else True, "Incorrect agent ID {}".format(query_elements[1])),
-            (query_elements[sql_first_index+1] == 'select', "The API can only send select requests to WDB")
+            (query_elements[sql_first_index+1] == 'select', "The API can only send select requests to WDB"),
+            (not ';' in query, "Found a not valid symbol in database query: ;")
         ]
 
         for check, error_text in input_val_errors:
@@ -74,24 +75,24 @@ class WazuhDBConnection():
         offset = 0
         if 'offset' in query_lower:
             offset = int(re.compile(r".* offset (\d)+").match(query_lower).group(1))
-            query_lower = query_lower.replace("offset {}".format(offset), "")
+            query_lower = query_lower.replace(" offset {}".format(offset), "")
 
         if 'count' not in query_lower:
             lim = 0
             if'limit' in query_lower:
                 lim  = int(re.compile(r".* limit (\d)+").match(query_lower).group(1))
-                query_lower = query_lower.replace("limit {}".format(lim), "")
+                query_lower = query_lower.replace(" limit {}".format(lim), "")
 
             regex  = re.compile(r"\w+ \d+? sql select ([a-z0-9,* ]+) from")
             select = regex.match(query_lower).group(1)
-            countq = query_lower.replace(select, "count({})".format(select))
+            countq = query_lower.replace(select, "count(*)")
             total  = self.__send(countq)[0].values()[0]
 
             limit = total if lim == 0  else lim
 
             response = []
             step = limit if limit < self.request_slice  else self.request_slice
-            for off in range(offset, limit+1, step):
+            for off in range(offset, limit+offset, step):
                 request = "{} limit {} offset {}".format(query_lower, step, off)
                 response.extend(self.__send(request))
             return response


### PR DESCRIPTION
Hello,

This PR adds a python wrapper to make requests to wazuh-db. Below an example of use is shown.

```python
>>> from wazuh.wdb import WazuhDBConnection

>>> wdb_con = WazuhDBConnection()

>>> wdb_con.execute("agent 000 sql select * from programs limit 2")
[{u'architecture': u'x86_64',
  u'description': u'Team device plugin for NetworkManager',
  u'format': u'rpm',
  u'name': u'NetworkManager-team',
  u'scan_id': 492271232,
  u'scan_time': u'2018/02/09 10:57:50',
  u'vendor': u'CentOS',
  u'version': u'1:1.4.0-12.el7'},
 {u'architecture': u'x86_64',
  u'description': u'CentOS Linux release file',
  u'format': u'rpm',
  u'name': u'centos-release',
  u'scan_id': 492271232,
  u'scan_time': u'2018/02/09 10:57:50',
  u'vendor': u'CentOS',
  u'version': u'7-3.1611.el7.centos'}]

>>> wdb_con.execute("agent 000 select * from programs limit 2")
WazuhException: Error 2004 - Database query not valid: Incorrect WDB request type.
```

The first example shows a correct request and its response. The second one shows an incorrect request and the exception it raises.

Best regards,
Marta