### PR TITLE
Allow inserting static decoder in rules description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Supporting multiple socket output in Logcollector. ([#395](https://github.com/wazuh/wazuh/pull/395))
+- Allow inserting static field parameters in rule comments. ([#397](https://github.com/wazuh/wazuh/pull/397))
 
 ## [v3.2.0] 2018-02-13
 

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -341,7 +341,7 @@ void *Protocol_FP(Eventinfo *lf, char *field, __attribute__((unused)) const char
 {
 #ifdef TESTRULE
     if (!alert_only) {
-        print_out("       proto: '%s'", field);
+        print_out("       protocol: '%s'", field);
     }
 #endif
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -707,6 +707,7 @@ char* ParseRuleComment(Eventinfo *lf) {
     strncpy(orig, lf->generated_rule->comment, OS_COMMENT_MAX);
 
     for (str = orig; (tok = strstr(str, "$(")); str = end) {
+        field = NULL;
         *tok = '\0';
         var = tok + 2;
 
@@ -724,21 +725,52 @@ char* ParseRuleComment(Eventinfo *lf) {
 
         *(end++) = '\0';
 
-        if ((field = FindField(lf, var))) {
+        // Find static fields
+
+        if (strcmp(var, "dstuser") == 0) {
+            field = lf->dstuser;
+        } else if (strcmp(var, "srcuser") == 0) {
+            field = lf->srcuser;
+        } else if (strcmp(var, "srcip") == 0) {
+            field = lf->srcip;
+        } else if (strcmp(var, "dstip") == 0) {
+            field = lf->dstip;
+#ifdef LIBGEOIP_ENABLED
+        } else if (strcmp(var, "srcgeoip") == 0) {
+            field = lf->srcgeoip;
+        } else if (strcmp(var, "dstuser") == 0) {
+            field = lf->dstgeoip;
+#endif
+        } else if (strcmp(var, "srcport") == 0) {
+            field = lf->srcport;
+        } else if (strcmp(var, "protocol") == 0) {
+            field = lf->protocol;
+        } else if (strcmp(var, "action") == 0) {
+            field = lf->action;
+        } else if (strcmp(var, "id") == 0) {
+            field = lf->id;
+        } else if (strcmp(var, "url") == 0) {
+            field = lf->url;
+        } else if (strcmp(var, "data") == 0 || strcmp(var, "extra_data") == 0) {
+            field = lf->data;
+        } else if (strcmp(var, "status") == 0) {
+            field = lf->status;
+        } else if (strcmp(var, "system_name") == 0) {
+            field = lf->systemname;
+        }
+
+        // Find dynamic fields
+
+        else {
+            field = FindField(lf, var);
+        }
+
+        if (field) {
             if (n + (z = strlen(field)) >= OS_COMMENT_MAX)
                 return strdup(lf->generated_rule->comment);
 
             strncpy(&final[n], field, z);
             n += z;
-        } else {
-            *tok = '$';
-
-            if (n + (z = strlen(tok)) + 1 >= OS_COMMENT_MAX)
-                return strdup(lf->generated_rule->comment);
-
-            strncpy(&final[n], tok, z);
-            n += z;
-            final[n++] = ')';
         }
     }
 


### PR DESCRIPTION
This PR allows static field substitution in rule comments.

If a field does not exist or it's empty, the parameter will be deleted.

## Example

**Decoder:**

```xml
<decoder name="demo">
  <prematch>^demo: </prematch>
  <program_name>myapp</program_name>
  <regex offset="after_prematch">^(\S+) (\S+) (\S+) (\S+) (\S+)</regex>
  <order>srcip,action,item,url,arg</order>
</decoder>
```

**Rule:**

```xml
<rule id="100001" level="5">
  <decoded_as>demo</decoded_as>
  <description>srcip=$(srcip), action=$(action), item=$(item), url=$(url), dstip=$(dstip), fz=$(fz), k=$k</description>
</rule>
```

**Alert example:**

```
Feb 16 14:00:00 localhost myapp: demo: 1.2.3.4 insert tuple http://example.com 2.3.4.5


**Phase 1: Completed pre-decoding.
       full event: 'Feb 16 14:00:00 localhost myapp: demo: 1.2.3.4 insert tuple http://example.com 2.3.4.5'
       timestamp: 'Feb 16 14:00:00'
       hostname: 'localhost'
       program_name: 'myapp'
       log: 'demo: 1.2.3.4 insert tuple http://example.com 2.3.4.5'

**Phase 2: Completed decoding.
       decoder: 'demo'
       srcip: '1.2.3.4'
       action: 'insert'
       item: 'tuple'
       url: 'http://example.com'
       arg: '2.3.4.5'

**Phase 3: Completed filtering (rules).
       Rule id: '100001'
       Level: '5'
       Description: 'srcip=1.2.3.4, action=insert, item=tuple, url=http://example.com, dstip=, fz=, k=$k'
**Alert to be generated.
```