### PR TITLE
Fix defects found by Coverity

### DIFF
--- a/src/os_dbd/config.c
+++ b/src/os_dbd/config.c
@@ -39,6 +39,7 @@ int OS_ReadDBConf(__attribute__((unused)) int test_config, const char *cfgfile, 
 
     /* Read configuration */
     if (ReadConfig(modules, cfgfile, tmp_config, db_config) < 0) {
+        free(tmp_config);
         return (OS_INVALID);
     }
 
@@ -109,4 +110,3 @@ int OS_ReadDBConf(__attribute__((unused)) int test_config, const char *cfgfile, 
 
     return (1);
 }
-

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -231,7 +231,6 @@ void wm_sync_manager() {
     OS_ClearXML(&xml);
 
     if ((os_uname = strdup(getuname()))) {
-        os_arch = (char *) malloc(50);
         os_arch = wm_get_os_arch(os_uname);
         char *ptr;
 


### PR DESCRIPTION
This PR fixes these two defects detected by Coverity:

**CID 1469195:  Resource leaks  (RESOURCE_LEAK)**
```
/os_dbd/config.c: 42 in OS_ReadDBConf()
36         db_config->sock = NULL;
37         db_config->db_type = 0;
38         db_config->maxreconnect = 0;
39     
40         /* Read configuration */
41         if (ReadConfig(modules, cfgfile, tmp_config, db_config) < 0) {
```
>     CID 1469195:  Resource leaks  (RESOURCE_LEAK)
>     Variable "tmp_config" going out of scope leaks the storage it points to.
```
42             return (OS_INVALID);
43         }
44     
45         /* Assign the rules to db_config and free the rest of the Config */
46         db_config->includes = tmp_config->includes;
47         free(tmp_config);
```

**CID 1465836:  Resource leaks  (RESOURCE_LEAK)**
```
/wazuh_modules/wm_database.c: 235 in wm_sync_manager()
229         node_name = OS_GetOneContentforElement(&xml, xml_node);
230     
231         OS_ClearXML(&xml);
232     
233         if ((os_uname = strdup(getuname()))) {
234             os_arch = (char *) malloc(50);
```
>     CID 1465836:  Resource leaks  (RESOURCE_LEAK)
>     Overwriting "os_arch" in "os_arch = wm_get_os_arch(os_uname)" leaks the storage that "os_arch" points to.
```
235             os_arch = wm_get_os_arch(os_uname);
236             char *ptr;
237     
238             if ((ptr = strstr(os_uname, " - ")))
239                 *ptr = '\0';
```