### PR TITLE
CIS-CAT: Support full and relative paths in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Verify all modules for the shared configuration. ([#408](https://github.com/wazuh/wazuh/pull/408))
 - Updated OpenSSL library to 1.1.0g.
 - Insert agent labels in JSON archives no matter the event matched a rule.
+- Support for relative/full/network paths in the CIS-CAT configuration. ([#419](https://github.com/wazuh/wazuh/pull/419))
 
 ### Fixed
 

--- a/etc/templates/config/generic/wodle-ciscat.template
+++ b/etc/templates/config/generic/wodle-ciscat.template
@@ -4,6 +4,6 @@
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
 
-    <java_path>/usr/bin</java_path>
-    <ciscat_path>${INSTALLDIR}/wodles/ciscat</ciscat_path>
+    <java_path>wodles/java</java_path>
+    <ciscat_path>wodles/ciscat</ciscat_path>
   </wodle>

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -268,3 +268,33 @@ int wm_sendmsg(int usec, int queue, const char *message, const char *locmsg, cha
 
     return 0;
 }
+
+// Check if a path is relative or absolute.
+// Returns 0 if absolute, 1 if relative or -1 on error.
+int wm_relative_path(const char * path) {
+
+    if (!path || path[0] == '\0') {
+        merror("At wm_relative_path(): Null path.");
+        return -1;
+    }
+
+#ifdef WIN32
+    if (((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z')) && path[1] == ':') {
+        // Is a full path
+        return 0;
+    } else if ((path[0] == '\\' && path[1] == '\\')) {
+        // Is a network resource
+        return 0;
+    } else {
+        // Relative path
+        return 1;
+    }
+#else
+    if (path[0] != '/') {
+        // Relative path
+        return 1;
+    }
+#endif
+
+    return 0;
+}

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -124,4 +124,8 @@ void wm_free(wmodule * c);
 // Send message to a queue with a specific delay
 int wm_sendmsg(int usec, int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
 
+// Check if a path is relative or absolute.
+// Returns 0 if absolute, 1 if relative or -1 on error.
+int wm_relative_path(const char * path);
+
 #endif // W_MODULES

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -156,8 +156,8 @@
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
 
-    <java_path>\\server\jre\bin\java.exe</java_path>
-    <ciscat_path>C:\cis-cat</ciscat_path>
+    <java_path>wodles\java</java_path>
+    <ciscat_path>wodles\cis-cat</ciscat_path>
   </wodle>
 
   <!-- Active response -->


### PR DESCRIPTION
Added the possibility of defining the configurable paths of the CIS-CAT wodle configuration in two different ways:

- Using the full path:

```
  <!-- CIS policies evaluation -->
  <wodle name="cis-cat">
    <disabled>no</disabled>
    <timeout>1800</timeout>
    <interval>1d</interval>
    <scan-on-start>yes</scan-on-start>

    <java_path>C:\Program Files (x86)\ossec-agent\wodles\ciscat\Java\bin</java_path>
    <ciscat_path>C:\Program Files (x86)\ossec-agent\wodles\ciscat\cis-cat-full</ciscat_path>
	
	<content type="xccdf" path="C:\Program Files (x86)\ossec-agent\wodles\ciscat\cis-cat-full\benchmarks\CIS_Microsoft_Windows_7_Benchmark_v3.0.1-xccdf.xml" />
  </wodle>
```

- Or using relative paths (for any of the needed path):

```
  <!-- CIS policies evaluation -->
  <wodle name="cis-cat">
    <disabled>no</disabled>
    <timeout>1800</timeout>
    <interval>1d</interval>
    <scan-on-start>yes</scan-on-start>

    <java_path>wodles\ciscat\Java\bin</java_path>
    <ciscat_path>wodles\ciscat\cis-cat-full</ciscat_path>
	
	<content type="xccdf" path="benchmarks\CIS_Microsoft_Windows_7_Benchmark_v3.0.1-xccdf.xml" />
  </wodle>
```

For Windows systems, it is also possible to set the location in shared folders as follows:

```
  <!-- CIS policies evaluation -->
  <wodle name="cis-cat">
    <disabled>no</disabled>
    <timeout>1800</timeout>
    <interval>1d</interval>
    <scan-on-start>yes</scan-on-start>

    <java_path>\\myserver\wodles\ciscat\Java\bin</java_path>
    <ciscat_path>wodles\ciscat\cis-cat-full</ciscat_path>
	
	<content type="xccdf" path="\\myserver\benchmarks\CIS_Microsoft_Windows_7_Benchmark_v3.0.1-xccdf.xml" />
  </wodle>
```

Both ways allow the wodle to validate the input paths.

If a relative path is specified for the benchmark file, **it will be relative to the location of the CIS-CAT scripts**. On the other hand, when setting a relative path for Java or CIS-CAT location, it is **relative to the Installation directory**.

The three modified paths have been tested on Linux (Ubuntu 16.04) and Windows 7 for the following cases:

- A full path.
- A relative path.
- A wrong path.
- An empty path with only the tags.
- An empty path without any tag.

Always with the desired behavior. 