### PR TITLE
Add GPG13 to the Elasticsearch template

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -281,6 +281,10 @@
             "gdpr": {
               "type": "keyword",
               "doc_values": "true"
+            },
+            "gpg13": {
+              "type": "keyword",
+              "doc_values": "true"
             }
           }
         },


### PR DESCRIPTION
Hello team,

After the merge of #608, `GPG13` has to be added to the Elasticsearch template in order to properly parse the new item from the `alerts.json` file.

This pull request adds that to the mentioned file.

Best regards,
Juanjo