### PR TITLE
Fix bug when receiving a connection with a client with a repeated name

### DIFF
--- a/framework/wazuh/cluster/communication.py
+++ b/framework/wazuh/cluster/communication.py
@@ -535,7 +535,7 @@ class Server(asyncore.dispatcher):
         node_id = name
         with self._clients_lock:
             if node_id in self._clients or node_id == handler.server.config['node_name']:
-                raise Exception("Received a connection from a client with a repeated node name '{}'. Rejecting.".format(node_id))
+                raise Exception("Incoming connection from '{0}' rejected: There is already a node with the same ID ('{1}') connected.".format(ip, node_id))
 
             self._clients[node_id] = {
                 'handler': handler,


### PR DESCRIPTION
Hello team,

This PR fixes a bug in the cluster when two nodes share the same name. When the master receives a connection from a node with an already existing name, it must reject the connection, since the name is used as node ID.

https://github.com/wazuh/wazuh/blob/b5933d39a403a735a524bfcee32979b90f70fd1d/framework/wazuh/cluster/communication.py#L537-L538

Best regards,
Marta