### PR TITLE
Fix comparison between agent ID when deleting timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Fix epoch check in vulnerability-detector.
 - Fixed hash sum in logs rotation. ([#636](https://github.com/wazuh/wazuh/issues/636))
 - Fixed cluster CPU usage.
+- Fixed invalid deletion of agent timestamp entries. ([#639](https://github.com/wazuh/wazuh/issues/639))
 - Fixed segmentation fault in logcollector when multi-line is applied to a remote configuration. ([#641](https://github.com/wazuh/wazuh/pull/641))
 
 ### Removed

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -779,9 +779,9 @@ void OS_RemoveAgentTimestamp(const char *id)
     File file;
     char *buffer;
     char line[OS_BUFFER_SIZE];
-    int idlen = strlen(id);
     int pos = 0;
     struct stat fp_stat;
+    char * sep;
 
     fp = fopen(TIMESTAMP_FILE, "r");
 
@@ -797,7 +797,11 @@ void OS_RemoveAgentTimestamp(const char *id)
     os_calloc(fp_stat.st_size + 1, sizeof(char), buffer);
 
     while (fgets(line, OS_BUFFER_SIZE, fp)) {
-        if (strncmp(id, line, idlen)) {
+        if (sep = strchr(line, ' '), sep) {
+            *sep = '\0';
+        }
+        if (strcmp(id, line)) {
+            *sep = ' ';
             strncpy(&buffer[pos], line, fp_stat.st_size - pos);
             pos += strlen(line);
         }


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/629.

When an agent is removed, its corresponding line at the file `agents-timestamp` is also removed.

Looking for that line, the agent ID was being compared by looking for the first digits of the ID, deleting, for example, the timestamp of agents "100, 1000, 1001, 1002, etc." when we were deleting the agent 100.