### PR TITLE
Fix Windows realtime functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Add default value for option -x in agent_control tool.
 - Syscheck RT process granularized to make frequency option more accurate.
 - External libraries moved to an external repository.
+- Allow more than 256 directories in real-time for Windows agent using recursive watchers. ([#540](https://github.com/wazuh/wazuh/pull/540))
 
 ### Fixed
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -158,6 +158,8 @@ syscheck.sleep_after=15
 # triggering on some temporary files like vim edits. (ms) [1..1000]
 syscheck.rt_delay=10
 
+# Maximum number of subdirectories monitorized for realtime on windows [256..1024]
+syscheck.max_fd_win_rt=256
 
 # Rootcheck checking/usage speed. The default is to sleep 50 milliseconds
 # per each PID or suspictious port.

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -353,7 +353,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 if (strcmp(*values, "yes") == 0) {
                     opts |= CHECK_SHA256SUM;
                 } else if (strcmp(*values, "no") == 0) {
-                opts &= ~ CHECK_SHA256SUM;
+                    opts &= ~ CHECK_SHA256SUM;
                 } else {
                     merror(SK_INV_OPT, *values, *attrs);
                     ret = 0;

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -93,6 +93,7 @@ typedef struct _config {
     registry_regex *registry_ignore_regex;      /* regex of registry entries to ignore */
     registry *registry;                         /* array of registry entries to be scanned */
     FILE *reg_fp;
+    int max_fd_win_rt;
 #endif
 
     OSHash *fp;

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -40,6 +40,7 @@ int Read_Syscheck_Config(const char *cfgfile)
 #ifdef WIN32
     syscheck.registry       = NULL;
     syscheck.reg_fp         = NULL;
+    syscheck.max_fd_win_rt  = 0;
 #endif
     syscheck.prefilter_cmd  = NULL;
 
@@ -78,6 +79,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     if ((syscheck.dir[0] == NULL) && (syscheck.registry[0].entry == NULL)) {
         return (1);
     }
+    syscheck.max_fd_win_rt = getDefine_Int("syscheck", "max_fd_win_rt", 256, 1024);
 #endif
 
     return (0);

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -271,7 +271,7 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
     int lcount;
     size_t offset = 0;
     char *ptfile;
-    char wdchar[32 + 1];
+    char wdchar[260 + 1];
     char final_path[MAX_LINE + 1];
     win32rtfim *rtlocald;
     PFILE_NOTIFY_INFORMATION pinfo;
@@ -288,8 +288,8 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
     }
 
     /* Get hash to parse the data */
-    wdchar[32] = '\0';
-    snprintf(wdchar, 32, "%d", (int)overlap->Offset);
+    wdchar[260] = '\0';
+    snprintf(wdchar, 260, "%s", (char*)overlap->Pointer);
     rtlocald = OSHash_Get(syscheck.realtime->dirtb, wdchar);
     if (rtlocald == NULL) {
         merror("real time call back called, but hash is empty.");
@@ -360,7 +360,7 @@ int realtime_win32read(win32rtfim *rtlocald)
 
 int realtime_adddir(const char *dir)
 {
-    char wdchar[32 + 1];
+    char wdchar[260 + 1];
     win32rtfim *rtlocald;
 
     if (!syscheck.realtime) {
@@ -368,50 +368,45 @@ int realtime_adddir(const char *dir)
     }
 
     /* Maximum limit for realtime on Windows */
-    if (syscheck.realtime->fd > 256) {
+    if (syscheck.realtime->fd > syscheck.max_fd_win_rt) {
         merror("Unable to add directory to real time monitoring: '%s' - Maximum size permitted.", dir);
         return (0);
     }
 
-    os_calloc(1, sizeof(win32rtfim), rtlocald);
-
-    rtlocald->h = CreateFile(dir,
-                             FILE_LIST_DIRECTORY,
-                             FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                             NULL,
-                             OPEN_EXISTING,
-                             FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
-                             NULL);
-
-
-    if (rtlocald->h == INVALID_HANDLE_VALUE ||
-            rtlocald->h == NULL) {
-        free(rtlocald);
-        rtlocald = NULL;
-        merror("Unable to add directory to real time monitoring: '%s'.", dir);
-        return (0);
-    }
-
-    rtlocald->overlap.Offset = ++syscheck.realtime->fd;
-
     /* Set key for hash */
-    wdchar[32] = '\0';
-    snprintf(wdchar, 32, "%d", (int)rtlocald->overlap.Offset);
-
-    if (OSHash_Get(syscheck.realtime->dirtb, wdchar)) {
-        merror("Entry already in the real time hash: %s", wdchar);
-        CloseHandle(rtlocald->overlap.hEvent);
-        free(rtlocald);
-        rtlocald = NULL;
-        return (0);
+    wdchar[260] = '\0';
+    snprintf(wdchar, 260, "%s", dir);
+    if(OSHash_Get(syscheck.realtime->dirtb, wdchar)) {
+        mdebug2("Entry '%s' already exists in the RT hash.", wdchar);
     }
+    else {
+        os_calloc(1, sizeof(win32rtfim), rtlocald);
 
-    /* Add final elements to the hash */
-    os_strdup(dir, rtlocald->dir);
-    OSHash_Add(syscheck.realtime->dirtb, strdup(wdchar), rtlocald);
+        rtlocald->h = CreateFile(dir,
+                                FILE_LIST_DIRECTORY,
+                                FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                NULL,
+                                OPEN_EXISTING,
+                                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
+                                NULL);
 
-    /* Add directory to be monitored */
-    realtime_win32read(rtlocald);
+
+        if (rtlocald->h == INVALID_HANDLE_VALUE || rtlocald->h == NULL) {
+            free(rtlocald);
+            rtlocald = NULL;
+            merror("Unable to add directory to real time monitoring: '%s'.", dir);
+            return (0);
+        }
+        syscheck.realtime->fd++;
+
+        /* Add final elements to the hash */
+        os_strdup(dir, rtlocald->dir);
+        os_strdup(dir, rtlocald->overlap.Pointer);
+        OSHash_Add(syscheck.realtime->dirtb, wdchar, rtlocald);
+
+        /* Add directory to be monitored */
+        realtime_win32read(rtlocald);
+    }
 
     return (1);
 }


### PR DESCRIPTION
This PR solves issue #530  .

Use one recursive waches per directory configured in `realtime` and the option to add 256 directories by default (up to 1024)
