### PR TITLE
Create input queue for Remoted

### DIFF
--- a/etc/templates/config/generic/remote-secure.template
+++ b/etc/templates/config/generic/remote-secure.template
@@ -2,4 +2,5 @@
     <connection>secure</connection>
     <port>1514</port>
     <protocol>udp</protocol>
+    <queue_size>16384</queue_size>
   </remote>

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -34,6 +34,7 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_remote_ipv6 = "ipv6";
     const char *xml_remote_connection = "connection";
     const char *xml_remote_lip = "local_ip";
+    const char * xml_queue_size = "queue_size";
 
     logr = (remoted *)d1;
 
@@ -190,6 +191,20 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             if (!OS_IsValidIP(node[i]->content, logr->denyips[deny_size - 2])) {
                 merror(INVALID_IP, node[i]->content);
                 return (OS_INVALID);
+            }
+        } else if (strcmp(node[i]->element, xml_queue_size) == 0) {
+            char * end;
+
+            logr->queue_size = strtol(node[i]->content, &end, 10);
+
+            if (*end || logr->queue_size < 1) {
+                merror("Invalid value for option '<%s>'", xml_queue_size);
+                return OS_INVALID;
+            }
+
+            if (*end) {
+                merror("Invalid value for option '<%s>'", xml_queue_size);
+                return OS_INVALID;
             }
         } else {
             merror(XML_INVELEM, node[i]->element);

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -31,6 +31,7 @@ typedef struct _remoted {
     int position;
     int nocmerged;
     socklen_t peer_size;
+    long queue_size;
 } remoted;
 
 #endif /* __CLOGREMOTE_H */

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -27,9 +27,19 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
     cfg->allowips = NULL;
     cfg->denyips = NULL;
     cfg->nocmerged = 0;
+    cfg->queue_size = 16384;
 
     if (ReadConfig(modules, cfgfile, cfg, NULL) < 0) {
         return (OS_INVALID);
+    }
+
+    if (cfg->queue_size < 1) {
+        merror("Queue size is invalid. Review configuration.");
+        return OS_INVALID;
+    }
+
+    if (cfg->queue_size > 262144) {
+        mwarn("Queue size is very high. The application may run out of memory.");
     }
 
     const char *(xmlf[]) = {"ossec_config", "cluster", "node_name", NULL};

--- a/src/remoted/queue.c
+++ b/src/remoted/queue.c
@@ -1,0 +1,77 @@
+/* Remoted queue handling library
+ * Copyright (C) 2018 Wazuh Inc.
+ * April 2, 2018.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <shared.h>
+#include "remoted.h"
+
+static w_queue_t * queue;
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t available = PTHREAD_COND_INITIALIZER;
+
+// Init message queue
+void rem_msginit(size_t size) {
+    queue = queue_init(size);
+}
+
+// Push message into queue
+int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_in * addr, int sock) {
+    message_t * message;
+    int result;
+    static int reported = 0;
+
+    os_malloc(sizeof(message_t), message);
+    os_malloc(size, message->buffer);
+    memcpy(message->buffer, buffer, size);
+    message->size = size;
+    memcpy(&message->addr, addr, sizeof(struct sockaddr_in));
+    message->sock = sock;
+
+    w_mutex_lock(&mutex);
+
+    if (result = queue_push(queue, message), result == 0) {
+        w_cond_signal(&available);
+    }
+
+    w_mutex_unlock(&mutex);
+
+    if (result < 0) {
+        rem_msgfree(message);
+        mdebug2("Discarding event from host '%s'", inet_ntoa(addr->sin_addr));
+
+        if (!reported) {
+            mwarn("Message queue is full (%zu). Events may be lost.", queue->size);
+            reported = 1;
+        }
+    }
+
+    return result;
+}
+
+// Pop message from queue
+message_t * rem_msgpop() {
+    message_t * message;
+
+    w_mutex_lock(&mutex);
+
+    while (message = (message_t *)queue_pop(queue), !message) {
+        w_cond_wait(&available, &mutex);
+    }
+
+    w_mutex_unlock(&mutex);
+    return message;
+}
+
+// Free message
+void rem_msgfree(message_t * message) {
+    if (message) {
+        free(message->buffer);
+        free(message);
+    }
+}

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -32,6 +32,13 @@ typedef struct pending_data_t {
     int changed;
 } pending_data_t;
 
+typedef struct message_t {
+    char * buffer;
+    unsigned int size;
+    struct sockaddr_in addr;
+    int sock;
+} message_t;
+
 /** Function prototypes **/
 
 /* Read remoted config */
@@ -81,6 +88,18 @@ void key_lock_read(void);
 void key_lock_write(void);
 
 void key_unlock(void);
+
+// Init message queue
+void rem_msginit(size_t size);
+
+// Push message into queue
+int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_in * addr, int sock);
+
+// Pop message from queue
+message_t * rem_msgpop();
+
+// Free message
+void rem_msgfree(message_t * message);
 
 /** Global variables **/
 


### PR DESCRIPTION
This PR solves issue https://github.com/wazuh/wazuh/issues/501 partially.

A new queue has been introduced between the message receiving stage and the agent identification stage. This will prevent agent communication starvation.

This new option for secure connections in Remoted:
```xml
<remote>
  <queue_size>16384</queue_size>
</remote>
```

sets the size of that queue.

The buffer is consumed as fast as possible, no explicit delays here.

If the buffer gets full, Remoted will print a warning message in the _ossec.log_ file (once per execution). All messages arriving while the buffer is full will be discarded.
