### PR TITLE
Improve cluster logging when an error is detected

### DIFF
--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -121,7 +121,8 @@ class WazuhException(Exception):
         3013: 'Cluster is disabled',
         3014: 'Manager name or IP incorrect',
         3015: 'Cannot access directory',
-        3016: "Cluster nodes are not correctly configured at ossec.conf."
+        3016: "Cluster nodes are not correctly configured at ossec.conf.",
+        3017: "Could not get remote nodes' information"
 
         # > 9000: Authd
     }


### PR DESCRIPTION
Hello,

This PR improves error logging when an exception is caught during synchronization process:
https://github.com/wazuh/wazuh/blob/02b2313d8fc67e4ff55acac946b6e2b98d36dd3c/framework/scripts/wazuh-clusterd.py#L253-L263

Also, it controls the EINTR exception:
https://github.com/wazuh/wazuh/blob/02b2313d8fc67e4ff55acac946b6e2b98d36dd3c/framework/scripts/wazuh-clusterd.py#L241-L252

This will make the synchronization process of the cluster much more stable and administrator will be able to know what happened with more precision.

The message, _"sleeping for 2m"_ is now showed at INFO level instead of DEBUG:
https://github.com/wazuh/wazuh/blob/02b2313d8fc67e4ff55acac946b6e2b98d36dd3c/framework/scripts/wazuh-clusterd.py#L220

And clients will report whether the master node is down or not:
https://github.com/wazuh/wazuh/blob/6ec6ec56abbc7c152fa3367135332dbebe9d4d39/framework/scripts/wazuh-clusterd.py#L298-L302

Best regards,
Marta