### PR TITLE
Add support for GDPR rules in API

### DIFF
--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -46,6 +46,7 @@ class WazuhException(Exception):
         1202: 'Argument \'status\' must be: enabled, disabled or all',
         1203: 'Argument \'level\' must be a number or an interval separated by \'-\'',
         1204: 'Operation not implemented',
+        1205: 'Requirement not valid. Valid ones are pci and gdpr',
 
         # Stats: 1300 - 1399
         1307: 'Invalid parameters',


### PR DESCRIPTION
Hello,

This PR adds support to work with GDPR rules (https://github.com/wazuh/wazuh-ruleset/pull/120) at API level.

A new API call `GET/rules/gdpr` has been added:
```json
# curl -u foo:bar "localhost:55000/rules/gdpr?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 14,
      "items": [
         "24.2",
         "30.1.g",
         "32.2",
         "35.7",
         "35.7.d",
         "5.1.f",
         "II.5.1.f",
         "II_5.1.f",
         "IV_30.1.g",
         "IV_32.2",
         "IV_35.7.d"
      ]
   }
}
```

Also, a new parameter in `GET/rules` has been added to filter GDPR groups.

```json
# curl -u foo:bar "localhost:55000/rules?pretty&gdpr=30.1.g&limit=2"
{
   "error": 0,
   "data": {
      "totalItems": 91,
      "items": [
         {
            "status": "enabled",
            "pci": [],
            "description": "MS-DHCP: Started.",
            "file": "0110-ms_dhcp_rules.xml",
            "level": 3,
            "path": "/var/ossec/ruleset/rules",
            "details": {
               "if_sid": "6350",
               "id": "^11010"
            },
            "groups": [
               "service_start",
               "windows",
               "dhcp"
            ],
            "id": 6361,
            "gdpr": [
               "30.1.g"
            ]
         },
         {
            "status": "enabled",
            "pci": [],
            "description": "MS-DHCP: Stopped.",
            "file": "0110-ms_dhcp_rules.xml",
            "level": 7,
            "path": "/var/ossec/ruleset/rules",
            "details": {
               "if_sid": "6350",
               "id": "^11011"
            },
            "groups": [
               "service_availability",
               "windows",
               "dhcp"
            ],
            "id": 6362,
            "gdpr": [
               "35.7.d",
               "30.1.g"
            ]
         }
      ]
   }
}
```

Best regards,
Marta