### PR TITLE
Fix group in GET/agents

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -844,7 +844,7 @@ class Agent:
             valid_select_fields.remove('node_name') # only return node_type if asked
             select_fields = valid_select_fields
 
-        set_select_fields = set(select['fields']) if select else select_fields
+        set_select_fields = set(select['fields']) if select else select_fields.copy()
 
         if status != "all":
             limit_seconds = 600*3 + 30
@@ -1002,7 +1002,7 @@ class Agent:
                 if value != None and field == 'node_name' and field in set_select_fields:
                     data_tuple['node_name'] = value
 
-                if value != None and field == '`group`' and field in set_select_fields:
+                if value != None and field == '`group`' and 'group' in set_select_fields:
                     data_tuple['group'] = value
 
                 if value != None and field == 'merged_sum' and field in set_select_fields:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -832,7 +832,7 @@ class Agent:
                                'group', 'merged_sum', 'config_sum','os_codename', 'os_major', 'os_uname',
                                'last_keepalive', 'os_arch'}
         select_fields = {'id', 'version', 'last_keepalive'}
-        search_fields = {"id", "name", "ip", "os_name", "os_version", "os_platform", "manager_host", "version"}
+        search_fields = {"id", "name", "ip", "os_name", "os_version", "os_platform", "manager_host", "version", "`group`"}
         request = {}
         if select:
             if not set(select['fields']).issubset(valid_select_fields):
@@ -933,7 +933,6 @@ class Agent:
             if not select_os_uname:
                 select_fields.add('os_uname')
                 set_select_fields.add('os_uname')
-
         conn.execute(query.format(','.join(select_fields)), request)
 
         data['items'] = []
@@ -1003,7 +1002,7 @@ class Agent:
                 if value != None and field == 'node_name' and field in set_select_fields:
                     data_tuple['node_name'] = value
 
-                if value != None and field == '`group`' and 'group' in set_select_fields:
+                if value != None and field == '`group`' and field in set_select_fields:
                     data_tuple['group'] = value
 
                 if value != None and field == 'merged_sum' and field in set_select_fields:


### PR DESCRIPTION
This PR fixes a bug getting the group and searching by group in GET/agents.

### Before

```
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "status": "Active",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "name": "agent001",
            "mergedSum": "7d2d2c2eb83bb8b529a9f99e506368a6",
            "ip": "any",
            "dateAdd": "2018-02-13 11:46:58",
            "version": "Wazuh v3.2.0",
            "manager_host": "manager",
            "lastKeepAlive": "2018-02-13 11:47:36",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |manager |3.10.0-693.11.1.el7.x86_64 |#1 SMP Mon Dec 4 23:52:40 UTC 2017 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "001"
         }
      ]
   }
}
```

### Now

```
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "status": "Active",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": "dbms",
            "name": "agent001",
            "mergedSum": "7d2d2c2eb83bb8b529a9f99e506368a6",
            "ip": "any",
            "dateAdd": "2018-02-13 11:46:58",
            "version": "Wazuh v3.2.0",
            "manager_host": "manager",
            "lastKeepAlive": "2018-02-13 11:47:36",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |manager |3.10.0-693.11.1.el7.x86_64 |#1 SMP Mon Dec 4 23:52:40 UTC 2017 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "001"
         }
      ]
   }
}
```