### PR TITLE
Adds backward compatibility with old vulnerability-detector configuration

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -13,6 +13,9 @@
 #ifndef WIN32
 #include "wazuh_modules/wmodules.h"
 
+static int get_interval(char *source, unsigned long *interval);
+static int set_oval_version(char *feed, char *version, update_node **upd_list, update_node *upd);
+
 //Options
 static const char *XML_DISABLED = "disabled";
 static const char *XML_INTERVAL = "interval";
@@ -27,6 +30,7 @@ static const char *XML_PORT = "port";
 // Deprecated
 static const char *XML_UPDATE_UBUNTU_OVAL = "update_ubuntu_oval";
 static const char *XML_UPDATE_REDHAT_OVAL = "update_redhat_oval";
+static const char *XML_VERSION = "version";
 
 agent_software * skip_agent(agent_software *agents, agent_software **agents_list) {
     agent_software *next = NULL;
@@ -48,6 +52,61 @@ agent_software * skip_agent(agent_software *agents, agent_software **agents_list
     free(agents);
 
     return next;
+}
+
+int set_oval_version(char *feed, char *version, update_node **upd_list, update_node *upd) {
+    cve_db os_index;
+
+    if (!strcmp(feed, vu_dist[DIS_UBUNTU])) {
+        if (!strcmp(version, "12") || strcasestr(version, vu_dist[DIS_PRECISE])) {
+            os_index = CVE_PRECISE;
+            os_strdup(vu_dist[DIS_PRECISE], upd->version);
+        } else if (!strcmp(version, "14") || strcasestr(version, vu_dist[DIS_TRUSTY])) {
+            os_index = CVE_TRUSTY;
+            os_strdup(vu_dist[DIS_TRUSTY], upd->version);
+        } else if (!strcmp(version, "16") || strcasestr(version, vu_dist[DIS_XENIAL])) {
+            os_index = CVE_XENIAL;
+            os_strdup(vu_dist[DIS_XENIAL], upd->version);
+        } else {
+            merror("Invalid Ubuntu version '%s'.", version);
+            return OS_INVALID;
+        }
+    } else if (!strcmp(feed, vu_dist[DIS_REDHAT])) {
+        if (!strcmp(version, "5")) {
+            os_index = CVE_RHEL5;
+        } else if (!strcmp(version, "6")) {
+            os_index = CVE_RHEL6;
+        } else if (!strcmp(version, "7")) {
+            os_index = CVE_RHEL7;
+        } else {
+            merror("Invalid Redhat version '%s'.", version);
+            return OS_INVALID;
+        }
+    } else {
+        merror("Invalid OS for tag '%s' at module '%s'.", XML_FEED, WM_VULNDETECTOR_CONTEXT.name);
+        return OS_INVALID;
+    }
+
+    os_strdup(feed, upd->dist);
+    if (!upd->version) {
+        os_strdup(version, upd->version);
+    }
+
+    if (upd_list[os_index]) {
+        mwarn("Duplicate OVAL configuration for '%s %s'.", upd->dist, upd->version);
+        free(upd->dist);
+        free(upd->version);
+        free(upd);
+        return OS_SUPP_SIZE;
+    }
+
+    upd_list[os_index] = upd;
+
+    upd->url = NULL;
+    upd->path = NULL;
+    upd->port = 0;
+
+    return os_index;
 }
 
 int get_interval(char *source, unsigned long *interval) {
@@ -120,7 +179,7 @@ int wm_vulnerability_detector_read(const OS_XML *xml, xml_node **nodes, wmodule 
         } else if (!strcmp(nodes[i]->element, XML_FEED)) {
             char *feed;
             char *version;
-            cve_db os_index;
+            int os_index;
             update_node *upd;
 
             if (!nodes[i]->attributes || strcmp(*nodes[i]->attributes, XML_NAME)) {
@@ -143,50 +202,16 @@ int wm_vulnerability_detector_read(const OS_XML *xml, xml_node **nodes, wmodule 
 
             os_calloc(1, sizeof(update_node), upd);
 
-            // Check OS
-            if (!strcmp(feed, vu_dist[DIS_UBUNTU])) {
-                if (!strcmp(version, "12") || strcasestr(version, vu_dist[DIS_PRECISE])) {
-                    os_index = CVE_PRECISE;
-                    os_strdup(vu_dist[DIS_PRECISE], upd->version);
-                } else if (!strcmp(version, "14") || strcasestr(version, vu_dist[DIS_TRUSTY])) {
-                    os_index = CVE_TRUSTY;
-                    os_strdup(vu_dist[DIS_TRUSTY], upd->version);
-                } else if (!strcmp(version, "16") || strcasestr(version, vu_dist[DIS_XENIAL])) {
-                    os_index = CVE_XENIAL;
-                    os_strdup(vu_dist[DIS_XENIAL], upd->version);
-                } else {
-                    merror("Invalid Ubuntu version '%s'.", version);
-                    return OS_INVALID;
-                }
-            } else if (!strcmp(feed, vu_dist[DIS_REDHAT])) {
-                if (!strcmp(version, "5")) {
-                    os_index = CVE_RHEL5;
-                } else if (!strcmp(version, "6")) {
-                    os_index = CVE_RHEL6;
-                } else if (!strcmp(version, "7")) {
-                    os_index = CVE_RHEL7;
-                } else {
-                    merror("Invalid Redhat version '%s'.", version);
-                    return OS_INVALID;
-                }
-            } else {
-                merror("Invalid OS for tag '%s' at module '%s'.", XML_FEED, WM_VULNDETECTOR_CONTEXT.name);
+            if (os_index = set_oval_version(feed, version, vulnerability_detector->updates, upd), os_index == OS_INVALID) {
                 return OS_INVALID;
+            } else if (os_index == OS_SUPP_SIZE) {
+                continue;
             }
 
             if (chld_node = OS_GetElementsbyNode(xml, nodes[i]), !chld_node) {
                 merror(XML_INVELEM, nodes[i]->element);
                 return OS_INVALID;
             }
-
-            vulnerability_detector->updates[os_index] = upd;
-            os_strdup(feed, upd->dist);
-            if (!upd->version) {
-                os_strdup(version, upd->version);
-            }
-            upd->url = NULL;
-            upd->path = NULL;
-            upd->port = 0;
 
             for (j = 0; chld_node[j]; j++) {
                 if (!strcmp(chld_node[j]->element, XML_DISABLED)) {
@@ -248,9 +273,168 @@ int wm_vulnerability_detector_read(const OS_XML *xml, xml_node **nodes, wmodule 
                 merror("Invalid ignore_time at module '%s'", WM_VULNDETECTOR_CONTEXT.name);
                 return OS_INVALID;
             }
-        } else if (!strcmp(nodes[i]->element, XML_UPDATE_UBUNTU_OVAL) || !strcmp(nodes[i]->element, XML_UPDATE_REDHAT_OVAL)) {
-            merror("'%s' option at module '%s' is deprecated. Use '%s' instead.", nodes[i]->element, WM_VULNDETECTOR_CONTEXT.name, XML_FEED);
-            return OS_INVALID;
+        } else if (!strcmp(nodes[i]->element, XML_UPDATE_UBUNTU_OVAL)) {
+            int enabled = 0;
+            long unsigned int interval = 0;
+            int precise = 0, trusty = 0, xenial = 0;
+            mwarn("'%s' option at module '%s' is deprecated. Use '%s' instead.", nodes[i]->element, WM_VULNDETECTOR_CONTEXT.name, XML_FEED);
+
+            if (!strcmp(nodes[i]->content, "yes")) {
+                enabled = 1;
+                if (nodes[i]->attributes) {
+                    for (j = 0; nodes[i]->attributes[j]; j++) {
+                        if (!strcmp(nodes[i]->attributes[j], XML_VERSION)) {
+                            int k;
+                            char * version = nodes[i]->values[j];
+                            for (k = 0;; k++) {
+                                int out = (version[k] == '\0');
+                                if (version[k] == ',' || out) {
+                                    version[k] = '\0';
+                                    if (!strcmp(version, "12")) {
+                                        precise = 1;
+                                    } else if (!strcmp(version, "14")) {
+                                        trusty = 1;
+                                    } else if (!strcmp(version, "16")) {
+                                        xenial = 1;
+                                    } else {
+                                        merror("Invalid Ubuntu version '%s'.", version);
+                                    }
+                                    version = &version[k] + 1;
+                                    k = 0;
+                                }
+                                if (out)
+                                    break;
+                            }
+                        } else if (!strcmp(nodes[i]->attributes[j], XML_INTERVAL)) {
+                            if (get_interval(nodes[i]->values[j], &interval)) {
+                                merror("Invalid interval at module '%s'", WM_VULNDETECTOR_CONTEXT.name);
+                                return OS_INVALID;
+                            }
+                        } else {
+                            merror("Invalid attribute '%s' for '%s'", nodes[i]->attributes[j], XML_UPDATE_UBUNTU_OVAL);
+                        }
+                    }
+                }
+            } else if (!strcmp(nodes[i]->content, "no")) {
+                enabled = 0;
+            } else {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_RUN_ON_START, WM_VULNDETECTOR_CONTEXT.name);
+                return OS_INVALID;
+            }
+
+            if (enabled) {
+                int os_index;
+                update_node *upd;
+
+                if (precise) {
+                    os_calloc(1, sizeof(update_node), upd);
+                    if (os_index = set_oval_version("UBUNTU", "12", vulnerability_detector->updates, upd), os_index == OS_INVALID) {
+                        return OS_INVALID;
+                    } else if (os_index == OS_SUPP_SIZE) {
+                        continue;
+                    }
+                    upd->interval = interval;
+                }
+                if (trusty) {
+                    os_calloc(1, sizeof(update_node), upd);
+                    if (os_index = set_oval_version("UBUNTU", "14", vulnerability_detector->updates, upd), os_index == OS_INVALID) {
+                        return OS_INVALID;
+                    } else if (os_index == OS_SUPP_SIZE) {
+                        continue;
+                    }
+                    upd->interval = interval;
+                }
+                if (xenial) {
+                    os_calloc(1, sizeof(update_node), upd);
+                    if (os_index = set_oval_version("UBUNTU", "16", vulnerability_detector->updates, upd), os_index == OS_INVALID) {
+                        return OS_INVALID;
+                    } else if (os_index == OS_SUPP_SIZE) {
+                        continue;
+                    }
+                    upd->interval = interval;
+                }
+            }
+        } else if (!strcmp(nodes[i]->element, XML_UPDATE_REDHAT_OVAL)) {
+            int enabled = 0;
+            long unsigned int interval = 0;
+            int rhel5 = 0, rhel6 = 0, rhel7 = 0;
+            mwarn("'%s' option at module '%s' is deprecated. Use '%s' instead.", nodes[i]->element, WM_VULNDETECTOR_CONTEXT.name, XML_FEED);
+
+            if (!strcmp(nodes[i]->content, "yes")) {
+                enabled = 1;
+                if (nodes[i]->attributes) {
+                    for (j = 0; nodes[i]->attributes[j]; j++) {
+                        if (!strcmp(nodes[i]->attributes[j], XML_VERSION)) {
+                            int k;
+                            char * version = nodes[i]->values[j];
+                            for (k = 0;; k++) {
+                                int out = (version[k] == '\0');
+                                if (version[k] == ',' || out) {
+                                    version[k] = '\0';
+                                    if (!strcmp(version, "5")) {
+                                        rhel5 = 1;
+                                    } else if (!strcmp(version, "6")) {
+                                        rhel6 = 1;
+                                    } else if (!strcmp(version, "7")) {
+                                        rhel7 = 1;
+                                    } else {
+                                        merror("Invalid RedHat version '%s'.", version);
+                                    }
+                                    version = &version[k] + 1;
+                                    k = 0;
+                                }
+                                if (out)
+                                    break;
+                            }
+                        } else if (!strcmp(nodes[i]->attributes[j], XML_INTERVAL)) {
+                            if (get_interval(nodes[i]->values[j], &interval)) {
+                                merror("Invalid interval at module '%s'", WM_VULNDETECTOR_CONTEXT.name);
+                                return OS_INVALID;
+                            }
+                        } else {
+                            merror("Invalid attribute '%s' for '%s'", nodes[i]->attributes[j], XML_UPDATE_REDHAT_OVAL);
+                        }
+                    }
+                }
+            } else if (!strcmp(nodes[i]->content, "no")) {
+                enabled = 0;
+            } else {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_RUN_ON_START, WM_VULNDETECTOR_CONTEXT.name);
+                return OS_INVALID;
+            }
+
+            if (enabled) {
+                int os_index;
+                update_node *upd;
+
+                if (rhel5) {
+                    os_calloc(1, sizeof(update_node), upd);
+                    if (os_index = set_oval_version("REDHAT", "5", vulnerability_detector->updates, upd), os_index == OS_INVALID) {
+                        return OS_INVALID;
+                    } else if (os_index == OS_SUPP_SIZE) {
+                        continue;
+                    }
+                    upd->interval = interval;
+                }
+                if (rhel6) {
+                    os_calloc(1, sizeof(update_node), upd);
+                    if (os_index = set_oval_version("REDHAT", "6", vulnerability_detector->updates, upd), os_index == OS_INVALID) {
+                        return OS_INVALID;
+                    } else if (os_index == OS_SUPP_SIZE) {
+                        continue;
+                    }
+                    upd->interval = interval;
+                }
+                if (rhel7) {
+                    os_calloc(1, sizeof(update_node), upd);
+                    if (os_index = set_oval_version("REDHAT", "7", vulnerability_detector->updates, upd), os_index == OS_INVALID) {
+                        return OS_INVALID;
+                    } else if (os_index == OS_SUPP_SIZE) {
+                        continue;
+                    }
+                    upd->interval = interval;
+                }
+            }
         } else {
             merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_VULNDETECTOR_CONTEXT.name);
             return OS_INVALID;

--- a/src/wazuh_modules/wm_vuln_detector.h
+++ b/src/wazuh_modules/wm_vuln_detector.h
@@ -195,7 +195,6 @@ typedef struct last_scan {
 } last_scan;
 
 int wm_vulnerability_detector_read(const OS_XML *xml, xml_node **nodes, wmodule *module);
-int get_interval(char *source, unsigned long *interval);
 int wm_vunlnerability_detector_set_agents_info(agent_software **agents_software);
 agent_software * skip_agent(agent_software *agents, agent_software **agents_list);
 


### PR DESCRIPTION
This branch adds support for the above options for upgrading OVALs:

- update_ubuntu_oval
- update_redhat_oval

This bug has been mentioned in issues #520 and #503.