### PR TITLE
Several fixes for command wodle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Fixed dangling db files at DB Sync module folder. ([#489](https://github.com/wazuh/wazuh/pull/489))
 - Fixed agent group file deletion when using Authd.
 - Fix memory leak in Maild with JSON input. ([#498](https://github.com/wazuh/wazuh/pull/498))
+- Fixed remote command switch option. ([#504](https://github.com/wazuh/wazuh/pull/504))
 
 ## [v3.2.1]
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -233,8 +233,8 @@ wazuh_db.open_db_limit=64
 # Wazuh Command Module - If it should accept remote commands from the manager
 wazuh_command.remote_commands=0
 
-# Wazuh Command Module - Seconds to wait for the command output (0..1800)
-wazuh_command.timeout=10
+# Wazuh Command Module - Seconds to wait for the command output [0 means wait indefinitely] (0..1800)
+wazuh_command.timeout=0
 
 
 # Debug options.

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -233,6 +233,9 @@ wazuh_db.open_db_limit=64
 # Wazuh Command Module - If it should accept remote commands from the manager
 wazuh_command.remote_commands=0
 
+# Wazuh Command Module - Seconds to wait for the command output (0..1800)
+wazuh_command.timeout=10
+
 
 # Debug options.
 # Debug 0 -> no debug

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -233,9 +233,6 @@ wazuh_db.open_db_limit=64
 # Wazuh Command Module - If it should accept remote commands from the manager
 wazuh_command.remote_commands=0
 
-# Wazuh Command Module - Seconds to wait for the command output [0 means wait indefinitely] (0..1800)
-wazuh_command.timeout=0
-
 
 # Debug options.
 # Debug 0 -> no debug

--- a/src/config/wmodules-command.c
+++ b/src/config/wmodules-command.c
@@ -17,6 +17,7 @@ static const char *XML_COMMAND = "command";
 static const char *XML_INTERVAL = "interval";
 static const char *XML_IGNORE_OUTPUT = "ignore_output";
 static const char *XML_RUN_ON_START = "run_on_start";
+static const char *XML_TIMEOUT = "timeout";
 
 // Parse XML
 
@@ -108,6 +109,14 @@ int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg)
                 command->ignore_output = 0;
             else {
                 merror("Invalid content for tag '%s' at module '%s'.", XML_IGNORE_OUTPUT, WM_COMMAND_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
+            char *endptr;
+            command->timeout = strtol(nodes[i]->content, &endptr, 0);
+
+            if (*endptr || command->timeout < 0) {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_TIMEOUT, WM_COMMAND_CONTEXT.name);
                 return OS_INVALID;
             }
         } else {

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -43,8 +43,6 @@ void * wm_command_main(wm_command_t * command) {
     }
 #endif
 
-    int command_timeout = getDefine_Int("wazuh_command", "timeout", 0, 1800);
-
     mtinfo(WM_COMMAND_LOGTAG, "Module command:%s started", command->tag);
 
     // Set extended tag
@@ -94,7 +92,7 @@ void * wm_command_main(wm_command_t * command) {
         // Get time and execute
         time_start = time(NULL);
 
-        switch (wm_exec(command->command, command->ignore_output ? NULL : &output, &status, command_timeout)) {
+        switch (wm_exec(command->command, command->ignore_output ? NULL : &output, &status, command->timeout)) {
         case 0:
             if (status > 0) {
                 mtwarn(WM_COMMAND_LOGTAG, "Command '%s' returned exit code %d.", command->tag, status);

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -44,6 +44,8 @@ void * wm_command_main(wm_command_t * command) {
     }
 #endif
 
+    int command_timeout = getDefine_Int("wazuh_command", "timeout", 0, 1800);
+
     mtinfo(WM_COMMAND_LOGTAG, "Module command:%s started", command->tag);
 
     // Set extended tag
@@ -91,7 +93,7 @@ void * wm_command_main(wm_command_t * command) {
         // Get time and execute
         time_start = time(NULL);
 
-        switch (wm_exec(command->command, command->ignore_output ? NULL : &output, &status, 0)) {
+        switch (wm_exec(command->command, command->ignore_output ? NULL : &output, &status, command_timeout)) {
         case 0:
             if (status > 0) {
                 mtwarn(WM_COMMAND_LOGTAG, "Command '%s' returned exit code %d.", command->tag, status);

--- a/src/wazuh_modules/wm_command.h
+++ b/src/wazuh_modules/wm_command.h
@@ -29,6 +29,7 @@ typedef struct wm_command_t {
     unsigned int run_on_start:1;
     unsigned int ignore_output:1;
     unsigned int agent_cfg:1;
+    int timeout;
 } wm_command_t;
 
 extern const wm_context WM_COMMAND_CONTEXT;   // Context

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -92,7 +92,7 @@ int wm_exec(char *command, char **output, int *status, int secs) {
         }
     }
 
-    switch (WaitForSingleObject(pinfo.hProcess, secs * 1000)) {
+    switch (WaitForSingleObject(pinfo.hProcess, secs ? (unsigned)(secs * 1000) : INFINITE)) {
     case 0:
         if (status) {
             DWORD exitcode;

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -28,6 +28,10 @@ int wm_config() {
     wm_max_eps = getDefine_Int("wazuh_modules", "max_eps", 100, 1000);
     wm_kill_timeout = getDefine_Int("wazuh_modules", "kill_timeout", 0, 3600);
 
+#ifdef CLIENT
+    agent_cfg = 1;
+#endif
+
     // Read configuration: ossec.conf
 
     if (ReadConfig(CWMODULE, DEFAULTCPATH, &wmodules, &agent_cfg) < 0) {
@@ -36,7 +40,6 @@ int wm_config() {
 
 #ifdef CLIENT
     // Read configuration: agent.conf
-    agent_cfg = 1;
     ReadConfig(CWMODULE | CAGENT_CONFIG, AGENTCONFIG, &wmodules, &agent_cfg);
 #else
     wmodule *database;


### PR DESCRIPTION
This PR adds several fixes for the Command module including the following:

- Fix control when checking if the remote commands are allowed to be executed by agents when a command is configured in the ``ossec.conf``.

- Added a timeout to wait for the command output.

- Send command output messages to the manager to the correct agent queue.

