### PR TITLE
Fix file descriptor leak in Remoted

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2071,5 +2071,6 @@ char ** wreaddir(const char * name) {
 
     files[i] = NULL;
     qsort(files, i, sizeof(char *), qsort_strcmp);
+    closedir(dir);
     return files;
 }


### PR DESCRIPTION
There was a file descriptor leak in Remoted, when it opens the agent group directories to update the merged files it did not close such directory.

This PR simply adds a `closedir()` instruction.