### PR TITLE
Fix Windows delete pending active-responses before reset agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Fixed invalid alerts reported by Syscollector when the event contains the word "error". ([#461](https://github.com/wazuh/wazuh/pull/461))
 - Fixed registry_ignore problem on syscheck for Windows when arch="both" was used. ([#525](https://github.com/wazuh/wazuh/pull/525))
 - Silenced Vuls integration starting and ending alerts. ([#541](https://github.com/wazuh/wazuh/pull/541))
+- Windows delete pending active-responses before reset agent. ([#563](https://github.com/wazuh/wazuh/pull/563))
 
 ### Removed
 

--- a/active-response/win/route-null.cmd
+++ b/active-response/win/route-null.cmd
@@ -23,7 +23,7 @@ EXIT /B 1
 :: Check for a valid IP
 ECHO "%3" | %WINDIR%\system32\findstr.exe /R %IP_REGEX% >nul || ECHO Invalid IP && EXIT /B 2
 :: Extracts last ip address from ipconfig and routes to this address. Windows will not allow routing to 127.0.0.1
-FOR /F "TOKENS=2* DELIMS=:" %%A IN ('%WINDIR%\system32\ipconfig.exe ^| %WINDIR%\system32\findstr.exe /R /C:"IPv*4* Address"') DO FOR %%B IN (%%A) DO SET IPADDR=%%B
+FOR /F "TOKENS=2* DELIMS=:" %%A IN ('%WINDIR%\system32\ipconfig.exe ^| %WINDIR%\system32\findstr.exe /R /C:".*IP.*[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"') DO FOR %%B IN (%%A) DO SET IPADDR=%%B
 :: Adding IP to be null-routed. IP will be routed to local machine IP
 %WINDIR%\system32\route.exe -p ADD %3 MASK 255.255.255.255 %IPADDR%
 GOTO LOG

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -59,6 +59,7 @@ static void execd_shutdown(int sig)
 
         list_entry = (timeout_data *)timeout_node->data;
 
+        mdebug2("Delete pending AR: %s", list_entry->command);
         ExecCmd(list_entry->command);
 
         /* Delete current node - already sets the pointer to next */

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -26,7 +26,7 @@ OSList *timeout_list;
 OSListNode *timeout_node;
 
 /* Shut down win-execd properly */
-static void WinExecd_Shutdown(int signal)
+static void WinExecd_Shutdown()
 {
     /* Remove pending active responses */
     minfo(EXEC_SHUTDOWN);
@@ -78,6 +78,9 @@ int WinExecd_Start()
     if (!timeout_list) {
         merror_exit(LIST_ERROR);
     }
+
+    /* Delete pending AR at succesfull exit */
+    atexit(WinExecd_Shutdown);
 
     /* Start up message */
     minfo(STARTUP_MSG, getpid());
@@ -133,9 +136,6 @@ void WinExecdRun(char *exec_msg)
     char buffer[OS_MAXSTR + 1];
 
     timeout_data *timeout_entry;
-
-    /* Delete pending AR at succesfull exit */
-    atexit(WinExecd_Shutdown);
 
     /* Current time */
     curr_time = time(0);

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -44,8 +44,6 @@ static void WinExecd_Shutdown()
         OSList_DeleteCurrentlyNode(timeout_list);
         timeout_node = OSList_GetCurrentlyNode(timeout_list);
 
-        /* Continue with the next entry in timeout list */
-        timeout_node = OSList_GetNextNode(timeout_list);
         /* Clear the memory */
         FreeTimeoutEntry(list_entry);
     }


### PR DESCRIPTION
This PR solves [#376](https://github.com/wazuh/wazuh/issues/376)

Added function to remove active responses when an output signal is received.