### PR TITLE
Silence Vuls integration starting and ending alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Fix weird behavior in Syscheck when a modified file returns back to its first state. ([#434](https://github.com/wazuh/wazuh/pull/434))
 - Fixed invalid alerts reported by Syscollector when the event contains the word "error". ([#461](https://github.com/wazuh/wazuh/pull/461))
 - Fixed registry_ignore problem on syscheck for Windows when arch="both" was used. ([#525](https://github.com/wazuh/wazuh/pull/525))
+- Silenced Vuls integration starting and ending alerts. ([#541](https://github.com/wazuh/wazuh/pull/541))
 
 ### Removed
 

--- a/etc/rules/0015-ossec_rules.xml
+++ b/etc/rules/0015-ossec_rules.xml
@@ -95,7 +95,8 @@
     <match>^Starting rootcheck scan|^Ending rootcheck scan.|</match>
     <match>^Starting syscheck scan|^Ending syscheck scan.|</match>
     <match>^Starting OpenSCAP scan|^Ending OpenSCAP scan.|</match>
-    <match>^Starting CIS-CAT scan|^Ending CIS-CAT scan.</match>
+    <match>^Starting CIS-CAT scan|^Ending CIS-CAT scan.|</match>
+    <match>^Starting vulnerability scan|^Ending vulnerability scan.</match>
     <description>Ignoring scan messages.</description>
     <group>rootcheck,syscheck,pci_dss_10.6.1,</group>
   </rule>


### PR DESCRIPTION
The Vuls integration made this alert fire:
```
** Alert 1523756607.3400683: - ossec,rootcheck,
2018 Apr 15 01:43:27 (ag-redhat) 10.0.0.166->rootcheck
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
{'event': 'Ending vulnerability scan.'}
title: {'event': 'Ending vulnerability scan.'}
```

This is due to a rootcheck-type notification when the scan starts and ends. This alert should be in plain-text and ignored by default.

If you approve this PR please accept this other: https://github.com/wazuh/wazuh-ruleset/pull/122