### PR TITLE
Fix openssl compilation warnings

### DIFF
--- a/src/os_auth/check_cert.c
+++ b/src/os_auth/check_cert.c
@@ -302,7 +302,7 @@ char *asn1_to_cstr(ASN1_STRING *astr)
         return NULL;
     }
 
-    if (!(tmp = (char *)ASN1_STRING_data(astr))) {
+    if (!(tmp = (char *)ASN1_STRING_get0_data(astr))) {
         return NULL;
     }
 

--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -102,7 +102,7 @@ SSL_CTX *get_ssl_context(const char *ciphers, int auto_method)
 
     /* Create our context */
 
-    if (!(ctx = auto_method ? SSL_CTX_new(SSLv23_method()) : SSL_CTX_new(TLSv1_2_method()))) {
+    if (!(ctx = auto_method ? SSL_CTX_new(SSLv23_method()) : SSL_CTX_new(TLS_method()))) {
         goto CONTEXT_ERR;
     }
 

--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -102,12 +102,17 @@ SSL_CTX *get_ssl_context(const char *ciphers, int auto_method)
 
     /* Create our context */
 
-    if (!(ctx = auto_method ? SSL_CTX_new(SSLv23_method()) : SSL_CTX_new(TLS_method()))) {
+    if (ctx = SSL_CTX_new(TLS_method()), !ctx) {
         goto CONTEXT_ERR;
     }
 
     /* Explicitly set options and cipher list */
-    SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2);
+
+    // If auto_method isn't set, allow TLSv1.2 only
+    if (!auto_method) {
+        SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
+    }
+
     if (!(SSL_CTX_set_cipher_list(ctx, ciphers))) {
         goto CONTEXT_ERR;
     }


### PR DESCRIPTION
This fixes compilation warnings for deprecated functions when building os_auth