### PR TITLE
Add configured delay between messages for wodles

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -44,6 +44,9 @@ void sys_programs_bsd(int queue_fd, const char* LOCATION){
     struct tm localtm;
     int status;
 
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
     now = time(NULL);
     localtime_r(&now, &localtm);
 
@@ -100,7 +103,7 @@ void sys_programs_bsd(int queue_fd, const char* LOCATION){
 
             string = cJSON_PrintUnformatted(object);
             mtdebug2(WM_SYS_LOGTAG, "sys_programs_bsd() sending '%s'", string);
-            SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+            wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
             cJSON_Delete(object);
 
             free(string);
@@ -122,7 +125,7 @@ void sys_programs_bsd(int queue_fd, const char* LOCATION){
     char *string;
     string = cJSON_PrintUnformatted(object);
     mtdebug2(WM_SYS_LOGTAG, "sys_programs_bsd() sending '%s'", string);
-    SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
     cJSON_Delete(object);
     free(string);
     free(timestamp);
@@ -364,6 +367,9 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
     char *timestamp;
     time_t now;
     struct tm localtm;
+
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
 
     now = time(NULL);
     localtime_r(&now, &localtm);
@@ -607,7 +613,7 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
         /* Send interface data in JSON format */
         string = cJSON_PrintUnformatted(object);
         mtdebug2(WM_SYS_LOGTAG, "sys_network_bsd() sending '%s'", string);
-        SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+        wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
         cJSON_Delete(object);
         free(string);
     }
@@ -626,7 +632,7 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
     char *string;
     string = cJSON_PrintUnformatted(object);
     mtdebug2(WM_SYS_LOGTAG, "sys_network_bsd() sending '%s'", string);
-    SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
     cJSON_Delete(object);
     free(string);
     free(timestamp);

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -97,6 +97,9 @@ void get_ipv4_ports(int queue_fd, const char* LOCATION, const char* protocol, in
     FILE *output;
     int status;
 
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
     snprintf(file, OS_MAXSTR, "%s%s", WM_SYS_NET_DIR, protocol);
 
     os_calloc(NI_MAXHOST, sizeof(char), laddress);
@@ -189,7 +192,7 @@ void get_ipv4_ports(int queue_fd, const char* LOCATION, const char* protocol, in
                 char *string;
                 string = cJSON_PrintUnformatted(object);
                 mtdebug2(WM_SYS_LOGTAG, "sys_ports_linux() sending '%s'", string);
-                SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+                wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
                 cJSON_Delete(object);
                 free(string);
 
@@ -225,6 +228,9 @@ void get_ipv6_ports(int queue_fd, const char* LOCATION, const char* protocol, in
     char command[OS_MAXSTR];
     FILE *output;
     int status;
+
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
 
     snprintf(file, OS_MAXSTR, "%s%s", WM_SYS_NET_DIR, protocol);
     memset(read_buff, 0, OS_MAXSTR);
@@ -319,7 +325,7 @@ void get_ipv6_ports(int queue_fd, const char* LOCATION, const char* protocol, in
                 char *string;
                 string = cJSON_PrintUnformatted(object);
                 mtdebug2(WM_SYS_LOGTAG, "sys_ports_linux() sending '%s'", string);
-                SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+                wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
                 cJSON_Delete(object);
                 free(string);
 
@@ -411,6 +417,9 @@ void sys_programs_linux(int queue_fd, const char* LOCATION){
     struct tm localtm;
     int status;
 
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
     now = time(NULL);
     localtime_r(&now, &localtm);
 
@@ -498,7 +507,7 @@ void sys_programs_linux(int queue_fd, const char* LOCATION){
 
             string = cJSON_PrintUnformatted(object);
             mtdebug2(WM_SYS_LOGTAG, "sys_programs_linux() sending '%s'", string);
-            SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+            wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
             cJSON_Delete(object);
 
             free(string);
@@ -521,7 +530,7 @@ void sys_programs_linux(int queue_fd, const char* LOCATION){
     char *end_msg;
     end_msg = cJSON_PrintUnformatted(object);
     mtdebug2(WM_SYS_LOGTAG, "sys_programs_linux() sending '%s'", end_msg);
-    SendMSG(queue_fd, end_msg, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, queue_fd, end_msg, LOCATION, SYSCOLLECTOR_MQ);
     cJSON_Delete(object);
     free(end_msg);
     free(timestamp);
@@ -648,6 +657,9 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
     char *timestamp;
     time_t now;
     struct tm localtm;
+
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
 
     now = time(NULL);
     localtime_r(&now, &localtm);
@@ -880,7 +892,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
         /* Send interface data in JSON format */
         string = cJSON_PrintUnformatted(object);
         mtdebug2(WM_SYS_LOGTAG, "sys_network_linux() sending '%s'", string);
-        SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+        wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
         cJSON_Delete(object);
 
         free(string);
@@ -900,7 +912,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
     char *string;
     string = cJSON_PrintUnformatted(object);
     mtdebug2(WM_SYS_LOGTAG, "sys_network_linux() sending '%s'", string);
-    SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
     cJSON_Delete(object);
     free(string);
     free(timestamp);
@@ -1350,6 +1362,9 @@ void sys_proc_linux(int queue_fd, const char* LOCATION) {
     time_t now;
     struct tm localtm;
 
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
     now = time(NULL);
     localtime_r(&now, &localtm);
 
@@ -1434,13 +1449,13 @@ void sys_proc_linux(int queue_fd, const char* LOCATION) {
 
     string = cJSON_PrintUnformatted(id_msg);
     mtdebug2(WM_SYS_LOGTAG, "sys_proc_linux() sending '%s'", string);
-    SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
     free(string);
 
     cJSON_ArrayForEach(item, proc_array) {
         string = cJSON_PrintUnformatted(item);
         mtdebug2(WM_SYS_LOGTAG, "sys_proc_linux() sending '%s'", string);
-        SendMSG(queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
+        wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
         free(string);
     }
 
@@ -1456,7 +1471,7 @@ void sys_proc_linux(int queue_fd, const char* LOCATION) {
     char *end_msg;
     end_msg = cJSON_PrintUnformatted(object);
     mtdebug2(WM_SYS_LOGTAG, "sys_proc_linux() sending '%s'", end_msg);
-    SendMSG(queue_fd, end_msg, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, queue_fd, end_msg, LOCATION, SYSCOLLECTOR_MQ);
     cJSON_Delete(object);
     free(end_msg);
     free(timestamp);

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -134,6 +134,9 @@ void sys_ports_windows(const char* LOCATION, int check_all){
     int listening;
     int i = 0;
 
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
     // Set random ID for each scan
 
     unsigned int ID1 = os_random();
@@ -239,7 +242,7 @@ void sys_ports_windows(const char* LOCATION, int check_all){
                 char *string;
                 string = cJSON_PrintUnformatted(object);
                 mtdebug2(WM_SYS_LOGTAG, "sys_ports_windows() sending '%s'", string);
-                SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+                wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
                 cJSON_Delete(object);
                 free(string);
 
@@ -351,7 +354,7 @@ void sys_ports_windows(const char* LOCATION, int check_all){
                 char *string;
                 string = cJSON_PrintUnformatted(object);
                 mtdebug2(WM_SYS_LOGTAG, "sys_ports_windows() sending '%s'", string);
-                SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+                wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
                 cJSON_Delete(object);
                 free(string);
 
@@ -383,7 +386,7 @@ void sys_ports_windows(const char* LOCATION, int check_all){
         char *string;
         string = cJSON_PrintUnformatted(object);
         mtdebug2(WM_SYS_LOGTAG, "sys_ports_windows() sending '%s'", string);
-        SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+        wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
         cJSON_Delete(object);
         free(string);
         free(timestamp);
@@ -442,7 +445,7 @@ void sys_ports_windows(const char* LOCATION, int check_all){
 
             string = cJSON_PrintUnformatted(object);
             mtdebug2(WM_SYS_LOGTAG, "sys_ports_windows() sending '%s'", string);
-            SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+            wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
             cJSON_Delete(object);
 
             free(string);
@@ -510,7 +513,7 @@ void sys_ports_windows(const char* LOCATION, int check_all){
 
             string = cJSON_PrintUnformatted(object);
             mtdebug2(WM_SYS_LOGTAG, "sys_ports_windows() sending '%s'", string);
-            SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+            wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
             cJSON_Delete(object);
 
             free(laddress);
@@ -536,7 +539,7 @@ void sys_ports_windows(const char* LOCATION, int check_all){
     char *string;
     string = cJSON_PrintUnformatted(object);
     mtdebug2(WM_SYS_LOGTAG, "sys_ports_windows() sending '%s'", string);
-    SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
     cJSON_Delete(object);
     free(string);
     free(timestamp);
@@ -552,6 +555,9 @@ void sys_programs_windows(const char* LOCATION){
     char read_buff[OS_MAXSTR];
     int i;
     int status;
+
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
 
     // Set timestamp
 
@@ -635,7 +641,7 @@ void sys_programs_windows(const char* LOCATION){
 
             string = cJSON_PrintUnformatted(object);
             mtdebug2(WM_SYS_LOGTAG, "sys_programs_windows() sending '%s'", string);
-            SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+            wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
             cJSON_Delete(object);
             free(string);
         }
@@ -653,7 +659,7 @@ void sys_programs_windows(const char* LOCATION){
     char *string;
     string = cJSON_PrintUnformatted(object);
     mtdebug2(WM_SYS_LOGTAG, "sys_programs_windows() sending '%s'", string);
-    SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
     cJSON_Delete(object);
     free(string);
     free(timestamp);
@@ -837,6 +843,9 @@ void sys_network_windows(const char* LOCATION){
             return;
         }else{
 
+            // Define time to sleep between messages sent
+            int usec = 1000000 / wm_max_eps;
+
             // Set random ID and timestamp
 
             unsigned int ID1 = os_random();
@@ -915,7 +924,7 @@ void sys_network_windows(const char* LOCATION){
                     string = _get_network_win(pCurrAddresses, ID, timestamp);
 
                     mtdebug2(WM_SYS_LOGTAG, "sys_network_windows() sending '%s'", string);
-                    SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+                    wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
 
                     free(string);
 
@@ -954,7 +963,7 @@ void sys_network_windows(const char* LOCATION){
             char *string;
             string = cJSON_PrintUnformatted(object);
             mtdebug2(WM_SYS_LOGTAG, "sys_network_windows() sending '%s'", string);
-            SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+            wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
             cJSON_Delete(object);
             free(string);
             free(timestamp);
@@ -1145,6 +1154,9 @@ void sys_proc_windows(const char* LOCATION) {
     char read_buff[OS_MAXSTR];
     int status;
 
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
     // Set timestamp
 
     char *timestamp;
@@ -1226,12 +1238,12 @@ void sys_proc_windows(const char* LOCATION) {
 
         string = cJSON_PrintUnformatted(id_msg);
         mtdebug2(WM_SYS_LOGTAG, "sys_proc_windows() sending '%s'", string);
-        SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+        wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
 
         cJSON_ArrayForEach(item, proc_array) {
             string = cJSON_PrintUnformatted(item);
             mtdebug2(WM_SYS_LOGTAG, "sys_proc_windows() sending '%s'", string);
-            SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+            wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
         }
 
         free(string);
@@ -1251,7 +1263,7 @@ void sys_proc_windows(const char* LOCATION) {
     char *string;
     string = cJSON_PrintUnformatted(object);
     mtdebug2(WM_SYS_LOGTAG, "sys_proc_windows() sending '%s'", string);
-    SendMSG(0, string, LOCATION, SYSCOLLECTOR_MQ);
+    wm_sendmsg(usec, 0, string, LOCATION, SYSCOLLECTOR_MQ);
     cJSON_Delete(object);
     free(string);
     free(timestamp);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -27,8 +27,9 @@ const wm_context WM_AWS_CONTEXT = {
 void * wm_aws_main(wm_aws_t * config) {
     time_t time_start;
     time_t time_sleep = 0;
+
+    // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
-    struct timeval timeout = { 0, usec };
 
     if (!config->enabled) {
         mtwarn(WM_AWS_LOGTAG, "Module AWS-CloudTrail is disabled. Exiting.");
@@ -38,7 +39,7 @@ void * wm_aws_main(wm_aws_t * config) {
     mtinfo(WM_AWS_LOGTAG, "Module AWS-CloudTrail started");
 
     // Connect to socket
-    
+
     int i;
 
     for (i = 0; config->queue_fd = StartMQ(DEFAULTQPATH, WRITE), config->queue_fd < 0 && i < WM_MAX_ATTEMPTS; i++) {
@@ -64,8 +65,8 @@ void * wm_aws_main(wm_aws_t * config) {
     while (1) {
         int status;
         char * output = NULL;
-        char *command = NULL;  
-  
+        char *command = NULL;
+
         // Create arguments
 
         wm_strcat(&command, WM_AWS_SCRIPT_PATH, '\0');
@@ -113,9 +114,7 @@ void * wm_aws_main(wm_aws_t * config) {
         char * line;
 
         for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
-            timeout.tv_usec = usec;
-            select(0 , NULL, NULL, NULL, &timeout);
-            SendMSG(config->queue_fd, line, WM_AWS_CONTEXT.name, LOCALFILE_MQ);
+            wm_sendmsg(usec, config->queue_fd, line, WM_AWS_CONTEXT.name, LOCALFILE_MQ);
         }
 
         free(output);

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -1112,6 +1112,9 @@ void wm_ciscat_send_scan(wm_scan_data *info){
     cJSON *object = NULL;
     cJSON *data = NULL;
 
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
     // Set pointer to the head of the linked list
 
     rule = head;
@@ -1164,9 +1167,9 @@ void wm_ciscat_send_scan(wm_scan_data *info){
     msg = cJSON_PrintUnformatted(object);
     mtdebug2(WM_CISCAT_LOGTAG, "Sending CIS-CAT event: '%s'", msg);
 #ifdef WIN32
-    SendMSG(0, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
+    wm_sendmsg(usec, 0, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
 #else
-    SendMSG(queue_fd, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
+    wm_sendmsg(usec, queue_fd, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
 #endif
     cJSON_Delete(object);
 
@@ -1203,9 +1206,9 @@ void wm_ciscat_send_scan(wm_scan_data *info){
         msg = cJSON_PrintUnformatted(object);
         mtdebug2(WM_CISCAT_LOGTAG, "Sending CIS-CAT event: '%s'", msg);
     #ifdef WIN32
-        SendMSG(0, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
+        wm_sendmsg(usec, 0, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
     #else
-        SendMSG(queue_fd, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
+        wm_sendmsg(usec, queue_fd, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
     #endif
         cJSON_Delete(object);
 

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -140,9 +140,7 @@ void wm_oscap_run(wm_oscap_eval *eval) {
     wm_oscap_profile *profile;
 
     // Define time to sleep between messages sent
-
     int usec = 1000000 / wm_max_eps;
-    struct timeval timeout = {0, usec};
 
     // Create arguments
 
@@ -222,15 +220,11 @@ void wm_oscap_run(wm_oscap_eval *eval) {
     }
 
     for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
-        timeout.tv_usec = usec;
-        select(0 , NULL, NULL, NULL, &timeout);
-        SendMSG(queue_fd, line, WM_OSCAP_LOCATION, LOCALFILE_MQ);
+        wm_sendmsg(usec, queue_fd, line, WM_OSCAP_LOCATION, LOCALFILE_MQ);
     }
 
     snprintf(msg, OS_MAXSTR, "Ending OpenSCAP scan. File: %s. ", eval->path);
-    timeout.tv_usec = usec;
-    select(0 , NULL, NULL, NULL, &timeout);
-    SendMSG(queue_fd, msg, "rootcheck", ROOTCHECK_MQ);
+    wm_sendmsg(usec, queue_fd, msg, "rootcheck", ROOTCHECK_MQ);
 
     free(output);
     free(command);

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -325,6 +325,9 @@ int wm_vulnerability_detector_report_agent_vulnerabilities(agent_software *agent
     char *rationale;
     int i;
 
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
     if (alert = cJSON_CreateObject(), !alert) {
         return OS_INVALID;
     }
@@ -411,7 +414,7 @@ int wm_vulnerability_detector_report_agent_vulnerabilities(agent_software *agent
             snprintf(alert_msg, OS_MAXSTR, VU_ALERT_JSON, str_json);
             free(str_json);
 
-            if (SendMSG(*vu_queue, alert_msg, header, SECURE_MQ) < 0) {
+            if (wm_sendmsg(usec, *vu_queue, alert_msg, header, SECURE_MQ) < 0) {
                 mterror(WM_VULNDETECTOR_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
                 if ((*vu_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
                     mterror_exit(WM_VULNDETECTOR_LOGTAG, QUEUE_FATAL, DEFAULTQUEUE);

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -249,3 +249,22 @@ void wm_free(wmodule * config) {
         free(cur_module);
     }
 }
+
+// Send message to a queue waiting for a specific delay
+int wm_sendmsg(int usec, int queue, const char *message, const char *locmsg, char loc) {
+
+#ifdef WIN32
+    int msec = usec / 1000;
+    Sleep(msec);
+#else
+    struct timeval timeout = {0, usec};
+    select(0, NULL, NULL, NULL, &timeout);
+#endif
+
+    if (SendMSG(queue, message, locmsg, loc) < 0) {
+        merror("At wm_sendmsg(): Unable to send message to queue: (%s)", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -121,4 +121,7 @@ int wm_state_io(const char * tag, int op, void *state, size_t size);
 // Frees the wmodule struct
 void wm_free(wmodule * c);
 
+// Send message to a queue with a specific delay
+int wm_sendmsg(int usec, int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
+
 #endif // W_MODULES


### PR DESCRIPTION
This PR adds a configurable maximum of events per seconds for all wodles.

It is configurable by the internal option `wazuh_modules.max_eps` in events/second.

This avoids flooding the manager if a wodle sends more events than the agent bucket or the manager can ingest.