### PR TITLE
Verify all configuration modules with the "verify-agent-conf" tool

### DIFF
--- a/src/util/verify-agent-conf.c
+++ b/src/util/verify-agent-conf.c
@@ -19,6 +19,7 @@
 
 /* Prototypes */
 static void helpmsg(void) __attribute__((noreturn));
+static int verify_agent_conf(const char * path);
 
 
 static void helpmsg()
@@ -42,11 +43,6 @@ int main(int argc, char **argv)
     struct dirent *entry;
     int c = 0;
     int error = 0;
-    int modules = 0;
-    logreader_config log_config;
-
-    modules |= CLOCALFILE;
-    modules |= CAGENT_CONFIG;
 
     /* Set the name */
     OS_SetName(ARGV0);
@@ -76,9 +72,7 @@ int main(int argc, char **argv)
                             break;
                         }
 
-                        log_config.config = NULL;
-
-                        if (ReadConfig(modules, optarg, &log_config, NULL) < 0)
+                        if (verify_agent_conf(optarg) < 0)
                             error = 1;
                         else
                             printf("%s: OK\n", ARGV0);
@@ -133,9 +127,7 @@ int main(int argc, char **argv)
                 continue;
             }
 
-            log_config.config = NULL;
-
-            if (ReadConfig(modules, path_f, &log_config, NULL) < 0)
+            if (verify_agent_conf(path_f) < 0)
                 error = 1;
             else
                 printf("%s: OK\n", ARGV0);
@@ -146,4 +138,25 @@ int main(int argc, char **argv)
     }
     printf("\n");
     return (error);
+}
+
+int verify_agent_conf(const char * path) {
+
+    if (Test_Syscheck(path) < 0) {
+        return -1;
+    } else if (Test_Rootcheck(path) < 0) {
+        return -1;
+    } else if (Test_Localfile(path) < 0) {
+        return -1;
+    } else if (Test_Client(path) < 0) {
+        return -1;
+    } else if (Test_ClientBuffer(path) < 0) {
+        return -1;
+    } else if (Test_WModule(path) < 0) {
+        return -1;
+    } else if (Test_Labels(path) < 0) {
+        return -1;
+    }
+
+    return 0;
 }

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -15,6 +15,7 @@
 static wm_sys_t *sys;                           // Pointer to configuration
 
 static void* wm_sys_main(wm_sys_t *sys);        // Module main function. It won't return
+static void wm_sys_destroy(wm_sys_t *sys);      // Destroy data
 const char *WM_SYS_LOCATION = "syscollector";   // Location field for event sending
 
 // Syscollector module context definition
@@ -22,7 +23,7 @@ const char *WM_SYS_LOCATION = "syscollector";   // Location field for event send
 const wm_context WM_SYS_CONTEXT = {
     "syscollector",
     (wm_routine)wm_sys_main,
-    NULL
+    (wm_routine)wm_sys_destroy
 };
 
 #ifndef WIN32
@@ -262,4 +263,8 @@ void delay(unsigned int ms) {
     select(0, NULL, NULL, NULL, &timeout);
 #endif
 
+}
+
+void wm_sys_destroy(wm_sys_t *sys) {
+    free(sys);
 }


### PR DESCRIPTION
Added checks for all modules supported by the centralized configuration looking for a wrong configuration in the ``agent.conf`` file.

Example with a bad configuration:

```
root@ubuntu:/var/ossec/bin# ./verify-agent-conf

verify-agent-conf: Verifying [/var/ossec/etc/shared/default/agent.conf]
2018/02/20 12:32:26 verify-agent-conf: ERROR: No such tag 'scan-on-start' at module 'syscollector'.
2018/02/20 12:32:26 verify-agent-conf: ERROR: (1202): Configuration error at '/var/ossec/etc/shared/default/agent.conf'. Exiting.
2018/02/20 12:32:26 verify-agent-conf: ERROR: (1207): WModule remote configuration in '/var/ossec/etc/shared/default/agent.conf' is corrupted.
```