### PR TITLE
Added more verbose to error message on framework

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -443,8 +443,8 @@ def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filenam
 
         # Parse XML to JSON
         data = _agentconf2json(xml_data)
-    except:
-        raise WazuhException(1101)
+    except Exception as e:
+        raise WazuhException(1101, str(e))
 
 
     return {'totalItems': len(data), 'items': cut_array(data, offset, limit)}


### PR DESCRIPTION
Hello team!

This PR adds a more descriptive error message when there's an exception loading the group configuration. There was only one missing fragment of `str(e)` code.

Best regards,
Juanjo