### PR TITLE
Fix bug cluster sends junk bytes

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -68,8 +68,8 @@ class WazuhClusterHandler(asynchat.async_chat):
         self.addr = addr
         self.f = Fernet(key.encode('base64','strict'))
         self.set_terminator('\n\t\t\n')
-        self.received_data=[]
-        self.data=""
+        self.received_data = []
+        self.data = ""
         self.counter = 0
         self.node_type = node_type
         self.requests_queue = requests_queue
@@ -147,12 +147,11 @@ class WazuhClusterHandler(asynchat.async_chat):
         while i < msg_len:
             next_i = i+4096 if i+4096 < msg_len else msg_len
             sent = self.send(msg[i:next_i])
-            if sent == 4096 or next_i == msg_len:
-                i = next_i
-            logging.debug("SERVER: Sending {} of {}".format(i, msg_len))
+            i += sent
 
-        logging.debug("Data sent to {0}".format(self.addr))
+        logging.debug("SERVER: Sent {}/{} bytes to {}".format(i, msg_len, self.addr))
         self.handle_close()
+
 
 class WazuhClusterServer(asyncore.dispatcher):
 

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -102,6 +102,7 @@ class WazuhClusterClient(asynchat.async_chat):
         self.file = file
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
         self.socket.settimeout(common.cluster_timeout)
+        self.addr = host
         try:
             self.socket.connect((host, port))
         except socket.error as e:
@@ -146,11 +147,9 @@ class WazuhClusterClient(asynchat.async_chat):
         while i < msg_len:
             next_i = i+4096 if i+4096 < msg_len else msg_len
             sent = self.send(msg[i:next_i])
-            if sent == 4096 or next_i == msg_len:
-                i = next_i
-            logging.debug("CLIENT: Sending {} of {}".format(i, msg_len))
+            i += sent
 
-
+        logging.debug("CLIENT: Sent {}/{} bytes to {}".format(i, msg_len, self.addr))
         self.can_read=True
         self.can_write=False
 


### PR DESCRIPTION
This PR fixes the following bug:

Sometimes the cluster repeats fragments of bytes already sent in a request.

### When it happens
Sending requests/responses greater than 4KB. The probability is greater in larger responses.