### PR TITLE
Add rootcheck cis windows 2012 r2

### DIFF
--- a/src/rootcheck/db/cis_apache2224_rcl.txt
+++ b/src/rootcheck/db/cis_apache2224_rcl.txt
@@ -1,0 +1,505 @@
+# OSSEC Linux Audit - (C) 2017
+#
+# Released under the same license as OSSEC.
+# More details at the LICENSE file included with OSSEC or online
+# at: https://github.com/ossec/ossec-hids/blob/master/LICENSE
+#
+# [Application name] [any or all] [reference]
+# type:<entry name>;
+#
+# Type can be:
+#             - f (for file or directory)
+#             - p (process running)
+#             - d (any file inside the directory)
+#
+# Additional values:
+# For the registry , use "->" to look for a specific entry and another
+# "->" to look for the value.
+# For files, use "->" to look for a specific value in the file.
+#
+# Values can be preceeded by: =: (for equal) - default
+#                             r: (for ossec regexes)
+#                             >: (for strcmp greater)
+#                             <: (for strcmp  lower)
+# Multiple patterns can be specified by using " && " between them.
+# (All of them must match for it to return true).
+
+# CIS Checks for Apache Https Server 
+# Based on Center for Internet Security Benchmark for Apache HttpSserver 2.4 v1.3.1 and Apache HttpsServer 2.2 v3.4.1 (https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308)
+#
+#
+$main-conf=/etc/apache2/apache2.conf,/etc/httpd/conf/httpd.conf;
+$conf-dirs=/etc/apache2/conf-enabled,/etc/apache2/mods-enabled,/etc/apache2/sites-enabled,/etc/httpd/conf.d,/etc/httpd/modsecurity.d;
+$ssl-confs=/etc/apache2/mods-enabled/ssl.conf,/etc/httpd/conf.d/ssl.conf;
+$mods-en=/etc/apache2/mods-enabled;
+$request-confs=/etc/httpd/conf/httpd.conf,/etc/apache2/mods-enabled/reqtimeout.conf;
+$traceen=/etc/apache2/apache2.conf,/etc/httpd/conf/httpd.conf,/etc/apache2/conf-enabled/security.conf;
+#
+#
+#2.3 Disable WebDAV Modules
+[CIS - Apache Configuration - 2.3: WebDAV Modules are enabled] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:loadmodule\sdav;
+d:$conf-dirs -> load -> !r:^# && r:loadmodule\sdav;
+f:/etc/httpd/conf.d -> !r:^# && r:loadmodule\sdav;
+d:$mods-en -> dav.load;
+#
+#
+#2.4 Disable Status Module
+[CIS - Apache Configuration - 2.4: Status Module is enabled] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:loadmodule\sstatus;
+d:$conf-dirs -> load -> !r:^# && r:loadmodule\sstatus;
+f:/etc/httpd/conf.d -> !r:^# && r:loadmodule\sstatus;
+d:$mods-en -> status.load;
+#
+#
+#2.5 Disable Autoindex Module
+[CIS - Apache Configuration - 2.5: Autoindex Module is enabled] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:loadmodule\sautoindex;
+d:$conf-dirs -> load -> !r:^# && r:loadmodule\sautoindex;
+f:/etc/httpd/conf.d -> !r:^# && r:loadmodule\sautoindex;
+d:$mods-en -> autoindex.load;
+#
+#
+#2.6 Disable Proxy Modules
+[CIS - Apache Configuration - 2.6: Proxy Modules are enabled] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:loadmodule\sproxy;
+d:$conf-dirs -> load -> !r:^# && r:loadmodule\sproxy;
+f:/etc/httpd/conf.d -> !r:^# && r:loadmodule\sproxy;
+d:$mods-en -> proxy.load;
+#
+#
+#2.7 Disable User Directories Modules
+[CIS - Apache Configuration - 2.7: User Directories Modules are enabled] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:loadmodule\suserdir;
+d:$conf-dirs -> load -> !r:^# && r:loadmodule\suserdir;
+f:/etc/httpd/conf.d -> !r:^# && r:loadmodule\suserdir;
+d:$mods-en -> userdir.load;
+#
+#
+#2.8 Disable Info Module
+[CIS - Apache Configuration - 2.8: Info Module is enabled] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:loadmodule\sinfo;
+d:$conf-dirs -> load -> !r:^# && r:loadmodule\sinfo;
+d:$conf-dirs -> conf -> !r:^# && r:loadmodule\sinfo;
+d:$mods-en -> info.load;
+#
+#
+#3.2 Give the Apache User Account an Invalid Shell 
+[CIS - Apache Configuration - 3.2: Apache User Account has got a valid shell] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:/etc/passwd -> r:/var/www && !r:\.*/bin/false$|/sbin/nologin$;
+#
+#
+#3.3 Lock the Apache User Account
+[CIS - Apache Configuration - 3.3: Lock the Apache User Account] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:/etc/shadow -> r:^daemon|^wwwrun|^www-data|^apache && !r:\p!\.*$; 
+#
+#
+#4.4 Restrict Override for All Directories
+[CIS - Apache Configuration - 4.4: Restrict Override for All Directories] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && !r:\w+ && r:allowoverride && !r:none$;
+d:$conf-dirs -> conf -> !r:^# && !r:\w+ && r:allowoverridelist;
+f:$main-conf -> !r:^# && !r:\w+ && r:allowoverride && !r:none$;
+f:$main-conf -> !r:^# && !r:\w+ && r:allowoverridelist;
+#
+#
+#5.3 Minimize Options for Other Directories
+[CIS - Apache Configuration - 5.3: Minimize Options for other directories] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:options\sincludes;
+f:$main-conf -> !r:^# && r:options\sincludes;
+#
+#
+#5.4.1 Remove default index.html sites
+[CIS - Apache Configuration - 5.4.1: Remove default index.html sites] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:/var/www -> index.html;
+d:/var/www/html -> index.html;
+#
+#
+#5.4.2 Remove the Apache user manual
+[CIS - Apache Configuration - 5.4.2: Remove the Apache user manual] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:/etc/httpd/conf.d -> manual.conf; 
+d:/etc/apache2/conf-enabled -> apache2-doc.conf;
+#
+#
+#5.4.5 Verify that no Handler is enabled 
+[CIS - Apache Configuration - 5.4.5: A Handler is configured] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:/wsethandler;
+f:$main-conf -> !r:^# && r:/wsethandler;
+#
+#
+#5.5 Remove default CGI content printenv 
+[CIS - Apache Configuration - 5.5: Remove default CGI content printenv] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:/var/www/cgi-bin -> printenv;
+d:/usr/lib/cgi-bin -> printenv;
+#
+#
+#5.6 Remove default CGI content test-cgi 
+[CIS - Apache Configuration - 5.6: Remove default CGI content test-cgi] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:/var/www/cgi-bin -> test-cgi;
+d:/usr/lib/cgi-bin -> test-cgi;
+#
+#
+#5.7 Limit HTTP Request Method
+[CIS - Apache Configuration - 5.7: Disable HTTP Request Method] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:<limitexcept\sget\spost\soptions>;
+#
+#
+#5.8 Disable HTTP Trace Method
+[CIS - Apache Configuration - 5.8: Disable HTTP Trace Method] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$traceen -> !r:^# && r:traceenable\s+on\s*$;
+#
+#
+#5.9 Restrict HTTP Protocol Versions
+[CIS - Apache Configuration - 5.9: Restrict HTTP Protocol Versions] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:/etc/httpd/conf/httpd.conf -> !r:loadmodule\srewrite;
+d:$mods-en -> !f:rewrite.load;
+f:$main-conf -> !r:rewriteengine\son;
+f:$main-conf -> !r:rewritecond && !r:%{THE_REQUEST} && !r:!HTTP/1\\.1\$; 
+f:$main-conf -> !r:rewriterule && !r:.* - [F];
+#
+#
+#5.12 Deny IP Address Based Requests
+[CIS - Apache Configuration - 5.12: Deny IP Address Based Requests] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:/etc/httpd/conf/httpd.conf -> !r:loadmodule\srewrite;
+d:$mods-en -> !f:rewrite.load;
+f:$main-conf -> !r:rewriteengine\son;
+f:$main-conf -> !r:rewritecond && !r:%{HTTP_HOST} && !r:www\\.\w+\\.\w+ [NC]$;
+f:$main-conf -> !r:rewritecond && !r:%{REQUEST_URI} && !r:/error [NC]$; 
+f:$main-conf -> !r:rewriterule && !r:.\(.*\) - [L,F]$;
+#
+#
+#5.13 Restrict Listen Directive 
+[CIS - Apache Configuration - 5.13: Restrict Listen Directive] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:listen\s80$;
+d:$conf-dirs -> conf -> !r:^# && r:listen\s0.0.0.0\p80;
+d:$conf-dirs -> conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p80;
+f:$main-conf -> !r:^# && r:listen\s80$;
+f:$main-conf -> !r:^# && r:listen\s0.0.0.0\p\d*;
+f:$main-conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p\d*; 
+f:/etc/apache2/sites-enabled/000-default.conf -> !r:^# && r:listen\s80$;
+f:/etc/apache2/sites-enabled/000-default.conf -> !r:^# && r:listen\s0.0.0.0\p\d*;
+f:/etc/apache2/sites-enabled/000-default.conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p\d*;
+f:/etc/apache2/ports.conf -> !r:^# && r:listen\s80$;
+f:/etc/apache2/ports.conf -> !r:^# && r:listen\s0.0.0.0\p\d*;
+f:/etc/apache2/ports.conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p\d*;
+#
+#
+#5.14 Restrict Browser Frame Options 
+[CIS - Apache Configuration - 5.14: Restrict Browser Frame Options] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:header\salways\sappend\sx-frame-options && !r:sameorigin|deny; 
+#
+#
+#6.1 Configure the Error Log to notice at least
+[CIS - Apache Configuration - 6.1: Configure the Error Log to notice at least] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:^# && r:loglevel\snotice\score\p && r:warn|emerg|alert|crit|error|notice;
+f:$main-conf -> !r:loglevel\snotice\score\p && !r:info|debug;
+#
+#
+#6.2 Configure a Syslog facility for Error Log 
+[CIS - Apache Configuration - 6.2: Configure a Syslog facility for Error Log] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:errorlog\s+\p*syslog\p\.*\p*;
+#
+#
+#7.6 Disable SSL Insecure Renegotiation 
+[CIS - Apache Configuration - 7.6: Disable SSL Insecure Renegotiation] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$ssl-confs -> !r:^\t*\s*# && r:sslinsecurerenegotiation\s+on\s*;
+f:$ssl-confs -> !r:^\t*\s*# && r:sslinsecurerenegotiation\s*$;
+#
+#
+#7.7 Ensure SSL Compression is not enabled 
+[CIS - Apache Configuration - 7.7: Ensure SSL Compression is not enabled] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$ssl-confs -> !r:^\t*\s*# && r:sslcompression\s+on\s*;
+f:$ssl-confs -> !r:^\t*\s*# && r:sslcompression\s*$;
+#
+#
+#7.8 Disable SSL TLS v1.0 Protocol
+[CIS - Apache Configuration - 7.8: Disable insecure TLS Protocol] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$ssl-confs -> !r:^\t*\s*sslprotocol;
+f:$ssl-confs -> !r:^\t*\s*# && r:sslprotocol\s+all;
+f:$ssl-confs -> !r:^\t*\s*# && r:sslprotocol\s+\.*tlsv1\P\s*;
+f:$ssl-confs -> !r:^\t*\s*# && r:sslprotocol\s+\.*sslv2\P\s*;
+f:$ssl-confs -> !r:^\t*\s*# && r:sslprotocol\s+\.*sslv3\P\s*;
+#
+#
+#7.9 Enable OCSP Stapling
+[CIS - Apache Configuration - 7.9: Enable OCSP Stapling] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:/etc/httpd/conf/httpd.conf -> !r:^loadmodule\s+ssl;
+d:$mods-en -> !f:ssl.load;
+f:$ssl-confs -> !r:\t*\s*# && r:sslusestapling\s+off;
+f:$ssl-confs -> !r:\t*\s*sslusestapling\s+on;
+f:$ssl-confs -> !r:\t*\s*sslstaplingcache\s+\.+;
+#
+#
+#7.10 Enable HTTP Strict Transport Security 
+[CIS - Apache Configuration - 7.10: Enable HTTP Strict Transport Security] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:/etc/apache2/apache2.conf -> !r:Header\salways\sset\sStrict-Transport-Security\s"max-age=\d\d\d\d*";
+f:/etc/apache2/apache2.conf -> !r:^# && r:Header\salways\sset\sStrict-Transport-Security\s"max-age=1\d\d";
+f:/etc/apache2/apache2.conf -> !r:^# && r:Header\salways\sset\sStrict-Transport-Security\s"max-age=2\d\d";
+f:/etc/apache2/apache2.conf -> !r:^# && r:Header\salways\sset\sStrict-Transport-Security\s"max-age=3\d\d";
+f:/etc/apache2/apache2.conf -> !r:^# && r:Header\salways\sset\sStrict-Transport-Security\s"max-age=4\d\d";
+f:/etc/apache2/apache2.conf -> !r:^# && r:Header\salways\sset\sStrict-Transport-Security\s"max-age=5\d\d";
+#
+#
+#8.1 Set ServerToken to Prod or ProductOnly 
+[CIS - Apache Configuration - 8.1: Set ServerToken to Prod or ProductOnly] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:servertokens\s+major;
+d:$conf-dirs -> conf -> !r:^# && r:servertokens\s+minor;
+d:$conf-dirs -> conf -> !r:^# && r:servertokens\s+min;
+d:$conf-dirs -> conf -> !r:^# && r:servertokens\s+minimal;
+d:$conf-dirs -> conf -> !r:^# && r:servertokens\s+os;
+d:$conf-dirs -> conf -> !r:^# && r:servertokens\s+full;
+#
+#
+#8.2: Set ServerSignature to Off
+[CIS - Apache Configuration - 8.2: Set ServerSignature to Off] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^# && r:serversignature\s+email;
+d:$conf-dirs -> conf -> !r:^# && r:serversignature\s+on;
+#
+#
+#8.3: Prevent Information Leakage via Default Apache Content 
+[CIS - Apache Configuration - 8.3: Prevent Information Leakage via Default Apache Content] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+d:$conf-dirs -> conf -> !r:^\t*\s*# && r:include\s*\w*httpd-autoindex.conf;
+d:$conf-dirs -> conf -> !r:^\t*\s*# && r:alias\s*/icons/\s*\.*;
+#
+#
+#9.1:Set TimeOut to 10 or less 
+[CIS - Apache Configuration - 9.1: Set TimeOut to 10 or less] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:^# && r:timeout\s+9\d;
+f:$main-conf -> !r:^# && r:timeout\s+8\d;
+f:$main-conf -> !r:^# && r:timeout\s+7\d;
+f:$main-conf -> !r:^# && r:timeout\s+6\d;
+f:$main-conf -> !r:^# && r:timeout\s+5\d;
+f:$main-conf -> !r:^# && r:timeout\s+4\d;
+f:$main-conf -> !r:^# && r:timeout\s+3\d;
+f:$main-conf -> !r:^# && r:timeout\s+2\d;
+f:$main-conf -> !r:^# && r:timeout\s+11;
+f:$main-conf -> !r:^# && r:timeout\s+12;
+f:$main-conf -> !r:^# && r:timeout\s+13;
+f:$main-conf -> !r:^# && r:timeout\s+14;
+f:$main-conf -> !r:^# && r:timeout\s+15;
+f:$main-conf -> !r:^# && r:timeout\s+16;
+f:$main-conf -> !r:^# && r:timeout\s+17;
+f:$main-conf -> !r:^# && r:timeout\s+18;
+f:$main-conf -> !r:^# && r:timeout\s+19;
+f:$main-conf -> !r:^timeout\s+\d\d*;
+f:$main-conf -> !r:^# && r:timeout\s+\d\d\d+;
+#
+#
+#9.2:Set the KeepAlive directive to On 
+[CIS - Apache Configuration - 9.2: Set the KeepAlive directive to On] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:^# && r:keepalive\s+off;
+f:$main-conf -> !r:keepalive\s+on;
+#
+#
+#9.3:Set MaxKeepAliveRequests to 100 or greater
+[CIS - Apache Configuration - 9.3: Set MaxKeepAliveRequest to 100 or greater] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:^maxkeepaliverequests\s+\d\d\d+;
+#
+#
+#9.4: Set KeepAliveTimeout Low to Mitigate Denial of Service
+[CIS - Apache Configuration - 9.4: Set KeepAliveTimeout Low] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:keepalivetimeout\s+\d\d*;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+16;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+17;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+18;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+19;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+2\d;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+3\d;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+4\d;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+5\d;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+6\d;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+7\d;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+8\d;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+9\d;
+f:$main-conf -> !r:^# && r:keepalivetimeout\s+\d\d\d+;
+#
+#
+#9.5 Set Timeout Limits for Request Headers
+[CIS - Apache Configuration - 9.5: Set Timeout Limits for Request Headers] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:/etc/httpd/conf/httpd.conf -> !r:^loadmodule\s+reqtimeout;
+d:$mods-en -> !f:reqtimeout.load;
+f:$request-confs -> !r:^\t*\s*requestreadtimeout\.+header\p\d\d*\D\d\d*;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D41;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D42;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D43;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D44;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D45;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D46;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D47;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D48;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D49;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D5\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D6\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D7\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D8\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D9\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D\d\d\d+;
+#
+#
+#9.6 Set Timeout Limits for Request Body 
+[CIS - Apache Configuration - 9.6: Set Timeout Limits for Request Body] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:/etc/httpd/conf/httpd.conf -> !r:^loadmodule\s+reqtimeout;
+d:$mods-en -> !f:reqtimeout.load;
+f:$request-confs -> !r:\t*\s*requestreadtimeout\.+body\p\d\d*;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p21;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p22;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p23;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p24;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p25;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p26;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p27;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p28;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p29;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p3\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p4\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p5\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p6\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p7\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p8\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p9\d;
+f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+body\p\d\d\d+;
+#
+#
+#10.1 Set the LimitRequestLine directive to 512 or less
+[CIS - Apache Configuration - 10.1: Set LimitRequestLine to 512 or less] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:^limitrequestline\s+\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\13;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\14;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\15;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\16;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\17;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\18;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\19;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\2\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\3\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\4\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\5\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\6\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\7\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\8\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+5\9\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+6\d\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+7\d\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+8\d\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+9\d\d;
+f:$main-conf -> !r:^# && r:limitrequestline\s+\d\d\d\d+;
+#
+#
+#10.2 Set the LimitRequestFields directive to 100 or less
+[CIS - Apache Configuration - 10.2: Set LimitRequestFields to 100 or less] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:^limitrequestfields\s\d\d*;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d1;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d2;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d3;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d4;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d5;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d6;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d7;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d8;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+1\d9;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+11\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+12\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+13\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+14\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+15\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+16\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+17\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+18\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+19\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+2\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+3\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+4\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+5\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+6\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+7\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+8\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+9\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfields\s+\d\d\d\d+;
+#
+#
+#10.3 Set the LimitRequestFieldsize directive to 1024 or less
+[CIS - Apache Configuration - 10.3: Set LimitRequestFieldsize to 1024 or less] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:^limitrequestfieldsize\s+\d\d*;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d25;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d26;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d27;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d28;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d29;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d3\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d4\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d5\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d6\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d7\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d8\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+1\d9\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+11\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+12\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+13\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+14\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+15\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+16\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+17\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+18\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+19\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+2\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+3\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+4\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+5\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+6\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+7\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+8\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+9\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestfieldsize\s+\d\d\d\d\d+;
+#
+#
+#10.4 Set the LimitRequestBody directive to 102400 or less
+[CIS - Apache Configuration - 10.4: Set LimitRequestBody to 102400 or less] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
+f:$main-conf -> !r:^limitrequestbody\s+\d\d*;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+0\s*$;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d1;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d2;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d3;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d4;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d5;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d6;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d7;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d8;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d24\d9;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d241\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d242\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d243\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d244\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d245\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d246\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d247\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d248\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d249\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d25\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d26\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d27\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d28\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d29\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d3\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d4\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d5\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d6\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d7\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d8\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+1\d9\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+11\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+12\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+13\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+14\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+15\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+16\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+17\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+18\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+19\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+2\d\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+3\d\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+4\d\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+5\d\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+6\d\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+7\d\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+8\d\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+9\d\d\d\d\d;
+f:$main-conf -> !r:^# && r:limitrequestbody\s+\d\d\d\d\d\d\d+;

--- a/src/rootcheck/db/cis_win2012r2_domainL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_domainL1_rcl.txt
@@ -1,0 +1,1092 @@
+# OSSEC Linux Audit - (C) 2018 OSSEC Project
+#
+# Released under the same license as OSSEC.
+# More details at the LICENSE file included with OSSEC or online
+# at: https://github.com/ossec/ossec-hids/blob/master/LICENSE
+#
+# [Application name] [any or all] [reference]
+# type:<entry name>;
+#
+# Type can be:
+#             - f (for file or directory)
+#             - r (registry entry)
+#             - p (process running)
+#
+# Additional values:
+# For the registry and for directories, use "->" to look for a specific entry and another
+# "->" to look for the value.
+# Also, use " -> r:^\. -> ..." to search all files in a directory
+# For files, use "->" to look for a specific value in the file.
+#
+# Values can be preceeded by: =: (for equal) - default
+#                             r: (for ossec regexes)
+#                             >: (for strcmp greater)
+#                             <: (for strcmp  lower)
+# Multiple patterns can be specified by using " && " between them.
+# (All of them must match for it to return true).
+
+# CIS Checks for Windows Server 2012 R2 Domain Controller L1
+# Based on Center for Internet Security Benchmark v2.2.1 for Microsoft Windows Server 2012 R2 (https://workbench.cisecurity.org/benchmarks/288)
+#
+#
+#
+#1.1.2 Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'
+[CIS - Microsoft Windows Server 2012 R2 - Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> 0;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> 3D;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> 3E;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> 3F;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:4\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:5\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:6\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:7\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:8\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:9\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:A\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:B\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:C\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:D\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:E\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:F\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> r:\w\w\w+;
+#
+#
+#2.3.1.2 Ensure 'Accounts: Block Microsoft accounts' is set to 'Users can't add or log on with Microsoft accounts'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.1.2: Ensure 'Accounts: Block Microsoft accounts' is set to 'Users can't add or log on with Microsoft accounts'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> NoConnectedUser -> 0;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> NoConnectedUser -> 1;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> !NoConnectedUser;
+#
+#
+#2.3.1.4 Ensure 'Accounts: Limit local account use of blank passwords to console logon only' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.1.4: Ensure 'Accounts: Limit local account use of blank passwords to console logon only' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> LimitBlankPasswordUse -> 0;
+#
+#
+#2.3.2.1 Ensure 'Audit: Force audit policy subcategory settings (Windows Vista or later) to override audit policy category settings' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.2.1: Ensure 'Audit: Force audit policy subcategory settings (Windows Vista or later) to override audit policy category settings' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> SCENoApplyLegacyAuditPolicy -> !1;
+#
+#
+#2.3.2.2 Ensure 'Audit: Shut down system immediately if unable to log security audits' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.2.2: Ensure 'Audit: Shut down system immediately if unable to log security audits' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> CrashOnAuditFail -> 1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> CrashOnAuditFail -> 2;
+#
+#
+#2.3.4.1 Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators' 
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.4.1: Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 1;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 2;
+#
+#
+#2.3.4.2 Ensure 'Devices: Prevent users from installing printer drivers' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.4.2: Ensure 'Devices: Prevent users from installing printer drivers' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Print\Providers\LanMan Print Services\Servers -> AddPrinterDrivers -> !1;
+#
+#
+#2.3.5.1 Ensure 'Domain controller: Allow server operators to schedule tasks' is set to 'Disabled' (DC only)
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.5.1: Ensure 'Domain controller: Allow server operators to schedule tasks' is set to 'Disabled' (DC only)] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\SubmitControl -> !0;
+
+#
+#
+#2.3.5.2 Ensure 'Domain controller: LDAP server signing requirements' is set to 'Require signing'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.5.2: Ensure 'Domain controller: LDAP server signing requirements' is set to 'Require signing'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\NTDS\Parameters -> LDAPServerIntegrity -> !2;
+#
+#
+#2.3.5.3 Ensure 'Domain controller: Refuse machine account password changes' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.5.3: Ensure 'Domain controller: Refuse machine account password changes' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> RefusePasswordChange -> 1;
+#
+#
+#2.3.6.1 Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.6.1: Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> RequireSignOrSeal -> 0;
+#
+#
+#2.3.6.2 Ensure 'Domain member: Digitally encrypt secure channel data (when possible)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.6.2: Ensure 'Domain member: Digitally encrypt secure channel data (when possible)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> SealSecureChannel -> 0;
+#
+#
+#2.3.6.3 Ensure 'Domain member: Digitally sign secure channel data (when possible)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.6.3: Ensure 'Domain member: Digitally sign secure channel data (when possible)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> SignSecureChannel -> 0;
+#
+#
+#2.3.6.4 Ensure 'Domain member: Disable machine account password changes' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.6.4: Ensure 'Domain member: Disable machine account password changes' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> DisablePasswordChange -> 1;
+#
+#
+#2.3.6.6 Ensure 'Domain member: Require strong (Windows 2000 or later) session key' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.6.6: Ensure 'Domain member: Require strong session key' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> RequireStrongKey -> 0;
+#
+#
+#2.3.7.1 Ensure 'Interactive logon: Do not display last user name' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.7.1: Ensure 'Interactive logon: Do not display last user name' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> DontDisplayLastUserName -> 0;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> !DontDisplayLastUserName;
+#
+#
+#2.3.7.2 Ensure 'Interactive logon: Do not require CTRL+ALT+DEL' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.7.2: Ensure 'Interactive logon: Do not require CTRL+ALT+DEL' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> DisableCAD -> 1;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> !DisableCAD;
+#
+#
+#2.3.7.3 Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.7.3: Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> 0;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> 385;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> 386;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> 387;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> 388;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> 389;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:38\D;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:39\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:3\D\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:4\w\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:5\w\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:6\w\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:7\w\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:8\w\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:9\w\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:\D\w\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> InactivityTimeoutSecs -> r:\w\w\w\w+;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> !InactivityTimeoutSecs;
+#
+#
+#2.3.7.7 Ensure 'Interactive logon: Prompt user to change password before expiration' is set to 'between 5 and 14 days'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.7.7: Ensure 'Interactive logon: Prompt user to change password before expiration' is set to 'between 5 and 14 days'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 1;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 2;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 3;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 4;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0F;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:1\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:2\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:3\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:4\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:5\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:6\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:7\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:8\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:9\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\D\w;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\w\w\w+;
+#
+#
+#2.3.7.9 Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.7.9: Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> ScRemoveOption -> 0;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> !ScRemoveOption;
+#
+#
+#2.3.8.1 Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.8.1: Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> RequireSecuritySignature -> !1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> !RequireSecuritySignature;
+#
+#
+#2.3.8.2 Ensure 'Microsoft network client: Digitally sign communications (if server agrees)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.8.2: Ensure 'Microsoft network client: Digitally sign communications (if server agrees)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> EnableSecuritySignature -> !1;
+#
+#
+#2.3.8.3 Ensure 'Microsoft network client: Send unencrypted password to third-party SMB servers' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.8.3: Ensure 'Microsoft network client: Send unencrypted password to third-party SMB servers' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> EnablePlainTextPassword -> !0;
+#
+#
+#2.3.9.1 Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s), but not 0'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.9.1: Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s), but not 0'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> 0;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:1\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:2\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:3\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:4\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:5\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:6\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:7\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:8\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:9\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:\D\w;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> AutoDisconnect -> r:\w\w\w+;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> !AutoDisconnect;
+#
+#
+#2.3.9.2 Ensure 'Microsoft network server: Digitally sign communications (always)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.9.2: Ensure 'Microsoft network server: Digitally sign communications (always)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> RequireSecuritySignature -> !1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> !RequireSecuritySignature;
+#
+#
+#2.3.9.3 Ensure 'Microsoft network server: Digitally sign communications (if client agrees)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.9.3: Ensure 'Microsoft network server: Digitally sign communications (if client agrees)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> EnableSecuritySignature -> !1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> !EnableSecuritySignature;
+#
+#
+#2.3.9.4 Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.9.4: Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> EnableForcedLogOff -> !1;
+#
+#
+#2.3.10.2 Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts' is set to 'Enabled' (MS only)
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.2: Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> RestrictAnonymousSAM -> 0;
+#
+#
+#2.3.10.5 Ensure 'Network access: Let Everyone permissions apply to anonymous users' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.5: Ensure 'Network access: Let Everyone permissions apply to anonymous users' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> EveryoneIncludesAnonymous -> 1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> EveryoneIncludesAnonymous -> 2;
+#
+#
+#2.3.10.6 Configure 'Network access: Named Pipes that can be accessed anonymously'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.6: Configure 'Network access: Named Pipes that can be accessed anonymously'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> !r:lsarpc|netlogon|samr;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> !NullSessionPipes;
+#
+#
+#2.3.10.7 Configure 'Network access: Remotely accessible registry paths'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.7: Configure 'Network access: Remotely accessible registry paths'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\Winreg\AllowedExactPaths -> Machine -> !r:System\\CurrentControlSet\\Control\\ProductOptions|System\\CurrentControlSet\\Control\\Server Applications|Software\\Microsoft\\Windows NT\\CurrentVersion;
+#
+#
+#2.3.10.8 Configure 'Network access: Remotely accessible registry paths and sub-paths'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.8: Configure 'Network access: Remotely accessible registry paths and sub-paths'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\Winreg\AllowedPaths -> Machine -> !r:Software\\Microsoft\\Windows NT\\CurrentVersion\\Print|Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows|System\\CurrentControlSet\\Control\\Print\\Printers|System\\CurrentControlSet\\Services\\Eventlog|Software\\Microsoft\\OLAP Server|System\\CurrentControlSet\\Control\\ContentIndex|System\\CurrentControlSet\\Control\\Terminal Server|System\\CurrentControlSet\\Control\\Terminal Server\\UserConfig|System\\CurrentControlSet\\Control\\Terminal Server\\DefaultUserConfiguration|Software\\Microsoft\\Windows NT\\CurrentVersion\\Perflib|System\\CurrentControlSet\\Services\\SysmonLog|System\\CurrentControlSet\\Services\\CertSvc|System\\CurrentControlSet\\Services\\WINS;
+#
+#
+#2.3.10.9 Ensure 'Network access: Restrict anonymous access to Named Pipes and Shares' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.9: Ensure 'Network access: Restrict anonymous access to Named Pipes and Shares' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> RestrictNullSessAccess -> !1;
+#
+#
+#2.3.10.10 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.10: Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\.+;
+#
+#
+#2.3.10.11 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.11: Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> ForceGuest -> 1;
+#
+#
+#2.3.11.1 Ensure 'Network security: Allow Local System to use computer identity for NTLM' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.11.1: Ensure 'Network security: Allow Local System to use computer identity for NTLM' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> UseMachineId -> !1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> !UseMachineId;
+#
+#
+#2.3.11.2 Ensure 'Network security: Allow LocalSystem NULL session fallback' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.11.2: Ensure 'Network security: Allow LocalSystem NULL session fallback' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0 -> allownullsessionfallback -> 1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0 -> !allownullsessionfallback;
+#
+#
+#2.3.11.3 Ensure 'Network Security: Allow PKU2U authentication requests to this computer to use online identities' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.11.3: Ensure 'Network Security: Allow PKU2U authentication requests to this computer to use online identities' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\pku2u -> AllowOnlineID -> !0;
+#
+#
+#2.3.11.4 Ensure 'Network Security: Configure encryption types allowed for Kerberos' is set to 'RC4_HMAC_MD5, AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.11.4: Ensure 'Network Security: Configure encryption types allowed for Kerberos' is set to 'RC4_HMAC_MD5, AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters -> SupportedEncryptionTypes -> !2147483644;
+#
+#
+#2.3.11.5 Ensure 'Network security: Do not store LAN Manager hash value on next password change' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.11.5: Ensure 'Network security: Do not store LAN Manager hash value on next password change' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> NoLMHash -> 0;
+#
+#
+#2.3.11.7 Ensure 'Network security: LAN Manager authentication level' is set to 'Send NTLMv2 response only. Refuse LM & NTLM'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.11.7: Ensure 'Network security: LAN Manager authentication level' is set to 'Send NTLMv2 response only. Refuse LM & NTLM'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> LmCompatibilityLevel -> 0;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> LmCompatibilityLevel -> 1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> LmCompatibilityLevel -> 2;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> LmCompatibilityLevel -> 3;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> LmCompatibilityLevel -> 4;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> !LmCompatibilityLevel;
+#
+#
+#2.3.11.8 Ensure 'Network security: LDAP client signing requirements' is set to 'Negotiate signing' or higher
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LDAP -> LDAPClientIntegrity -> !1;
+#
+#
+#2.3.11.9 Ensure 'Network security: Minimum session security for NTLM SSP based (including secure RPC) clients' is set to 'Require NTLMv2 session security, Require 128-bit encryption'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.11.9: Ensure 'Network security: Minimum session security for NTLM SSP based (including secure RPC) clients' is set to 'Require NTLMv2 session security, Require 128-bit encryption''] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0 -> NTLMMinClientSec -> !537395200;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0 -> !NTLMMinClientSec;
+#
+#
+#2.3.11.10 Ensure 'Network security: Minimum session security for NTLM SSP based (including secure RPC) servers' is set to 'Require NTLMv2 session security, Require 128-bit encryption'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.11.10: Ensure 'Network security: Minimum session security for NTLM SSP based (including secure RPC) servers' is set to 'Require NTLMv2 session security, Require 128-bit encryption'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0 -> NTLMMinServerSec -> !537395200;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0 -> !NTLMMinServerSec;
+#
+#
+#2.3.13.1 Ensure 'Shutdown: Allow system to be shut down without having to log on' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.13.1: Ensure 'Shutdown: Allow system to be shut down without having to log on' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> ShutdownWithoutLogon -> 1;
+#
+#
+#2.3.15.1 Ensure 'System objects: Require case insensitivity for non-Windows subsystems' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.15.1: Ensure 'System objects: Require case insensitivity for non-Windows subsystems' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Kernel -> ObCaseInsensitive -> !1;
+#
+#
+#2.3.15.2 Ensure 'System objects: Strengthen default permissions of internal system objects (e.g. Symbolic Links)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.15.2: Ensure 'System objects: Strengthen default permissions of internal system objects (e.g. Symbolic Links)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager -> ProtectionMode -> !1;
+#
+#
+#2.3.17.1 Ensure 'User Account Control: Admin Approval Mode for the Built-in Administrator account' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.17.1: Ensure 'User Account Control: Admin Approval Mode for the Built-in Administrator account' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> FilterAdministratorToken -> 0;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> !FilterAdministratorToken;
+#
+#
+#2.3.17.2 Ensure 'User Account Control: Allow UIAccess applications to prompt for elevation without using the secure desktop' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.17.2: Ensure 'User Account Control: Allow UIAccess applications to prompt for elevation without using the secure desktop' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> EnableUIADesktopToggle -> 1;
+#
+#
+#2.3.17.3 Ensure 'User Account Control: Behavior of the elevation prompt for administrators in Admin Approval Mode' is set to 'Prompt for consent on the secure desktop'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.17.3: Ensure 'User Account Control: Behavior of the elevation prompt for administrators in Admin Approval Mode' is set to 'Prompt for consent on the secure desktop'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> ConsentPromptBehaviorAdmin -> 0;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> ConsentPromptBehaviorAdmin -> 1;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> !ConsentPromptBehaviorAdmin;
+#
+#
+#2.3.17.4 Ensure 'User Account Control: Behavior of the elevation prompt for standard users' is set to 'Automatically deny elevation requests'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.17.4: Ensure 'User Account Control: Behavior of the elevation prompt for standard users' is set to 'Automatically deny elevation requests'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> ConsentPromptBehaviorUser -> 1;
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> !ConsentPromptBehaviorUser;
+#
+#
+#2.3.17.5 Ensure 'User Account Control: Detect application installations and prompt for elevation' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.17.5: Ensure 'User Account Control: Detect application installations and prompt for elevation' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> EnableInstallerDetection -> 0;
+r:HKEY_LOCAL_MACHINE\MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> !EnableInstallerDetection;
+#
+#
+#2.3.17.6 Ensure 'User Account Control: Only elevate UIAccess applications that are installed in secure locations' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.17.6: Ensure 'User Account Control: Only elevate UIAccess applications that are installed in secure locations' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> EnableSecureUIAPaths -> 0;
+#
+#
+#2.3.17.7 Ensure 'User Account Control: Run all administrators in Admin Approval Mode' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.17.7: Ensure 'User Account Control: Run all administrators in Admin Approval Mode' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> EnableLUA -> 0;
+#
+#
+#2.3.17.8 Ensure 'User Account Control: Switch to the secure desktop when prompting for elevation' is set to 'Enabled'
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> PromptOnSecureDesktop -> 0;
+#
+#
+#2.3.17.9 Ensure 'User Account Control: Virtualize file and registry write failures to per-user locations' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.17.9: Ensure 'User Account Control: Virtualize file and registry write failures to per-user locations' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -> EnableVirtualization -> 0;
+#
+#
+#9.1.1 Ensure 'Windows Firewall: Domain: Firewall state' is set to 'On'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.1: Ensure 'Windows Firewall: Domain: Firewall state' is set to 'On'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile -> EnableFirewall -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile -> EnableFirewall -> 0;
+#
+#
+#9.1.2 Ensure 'Windows Firewall: Domain: Inbound connections' is set to 'Block (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.2: Ensure 'Windows Firewall: Domain: Inbound connections' is set to 'Block'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile -> DefaultInboundAction -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile -> DefaultInboundAction -> 0;
+#
+#
+#9.1.3 Ensure 'Windows Firewall: Domain: Outbound connections' is set to 'Allow (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.3: Ensure 'Windows Firewall: Domain: Outbound connections' is set to 'Allow'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile -> DefaultOutboundAction -> 1;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile -> DefaultOutboundAction -> 1;
+#
+#
+#9.1.4 Ensure 'Windows Firewall: Domain: Settings: Display a notification' is set to 'No'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.4: Ensure 'Windows Firewall: Domain: Settings: Display a notification' is set to 'No'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile -> DisableNotifications -> 0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile -> !DisableNotifications;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile -> DisableNotifications -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile -> !DisableNotifications;
+#
+#
+#9.1.5 Ensure 'Windows Firewall: Domain: Settings: Apply local firewall rules' is set to 'Yes (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.5: Ensure 'Windows Firewall: Domain: Settings: Apply local firewall rules' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile -> AllowLocalPolicyMerge -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile -> AllowLocalPolicyMerge -> 0;
+#
+#
+#9.1.6 Ensure 'Windows Firewall: Domain: Settings: Apply local connection security rules' is set to 'Yes (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.6: Ensure 'Windows Firewall: Domain: Settings: Apply local connection security rules' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile -> AllowLocalIPsecPolicyMerge -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile -> AllowLocalIPsecPolicyMerge -> 0;
+#
+#
+#9.1.7 Ensure 'Windows Firewall: Domain: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.7: Ensure 'Windows Firewall: Domain: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
+#
+#
+#9.1.8 Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16384 KB or greater'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.8: Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16384 KB or greater'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogFileSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogFileSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogFileSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogFileSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogFileSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogFileSize -> r:3\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogFileSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogFileSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogFileSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogFileSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogFileSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogFileSize -> r:3\w\w\w;
+#
+#
+#9.1.9 Ensure 'Windows Firewall: Domain: Logging: Log dropped packets' is set to 'Yes'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.9: Ensure 'Windows Firewall: Domain: Logging: Log dropped packets' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogDroppedPackets -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogDroppedPackets -> 0;
+#
+#
+#9.1.10 Ensure 'Windows Firewall: Domain: Logging: Log successful connections' is set to 'Yes'
+[CIS - Microsoft Windows Server 2012 R2 - 9.1.10: Ensure 'Windows Firewall: Domain: Logging: Log successful connections' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging -> LogSuccessfulConnections -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\Logging -> LogSuccessfulConnections -> 0;
+#
+#
+#9.2.1 Ensure 'Windows Firewall: Private: Firewall state' is set to 'On'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.1: Ensure 'Windows Firewall: Private: Firewall state' is set to 'On'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> EnableFirewall -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile -> EnableFirewall -> 0;
+#
+#
+#9.2.2 Ensure 'Windows Firewall: Private: Inbound connections' is set to 'Block (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.2: Ensure 'Windows Firewall: Private: Inbound connections' is set to 'Block'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> DefaultInboundAction -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile -> DefaultInboundAction -> 0;
+#
+#
+#9.2.3 Ensure 'Windows Firewall: Private: Outbound connections' is set to 'Allow (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.3: Ensure 'Windows Firewall: Private: Outbound connections' is set to 'Allow'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> DefaultOutboundAction -> 1;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile -> DefaultOutboundAction -> 1;
+#
+#
+#9.2.4 Ensure 'Windows Firewall: Private: Settings: Display a notification' is set to 'No'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.4: Ensure 'Windows Firewall: Private: Settings: Display a notification' is set to 'No'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> DisableNotifications -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile -> DisableNotifications -> 0;
+#
+#
+#9.2.5 Ensure 'Windows Firewall: Private: Settings: Apply local firewall rules' is set to 'Yes (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.5: Ensure 'Windows Firewall: Private: Settings: Apply local firewall rules' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> AllowLocalPolicyMerge -> 0; 
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile -> AllowLocalPolicyMerge -> 0;
+#
+#
+#9.2.6 Ensure 'Windows Firewall: Private: Settings: Apply local connection security rules' is set to 'Yes (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.6: Ensure 'Windows Firewall: Private: Settings: Apply local connection security rules' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> AllowLocalIPsecPolicyMerge -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile -> AllowLocalIPsecPolicyMerge -> 0;
+#
+#
+#9.2.7 Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.7: Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
+#
+#
+#9.2.8 Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16384 KB or greater'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.8: Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16384 KB or greater'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:3\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w; 
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:3\w\w\w;
+#
+#
+#9.2.9 Ensure 'Windows Firewall: Private: Logging: Log dropped packets' is set to 'Yes'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.9: Ensure 'Windows Firewall: Private: Logging: Log dropped packets' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogDroppedPackets -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogDroppedPackets -> 0;
+#
+#
+#9.2.10 Ensure 'Windows Firewall: Domain: Logging: Log successful connections' is set to 'Yes'
+[CIS - Microsoft Windows Server 2012 R2 - 9.2.10: Ensure 'Windows Firewall: Domain: Logging: Log successful connections' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogSuccessfulConnections -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogSuccessfulConnections -> 0;
+#
+#
+#9.3.1 Ensure 'Windows Firewall: Public: Firewall state' is set to 'On'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.1: Ensure 'Windows Firewall: Public: Firewall state' is set to 'On'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile -> EnableFirewall -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile -> EnableFirewall -> 0;
+#
+#
+#9.3.2 Ensure 'Windows Firewall: Public: Inbound connections' is set to 'Block (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.2: Ensure 'Windows Firewall: Public: Inbound connections' is set to 'Block'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile -> DefaultInboundAction -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile -> DefaultInboundAction -> 0;
+#
+#
+#9.3.3 Ensure 'Windows Firewall: Public: Outbound connections' is set to 'Allow (default)'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.3: Ensure 'Windows Firewall: Public: Outbound connections' is set to 'Allow'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile -> DefaultOutboundAction -> 1;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile -> DefaultOutboundAction -> 1;
+#
+#
+#9.3.4 Ensure 'Windows Firewall: Public: Settings: Display a notification' is set to 'Yes'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.4: Ensure 'Windows Firewall: Public: Settings: Display a notification' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile -> DisableNotifications -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile -> DisableNotifications -> 0;
+#
+#
+#9.3.5 Ensure 'Windows Firewall: Public: Settings: Apply local firewall rules' is set to 'No'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.5: Ensure 'Windows Firewall: Public: Settings: Apply local firewall rules' is set to 'No'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile -> AllowLocalPolicyMerge -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile -> AllowLocalPolicyMerge -> 0;
+#
+#
+#9.3.6 Ensure 'Windows Firewall: Public: Settings: Apply local connection security rules' is set to 'No'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.6: Ensure 'Windows Firewall: Public: Settings: Apply local connection security rules' is set to 'No'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile -> AllowLocalIPsecPolicyMerge -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile -> AllowLocalIPsecPolicyMerge -> 0;
+#
+#
+#9.3.7 Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.7: Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog; 
+#
+#
+#9.3.8 Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16384 KB or greater'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.8: Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16384 KB or greater'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFileSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFileSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFileSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFileSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFileSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFileSize -> r:3\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFileSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFileSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFileSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFileSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFileSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFileSize -> r:3\w\w\w;
+#
+#
+#9.3.9 Ensure 'Windows Firewall: Public: Logging: Log dropped packets' is set to 'Yes'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.9: Ensure 'Windows Firewall: Public: Logging: Log dropped packets' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogDroppedPackets -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogDroppedPackets -> 0;
+#
+#
+#9.3.10 Ensure 'Windows Firewall: Public: Logging: Log successful connections' is set to 'Yes'
+[CIS - Microsoft Windows Server 2012 R2 - 9.3.10: Ensure 'Windows Firewall: Public: Logging: Log successful connections' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogSuccessfulConnections -> 0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogSuccessfulConnections -> 0;
+#
+#
+#18.1.1.1 Ensure 'Prevent enabling lock screen camera' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.1.1.1: Ensure 'Prevent enabling lock screen camera' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization -> NoLockScreenCamera -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization -> !NoLockScreenCamera;
+#
+#
+#18.1.1.2 Ensure 'Prevent enabling lock screen slide show' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.1.1.2: Ensure 'Prevent enabling lock screen slide show' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization -> NoLockScreenSlideshow -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization -> !NoLockScreenSlideshow;
+#
+#
+#18.3.1 Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended)' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.1: Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> AutoAdminLogon -> !0;
+#
+#
+#18.3.2 Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing protection level (protects against packet spoofing)' is set to 'Enabled: Highest protection, source routing is completely disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.2: Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing protection level (protects against packet spoofing)' is set to 'Enabled: Highest protection, source routing is completely disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters -> DisableIPSourceRouting -> !2;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters -> !DisableIPSourceRouting;
+#
+#
+#18.3.3 Ensure 'MSS: (DisableIPSourceRouting) IP source routing protection level (protects against packet spoofing)' is set to 'Enabled: Highest protection, source routing is completely disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.3: Ensure 'MSS: (DisableIPSourceRouting) IP source routing protection level (protects against packet spoofing)' is set to 'Enabled: Highest protection, source routing is completely disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> DisableIPSourceRouting -> !2;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> !DisableIPSourceRouting;
+#
+#
+#18.3.4 Ensure 'MSS: (EnableICMPRedirect) Allow ICMP redirects to override OSPF generated routes' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.4: Ensure 'MSS: (EnableICMPRedirect) Allow ICMP redirects to override OSPF generated routes' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> EnableICMPRedirect -> 1;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> !EnableICMPRedirect;
+#
+#
+#18.3.6 Ensure 'MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.6: Ensure 'MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetBT\Parameters -> NoNameReleaseOnDemand -> !1;
+#
+#
+#18.3.8 Ensure 'MSS: (SafeDllSearchMode) Enable Safe DLL search mode (recommended)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.8: Ensure 'MSS: (SafeDllSearchMode) Enable Safe DLL search mode (recommended)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager -> SafeDllSearchMode -> 0;
+#
+#
+#18.3.9 Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.9: Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires' is set to 'Enabled: 5 or fewer seconds'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> ScreenSaverGracePeriod -> 6;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> ScreenSaverGracePeriod -> 7;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> ScreenSaverGracePeriod -> 8;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> ScreenSaverGracePeriod -> 9;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> ScreenSaverGracePeriod -> r:\w\w+;
+#
+#
+#18.3.12 Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.12: Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> 5B;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> 5C;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> 5D;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> 5E;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> 5F;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> r:6\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> r:7\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> r:8\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> r:9\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> r:\D\w;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> WarningLevel -> r:\w\w\w+;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security -> !WarningLevel;
+#
+#
+#18.4.11.2 Ensure 'Prohibit installation and configuration of Network Bridge on your DNS domain network' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.11.2: Ensure 'Prohibit installation and configuration of Network Bridge on your DNS domain network' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections -> NC_AllowNetBridge_NLA -> 1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections -> !NC_AllowNetBridge_NLA;
+#
+#
+#18.4.11.3 Ensure 'Require domain users to elevate when setting a network's location' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.11.3: Ensure 'Require domain users to elevate when setting a network's location' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections -> NC_StdDomainUserSetLocation -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections -> !NC_StdDomainUserSetLocation;
+#
+#
+#18.4.21.1 Ensure 'Minimize the number of simultaneous connections to the Internet or a Windows Domain' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.21.1: Ensure 'Minimize the number of simultaneous connections to the Internet or a Windows Domain' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy -> fMinimizeConnections -> !1;
+#
+#
+#18.6.2 Ensure 'WDigest Authentication' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.6.2: Ensure 'WDigest Authentication' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest -> UseLogonCredential -> !0;
+#
+#
+#18.8.3.1 Ensure 'Include command line in process creation events' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.3.1: Ensure 'Include command line in process creation events' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit -> ProcessCreationIncludeCmdLine_Enabled -> !0;
+#
+#
+#18.8.12.1 Ensure 'Boot-Start Driver Initialization Policy' is set to 'Enabled: Good, unknown and bad but critical'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.12.1: Ensure 'Boot-Start Driver Initialization Policy' is set to 'Enabled: Good, unknown and bad but critical'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\EarlyLaunch -> DriverLoadPolicy -> !3;
+#
+#
+#18.8.19.2 Ensure 'Configure registry policy processing: Do not apply during periodic background processing' is set to 'Enabled: FALSE'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.19.2: Ensure 'Configure registry policy processing: Do not apply during periodic background processing' is set to 'Enabled: FALSE'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2} -> NoBackgroundPolicy -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2} -> !NoBackgroundPolicy;
+#
+#
+#18.8.19.3 Ensure 'Configure registry policy processing: Process even if the Group Policy objects have not changed' is set to 'Enabled: TRUE'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.19.3: Ensure 'Configure registry policy processing: Process even if the Group Policy objects have not changed' is set to 'Enabled: TRUE'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2} -> NoGPOListChanges -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2} -> !NoGPOListChanges;
+#
+#
+#18.8.19.4 Ensure 'Turn off background refresh of Group Policy' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.19.4: Ensure 'Turn off background refresh of Group Policy' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -> DisableBkGndGroupPolicy -> !0;
+#
+#
+#18.8.25.1 Ensure 'Do not display network selection UI' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.25.1: Ensure 'Do not display network selection UI' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> DontDisplayNetworkSelectionUI -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> !DontDisplayNetworkSelectionUI;
+#
+#
+#18.8.25.2 Ensure 'Do not enumerate connected users on domain-joined computers' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.25.2: Ensure 'Do not enumerate connected users on domain-joined computers' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> DontEnumerateConnectedUsers -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> !DontEnumerateConnectedUsers;
+#
+#
+#18.8.25.3 Ensure 'Enumerate local users on domain-joined computers' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.25.3: Ensure 'Enumerate local users on domain-joined computers' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> EnumerateLocalUsers -> !0;
+#
+#
+#18.8.25.4 Ensure 'Turn off app notifications on the lock screen' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.25.4: Ensure 'Turn off app notifications on the lock screen' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> DisableLockScreenAppNotifications -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> !DisableLockScreenAppNotifications;
+#
+#
+#18.8.25.5 Ensure 'Turn on convenience PIN sign-in' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.25.5: Ensure 'Turn on convenience PIN sign-in' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> AllowDomainPINLogon -> !0;
+#
+#
+#18.8.31.1 Ensure 'Configure Offer Remote Assistance' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.31.1: Ensure 'Configure Offer Remote Assistance' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fAllowUnsolicited -> !0;
+#
+#
+#18.8.31.2 Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.31.2: Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fAllowToGetHelp -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fAllowToGetHelp;
+#
+#
+#18.9.6.1 Ensure 'Allow Microsoft accounts to be optional' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.6.1: Ensure 'Allow Microsoft accounts to be optional' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -> MSAOptional -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -> !MSAOptional;
+#
+#
+#18.9.8.1 Ensure 'Disallow Autoplay for non-volume devices' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.8.1: Ensure 'Disallow Autoplay for non-volume devices' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoAutoplayfornonVolume -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoAutoplayfornonVolume;
+#
+#
+#18.9.8.2 Ensure 'Set the default behavior for AutoRun' is set to 'Enabled: Do not execute any autorun commands'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.8.2: Ensure 'Set the default behavior for AutoRun' is set to 'Enabled: Do not execute any autorun commands'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoAutorun -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoAutorun;
+#
+#
+#18.9.8.3 Ensure 'Turn off Autoplay' is set to 'Enabled: All drives'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.8.3: Ensure 'Turn off Autoplay' is set to 'Enabled: All drives'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer-> NoDriveTypeAutoRun -> !ff;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer-> !NoDriveTypeAutoRun;
+#
+#
+#18.9.15.1 Ensure 'Do not display the password reveal button' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.15.1: Ensure 'Do not display the password reveal button' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CredUI -> DisablePasswordReveal -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CredUI -> !DisablePasswordReveal;
+#
+#
+#18.9.15.2 Ensure 'Enumerate administrator accounts on elevation' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.15.2: Ensure 'Enumerate administrator accounts on elevation' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\CredUI -> EnumerateAdministrators -> !0;
+#
+#
+#18.9.26.1.1 Ensure 'Application: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.26.1.1: Ensure 'Application: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> Retention -> !0;
+#
+#
+#18.9.26.1.2 Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.26.1.2: Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:0\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:3\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:4\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:5\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:6\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> MaxSize -> r:7\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application -> !MaxSize;
+#
+#
+#18.9.26.2.1 Ensure 'Security: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.26.2.1: Ensure 'Security: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> Retention -> !0;
+#
+#
+#18.9.26.2.2 Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.26.2.2: Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> MaxSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> MaxSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> MaxSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> MaxSize -> r:\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> MaxSize -> r:0\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> MaxSize -> r:1\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> MaxSize -> r:2\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security -> !MaxSize;
+#
+#
+#18.9.26.3.1 Ensure 'Setup: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.26.3.1: Ensure 'Setup: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> Retention -> !0;
+#
+#
+#18.9.26.3.2 Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.26.3.2: Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:0\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:3\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:4\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:5\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:6\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> MaxSize -> r:7\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup -> !MaxSize;
+#
+#
+#18.9.26.4.1 Ensure 'System: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.26.4.1: Ensure 'System: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> Retention -> !0;
+#
+#
+#18.9.26.4.2 Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.26.4.2: Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:0\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:1\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:2\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:3\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:4\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:5\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:6\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> MaxSize -> r:7\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\System -> !MaxSize;
+#
+#
+#18.9.30.1 Ensure 'Configure Windows SmartScreen' is set to 'Enabled: Require approval from an administrator before running downloaded unknown software'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.30.2: Ensure 'Configure Windows SmartScreen' is set to 'Enabled: Require approval from an administrator before running downloaded unknown software'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> EnableSmartScreen -> !2;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System -> !EnableSmartScreen;
+#
+#
+#18.9.30.3 Ensure 'Turn off Data Execution Prevention for Explorer' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.30.3: Ensure 'Turn off Data Execution Prevention for Explorer' is set to 'Disabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoDataExecutionPrevention -> !0;
+#
+#
+#18.9.30.4 Ensure 'Turn off heap termination on corruption' is set to 'Disabled'[CIS - Microsoft Windows Server 2012 R2 - 18.9.30.4: Ensure 'Turn off heap termination on corruption' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoHeapTerminationOnCorruption -> !0;
+#
+#
+#18.9.30.5 Ensure 'Turn off shell protocol protected mode' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.30.5: Ensure 'Turn off shell protocol protected mode' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> PreXPSP2ShellProtocolBehavior -> !0;
+#
+#
+#18.9.47.1 Ensure 'Prevent the usage of OneDrive for file storage' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.47.1: Ensure 'Prevent the usage of OneDrive for file storage' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\OneDrive -> DisableFileSyncNGSC -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\OneDrive -> !DisableFileSyncNGSC;
+#
+#
+#18.9.47.2 Ensure 'Prevent the usage of OneDrive for file storage on Windows 8.1' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.47.2: Ensure 'Prevent the usage of OneDrive for file storage on Windows 8.1' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Skydrive -> DisableFileSync -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Skydrive -> !DisableFileSync;
+#
+#
+#18.9.52.2.2 Ensure 'Do not allow passwords to be saved' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.2.2: Ensure 'Do not allow passwords to be saved' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> DisablePasswordSaving -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !DisablePasswordSaving;
+#
+#
+#18.9.52.3.3.2 Ensure 'Do not allow drive redirection' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.3.2: Ensure 'Do not allow drive redirection' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisableCdm -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisableCdm;
+#
+#
+#18.9.52.3.9.1 Ensure 'Always prompt for password upon connection' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.9.1: Ensure 'Always prompt for password upon connection' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fPromptForPassword -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fPromptForPassword;
+#
+#
+#18.9.52.3.9.2 Ensure 'Require secure RPC communication' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.9.2: Ensure 'Require secure RPC communication' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fEncryptRPCTraffic -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fEncryptRPCTraffic;
+#
+#
+#18.9.52.3.9.3 Ensure 'Set client connection encryption level' is set to 'Enabled: High Level'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.9.3: Ensure 'Set client connection encryption level' is set to 'Enabled: High Level'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MinEncryptionLevel -> !3;
+#
+#
+#18.9.52.3.10.1 Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.10.1: Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba2;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba3;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba4;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba5;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba6;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba7;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba8;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba9;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba\D;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbb\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbc\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbd\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbe\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbf\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbc\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbd\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbe\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbf\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dc\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dd\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:de\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:df\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:e\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:f\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:\w\w\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !MaxIdleTime;
+#
+#
+#18.9.52.3.11.1 Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.11.1: Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> DeleteTempDirsOnExit -> !1;
+#
+#
+#18.9.52.3.11.2 Ensure 'Do not use temporary folders per session' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.11.2: Ensure 'Do not use temporary folders per session' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> PerSessionTempDir -> !1;
+#
+#
+#18.9.53.1 Ensure 'Prevent downloading of enclosures' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.53.1: Ensure 'Prevent downloading of enclosures' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Internet Explorer\Feeds -> DisableEnclosureDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Internet Explorer\Feeds -> !DisableEnclosureDownload;
+#
+#
+#18.9.54.2 Ensure 'Allow indexing of encrypted files' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.54.2: Ensure 'Allow indexing of encrypted files' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search -> AllowIndexingEncryptedStoresOrItems -> !0;
+#
+#
+#18.9.61.1 Ensure 'Turn off Automatic Download and Install of updates' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.61.1: Ensure 'Turn off Automatic Download and Install of updates' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore -> AutoDownload -> !4;
+#
+#
+#18.9.61.2 Ensure 'Turn off the offer to update to the latest version of Windows' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.61.2: Ensure 'Turn off the offer to update to the latest version of Windows' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore -> DisableOSUpgrade -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore -> !DisableOSUpgrade;
+#
+#
+#18.9.70.2.1 Ensure 'Configure Default consent' is set to 'Enabled: Always ask before sending data'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.70.2.1: Ensure 'Configure Default consent' is set to 'Enabled: Always ask before sending data'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting\Consent -> DefaultConsent -> !1;
+#
+#
+#18.9.70.3 Ensure 'Automatically send memory dumps for OS-generated error reports' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.70.3: Ensure 'Automatically send memory dumps for OS-generated error reports' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> AutoApproveOSDumps -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !AutoApproveOSDumps;
+#
+#
+#18.9.74.1 Ensure 'Allow user control over installs' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.74.1: Ensure 'Allow user control over installs' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Installer -> EnableUserControl -> !0;
+#
+#
+#18.9.74.2 Ensure 'Always install with elevated privileges' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.74.2: Ensure 'Always install with elevated privileges' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Installer -> AlwaysInstallElevated -> !0;
+#
+#
+#18.9.75.1 Ensure 'Sign-in last interactive user automatically after a system-initiated restart' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.75.1: Ensure 'Sign-in last interactive user automatically after a system-initiated restart' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -> DisableAutomaticRestartSignOn -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -> !DisableAutomaticRestartSignOn;
+#
+#
+#18.9.84.1 Ensure 'Turn on PowerShell Script Block Logging' is set to 'Disabled'[CIS - Microsoft Windows Server 2012 R2 - 18.9.84.1: Ensure 'Turn on PowerShell Script Block Logging' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging -> EnableScriptBlockLogging -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging -> !EnableScriptBlockLogging;
+#
+#
+#18.9.84.2 Ensure 'Turn on PowerShell Transcription' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.84.2: Ensure 'Turn on PowerShell Transcription' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription -> EnableTranscripting -> !0;
+#
+#
+#18.9.86.1.1 Ensure 'Allow Basic authentication' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.86.1.1: Ensure 'Allow Basic authentication' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client -> AllowBasic -> !0;
+#
+#
+#18.9.86.1.2 Ensure 'Allow unencrypted traffic' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.86.1.2: Ensure 'Allow unencrypted traffic' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client -> AllowUnencryptedTraffic -> !0;
+#
+#
+#18.9.86.1.3 Ensure 'Disallow Digest authentication' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.86.1.3: Ensure 'Disallow Digest authentication' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client -> AllowDigest -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client -> !AllowDigest;
+#
+#
+#18.9.86.2.1 Ensure 'Allow Basic authentication' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.86.2.1: Ensure 'Allow Basic authentication' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service -> AllowBasic -> !0;
+#
+#
+#18.9.86.2.3 Ensure 'Allow unencrypted traffic' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.86.2.3: Ensure 'Allow unencrypted traffic' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service -> AllowUnencryptedTraffic -> !0;
+#
+#
+#18.9.86.2.4 Ensure 'Disallow WinRM from storing RunAs credentials' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.86.2.4: Ensure 'Disallow WinRM from storing RunAs credentials' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service -> DisableRunAs -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service -> !DisableRunAs;
+#
+#
+#18.9.90.2 Ensure 'Configure Automatic Updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.90.2: Ensure 'Configure Automatic Updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -> NoAutoUpdate -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -> !NoAutoUpdate;
+#
+#
+#18.9.90.3 Ensure 'Configure Automatic Updates: Scheduled install day' is set to '0 - Every day'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.90.3: Ensure 'Configure Automatic Updates: Scheduled install day' is set to '0 - Every day'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -> ScheduledInstallDay -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -> !ScheduledInstallDay;
+#
+#
+#18.9.90.4 Ensure 'No auto-restart with logged on users for scheduled automatic updates installations' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.90.4: Ensure 'No auto-restart with logged on users for scheduled automatic updates installations' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -> NoAutoRebootWithLoggedOnUsers -> !0;
+#

--- a/src/rootcheck/db/cis_win2012r2_domainL2_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_domainL2_rcl.txt
@@ -1,0 +1,340 @@
+# OSSEC Linux Audit - (C) 2018 OSSEC Project
+#
+# Released under the same license as OSSEC.
+# More details at the LICENSE file included with OSSEC or online
+# at: https://github.com/ossec/ossec-hids/blob/master/LICENSE
+#
+# [Application name] [any or all] [reference]
+# type:<entry name>;
+#
+# Type can be:
+#             - f (for file or directory)
+#             - r (registry entry)
+#             - p (process running)
+#
+# Additional values:
+# For the registry and for directories, use "->" to look for a specific entry and another
+# "->" to look for the value.
+# Also, use " -> r:^\. -> ..." to search all files in a directory
+# For files, use "->" to look for a specific value in the file.
+#
+# Values can be preceeded by: =: (for equal) - default
+#                             r: (for ossec regexes)
+#                             >: (for strcmp greater)
+#                             <: (for strcmp  lower)
+# Multiple patterns can be specified by using " && " between them.
+# (All of them must match for it to return true).
+
+# CIS Checks for Windows Server 2012 R2 Domain Controller L2
+# Based on Center for Internet Security Benchmark v2.2.1 for Microsoft Windows Server 2012 R2 (https://workbench.cisecurity.org/benchmarks/288)
+#
+#
+#2.3.10.4 Ensure 'Network access: Do not allow storage of passwords and credentials for network authentication' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.4: Ensure 'Network access: Do not allow storage of passwords and credentials for network authentication' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> DisableDomainCreds -> !1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> !DisableDomainCreds;
+#
+#
+#18.3.5 Ensure 'MSS: (KeepAliveTime) How often keep-alive packets are sent in milliseconds' is set to 'Enabled: 300,000 or 5 minutes'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.5: Ensure 'MSS: (KeepAliveTime) How often keep-alive packets are sent in milliseconds' is set to 'Enabled: 300,000 or 5 minutes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> KeepAliveTime -> !493e0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> !KeepAliveTime;
+#
+#
+#18.3.7 Ensure 'MSS: (PerformRouterDiscovery) Allow IRDP to detect and configure Default Gateway addresses (could lead to DoS)' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.7: Ensure 'MSS: (PerformRouterDiscovery) Allow IRDP to detect and configure Default Gateway addresses (could lead to DoS)' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> PerformRouterDiscovery  -> !0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> !PerformRouterDiscovery;
+#
+#
+#18.3.10 Ensure 'MSS: (TcpMaxDataRetransmissions IPv6) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.10: Ensure 'MSS: (TcpMaxDataRetransmissions IPv6) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters -> TcpMaxDataRetransmissions -> !3;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters -> !TcpMaxDataRetransmissions;
+#
+#
+#18.3.11 Ensure 'MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.11: Ensure 'MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> TcpMaxDataRetransmissions -> !3;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> !TcpMaxDataRetransmissions;
+#
+#
+#18.4.9.1 Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.9.1: Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> AllowLLTDIOOnDomain -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> AllowLLTDIOOnPublicNet -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> EnableLLTDIO -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> ProhibitLLTDIOOnPrivateNet -> !0;
+#
+#
+#18.4.9.2 Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.9.2: Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> AllowRspndrOnDomain -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> AllowRspndrOnPublicNet -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> EnableRspndr -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> ProhibitRspndrOnPrivateNet -> !0;
+#
+#
+#18.4.10.2 Ensure 'Turn off Microsoft Peer-to-Peer Networking Services' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.10.2: Ensure 'Turn off Microsoft Peer-to-Peer Networking Services' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Peernet -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Peernet -> !Disabled;
+#
+#
+#18.4.19.2.1 Disable IPv6 (Ensure TCPIP6 Parameter 'DisabledComponents' is set to '0xff (255)')
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.19.2.1: Disable IPv6 (Ensure TCPIP6 Parameter 'DisabledComponents' is set to '0xff (255)')] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters -> DisabledComponents -> !ff;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters -> !DisabledComponents;
+#
+#
+#18.4.20.1 Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.20.1: Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> EnableRegistrars -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !EnableRegistrars;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> DisableUPnPRegistrar -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !DisableUPnPRegistrar;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> DisableInBand802DOT11Registrar -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !DisableInBand802DOT11Registrar;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> DisableFlashConfigRegistrar -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !DisableFlashConfigRegistrar;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> DisableWPDRegistrar -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !DisableWPDRegistrar;
+#
+#
+#18.4.20.2 Ensure 'Prohibit access of the Windows Connect Now wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.20.2: Ensure 'Prohibit access of the Windows Connect Now wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\UI -> DisableWcnUi -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\UI -> !DisableWcnUi;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+#18.8.24.1 Ensure 'Disallow copying of user input methods to the system account for sign-in' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.24.1: Ensure 'Disallow copying of user input methods to the system account for sign-in' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Control Panel\International -> BlockUserInputMethodsForSignIn -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Control Panel\International -> !BlockUserInputMethodsForSignIn;
+#
+#
+#18.8.29.5.1 Ensure 'Require a password when a computer wakes (on battery)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.29.5.1: Ensure 'Require a password when a computer wakes (on battery)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51 -> DCSettingIndex -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51 -> !DCSettingIndex;
+#
+#
+#18.8.29.5.2 Ensure 'Require a password when a computer wakes (plugged in)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.29.5.2: Ensure 'Require a password when a computer wakes (plugged in)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51 -> ACSettingIndex -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51 -> !ACSettingIndex;
+#
+#
+#18.8.39.5.1 Ensure 'Microsoft Support Diagnostic Tool: Turn on MSDT interactive communication with support provider' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.39.5.1: Ensure 'Microsoft Support Diagnostic Tool: Turn on MSDT interactive communication with support provider' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\ScriptedDiagnosticsProvider\Policy -> DisableQueryRemoteServer -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\ScriptedDiagnosticsProvider\Policy -> !DisableQueryRemoteServer;
+#
+#
+#18.8.39.11.1 Ensure 'Enable/Disable PerfTrack' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.39.11.1: Ensure 'Enable/Disable PerfTrack' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WDI\{9c5a40da-b965-4fc3-8781-88dd50a6299d} -> ScenarioExecutionEnabled -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WDI\{9c5a40da-b965-4fc3-8781-88dd50a6299d} -> !ScenarioExecutionEnabled;
+#
+#
+#18.8.41.1 Ensure 'Turn off the advertising ID' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.41.1: Ensure 'Turn off the advertising ID' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo -> DisabledByGroupPolicy -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo -> !DisabledByGroupPolicy;
+#
+#
+#18.8.44.1.1 Ensure 'Enable Windows NTP Client' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.44.1.1: Ensure 'Enable Windows NTP Client' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\W32Time\TimeProviders\NtpClient -> Enabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\W32Time\TimeProviders\NtpClient -> !Enabled;
+#
+#
+#18.9.37.1 Ensure 'Turn off location' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.37.1: Ensure 'Turn off location' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors -> DisableLocation -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors -> !DisableLocation;
+#
+#
+#18.9.52.3.2.1 Ensure 'Restrict Remote Desktop Services users to a single Remote Desktop Services session' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.2.1: Ensure 'Restrict Remote Desktop Services users to a single Remote Desktop Services session' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fSingleSessionPerUser -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fSingleSessionPerUser;
+#
+#
+#18.9.52.3.3.1 Ensure 'Do not allow COM port redirection' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.3.1: Ensure 'Restrict Remote Desktop Services users to a single Remote Desktop Services session' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisableCcm -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisableCcm;
+#
+#
+#18.9.52.3.3.3 Ensure 'Do not allow LPT port redirection' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.3.3: Ensure 'Do not allow LPT port redirection' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisableLPT -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisableLPT;
+#
+#
+#18.9.52.3.3.4 Ensure 'Do not allow supported Plug and Play device redirection' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.3.4: Ensure 'Do not allow supported Plug and Play device redirection' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisablePNPRedir -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisablePNPRedir;
+#
+#
+#18.9.52.3.10.1 Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.10.1: Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba2;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba3;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba4;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba5;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba6;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba7;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba8;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba9;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba\D;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbb\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbc\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbd\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbe\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbf\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbc\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbd\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbe\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbf\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dc\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dd\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:de\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:df\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:e\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:f\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:\w\w\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !MaxIdleTime;
+#
+#
+#18.9.52.3.10.2 Ensure 'Set time limit for disconnected sessions' is set to 'Enabled: 1 minute'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.10.2: Ensure 'Set time limit for disconnected sessions' is set to 'Enabled: 1 minute'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxDisconnectionTime -> !EA60;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !MaxDisconnectionTime;
+#
+#
+#18.9.54.3 Ensure 'Set what information is shared in Search' is set to 'Enabled: Anonymous info'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.54.3: Ensure 'Set what information is shared in Search' is set to 'Enabled: Anonymous info'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search -> ConnectedSearchPrivacy -> !3;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search -> !ConnectedSearchPrivacy;
+#
+#
+#18.9.59.1 Ensure 'Turn off KMS Client Online AVS Validation' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.59.1: Ensure 'Turn off KMS Client Online AVS Validation' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\Software Protection Platform -> NoGenTicket -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\Software Protection Platform -> !NoGenTicket;
+#
+#
+#18.9.61.3 Ensure 'Turn off the Store application' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.61.3: Ensure 'Turn off the Store application' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore -> RemoveWindowsStore -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore -> !RemoveWindowsStore;
+#
+#
+#18.9.69.3.1 Ensure 'Join Microsoft MAPS' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.69.3.1: Ensure 'Join Microsoft MAPS' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Spynet -> SpynetReporting -> !0;
+#
+#
+#18.9.74.3 Ensure 'Prevent Internet Explorer security prompt for Windows Installer scripts' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.74.3: Ensure 'Join Microsoft MAPS' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Installer -> SafeForScripting -> !0;
+#
+#
+#18.9.86.2.2 Ensure 'Allow remote server management through WinRM' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.86.2.2: Ensure 'Allow remote server management through WinRM' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service -> AllowAutoConfig -> !0;
+#
+#
+#18.9.87.1 Ensure 'Allow Remote Shell Access' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.87.1: Ensure 'Allow Remote Shell Access' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service\WinRS -> AllowRemoteShellAccess -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service\WinRS -> !AllowRemoteShellAccess;
+#

--- a/src/rootcheck/db/cis_win2012r2_memberL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_memberL1_rcl.txt
@@ -25,9 +25,8 @@
 # Multiple patterns can be specified by using " && " between them.
 # (All of them must match for it to return true).
 
-# CIS Checks for Windows Server 2012 R2 Domain Controller L1
+# CIS Checks for Windows Server 2012 R2 Domain Controller L2
 # Based on Center for Internet Security Benchmark v2.2.1 for Microsoft Windows Server 2012 R2 (https://workbench.cisecurity.org/benchmarks/288)
-#
 #
 #
 #1.1.2 Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'
@@ -74,7 +73,7 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> CrashOnAuditFail ->
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> CrashOnAuditFail -> 2;
 #
 #
-#2.3.4.1 Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators' 
+#2.3.4.1 Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators'
 [CIS - Microsoft Windows Server 2012 R2 - 2.3.4.1: Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 1;
 r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 2;
@@ -83,22 +82,6 @@ r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> All
 #2.3.4.2 Ensure 'Devices: Prevent users from installing printer drivers' is set to 'Enabled'
 [CIS - Microsoft Windows Server 2012 R2 - 2.3.4.2: Ensure 'Devices: Prevent users from installing printer drivers' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Print\Providers\LanMan Print Services\Servers -> AddPrinterDrivers -> !1;
-#
-#
-#2.3.5.1 Ensure 'Domain controller: Allow server operators to schedule tasks' is set to 'Disabled' (DC only)
-[CIS - Microsoft Windows Server 2012 R2 - 2.3.5.1: Ensure 'Domain controller: Allow server operators to schedule tasks' is set to 'Disabled' (DC only)] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\SubmitControl -> !0;
-
-#
-#
-#2.3.5.2 Ensure 'Domain controller: LDAP server signing requirements' is set to 'Require signing'
-[CIS - Microsoft Windows Server 2012 R2 - 2.3.5.2: Ensure 'Domain controller: LDAP server signing requirements' is set to 'Require signing'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\NTDS\Parameters -> LDAPServerIntegrity -> !2;
-#
-#
-#2.3.5.3 Ensure 'Domain controller: Refuse machine account password changes' is set to 'Disabled'
-[CIS - Microsoft Windows Server 2012 R2 - 2.3.5.3: Ensure 'Domain controller: Refuse machine account password changes' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> RefusePasswordChange -> 1;
 #
 #
 #2.3.6.1 Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'
@@ -181,6 +164,12 @@ r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> Pas
 r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\w\w\w+;
 #
 #
+#2.3.7.8 Ensure 'Interactive logon: Require Domain Controller Authentication to unlock workstation' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.7.8: Ensure 'Interactive logon: Require Domain Controller Authentication to unlock workstation' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> ForceUnlockLogon -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> !ForceUnlockLogon;
+#
+#
 #2.3.7.9 Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher
 [CIS - Microsoft Windows Server 2012 R2 - 2.3.7.9: Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> ScRemoveOption -> 0;
@@ -235,6 +224,22 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -
 #2.3.9.4 Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'
 [CIS - Microsoft Windows Server 2012 R2 - 2.3.9.4: Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> EnableForcedLogOff -> !1;
+#
+#
+#2.3.9.5 Ensure 'Microsoft network server: Server SPN target name validation level' is set to 'Accept if provided by client' or higher
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.9.5: Ensure 'Microsoft network server: Server SPN target name validation level' is set to 'Accept if provided by client' or higher] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters -> SMBServerNameHardeningLevel -> !0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters -> !SMBServerNameHardeningLevel;
+#
+#
+#2.3.10.2 Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.2: Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> RestrictAnonymousSAM -> 0;
+#
+#
+#2.3.10.3 Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts and shares' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.3: Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts and shares' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> RestrictAnonymous -> !1;
 #
 #
 #2.3.10.5 Ensure 'Network access: Let Everyone permissions apply to anonymous users' is set to 'Disabled'
@@ -495,7 +500,7 @@ r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\F
 #
 #9.2.5 Ensure 'Windows Firewall: Private: Settings: Apply local firewall rules' is set to 'Yes (default)'
 [CIS - Microsoft Windows Server 2012 R2 - 9.2.5: Ensure 'Windows Firewall: Private: Settings: Apply local firewall rules' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> AllowLocalPolicyMerge -> 0; 
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> AllowLocalPolicyMerge -> 0;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile -> AllowLocalPolicyMerge -> 0;
 #
 #
@@ -519,7 +524,7 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:1\w\w\w;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:2\w\w\w;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:3\w\w\w;
-r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w; 
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w\w;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w\w\w;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:1\w\w\w;
@@ -578,7 +583,7 @@ r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\F
 #9.3.7 Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'
 [CIS - Microsoft Windows Server 2012 R2 - 9.3.7: Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
-r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog; 
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
 #
 #
 #9.3.8 Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16384 KB or greater'
@@ -619,6 +624,54 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization -> !NoL
 [CIS - Microsoft Windows Server 2012 R2 - 18.1.1.2: Ensure 'Prevent enabling lock screen slide show' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization -> NoLockScreenSlideshow -> !1;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization -> !NoLockScreenSlideshow;
+#
+#
+#18.2.1 Ensure LAPS AdmPwd GPO Extension / CSE is installed
+[CIS - Microsoft Windows Server 2012 R2 - 18.2.1: Ensure LAPS AdmPwd GPO Extension / CSE is installed] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\GPExtensions\{D76B9641-3288-4f75-942D-087DE603E3EA} -> !DllName;
+#
+#
+#18.2.2 Ensure 'Do not allow password expiration time longer than required by policy' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.2.2: Ensure 'Do not allow password expiration time longer than required by policy' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PwdExpirationProtectionEnabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> !PwdExpirationProtectionEnabled;
+#
+#
+#18.2.3 Ensure 'Enable Local Admin Password Management' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.2.3: Ensure 'Enable Local Admin Password Management' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> AdmPwdEnabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> !AdmPwdEnabled;
+#
+#
+#18.2.4 Ensure 'Password Settings: Password Complexity' is set to 'Enabled: Large letters + small letters + numbers + special characters'
+[CIS - Microsoft Windows Server 2012 R2 - 18.2.4: Ensure 'Password Settings: Password Complexity' is set to 'Enabled: Large letters + small letters + numbers + special characters'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordComplexity -> !4;
+#
+#
+#18.2.5 Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more'
+[CIS - Microsoft Windows Server 2012 R2 - 18.2.5: Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordLength -> r:\d;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordLength -> r:a;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordLength -> r:b;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordLength -> r:c;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordLength -> r:d;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordLength -> r:e;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> !PasswordLength;
+#
+#
+#18.2.6 Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer'
+[CIS - Microsoft Windows Server 2012 R2 - 18.2.6: Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> 1F;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:2\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:3\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:4\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:5\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:6\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:7\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:8\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:9\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:\D\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd -> PasswordAgeDays -> r:\w\w\w+;
 #
 #
 #18.3.1 Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended)' is set to 'Disabled'
@@ -696,6 +749,11 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections -> 
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy -> fMinimizeConnections -> !1;
 #
 #
+#18.6.1 Ensure 'Apply UAC restrictions to local accounts on network logons' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.6.1: Ensure 'Apply UAC restrictions to local accounts on network logons' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -> LocalAccountTokenFilterPolicy -> !0;
+#
+#
 #18.6.2 Ensure 'WDigest Authentication' is set to 'Disabled'
 [CIS - Microsoft Windows Server 2012 R2 - 18.6.2: Ensure 'WDigest Authentication' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest -> UseLogonCredential -> !0;
@@ -765,6 +823,12 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services ->
 [CIS - Microsoft Windows Server 2012 R2 - 18.8.31.2: Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fAllowToGetHelp -> !0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fAllowToGetHelp;
+#
+#
+#18.8.32.1 Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.32.1: Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc -> EnableAuthEpResolution -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc -> !EnableAuthEpResolution;
 #
 #
 #18.9.6.1 Ensure 'Allow Microsoft accounts to be optional' is set to 'Enabled'
@@ -1059,4 +1123,6 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -> !Sc
 #18.9.90.4 Ensure 'No auto-restart with logged on users for scheduled automatic updates installations' is set to 'Disabled'
 [CIS - Microsoft Windows Server 2012 R2 - 18.9.90.4: Ensure 'No auto-restart with logged on users for scheduled automatic updates installations' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -> NoAutoRebootWithLoggedOnUsers -> !0;
+#
+#
 #

--- a/src/rootcheck/db/cis_win2012r2_memberL2_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_memberL2_rcl.txt
@@ -1,0 +1,4726 @@
+# OSSEC Linux Audit - (C) 2018 OSSEC Project
+#
+# Released under the same license as OSSEC.
+# More details at the LICENSE file included with OSSEC or online
+# at: https://github.com/ossec/ossec-hids/blob/master/LICENSE
+#
+# [Application name] [any or all] [reference]
+# type:<entry name>;
+#
+# Type can be:
+#             - f (for file or directory)
+#             - r (registry entry)
+#             - p (process running)
+#
+# Additional values:
+# For the registry and for directories, use "->" to look for a specific entry and another
+# "->" to look for the value.
+# Also, use " -> r:^\. -> ..." to search all files in a directory
+# For files, use "->" to look for a specific value in the file.
+#
+# Values can be preceeded by: =: (for equal) - default
+#                             r: (for ossec regexes)
+#                             >: (for strcmp greater)
+#                             <: (for strcmp  lower)
+# Multiple patterns can be specified by using " && " between them.
+# (All of them must match for it to return true).
+
+# CIS Checks for Windows Server 2012 R2 Domain Controller L2
+# Based on Center for Internet Security Benchmark v2.2.1 for Microsoft Windows Server 2012 R2 (https://workbench.cisecurity.org/benchmarks/288)
+#
+#
+#2.3.7.6 Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)'
+[CIS - Microsoft Windows Server 2012 R2 - Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> 5;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> 6;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> 7;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> 8;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> 9;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> a;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> b;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> c;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> d;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> e;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> f;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> CachedLogonsCount -> \w\w+;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon -> !CachedLogonsCount;
+#
+#
+#2.3.10.4 Ensure 'Network access: Do not allow storage of passwords and credentials for network authentication' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 2.3.10.4: Ensure 'Network access: Do not allow storage of passwords and credentials for network authentication' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> DisableDomainCreds -> !1;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> !DisableDomainCreds;
+#
+#
+#18.3.5 Ensure 'MSS: (KeepAliveTime) How often keep-alive packets are sent in milliseconds' is set to 'Enabled: 300,000 or 5 minutes'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.5: Ensure 'MSS: (KeepAliveTime) How often keep-alive packets are sent in milliseconds' is set to 'Enabled: 300,000 or 5 minutes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> KeepAliveTime -> !493e0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> !KeepAliveTime;
+#
+#
+#18.3.7 Ensure 'MSS: (PerformRouterDiscovery) Allow IRDP to detect and configure Default Gateway addresses (could lead to DoS)' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.7: Ensure 'MSS: (PerformRouterDiscovery) Allow IRDP to detect and configure Default Gateway addresses (could lead to DoS)' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> PerformRouterDiscovery  -> !0;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> !PerformRouterDiscovery;
+#
+#
+#18.3.10 Ensure 'MSS: (TcpMaxDataRetransmissions IPv6) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.10: Ensure 'MSS: (TcpMaxDataRetransmissions IPv6) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters -> TcpMaxDataRetransmissions -> !3;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters -> !TcpMaxDataRetransmissions;
+#
+#
+#18.3.11 Ensure 'MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'
+[CIS - Microsoft Windows Server 2012 R2 - 18.3.11: Ensure 'MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> TcpMaxDataRetransmissions -> !3;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters -> !TcpMaxDataRetransmissions;
+#
+#
+#18.4.9.1 Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.9.1: Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> AllowLLTDIOOnDomain -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> AllowLLTDIOOnPublicNet -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> EnableLLTDIO -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> ProhibitLLTDIOOnPrivateNet -> !0;
+#
+#
+#18.4.9.2 Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.9.2: Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> AllowRspndrOnDomain -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> AllowRspndrOnPublicNet -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> EnableRspndr -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD -> ProhibitRspndrOnPrivateNet -> !0;
+#
+#
+#18.4.10.2 Ensure 'Turn off Microsoft Peer-to-Peer Networking Services' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.10.2: Ensure 'Turn off Microsoft Peer-to-Peer Networking Services' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Peernet -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Peernet -> !Disabled;
+#
+#
+#18.4.19.2.1 Disable IPv6 (Ensure TCPIP6 Parameter 'DisabledComponents' is set to '0xff (255)')
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.19.2.1: Disable IPv6 (Ensure TCPIP6 Parameter 'DisabledComponents' is set to '0xff (255)')] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters -> DisabledComponents -> !ff;
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters -> !DisabledComponents;
+#
+#
+#18.4.20.1 Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.20.1: Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> EnableRegistrars -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !EnableRegistrars;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> DisableUPnPRegistrar -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !DisableUPnPRegistrar;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> DisableInBand802DOT11Registrar -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !DisableInBand802DOT11Registrar;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> DisableFlashConfigRegistrar -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !DisableFlashConfigRegistrar;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> DisableWPDRegistrar -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\Registrars -> !DisableWPDRegistrar;
+#
+#
+#18.4.20.2 Ensure 'Prohibit access of the Windows Connect Now wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.20.2: Ensure 'Prohibit access of the Windows Connect Now wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\UI -> DisableWcnUi -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WCN\UI -> !DisableWcnUi;
+#
+#
+#18.4.21.2 Ensure 'Prohibit connection to non-domain networks when connected to domain authenticated network' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.4.21.2: Ensure 'Prohibit connection to non-domain networks when connected to domain authenticated network' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy -> fBlockNonDomain -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy -> !fBlockNonDomain;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+ -> !1;
+#
+#
+#18.8.20.1.1 Ensure 'Turn off access to the Store' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.1: Ensure 'Turn off access to the Store' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> NoUseStoreOpenWith -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer -> !NoUseStoreOpenWith;
+#
+#
+#18.8.20.1.2 Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.2: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableWebPnPDownload -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableWebPnPDownload;
+#
+#
+#18.8.20.1.3 Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.3: Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> PreventHandwritingDataSharing -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\TabletPC -> !PreventHandwritingDataSharing;
+#
+#
+#18.8.20.1.4 Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.4: Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> PreventHandwritingErrorReports -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports -> !PreventHandwritingErrorReports;
+#
+#
+#18.8.20.1.5 Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.5: Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> ExitOnMSICW -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Connection Wizard -> !ExitOnMSICW;
+#
+#
+#18.8.20.1.6 Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.6: Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoWebServices -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoWebServices;
+#
+#
+#18.8.20.1.7 Ensure 'Turn off printing over HTTP' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.7: Ensure 'Turn off printing over HTTP' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> DisableHTTPPrinting -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers -> !DisableHTTPPrinting;
+#
+#
+#18.8.20.1.8 Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.8: Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> NoRegistration -> !1;
+r:HKEY_LOCAL_MACHINE\Policies\Microsoft\Windows\Registration Wizard Control -> !NoRegistration;
+#
+#
+#18.8.20.1.9 Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.9: Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> DisableContentFileUpdates -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SearchCompanion -> !DisableContentFileUpdates;
+#
+#
+#18.8.20.1.10 Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.10: Ensure 'Turn off the "Order Prints" picture task' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoOnlinePrintsWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoOnlinePrintsWizard;
+#
+#
+#18.8.20.1.11 Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.11: Ensure 'Turn off the "Publish to Web" task for files and folders' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> NoPublishingWizard -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer -> !NoPublishingWizard;
+#
+#
+#18.8.20.1.12 Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.12: Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;
+#
+#
+#18.8.20.1.13 Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.13: Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> CEIPEnable -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnable;
+#
+#
+#18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+#
+#
+#18.8.24.1 Ensure 'Disallow copying of user input methods to the system account for sign-in' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.24.1: Ensure 'Disallow copying of user input methods to the system account for sign-in' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Control Panel\International -> BlockUserInputMethodsForSignIn -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Control Panel\International -> !BlockUserInputMethodsForSignIn;
+#
+#
+#18.8.29.5.1 Ensure 'Require a password when a computer wakes (on battery)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.29.5.1: Ensure 'Require a password when a computer wakes (on battery)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51 -> DCSettingIndex -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51 -> !DCSettingIndex;
+#
+#
+#18.8.29.5.2 Ensure 'Require a password when a computer wakes (plugged in)' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.29.5.2: Ensure 'Require a password when a computer wakes (plugged in)' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51 -> ACSettingIndex -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51 -> !ACSettingIndex;
+#
+#
+#18.8.32.2 Ensure 'Restrict Unauthenticated RPC clients' is set to 'Enabled: Authenticated'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.32.2: Ensure 'Restrict Unauthenticated RPC clients' is set to 'Enabled: Authenticated'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc -> RestrictRemoteClients -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc -> !RestrictRemoteClients;
+#
+#
+#18.8.39.5.1 Ensure 'Microsoft Support Diagnostic Tool: Turn on MSDT interactive communication with support provider' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.39.5.1: Ensure 'Microsoft Support Diagnostic Tool: Turn on MSDT interactive communication with support provider' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\ScriptedDiagnosticsProvider\Policy -> DisableQueryRemoteServer -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\ScriptedDiagnosticsProvider\Policy -> !DisableQueryRemoteServer;
+#
+#
+#18.8.39.11.1 Ensure 'Enable/Disable PerfTrack' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.39.11.1: Ensure 'Enable/Disable PerfTrack' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WDI\{9c5a40da-b965-4fc3-8781-88dd50a6299d} -> ScenarioExecutionEnabled -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WDI\{9c5a40da-b965-4fc3-8781-88dd50a6299d} -> !ScenarioExecutionEnabled;
+#
+#
+#18.8.41.1 Ensure 'Turn off the advertising ID' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.41.1: Ensure 'Turn off the advertising ID' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo -> DisabledByGroupPolicy -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo -> !DisabledByGroupPolicy;
+#
+#
+#18.8.44.1.1 Ensure 'Enable Windows NTP Client' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.44.1.1: Ensure 'Enable Windows NTP Client' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\W32Time\TimeProviders\NtpClient -> Enabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\W32Time\TimeProviders\NtpClient -> !Enabled;
+#
+#
+#18.8.44.1.2 Ensure 'Enable Windows NTP Server' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.8.44.1.2: Ensure 'Enable Windows NTP Server' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\W32Time\TimeProviders\NtpServer -> Enabled -> !0;
+#
+#
+#18.9.37.1 Ensure 'Turn off location' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.37.1: Ensure 'Turn off location' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors -> DisableLocation -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors -> !DisableLocation;
+#
+#
+#18.9.52.3.2.1 Ensure 'Restrict Remote Desktop Services users to a single Remote Desktop Services session' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.2.1: Ensure 'Restrict Remote Desktop Services users to a single Remote Desktop Services session' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fSingleSessionPerUser -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fSingleSessionPerUser;
+#
+#
+#18.9.52.3.3.1 Ensure 'Do not allow COM port redirection' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.3.1: Ensure 'Restrict Remote Desktop Services users to a single Remote Desktop Services session' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisableCcm -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisableCcm;
+#
+#
+#18.9.52.3.3.3 Ensure 'Do not allow LPT port redirection' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.3.3: Ensure 'Do not allow LPT port redirection' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisableLPT -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisableLPT;
+#
+#
+#18.9.52.3.3.4 Ensure 'Do not allow supported Plug and Play device redirection' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.3.4: Ensure 'Do not allow supported Plug and Play device redirection' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisablePNPRedir -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisablePNPRedir;
+#
+#
+#18.9.52.3.10.1 Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.10.1: Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba2;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba3;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba4;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba5;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba6;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba7;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba8;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba9;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbba\D;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbb\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbc\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbd\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbe\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbbf\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbc\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbd\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbe\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dbf\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dc\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:dd\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:de\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:df\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:e\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:f\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxIdleTime -> r:\w\w\w\w\w\w;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !MaxIdleTime;
+#
+#
+#18.9.52.3.10.2 Ensure 'Set time limit for disconnected sessions' is set to 'Enabled: 1 minute'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.52.3.10.2: Ensure 'Set time limit for disconnected sessions' is set to 'Enabled: 1 minute'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> MaxDisconnectionTime -> !EA60;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !MaxDisconnectionTime;
+#
+#
+#18.9.54.3 Ensure 'Set what information is shared in Search' is set to 'Enabled: Anonymous info'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.54.3: Ensure 'Set what information is shared in Search' is set to 'Enabled: Anonymous info'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search -> ConnectedSearchPrivacy -> !3;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search -> !ConnectedSearchPrivacy;
+#
+#
+#18.9.59.1 Ensure 'Turn off KMS Client Online AVS Validation' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.59.1: Ensure 'Turn off KMS Client Online AVS Validation' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\Software Protection Platform -> NoGenTicket -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\Software Protection Platform -> !NoGenTicket;
+#
+#
+#18.9.61.3 Ensure 'Turn off the Store application' is set to 'Enabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.61.3: Ensure 'Turn off the Store application' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore -> RemoveWindowsStore -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore -> !RemoveWindowsStore;
+#
+#
+#18.9.69.3.1 Ensure 'Join Microsoft MAPS' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.69.3.1: Ensure 'Join Microsoft MAPS' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Spynet -> SpynetReporting -> !0;
+#
+#
+#18.9.74.3 Ensure 'Prevent Internet Explorer security prompt for Windows Installer scripts' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.74.3: Ensure 'Join Microsoft MAPS' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Installer -> SafeForScripting -> !0;
+#
+#
+#18.9.86.2.2 Ensure 'Allow remote server management through WinRM' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.86.2.2: Ensure 'Allow remote server management through WinRM' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service -> AllowAutoConfig -> !0;
+#
+#
+#18.9.87.1 Ensure 'Allow Remote Shell Access' is set to 'Disabled'
+[CIS - Microsoft Windows Server 2012 R2 - 18.9.87.1: Ensure 'Allow Remote Shell Access' is set to 'Disabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service\WinRS -> AllowRemoteShellAccess -> !0;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service\WinRS -> !AllowRemoteShellAccess;
+#
+
+


### PR DESCRIPTION
Hardening Checks for Win2012R2. Not all rules are working correct in 64bit systems due to windows registry redirection, i think.
Maybe there is a workaround i haven't seen/understood.

I do not know why the apache check is shown as new commit again and how to remove it? Sorry for that.