### PR TITLE
Improvements in syscheck realtime monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ All notable changes to this project will be documented in this file.
 
 - Supporting multiple socket output in Logcollector. ([#395](https://github.com/wazuh/wazuh/pull/395))
 - Allow inserting static field parameters in rule comments. ([#397](https://github.com/wazuh/wazuh/pull/397))
+- Added an internal option for Syscheck to tune the RT alerting delay. ([#434](https://github.com/wazuh/wazuh/pull/434))
 
 ### Changed
 
 - Add default value for option -x in agent_control tool.
+- Syscheck RT process granularized to make frequency option more accurate.
 
 ### Fixed
 
 - Fix bug in Logcollector when removing duplicate localfiles. ([#402](https://github.com/wazuh/wazuh/pull/402))
+- Fix weird behavior in Syscheck when a modified file returns back to its first state. ([#434](https://github.com/wazuh/wazuh/pull/434))
 
 ## [v3.2.1]
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -151,6 +151,10 @@ monitord.daily_rotations=12
 syscheck.sleep=2
 syscheck.sleep_after=15
 
+# Syscheck perform a delay when dispatching real-time notifications so it avoids
+# triggering on some temporary files like vim edits. (ms) [1..1000]
+syscheck.rt_delay=10
+
 # Rootcheck checking/usage speed. The default is to sleep 50 milliseconds
 # per each PID or suspictious port.
 rootcheck.sleep=50

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -12,7 +12,7 @@
 
 #define MAX_DIR_SIZE    64
 #define MAX_DIR_ENTRY   128
-#define SYSCHECK_WAIT   300
+#define SYSCHECK_WAIT   1
 
 /* Checking options */
 #define CHECK_MD5SUM        0000001

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -64,6 +64,7 @@ typedef struct _config {
     int scan_on_start;
     int realtime_count;
     short skip_nfs;
+    int rt_delay;                   /* Delay before real-time dispatching (ms) */
 
     int time;                       /* frequency (secs) for syscheck to run */
     int queue;                      /* file descriptor of socket to write to queue */

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -237,10 +237,13 @@ int realtime_process()
                 snprintf(final_name, MAX_LINE, "%s/%s",
                          (char *)OSHash_Get(syscheck.realtime->dirtb, wdchar),
                          event->name);
-		/* Need a sleep here to avoid triggering on vim edits
-  		 * (and finding the file removed)
-  		 */
-		sleep(1);
+
+                /* Need a sleep here to avoid triggering on vim
+                * (and finding the file removed)
+                */
+
+                struct timeval timeout = {0, syscheck.rt_delay * 1000};
+                select(0, NULL, NULL, NULL, &timeout);
 
                 realtime_checksumfile(final_name);
             }

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -47,6 +47,7 @@ static void read_internal(int debug_level)
 {
     syscheck.tsleep = (unsigned int) getDefine_Int("syscheck", "sleep", 0, 64);
     syscheck.sleep_after = getDefine_Int("syscheck", "sleep_after", 1, 9999);
+    syscheck.rt_delay = getDefine_Int("syscheck", "rt_delay", 1, 1000);
 
     /* Check current debug_level
      * Command line setting takes precedence

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -150,7 +150,7 @@ int Start_win32_Syscheck()
     minfo(STARTUP_MSG, getpid());
 
     /* Some sync time */
-    sleep(syscheck.tsleep + 10);
+    sleep(syscheck.tsleep * 5);
 
     /* Wait if agent started properly */
     os_wait();
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
     }
 
     /* Some sync time */
-    sleep(syscheck.tsleep + 10);
+    sleep(syscheck.tsleep * 5);
 
     /* Start the daemon */
     start_daemon();


### PR DESCRIPTION
Related issue: https://github.com/wazuh/wazuh/issues/431

- Upgrade checksum hash table for every reported file (not only the first time)
- Internal option `syscheck.rt_delay` to tune the delay before attending an RT notification. *The default configuration decreases the delay from 1 second to 10 milliseconds*
- Granularize syscheck RT process from 5 minutes to 1 second. This will make the frequency option more accurate.
 - Allow to speed up the startup time: formula changed from `tsleep + 10` to `tsleep * 5`. The actual delay will remain for the default configuration, but this formula allows to null the time if `syscheck.sleep` is set to `0` in the internal options.