### PR TITLE
Add timestamp timing to JSON events

### DIFF
--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -85,7 +85,7 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
                  ar->name,
                  user,
                  ip,
-                 (long int)lf->time,
+                 (long int)lf->time.tv_sec,
                  __crt_ftell,
                  lf->generated_rule->sigid,
                  lf->location,
@@ -113,7 +113,7 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
                      ar->name,
                      user,
                      ip,
-                     (long int)lf->time,
+                     (long int)lf->time.tv_sec,
                      __crt_ftell,
                      lf->generated_rule->sigid,
                      lf->location,
@@ -129,7 +129,7 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
                      ar->name,
                      user,
                      ip,
-                     (long int)lf->time,
+                     (long int)lf->time.tv_sec,
                      __crt_ftell,
                      lf->generated_rule->sigid,
                      lf->location,
@@ -153,4 +153,3 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
 
     return;
 }
-

--- a/src/analysisd/alerts/getloglocation.c
+++ b/src/analysisd/alerts/getloglocation.c
@@ -92,7 +92,7 @@ int OS_GetLogLocation(const Eventinfo *lf)
 
     /* Setting the new day */
     __crt_day = lf->day;
-    __crt_rsec = lf->time;
+    __crt_rsec = lf->time.tv_sec;
 
     return (0);
 }

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -124,7 +124,7 @@ void OS_LogOutput(Eventinfo *lf)
         "** Alert %ld.%ld:%s - %s\n"
         "%d %s %02d %s %s%s%s\n%sRule: %d (level %d) -> '%s'"
         "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%.1256s\n",
-        (long int)lf->time,
+        (long int)lf->time.tv_sec,
         __crt_ftell,
         lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
         lf->generated_rule->group,
@@ -292,7 +292,7 @@ void OS_Log(Eventinfo *lf)
             "** Alert %ld.%ld:%s - %s\n"
             "%d %s %02d %s %s%s%s\n%sRule: %d (level %d) -> '%s'"
             "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%.1256s\n",
-            (long int)lf->time,
+            (long int)lf->time.tv_sec,
             __crt_ftell,
             lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
             lf->generated_rule->group,
@@ -441,7 +441,7 @@ void OS_CustomLog(const Eventinfo *lf, const char *format)
     /* Replace all the tokens */
     os_strdup(format, log);
 
-    snprintf(tmp_buffer, 1024, "%ld", (long int)lf->time);
+    snprintf(tmp_buffer, 1024, "%ld", (long int)lf->time.tv_sec);
     tmp_log = searchAndReplace(log, CustomAlertTokenName[CUSTOM_ALERT_TOKEN_TIMESTAMP], tmp_buffer);
     free(log);
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -64,7 +64,7 @@ int prev_year;
 char prev_month[4];
 int __crt_hour;
 int __crt_wday;
-time_t c_time;
+struct timespec c_timespec;
 char __shost[512];
 OSDecoderInfo *NULL_Decoder;
 
@@ -630,7 +630,7 @@ void OS_ReadMSG_analysisd(int m_queue)
     mdebug1("Active response Init completed.");
 
     /* Get current time before starting */
-    c_time = time(NULL);
+    gettime(&c_timespec);
 
     /* Start the hourly/weekly stats */
     if (Start_Hour() < 0) {
@@ -690,7 +690,7 @@ void OS_ReadMSG_analysisd(int m_queue)
             RuleNode *rulenode_pt;
 
             /* Get the time we received the event */
-            c_time = time(NULL);
+            gettime(&c_timespec);
 
             /* Default values for the log info */
             Zero_Eventinfo(lf);
@@ -896,17 +896,17 @@ void OS_ReadMSG_analysisd(int m_queue)
                 /* Check ignore time */
                 if (currently_rule->ignore_time) {
                     if (currently_rule->time_ignored == 0) {
-                        currently_rule->time_ignored = lf->time;
+                        currently_rule->time_ignored = lf->time.tv_sec;
                     }
                     /* If the current time - the time the rule was ignored
                      * is less than the time it should be ignored,
                      * leave (do not alert again)
                      */
-                    else if ((lf->time - currently_rule->time_ignored)
+                    else if ((lf->time.tv_sec - currently_rule->time_ignored)
                              < currently_rule->ignore_time) {
                         break;
                     } else {
-                        currently_rule->time_ignored = lf->time;
+                        currently_rule->time_ignored = lf->time.tv_sec;
                     }
                 }
 

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -23,7 +23,8 @@ extern char prev_month[4];
 extern int __crt_hour;
 extern int __crt_wday;
 
-extern time_t c_time; /* Current time of event. Used everywhere */
+extern struct timespec c_timespec; /* Current time of event. Used everywhere */
+#define c_time c_timespec.tv_sec
 
 /* Local host name */
 extern char __shost[512];

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -539,7 +539,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     }
 
     /* Set up the event data */
-    lf->time = c_time;
+    lf->time = c_timespec;
     p = localtime(&c_time);
 
     /* Assign hour, day, year and month values */

--- a/src/analysisd/decoders/rootcheck.c
+++ b/src/analysisd/decoders/rootcheck.c
@@ -198,7 +198,7 @@ int DecodeRootcheck(Eventinfo *lf)
                     merror("Error handling rootcheck database (fsetpos).");
                     return (0);
                 }
-                fprintf(fp, "!%ld", (long int)lf->time);
+                fprintf(fp, "!%ld", (long int)lf->time.tv_sec);
                 fflush(fp);
                 rootcheck_dec->fts = 0;
                 lf->decoder_info = rootcheck_dec;
@@ -220,7 +220,7 @@ int DecodeRootcheck(Eventinfo *lf)
 
     /* Add the new entry at the end of the file */
     fseek(fp, 0, SEEK_END);
-    fprintf(fp, "!%ld!%ld %s\n", (long int)lf->time, (long int)lf->time, lf->log);
+    fprintf(fp, "!%ld!%ld %s\n", (long int)lf->time.tv_sec, (long int)lf->time.tv_sec, lf->log);
     fflush(fp);
 
     rootcheck_dec->fts = FTS_DONE;

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -337,7 +337,7 @@ static int DB_Search(const char *f_name, char *c_sum, Eventinfo *lf)
                 p >= 1 ? '!' : '+',
                 p == 2 ? '!' : (p > 2) ? '?' : '+',
                 c_sum,
-                (long int)lf->time,
+                (long int)lf->time.tv_sec,
                 f_name);
         fflush(fp);
 
@@ -523,7 +523,7 @@ static int DB_Search(const char *f_name, char *c_sum, Eventinfo *lf)
 
     /* If we reach here, this file is not present in our database */
     fseek(fp, 0, SEEK_END);
-    fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name);
+    fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time.tv_sec, f_name);
     fflush(fp);
 
     /* Insert row in SQLite DB*/

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -49,7 +49,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
         lf = (Eventinfo *)lf_node->data;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > rule->timeframe) {
+        if ((c_time - lf->time.tv_sec) > rule->timeframe) {
             return (NULL);
         }
 
@@ -202,7 +202,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
         lf = (Eventinfo *)lf_node->data;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > rule->timeframe) {
+        if ((c_time - lf->time.tv_sec) > rule->timeframe) {
             return (NULL);
         }
 
@@ -349,7 +349,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
         lf = eventnode_pt->event;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > rule->timeframe) {
+        if ((c_time - lf->time.tv_sec) > rule->timeframe) {
             return (NULL);
         }
 
@@ -491,7 +491,8 @@ void Zero_Eventinfo(Eventinfo *lf)
 
     lf->nfields = 0;
 
-    lf->time = 0;
+    lf->time.tv_sec = 0;
+    lf->time.tv_nsec = 0;
     lf->matched = 0;
 
     lf->year = 0;

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -68,7 +68,7 @@ typedef struct _Eventinfo {
     /* Other internal variables */
     int matched;
 
-    time_t time;
+    struct timespec time;
     int day;
     int year;
     char hour[10];

--- a/src/analysisd/eventinfo_list.c
+++ b/src/analysisd/eventinfo_list.c
@@ -76,7 +76,7 @@ void OS_AddEvent(Eventinfo *lf)
              * or the events that will not match anymore
              * (higher than max frequency)
              */
-            while ((i < 10) || ((lf->time - lastnode->event->time) > _max_freq)) {
+            while ((i < 10) || ((lf->time.tv_sec - lastnode->event->time.tv_sec) > _max_freq)) {
                 oldlast = lastnode;
                 lastnode = lastnode->prev;
                 lastnode->next = NULL;
@@ -107,4 +107,3 @@ void OS_AddEvent(Eventinfo *lf)
 
     return;
 }
-

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -303,30 +303,17 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
 // Parse timestamp
 void W_JSON_AddTimestamp(cJSON* root, const Eventinfo* lf)
 {
-    char buffer[25] = "";
+    char timestamp[64];
+    char datetime[64];
+    char timezone[64];
     struct tm tm;
-    time_t timestamp;
-    char *end;
 
-    if (lf->year && lf->mon[0] && lf->day && lf->hour[0]) {
-        timestamp = time(NULL);
-        memcpy(&tm, localtime(&timestamp), sizeof(struct tm));
-
-        if (!(end = strptime(lf->hour, "%T", &tm)) || *end) {
-            merror("Could not parse hour '%s'.", lf->hour);
-            return;
-        }
-
-        if (!(end = strptime(lf->mon, "%b", &tm)) || *end) {
-            merror("Could not parse month '%s'.", lf->mon);
-            return;
-        }
-
-        tm.tm_year = lf->year - 1900;
-        tm.tm_mday = lf->day;
-
-        strftime(buffer, 25, "%FT%T%z", &tm);
-        cJSON_AddStringToObject(root, "timestamp", buffer);
+    if (lf->time.tv_sec) {
+        localtime_r(&lf->time.tv_sec, &tm);
+        strftime(datetime, sizeof(datetime), "%FT%T", &tm);
+        strftime(timezone, sizeof(timezone), "%z", &tm);
+        snprintf(timestamp, sizeof(timestamp), "%s.%ld%s", datetime, lf->time.tv_nsec / 1000000, timezone);
+        cJSON_AddStringToObject(root, "timestamp", timestamp);
     }
 }
 

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -41,11 +41,11 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     cJSON_AddItemToObject(root, "manager", manager = cJSON_CreateObject());
     data = cJSON_CreateObject();
 
-    if ( lf->time ) {
+    if ( lf->time.tv_sec ) {
 
         char alert_id[19];
         alert_id[18] = '\0';
-        if((snprintf(alert_id, 18, "%ld.%ld", (long int)lf->time, __crt_ftell)) < 0) {
+        if((snprintf(alert_id, 18, "%ld.%ld", (long int)lf->time.tv_sec, __crt_ftell)) < 0) {
             merror("snprintf failed");
         }
 

--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -28,7 +28,7 @@ int prev_year;
 char prev_month[4];
 int __crt_hour;
 int __crt_wday;
-time_t c_time;
+struct timespec c_timespec;
 char __shost[512];
 OSDecoderInfo *NULL_Decoder;
 
@@ -176,4 +176,3 @@ int main(int argc, char **argv)
 
     exit(0);
 }
-

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -522,13 +522,13 @@ void OS_ReadMSG(char *ut_str)
                 /* Check ignore time */
                 if (currently_rule->ignore_time) {
                     if (currently_rule->time_ignored == 0) {
-                        currently_rule->time_ignored = lf->time;
+                        currently_rule->time_ignored = lf->time.tv_sec;
                     }
                     /* If the current time - the time the rule was ignored
                      * is less than the time it should be ignored,
                      * do not alert again
                      */
-                    else if ((lf->time - currently_rule->time_ignored)
+                    else if ((lf->time.tv_sec - currently_rule->time_ignored)
                              < currently_rule->ignore_time) {
                         break;
                     } else {


### PR DESCRIPTION
This PR solves issue https://github.com/wazuh/wazuh/issues/466.

From now on, timestamps will include millisecond timing.

Example:
```json
{
  "timestamp": "2018-03-21T18:44:30.306-0700",
  "rule": {
    "level": 3,
    "description": "New ossec agent connected.",
    "id": "501",
    "firedtimes": 1,
    "mail": true,
    "groups": [
      "ossec",
      "gpg13_10.1"
    ]
  }
}
```