### PR TITLE
Compile external libraries as shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - External libraries moved to an external repository.
 - Allow more than 256 directories in real-time for Windows agent using recursive watchers. ([#540](https://github.com/wazuh/wazuh/pull/540))
 - Ignore OverlayFS directories on Rootcheck system scan.
+- Compiling external libraries as shared objects in order to shrink space. ([#483](https://github.com/wazuh/wazuh/pull/483))
 
 ### Fixed
 

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -11,18 +11,18 @@ PREFIX       = /var/ossec
 
 OPENSSL_DIR      = ../src/external/openssl
 JSON_DIR         = ../src/external/cJSON
+SQLITE_DIR       = ../src/external/sqlite
 
 CC           = gcc
 CFLAGS       = -pipe -Wall -Wextra
-LDFLAGS      = -L$(JSON_DIR) -L$(OPENSSL_DIR) -Wl,-rpath,../lib
-LIBS         = -lcjson -lssl -lcrypto -ldl -lm
+LDFLAGS      = -L$(JSON_DIR) -L$(OPENSSL_DIR) -L$(SQLITE_DIR) -Wl,-rpath,../lib
+LIBS         = -lcjson -lssl -lcrypto -ldl -lm -lsqlite3 -ldl
 THREAD_FLAGS = -pthread
 RM_FILE      = rm -f
 INSTALL_DIR  = install -o root -g ${OSSEC_GROUP} -m 0750  -d
 INSTALL_EXEC = install -o root -g ${OSSEC_GROUP} -m 0750
 INSTALL_FILE = install -o root -g ${OSSEC_GROUP} -m 0640
 
-SQLITE_DIR       = ../src/external/sqlite
 HEADERS_DIR      = ../src/headers
 MD5_DIR          = ../src/os_crypto/md5
 
@@ -47,8 +47,6 @@ DEBUG_OP_DEPS    = $(DEBUG_OP) $(JSON_LIB) $(XML_LIB) $(XML_ACCESS) $(STRBREAK) 
 HASH_OP_DEPS     = $(HASH_OP) $(MATH_OP) $(RANDOMBYTES)
 MD5_DEPS         = $(MD5_OP)
 
-BUILD_TARGET     = libsqlite3.so.0
-
 ifeq (${uname_S},Linux)
 BUILD_TARGET     += wazuh-clusterd-internal
 endif
@@ -68,13 +66,11 @@ all: build
 install:
 	$(INSTALL_DIR) $(PREFIX)/framework
 	$(INSTALL_DIR) $(PREFIX)/framework/wazuh
-	$(INSTALL_DIR) $(PREFIX)/framework/lib
 
 	$(INSTALL_FILE) wazuh/*.py ${PREFIX}/framework/wazuh
 	$(INSTALL_FILE) wazuh/*.json ${PREFIX}/framework/wazuh
 	$(INSTALL_DIR) $(PREFIX)/framework/wazuh/cluster
 	$(INSTALL_FILE) wazuh/cluster/*.py ${PREFIX}/framework/wazuh/cluster
-	$(INSTALL_FILE) libsqlite3.so.0 ${PREFIX}/framework/lib/
 ifeq (${uname_S},Linux)
 	$(INSTALL_EXEC) wazuh-clusterd-internal ${PREFIX}/bin
 endif
@@ -88,11 +84,8 @@ examples: install
 
 build: $(BUILD_TARGET)
 
-libsqlite3.so.0: $(SQLITE_DIR)/sqlite3.o
-	$(CC) $(LFLAGS) -shared -o $@ $^
-
 ifeq (${uname_S},Linux)
-wazuh-clusterd-internal: wazuh-clusterd-internal.o $(SQLITE_DIR)/sqlite3.o $(DEBUG_OP_DEPS) $(HASH_OP_DEPS) $(QUEUE_OP) $(MD5_DEPS)
+wazuh-clusterd-internal: wazuh-clusterd-internal.o $(DEBUG_OP_DEPS) $(HASH_OP_DEPS) $(QUEUE_OP) $(MD5_DEPS)
 	$(CC) $(THREAD_FLAGS) -DDEFAULTDIR=\"${PREFIX}\" $(LDFLAGS) $^ -o $@ $(LIBS)
 endif
 
@@ -102,4 +95,4 @@ wazuh-clusterd-internal.o: wazuh/wazuh-clusterd-internal.c
 endif
 
 clean:
-	$(RM_FILE) $(BUILD_TARGET) *.o *.so.0
+	$(RM_FILE) $(BUILD_TARGET) *.o

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -10,9 +10,12 @@ OSSEC_GROUP  = ossec
 PREFIX       = /var/ossec
 
 OPENSSL_DIR      = ../src/external/openssl
+JSON_DIR         = ../src/external/cJSON
 
 CC           = gcc
 CFLAGS       = -pipe -Wall -Wextra
+LDFLAGS      = -L$(JSON_DIR) -L$(OPENSSL_DIR) -Wl,-rpath,../lib
+LIBS         = -lcjson -lssl -lcrypto -ldl -lm
 THREAD_FLAGS = -pthread
 RM_FILE      = rm -f
 INSTALL_DIR  = install -o root -g ${OSSEC_GROUP} -m 0750  -d
@@ -20,12 +23,10 @@ INSTALL_EXEC = install -o root -g ${OSSEC_GROUP} -m 0750
 INSTALL_FILE = install -o root -g ${OSSEC_GROUP} -m 0640
 
 SQLITE_DIR       = ../src/external/sqlite
-JSON_DIR         = ../src/external/cJSON
 HEADERS_DIR      = ../src/headers
 MD5_DIR          = ../src/os_crypto/md5
 
 DEBUG_OP         = ../src/shared/debug_op.o
-JSON_LIB         = $(JSON_DIR)/cJSON.o
 XML_LIB          = ../src/os_xml/os_xml.o
 XML_ACCESS       = ../src/os_xml/os_xml_access.o
 STRBREAK         = ../src/os_regex/os_regex_strbreak.o
@@ -92,7 +93,7 @@ libsqlite3.so.0: $(SQLITE_DIR)/sqlite3.o
 
 ifeq (${uname_S},Linux)
 wazuh-clusterd-internal: wazuh-clusterd-internal.o $(SQLITE_DIR)/sqlite3.o $(DEBUG_OP_DEPS) $(HASH_OP_DEPS) $(QUEUE_OP) $(MD5_DEPS)
-	$(CC) $(THREAD_FLAGS) -DDEFAULTDIR=\"${PREFIX}\" $^ -o $@ $(OPENSSL_DIR)/libssl.a $(OPENSSL_DIR)/libcrypto.a -L$(OPENSSL_DIR) -lcrypto -lssl -ldl -lm
+	$(CC) $(THREAD_FLAGS) -DDEFAULTDIR=\"${PREFIX}\" $(LDFLAGS) $^ -o $@ $(LIBS)
 endif
 
 ifeq (${uname_S},Linux)

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,7 +44,7 @@ ifneq (,$(filter ${REUSE_ID},yes y Y 1))
 	DEFINES+=-DREUSE_ID
 endif
 
-OSSEC_LDFLAGS=-L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -lcjson -lm -lssl -lcrypto ${LDFLAGS}
+OSSEC_LDFLAGS=-L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -L$(EXTERNAL_ZLIB) -lcjson -lm -lssl -lcrypto -lz ${LDFLAGS}
 
 ifneq (${TARGET},winagent)
 		OSSEC_LDFLAGS+=-L$(EXTERNAL_SQLITE) -lsqlite3
@@ -495,7 +495,7 @@ $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
 winagent: external win32/libwinpthread-1.dll
-	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -I./${EXTERNAL_ZLIB} -pthread" LDFLAGS="-L$(EXTERNAL_JSON) -lwsock32 -lwevtapi -lshlwapi -lcomctl32 -pthread -ladvapi32 -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lcjson"
+	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -pthread" LDFLAGS="-L$(EXTERNAL_JSON) -lwsock32 -lwevtapi -lshlwapi -lcomctl32 -pthread -ladvapi32 -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lcjson"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
 	cd win32/ && ./unix2dos.pl help.txt > help_win.txt
 	cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
@@ -516,16 +516,18 @@ win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 
 ifeq (${TARGET},winagent)
 OPENSSL_LIB = $(EXTERNAL_OPENSSL)libssl-1_1.$(SHARED)
+ZLIB_LIB    = $(EXTERNAL_ZLIB)/zlib1.$(SHARED)
 else
 OPENSSL_LIB = $(EXTERNAL_OPENSSL)libssl.$(SHARED)
 CRYPTO_LIB = $(EXTERNAL_OPENSSL)libcrypto.$(SHARED)
+ZLIB_LIB    = $(EXTERNAL_ZLIB)/libz.$(SHARED)
 endif
 
 SQLITE_LIB  = $(EXTERNAL_SQLITE)libsqlite3.$(SHARED)
 JSON_LIB    = $(EXTERNAL_JSON)libcjson.$(SHARED)
 PROCPS_LIB  = $(EXTERNAL_PROCPS)/libproc.$(SHARED)
 
-EXTERNAL_LIBS := $(JSON_LIB) ${EXTERNAL_ZLIB}libz.a $(OPENSSL_LIB)
+EXTERNAL_LIBS := $(JSON_LIB) $(ZLIB_LIB) $(OPENSSL_LIB)
 
 ifneq (${TARGET},winagent)
 EXTERNAL_LIBS += $(SQLITE_LIB)
@@ -575,20 +577,22 @@ endif
 
 #### zlib ##########
 
-${EXTERNAL_ZLIB}libz.a:
+$(ZLIB_LIB):
 ifeq (${TARGET},winagent)
-	cd ${EXTERNAL_ZLIB} && cp zconf.h.in zconf.h && ${MAKE} -f win32/Makefile.gcc PREFIX=${MING_BASE} libz.a
+	cd ${EXTERNAL_ZLIB} && cp zconf.h.in zconf.h && ${MAKE} -f win32/Makefile.gcc PREFIX=${MING_BASE} zlib1.dll
 else
-	cd ${EXTERNAL_ZLIB} && ./configure && ${MAKE} libz.a
+	cd ${EXTERNAL_ZLIB} && ./configure && ${MAKE} shared
+ifeq (${uname_S},Darwin)
+	install_name_tool -id "@rpath/libz.1.dylib" $@
+endif
 endif
 
-ZLIB_LIB=os_zlib.a ${EXTERNAL_ZLIB}libz.a
 ZLIB_INCLUDE=-I./${EXTERNAL_ZLIB}
 
 os_zlib_c := os_zlib/os_zlib.c
 os_zlib_o := $(os_zlib_c:.c=.o)
 
-os_zlib/%.o: os_zlib/%.c ${EXTERNAL_ZLIB}libz.a
+os_zlib/%.o: os_zlib/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $< -o $@
 
 os_zlib.a: ${os_zlib_o}
@@ -676,7 +680,7 @@ external/%.tar.gz:
 #### OSSEC Libs ####
 ####################
 
-ossec_libs = config.a wmodules.a os_crypto.a shared.a os_net.a os_regex.a os_xml.a
+ossec_libs = config.a wmodules.a os_crypto.a shared.a os_net.a os_regex.a os_xml.a os_zlib.a
 
 #### os_xml ########
 
@@ -845,13 +849,13 @@ os_crypto/hmac/%.o: os_crypto/hmac/%.c
 crypto_shared_c := $(wildcard os_crypto/shared/*.c)
 crypto_shared_o := $(crypto_shared_c:.c=.o)
 
-os_crypto/shared/%.o: os_crypto/shared/%.c ${ZLIB_LIB}
+os_crypto/shared/%.o: os_crypto/shared/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $< -o $@
 
 crypto_signature_c := $(wildcard os_crypto/signature/*.c)
 crypto_signature_o := $(crypto_signature_c:.c=.o)
 
-os_crypto/signature/%.o: os_crypto/signature/%.c ${ZLIB_LIB}
+os_crypto/signature/%.o: os_crypto/signature/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $< -o $@
 
 
@@ -879,7 +883,7 @@ os_maild_o := $(os_maild_c:.c=.o)
 os_maild/%.o: os_maild/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-maild\" -c $^ -o $@
 
-ossec-maild: ${os_maild_o} ${ossec_libs} ${ZLIB_LIB}
+ossec-maild: ${os_maild_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### os_dbd ##########
@@ -890,7 +894,7 @@ os_dbd_o := $(os_dbd_c:.c=.o)
 os_dbd/%.o: os_dbd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${MI} ${PI} -DARGV0=\"ossec-dbd\" -c $^ -o $@
 
-ossec-dbd: ${os_dbd_o} ${ossec_libs} ${ZLIB_LIB}
+ossec-dbd: ${os_dbd_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${MI} ${PI} $^ -lm ${OSSEC_LDFLAGS} -o $@
 
 
@@ -902,7 +906,7 @@ os_csyslogd_o := $(os_csyslogd_c:.c=.o)
 os_csyslogd/%.o: os_csyslogd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-csyslogd\" -c $^ -o $@
 
-ossec-csyslogd: ${os_csyslogd_o} ${ossec_libs} ${ZLIB_LIB}
+ossec-csyslogd: ${os_csyslogd_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ -lm ${OSSEC_LDFLAGS} -o $@
 
 
@@ -914,7 +918,7 @@ os_agentlessd_o := $(os_agentlessd_c:.c=.o)
 agentlessd/%.o: agentlessd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-agentlessd\" -c $^ -o $@
 
-ossec-agentlessd: ${os_agentlessd_o} ${ossec_libs} ${ZLIB_LIB}
+ossec-agentlessd: ${os_agentlessd_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### os_execd #####
@@ -925,7 +929,7 @@ os_execd_o := $(os_execd_c:.c=.o)
 os_execd/%.o: os_execd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-execd\" -c $^ -o $@
 
-ossec-execd: ${os_execd_o} ${ossec_libs} ${ZLIB_LIB}
+ossec-execd: ${os_execd_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ -lm ${OSSEC_LDFLAGS} -o $@
 
 
@@ -941,7 +945,7 @@ logcollector/%.o: logcollector/%.c
 logcollector/%-event.o: logcollector/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DEVENTCHANNEL_SUPPORT -DARGV0=\"ossec-logcollector\" -c $^ -o $@
 
-ossec-logcollector: ${os_logcollector_o} ${ossec_libs} ${ZLIB_LIB}
+ossec-logcollector: ${os_logcollector_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### remoted #########
@@ -950,10 +954,10 @@ remoted_c := $(wildcard remoted/*.c)
 remoted_o := $(remoted_c:.c=.o)
 
 remoted/%.o: remoted/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I./remoted ${ZLIB_INCLUDE} -DARGV0=\"ossec-remoted\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I./remoted -DARGV0=\"ossec-remoted\" -c $^ -o $@
 
-ossec-remoted: ${remoted_o} ${ossec_libs} ${ZLIB_LIB} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-remoted: ${remoted_o} ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### ossec-agentd ####
 
@@ -961,10 +965,10 @@ client_agent_c := $(wildcard client-agent/*.c)
 client_agent_o := $(client_agent_c:.c=.o)
 
 client-agent/%.o: client-agent/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I./client-agent ${ZLIB_INCLUDE} -DARGV0=\"ossec-agentd\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I./client-agent -DARGV0=\"ossec-agentd\" -c $^ -o $@
 
-ossec-agentd: ${client_agent_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-agentd: ${client_agent_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### addagent ######
 
@@ -972,11 +976,11 @@ addagent_c := $(wildcard addagent/*.c)
 addagent_o := $(addagent_c:.c=.o)
 
 addagent/%.o: addagent/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I./addagent ${ZLIB_INCLUDE} -DARGV0=\"manage_agents\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I./addagent -DARGV0=\"manage_agents\" -c $^ -o $@
 
 
-manage_agents: ${addagent_o} ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+manage_agents: ${addagent_o} ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### Util ##########
 
@@ -989,31 +993,31 @@ util_c := $(wildcard util/*.c)
 util_o := $(util_c:.c=.o)
 
 util/%.o: util/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I./util ${ZLIB_INCLUDE} -DARGV0=\"utils\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I./util -DARGV0=\"utils\" -c $^ -o $@
 
-syscheck_update: util/syscheck_update.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+syscheck_update: util/syscheck_update.o addagent/validate.o ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-clear_stats: util/clear_stats.o ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+clear_stats: util/clear_stats.o ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-list_agents: util/list_agents.o ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+list_agents: util/list_agents.o ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-verify-agent-conf: util/verify-agent-conf.o ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+verify-agent-conf: util/verify-agent-conf.o ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-agent_control: util/agent_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ -lm ${OSSEC_LDFLAGS} -o $@
+agent_control: util/agent_control.o addagent/validate.o ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ -lm ${OSSEC_LDFLAGS} -o $@
 
-syscheck_control: util/syscheck_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+syscheck_control: util/syscheck_control.o addagent/validate.o ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-rootcheck_control: util/rootcheck_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+rootcheck_control: util/rootcheck_control.o addagent/validate.o ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-ossec-regex: util/ossec-regex.o ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-regex: util/ossec-regex.o ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### rootcheck #####
 
@@ -1039,7 +1043,7 @@ rootcheck.a: ${rootcheck_o_lib}
 #	@echo ${rootcheck_o_cmd}
 #	@echo ${rootcheck_o_lib}
 #	@echo ${rootcheck_o}
-#	${OSSEC_CC} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} rootcheck/rootcheck-config.o rootcheck.a rootcheck/rootcheck.c ${ZLIB_LIB} ${ossec_libs}  -o $@
+#	${OSSEC_CC} ${OSSEC_CFLAGS} rootcheck/rootcheck-config.o rootcheck.a rootcheck/rootcheck.c ${ossec_libs}  -o $@
 
 #### syscheck ######
 
@@ -1050,19 +1054,19 @@ syscheck_o := $(syscheck_c:.c=.o)
 syscheckd/%.o: syscheckd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-syscheckd\" -c $^ -o $@
 
-ossec-syscheckd: ${syscheck_o} rootcheck.a ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-syscheckd: ${syscheck_o} rootcheck.a ${ossec_libs}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### Monitor #######
 
 monitor_c := $(wildcard monitord/*.c)
 monitor_o := $(monitor_c:.c=.o)
 
-monitord/%.o: monitord/%.c ${ZLIB_LIB}
+monitord/%.o: monitord/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-monitord\" -c $< -o $@
 
-ossec-monitord: ${monitor_o} ${ossec_libs} os_maild/sendcustomemail.o ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-monitord: ${monitor_o} ${ossec_libs} os_maild/sendcustomemail.o
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 
 #### reportd #######
@@ -1085,10 +1089,10 @@ os_auth_o := $(os_auth_c:.c=.o)
 os_auth/%.o: os_auth/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -pthread -I./os_auth -DARGV0=\"ossec-authd\" -c $^ -o $@
 
-agent-auth: addagent/validate.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o ${ossec_libs} ${ZLIB_LIB}
+agent-auth: addagent/validate.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@
 
-ossec-authd: addagent/validate.o os_auth/main-server.o os_auth/local-server.o os_auth/ssl.o os_auth/check_cert.o os_auth/config.o ${ossec_libs} ${ZLIB_LIB}
+ossec-authd: addagent/validate.o os_auth/main-server.o os_auth/local-server.o os_auth/ssl.o os_auth/check_cert.o os_auth/config.o ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@
 
 #### integratord #####
@@ -1099,7 +1103,7 @@ integrator_o := $(integrator_c:.c=.o)
 os_integrator/%.o: os_integrator/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS}  -I./os_integrator -DARGV0=\"ossec-integratord\" -c $^ -o $@
 
-ossec-integratord: ${integrator_o} ${ossec_libs} ${ZLIB_LIB}
+ossec-integratord: ${integrator_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_integrator $^ ${OSSEC_LDFLAGS} -o $@
 
 #### analysisd #####
@@ -1198,13 +1202,13 @@ analysisd/%-test.o: analysisd/%.c analysisd/compiled_rules/compiled_rules.h
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DTESTRULE -DARGV0=\"ossec-analysisd\" -I./analysisd -c $< -o $@
 
 
-ossec-logtest: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-test.o analysisd/analysisd-test.o alerts.a cdb.a decoders-test.a ${ossec_libs} ${ZLIB_LIB}
+ossec-logtest: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-test.o analysisd/analysisd-test.o alerts.a cdb.a decoders-test.a ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -DTESTRULE $^ ${OSSEC_LDFLAGS} -o $@
 
-ossec-analysisd: ${analysisd_live_o} analysisd/analysisd-live.o ${output_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs} ${ZLIB_LIB}
+ossec-analysisd: ${analysisd_live_o} analysisd/analysisd-live.o ${output_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs} ${ZLIB_LIB}
+ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 ### wazuh-modulesd ##
@@ -1212,7 +1216,7 @@ ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} aler
 wmodulesd_c := wazuh_modules/main.c
 wmodulesd_o := $(wmodulesd_c:.c=.o)
 
-wazuh-modulesd: ${wmodulesd_o} ${ossec_libs} ${ZLIB_LIB}
+wazuh-modulesd: ${wmodulesd_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 ### wazuh-framework ##
@@ -1253,7 +1257,7 @@ test_o := $(test_c:.c=.o)
 tests/%.o: tests/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
-test_os_zlib: tests/test_os_zlib.o ${ZLIB_LIB}
+test_os_zlib: tests/test_os_zlib.o
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 test_os_xml: tests/test_os_xml.o ${os_xml_o}
@@ -1262,7 +1266,7 @@ test_os_xml: tests/test_os_xml.o ${os_xml_o}
 test_os_regex: tests/test_os_regex.c ${os_regex_o}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-test_os_crypto: tests/test_os_crypto.c ${crypto_o} ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o} ${ZLIB_LIB}
+test_os_crypto: tests/test_os_crypto.c ${crypto_o} ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 test_os_net: tests/test_os_net.c ${os_net_o} ${shared_o} ${os_regex_o} ${os_xml_o}
@@ -1318,16 +1322,16 @@ win32_ui_o := $(win32_ui_c:.c=.o)
 win32/ui/%.o: win32/ui/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -UOSSECHIDS -DARGV0=\"ossec-win32ui\" -c $^ -o $@
 
-win32/ossec-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll ${ZLIB_LIB}
+win32/ossec-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll
 	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-win32/ossec-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll ${ZLIB_LIB}
+win32/ossec-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll
 	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 win32/ossec-rootcheck.exe: win32/icon.o win32/win_service_rk.o ${rootcheck_rk_o} ${ossec_libs}
 	${OSSEC_CCBIN} -DARGV0=\"ossec-rootcheck\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-win32/manage_agents.exe: win32/win_service_rk.o ${addagent_o} ${ossec_libs} ${ZLIB_LIB}
+win32/manage_agents.exe: win32/win_service_rk.o ${addagent_o} ${ossec_libs}
 	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 win32/setup-windows.exe: win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o ${ossec_libs}
@@ -1348,7 +1352,7 @@ win32/resource.o: win32/ui/win32ui.rc
 win32/os_win32ui.exe: win32/resource.o win32/win_service_rk.o ${win32_ui_o} addagent/b64.o ${ossec_libs}
 	${OSSEC_CCBIN} -DARGV0=\"ossec-win32ui\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -mwindows -o $@
 
-win32/agent-auth.exe: win32/win_service_rk.o win32/agent_auth.c addagent/validate.c ${ossec_libs} ${ZLIB_LIB}
+win32/agent-auth.exe: win32/win_service_rk.o win32/agent_auth.c addagent/validate.c ${ossec_libs}
 	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -lshlwapi -lwsock32 -lsecur32 -flto -o $@
 
 ####################
@@ -1366,7 +1370,8 @@ clean-test:
 clean-external:
 ifneq ($(wildcard external/*/*),)
 	rm -f ${cjson_o} $(EXTERNAL_JSON)libcjson.*
-	cd ${EXTERNAL_ZLIB} && ${MAKE} -f Makefile.in distclean
+	-cd ${EXTERNAL_ZLIB} && ${MAKE} -f Makefile.in distclean
+	-cd ${EXTERNAL_ZLIB} && ${MAKE} -f win32/Makefile.gcc clean
 	rm -f ${EXTERNAL_ZLIB}/Makefile ${EXTERNAL_ZLIB}/zconf.h
 	-cd ${EXTERNAL_OPENSSL} && ${MAKE} distclean
 	rm -f ${procps_o} $(PROCPS_LIB)
@@ -1381,7 +1386,6 @@ clean-deps:
 	rm -rf $(EXTERNAL_DIR)
 
 clean-internals:
-	rm -f ${os_zlib_o} os_zlib.a
 	rm -f ${os_xml_o} os_xml.a
 	rm -f ${os_regex_o} os_regex.a
 	rm -f ${os_net_o} os_net.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,40 +44,39 @@ ifneq (,$(filter ${REUSE_ID},yes y Y 1))
 	DEFINES+=-DREUSE_ID
 endif
 
-OSSEC_LDFLAGS=-L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -L$(EXTERNAL_ZLIB) -lcjson -lm -lssl -lcrypto -lz ${LDFLAGS}
+OSSEC_CFLAGS = -pthread ${CFLAGS}
+OSSEC_LDFLAGS = -pthread -L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -L$(EXTERNAL_ZLIB) ${LDFLAGS}
+OSSEC_LIBS = -lcjson -lm -lssl -lcrypto -lz $(LIBS)
 
 ifneq (${TARGET},winagent)
-		OSSEC_LDFLAGS+=-L$(EXTERNAL_SQLITE) -lsqlite3
+		OSSEC_LDFLAGS+=-L$(EXTERNAL_SQLITE)
+		OSSEC_LIBS+=-lsqlite3
 ifeq (${uname_S},Linux)
 		DEFINES+=-DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE
 #		DEFINES+=-DUSE_MAGIC
-		OSSEC_LDFLAGS+=-pthread -lrt -ldl
-		OSSEC_LDFLAGS+=-L$(EXTERNAL_PROCPS) -lproc
-		OSSEC_LDFLAGS+=-L${EXTERNAL_LIBDB}.libs -ldb-6.2
+		OSSEC_CFLAGS+=-I${EXTERNAL_LIBDB}
+		OSSEC_LDFLAGS+=-L$(EXTERNAL_PROCPS)
+		OSSEC_LDFLAGS+=-L${EXTERNAL_LIBDB}.libs
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
+		OSSEC_LIBS+=-lrt -ldl -lproc -ldb-6.2
 #		OSSEC_LDFLAGS+=-lmagic
-		CFLAGS+=-Wl,--start-group
 else
 ifeq (${uname_S},AIX)
 		DEFINES+=-DAIX
 		DEFINES+=-DHIGHFIRST
 		PATH:=${PATH}:/usr/vac/bin
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
-		OSSEC_LDFLAGS+=-pthread
 		CC=gcc
 else
 ifeq (${uname_S},SunOS)
 		DEFINES+=-DSOLARIS
 		DEFINES+=-DHIGHFIRST
 		DEFINES+=-std=gnu99
-		CFLAGS+=-Wl,--start-group
-		OSSEC_LDFLAGS+=-Wl,--end-group
 		OSSEC_LDFLAGS+=-z relax=secadj
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
-		OSSEC_LDFLAGS+=-lsocket -lnsl -lresolv
+		OSSEC_LIBS+=-lsocket -lnsl -lresolv -lrt
 		PATH:=${PATH}:/usr/ccs/bin:/usr/xpg4/bin:/opt/csw/gcc3/bin:/opt/csw/bin:/usr/sfw/bin
 		CC=gcc
-		OSSEC_LDFLAGS+=-pthread -lrt
 		uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 else
 ifeq (${uname_S},Darwin)
@@ -88,21 +87,17 @@ ifeq (${uname_S},Darwin)
 else
 ifeq (${uname_S},FreeBSD)
 		DEFINES+=-DFreeBSD
-		OSSEC_LDFLAGS+=-pthread
-		CFLAGS+=-I/usr/local/include -Wl,--start-group
+		OSSEC_CFLAGS+=-I/usr/local/include
 		OSSEC_LDFLAGS+=-L/usr/local/lib
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 else
 ifeq (${uname_S},NetBSD)
 		DEFINES+=-DNetBSD
-		OSSEC_LDFLAGS+=-pthread
-		CFLAGS+=-Wl,--start-group
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 else
 ifeq (${uname_S},OpenBSD)
 #		DEFINES+=-DOpenBSD
 		DEFINES+=-pthread
-		CFLAGS+=-I/usr/local/include -Wl,--start-group
 		OSSEC_LDFLAGS+=-L/usr/local/lib
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 else
@@ -112,7 +107,7 @@ ifeq (${uname_S},HP-UX)
 		DEFINES+=-DHIGHFIRST
 		DEFINES+=-D_REENTRANT
 		DEFINES+=-DOS_BIG_ENDIAN
-		OSSEC_LDFLAGS+=-pthread -lrt
+		OSSEC_LDFLAGS+=-lrt
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 		PATH:=${PATH}:/usr/local/bin
 		CC=gcc
@@ -143,8 +138,6 @@ ifdef DEBUGAD
 	DEFINES+=-DDEBUGAD
 endif
 
-OSSEC_CFLAGS=${CFLAGS}
-
 ifdef DEBUG
 	OSSEC_CFLAGS+=-g
 else
@@ -152,6 +145,7 @@ else
 endif #DEBUG
 
 OSSEC_CFLAGS+=${OFLAGS}
+OSSEC_LDFLAGS+=${OFLAGS}
 
 ifneq (,$(filter ${CLEANFULL},yes y Y 1))
 	DEFINES+=-DCLEANFULL
@@ -245,7 +239,7 @@ endif # USE_PRELUDE
 ifneq (,$(filter ${USE_ZEROMQ},auto yes y Y 1))
 	DEFINES+=-DZEROMQ_OUTPUT_ENABLED
 	#LDFLAGS+=-L/usr/local/lib -I/usr/local/include -lzmq -lczmq
-	OSSEC_LDFLAGS+=-lzmq -lczmq -lm
+	OSSEC_LDFLAGS+=-lzmq -lczmq
 endif # USE_ZEROMQ
 
 ifneq (,$(filter ${USE_GEOIP},auto yes y Y 1))
@@ -432,11 +426,11 @@ settings:
 	@echo "    MAKE            ${MAKE}"
 
 
-BUILD_SERVER+=ossec-maild
-BUILD_SERVER+=ossec-csyslogd
-BUILD_SERVER+=ossec-agentlessd
-BUILD_SERVER+=ossec-execd
-BUILD_SERVER+=ossec-logcollector
+BUILD_SERVER+=ossec-maild -
+BUILD_SERVER+=ossec-csyslogd -
+BUILD_SERVER+=ossec-agentlessd -
+BUILD_SERVER+=ossec-execd -
+BUILD_SERVER+=ossec-logcollector -
 BUILD_SERVER+=ossec-remoted
 BUILD_SERVER+=ossec-agentd
 BUILD_SERVER+=manage_agents
@@ -448,7 +442,7 @@ BUILD_SERVER+=ossec-authd
 BUILD_SERVER+=ossec-analysisd
 BUILD_SERVER+=ossec-logtest
 BUILD_SERVER+=ossec-makelists
-BUILD_SERVER+=ossec-dbd
+BUILD_SERVER+=ossec-dbd -
 BUILD_SERVER+=ossec-integratord
 BUILD_SERVER+=wazuh-modulesd
 BUILD_SERVER+=wazuh-db
@@ -495,7 +489,7 @@ $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
 winagent: external win32/libwinpthread-1.dll
-	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -pthread" LDFLAGS="-L$(EXTERNAL_JSON) -lwsock32 -lwevtapi -lshlwapi -lcomctl32 -pthread -ladvapi32 -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lcjson"
+	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
 	cd win32/ && ./unix2dos.pl help.txt > help_win.txt
 	cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
@@ -595,10 +589,6 @@ os_zlib_o := $(os_zlib_c:.c=.o)
 os_zlib/%.o: os_zlib/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $< -o $@
 
-os_zlib.a: ${os_zlib_o}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
-
 #### SQLite #########
 
 ifeq (${uname_S},Darwin)
@@ -680,7 +670,9 @@ external/%.tar.gz:
 #### OSSEC Libs ####
 ####################
 
-ossec_libs = config.a wmodules.a os_crypto.a shared.a os_net.a os_regex.a os_xml.a os_zlib.a
+BUILD_LIBS = libwazuh.a
+
+$(BUILD_SERVER) $(BUILD_AGENT) $(WINDOWS_BINS): $(BUILD_LIBS)
 
 #### os_xml ########
 
@@ -690,11 +682,6 @@ os_xml_o := $(os_xml_c:.c=.o)
 os_xml/%.o: os_xml/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
-os_xml.a: ${os_xml_o}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
-
-
 #### os_regex ######
 
 os_regex_c := $(wildcard os_regex/*.c)
@@ -702,10 +689,6 @@ os_regex_o := $(os_regex_c:.c=.o)
 
 os_regex/%.o: os_regex/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
-
-os_regex.a: ${os_regex_o}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
 
 #### os_net ##########
 
@@ -715,21 +698,13 @@ os_net_o := $(os_net_c:.c=.o)
 os_net/%.o: os_net/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
-os_net.a: ${os_net_o}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
-
 #### Shared ##########
 
 shared_c := $(wildcard shared/*.c)
 shared_o := $(shared_c:.c=.o)
 
 shared/%.o: shared/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-remoted\" -pthread -c $^ -o $@
-
-shared.a: ${shared_o}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-remoted\" -c $^ -o $@
 
 #### Wazuh DB ####
 
@@ -744,8 +719,8 @@ wazuh_db/schema_%.o: wazuh_db/schema_%.sql
 wazuh_db/%.o: wazuh_db/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"wazuh-db\" -c $^ -o $@
 
-wazuh-db: ${wdb_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+wazuh-db: ${wdb_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### Config ##########
 
@@ -754,10 +729,6 @@ config_o := $(config_c:.c=.o)
 
 config/%.o: config/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
-
-config.a: ${config_o}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
 
 #### Wazuh modules ##
 
@@ -774,16 +745,16 @@ endif
 wmodules_o := $(wmodules_c:.c=.o)
 
 wazuh_modules/%.o: wazuh_modules/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -pthread -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
 ifeq (${TARGET},winagent)
 wazuh_modules/syscollector/syscollector_win_ext.dll: wazuh_modules/syscollector/syscollector_win_ext.o
-	${OSSEC_CC} -pipe -O2 -shared -o $@ $^ ${OSSEC_LDFLAGS}
+	${OSSEC_SHARED} ${OSSEC_LDFLAGS} $^ -o $@ $(OSSEC_LIBS)
 endif # DLL for Windows
 
 ifndef DISABLE_SYSC
 wazuh_modules/syscollector/%.o: wazuh_modules/syscollector/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I${EXTERNAL_LIBDB} -pthread -c $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 endif
 
 wmodules_dep := ${wmodules_o} ${wdblib_o}
@@ -791,10 +762,6 @@ wmodules_dep := ${wmodules_o} ${wdblib_o}
 ifeq (${uname_S},HP-UX)
 	wmodules_dep := ${wmodules_dep} ${config_o}
 endif
-
-wmodules.a: ${wmodules_dep}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
 
 #### crypto ##########
 
@@ -870,10 +837,11 @@ crypto_o := ${crypto_blowfish_o} \
 					 ${crypto_hmac_o} \
 					 ${crypto_signature_o}
 
-os_crypto.a: ${crypto_o}
+#### libwazuh #########
+
+libwazuh.a: ${config_o} ${wmodules_dep} ${crypto_o} ${shared_o} ${os_net_o} ${os_regex_o} ${os_xml_o} ${os_zlib_o}
 	${OSSEC_LINK} $@ $^
 	${OSSEC_RANLIB} $@
-
 
 #### os_mail #########
 
@@ -883,8 +851,8 @@ os_maild_o := $(os_maild_c:.c=.o)
 os_maild/%.o: os_maild/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-maild\" -c $^ -o $@
 
-ossec-maild: ${os_maild_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-maild: ${os_maild_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### os_dbd ##########
 
@@ -894,8 +862,8 @@ os_dbd_o := $(os_dbd_c:.c=.o)
 os_dbd/%.o: os_dbd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${MI} ${PI} -DARGV0=\"ossec-dbd\" -c $^ -o $@
 
-ossec-dbd: ${os_dbd_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${MI} ${PI} $^ -lm ${OSSEC_LDFLAGS} -o $@
+ossec-dbd: ${os_dbd_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} ${MI} ${PI} $^  ${OSSEC_LIBS} -o $@
 
 
 #### os_csyslogd #####
@@ -906,8 +874,8 @@ os_csyslogd_o := $(os_csyslogd_c:.c=.o)
 os_csyslogd/%.o: os_csyslogd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-csyslogd\" -c $^ -o $@
 
-ossec-csyslogd: ${os_csyslogd_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ -lm ${OSSEC_LDFLAGS} -o $@
+ossec-csyslogd: ${os_csyslogd_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 
 #### agentlessd ####
@@ -918,8 +886,8 @@ os_agentlessd_o := $(os_agentlessd_c:.c=.o)
 agentlessd/%.o: agentlessd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-agentlessd\" -c $^ -o $@
 
-ossec-agentlessd: ${os_agentlessd_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-agentlessd: ${os_agentlessd_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### os_execd #####
 
@@ -929,8 +897,8 @@ os_execd_o := $(os_execd_c:.c=.o)
 os_execd/%.o: os_execd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-execd\" -c $^ -o $@
 
-ossec-execd: ${os_execd_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ -lm ${OSSEC_LDFLAGS} -o $@
+ossec-execd: ${os_execd_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 
 #### logcollectord ####
@@ -945,8 +913,8 @@ logcollector/%.o: logcollector/%.c
 logcollector/%-event.o: logcollector/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DEVENTCHANNEL_SUPPORT -DARGV0=\"ossec-logcollector\" -c $^ -o $@
 
-ossec-logcollector: ${os_logcollector_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-logcollector: ${os_logcollector_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### remoted #########
 
@@ -956,8 +924,8 @@ remoted_o := $(remoted_c:.c=.o)
 remoted/%.o: remoted/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./remoted -DARGV0=\"ossec-remoted\" -c $^ -o $@
 
-ossec-remoted: ${remoted_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-remoted: ${remoted_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### ossec-agentd ####
 
@@ -967,8 +935,8 @@ client_agent_o := $(client_agent_c:.c=.o)
 client-agent/%.o: client-agent/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./client-agent -DARGV0=\"ossec-agentd\" -c $^ -o $@
 
-ossec-agentd: ${client_agent_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-agentd: ${client_agent_o} monitord/rotate_log.o monitord/compress_log.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### addagent ######
 
@@ -979,12 +947,14 @@ addagent/%.o: addagent/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./addagent -DARGV0=\"manage_agents\" -c $^ -o $@
 
 
-manage_agents: ${addagent_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+manage_agents: ${addagent_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### Util ##########
 
 util_programs = syscheck_update clear_stats list_agents agent_control syscheck_control rootcheck_control verify-agent-conf ossec-regex
+
+$(util_programs): $(BUILD_LIBS)
 
 .PHONY: utils
 utils: ${util_programs}
@@ -995,29 +965,29 @@ util_o := $(util_c:.c=.o)
 util/%.o: util/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./util -DARGV0=\"utils\" -c $^ -o $@
 
-syscheck_update: util/syscheck_update.o addagent/validate.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+syscheck_update: util/syscheck_update.o addagent/validate.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-clear_stats: util/clear_stats.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+clear_stats: util/clear_stats.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-list_agents: util/list_agents.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+list_agents: util/list_agents.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-verify-agent-conf: util/verify-agent-conf.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+verify-agent-conf: util/verify-agent-conf.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-agent_control: util/agent_control.o addagent/validate.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ -lm ${OSSEC_LDFLAGS} -o $@
+agent_control: util/agent_control.o addagent/validate.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-syscheck_control: util/syscheck_control.o addagent/validate.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+syscheck_control: util/syscheck_control.o addagent/validate.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-rootcheck_control: util/rootcheck_control.o addagent/validate.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+rootcheck_control: util/rootcheck_control.o addagent/validate.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-ossec-regex: util/ossec-regex.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-regex: util/ossec-regex.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### rootcheck #####
 
@@ -1039,11 +1009,11 @@ rootcheck.a: ${rootcheck_o_lib}
 	${OSSEC_LINK} $@ $^
 	${OSSEC_RANLIB} $@
 
-#ossec-rootcheck: rootcheck/rootcheck-config.o rootcheck.a ${ossec_libs}
+#ossec-rootcheck: rootcheck/rootcheck-config.o rootcheck.a
 #	@echo ${rootcheck_o_cmd}
 #	@echo ${rootcheck_o_lib}
 #	@echo ${rootcheck_o}
-#	${OSSEC_CC} ${OSSEC_CFLAGS} rootcheck/rootcheck-config.o rootcheck.a rootcheck/rootcheck.c ${ossec_libs}  -o $@
+#	${OSSEC_CC} ${OSSEC_CFLAGS} rootcheck/rootcheck-config.o rootcheck.a rootcheck/rootcheck.c  -o $@
 
 #### syscheck ######
 
@@ -1054,8 +1024,8 @@ syscheck_o := $(syscheck_c:.c=.o)
 syscheckd/%.o: syscheckd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-syscheckd\" -c $^ -o $@
 
-ossec-syscheckd: ${syscheck_o} rootcheck.a ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-syscheckd: ${syscheck_o} rootcheck.a
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### Monitor #######
 
@@ -1065,8 +1035,8 @@ monitor_o := $(monitor_c:.c=.o)
 monitord/%.o: monitord/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-monitord\" -c $< -o $@
 
-ossec-monitord: ${monitor_o} ${ossec_libs} os_maild/sendcustomemail.o
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-monitord: ${monitor_o} os_maild/sendcustomemail.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 
 #### reportd #######
@@ -1077,8 +1047,8 @@ report_o := $(report_c:.c=.o)
 reportd/%.o: reportd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-reportd\" -c $^ -o $@
 
-ossec-reportd: ${report_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-reportd: ${report_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 
 #### os_auth #######
@@ -1087,13 +1057,13 @@ os_auth_c := ${wildcard os_auth/*.c}
 os_auth_o := $(os_auth_c:.c=.o)
 
 os_auth/%.o: os_auth/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -pthread -I./os_auth -DARGV0=\"ossec-authd\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I./os_auth -DARGV0=\"ossec-authd\" -c $^ -o $@
 
-agent-auth: addagent/validate.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@
+agent-auth: addagent/validate.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-ossec-authd: addagent/validate.o os_auth/main-server.o os_auth/local-server.o os_auth/ssl.o os_auth/check_cert.o os_auth/config.o ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@
+ossec-authd: addagent/validate.o os_auth/main-server.o os_auth/local-server.o os_auth/ssl.o os_auth/check_cert.o os_auth/config.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### integratord #####
 
@@ -1103,8 +1073,8 @@ integrator_o := $(integrator_c:.c=.o)
 os_integrator/%.o: os_integrator/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS}  -I./os_integrator -DARGV0=\"ossec-integratord\" -c $^ -o $@
 
-ossec-integratord: ${integrator_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_integrator $^ ${OSSEC_LDFLAGS} -o $@
+ossec-integratord: ${integrator_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### analysisd #####
 
@@ -1202,22 +1172,22 @@ analysisd/%-test.o: analysisd/%.c analysisd/compiled_rules/compiled_rules.h
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DTESTRULE -DARGV0=\"ossec-analysisd\" -I./analysisd -c $< -o $@
 
 
-ossec-logtest: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-test.o analysisd/analysisd-test.o alerts.a cdb.a decoders-test.a ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -DTESTRULE $^ ${OSSEC_LDFLAGS} -o $@
+ossec-logtest: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-test.o analysisd/analysisd-test.o alerts.a cdb.a decoders-test.a
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-ossec-analysisd: ${analysisd_live_o} analysisd/analysisd-live.o ${output_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-analysisd: ${analysisd_live_o} analysisd/analysisd-live.o ${output_o} ${format_o} alerts.a cdb.a decoders-live.a
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} alerts.a cdb.a decoders-live.a
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 ### wazuh-modulesd ##
 
 wmodulesd_c := wazuh_modules/main.c
 wmodulesd_o := $(wmodulesd_c:.c=.o)
 
-wazuh-modulesd: ${wmodulesd_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+wazuh-modulesd: ${wmodulesd_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 ### wazuh-framework ##
 
@@ -1258,22 +1228,22 @@ tests/%.o: tests/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
 test_os_zlib: tests/test_os_zlib.o
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_os_xml: tests/test_os_xml.o ${os_xml_o}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_os_regex: tests/test_os_regex.c ${os_regex_o}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_os_crypto: tests/test_os_crypto.c ${crypto_o} ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_os_net: tests/test_os_net.c ${os_net_o} ${shared_o} ${os_regex_o} ${os_xml_o}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_shared: tests/test_shared.c ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_valgrind: build_tests
 	${MAKE} run_tests
@@ -1322,38 +1292,38 @@ win32_ui_o := $(win32_ui_c:.c=.o)
 win32/ui/%.o: win32/ui/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -UOSSECHIDS -DARGV0=\"ossec-win32ui\" -c $^ -o $@
 
-win32/ossec-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll
-	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+win32/ossec-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll
+	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/ossec-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll
-	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+win32/ossec-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll
+	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/ossec-rootcheck.exe: win32/icon.o win32/win_service_rk.o ${rootcheck_rk_o} ${ossec_libs}
-	${OSSEC_CCBIN} -DARGV0=\"ossec-rootcheck\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+win32/ossec-rootcheck.exe: win32/icon.o win32/win_service_rk.o ${rootcheck_rk_o}
+	${OSSEC_CCBIN} -DARGV0=\"ossec-rootcheck\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/manage_agents.exe: win32/win_service_rk.o ${addagent_o} ${ossec_libs}
-	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+win32/manage_agents.exe: win32/win_service_rk.o ${addagent_o}
+	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/setup-windows.exe: win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o ${ossec_libs}
-	${OSSEC_CCBIN} -DARGV0=\"setup-windows\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+win32/setup-windows.exe: win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o
+	${OSSEC_CCBIN} -DARGV0=\"setup-windows\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/setup-syscheck.exe: win32/setup-syscheck.o win32/setup-shared.o ${ossec_libs}
-	${OSSEC_CCBIN} -DARGV0=\"setup-syscheck\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+win32/setup-syscheck.exe: win32/setup-syscheck.o win32/setup-shared.o
+	${OSSEC_CCBIN} -DARGV0=\"setup-syscheck\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/setup-iis.exe: win32/setup-iis.o ${ossec_libs}
-	${OSSEC_CCBIN} -DARGV0=\"setup-iis\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+win32/setup-iis.exe: win32/setup-iis.o
+	${OSSEC_CCBIN} -DARGV0=\"setup-iis\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/add-localfile.exe: win32/add-localfile.o ${ossec_libs}
-	${OSSEC_CCBIN} -DARGV0=\"add-localfile\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+win32/add-localfile.exe: win32/add-localfile.o
+	${OSSEC_CCBIN} -DARGV0=\"add-localfile\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 win32/resource.o: win32/ui/win32ui.rc
 	${OSSEC_WINDRES} -i $< -o $@
 
-win32/os_win32ui.exe: win32/resource.o win32/win_service_rk.o ${win32_ui_o} addagent/b64.o ${ossec_libs}
-	${OSSEC_CCBIN} -DARGV0=\"ossec-win32ui\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -mwindows -o $@
+win32/os_win32ui.exe: win32/resource.o win32/win_service_rk.o ${win32_ui_o} addagent/b64.o
+	${OSSEC_CCBIN} -DARGV0=\"ossec-win32ui\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -mwindows -o $@
 
-win32/agent-auth.exe: win32/win_service_rk.o win32/agent_auth.c addagent/validate.c ${ossec_libs}
-	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -lshlwapi -lwsock32 -lsecur32 -flto -o $@
+win32/agent-auth.exe: win32/win_service_rk.o win32/agent_auth.o addagent/validate.o
+	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -lshlwapi -lwsock32 -lsecur32 -flto -o $@
 
 ####################
 #### Clean #########
@@ -1386,32 +1356,35 @@ clean-deps:
 	rm -rf $(EXTERNAL_DIR)
 
 clean-internals:
-	rm -f ${os_xml_o} os_xml.a
-	rm -f ${os_regex_o} os_regex.a
-	rm -f ${os_net_o} os_net.a
-	rm -f ${shared_o} shared.a
-	rm -f ${config_o} config.a
-	rm -f ${os_maild_o} ossec-maild
-	rm -f ${crypto_o} os_crypto.a
-	rm -f ${os_csyslogd_o} ossec-csyslogd
-	rm -f ${os_dbd_o} ossec-dbd
-	rm -f ${os_agentlessd_o} ossec-agentlessd
-	rm -f ${os_execd_o} ossec-execd
-	rm -f ${os_logcollector_o} ${os_logcollector_eventchannel_o} ossec-logcollector
-	rm -f ${remoted_o} ossec-remoted
-	rm -f ${report_o} ossec-reportd
-	rm -f ${client_agent_o} ossec-agentd
-	rm -f ${addagent_o} manage_agents
+	rm -f $(BUILD_SERVER)
+	rm -f $(BUILD_AGENT)
+	rm -f $(BUILD_LIBS)
+	rm -f ${os_zlib_o}
+	rm -f ${os_xml_o}
+	rm -f ${os_regex_o}
+	rm -f ${os_net_o}
+	rm -f ${shared_o}
+	rm -f ${config_o}
+	rm -f ${os_maild_o}
+	rm -f ${crypto_o}
+	rm -f ${os_csyslogd_o}
+	rm -f ${os_dbd_o}
+	rm -f ${os_agentlessd_o}
+	rm -f ${os_execd_o}
+	rm -f ${os_logcollector_o} ${os_logcollector_eventchannel_o}
+	rm -f ${remoted_o}
+	rm -f ${report_o}
+	rm -f ${client_agent_o}
+	rm -f ${addagent_o}
 	rm -f ${util_o} ${util_programs}
 	rm -f ${rootcheck_o} ${rootcheck_rk_o} rootcheck.a
-	rm -f ${syscheck_o} ossec-syscheckd
-	rm -f ${monitor_o} ossec-monitord
-	rm -f ${os_auth_o} ossec-authd agent-auth
+	rm -f ${syscheck_o}
+	rm -f ${monitor_o}
+	rm -f ${os_auth_o}
 	rm -f ${all_analysisd_o} ${all_analysisd_libs} analysisd/compiled_rules/compiled_rules.h
-	rm -f ossec-logtest ossec-analysisd ossec-makelists
-	rm -f ${integrator_o} ossec-integratord
-	rm -f ${wmodulesd_o} ${wmodules_o} wazuh-modulesd wmodules.a
-	rm -f ${wdb_o} wazuh-db
+	rm -f ${integrator_o}
+	rm -f ${wmodulesd_o} ${wmodules_o}
+	rm -f ${wdb_o}
 
 clean-framework:
 	${MAKE} -C ../framework clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,6 +21,7 @@ OSSEC_GROUP?=ossec
 OSSEC_USER?=ossec
 OSSEC_USER_MAIL?=ossecm
 OSSEC_USER_REM?=ossecr
+SHARED=so
 
 USE_PRELUDE?=no
 USE_ZEROMQ?=no
@@ -43,7 +44,7 @@ ifneq (,$(filter ${REUSE_ID},yes y Y 1))
 	DEFINES+=-DREUSE_ID
 endif
 
-OSSEC_LDFLAGS=-L${EXTERNAL_OPENSSL} -lm -lssl -lcrypto ${LDFLAGS}
+OSSEC_LDFLAGS=-L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -lcjson -lm -lssl -lcrypto ${LDFLAGS} -Wl,-rpath,../lib
 
 ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)
@@ -78,7 +79,7 @@ else
 ifeq (${uname_S},Darwin)
 		DEFINES+=-DDarwin
 		DEFINES+=-DHIGHFIRST
-
+		SHARED=dylib
 else
 ifeq (${uname_S},FreeBSD)
 		DEFINES+=-DFreeBSD
@@ -117,6 +118,8 @@ endif # Darwin
 endif # SunOS
 endif # AIX
 endif # Linux
+else
+		SHARED=dll
 endif # winagent
 
 ifndef DISABLE_SYSC
@@ -151,7 +154,7 @@ endif
 
 OSSEC_CFLAGS+=${DEFINES}
 OSSEC_CFLAGS+=-pipe -Wall -Wextra
-OSSEC_CFLAGS+=-I./ -I./headers/ -I${EXTERNAL_OPENSSL}include
+OSSEC_CFLAGS+=-I./ -I./headers/ -I${EXTERNAL_OPENSSL}include -I$(EXTERNAL_JSON)
 
 
 
@@ -205,6 +208,7 @@ endif #winagent
 
 OSSEC_CC      =${QUIET_CC}${MING_BASE}${CC}
 OSSEC_CCBIN   =${QUIET_CCBIN}${MING_BASE}${CC}
+OSSEC_SHARED  =${QUIET_CCBIN}${MING_BASE}${CC} -shared
 OSSEC_LINK    =${QUIET_LINK}${MING_BASE}ar -crus
 OSSEC_RANLIB  =${QUIET_RANLIB}${MING_BASE}ranlib
 OSSEC_WINDRES =${QUIET_CCBIN}${MING_BASE}windres
@@ -481,8 +485,8 @@ ifeq (${MAKECMDGOALS},winagent)
 $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
-winagent: external win32/libwinpthread-1.dll wazuh_modules/syscollector/syscollector_win_ext.dll
-	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -I./${EXTERNAL_ZLIB} -pthread" LDFLAGS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -pthread -ladvapi32 -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
+winagent: external win32/libwinpthread-1.dll
+	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -I./${EXTERNAL_ZLIB} -pthread" LDFLAGS="-L$(EXTERNAL_JSON) -lwsock32 -lwevtapi -lshlwapi -lcomctl32 -pthread -ladvapi32 -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lcjson"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
 	cd win32/ && ./unix2dos.pl help.txt > help_win.txt
 	cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
@@ -501,7 +505,7 @@ win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 #### External ######
 ####################
 
-EXTERNAL_LIBS := libcJSON.a ${EXTERNAL_ZLIB}libz.a ${EXTERNAL_OPENSSL}libssl.a ${EXTERNAL_OPENSSL}libcrypto.a
+EXTERNAL_LIBS := $(EXTERNAL_JSON)libcjson.$(SHARED) ${EXTERNAL_ZLIB}libz.a ${EXTERNAL_OPENSSL}libssl.a ${EXTERNAL_OPENSSL}libcrypto.a
 
 ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)
@@ -578,18 +582,20 @@ os_zlib.a: ${os_zlib_o}
 
 #### cJSON #########
 
-JSON_LIB=libcJSON.a
-JSON_INCLUDE=-I./${EXTERNAL_JSON}
+JSON_LIB=$(EXTERNAL_JSON)libcjson.$(SHARED)
+
+ifeq (${uname_S},Darwin)
+JSON_SHFLAGS=-install_name @loader_path/../lib/libcjson.$(SHARED)
+endif
 
 cjson_c := ${EXTERNAL_JSON}cJSON.c
 cjson_o := $(cjson_c:.c=.o)
 
-${EXTERNAL_JSON}%.o: ${EXTERNAL_JSON}%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
+$(JSON_LIB): ${cjson_o}
+	${OSSEC_SHARED} ${OSSEC_CFLAGS} $(JSON_SHFLAGS) -o $@ $^
 
-libcJSON.a: ${cjson_o}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
+${EXTERNAL_JSON}%.o: ${EXTERNAL_JSON}%.c
+	${OSSEC_CC} ${OSSEC_CFLAGS} -fPIC -c $^ -o $@
 
 #### procps #########
 ifneq (${TARGET},winagent)
@@ -647,7 +653,7 @@ external/%.tar.gz:
 #### OSSEC Libs ####
 ####################
 
-ossec_libs = config.a wmodules.a os_crypto.a shared.a os_net.a os_regex.a os_xml.a ${JSON_LIB} ${PROCPS_LIB}
+ossec_libs = config.a wmodules.a os_crypto.a shared.a os_net.a os_regex.a os_xml.a ${PROCPS_LIB}
 
 #### os_xml ########
 
@@ -747,13 +753,13 @@ wazuh_modules/%.o: wazuh_modules/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -pthread -c $^ -o $@
 
 ifeq (${TARGET},winagent)
-wazuh_modules/syscollector/syscollector_win_ext.dll: wazuh_modules/syscollector/syscollector_win_ext.o ${JSON_LIB}
-	${OSSEC_CC} -pipe -O2 -shared -o $@ $^ -liphlpapi -lws2_32
+wazuh_modules/syscollector/syscollector_win_ext.dll: wazuh_modules/syscollector/syscollector_win_ext.o
+	${OSSEC_CC} -pipe -O2 -shared -o $@ $^ ${OSSEC_LDFLAGS}
 endif # DLL for Windows
 
 ifndef DISABLE_SYSC
 wazuh_modules/syscollector/%.o: wazuh_modules/syscollector/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I${EXTERNAL_LIBDB} -pthread -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I${EXTERNAL_LIBDB} -pthread -c $^ ${OSSEC_LDFLAGS} -o $@
 endif
 
 wmodules_dep := ${wmodules_o} ${wdblib_o}
@@ -853,7 +859,7 @@ os_maild_o := $(os_maild_c:.c=.o)
 os_maild/%.o: os_maild/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-maild\" -c $^ -o $@
 
-ossec-maild: ${os_maild_o} ${ossec_libs} ${JSON_LIB} ${ZLIB_LIB}
+ossec-maild: ${os_maild_o} ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### os_dbd ##########
@@ -864,8 +870,8 @@ os_dbd_o := $(os_dbd_c:.c=.o)
 os_dbd/%.o: os_dbd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${MI} ${PI} -DARGV0=\"ossec-dbd\" -c $^ -o $@
 
-ossec-dbd: ${os_dbd_o} ${ossec_libs} ${JSON_LIB} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${MI} ${PI} ${JSON_INCLUDE} $^ -lm ${OSSEC_LDFLAGS} -o $@
+ossec-dbd: ${os_dbd_o} ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${MI} ${PI} $^ -lm ${OSSEC_LDFLAGS} -o $@
 
 
 #### os_csyslogd #####
@@ -874,10 +880,10 @@ os_csyslogd_c := $(wildcard os_csyslogd/*.c)
 os_csyslogd_o := $(os_csyslogd_c:.c=.o)
 
 os_csyslogd/%.o: os_csyslogd/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} ${JSON_INCLUDE} -DARGV0=\"ossec-csyslogd\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-csyslogd\" -c $^ -o $@
 
-ossec-csyslogd: ${os_csyslogd_o} ${ossec_libs} ${JSON_LIB} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${JSON_INCLUDE} $^ -lm ${OSSEC_LDFLAGS} -o $@
+ossec-csyslogd: ${os_csyslogd_o} ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ -lm ${OSSEC_LDFLAGS} -o $@
 
 
 #### agentlessd ####
@@ -888,7 +894,7 @@ os_agentlessd_o := $(os_agentlessd_c:.c=.o)
 agentlessd/%.o: agentlessd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-agentlessd\" -c $^ -o $@
 
-ossec-agentlessd: ${os_agentlessd_o} ${ossec_libs} ${JSON_LIB} ${ZLIB_LIB}
+ossec-agentlessd: ${os_agentlessd_o} ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### os_execd #####
@@ -899,8 +905,8 @@ os_execd_o := $(os_execd_c:.c=.o)
 os_execd/%.o: os_execd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-execd\" -c $^ -o $@
 
-ossec-execd: ${os_execd_o} ${ossec_libs} ${JSON_LIB} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${JSON_INCLUDE} $^ -lm ${OSSEC_LDFLAGS} -o $@
+ossec-execd: ${os_execd_o} ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ -lm ${OSSEC_LDFLAGS} -o $@
 
 
 #### logcollectord ####
@@ -915,7 +921,7 @@ logcollector/%.o: logcollector/%.c
 logcollector/%-event.o: logcollector/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DEVENTCHANNEL_SUPPORT -DARGV0=\"ossec-logcollector\" -c $^ -o $@
 
-ossec-logcollector: ${os_logcollector_o} ${ossec_libs} ${JSON_LIB} ${ZLIB_LIB}
+ossec-logcollector: ${os_logcollector_o} ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### remoted #########
@@ -926,7 +932,7 @@ remoted_o := $(remoted_c:.c=.o)
 remoted/%.o: remoted/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./remoted ${ZLIB_INCLUDE} -DARGV0=\"ossec-remoted\" -c $^ -o $@
 
-ossec-remoted: ${remoted_o} ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB} ${ZLIB_LIB}
+ossec-remoted: ${remoted_o} ${ossec_libs} ${ZLIB_LIB} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### ossec-agentd ####
@@ -937,7 +943,7 @@ client_agent_o := $(client_agent_c:.c=.o)
 client-agent/%.o: client-agent/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./client-agent ${ZLIB_INCLUDE} -DARGV0=\"ossec-agentd\" -c $^ -o $@
 
-ossec-agentd: ${client_agent_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o ${ZLIB_LIB} ${JSON_LIB}
+ossec-agentd: ${client_agent_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### addagent ######
@@ -949,8 +955,8 @@ addagent/%.o: addagent/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./addagent ${ZLIB_INCLUDE} -DARGV0=\"manage_agents\" -c $^ -o $@
 
 
-manage_agents: ${addagent_o} ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} ${JSON_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+manage_agents: ${addagent_o} ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### Util ##########
 
@@ -965,28 +971,28 @@ util_o := $(util_c:.c=.o)
 util/%.o: util/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./util ${ZLIB_INCLUDE} -DARGV0=\"utils\" -c $^ -o $@
 
-syscheck_update: util/syscheck_update.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} ${JSON_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
-
-clear_stats: util/clear_stats.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+syscheck_update: util/syscheck_update.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
-list_agents: util/list_agents.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+clear_stats: util/clear_stats.o ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
-verify-agent-conf: util/verify-agent-conf.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+list_agents: util/list_agents.o ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
-agent_control: util/agent_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} ${JSON_INCLUDE} $^ -lm ${OSSEC_LDFLAGS} -o $@
+verify-agent-conf: util/verify-agent-conf.o ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
-syscheck_control: util/syscheck_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} ${JSON_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+agent_control: util/agent_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ -lm ${OSSEC_LDFLAGS} -o $@
 
-rootcheck_control: util/rootcheck_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} ${JSON_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+syscheck_control: util/syscheck_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
-ossec-regex: util/ossec-regex.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+rootcheck_control: util/rootcheck_control.o addagent/validate.o ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+
+ossec-regex: util/ossec-regex.o ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### rootcheck #####
@@ -1024,7 +1030,7 @@ syscheck_o := $(syscheck_c:.c=.o)
 syscheckd/%.o: syscheckd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-syscheckd\" -c $^ -o $@
 
-ossec-syscheckd: ${syscheck_o} rootcheck.a ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+ossec-syscheckd: ${syscheck_o} rootcheck.a ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
 #### Monitor #######
@@ -1035,7 +1041,7 @@ monitor_o := $(monitor_c:.c=.o)
 monitord/%.o: monitord/%.c ${ZLIB_LIB}
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-monitord\" -c $< -o $@
 
-ossec-monitord: ${monitor_o} ${ossec_libs} os_maild/sendcustomemail.o ${ZLIB_LIB} ${JSON_LIB}
+ossec-monitord: ${monitor_o} ${ossec_libs} os_maild/sendcustomemail.o ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
 
 
@@ -1047,7 +1053,7 @@ report_o := $(report_c:.c=.o)
 reportd/%.o: reportd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-reportd\" -c $^ -o $@
 
-ossec-reportd: ${report_o} ${ossec_libs} ${JSON_LIB}
+ossec-reportd: ${report_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 
@@ -1059,11 +1065,11 @@ os_auth_o := $(os_auth_c:.c=.o)
 os_auth/%.o: os_auth/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -pthread -I./os_auth -DARGV0=\"ossec-authd\" -c $^ -o $@
 
-agent-auth: addagent/validate.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${JSON_INCLUDE} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@
+agent-auth: addagent/validate.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@
 
-ossec-authd: addagent/validate.o os_auth/main-server.o os_auth/local-server.o os_auth/ssl.o os_auth/check_cert.o os_auth/config.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${JSON_INCLUDE} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@
+ossec-authd: addagent/validate.o os_auth/main-server.o os_auth/local-server.o os_auth/ssl.o os_auth/check_cert.o os_auth/config.o ${ossec_libs} ${ZLIB_LIB}
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@
 
 #### integratord #####
 
@@ -1073,7 +1079,7 @@ integrator_o := $(integrator_c:.c=.o)
 os_integrator/%.o: os_integrator/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS}  -I./os_integrator -DARGV0=\"ossec-integratord\" -c $^ -o $@
 
-ossec-integratord: ${integrator_o} ${ossec_libs} ${JSON_LIB} ${ZLIB_LIB}
+ossec-integratord: ${integrator_o} ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -I./os_integrator $^ ${OSSEC_LDFLAGS} -o $@
 
 #### analysisd #####
@@ -1146,7 +1152,7 @@ format_o := ${format_c:.c=.o}
 all_analysisd_o += ${format_o}
 
 analysisd/format/%.o: analysisd/format/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} ${JSON_INCLUDE} -DARGV0=\"ossec-analysisd\" -I./analysisd -I./analysisd/decoders -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-analysisd\" -I./analysisd -I./analysisd/decoders -c $^ -o $@
 
 output_c := ${wildcard analysisd/output/*c}
 output_o := ${output_c:.c=.o}
@@ -1172,13 +1178,13 @@ analysisd/%-test.o: analysisd/%.c analysisd/compiled_rules/compiled_rules.h
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DTESTRULE -DARGV0=\"ossec-analysisd\" -I./analysisd -c $< -o $@
 
 
-ossec-logtest: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-test.o analysisd/analysisd-test.o alerts.a cdb.a decoders-test.a ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+ossec-logtest: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-test.o analysisd/analysisd-test.o alerts.a cdb.a decoders-test.a ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} -DTESTRULE $^ ${OSSEC_LDFLAGS} -o $@
 
-ossec-analysisd: ${analysisd_live_o} analysisd/analysisd-live.o ${output_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+ossec-analysisd: ${analysisd_live_o} analysisd/analysisd-live.o ${output_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 ### wazuh-modulesd ##
@@ -1186,7 +1192,7 @@ ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} aler
 wmodulesd_c := wazuh_modules/main.c
 wmodulesd_o := $(wmodulesd_c:.c=.o)
 
-wazuh-modulesd: ${wmodulesd_o} ${EXTERNAL_SQLITE}sqlite3.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB} ${PROCPS_LIB}
+wazuh-modulesd: ${wmodulesd_o} ${EXTERNAL_SQLITE}sqlite3.o ${ossec_libs} ${ZLIB_LIB} ${PROCPS_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 ### wazuh-framework ##
@@ -1236,13 +1242,13 @@ test_os_xml: tests/test_os_xml.o ${os_xml_o}
 test_os_regex: tests/test_os_regex.c ${os_regex_o}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-test_os_crypto: tests/test_os_crypto.c ${crypto_o} ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o} ${ZLIB_LIB} ${JSON_LIB}
+test_os_crypto: tests/test_os_crypto.c ${crypto_o} ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-test_os_net: tests/test_os_net.c ${os_net_o} ${shared_o} ${os_regex_o} ${os_xml_o} ${JSON_LIB}
+test_os_net: tests/test_os_net.c ${os_net_o} ${shared_o} ${os_regex_o} ${os_xml_o}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-test_shared: tests/test_shared.c ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o} ${JSON_LIB}
+test_shared: tests/test_shared.c ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 test_valgrind: build_tests
@@ -1292,19 +1298,19 @@ win32_ui_o := $(win32_ui_c:.c=.o)
 win32/ui/%.o: win32/ui/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -UOSSECHIDS -DARGV0=\"ossec-win32ui\" -c $^ -o $@
 
-win32/ossec-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o ${ZLIB_LIB} ${JSON_LIB}
+win32/ossec-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll ${ZLIB_LIB}
 	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-win32/ossec-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o ${ZLIB_LIB} ${JSON_LIB}
+win32/ossec-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} ${ossec_libs} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll ${ZLIB_LIB}
 	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-win32/ossec-rootcheck.exe: win32/icon.o win32/win_service_rk.o ${rootcheck_rk_o} ${ossec_libs} ${JSON_LIB}
+win32/ossec-rootcheck.exe: win32/icon.o win32/win_service_rk.o ${rootcheck_rk_o} ${ossec_libs}
 	${OSSEC_CCBIN} -DARGV0=\"ossec-rootcheck\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-win32/manage_agents.exe: win32/win_service_rk.o ${addagent_o} ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+win32/manage_agents.exe: win32/win_service_rk.o ${addagent_o} ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
-win32/setup-windows.exe: win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o ${ossec_libs} ${JSON_LIB}
+win32/setup-windows.exe: win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o ${ossec_libs}
 	${OSSEC_CCBIN} -DARGV0=\"setup-windows\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 win32/setup-syscheck.exe: win32/setup-syscheck.o win32/setup-shared.o ${ossec_libs}
@@ -1319,10 +1325,10 @@ win32/add-localfile.exe: win32/add-localfile.o ${ossec_libs}
 win32/resource.o: win32/ui/win32ui.rc
 	${OSSEC_WINDRES} -i $< -o $@
 
-win32/os_win32ui.exe: win32/resource.o win32/win_service_rk.o ${win32_ui_o} addagent/b64.o ${ossec_libs} ${JSON_LIB}
+win32/os_win32ui.exe: win32/resource.o win32/win_service_rk.o ${win32_ui_o} addagent/b64.o ${ossec_libs}
 	${OSSEC_CCBIN} -DARGV0=\"ossec-win32ui\" ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -mwindows -o $@
 
-win32/agent-auth.exe: win32/win_service_rk.o win32/agent_auth.c addagent/validate.c ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+win32/agent-auth.exe: win32/win_service_rk.o win32/agent_auth.c addagent/validate.c ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -lshlwapi -lwsock32 -lsecur32 -flto -o $@
 
 ####################
@@ -1339,7 +1345,7 @@ clean-test:
 
 clean-external:
 ifneq ($(wildcard external/*/*),)
-	rm -f ${cjson_o} libcJSON.a
+	rm -f ${cjson_o} $(EXTERNAL_JSON)libcjson.*
 	cd ${EXTERNAL_ZLIB} && ${MAKE} -f Makefile.in distclean
 	rm -f ${EXTERNAL_ZLIB}/Makefile ${EXTERNAL_ZLIB}/zconf.h
 	-cd ${EXTERNAL_OPENSSL} && ${MAKE} distclean

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,9 +44,10 @@ ifneq (,$(filter ${REUSE_ID},yes y Y 1))
 	DEFINES+=-DREUSE_ID
 endif
 
-OSSEC_LDFLAGS=-L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -lcjson -lm -lssl -lcrypto ${LDFLAGS} -Wl,-rpath,../lib
+OSSEC_LDFLAGS=-L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -lcjson -lm -lssl -lcrypto ${LDFLAGS}
 
 ifneq (${TARGET},winagent)
+		OSSEC_LDFLAGS+=-L$(EXTERNAL_SQLITE) -lsqlite3 -Wl,-rpath,../lib
 ifeq (${uname_S},Linux)
 		DEFINES+=-DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE
 #		DEFINES+=-DUSE_MAGIC
@@ -508,6 +509,8 @@ win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 EXTERNAL_LIBS := $(EXTERNAL_JSON)libcjson.$(SHARED) ${EXTERNAL_ZLIB}libz.a ${EXTERNAL_OPENSSL}libssl.a ${EXTERNAL_OPENSSL}libcrypto.a
 
 ifneq (${TARGET},winagent)
+EXTERNAL_LIBS += ${EXTERNAL_SQLITE}libsqlite3.$(SHARED)
+
 ifeq (${uname_S},Linux)
 EXTERNAL_LIBS += libproc.a ${EXTERNAL_LIBDB}.libs/libdb-6.2.so
 endif
@@ -578,7 +581,22 @@ os_zlib.a: ${os_zlib_o}
 	${OSSEC_LINK} $@ $^
 	${OSSEC_RANLIB} $@
 
+#### SQLite #########
 
+SQLITE_LIB = ${EXTERNAL_SQLITE}libsqlite3.$(SHARED)
+
+ifeq (${uname_S},Darwin)
+SQLITE_SHFLAGS=-install_name @loader_path/../lib/libsqlite3.$(SHARED)
+endif
+
+sqlite_c = ${EXTERNAL_SQLITE}sqlite3.c
+sqlite_o = ${EXTERNAL_SQLITE}sqlite3.o
+
+$(SQLITE_LIB): $(sqlite_o)
+	${OSSEC_SHARED} ${OSSEC_CFLAGS} $(SQLITE_SHFLAGS) -o $@ $^
+
+$(sqlite_o): $(sqlite_c)
+	${OSSEC_CC} ${OSSEC_CFLAGS} -w -fPIC -c $^ -o $@ -fPIC
 
 #### cJSON #########
 
@@ -707,7 +725,7 @@ shared.a: ${shared_o}
 #### Wazuh DB ####
 
 wdb_sql := $(wildcard wazuh_db/*.sql)
-wdblib_c := $(wildcard wazuh_db/wdb*.c) ${EXTERNAL_SQLITE}sqlite3.c
+wdblib_c := $(wildcard wazuh_db/wdb*.c)
 wdblib_o := $(wdblib_c:.c=.o) $(wdb_sql:.sql=.o)
 wdb_o := wazuh_db/main.o $(wdblib_o:.c=.o) $(wdb_c:.c=.o) $(wdb_sql:.sql=.o)
 
@@ -716,9 +734,6 @@ wazuh_db/schema_%.o: wazuh_db/schema_%.sql
 
 wazuh_db/%.o: wazuh_db/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"wazuh-db\" -c $^ -o $@
-
-${EXTERNAL_SQLITE}sqlite3.o: ${EXTERNAL_SQLITE}sqlite3.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -w -c $^ -o $@ -fPIC
 
 wazuh-db: ${wdb_o} ${ossec_libs}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
@@ -1192,7 +1207,7 @@ ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} aler
 wmodulesd_c := wazuh_modules/main.c
 wmodulesd_o := $(wmodulesd_c:.c=.o)
 
-wazuh-modulesd: ${wmodulesd_o} ${EXTERNAL_SQLITE}sqlite3.o ${ossec_libs} ${ZLIB_LIB} ${PROCPS_LIB}
+wazuh-modulesd: ${wmodulesd_o} ${ossec_libs} ${ZLIB_LIB} ${PROCPS_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 ### wazuh-framework ##
@@ -1352,6 +1367,7 @@ ifneq ($(wildcard external/*/*),)
 	rm -f ${OPENSSL_LIB}
 	rm -f ${CRYPTO_LIB}
 	rm -f ${procps_o} libproc.a
+	rm -f $(sqlite_o) $(EXTERNAL_SQLITE)/libsqlite3.*
 
 ifneq ($(wildcard external/libdb/build_unix/*),)
 	cd ${EXTERNAL_LIBDB} && make realclean

--- a/src/Makefile
+++ b/src/Makefile
@@ -47,13 +47,13 @@ endif
 OSSEC_LDFLAGS=-L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -lcjson -lm -lssl -lcrypto ${LDFLAGS}
 
 ifneq (${TARGET},winagent)
-		OSSEC_LDFLAGS+=-L$(EXTERNAL_SQLITE) -lsqlite3 -Wl,-rpath,../lib
+		OSSEC_LDFLAGS+=-L$(EXTERNAL_SQLITE) -lsqlite3
 ifeq (${uname_S},Linux)
 		DEFINES+=-DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE
 #		DEFINES+=-DUSE_MAGIC
 		OSSEC_LDFLAGS+=-pthread -lrt -ldl
 		OSSEC_LDFLAGS+=-L${EXTERNAL_LIBDB}.libs -ldb-6.2
-		OSSEC_LDFLAGS+=-Wl,-rpath,${PREFIX}/lib
+		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 #		OSSEC_LDFLAGS+=-lmagic
 		CFLAGS+=-Wl,--start-group
 else
@@ -61,6 +61,7 @@ ifeq (${uname_S},AIX)
 		DEFINES+=-DAIX
 		DEFINES+=-DHIGHFIRST
 		PATH:=${PATH}:/usr/vac/bin
+		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 		OSSEC_LDFLAGS+=-pthread
 		CC=gcc
 else
@@ -71,6 +72,7 @@ ifeq (${uname_S},SunOS)
 		CFLAGS+=-Wl,--start-group
 		OSSEC_LDFLAGS+=-Wl,--end-group
 		OSSEC_LDFLAGS+=-z relax=secadj
+		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 		OSSEC_LDFLAGS+=-lsocket -lnsl -lresolv
 		PATH:=${PATH}:/usr/ccs/bin:/usr/xpg4/bin:/opt/csw/gcc3/bin:/opt/csw/bin:/usr/sfw/bin
 		CC=gcc
@@ -80,6 +82,7 @@ else
 ifeq (${uname_S},Darwin)
 		DEFINES+=-DDarwin
 		DEFINES+=-DHIGHFIRST
+		OSSEC_LDFLAGS+=-Xlinker -rpath -Xlinker "@executable_path/../lib"
 		SHARED=dylib
 else
 ifeq (${uname_S},FreeBSD)
@@ -87,17 +90,20 @@ ifeq (${uname_S},FreeBSD)
 		OSSEC_LDFLAGS+=-pthread
 		CFLAGS+=-I/usr/local/include -Wl,--start-group
 		OSSEC_LDFLAGS+=-L/usr/local/lib
+		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 else
 ifeq (${uname_S},NetBSD)
 		DEFINES+=-DNetBSD
 		OSSEC_LDFLAGS+=-pthread
 		CFLAGS+=-Wl,--start-group
+		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 else
 ifeq (${uname_S},OpenBSD)
 #		DEFINES+=-DOpenBSD
 		DEFINES+=-pthread
 		CFLAGS+=-I/usr/local/include -Wl,--start-group
 		OSSEC_LDFLAGS+=-L/usr/local/lib
+		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 else
 ifeq (${uname_S},HP-UX)
 		DEFINES+=-DHPUX
@@ -106,6 +112,7 @@ ifeq (${uname_S},HP-UX)
 		DEFINES+=-D_REENTRANT
 		DEFINES+=-DOS_BIG_ENDIAN
 		OSSEC_LDFLAGS+=-pthread -lrt
+		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 		PATH:=${PATH}:/usr/local/bin
 		CC=gcc
 		INSTALL=/usr/local/coreutils/bin/install
@@ -506,10 +513,20 @@ win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 #### External ######
 ####################
 
-EXTERNAL_LIBS := $(EXTERNAL_JSON)libcjson.$(SHARED) ${EXTERNAL_ZLIB}libz.a ${EXTERNAL_OPENSSL}libssl.a ${EXTERNAL_OPENSSL}libcrypto.a
+ifeq (${TARGET},winagent)
+OPENSSL_LIB = $(EXTERNAL_OPENSSL)libssl-1_1.$(SHARED)
+else
+OPENSSL_LIB = $(EXTERNAL_OPENSSL)libssl.$(SHARED)
+CRYPTO_LIB = $(EXTERNAL_OPENSSL)libcrypto.$(SHARED)
+endif
+
+SQLITE_LIB  = $(EXTERNAL_SQLITE)libsqlite3.$(SHARED)
+JSON_LIB    = $(EXTERNAL_JSON)libcjson.$(SHARED)
+
+EXTERNAL_LIBS := $(JSON_LIB) ${EXTERNAL_ZLIB}libz.a $(OPENSSL_LIB)
 
 ifneq (${TARGET},winagent)
-EXTERNAL_LIBS += ${EXTERNAL_SQLITE}libsqlite3.$(SHARED)
+EXTERNAL_LIBS += $(SQLITE_LIB)
 
 ifeq (${uname_S},Linux)
 EXTERNAL_LIBS += libproc.a ${EXTERNAL_LIBDB}.libs/libdb-6.2.so
@@ -526,34 +543,29 @@ endif
 
 #### OpenSSL ##########
 
-OPENSSL_LIB=${EXTERNAL_OPENSSL}libssl.a
-CRYPTO_LIB=${EXTERNAL_OPENSSL}libcrypto.a
-OPENSSL_FLAGS = no-shared enable-weak-ssl-ciphers
-
-${CRYPTO_LIB}: ${OPENSSL_LIB}
-ifeq (${TARGET},winagent)
-	${OSSEC_RANLIB} ${CRYPTO_LIB}
-endif
+OPENSSL_FLAGS = enable-weak-ssl-ciphers
 
 ${OPENSSL_LIB}:
 ifeq (${TARGET},winagent)
-	cd ${EXTERNAL_OPENSSL} && CC=${MING_BASE}${CC} ./Configure ${OPENSSL_FLAGS} mingw && ${MAKE} build_libs
-	${OSSEC_RANLIB} ${OPENSSL_LIB}
+	cd ${EXTERNAL_OPENSSL} && CC=${MING_BASE}${CC} RC=${MING_BASE}windres ./Configure $(OPENSSL_FLAGS) mingw && ${MAKE} build_libs
 else
 ifeq (${uname_S},Darwin)
-	cd ${EXTERNAL_OPENSSL} && ./Configure ${OPENSSL_FLAGS} darwin64-x86_64-cc && ${MAKE} build_libs
+	cd ${EXTERNAL_OPENSSL} && ./Configure $(OPENSSL_FLAGS) darwin64-x86_64-cc && ${MAKE} build_libs
+	install_name_tool -id "@rpath/libssl.1.1.dylib" $(OPENSSL_LIB)
+	install_name_tool -id "@rpath/libcrypto.1.1.dylib" $(CRYPTO_LIB)
+	install_name_tool -change /usr/local/lib/libcrypto.1.1.dylib @rpath/libcrypto.1.1.dylib $(OPENSSL_LIB)
 else
 ifeq (${uname_S},HP-UX)
-	cd ${EXTERNAL_OPENSSL} && MAKE=gmake ./Configure ${OPENSSL_FLAGS} hpux-ia64-gcc && ${MAKE} build_libs
+	cd ${EXTERNAL_OPENSSL} && MAKE=gmake ./Configure $(OPENSSL_FLAGS) hpux-ia64-gcc && ${MAKE} build_libs
 else
 ifeq (${uname_S},SunOS)
 ifeq ($(uname_M),i86pc)
-	cd ${EXTERNAL_OPENSSL} && ./Configure ${OPENSSL_FLAGS} solaris-x86-gcc && ${MAKE} build_libs
+	cd ${EXTERNAL_OPENSSL} && ./Configure $(OPENSSL_FLAGS) solaris-x86-gcc && ${MAKE} build_libs
 else
-	cd ${EXTERNAL_OPENSSL} && ./Configure ${OPENSSL_FLAGS} solaris-sparcv9-gcc && ${MAKE} build_libs
+	cd ${EXTERNAL_OPENSSL} && ./Configure $(OPENSSL_FLAGS) solaris-sparcv9-gcc && ${MAKE} build_libs
 endif
 else
-	cd ${EXTERNAL_OPENSSL} && ./config ${OPENSSL_FLAGS} && ${MAKE} build_libs
+	cd ${EXTERNAL_OPENSSL} && ./config $(OPENSSL_FLAGS) && ${MAKE} build_libs
 endif
 endif
 endif
@@ -583,10 +595,8 @@ os_zlib.a: ${os_zlib_o}
 
 #### SQLite #########
 
-SQLITE_LIB = ${EXTERNAL_SQLITE}libsqlite3.$(SHARED)
-
 ifeq (${uname_S},Darwin)
-SQLITE_SHFLAGS=-install_name @loader_path/../lib/libsqlite3.$(SHARED)
+SQLITE_SHFLAGS=-install_name @rpath/libsqlite3.$(SHARED)
 endif
 
 sqlite_c = ${EXTERNAL_SQLITE}sqlite3.c
@@ -600,10 +610,8 @@ $(sqlite_o): $(sqlite_c)
 
 #### cJSON #########
 
-JSON_LIB=$(EXTERNAL_JSON)libcjson.$(SHARED)
-
 ifeq (${uname_S},Darwin)
-JSON_SHFLAGS=-install_name @loader_path/../lib/libcjson.$(SHARED)
+JSON_SHFLAGS=-install_name @rpath/libcjson.$(SHARED)
 endif
 
 cjson_c := ${EXTERNAL_JSON}cJSON.c
@@ -1364,8 +1372,6 @@ ifneq ($(wildcard external/*/*),)
 	cd ${EXTERNAL_ZLIB} && ${MAKE} -f Makefile.in distclean
 	rm -f ${EXTERNAL_ZLIB}/Makefile ${EXTERNAL_ZLIB}/zconf.h
 	-cd ${EXTERNAL_OPENSSL} && ${MAKE} distclean
-	rm -f ${OPENSSL_LIB}
-	rm -f ${CRYPTO_LIB}
 	rm -f ${procps_o} libproc.a
 	rm -f $(sqlite_o) $(EXTERNAL_SQLITE)/libsqlite3.*
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,6 +52,7 @@ ifeq (${uname_S},Linux)
 		DEFINES+=-DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE
 #		DEFINES+=-DUSE_MAGIC
 		OSSEC_LDFLAGS+=-pthread -lrt -ldl
+		OSSEC_LDFLAGS+=-L$(EXTERNAL_PROCPS) -lproc
 		OSSEC_LDFLAGS+=-L${EXTERNAL_LIBDB}.libs -ldb-6.2
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 #		OSSEC_LDFLAGS+=-lmagic
@@ -522,6 +523,7 @@ endif
 
 SQLITE_LIB  = $(EXTERNAL_SQLITE)libsqlite3.$(SHARED)
 JSON_LIB    = $(EXTERNAL_JSON)libcjson.$(SHARED)
+PROCPS_LIB  = $(EXTERNAL_PROCPS)/libproc.$(SHARED)
 
 EXTERNAL_LIBS := $(JSON_LIB) ${EXTERNAL_ZLIB}libz.a $(OPENSSL_LIB)
 
@@ -529,7 +531,7 @@ ifneq (${TARGET},winagent)
 EXTERNAL_LIBS += $(SQLITE_LIB)
 
 ifeq (${uname_S},Linux)
-EXTERNAL_LIBS += libproc.a ${EXTERNAL_LIBDB}.libs/libdb-6.2.so
+EXTERNAL_LIBS += $(PROCPS_LIB) ${EXTERNAL_LIBDB}.libs/libdb-6.2.so
 endif
 endif
 
@@ -624,22 +626,17 @@ ${EXTERNAL_JSON}%.o: ${EXTERNAL_JSON}%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -fPIC -c $^ -o $@
 
 #### procps #########
-ifneq (${TARGET},winagent)
-ifeq (${uname_S},Linux)
-PROCPS_LIB=libproc.a
+
 PROCPS_INCLUDE=-I./${EXTERNAL_PROCPS}
 
 procps_c := $(wildcard ${EXTERNAL_PROCPS}*.c)
 procps_o := $(procps_c:.c=.o)
 
 ${EXTERNAL_PROCPS}%.o: ${EXTERNAL_PROCPS}%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -fPIC -c $^ -o $@
 
-libproc.a: ${procps_o}
-	${OSSEC_LINK} $@ $^
-	${OSSEC_RANLIB} $@
-endif
-endif
+$(PROCPS_LIB): ${procps_o}
+	${OSSEC_SHARED} ${OSSEC_CFLAGS} -o $@ $^
 
 #### Berkeley DB ######
 
@@ -679,7 +676,7 @@ external/%.tar.gz:
 #### OSSEC Libs ####
 ####################
 
-ossec_libs = config.a wmodules.a os_crypto.a shared.a os_net.a os_regex.a os_xml.a ${PROCPS_LIB}
+ossec_libs = config.a wmodules.a os_crypto.a shared.a os_net.a os_regex.a os_xml.a
 
 #### os_xml ########
 
@@ -1215,7 +1212,7 @@ ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} aler
 wmodulesd_c := wazuh_modules/main.c
 wmodulesd_o := $(wmodulesd_c:.c=.o)
 
-wazuh-modulesd: ${wmodulesd_o} ${ossec_libs} ${ZLIB_LIB} ${PROCPS_LIB}
+wazuh-modulesd: ${wmodulesd_o} ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
 
 ### wazuh-framework ##
@@ -1372,7 +1369,7 @@ ifneq ($(wildcard external/*/*),)
 	cd ${EXTERNAL_ZLIB} && ${MAKE} -f Makefile.in distclean
 	rm -f ${EXTERNAL_ZLIB}/Makefile ${EXTERNAL_ZLIB}/zconf.h
 	-cd ${EXTERNAL_OPENSSL} && ${MAKE} distclean
-	rm -f ${procps_o} libproc.a
+	rm -f ${procps_o} $(PROCPS_LIB)
 	rm -f $(sqlite_o) $(EXTERNAL_SQLITE)/libsqlite3.*
 
 ifneq ($(wildcard external/libdb/build_unix/*),)

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -601,6 +601,7 @@ InstallCommon(){
     OSSEC_USER_REM='ossecr'
     EXTERNAL_BERKELEY='external/libdb/build_unix/'
     EXTERNAL_JSON="external/cJSON/"
+    EXTERNAL_SQLITE="external/sqlite/"
     INSTALL="install"
 
     if [ ${INSTYPE} = 'server' ]; then
@@ -644,6 +645,7 @@ InstallCommon(){
   ${INSTALL} -d -m 0750 -o root -g 0 ${PREFIX}/lib
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_BERKELEY}.libs/libdb-6.2.so ${PREFIX}/lib
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_JSON}libcjson.* ${PREFIX}/lib
+  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SQLITE}libsqlite3.* ${PREFIX}/lib
 
   ${INSTALL} -m 0750 -o root -g 0 ossec-logcollector ${PREFIX}/bin
   ${INSTALL} -m 0750 -o root -g 0 ossec-syscheckd ${PREFIX}/bin

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -600,6 +600,7 @@ InstallCommon(){
     OSSEC_USER_MAIL='ossecm'
     OSSEC_USER_REM='ossecr'
     EXTERNAL_BERKELEY='external/libdb/build_unix/'
+    EXTERNAL_JSON="external/cJSON/"
     INSTALL="install"
 
     if [ ${INSTYPE} = 'server' ]; then
@@ -642,6 +643,8 @@ InstallCommon(){
 
   ${INSTALL} -d -m 0750 -o root -g 0 ${PREFIX}/lib
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_BERKELEY}.libs/libdb-6.2.so ${PREFIX}/lib
+  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_JSON}libcjson.* ${PREFIX}/lib
+
   ${INSTALL} -m 0750 -o root -g 0 ossec-logcollector ${PREFIX}/bin
   ${INSTALL} -m 0750 -o root -g 0 ossec-syscheckd ${PREFIX}/bin
   ${INSTALL} -m 0750 -o root -g 0 ossec-execd ${PREFIX}/bin

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -603,6 +603,7 @@ InstallCommon(){
     EXTERNAL_JSON="external/cJSON/"
     EXTERNAL_SQLITE="external/sqlite/"
     EXTERNAL_SSL="external/openssl/"
+    EXTERNAL_PROCPS="external/procps/"
     INSTALL="install"
 
     if [ ${INSTYPE} = 'server' ]; then
@@ -649,6 +650,11 @@ InstallCommon(){
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SQLITE}libsqlite3.* ${PREFIX}/lib
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libssl*1.1* ${PREFIX}/lib
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libcrypto*1.1* ${PREFIX}/lib
+
+    if [ ${NUNAME} = 'Linux' ]
+    then
+      ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_PROCPS}libproc.so ${PREFIX}/lib
+    fi
 
   ${INSTALL} -m 0750 -o root -g 0 ossec-logcollector ${PREFIX}/bin
   ${INSTALL} -m 0750 -o root -g 0 ossec-syscheckd ${PREFIX}/bin

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -602,6 +602,7 @@ InstallCommon(){
     EXTERNAL_BERKELEY='external/libdb/build_unix/'
     EXTERNAL_JSON="external/cJSON/"
     EXTERNAL_SQLITE="external/sqlite/"
+    EXTERNAL_SSL="external/openssl/"
     INSTALL="install"
 
     if [ ${INSTYPE} = 'server' ]; then
@@ -646,6 +647,8 @@ InstallCommon(){
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_BERKELEY}.libs/libdb-6.2.so ${PREFIX}/lib
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_JSON}libcjson.* ${PREFIX}/lib
   ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SQLITE}libsqlite3.* ${PREFIX}/lib
+  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libssl*1.1* ${PREFIX}/lib
+  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libcrypto*1.1* ${PREFIX}/lib
 
   ${INSTALL} -m 0750 -o root -g 0 ossec-logcollector ${PREFIX}/bin
   ${INSTALL} -m 0750 -o root -g 0 ossec-syscheckd ${PREFIX}/bin

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -604,6 +604,7 @@ InstallCommon(){
     EXTERNAL_SQLITE="external/sqlite/"
     EXTERNAL_SSL="external/openssl/"
     EXTERNAL_PROCPS="external/procps/"
+    EXTERNAL_ZLIB="external/zlib/"
     INSTALL="install"
 
     if [ ${INSTYPE} = 'server' ]; then
@@ -645,15 +646,26 @@ InstallCommon(){
     fi
 
   ${INSTALL} -d -m 0750 -o root -g 0 ${PREFIX}/lib
-  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_BERKELEY}.libs/libdb-6.2.so ${PREFIX}/lib
-  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_JSON}libcjson.* ${PREFIX}/lib
-  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SQLITE}libsqlite3.* ${PREFIX}/lib
-  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libssl*1.1* ${PREFIX}/lib
-  ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libcrypto*1.1* ${PREFIX}/lib
 
-    if [ ${NUNAME} = 'Linux' ]
+    if [ ${NUNAME} = 'Darwin' ]
     then
-      ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_PROCPS}libproc.so ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_JSON}libcjson.dylib ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SQLITE}libsqlite3.dylib ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libssl.1.1.dylib ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libcrypto.1.1.dylib ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_ZLIB}libz.1.dylib ${PREFIX}/lib
+    else
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_JSON}libcjson.so ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SQLITE}libsqlite3.so ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libssl.so.1.1 ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libcrypto.so.1.1 ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_ZLIB}libz.so.1 ${PREFIX}/lib
+
+        if [ ${NUNAME} = 'Linux' ]
+        then
+            ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_BERKELEY}.libs/libdb-6.2.so ${PREFIX}/lib
+            ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_PROCPS}libproc.so ${PREFIX}/lib
+        fi
     fi
 
   ${INSTALL} -m 0750 -o root -g 0 ossec-logcollector ${PREFIX}/bin

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -13,7 +13,7 @@
 #include "os_net/os_net.h"
 #include <pthread.h>
 
-#if defined(__FreeBSD__) || defined(__MACH__)
+#if defined(__FreeBSD__) || defined(__MACH__) || defined(__sun__)
 #define HOST_NAME_MAX 64
 #endif
 

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -207,6 +207,7 @@ Section "Wazuh Agent (required)" MainSec
     File /oname=wpk_root.pem ../../etc/wpk_root.pem
     File ../wazuh_modules/syscollector/syscollector_win_ext.dll
     File /oname=libcjson.dll ../external/cJSON/libcjson.dll
+    File /oname=libcrypto-1_1.dll ../external/openssl/libcrypto-1_1.dll
     File VERSION
     File REVISION
 
@@ -482,6 +483,7 @@ Section "Uninstall"
     Delete "$INSTDIR\wodles\*"
     Delete "$INSTDIR\syscollector_win_ext.dll"
     Delete "$INSTDIR\libcjson.dll"
+    Delete "$INSTDIR\libcrypto-1_1.dll"
 
     ; remove shortcuts
     SetShellVarContext all

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -208,6 +208,7 @@ Section "Wazuh Agent (required)" MainSec
     File ../wazuh_modules/syscollector/syscollector_win_ext.dll
     File /oname=libcjson.dll ../external/cJSON/libcjson.dll
     File /oname=libcrypto-1_1.dll ../external/openssl/libcrypto-1_1.dll
+    File /oname=zlib1.dll ../external/zlib/zlib1.dll
     File VERSION
     File REVISION
 
@@ -484,6 +485,7 @@ Section "Uninstall"
     Delete "$INSTDIR\syscollector_win_ext.dll"
     Delete "$INSTDIR\libcjson.dll"
     Delete "$INSTDIR\libcrypto-1_1.dll"
+    Delete "$INSTDIR\zlib1.dll"
 
     ; remove shortcuts
     SetShellVarContext all

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -206,6 +206,7 @@ Section "Wazuh Agent (required)" MainSec
 	File agent-auth.exe
     File /oname=wpk_root.pem ../../etc/wpk_root.pem
     File ../wazuh_modules/syscollector/syscollector_win_ext.dll
+    File /oname=libcjson.dll ../external/cJSON/libcjson.dll
     File VERSION
     File REVISION
 
@@ -480,6 +481,7 @@ Section "Uninstall"
     Delete "$INSTDIR\incoming\*"
     Delete "$INSTDIR\wodles\*"
     Delete "$INSTDIR\syscollector_win_ext.dll"
+    Delete "$INSTDIR\libcjson.dll"
 
     ; remove shortcuts
     SetShellVarContext all

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -65,8 +65,17 @@
                     <Component Id="AGENT_AUTH.EXE" DiskId="1" Guid="F99FEE7C-A021-4D43-9119-98A8D72EAB65">
                         <File Id="AGENT_AUTH.EXE" Name="agent-auth.exe" Source="agent-auth.exe" />
                     </Component>
-		            <Component Id="SYSCOLLECTOR_DLL" DiskId="1" Guid="3F72347F-1282-44C1-8A97-40BB68CAE4FB">
+                    <Component Id="SYSCOLLECTOR_DLL" DiskId="1" Guid="3F72347F-1282-44C1-8A97-40BB68CAE4FB">
                         <File Id="SYSCOLLECTOR_DLL" Name="syscollector_win_ext.dll" Source="..\wazuh_modules\syscollector\syscollector_win_ext.dll" />
+                    </Component>
+                    <Component Id="LIBCJSON_DLL" DiskId="1" Guid="31F7B5FA-9678-427B-9536-88AAA897A82A">
+                        <File Id="LIBCJSON_DLL" Name="libcjson.dll" Source="..\external\cJSON\libcjson.dll" />
+                    </Component>
+                    <Component Id="LIBCRYPTO_1_1_DLL" DiskId="1" Guid="F1EBAC23-CCA0-4C55-BC36-AFFA0082A4A3">
+                        <File Id="LIBCRYPTO_1_1_DLL" Name="libcrypto-1_1.dll" Source="..\external\openssl\libcrypto-1_1.dll" />
+                    </Component>
+                    <Component Id="ZLIB1_DLL" DiskId="1" Guid="3DF8C897-2C3F-45E0-A988-B5D794478745">
+                        <File Id="ZLIB1_DLL" Name="zlib1.dll" Source="..\external\zlib\zlib1.dll" />
                     </Component>
                     <Component Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" DiskId="1" Guid="10245598-2EE7-4EDB-A114-5398F01A21F9">
                         <File Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" Name="default-local_internal_options.conf" Source="default-local_internal_options.conf">
@@ -294,6 +303,9 @@
         <Feature Id="MainFeature" Title="Wazuh Agent" Description="Install the Wazuh Agent program files" ConfigurableDirectory="APPLICATIONFOLDER" InstallDefault="local" TypicalDefault="install" AllowAdvertise="no" Absent="disallow">
             <ComponentRef Id="AGENT_AUTH.EXE" />
             <ComponentRef Id="SYSCOLLECTOR_DLL" />
+            <ComponentRef Id="LIBCJSON_DLL" />
+            <ComponentRef Id="LIBCRYPTO_1_1_DLL" />
+            <ComponentRef Id="ZLIB1_DLL" />
             <ComponentRef Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" />
             <ComponentRef Id="DEFAULT_OSSEC.CONF" />
             <ComponentRef Id="OSSEC.CONF" />


### PR DESCRIPTION
This PR solves issue https://github.com/wazuh/wazuh/issues/432.

## Testing

This pull request needs to be tested under all these platforms before being merged:

- [X] Linux
- [X] Windows (NSIS)
- [x] Windows (MSI)
- [X] macOS
- [x] Solaris
- [x] FreeBSD
- [x] OpenBSD
- [ ] NetBSD
- [ ] HP-UX
- [ ] AIX

## Description

The size of the Wazuh (current branch _master_) binaries is significantly high:

```shell
# ls -lh ossec-* wazuh-*
-rwxr-xr-x 1 root root 5.7M Mar 25 15:08 ossec-agentd
-rwxr-xr-x 1 root root 5.5M Mar 25 15:08 ossec-agentlessd
-rwxr-xr-x 1 root root 6.1M Mar 25 15:08 ossec-analysisd
-rwxr-xr-x 1 root root 5.6M Mar 25 15:08 ossec-authd
-rwxr-xr-x 1 root root 5.5M Mar 25 15:08 ossec-csyslogd
-rwxr-xr-x 1 root root 5.6M Mar 25 15:08 ossec-dbd
-rwxr-xr-x 1 root root 5.6M Mar 25 15:08 ossec-execd
-rwxr-xr-x 1 root root 5.5M Mar 25 15:08 ossec-integratord
-rwxr-xr-x 1 root root 5.6M Mar 25 15:08 ossec-logcollector
-rwxr-xr-x 1 root root 6.1M Mar 25 15:08 ossec-logtest
-rwxr-xr-x 1 root root 5.5M Mar 25 15:08 ossec-maild
-rwxr-xr-x 1 root root 5.9M Mar 25 15:08 ossec-makelists
-rwxr-xr-x 1 root root 5.6M Mar 25 15:08 ossec-monitord
-rwxr-xr-x 1 root root 199K Mar 25 15:08 ossec-regex
-rwxr-xr-x 1 root root 5.6M Mar 25 15:08 ossec-remoted
-rwxr-xr-x 1 root root 249K Mar 25 15:08 ossec-reportd
-rwxr-xr-x 1 root root 5.7M Mar 25 15:08 ossec-syscheckd
-rwxr-xr-x 1 root root 1.8M Mar 25 15:08 wazuh-db
-rwxr-xr-x 1 root root 5.5M Mar 25 15:08 wazuh-modulesd

# du -h -d1 /var/ossec
1.2M	/var/ossec/ruleset
52K	/var/ossec/queue
2.0M	/var/ossec/framework
136K	/var/ossec/var
16K	/var/ossec/backup
76K	/var/ossec/wodles
76K	/var/ossec/logs
20K	/var/ossec/integrations
1.1M	/var/ossec/etc
44K	/var/ossec/stats
64K	/var/ossec/agentless
64K	/var/ossec/active-response
113M	/var/ossec/bin
1.2M	/var/ossec/lib
4.0K	/var/ossec/.ssh
4.0K	/var/ossec/tmp
119M	/var/ossec
```

The total binary size is **114,2 MiB**.

The main reason for this issue is that the project uses static libraries so every executable contains a lot of shareable code.

### Size after changes

This change aims to compile the external libraries as shared code (`.so`, `.dll`, `.dylib` files). 

This is the new size of the files:

```shell
# ls -lh ossec-* wazuh-*
-rwxr-xr-x 1 root root 421K Mar 25 21:28 ossec-agentd
-rwxr-xr-x 1 root root 389K Mar 25 21:28 ossec-agentlessd
-rwxr-xr-x 1 root root 560K Mar 25 21:28 ossec-analysisd
-rwxr-xr-x 1 root root 439K Mar 25 21:28 ossec-authd
-rwxr-xr-x 1 root root 394K Mar 25 21:28 ossec-csyslogd
-rwxr-xr-x 1 root root 410K Mar 25 21:28 ossec-dbd
-rwxr-xr-x 1 root root 412K Mar 25 21:28 ossec-execd
-rwxr-xr-x 1 root root 390K Mar 25 21:28 ossec-integratord
-rwxr-xr-x 1 root root 411K Mar 25 21:28 ossec-logcollector
-rwxr-xr-x 1 root root 564K Mar 25 21:28 ossec-logtest
-rwxr-xr-x 1 root root 406K Mar 25 21:28 ossec-maild
-rwxr-xr-x 1 root root 487K Mar 25 21:28 ossec-makelists
-rwxr-xr-x 1 root root 424K Mar 25 21:28 ossec-monitord
-rwxr-xr-x 1 root root  73K Mar 25 21:28 ossec-regex
-rwxr-xr-x 1 root root 412K Mar 25 21:28 ossec-remoted
-rwxr-xr-x 1 root root  92K Mar 25 21:28 ossec-reportd
-rwxr-xr-x 1 root root 443K Mar 25 21:28 ossec-syscheckd
-rwxr-xr-x 1 root root 162K Mar 25 21:28 wazuh-db
-rwxr-xr-x 1 root root 385K Mar 25 21:28 wazuh-modulesd

# du -h -d1 /var/ossec
1.2M	/var/ossec/ruleset
52K	/var/ossec/queue
528K	/var/ossec/framework
128K	/var/ossec/var
16K	/var/ossec/backup
76K	/var/ossec/wodles
76K	/var/ossec/logs
20K	/var/ossec/integrations
1.1M	/var/ossec/etc
44K	/var/ossec/stats
64K	/var/ossec/agentless
64K	/var/ossec/active-response
8.4M	/var/ossec/bin
5.5M	/var/ossec/lib
4.0K	/var/ossec/.ssh
4.0K	/var/ossec/tmp
18M	/var/ossec
```

The new size of the binaries (executables + libraries) is **13,9 MiB**. This means that **the size has been reduced by 88%**.
