### PR TITLE
Use multithread compilation in source installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ Install()
 
         # Add DATABASE=pgsql or DATABASE=mysql to add support for database
         # alert entry
-        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} build
+        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} -j${THREADS} build
         if [ $? != 0 ]; then
             cd ../
             catError "0x5-build"

--- a/src/init/shared.sh
+++ b/src/init/shared.sh
@@ -50,3 +50,18 @@ OSSECMX3="devmail.ossec.net mail is handled by 10 ossec.mooo.COM."
 
 ## Predefined file
 PREDEF_FILE="./etc/preloaded-vars.conf"
+
+# Get number of processors
+if [ -z "$THREADS" ]
+then
+    case $(uname) in
+    Linux)
+        THREADS=$(grep processor /proc/cpuinfo | wc -l)
+        ;;
+    Darwin)
+        THREADS=$(sysctl -n hw.ncpu)
+        ;;
+    *)
+        THREADS=1
+    esac
+fi


### PR DESCRIPTION
This PR solves issue https://github.com/wazuh/wazuh/issues/476.

It detects automatically the number of processors in the host and runs GNU Make in multithread mode.

The number of threads may be overwritten with:

`THREADS=X ./install.sh`