### PR TITLE
 Fix unrecognizable characters error in Windows version name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Added a synchronization timeout in the cluster to prevent it from blocking ([#447](https://github.com/wazuh/wazuh/pull/447))
 - Fixed issue in CSyslogd when filtering by rule group. ([#446](https://github.com/wazuh/wazuh/pull/446))
 - Fixed error on DB daemon when parsing rules with options introduced in version 3.0.0.
+- Fixed unrecognizable characters error in Windows version name. ([#478](https://github.com/wazuh/wazuh/pull/478))
 - Fix Authd client in old versions of Windows ([#479](https://github.com/wazuh/wazuh/pull/479))
 
 ## [v3.2.1]

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -947,31 +947,33 @@ void goDaemon()
 
 int checkVista()
 {
-    const char *m_uname;
+    /* Check if the system is Vista (must be called during the startup) */
     isVista = 0;
 
-    m_uname = getuname();
-    if (!m_uname) {
-        merror(MEM_ERROR, errno, strerror(errno));
-        return (0);
+    OSVERSIONINFOEX osvi;
+    BOOL bOsVersionInfoEx;
+
+    ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
+    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
+
+    if (!(bOsVersionInfoEx = GetVersionEx ((OSVERSIONINFO *) &osvi))) {
+        osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+        if (!GetVersionEx((OSVERSIONINFO *)&osvi)) {
+            merror("Cannot get Windows version number.");
+            return -1;
+        }
     }
 
-    /* Check if the system is Vista (must be called during the startup) */
-    if (strstr(m_uname, "Windows Server 2008") ||
-            strstr(m_uname, "Vista") ||
-            strstr(m_uname, "Windows 7") ||
-            strstr(m_uname, "Windows 8") ||
-            strstr(m_uname, "Windows 10") ||
-            strstr(m_uname, "Windows Server 2012") ||
-            strstr(m_uname, "Windows Server 2016")) {
+    if (osvi.dwMajorVersion >= 6) {
         isVista = 1;
-        minfo("System is Vista or newer (%s).", m_uname);
-    } else {
-        minfo("System is older than Vista (%s).", m_uname);
+        minfo("Windows version is 6.0 or newer.");
     }
+    else
+        minfo("Windows version is older than 6.0.");
 
     return (isVista);
 }
+
 
 /* Get basename of path */
 char *basename_ex(char *path)

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -948,7 +948,10 @@ void goDaemon()
 int checkVista()
 {
     /* Check if the system is Vista (must be called during the startup) */
+    const char *m_uname;
     isVista = 0;
+
+    m_uname = getuname();
 
     OSVERSIONINFOEX osvi;
     BOOL bOsVersionInfoEx;
@@ -966,10 +969,10 @@ int checkVista()
 
     if (osvi.dwMajorVersion >= 6) {
         isVista = 1;
-        minfo("Windows version is 6.0 or newer.");
+        minfo("Windows version is 6.0 or newer. (%s).", m_uname);
     }
     else
-        minfo("Windows version is older than 6.0.");
+        minfo("Windows version is older than 6.0. (%s).", m_uname);
 
     return (isVista);
 }
@@ -1180,12 +1183,7 @@ const char *getuname()
     int ret_size = OS_SIZE_1024 - 2;
     static char ret[OS_SIZE_1024 + 1] = "";
     char os_v[128 + 1];
-    FILE *cmd_output;
-    char *command;
-    size_t buf_tam = 100;
-    char read_buff[buf_tam];
     int add_infoEx = 1;
-    int status;
 
     typedef void (WINAPI * PGNSI)(LPSYSTEM_INFO);
     typedef BOOL (WINAPI * PGPI)(DWORD, DWORD, DWORD, DWORD, PDWORD);
@@ -1365,41 +1363,29 @@ const char *getuname()
                 }
                 ret_size -= strlen(ret) + 1;
             } else if (osvi.dwMajorVersion == 6 && (osvi.dwMinorVersion == 2 || osvi.dwMinorVersion == 3)) {
-                command = "wmic os get caption";
-                char *end;
-                cmd_output = popen(command, "r");
-                if (!cmd_output) {
-                    merror("Unable to execute command: '%s'.", command);
-                } else {
-                    if (fgets(read_buff, buf_tam, cmd_output) && strncmp(read_buff,"Caption",7) == 0) {
-                        if (!fgets(read_buff, buf_tam, cmd_output)){
-                            merror("Can't get OS name.");
-                            strncat(ret, "Microsoft Windows unknown version ", ret_size - 1);
-                        }
-                        else if (end = strpbrk(read_buff,"\r\n"), end) {
-                            *end = '\0';
-                            int i = strlen(read_buff) - 1;
-                            while(read_buff[i] == 32){
-                                read_buff[i] = '\0';
-                                i--;
-                            }
-                            char * pch = strstr(read_buff, "Windows");
-                            strncat(ret, "Microsoft ", ret_size - 1);
-                            strncat(ret, pch, ret_size - 1);
-                        } else
-                            strncat(ret, "Microsoft Windows unknown version ", ret_size - 1);
-                    } else {
-                        mwarn("Can't get OS name (bad header)");
-                        strncat(ret, "Microsoft Windows unknown version ", ret_size - 1);
-                    }
+                // Read Windows Version from registry
+                DWORD dwRet;
+                HKEY RegistryKey;
+                const DWORD size = 1024;
+                TCHAR value[size];
+                DWORD dwCount = size;
+                add_infoEx = 0;
 
-                    if (status = pclose(cmd_output), status) {
-                        mwarn("Command 'wmic' returned %d getting OS name.", status);
-                    }
-
-                    add_infoEx = 0;
-                    ret_size -= strlen(ret) + 1;
+                if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+                    merror("Error opening Windows registry.");
                 }
+
+                dwRet = RegQueryValueEx(RegistryKey, TEXT("ProductName"), NULL, NULL, (LPBYTE)value, &dwCount);
+                if (dwRet != ERROR_SUCCESS) {
+                    merror("Error reading Windows registry. (Error %u)",(unsigned int)dwRet);
+                    strncat(ret, "Microsoft Windows undefined version", ret_size - 1);
+                }
+                else {
+                    RegCloseKey(RegistryKey);
+                    strncat(ret, "Microsoft ", ret_size - 1);
+                    strncat(ret, value, ret_size - 1);
+                }
+                ret_size -= strlen(ret) + 1;
             } else if (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2) {
                 pGNSI = (PGNSI) GetProcAddress(
                             GetModuleHandle("kernel32.dll"),
@@ -1591,32 +1577,67 @@ const char *getuname()
                 ret_size -= strlen(__wp) + 1;
                 RegCloseKey( hKey );
             } else if (osvi.dwMajorVersion == 6 && (osvi.dwMinorVersion == 2 || osvi.dwMinorVersion == 3)) {
+                // Read Windows Version number from registry
                 char __wp[64];
                 memset(__wp, '\0', 64);
-                command = "wmic os get Version";
-                cmd_output = popen(command, "r");
-                if (!cmd_output) {
-                    merror("Unable to execute command: '%s'.", command);
-                    snprintf(__wp, 63, " [Ver: %s]", "desc");
-                } else {
-                    if (fgets(read_buff, buf_tam, cmd_output) && strncmp(read_buff,"Version",7) == 0) {
-                        if (!fgets(read_buff, buf_tam, cmd_output)){
-                            merror("Can't get OS version.");
-                            snprintf(__wp, 63, " [Ver: %s]", "desc");
+                DWORD dwRet;
+                HKEY RegistryKey;
+                const DWORD size = 30;
+                TCHAR winver[size];
+                TCHAR wincomp[size];
+                DWORD winMajor = 0;
+                DWORD winMinor = 0;
+                DWORD dwCount = size;
+                unsigned long type=REG_DWORD;
+
+                if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+                    merror("Error opening Windows registry.");
+                }
+
+                // Windows 10
+                dwRet = RegQueryValueEx(RegistryKey, TEXT("CurrentMajorVersionNumber"), NULL, &type, (LPBYTE)&winMajor, &dwCount);
+                if (dwRet == ERROR_SUCCESS) {
+                    dwCount = size;
+                    dwRet = RegQueryValueEx(RegistryKey, TEXT("CurrentMinorVersionNumber"), NULL, &type, (LPBYTE)&winMinor, &dwCount);
+                    if (dwRet != ERROR_SUCCESS) {
+                        merror("Error reading 'CurrentMinorVersionNumber' from Windows registry. (Error %u)",(unsigned int)dwRet);
+                    }
+                    else {
+                        dwCount = size;
+                        dwRet = RegQueryValueEx(RegistryKey, TEXT("CurrentBuildNumber"), NULL, NULL, (LPBYTE)wincomp, &dwCount);
+                        if (dwRet != ERROR_SUCCESS) {
+                            merror("Error reading 'CurrentBuildNumber' from Windows registry. (Error %u)",(unsigned int)dwRet);
+                            snprintf(__wp, 63, " [Ver: %d.%d]", (unsigned int)winMajor, (unsigned int)winMinor);
                         }
                         else {
-                            snprintf(__wp, 63, " [Ver: %s]", strtok(read_buff," "));
+                            snprintf(__wp, 63, " [Ver: %d.%d.%s]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp);
                         }
-                    } else {
-                        mwarn("Can't get OS version (bad header)");
-                        snprintf(__wp, 63, " [Ver: %s]", "desc");
                     }
-
-                    pclose(cmd_output);
-
-                    strncat(ret, __wp, ret_size - 1);
-                    ret_size -= strlen(__wp) + 1;
+                    RegCloseKey(RegistryKey);
                 }
+                // Windows 6.2 or 6.3
+                else {
+                    dwRet = RegQueryValueEx(RegistryKey, TEXT("CurrentVersion"), NULL, NULL, (LPBYTE)winver, &dwCount);
+                    if (dwRet != ERROR_SUCCESS) {
+                        merror("Error reading 'Current Version' from Windows registry. (Error %u)",(unsigned int)dwRet);
+                        snprintf(__wp, 63, " [Ver: 6.2]");
+                    }
+                    else {
+                        dwCount = size;
+                        dwRet = RegQueryValueEx(RegistryKey, TEXT("CurrentBuildNumber"), NULL, NULL, (LPBYTE)wincomp, &dwCount);
+                        if (dwRet != ERROR_SUCCESS) {
+                            merror("Error reading 'CurrentBuildNumber' from Windows registry. (Error %u)",(unsigned int)dwRet);
+                            snprintf(__wp, 63, " [Ver: 6.2]");
+                        }
+                        else {
+                            snprintf(__wp, 63, " [Ver: %s.%s]", winver,wincomp);
+                        }
+                        RegCloseKey(RegistryKey);
+                    }
+                }
+
+                strncat(ret, __wp, ret_size - 1);
+                ret_size -= strlen(ret) + 1;
             } else {
                 char __wp[64];
 


### PR DESCRIPTION
The Windows version name extraction was failing in non-english versions (https://github.com/wazuh/wazuh/issues/436). 
Now this issue is solved.

<img width="1019" alt="screen shot 2018-03-22 at 7 05 48 pm" src="https://user-images.githubusercontent.com/14975138/37807715-1c2b281a-2e04-11e8-9541-2e1d5b71c086.png">


<img width="1022" alt="screen shot 2018-03-22 at 1 42 54 pm" src="https://user-images.githubusercontent.com/14975138/37797573-743604ee-2dd7-11e8-8356-9e5a8ac38f5e.png">
