### PR TITLE
Improve error management for CIS-CAT wodle

### DIFF
--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -223,6 +223,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path) {
     char *ciscat_script;
     wm_scan_data *scan_info = NULL;
     wm_rule_data *rule_info = NULL;
+    char eval_path[OS_MAXSTR];
 
     os_calloc(OS_MAXSTR, sizeof(char), ciscat_script);
 
@@ -238,8 +239,11 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path) {
 
     switch (eval->type) {
     case WM_CISCAT_XCCDF:
+
+        snprintf(eval_path, OS_MAXSTR - 1, "\"%s\"", eval->path);
+
         wm_strcat(&command, "-b", ' ');
-        wm_strcat(&command, eval->path, ' ');
+        wm_strcat(&command, eval_path, ' ');
 
         if (eval->profile) {
             wm_strcat(&command, "-p", ' ');

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -14,6 +14,7 @@
 
 #define WM_DEF_TIMEOUT      1800            // Default runtime limit (30 minutes)
 #define WM_DEF_INTERVAL     86400           // Default cycle interval (1 day)
+#define MAX_RESULT          64              // Maximum result length
 
 #define WM_CISCAT_LOGTAG ARGV0 ":ciscat"
 #define WM_CISCAT_DEFAULT_DIR WM_DEFAULT_DIR "/ciscat"


### PR DESCRIPTION
This PR adds the following:

- Delete correctly the PID file when CIS-CAT is stopped suddenly.
- Validate the CIS-CAT tool location set in the configuration.
- Stop the evaluation process if any error is found.

Tested in Linux and Windows for the following use cases:

- Set a wrong CIS-CAT path.
- Delete the PID files correctly when an error stops the execution of the scan.
- Behaviour when some errors happen, such as the specification of an incorrect evaluation profile.

