### PR TITLE
Fix cluster start error in CentOS6 and improve logs

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -8,6 +8,13 @@
 #
 error_msg = ""
 try:
+    from sys import argv, exit, path, version_info
+
+    if version_info[0] == 2 and version_info[1] < 7:
+        print("Error starting wazuh-clusterd. Minimal Python version required is 2.7. Found version is {0}.{1}".format(
+            version_info[0], version_info[1]))
+        exit()
+
     import asyncore
     import threading
     import time
@@ -18,7 +25,6 @@ try:
     import ctypes.util
     import socket
     from signal import signal, SIGINT, SIGTERM
-    from sys import argv, exit, path, version_info
     from os.path import dirname
     from os import seteuid, setgid, getpid, kill, unlink
 
@@ -33,12 +39,8 @@ try:
 
         from wazuh import common
     except Exception as e:
-        if version_info[0] == 2 and version_info[1] < 7:
-            error_msg = "Python 2.7 required. Exiting."
-        else:
-            error_msg = str(e)
-        print(error_msg)
-        exit(1)
+        print("Error starting wazuh-clusterd: {}".format(e))
+        exit()
 
     try:
         from wazuh.exception import WazuhException

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -18,7 +18,6 @@ try:
     import ctypes.util
     import socket
     from signal import signal, SIGINT, SIGTERM
-    from pwd import getpwnam
     from sys import argv, exit, path, version_info
     from os.path import dirname
     from os import seteuid, setgid, getpid, kill, unlink
@@ -239,9 +238,8 @@ if __name__ == '__main__':
 
     # Drop privileges to ossec
     if not args.r:
-        pwdnam_ossec = getpwnam('ossec')
-        setgid(pwdnam_ossec.pw_gid)
-        seteuid(pwdnam_ossec.pw_uid)
+        setgid(common.ossec_gid)
+        seteuid(common.ossec_uid)
 
     # Creating pid file
     create_pid("wazuh-clusterd", getpid())

--- a/framework/wazuh/cluster/cluster.json
+++ b/framework/wazuh/cluster/cluster.json
@@ -60,7 +60,7 @@
             "description": "user CDB lists"
         },
 
-        "/queue/cluster/": {
+        "/queue/agent-info/": {
             "umask": "0o117",
             "source": "client",
             "write_mode": "atomic",

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -123,7 +123,7 @@ class WazuhException(Exception):
         3007: 'Client.keys file received in master node',
         3008: 'Received invalid agent status',
         3009: 'Error executing request to internal socket',
-
+        3010: 'Received the status/group of an unexisting agent',
         3011: 'Agent info file received in a client node',
         3012: 'Cluster is not running',
         3013: 'Cluster is disabled',


### PR DESCRIPTION
Hello team,

This PR fixes the following:

### Improves log message when the status of an unexisting agent is received:
Right now, the following log message is shown when the master node receives the status or the group of an agent that doesn't exist:

This should not be considered an error, but just a warning. Considering this message an error is very confusing to the user. Using the cluster without debugging is even more confusing.

```
2018-05-14 20:55:00,778 DEBUG2  : [Master] [node02] [AgentInfo-R  ]: Error updating file '/queue/agent-info/pepe-any': Received an unexistent agent status file: pepe
2018-05-14 20:55:00,779 DEBUG   : [Master] [node02] [AgentInfo-R  ]: Time updating client files: 0.00s. Total of updated client files: 0.
2018-05-14 20:55:00,779 ERROR   : [Master] [node02] [AgentInfo-R  ]: Errors updating client files: /queue/agent-info/: 1
```

The improved message is the following:
```
2018-05-15 09:45:06,212 DEBUG2  : [Master] [node02] [AgentInfo-R  ]: Warning updating file '/queue/agent-info/pepe-any': Error 3010 - Received the status/group of an unexisting agent: pepe
2018-05-15 09:45:06,212 DEBUG   : [Master] [node02] [AgentInfo-R  ]: Time updating client files: 0.00s. Total of updated client files: 0.
2018-05-15 09:45:06,212 WARNING : [Master] [node02] [AgentInfo-R  ]: Received non exiting clients' statuses or groups assignments to update. Skipping: /queue/agent-info/: 1
```

### Fixes Wazuh starts in CentOS 6.

A dependency error caused Wazuh's start in CentOS 6 to be crashed:

```
    Starting OSSEC: Traceback (most recent call last):
      File "/var/ossec/bin/wazuh-clusterd", line 62, in <module>
        logger = logging.getLogger()
    NameError: name 'logging' is not defined
```

This was caused because the check of the python version used was being done too late. The Wazuh start on CentOS 6 looks like the following:

```
# /var/ossec/bin/ossec-control restart
wazuh-clusterd not running...
Killing ossec-monitord...
Killing ossec-logcollector...
Killing ossec-remoted...
Killing ossec-syscheckd...
Killing ossec-analysisd...
ossec-maild not running...
Killing ossec-execd...
Killing wazuh-modulesd...
Killing wazuh-db...
Wazuh v3.2.3 Stopped
Starting Wazuh v3.2.3 (maintained by Wazuh Inc.)...
Started wazuh-db...
Started wazuh-modulesd...
Started ossec-execd...
Started ossec-analysisd...
Started ossec-syscheckd...
Started ossec-remoted...
Started ossec-logcollector...
Started ossec-monitord...
Error starting wazuh-clusterd. Minimal Python version required is 2.7. Found version is 2.6
Started wazuh-clusterd...
Completed.
```

### Use variable defined in `common.py` to drop privileges to ossec:
Since _ossec_ uid and gid are defined in `common.py`, I have removed from `wazuh-clusterd` this calculation:

https://github.com/wazuh/wazuh/blob/bf614fcbcfd18022b5a879589318f2d766fdfed8/framework/wazuh/common.py#L94-L95

Best regards,
Marta
