### PR TITLE
Output format option for localfile

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -31,6 +31,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_query = "query";
     const char *xml_localfile_label = "label";
     const char *xml_localfile_target = "target";
+    const char *xml_localfile_outformat = "out_format";
 
     logreader *logf;
     logreader_config *log_config;
@@ -42,23 +43,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     if (!log_config->config) {
         os_calloc(2, sizeof(logreader), log_config->config);
         logf = log_config->config;
-        logf[0].file = NULL;
-        logf[0].command = NULL;
-        logf[0].alias = NULL;
-        logf[0].logformat = NULL;
-        logf[0].future = 0;
-        logf[0].query = NULL;
-        logf[0].target = NULL;
-        logf[0].target_socket = NULL;
-        logf[1].file = NULL;
-        logf[1].command = NULL;
-        logf[1].alias = NULL;
-        logf[1].logformat = NULL;
-        logf[1].future = 0;
-        logf[1].query = NULL;
-        logf[1].target = NULL;
-        logf[1].target_socket = NULL;
-        logf[1].duplicated = 0;
+        memset(logf, 0, 2 * sizeof(logreader));
     } else {
         logf = log_config->config;
         while (logf[pl].file != NULL) {
@@ -68,30 +53,11 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         /* Allocate more memory */
         os_realloc(logf, (pl + 2)*sizeof(logreader), log_config->config);
         logf = log_config->config;
-        logf[pl + 1].file = NULL;
-        logf[pl + 1].command = NULL;
-        logf[pl + 1].alias = NULL;
-        logf[pl + 1].logformat = NULL;
-        logf[pl + 1].future = 0;
-        logf[pl + 1].query = NULL;
-        logf[pl + 1].target = NULL;
-        logf[pl + 1].target_socket = NULL;
-        logf[pl + 1].duplicated = 0;
+        memset(logf + pl + 1, 0, sizeof(logreader));
     }
 
-    logf[pl].file = NULL;
-    logf[pl].command = NULL;
-    logf[pl].alias = NULL;
-    logf[pl].logformat = NULL;
-    logf[pl].future = 0;
-    logf[pl].query = NULL;
-    logf[pl].target = NULL;
-    logf[pl].target_socket = NULL;
-    logf[pl].duplicated = 0;
+    memset(logf + pl, 0, sizeof(logreader));
     os_calloc(1, sizeof(wlabel_t), logf[pl].labels);
-    logf[pl].fp = NULL;
-    logf[pl].ffile = NULL;
-    logf[pl].djb_program_name = NULL;
     logf[pl].ign = 360;
     os_calloc(2, sizeof(logsocket *), logf[pl].target_socket);
 
@@ -125,6 +91,8 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             }
             os_realloc(logf[pl].target_socket, (count + 1) * sizeof(logsocket *), logf[pl].target_socket);
             memset(logf[pl].target_socket + count, 0, sizeof(logsocket *));
+        } else if (strcmp(node[i]->element, xml_localfile_outformat) == 0) {
+            os_strdup(node[i]->content, logf[pl].outformat);
         } else if (strcmp(node[i]->element, xml_localfile_label) == 0) {
             char *key_value = 0;
             int j;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -50,6 +50,7 @@ typedef struct _logreader {
     char *alias;
     char future;
     char *query;
+    char *outformat;
     char **target;
     logsocket **target_socket;
     int duplicated;

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -31,6 +31,6 @@ int StartMQ(const char *key, short int type) __attribute__((nonnull));
 
 int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
 
-int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logsocket **sockets) __attribute__((nonnull));
+int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logsocket **sockets, const char * pattern) __attribute__((nonnull));
 
 #endif

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -14,7 +14,7 @@
 #define MAX_HEADER 64
 
 /* Compile message from cache and send through queue */
-static void audit_send_msg(char **cache, int top, const char *file, int drop_it, logsocket **tsockets) {
+static void audit_send_msg(char **cache, int top, const char *file, int drop_it, logsocket **tsockets, const char * pattern) {
     int i;
     size_t n = 0;
     size_t z;
@@ -37,7 +37,7 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
     if (!drop_it) {
         message[n] = '\0';
 
-        if (SendMSGtoSCK(logr_queue, message, file, LOCALFILE_MQ, tsockets) < 0) {
+        if (SendMSGtoSCK(logr_queue, message, file, LOCALFILE_MQ, tsockets, pattern) < 0) {
             merror(QUEUE_SEND);
 
             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
@@ -98,7 +98,7 @@ void *read_audit(int pos, int *rc, int drop_it) {
         if (strncmp(id, header, z)) {
             // Current message belongs to another event: send cached messages
             if (icache > 0)
-                audit_send_msg(cache, icache, logff[pos].file, drop_it, logff[pos].target_socket);
+                audit_send_msg(cache, icache, logff[pos].file, drop_it, logff[pos].target_socket, logff[pos].outformat);
 
             // Store current event
             *cache = strdup(buffer);
@@ -114,7 +114,7 @@ void *read_audit(int pos, int *rc, int drop_it) {
     }
 
     if (icache > 0)
-        audit_send_msg(cache, icache, logff[pos].file, drop_it, logff[pos].target_socket);
+        audit_send_msg(cache, icache, logff[pos].file, drop_it, logff[pos].target_socket, logff[pos].outformat);
 
     mdebug2("Read %d lines from %s", lines, logff[pos].file);
     return NULL;

--- a/src/logcollector/read_command.c
+++ b/src/logcollector/read_command.c
@@ -64,7 +64,7 @@ void *read_command(int pos, int *rc, int drop_it)
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, str,
                         (NULL != logff[pos].alias) ? logff[pos].alias : logff[pos].command,
-                        LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -167,7 +167,7 @@ void *read_djbmultilog(int pos, int *rc, int drop_it)
 
         /* Send message to queue */
         if (drop_it == 0) {
-            if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, MYSQL_MQ, logff[pos].target_socket) < 0) {
+            if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, MYSQL_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_fullcommand.c
+++ b/src/logcollector/read_fullcommand.c
@@ -75,7 +75,7 @@ void *read_fullcommand(int pos, int *rc, int drop_it)
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, strfinal,
                         (NULL != logff[pos].alias) ? logff[pos].alias : logff[pos].command,
-                        LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -87,7 +87,7 @@ void *read_json(int pos, int *rc, int drop_it)
         /* Send message to queue */
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, jsonParsed, logff[pos].file,
-                        LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -18,7 +18,7 @@ static void __send_mssql_msg(int pos, int drop_it, char *buffer)
 {
     mdebug2("Reading MSSQL message: '%s'", buffer);
     if (drop_it == 0) {
-        if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+        if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
             merror(QUEUE_SEND);
             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -81,7 +81,7 @@ void *read_multiline(int pos, int *rc, int drop_it)
         /* Send message to queue */
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file,
-                        LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -126,7 +126,7 @@ void *read_mysql_log(int pos, int *rc, int drop_it)
 
         /* Send message to queue */
         if (drop_it == 0) {
-            if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, MYSQL_MQ, logff[pos].target_socket) < 0) {
+            if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, MYSQL_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -240,7 +240,7 @@ void *read_nmapg(int pos, int *rc, int drop_it)
         if (drop_it == 0) {
             /* Send message to queue */
             if (SendMSGtoSCK(logr_queue, final_msg, logff[pos].file,
-                        HOSTINFO_MQ, logff[pos].target_socket) < 0) {
+                        HOSTINFO_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -100,7 +100,7 @@ void *read_ossecalert(int pos, __attribute__((unused)) int *rc, int drop_it)
 
     /* Send message to queue */
     if (drop_it == 0) {
-        if (SendMSGtoSCK(logr_queue, syslog_msg, logff[pos].file, LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+        if (SendMSGtoSCK(logr_queue, syslog_msg, logff[pos].file, LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
             merror(QUEUE_SEND);
             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -18,7 +18,7 @@ static void __send_pgsql_msg(int pos, int drop_it, char *buffer)
 {
     mdebug2("Reading PostgreSQL message: '%s'", buffer);
     if (drop_it == 0) {
-        if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, POSTGRESQL_MQ, logff[pos].target_socket) < 0) {
+        if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, POSTGRESQL_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
             merror(QUEUE_SEND);
             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -72,7 +72,7 @@ void *read_snortfull(int pos, int *rc, int drop_it)
                     /* Send the message */
                     if (drop_it == 0) {
                         if (SendMSGtoSCK(logr_queue, f_msg, logff[pos].file,
-                                    LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+                                    LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                             merror(QUEUE_SEND);
                             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);
@@ -96,7 +96,7 @@ void *read_snortfull(int pos, int *rc, int drop_it)
                     /* Send the message */
                     if (drop_it == 0) {
                         if (SendMSGtoSCK(logr_queue, f_msg, logff[pos].file,
-                                    LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+                                    LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                             merror(QUEUE_SEND);
                             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -72,7 +72,7 @@ void *read_syslog(int pos, int *rc, int drop_it)
         /* Send message to queue */
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, str, logff[pos].file,
-                        LOCALFILE_MQ, logff[pos].target_socket) < 0) {
+                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);


### PR DESCRIPTION
This feature allows formatting logs from Logcollector using the same syntax as the rule description.

The syntax is: 
```
$(parameter)
```

Available parameters are:
- `log`: Message from log.
- `output`: Output from a command. Alias of `log`.
- `location`: Path to the log file.
- `command`: Command line or alias for a command. Alias of `location`.
- `timestamp`: Current timestamp (when the log is sent).
- `timestamp <format>`: Custom timestamp format (syntax from `strftime()`)
- `hostname`: System's host name.

Example:

```xml
<localfile>
  <log_format>syslog</log_format>
  <location>/root/test.log</location>
  <out_format>$(timestamp %Y-%m-%d %H:%M:%S) $(hostname) test[1]: $(log)</out_format>
</localfile>
```