### PR TITLE
Add Rids Syncronization

### DIFF
--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -33,6 +33,8 @@ typedef struct _keyentry {
     char *key;
     char *name;
 
+    ino_t inode;
+
     os_ip *ip;
     int sock;
     pthread_mutex_t mutex;

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -95,6 +95,7 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
     keys->keyentries[keys->keysize]->keyid = keys->keysize;
     keys->keyentries[keys->keysize]->global = 0;
     keys->keyentries[keys->keysize]->fp = NULL;
+    keys->keyentries[keys->keysize]->inode = 0;
     keys->keyentries[keys->keysize]->sock = -1;
     w_mutex_init(&keys->keyentries[keys->keysize]->mutex, NULL);
 


### PR DESCRIPTION
This PR add feature related issue [#456](https://github.com/wazuh/wazuh/issues/456)

- Add `ino_t inode` to store each agent's counter inode
- `ReloadCounter` function checks if the inode of the file has changed, if so, reloads the corresponding counters.
- flush the output buffer of StoreCounter.