### PR TITLE
Fixed double free memory segfault

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -444,7 +444,6 @@ void Free_Localfile(logreader_config * config){
     if (config) {
         if (config->config) {
             int i;
-
             for (i = 0; config->config[i].file; i++) {
                 free(config->config[i].ffile);
                 free(config->config[i].file);


### PR DESCRIPTION
Fixed double free memory segfault caused when using a wildcard option in the agent.conf

For example:

```
<localfile>
        <location>/var/log/*.log</location>
        <log_format>syslog</log_format>
</localfile>
```
Caused a segfault when running verify-agent-conf.