### PR TITLE
Allow decoders mix plugin and multiregex children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Allow inserting static field parameters in rule comments. ([#397](https://github.com/wazuh/wazuh/pull/397))
 - Included millisecond timing in timestamp to JSON events. ([#467](https://github.com/wazuh/wazuh/pull/467))
 - Added an option in Analysisd to set input event offset for plugin decoders. ([#512](https://github.com/wazuh/wazuh/pull/512))
+- Allow decoders mix plugin and multiregex children. ([#602](https://github.com/wazuh/wazuh/pull/602))
 
 ### Changed
 

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -141,15 +141,12 @@ void DecodeEvent(Eventinfo *lf)
             return;
         }
 
-        /* If we have an external decoder, execute it */
-        if (nnode->plugindecoder) {
-            nnode->plugindecoder(lf);
-            return;
-        }
-
         /* Get the regex */
         while (child_node) {
-            if (nnode->regex) {
+            /* If we have an external decoder, execute it */
+            if (nnode->plugindecoder) {
+                nnode->plugindecoder(lf);
+            } else if (nnode->regex) {
                 int i;
 
                 /* With regex we have multiple options
@@ -205,18 +202,19 @@ void DecodeEvent(Eventinfo *lf)
                     nnode->regex->sub_strings[i] = NULL;
                 }
 
-                /* If we have a next regex, try getting it */
-                if (nnode->get_next) {
-                    child_node = child_node->next;
-                    nnode = child_node->osdecoder;
-                    continue;
-                }
-
                 break;
+            } else {
+                /* If we don't have a regex, we may leave now */
+                return;
             }
 
-            /* If we don't have a regex, we may leave now */
-            return;
+            /* If we have a next regex, try getting it */
+            if (nnode->get_next) {
+                child_node = child_node->next;
+                nnode = child_node->osdecoder;
+            } else {
+                return;
+            }
         }
 
         /* ok to return  */

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -81,7 +81,7 @@ static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi)
                     goto error;
                 }
 
-                if (tmp_node->osdecoder->regex && pi->regex) {
+                if ((tmp_node->osdecoder->regex || tmp_node->osdecoder->plugindecoder) && (pi->regex || pi->plugindecoder)) {
                     tmp_node->osdecoder->get_next = 1;
                 } else {
                     merror(DUP_INV, pi->name);


### PR DESCRIPTION
The goal is to allow a regex extend the fields decoded by a plugin decoder like JSON.

Example:
```xml
<decoder name="json">
  <prematch>^{\s*"</prematch>
</decoder>

<decoder name="json_child">
  <parent>json</parent>
  <prematch>^{\s*"</prematch>
  <plugin_decoder>JSON_Decoder</plugin_decoder>
</decoder>

<decoder name="json_child">
  <parent>json</parent>
  <regex>@(\S+)"</regex>
  <order>user.email.domain</order>
</decoder>
```

With this input:
```json
{
  "user": {
    "name": "John",
    "surname": "Smith",
    "email": "john.smith@example.com"
  }
}
```

The decoder will extract the complete JSON plus the domain of the email:
```
decoder: 'json'
user.name: 'John'
user.surname: 'Smith'
user.email: 'john.smith@example.com'
user.email.domain: 'example.com'
```