### PR TITLE
Increase MAXAGENTS to 40000 and ulimits values

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -35,7 +35,7 @@ analysisd.label_cache_maxage=1
 # Show hidden labels on alerts
 analysisd.show_hidden_labels=0
 # Maximum number of file descriptor that Analysisd can open [1024..2147483647]
-analysisd.rlimit_nofile=16384
+analysisd.rlimit_nofile=131072
 # Minimum output rotate interval. This limits rotation by time and size. [10..86400]
 analysisd.min_rotate_interval=600
 
@@ -93,7 +93,7 @@ remoted.max_attempts=4
 remoted.shared_reload=10
 
 # Maximum number of file descriptor that Remoted can open [1024..2147483647]
-remoted.rlimit_nofile=16384
+remoted.rlimit_nofile=131072
 
 # Maximum time waiting for a client response in TCP (seconds) [1..60]
 remoted.recv_timeout=1

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ ifneq (${TARGET},winagent)
 EXTERNAL_PROCPS=external/procps/
 endif
 LUA_PLAT=posix
-MAXAGENTS?=8000
+MAXAGENTS?=40000
 REUSE_ID?=no
 # XXX Becareful NO EXTRA Spaces here
 PREFIX?=/var/ossec

--- a/src/systemd/wazuh-manager.service
+++ b/src/systemd/wazuh-manager.service
@@ -4,7 +4,7 @@ Description=Wazuh manager
 [Service]
 Type=forking
 EnvironmentFile=/etc/ossec-init.conf
-LimitNOFILE=16384
+LimitNOFILE=131072
 
 ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-control start
 ExecStop=/usr/bin/env ${DIRECTORY}/bin/ossec-control stop


### PR DESCRIPTION
Hello team

to improve the cluster capabilities, it is important to increase the number of agents supported by a manager. In this PR, this limit is changed from 8000 to 40000 agents.

But, in order to support up to 40K agents, it is needed to increase the value of `MAXAGENTS` in the Makefile, and also the _ulimit_ value for `wazuh-manager.service`. Also, in the internal_options.conf file, `analysisd.rlimit_nofile` and `remoted.rlimit_nofile` overwrite the value of `wazuh-manager.service` LimitNOFILE value, so the change is also applied here.

Regards,
Braulio.