### PR TITLE
Application inventory for Mac OS X 

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -78,6 +78,13 @@
 #define WM_SYS_NET_DIR  "/proc/net/"
 #define RPM_DATABASE    "/var/lib/rpm/Packages"
 
+/* MAC package search paths */
+
+#define MAC_APPS        "/Applications"
+#define UTILITIES       "/Applications/Utilities"
+#define HOMEBREW_APPS   "/usr/local/Cellar"
+#define INFO_FILE       "Contents/Info.plist"
+
 typedef struct rpm_data {
     char *tag;
     int type;
@@ -158,7 +165,7 @@ void list_programs(HKEY hKey, int arch, const char * root_key, int usec, const c
 void list_users(HKEY hKey, int usec, const char * timestamp, int ID, const char * LOCATION);
 #endif
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__MACH__)
 // Installed programs inventory for BSD based systems
 void sys_packages_bsd(int queue_fd, const char* LOCATION);
 #endif

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -120,7 +120,7 @@ void* wm_sys_main(wm_sys_t *sys) {
                 sys_programs_windows(WM_SYS_LOCATION);
             #elif defined(__linux__)
                 sys_packages_linux(queue_fd, WM_SYS_LOCATION);
-            #elif defined(__FreeBSD__)
+            #elif defined(__FreeBSD__) || defined(__MACH__)
                 sys_packages_bsd(queue_fd, WM_SYS_LOCATION);
             #else
                 sys->flags.programinfo = 0;


### PR DESCRIPTION
This PR adds the application inventory for MacOS. Collecting the applications located in the applications folder, as well as applications installed by Homebrew.

Please, merge this PR once the following one is merged into the master branch: https://github.com/wazuh/wazuh/pull/546

