### PR TITLE
Merge external libraries in a shared Wazuh library

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -869,8 +869,13 @@ WAZUH_SHFLAGS=-install_name @rpath/libwazuhext.$(SHARED)
 $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHFLAGS) -o $@ -Wl,-all_load $^ -Wl,-noall_load
 else
+ifeq (${TARGET}, winagent)
+$(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -static-libgcc -Wl,--export-all-symbols -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
+else
 $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
+endif
 endif
 
 #### os_mail #########

--- a/src/Makefile
+++ b/src/Makefile
@@ -48,22 +48,16 @@ ifneq (,$(filter ${REUSE_ID},yes y Y 1))
 endif
 
 OSSEC_CFLAGS = -pthread ${CFLAGS}
-OSSEC_LDFLAGS = -pthread -L${EXTERNAL_OPENSSL} -L$(EXTERNAL_JSON) -L$(EXTERNAL_ZLIB) ${LDFLAGS}
-OSSEC_LIBS = -lcjson -lm -lssl -lcrypto -lz $(LIBS)
+OSSEC_LDFLAGS = -pthread ${LDFLAGS}
+OSSEC_LIBS = $(LIBS)
 
 ifneq (${TARGET},winagent)
-ifneq (${TARGET},agent)
-		OSSEC_LDFLAGS += -L$(EXTERNAL_SQLITE) -L${EXTERNAL_CURL}lib/.libs -L${EXTERNAL_LIBYAML}src/.libs
-		OSSEC_LIBS += -lsqlite3 -lcurl -lyaml
-endif
 ifeq (${uname_S},Linux)
 		DEFINES+=-DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE
 #		DEFINES+=-DUSE_MAGIC
 		OSSEC_CFLAGS+=-I${EXTERNAL_LIBDB}
-		OSSEC_LDFLAGS+=-L$(EXTERNAL_PROCPS)
-		OSSEC_LDFLAGS+=-L${EXTERNAL_LIBDB}.libs
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
-		OSSEC_LIBS+=-lrt -ldl -lproc -ldb-6.2
+		OSSEC_LIBS+=-lrt -ldl
 #		OSSEC_LDFLAGS+=-lmagic
 else
 ifeq (${uname_S},AIX)
@@ -516,23 +510,18 @@ win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 #### External ######
 ####################
 
-ifeq (${TARGET},winagent)
-OPENSSL_LIB = $(EXTERNAL_OPENSSL)libssl-1_1.$(SHARED)
-ZLIB_LIB    = $(EXTERNAL_ZLIB)/zlib1.$(SHARED)
-else
-OPENSSL_LIB = $(EXTERNAL_OPENSSL)libssl.$(SHARED)
-CRYPTO_LIB = $(EXTERNAL_OPENSSL)libcrypto.$(SHARED)
-ZLIB_LIB    = $(EXTERNAL_ZLIB)/libz.$(SHARED)
-endif
+ZLIB_LIB    = $(EXTERNAL_ZLIB)/libz.a
+OPENSSL_LIB = $(EXTERNAL_OPENSSL)libssl.a
+CRYPTO_LIB = $(EXTERNAL_OPENSSL)libcrypto.a
 
-SQLITE_LIB  = $(EXTERNAL_SQLITE)libsqlite3.$(SHARED)
-JSON_LIB    = $(EXTERNAL_JSON)libcjson.$(SHARED)
-PROCPS_LIB  = $(EXTERNAL_PROCPS)/libproc.$(SHARED)
-DB_LIB      = $(EXTERNAL_LIBDB).libs/libdb-6.2.$(SHARED)
-LIBYAML_LIB = $(EXTERNAL_LIBYAML)src/.libs/libyaml.$(SHARED)
-LIBCURL_LIB = $(EXTERNAL_CURL)lib/.libs/libcurl.$(SHARED)
+SQLITE_LIB  = $(EXTERNAL_SQLITE)libsqlite3.a
+JSON_LIB    = $(EXTERNAL_JSON)libcjson.a
+PROCPS_LIB  = $(EXTERNAL_PROCPS)/libproc.a
+DB_LIB      = $(EXTERNAL_LIBDB).libs/libdb-6.2.a
+LIBYAML_LIB = $(EXTERNAL_LIBYAML)src/.libs/libyaml.a
+LIBCURL_LIB = $(EXTERNAL_CURL)lib/.libs/libcurl.a
 
-EXTERNAL_LIBS := $(JSON_LIB) $(ZLIB_LIB) $(OPENSSL_LIB)
+EXTERNAL_LIBS := $(JSON_LIB) $(ZLIB_LIB) $(OPENSSL_LIB) $(CRYPTO_LIB)
 
 ifneq (${TARGET},winagent)
 ifneq (${TARGET},agent)
@@ -553,17 +542,14 @@ endif
 
 #### OpenSSL ##########
 
-OPENSSL_FLAGS = enable-weak-ssl-ciphers
+OPENSSL_FLAGS = enable-weak-ssl-ciphers no-shared
 
-${OPENSSL_LIB}:
+${OPENSSL_LIB} $(CRYPTO_LIB):
 ifeq (${TARGET},winagent)
 	cd ${EXTERNAL_OPENSSL} && CC=${MING_BASE}${CC} RC=${MING_BASE}windres ./Configure $(OPENSSL_FLAGS) mingw && ${MAKE} build_libs
 else
 ifeq (${uname_S},Darwin)
 	cd ${EXTERNAL_OPENSSL} && ./Configure $(OPENSSL_FLAGS) darwin64-x86_64-cc && ${MAKE} build_libs
-	install_name_tool -id "@rpath/libssl.1.1.dylib" $(OPENSSL_LIB)
-	install_name_tool -id "@rpath/libcrypto.1.1.dylib" $(CRYPTO_LIB)
-	install_name_tool -change /usr/local/lib/libcrypto.1.1.dylib @rpath/libcrypto.1.1.dylib $(OPENSSL_LIB)
 else
 ifeq (${uname_S},HP-UX)
 	cd ${EXTERNAL_OPENSSL} && MAKE=gmake ./Configure $(OPENSSL_FLAGS) hpux-ia64-gcc && ${MAKE} build_libs
@@ -585,12 +571,9 @@ endif
 
 $(ZLIB_LIB):
 ifeq (${TARGET},winagent)
-	cd ${EXTERNAL_ZLIB} && cp zconf.h.in zconf.h && ${MAKE} -f win32/Makefile.gcc PREFIX=${MING_BASE} zlib1.dll
+	cd ${EXTERNAL_ZLIB} && cp zconf.h.in zconf.h && ${MAKE} -f win32/Makefile.gcc PREFIX=${MING_BASE} libz.a
 else
-	cd ${EXTERNAL_ZLIB} && ./configure && ${MAKE} shared
-ifeq (${uname_S},Darwin)
-	install_name_tool -id "@rpath/libz.1.dylib" $@
-endif
+	cd ${EXTERNAL_ZLIB} && CFLAGS=-fPIC ./configure && ${MAKE} libz.a
 endif
 
 ZLIB_INCLUDE=-I./${EXTERNAL_ZLIB}
@@ -603,15 +586,12 @@ os_zlib/%.o: os_zlib/%.c
 
 #### SQLite #########
 
-ifeq (${uname_S},Darwin)
-SQLITE_SHFLAGS=-install_name @rpath/libsqlite3.$(SHARED)
-endif
-
 sqlite_c = ${EXTERNAL_SQLITE}sqlite3.c
 sqlite_o = ${EXTERNAL_SQLITE}sqlite3.o
 
 $(SQLITE_LIB): $(sqlite_o)
-	${OSSEC_SHARED} ${OSSEC_CFLAGS} $(SQLITE_SHFLAGS) -o $@ $^
+	${OSSEC_LINK} $@ $^
+	${OSSEC_RANLIB} $@
 
 $(sqlite_o): $(sqlite_c)
 	${OSSEC_CC} ${OSSEC_CFLAGS} -w -fPIC -c $^ -o $@ -fPIC
@@ -626,7 +606,8 @@ cjson_c := ${EXTERNAL_JSON}cJSON.c
 cjson_o := $(cjson_c:.c=.o)
 
 $(JSON_LIB): ${cjson_o}
-	${OSSEC_SHARED} ${OSSEC_CFLAGS} $(JSON_SHFLAGS) -o $@ $^
+	${OSSEC_LINK} $@ $^
+	${OSSEC_RANLIB} $@
 
 ${EXTERNAL_JSON}%.o: ${EXTERNAL_JSON}%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -fPIC -c $^ -o $@
@@ -635,27 +616,21 @@ ${EXTERNAL_JSON}%.o: ${EXTERNAL_JSON}%.c
 
 ${LIBYAML_LIB}: $(EXTERNAL_LIBYAML)Makefile
 	$(MAKE) -C $(EXTERNAL_LIBYAML)
-ifeq (${uname_S},Darwin)
-	install_name_tool -id "@rpath/libyaml-0.2.dylib" $@
-endif
 
 $(EXTERNAL_LIBYAML)Makefile:
-	cd $(EXTERNAL_LIBYAML) && ./configure
+	cd $(EXTERNAL_LIBYAML) && CFLAGS=-fPIC ./configure --enable-static=yes
 
 #### curl ##########
 
 ${LIBCURL_LIB}: $(EXTERNAL_CURL)Makefile
 	${MAKE} -C $(EXTERNAL_CURL)lib
-ifeq (${uname_S},Darwin)
-	install_name_tool -id "@rpath/libcurl.4.dylib" $@
-endif
 
 ifeq (${uname_S},Darwin)
 $(EXTERNAL_CURL)Makefile:
 	cd $(EXTERNAL_CURL) && ./configure --with-darwinssl
 else
 $(EXTERNAL_CURL)Makefile: $(OPENSSL_LIB)
-	cd $(EXTERNAL_CURL) && CPPFLAGS="-I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LD_LIBRARY_PATH="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" ./configure
+	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" ./configure
 endif
 
 
@@ -670,13 +645,17 @@ ${EXTERNAL_PROCPS}%.o: ${EXTERNAL_PROCPS}%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -fPIC -c $^ -o $@
 
 $(PROCPS_LIB): ${procps_o}
-	${OSSEC_SHARED} ${OSSEC_CFLAGS} -o $@ $^
+	${OSSEC_LINK} $@ $^
+	${OSSEC_RANLIB} $@
 
 #### Berkeley DB ######
 
-${DB_LIB}:
 ifeq (${uname_S},Linux)
-	cd ${EXTERNAL_LIBDB} && ../dist/configure --with-cryptography=no --disable-queue --disable-heap --disable-partition --disable-mutexsupport --disable-replication --disable-verify --disable-statistics --enable-shared --enable-static=no && ${MAKE} library_build
+${DB_LIB}: $(EXTERNAL_LIBDB)Makefile
+	 ${MAKE} -C $(EXTERNAL_LIBDB) libdb.a
+
+$(EXTERNAL_LIBDB)Makefile:
+	cd ${EXTERNAL_LIBDB} && CPPFLAGS=-fPIC ../dist/configure --with-cryptography=no --disable-queue --disable-heap --disable-partition --disable-mutexsupport --disable-replication --disable-verify --disable-statistics
 endif
 
 ################################
@@ -708,7 +687,8 @@ external/%.tar.gz:
 #### OSSEC Libs ####
 ####################
 
-BUILD_LIBS = libwazuh.a
+WAZUHEXT_LIB = libwazuhext.$(SHARED)
+BUILD_LIBS = libwazuh.a $(WAZUHEXT_LIB)
 
 $(BUILD_SERVER) $(BUILD_AGENT) $(WINDOWS_BINS): $(BUILD_LIBS)
 
@@ -787,7 +767,7 @@ wazuh_modules/%.o: wazuh_modules/%.c
 
 ifeq (${TARGET},winagent)
 wazuh_modules/syscollector/syscollector_win_ext.dll: wazuh_modules/syscollector/syscollector_win_ext.o
-	${OSSEC_SHARED} ${OSSEC_LDFLAGS} $^ -o $@ $(OSSEC_LIBS)
+	${OSSEC_SHARED} ${OSSEC_LDFLAGS} $^ -o $@ $(OSSEC_LIBS) $(JSON_LIB)
 endif # DLL for Windows
 
 ifndef DISABLE_SYSC
@@ -880,6 +860,18 @@ crypto_o := ${crypto_blowfish_o} \
 libwazuh.a: ${config_o} ${wmodules_dep} ${crypto_o} ${shared_o} ${os_net_o} ${os_regex_o} ${os_xml_o} ${os_zlib_o}
 	${OSSEC_LINK} $@ $^
 	${OSSEC_RANLIB} $@
+
+### libwazuhext #########
+
+ifeq (${uname_S},Darwin)
+WAZUH_SHFLAGS=-install_name @rpath/libwazuhext.$(SHARED)
+
+$(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHFLAGS) -o $@ -Wl,-all_load $^ -Wl,-noall_load
+else
+$(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
+endif
 
 #### os_mail #########
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -490,7 +490,7 @@ ifeq (${MAKECMDGOALS},winagent)
 $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
-winagent: external win32/libwinpthread-1.dll
+winagent: external win32/libwinpthread-1.dll wazuh_modules/syscollector/syscollector_win_ext.dll
 	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
 	cd win32/ && ./unix2dos.pl help.txt > help_win.txt
@@ -767,7 +767,7 @@ wazuh_modules/%.o: wazuh_modules/%.c
 
 ifeq (${TARGET},winagent)
 wazuh_modules/syscollector/syscollector_win_ext.dll: wazuh_modules/syscollector/syscollector_win_ext.o
-	${OSSEC_SHARED} ${OSSEC_LDFLAGS} $^ -o $@ $(OSSEC_LIBS) $(JSON_LIB)
+	${OSSEC_SHARED} ${OSSEC_LDFLAGS} $^ -o $@ $(OSSEC_LIBS) $(JSON_LIB) -liphlpapi -lws2_32
 endif # DLL for Windows
 
 ifndef DISABLE_SYSC

--- a/src/Makefile
+++ b/src/Makefile
@@ -544,7 +544,9 @@ endif
 
 OPENSSL_FLAGS = enable-weak-ssl-ciphers no-shared
 
-${OPENSSL_LIB} $(CRYPTO_LIB):
+${CRYPTO_LIB}: ${OPENSSL_LIB}
+
+${OPENSSL_LIB}:
 ifeq (${TARGET},winagent)
 	cd ${EXTERNAL_OPENSSL} && CC=${MING_BASE}${CC} RC=${MING_BASE}windres ./Configure $(OPENSSL_FLAGS) mingw && ${MAKE} build_libs
 else

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -653,6 +653,9 @@ InstallCommon(){
         ${INSTALL} -m 0750 -o root -g 0 libwazuhext.dylib ${PREFIX}/lib
     else
         ${INSTALL} -m 0750 -o root -g 0 libwazuhext.so ${PREFIX}/lib
+        if [ "$DIST_NAME$DIST_VER"="rhel5" ]; then
+            chcon -t textrel_shlib_t ${PREFIX}/lib/libwazuhext.so
+        fi
     fi
 
   ${INSTALL} -m 0750 -o root -g 0 ossec-logcollector ${PREFIX}/bin

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -606,14 +606,6 @@ InstallCommon(){
     OSSEC_USER='ossec'
     OSSEC_USER_MAIL='ossecm'
     OSSEC_USER_REM='ossecr'
-    EXTERNAL_BERKELEY='external/libdb/build_unix/'
-    EXTERNAL_LIBYAML='external/libyaml/'
-    EXTERNAL_CURL='external/curl/'
-    EXTERNAL_JSON="external/cJSON/"
-    EXTERNAL_SQLITE="external/sqlite/"
-    EXTERNAL_SSL="external/openssl/"
-    EXTERNAL_PROCPS="external/procps/"
-    EXTERNAL_ZLIB="external/zlib/"
     INSTALL="install"
 
     if [ ${INSTYPE} = 'server' ]; then
@@ -658,21 +650,9 @@ InstallCommon(){
 
     if [ ${NUNAME} = 'Darwin' ]
     then
-        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_JSON}libcjson.dylib ${PREFIX}/lib
-        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libssl.1.1.dylib ${PREFIX}/lib
-        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libcrypto.1.1.dylib ${PREFIX}/lib
-        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_ZLIB}libz.1.dylib ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g 0 libwazuhext.dylib ${PREFIX}/lib
     else
-        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_JSON}libcjson.so ${PREFIX}/lib
-        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libssl.so.1.1 ${PREFIX}/lib
-        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_SSL}libcrypto.so.1.1 ${PREFIX}/lib
-        ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_ZLIB}libz.so.1 ${PREFIX}/lib
-
-        if [ ${NUNAME} = 'Linux' ]
-        then
-            ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_BERKELEY}.libs/libdb-6.2.so ${PREFIX}/lib
-            ${INSTALL} -m 0750 -o root -g 0 ${EXTERNAL_PROCPS}libproc.so ${PREFIX}/lib
-        fi
+        ${INSTALL} -m 0750 -o root -g 0 libwazuhext.so ${PREFIX}/lib
     fi
 
   ${INSTALL} -m 0750 -o root -g 0 ossec-logcollector ${PREFIX}/bin

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -206,9 +206,7 @@ Section "Wazuh Agent (required)" MainSec
 	File agent-auth.exe
     File /oname=wpk_root.pem ../../etc/wpk_root.pem
     File ../wazuh_modules/syscollector/syscollector_win_ext.dll
-    File /oname=libcjson.dll ../external/cJSON/libcjson.dll
-    File /oname=libcrypto-1_1.dll ../external/openssl/libcrypto-1_1.dll
-    File /oname=zlib1.dll ../external/zlib/zlib1.dll
+    File /oname=libwazuhext.dll ../libwazuhext.dll
     File VERSION
     File REVISION
 
@@ -483,9 +481,7 @@ Section "Uninstall"
     Delete "$INSTDIR\incoming\*"
     Delete "$INSTDIR\wodles\*"
     Delete "$INSTDIR\syscollector_win_ext.dll"
-    Delete "$INSTDIR\libcjson.dll"
-    Delete "$INSTDIR\libcrypto-1_1.dll"
-    Delete "$INSTDIR\zlib1.dll"
+    Delete "$INSTDIR\libwazuhext.dll"
 
     ; remove shortcuts
     SetShellVarContext all

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -68,14 +68,8 @@
                     <Component Id="SYSCOLLECTOR_DLL" DiskId="1" Guid="3F72347F-1282-44C1-8A97-40BB68CAE4FB">
                         <File Id="SYSCOLLECTOR_DLL" Name="syscollector_win_ext.dll" Source="..\wazuh_modules\syscollector\syscollector_win_ext.dll" />
                     </Component>
-                    <Component Id="LIBCJSON_DLL" DiskId="1" Guid="31F7B5FA-9678-427B-9536-88AAA897A82A">
-                        <File Id="LIBCJSON_DLL" Name="libcjson.dll" Source="..\external\cJSON\libcjson.dll" />
-                    </Component>
-                    <Component Id="LIBCRYPTO_1_1_DLL" DiskId="1" Guid="F1EBAC23-CCA0-4C55-BC36-AFFA0082A4A3">
-                        <File Id="LIBCRYPTO_1_1_DLL" Name="libcrypto-1_1.dll" Source="..\external\openssl\libcrypto-1_1.dll" />
-                    </Component>
-                    <Component Id="ZLIB1_DLL" DiskId="1" Guid="3DF8C897-2C3F-45E0-A988-B5D794478745">
-                        <File Id="ZLIB1_DLL" Name="zlib1.dll" Source="..\external\zlib\zlib1.dll" />
+                    <Component Id="LIBWAZUHEXT_DLL" DiskId="1" Guid="31F7B5FA-9678-427B-9536-88AAA897A82A"/>
+                        <File Id="LIBWAZUHEXT_DLL" Name="libwazuhext.dll" Source="..\libwazuhext.dll" />
                     </Component>
                     <Component Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" DiskId="1" Guid="10245598-2EE7-4EDB-A114-5398F01A21F9">
                         <File Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" Name="default-local_internal_options.conf" Source="default-local_internal_options.conf">
@@ -303,9 +297,7 @@
         <Feature Id="MainFeature" Title="Wazuh Agent" Description="Install the Wazuh Agent program files" ConfigurableDirectory="APPLICATIONFOLDER" InstallDefault="local" TypicalDefault="install" AllowAdvertise="no" Absent="disallow">
             <ComponentRef Id="AGENT_AUTH.EXE" />
             <ComponentRef Id="SYSCOLLECTOR_DLL" />
-            <ComponentRef Id="LIBCJSON_DLL" />
-            <ComponentRef Id="LIBCRYPTO_1_1_DLL" />
-            <ComponentRef Id="ZLIB1_DLL" />
+            <ComponentRef Id="LIBWAZUHEXT_DLL" />
             <ComponentRef Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" />
             <ComponentRef Id="DEFAULT_OSSEC.CONF" />
             <ComponentRef Id="OSSEC.CONF" />


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/583 by merging all the libraries used by Wazuh in a unique shared library called `libwazuhext`.

It has been tested in the following OS:

- [X] Ubuntu 18/16
- [X] CentOS/RHEL 7
- [X] RHEL/CentOS 5
- [X] macOS
- [x] Solaris 11/10
- [x] FreeBSD
- [x] Windows (NSIS)
- [x] Windows (MSI)