### PR TITLE
Fix mutex error in agent due to missing initialization

### DIFF
--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -315,6 +315,7 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
 
     /* Add additional entry for sender == keysize */
     os_calloc(1, sizeof(keyentry), keys->keyentries[keys->keysize]);
+    w_mutex_init(&keys->keyentries[keys->keysize]->mutex, NULL);
 
     return;
 }


### PR DESCRIPTION
This PR solves issue https://github.com/wazuh/wazuh/issues/522.

The keys structure creates N+1 entries: the extra entry is used for the sender. The issue was due to a missing entry mutex initialization.

I used extra logs to trace the issue:
```
2018/04/10 17:12:37 ossec-agentd: DEBUG:  -- OS_AddKey(): 100, keysize = 0
```

There should be another log with `keysize = 1`. I think this was causing the reported issue.

In Linux, a mutex structure is defined this way:

```c
# define PTHREAD_MUTEX_INITIALIZER \
  { { 0, 0, 0, 0, 0, { 0, 0 } } }
```

Since the extra memory space is set to `0`, the mutex is initialized properly by coincidence. However, in macOS the mutex is initialized this way:

```c
#define PTHREAD_MUTEX_INITIALIZER {0x32AAABA7, {0}}
```

That's why the mutex was working properly in Linux but was failing in macOS.