### PR TITLE
Internal option to enable merged file creation by Remoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.2.3]
 
+### Added
+
+- New internal option to enable merged file creation by Remoted. ([#603](https://github.com/wazuh/wazuh/pull/603))
+
 ### Fixed
 
 - Fixed agent wait condition and improve logging messages. ([#550](https://github.com/wazuh/wazuh/pull/550))

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -98,6 +98,11 @@ remoted.rlimit_nofile=16384
 # Maximum time waiting for a client response in TCP (seconds) [1..60]
 remoted.recv_timeout=1
 
+# Merge shared configuration to be broadcasted to agents
+# 0. Disable
+# 1. Enable (default)
+remoted.merge_shared=1
+
 # Timeout to execute remote requests [1..3600]
 execd.request_timeout=60
 

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
         merror_exit(CONFIG_ERROR, cfg);
     }
 
-    logr.nocmerged = nocmerged;
+    logr.nocmerged = nocmerged ? 1 : !getDefine_Int("remoted", "merge_shared", 0, 1);
 
     /* Exit if test_config is set */
     if (test_config) {


### PR DESCRIPTION
This PR completes issue https://github.com/wazuh/wazuh/issues/597.

The new internal option is:

```sh
# Merge shared configuration to be broadcasted to agents
# 0. Disable
# 1. Enable (default)
remoted.merge_shared=1
```