### PR TITLE
Fixed deprecated setting in Filebeat configuration file

### DIFF
--- a/extensions/filebeat/filebeat.yml
+++ b/extensions/filebeat/filebeat.yml
@@ -1,6 +1,6 @@
 filebeat:
  prospectors:
-  - input_type: log
+  - type: log
     paths:
      - "/var/ossec/logs/alerts/alerts.json"
     document_type: json


### PR DESCRIPTION
Hello all,

In this pull request, we've edited the Filebeat configuration file to avoid a `Warning - Deprecated` message on the log files.

With this change, it's not needed to create new packages, since we only use it in the documentation as a reference.

Regards,
Juanjo