### PR TITLE
Fixed ignoring windows registry entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Fix bug in Logcollector when removing duplicate localfiles. ([#402](https://github.com/wazuh/wazuh/pull/402))
 - Fix weird behavior in Syscheck when a modified file returns back to its first state. ([#434](https://github.com/wazuh/wazuh/pull/434))
 - Fixed invalid alerts reported by Syscollector when the event contains the word "error". ([#461](https://github.com/wazuh/wazuh/pull/461))
+- Fixed registry_ignore problem on syscheck for Windows when arch="both" was used. ([#525](https://github.com/wazuh/wazuh/pull/525))
 
 ### Removed
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -815,15 +815,13 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
                 if (arch != ARCH_BOTH)
                     dump_registry_ignore_regex(syscheck, node[i]->content, arch);
                 else {
-                    dump_registry_ignore_regex(syscheck, node[i]->content, ARCH_32BIT);
-                    dump_registry_ignore_regex(syscheck, node[i]->content, ARCH_64BIT);
+                    dump_registry_ignore_regex(syscheck, node[i]->content, ARCH_BOTH);
                 }
             } else {
                 if (arch != ARCH_BOTH)
                     dump_registry_ignore(syscheck, node[i]->content, arch);
                 else {
-                    dump_registry_ignore(syscheck, node[i]->content, ARCH_32BIT);
-                    dump_registry_ignore(syscheck, node[i]->content, ARCH_64BIT);
+                    dump_registry_ignore(syscheck, node[i]->content, ARCH_BOTH);
                 }
             }
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -93,8 +93,6 @@ void dump_registry_ignore(syscheck_config *syscheck, char *entry, int arch) {
     int ign_size = 0;
 
     if (syscheck->registry_ignore) {
-        int ign_size;
-
         /* We do not add duplicated entries */
         for (ign_size = 0; syscheck->registry_ignore[ign_size].entry; ign_size++)
             if (syscheck->registry_ignore[ign_size].arch == arch &&
@@ -815,13 +813,15 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
                 if (arch != ARCH_BOTH)
                     dump_registry_ignore_regex(syscheck, node[i]->content, arch);
                 else {
-                    dump_registry_ignore_regex(syscheck, node[i]->content, ARCH_BOTH);
+                    dump_registry_ignore_regex(syscheck, node[i]->content, ARCH_32BIT);
+                    dump_registry_ignore_regex(syscheck, node[i]->content, ARCH_64BIT);
                 }
             } else {
                 if (arch != ARCH_BOTH)
                     dump_registry_ignore(syscheck, node[i]->content, arch);
                 else {
-                    dump_registry_ignore(syscheck, node[i]->content, ARCH_BOTH);
+                    dump_registry_ignore(syscheck, node[i]->content, ARCH_32BIT);
+                    dump_registry_ignore(syscheck, node[i]->content, ARCH_64BIT);
                 }
             }
 

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -328,7 +328,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch)
     /* Registry ignore list */
     if (fullkey_name && syscheck.registry_ignore) {
         while (syscheck.registry_ignore[i].entry != NULL) {
-            if (syscheck.registry_ignore[i].arch == arch && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0) {
+            if ((syscheck.registry_ignore[i].arch == ARCH_BOTH && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0) || (syscheck.registry_ignore[i].arch == arch && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0)) {
                 return;
             }
             i++;
@@ -336,9 +336,9 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch)
     } else if (fullkey_name && syscheck.registry_ignore_regex) {
         i = 0;
         while (syscheck.registry_ignore_regex[i].regex != NULL) {
-            if (syscheck.registry_ignore[i].arch == arch &&
+            if ((syscheck.registry_ignore[i].arch == ARCH_BOTH && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0) || (syscheck.registry_ignore[i].arch == arch &&
                 OSMatch_Execute(fullkey_name, strlen(fullkey_name),
-                                syscheck.registry_ignore_regex[i].regex)) {
+                                syscheck.registry_ignore_regex[i].regex))) {
                 return;
             }
             i++;

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -328,7 +328,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch)
     /* Registry ignore list */
     if (fullkey_name && syscheck.registry_ignore) {
         while (syscheck.registry_ignore[i].entry != NULL) {
-            if ((syscheck.registry_ignore[i].arch == ARCH_BOTH && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0) || (syscheck.registry_ignore[i].arch == arch && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0)) {
+            if (syscheck.registry_ignore[i].arch == arch && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0) {
                 return;
             }
             i++;
@@ -336,9 +336,9 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch)
     } else if (fullkey_name && syscheck.registry_ignore_regex) {
         i = 0;
         while (syscheck.registry_ignore_regex[i].regex != NULL) {
-            if ((syscheck.registry_ignore[i].arch == ARCH_BOTH && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0) || (syscheck.registry_ignore[i].arch == arch &&
+            if (syscheck.registry_ignore[i].arch == arch &&
                 OSMatch_Execute(fullkey_name, strlen(fullkey_name),
-                                syscheck.registry_ignore_regex[i].regex))) {
+                                syscheck.registry_ignore_regex[i].regex)) {
                 return;
             }
             i++;


### PR DESCRIPTION
Fixed ignoring windows registry entries when using arch="both" on a <windows_registry> label.

For example a config like this:
 `<windows_registry arch="both">HKEY_LOCAL_MACHINE\Test>`

and later:
`<registry_ignore arch="both">HKEY_LOCAL_MACHINE\Test\001</registry_ignore>`

Would still spawn alerts. This is now fixed.
