### PR TITLE
Added GDPR field to Elasticsearch template

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -277,6 +277,10 @@
             "pci_dss": {
               "type": "keyword",
               "doc_values": "true"
+            },
+            "gdpr": {
+              "type": "keyword",
+              "doc_values": "true"
             }
           }
         },


### PR DESCRIPTION
Hello team,

This pull request adds the new GDPR field to the Elasticsearch template so the Wazuh app can properly show the new future GDPR alerts.

Regards,
Juanjo