### PR TITLE
Fixed compilation error when installing manager on CentOS 5

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -93,6 +93,14 @@ Install()
           MAKEBIN=/opt/freeware/bin/gmake
     fi
 
+    # On CentOS <= 5 we need to disable syscollector compilation
+    OS_VERSION_FOR_SYSC="${DIST_NAME}"
+    SYSC_FLAG=""
+ 
+    if ([ "X${OS_VERSION_FOR_SYSC}" = "Xrhel" ] || [ "X${OS_VERSION_FOR_SYSC}" = "Xcentos" ] || [ "X${OS_VERSION_FOR_SYSC}" = "XCentOS" ]) && [ ${DIST_VER} -le 5 ]; then
+        SYSC_FLAG="DISABLE_SYSC=true"
+    fi
+
 
     # Makefile
     echo " - ${runningmake}"
@@ -104,7 +112,7 @@ Install()
     if [ "X${USER_BINARYINSTALL}" = "X" ]; then
         # Add DATABASE=pgsql or DATABASE=mysql to add support for database
         # alert entry
-        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} build
+        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} build
         if [ $? != 0 ]; then
             cd ../
             catError "0x5-build"


### PR DESCRIPTION
When compiling on CentOS 5 we need to add DISABLE_SYSC=true flag. This flag is not reflected when running install.sh so it will try to compile syscollector throwing errors.

The flag is now activated on install.sh only if CentOS5 is detected.