### PR TITLE
Synchronize ossec.conf file in cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Supporting multiple socket output in Logcollector. ([#395](https://github.com/wazuh/wazuh/pull/395))
+- Allow inserting static field parameters in rule comments. ([#397](https://github.com/wazuh/wazuh/pull/397))
 
 ## [v3.2.0] 2018-02-13
 

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -214,7 +214,7 @@ def restart_manager():
 
 def crontab_sync_master(interval, config_cluster, requests_queue, connected_clients, finished_clients):
     def sleep_handler(n_signal, frame):
-        logging.debug("Sleeping for {}{}...".format(interval_number, interval_measure))
+        logging.info("Sleeping for {}{}...".format(interval_number, interval_measure))
         sleep(interval_number if interval_measure == 's' else interval_number*60)
 
     interval_number  = int(search('\d+', interval).group(0))

--- a/framework/wazuh/cluster.json
+++ b/framework/wazuh/cluster.json
@@ -5,7 +5,7 @@
         "source": "master",
         "write_mode": "atomic",
         "flags": ["IN_MOVED_TO"],
-        "files": ["client.keys"],
+        "files": ["client.keys", "ossec.conf"],
         "recursive": false,
         "restart": false,
         "description": "client keys file database"
@@ -85,7 +85,6 @@
 
     "excluded_files": [
         "ar.conf",
-        "merged.mg",
-        "ossec.conf"
+        "merged.mg"
     ]
 }

--- a/framework/wazuh/cluster.json
+++ b/framework/wazuh/cluster.json
@@ -1,87 +1,100 @@
 {
-    "/etc/": {
-        "umask": "0o117",
-        "format":"plain",
-        "source": "master",
-        "write_mode": "atomic",
-        "flags": ["IN_MOVED_TO"],
-        "files": ["client.keys", "ossec.conf"],
-        "recursive": false,
-        "restart": false,
-        "description": "client keys file database"
-    },
+    "/etc/": [
+        {
+            "umask": "0o117",
+            "format":"plain",
+            "source": "master",
+            "write_mode": "atomic",
+            "flags": ["IN_MOVED_TO"],
+            "files": ["client.keys"],
+            "recursive": false,
+            "restart": false,
+            "description": "agent keys database file"
+        },
+        {
+            "umask": "0o117",
+            "format":"plain",
+            "source": "master",
+            "write_mode": "atomic",
+            "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_MODIFY"],
+            "files": ["ossec.conf"],
+            "recursive": false,
+            "restart": true,
+            "description": "wazuh configuration file"
+        }
+    ],
 
-    "/etc/shared/": {
-        "umask": "0o117",
-        "format": "plain",
-        "source": "master",
-        "write_mode": "atomic",
-        "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE", "IN_CREATE", "IN_ISDIR"],
-        "files": ["all"],
-        "recursive": true,
-        "restart": false,
-        "description": "shared configuration files"
-    },
+    "/etc/shared/": [{
+            "umask": "0o117",
+            "format": "plain",
+            "source": "master",
+            "write_mode": "atomic",
+            "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE", "IN_CREATE", "IN_ISDIR"],
+            "files": ["all"],
+            "recursive": true,
+            "restart": false,
+            "description": "shared configuration files"
+        }],
 
-    "/queue/agent-info/": {
-        "umask": "0o117",
-        "format":"plain",
-        "source": "client",
-        "write_mode": "atomic",
-        "flags": ["IN_CLOSE_WRITE", "IN_ATTRIB", "IN_MOVED_TO", "IN_DELETE"],
-        "files": ["all"],
-        "recursive": false,
-        "restart": false,
-        "description": "agent status"
-    },
+    "/queue/agent-info/": [{
+            "umask": "0o117",
+            "format":"plain",
+            "source": "client",
+            "write_mode": "atomic",
+            "flags": ["IN_CLOSE_WRITE", "IN_ATTRIB", "IN_MOVED_TO", "IN_DELETE"],
+            "files": ["all"],
+            "recursive": false,
+            "restart": false,
+            "description": "agent status"
+        }],
 
-    "/queue/agent-groups/": {
-        "umask": "0o117",
-        "format":"plain",
-        "source": "all",
-        "write_mode": "atomic",
-        "flags": ["IN_CLOSE_WRITE", "IN_MOVED_TO", "IN_DELETE"],
-        "files": ["all"],
-        "recursive": false,
-        "restart": false,
-        "description": "agents group configuration"
-    },
+    "/queue/agent-groups/": [{
+            "umask": "0o117",
+            "format":"plain",
+            "source": "all",
+            "write_mode": "atomic",
+            "flags": ["IN_CLOSE_WRITE", "IN_MOVED_TO", "IN_DELETE"],
+            "files": ["all"],
+            "recursive": false,
+            "restart": false,
+            "description": "agents group configuration"
+        }],
 
-    "/etc/rules/": {
-        "umask": "0o137",
-        "format": "plain",
-        "source": "master",
-        "write_mode": "atomic",
-        "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
-        "files": ["all"],
-        "recursive": false,
-        "restart": true,
-        "description": "user rules"
-    },
+    "/etc/rules/": [{
+            "umask": "0o137",
+            "format": "plain",
+            "source": "master",
+            "write_mode": "atomic",
+            "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
+            "files": ["all"],
+            "recursive": false,
+            "restart": true,
+            "description": "user rules"
+        }],
 
-    "/etc/decoders/": {
-        "umask": "0o137",
-        "format": "plain",
-        "source": "master",
-        "write_mode": "atomic",
-        "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
-        "files": ["all"],
-        "recursive": false,
-        "restart": true,
-        "description": "user decoders"
-    },
+    "/etc/decoders/": [{
+            "umask": "0o137",
+            "format": "plain",
+            "source": "master",
+            "write_mode": "atomic",
+            "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
+            "files": ["all"],
+            "recursive": false,
+            "restart": true,
+            "description": "user decoders"
+        }],
 
-    "/etc/lists/": {
-        "umask": "0o137",
-        "format": "plain",
-        "source": "master",
-        "write_mode": "atomic",
-        "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
-        "files": ["all"],
-        "recursive": true,
-        "restart": true,
-        "description": "user CDB lists"
-    },
+    "/etc/lists/": [{
+            "umask": "0o137",
+            "format": "plain",
+            "source": "master",
+            "write_mode": "atomic",
+            "flags": ["IN_MOVED_TO", "IN_CLOSE_WRITE", "IN_DELETE"],
+            "files": ["all"],
+            "recursive": true,
+            "restart": true,
+            "description": "user CDB lists"
+        }],
 
     "excluded_files": [
         "ar.conf",

--- a/framework/wazuh/cluster/handler.py
+++ b/framework/wazuh/cluster/handler.py
@@ -354,13 +354,11 @@ def _check_ossec_conf(new_content, fullpath, mtime):
         local_ossec_conf = ET.fromstring('<root_tag>' + f.read() + '</root_tag>')
 
     xml_conf = ET.fromstring('<root_tag>' + new_content + '</root_tag>')
-    config = xml_conf.find('ossec_config')
-    config.remove(config.find('cluster'))
+    config = xml_conf.find('ossec_config').find('cluster')
 
     local_cluster_conf = local_ossec_conf.find('ossec_config').find('cluster')
-    config.insert(-1, local_cluster_conf)
 
-    return ET.tostring(xml_conf.find('ossec_config'))
+    return new_content.replace(ET.tostring(config), ET.tostring(local_cluster_conf))
 
 
 def _check_agent_infos(new_content, fullpath, mtime):

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -112,7 +112,7 @@ class WazuhException(Exception):
         3004: 'Error in cluster configuration',
         3005: 'Error reading cluster JSON file',
         3006: 'Error reading cluster configuration',
-        3007: 'Client.keys file received in master node',
+        3007: 'Invalid file received in master node',
         3008: 'Error importing cryptography module',
         3009: 'Error connecting to cluster database',
         3010: 'Error in cluster client',


### PR DESCRIPTION
Hello,

This PR adds support to synchronize the ossec.conf file in the cluster. To do so, the `<cluster>` section of the incoming ossec.conf is replaced by the `<cluster>` section of the local configuration before synchronizing. This way, each node will have its own cluster configuration and the master's configuration for the rest of Wazuh components.

Best regards,
Marta