### PR TITLE
Removed some fields from Logstash config files

### DIFF
--- a/extensions/logstash/01-wazuh-local.conf
+++ b/extensions/logstash/01-wazuh-local.conf
@@ -23,7 +23,7 @@ filter {
     geoip {
         source => "@src_ip"
         target => "GeoLocation"
-        fields => ["city_name", "continent_code", "country_code2", "country_name", "region_name", "location"]
+        fields => ["city_name", "country_name", "region_name", "location"]
     }
     date {
         match => ["timestamp", "ISO8601"]

--- a/extensions/logstash/01-wazuh-remote.conf
+++ b/extensions/logstash/01-wazuh-remote.conf
@@ -25,7 +25,7 @@ filter {
     geoip {
         source => "@src_ip"
         target => "GeoLocation"
-        fields => ["city_name", "continent_code", "country_code2", "country_name", "region_name", "location"]
+        fields => ["city_name", "country_name", "region_name", "location"]
     }
     date {
         match => ["timestamp", "ISO8601"]


### PR DESCRIPTION
Hello team,

This pull request closes https://github.com/wazuh/wazuh-kibana-app/issues/387. I've modified the template config files for Logstash to remove some unnecessary GeoLocation filter fields. This only affects the Elastic installation process, it doesn't touch any Wazuh core files.
![logstash](https://user-images.githubusercontent.com/10928321/39749612-74e7a8a6-52b3-11e8-8534-718a9bd4f460.png)

I've tested it and everything works well on clean an existing installations.

Regards,
Juanjo