### PR TITLE
CIS-CAT improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
     - Message input buffer in Analysisd to prevent control messages starvation in Remoted.
 - Module to download shared files for agent groups dinamically. ([#519](https://github.com/wazuh/wazuh/pull/519))
     - Added group creation for files.yml if the group does not exist. ([#1010](https://github.com/wazuh/wazuh/pull/1010))
+- Added scheduling options to CIS-CAT integration. ([#586](https://github.com/wazuh/wazuh/pull/586))
 - Option to download the wpk using http in `agent_upgrade`. ([#798](https://github.com/wazuh/wazuh/pull/798))
 - Add `172.0.0.1` as manager IP when creating `global.db`. ([#970](https://github.com/wazuh/wazuh/pull/970))
 - New requests for Syscollector. ([#728](https://github.com/wazuh/wazuh/pull/728))
@@ -43,6 +44,8 @@ All notable changes to this project will be documented in this file.
 - Extracts agent's OS from the database instead of the agent-info.
 - Increases the maximum size of XML parser to 20KB.
 - Extract CVE instead of RHSA codes into vulnerability-detector. ([#549](https://github.com/wazuh/wazuh/pull/549))
+- Store CIS-CAT results into Wazuh DB. ([#568](https://github.com/wazuh/wazuh/pull/568))
+- Add profile information to CIS-CAT reports. ([#658](https://github.com/wazuh/wazuh/pull/658))
 - Merge external libraries into a unique shared library. ([#620](https://github.com/wazuh/wazuh/pull/620))
 - Cluster log rotation: set correct permissions and store rotations in /logs/ossec. ([#667](https://github.com/wazuh/wazuh/pull/667))
 -`Distinct` requests don't allow `limit=0` or `limit>maximun_limit`. ([#1007](https://github.com/wazuh/wazuh/pull/1007))

--- a/etc/rules/0016-wazuh_rules.xml
+++ b/etc/rules/0016-wazuh_rules.xml
@@ -129,6 +129,7 @@
 
   <!-- Ignore syscollector events -->
   <rule id="221" level="0">
+    <category>ossec</category>
     <decoded_as>syscollector</decoded_as>
     <description>Syscollector event.</description>
   </rule>

--- a/etc/rules/0510-ciscat_rules.xml
+++ b/etc/rules/0510-ciscat_rules.xml
@@ -17,6 +17,12 @@
 <group name="ciscat,">
 
   <rule id="87401" level="0">
+    <category>ossec</category>
+    <decoded_as>ciscat</decoded_as>
+    <description>Event decoded by CIS-CAT decoder</description>
+  </rule>
+
+  <rule id="87402" level="0">
     <decoded_as>json</decoded_as>
     <field name="type">\.+</field>
     <field name="scan_id">\.+</field>
@@ -24,7 +30,7 @@
     <description>CIS-CAT events.</description>
   </rule>
 
-  <rule id="87402" level="0">
+  <rule id="87403" level="0">
     <decoded_as>json</decoded_as>
     <field name="type">\.+</field>
     <field name="scan_id">\.+</field>
@@ -32,115 +38,115 @@
     <description>Old CIS-CAT events.</description>
   </rule>
 
-  <rule id="87403" level="3">
-      <if_sid>87401</if_sid>
+  <rule id="87404" level="3">
+      <if_sid>87401, 87402</if_sid>
       <field name="type">^scan_info$</field>
       <description>CIS-CAT: assessment information for scan $(scan_id)</description>
       <group></group>
   </rule>
 
   <!-- Rule to support CIS-CAT rules of Wazuh 3.1 -->
-  <rule id="87404" level="3">
-      <if_sid>87402</if_sid>
+  <rule id="87405" level="3">
+      <if_sid>87403</if_sid>
       <field name="type">^scan_info$</field>
       <description>CIS-CAT: assessment information for scan $(scan_id)</description>
       <group></group>
   </rule>
 
-  <rule id="87405" level="0">
-      <if_sid>87401</if_sid>
+  <rule id="87406" level="0">
+      <if_sid>87401, 87402</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis.result">^pass$</field>
       <description>CIS-CAT: $(cis.rule_title) (passed)</description>
   </rule>
 
-  <rule id="87406" level="0">
-      <if_sid>87402</if_sid>
+  <rule id="87407" level="0">
+      <if_sid>87403</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^pass$</field>
       <description>CIS-CAT: $(cis-data.rule_title) (passed)</description>
   </rule>
 
-  <rule id="87407" level="0">
-      <if_sid>87401</if_sid>
+  <rule id="87408" level="0">
+      <if_sid>87401, 87402</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis.result">^notchecked$</field>
       <description>CIS-CAT: $(cis.rule_title) (not checked)</description>
   </rule>
 
-  <rule id="87408" level="0">
-      <if_sid>87402</if_sid>
+  <rule id="87409" level="0">
+      <if_sid>87403</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^notchecked$</field>
       <description>CIS-CAT: $(cis-data.rule_title) (not checked)</description>
   </rule>
 
-  <rule id="87409" level="0">
-      <if_sid>87401</if_sid>
+  <rule id="87410" level="0">
+      <if_sid>87401, 87402</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis.result">^notselected$</field>
       <description>CIS-CAT: $(cis.rule_title) (not selected)</description>
   </rule>
 
-  <rule id="87410" level="0">
-      <if_sid>87402</if_sid>
+  <rule id="87411" level="0">
+      <if_sid>87403</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^notselected$</field>
       <description>CIS-CAT: $(cis-data.rule_title) (not selected)</description>
   </rule>
 
-  <rule id="87411" level="3">
-      <if_sid>87401</if_sid>
+  <rule id="87412" level="3">
+      <if_sid>87401, 87402</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis.result">^error$</field>
       <description>CIS-CAT: $(cis.rule_title) (error)</description>
   </rule>
 
-  <rule id="87412" level="3">
-      <if_sid>87402</if_sid>
+  <rule id="87413" level="3">
+      <if_sid>87403</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^error$</field>
       <description>CIS-CAT: $(cis-data.rule_title) (error)</description>
   </rule>
 
-  <rule id="87413" level="3">
-      <if_sid>87401</if_sid>
+  <rule id="87414" level="3">
+      <if_sid>87401, 87402</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis.result">^unknown$</field>
       <description>CIS-CAT: $(cis.rule_title) (unknown)</description>
   </rule>
 
-  <rule id="87414" level="3">
-      <if_sid>87402</if_sid>
+  <rule id="87415" level="3">
+      <if_sid>87403</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^unknown$</field>
       <description>CIS-CAT: $(cis-data.rule_title) (unknown)</description>
   </rule>
 
-  <rule id="87415" level="1">
-      <if_sid>87401</if_sid>
+  <rule id="87416" level="1">
+      <if_sid>87401, 87402</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis.result">^informational$</field>
       <description>CIS-CAT: $(cis.rule_title) (informational)</description>
   </rule>
 
-  <rule id="87416" level="1">
-      <if_sid>87402</if_sid>
+  <rule id="87417" level="1">
+      <if_sid>87403</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^informational$</field>
       <description>CIS-CAT: $(cis-data.rule_title) (informational)</description>
   </rule>
 
-  <rule id="87417" level="7">
-      <if_sid>87401</if_sid>
+  <rule id="87418" level="7">
+      <if_sid>87401, 87402</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis.result">^fail$</field>
       <description>CIS-CAT: $(cis.rule_title) (failed)</description>
       <group>gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="87418" level="7">
-      <if_sid>87402</if_sid>
+  <rule id="87419" level="7">
+      <if_sid>87403</if_sid>
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^fail$</field>
       <description>CIS-CAT: $(cis-data.rule_title) (failed)</description>
@@ -151,53 +157,53 @@
 {"type":"scan_info","scan_id":75459013,"cis":{"benchmark":"CIS Ubuntu Linux 16.04 LTS Benchmark","hostname":"ubuntu","timestamp":"2017-12-21T03:16:54.431-08:00","score":76}}
 -->
 
-  <rule id="87419" level="4">
-    <if_sid>87401</if_sid>
+  <rule id="87420" level="4">
+    <if_sid>87401, 87402</if_sid>
     <field name="cis.score">^8\d</field>
     <description>CIS-CAT Report overview: Score less than 90% ($(cis.score))</description>
   </rule>
 
-  <rule id="87420" level="4">
-    <if_sid>87402</if_sid>
+  <rule id="87421" level="4">
+    <if_sid>87403</if_sid>
     <field name="cis-data.score">^8\d</field>
     <description>CIS-CAT Report overview: Score less than 90% ($(cis-data.score) %)</description>
   </rule>
 
-  <rule id="87421" level="5">
-    <if_sid>87401</if_sid>
+  <rule id="87422" level="5">
+    <if_sid>87401, 87402</if_sid>
     <field name="cis.score">^7\d|^6\d|^5\d</field>
     <description>CIS-CAT Report overview: Score less than 80% ($(cis.score))</description>
   </rule>
 
-  <rule id="87422" level="5">
-    <if_sid>87402</if_sid>
+  <rule id="87423" level="5">
+    <if_sid>87403</if_sid>
     <field name="cis-data.score">^7\d|^6\d|^5\d</field>
     <description>CIS-CAT Report overview: Score less than 80% ($(cis-data.score) %)</description>
   </rule>
 
-  <rule id="87423" level="7">
-    <if_sid>87401</if_sid>
+  <rule id="87424" level="7">
+    <if_sid>87401, 87402</if_sid>
     <field name="cis.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis.score))</description>
     <group>gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="87424" level="7">
-    <if_sid>87402</if_sid>
+  <rule id="87425" level="7">
+    <if_sid>87403</if_sid>
     <field name="cis-data.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis-data.score) %)</description>
     <group>gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="87425" level="9">
-    <if_sid>87401</if_sid>
+  <rule id="87426" level="9">
+    <if_sid>87401, 87402</if_sid>
     <field name="cis.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis.score))</description>
     <group>gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="87426" level="9">
-    <if_sid>87402</if_sid>
+  <rule id="87427" level="9">
+    <if_sid>87403</if_sid>
     <field name="cis-data.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis-data.score) %)</description>
     <group>gdpr_IV_35.7.d,</group>

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -53,6 +53,7 @@ int DecodeSyscheck(Eventinfo *lf);
 int DecodeRootcheck(Eventinfo *lf);
 int DecodeHostinfo(Eventinfo *lf);
 int DecodeSyscollector(Eventinfo *lf);
+int DecodeCiscat(Eventinfo *lf);
 
 /* For stats */
 static void DumpLogstats(void);
@@ -567,6 +568,9 @@ void OS_ReadMSG_analysisd(int m_queue)
     /* Initialize Syscollector */
     SyscollectorInit();
 
+    /* Initialize CIS-CAT */
+    CiscatInit();
+
     /* Initialize host info */
     HostinfoInit();
 
@@ -786,7 +790,15 @@ void OS_ReadMSG_analysisd(int m_queue)
             /* Syscollector decoding */
             else if (msg[0] == SYSCOLLECTOR_MQ) {
                 if (!DecodeSyscollector(lf)) {
-                    /* We don't process hostinfo events further */
+                    /* We don't process Syscollector events further */
+                    goto CLMEM;
+                }
+                lf->size = strlen(lf->log);
+            }
+            /* CIS-CAT decoding */
+            else if (msg[0] == CISCAT_MQ) {
+                if (!DecodeCiscat(lf)) {
+                    /* We don't process cis-cat events further */
                     goto CLMEM;
                 }
                 lf->size = strlen(lf->log);
@@ -877,6 +889,7 @@ void OS_ReadMSG_analysisd(int m_queue)
             }
 
             do {
+
                 if (lf->decoder_info->type == OSSEC_ALERT) {
                     if (!lf->generated_rule) {
                         goto CLMEM;

--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -1,0 +1,191 @@
+/*
+* Copyright (C) 2017 Wazuh Inc.
+* April 23, 2018.
+*
+* This program is a free software; you can redistribute it
+* and/or modify it under the terms of the GNU General Public
+* License (version 2) as published by the FSF - Free Software
+* Foundation.
+*/
+
+/* CIS-CAT decoder */
+
+#include "eventinfo.h"
+#include "decoder.h"
+#include "external/cJSON/cJSON.h"
+#include "plugin_decoders.h"
+#include "wazuh_modules/wmodules.h"
+#include "string_op.h"
+
+#define VAR_LENGTH  32
+
+/* Special decoder for CIS-CAT events */
+int DecodeCiscat(Eventinfo *lf)
+{
+    cJSON *logJSON;
+    char *msg_type = NULL;
+
+    // Parsing event.
+    logJSON = cJSON_Parse(lf->log);
+    if (!logJSON) {
+        mdebug1("Error parsing JSON event. %s", cJSON_GetErrorPtr());
+        return -1;
+    }
+
+    // Detect message type
+    msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
+    if (!msg_type) {
+        mdebug1("Invalid message. Type not found.");
+        return -1;
+    }
+
+    if (strcmp(msg_type, "scan_info") == 0) {
+
+        char *msg = NULL;
+        cJSON * cis_data;
+
+        os_calloc(OS_MAXSTR, sizeof(char), msg);
+
+        if (cis_data = cJSON_GetObjectItem(logJSON, "cis"), cis_data) {
+            cJSON * scan_id = cJSON_GetObjectItem(logJSON, "scan_id");
+            cJSON * scan_time = cJSON_GetObjectItem(cis_data, "timestamp");
+            cJSON * benchmark = cJSON_GetObjectItem(cis_data, "benchmark");
+            cJSON * pass = cJSON_GetObjectItem(cis_data, "pass");
+            cJSON * fail = cJSON_GetObjectItem(cis_data, "fail");
+            cJSON * error = cJSON_GetObjectItem(cis_data, "error");
+            cJSON * notchecked = cJSON_GetObjectItem(cis_data, "notchecked");
+            cJSON * unknown = cJSON_GetObjectItem(cis_data, "unknown");
+            cJSON * score = cJSON_GetObjectItem(cis_data, "score");
+
+            snprintf(msg, OS_MAXSTR - 1, "agent %s ciscat save", lf->agent_id);
+
+            if (scan_id) {
+                char id[OS_MAXSTR];
+                snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
+                wm_strcat(&msg, id, ' ');
+            } else {
+                wm_strcat(&msg, "NULL", ' ');
+            }
+
+            if (scan_time) {
+                wm_strcat(&msg, scan_time->valuestring, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (benchmark) {
+                wm_strcat(&msg, benchmark->valuestring, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (pass) {
+                char _pass[VAR_LENGTH];
+                snprintf(_pass, VAR_LENGTH - 1, "%d", pass->valueint);
+                wm_strcat(&msg, _pass, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (fail) {
+                char _fail[VAR_LENGTH];
+                snprintf(_fail, VAR_LENGTH - 1, "%d", fail->valueint);
+                wm_strcat(&msg, _fail, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (error) {
+                char _error[VAR_LENGTH];
+                snprintf(_error, VAR_LENGTH - 1, "%d", error->valueint);
+                wm_strcat(&msg, _error, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (notchecked) {
+                char _notchecked[VAR_LENGTH];
+                snprintf(_notchecked, VAR_LENGTH - 1, "%d", notchecked->valueint);
+                wm_strcat(&msg, _notchecked, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (unknown) {
+                char _unknown[VAR_LENGTH];
+                snprintf(_unknown, VAR_LENGTH - 1, "%d", unknown->valueint);
+                wm_strcat(&msg, _unknown, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (score) {
+                char *endptr;
+                char _score[VAR_LENGTH];
+                int score_i = strtoul(score->valuestring, &endptr, 10);
+                snprintf(_score, VAR_LENGTH - 1, "%d", score_i);
+                wm_strcat(&msg, _score, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (sc_send_db(msg) < 0) {
+                return -1;
+            }
+
+        } else if (cis_data = cJSON_GetObjectItem(logJSON, "cis-data"), cis_data) {
+            cJSON * scan_id = cJSON_GetObjectItem(logJSON, "scan_id");
+            cJSON * scan_time = cJSON_GetObjectItem(cis_data, "timestamp");
+            cJSON * benchmark = cJSON_GetObjectItem(cis_data, "benchmark");
+            cJSON * score = cJSON_GetObjectItem(cis_data, "score");
+
+            snprintf(msg, OS_MAXSTR - 1, "agent %s ciscat save", lf->agent_id);
+
+            if (scan_id) {
+                char id[OS_MAXSTR];
+                snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
+                wm_strcat(&msg, id, ' ');
+            } else {
+                wm_strcat(&msg, "NULL", ' ');
+            }
+
+            if (scan_time) {
+                wm_strcat(&msg, scan_time->valuestring, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (benchmark) {
+                wm_strcat(&msg, benchmark->valuestring, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            for (int i = 0; i<5; i++) {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (score) {
+                char _score[VAR_LENGTH];
+                snprintf(_score, VAR_LENGTH - 1, "%d", score->valueint);
+                wm_strcat(&msg, _score, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (sc_send_db(msg) < 0) {
+                return -1;
+            }
+        } else {
+            mdebug1("Unable to parse CIS-CAT event for agent '%s'", lf->agent_id);
+            return -1;
+        }
+    }
+    else {
+        mdebug1("Invalid message type: %s.", msg_type);
+        return -1;
+    }
+
+    cJSON_Delete (logJSON);
+    return 0;
+}

--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -71,6 +71,7 @@ int DecodeCiscat(Eventinfo *lf)
     msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
     if (!msg_type) {
         mdebug1("Invalid message. Type not found.");
+        cJSON_Delete(logJSON);
         return (0);
     }
 
@@ -172,10 +173,12 @@ int DecodeCiscat(Eventinfo *lf)
             }
 
             if (sc_send_db(msg) < 0) {
+                cJSON_Delete(logJSON);
                 return (0);
             }
         } else {
             mdebug1("Unable to parse CIS-CAT event for agent '%s'", lf->agent_id);
+            cJSON_Delete(logJSON);
             return (0);
         }
     }

--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -167,50 +167,6 @@ int DecodeCiscat(Eventinfo *lf)
             if (sc_send_db(msg) < 0) {
                 return (0);
             }
-
-        } else if (cis_data = cJSON_GetObjectItem(logJSON, "cis-data"), cis_data) {
-            cJSON * scan_id = cJSON_GetObjectItem(logJSON, "scan_id");
-            cJSON * scan_time = cJSON_GetObjectItem(cis_data, "timestamp");
-            cJSON * benchmark = cJSON_GetObjectItem(cis_data, "benchmark");
-            cJSON * score = cJSON_GetObjectItem(cis_data, "score");
-
-            snprintf(msg, OS_MAXSTR - 1, "agent %s ciscat save", lf->agent_id);
-
-            if (scan_id) {
-                char id[OS_MAXSTR];
-                snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
-                wm_strcat(&msg, id, ' ');
-            } else {
-                wm_strcat(&msg, "NULL", ' ');
-            }
-
-            if (scan_time) {
-                wm_strcat(&msg, scan_time->valuestring, '|');
-            } else {
-                wm_strcat(&msg, "NULL", '|');
-            }
-
-            if (benchmark) {
-                wm_strcat(&msg, benchmark->valuestring, '|');
-            } else {
-                wm_strcat(&msg, "NULL", '|');
-            }
-
-            for (int i = 0; i<5; i++) {
-                wm_strcat(&msg, "NULL", '|');
-            }
-
-            if (score) {
-                char _score[VAR_LENGTH];
-                snprintf(_score, VAR_LENGTH - 1, "%d", score->valueint);
-                wm_strcat(&msg, _score, '|');
-            } else {
-                wm_strcat(&msg, "NULL", '|');
-            }
-
-            if (sc_send_db(msg) < 0) {
-                return (0);
-            }
         } else {
             mdebug1("Unable to parse CIS-CAT event for agent '%s'", lf->agent_id);
             return (0);

--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -85,6 +85,7 @@ int DecodeCiscat(Eventinfo *lf)
             cJSON * scan_id = cJSON_GetObjectItem(logJSON, "scan_id");
             cJSON * scan_time = cJSON_GetObjectItem(cis_data, "timestamp");
             cJSON * benchmark = cJSON_GetObjectItem(cis_data, "benchmark");
+            cJSON * profile = cJSON_GetObjectItem(cis_data, "profile");
             cJSON * pass = cJSON_GetObjectItem(cis_data, "pass");
             cJSON * fail = cJSON_GetObjectItem(cis_data, "fail");
             cJSON * error = cJSON_GetObjectItem(cis_data, "error");
@@ -110,6 +111,12 @@ int DecodeCiscat(Eventinfo *lf)
 
             if (benchmark) {
                 wm_strcat(&msg, benchmark->valuestring, '|');
+            } else {
+                wm_strcat(&msg, "NULL", '|');
+            }
+
+            if (profile) {
+                wm_strcat(&msg, profile->valuestring, '|');
             } else {
                 wm_strcat(&msg, "NULL", '|');
             }

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -780,6 +780,7 @@ int SetDecodeXML()
     addDecoder2list(HOSTINFO_NEW);
     addDecoder2list(HOSTINFO_MOD);
     addDecoder2list(SYSCOLLECTOR_MOD);
+    addDecoder2list(CISCAT_MOD);
 
     /* Set ids - for our two lists */
     if (!os_setdecoderids(NULL)) {

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -73,6 +73,7 @@ void HostinfoInit(void);
 void SyscheckInit(void);
 void RootcheckInit(void);
 void SyscollectorInit(void);
+int sc_send_db(char * msg);
 
 int ReadDecodeXML(const char *file);
 

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -73,6 +73,7 @@ void HostinfoInit(void);
 void SyscheckInit(void);
 void RootcheckInit(void);
 void SyscollectorInit(void);
+void CiscatInit(void);
 int sc_send_db(char * msg);
 
 int ReadDecodeXML(const char *file);

--- a/src/analysisd/decoders/plugin_decoders.h
+++ b/src/analysisd/decoders/plugin_decoders.h
@@ -12,6 +12,9 @@
 
 #include "eventinfo.h"
 
+/* Decoder for Cis-cat events */
+int DecodeCiscat(Eventinfo *lf);
+
 /* Plugin decoder for OpenBSD PF */
 void *PF_Decoder_Init(void);
 void *PF_Decoder_Exec(Eventinfo *lf);

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -9,7 +9,6 @@
 */
 
 #include "../plugin_decoders.h"
-#include "../decoder.h"
 
 #include "shared.h"
 #include "eventinfo.h"
@@ -196,10 +195,6 @@ static void fillData(Eventinfo *lf, const char *key, const char *value)
     lf->fields[lf->nfields].value = strdup(value);
     lf->nfields++;
 
-    // If is a CIS-CAT event, save information into the agent DB
-    if (!strcmp(lf->location, "wodle_cis-cat") && !strcmp(key, "type") && !strcmp(value, "scan_info")) {
-        DecodeCiscat(lf);
-    }
 }
 
 static void readJSON (cJSON *logJSON, char *parent, Eventinfo *lf)

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -195,6 +195,11 @@ static void fillData(Eventinfo *lf, const char *key, const char *value)
     lf->fields[lf->nfields].key = strdup(key);
     lf->fields[lf->nfields].value = strdup(value);
     lf->nfields++;
+
+    // If is a CIS-CAT event, save information into the agent DB
+    if (!strcmp(lf->location, "wodle_cis-cat") && !strcmp(key, "type") && !strcmp(value, "scan_info")) {
+        DecodeCiscat(lf);
+    }
 }
 
 static void readJSON (cJSON *logJSON, char *parent, Eventinfo *lf)

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -28,7 +28,6 @@ static int prev_port_id = 0;
 static int error_process = 0;
 static int prev_process_id = 0;
 
-static int sc_send_db(char * msg);
 static int decode_netinfo(char *agent_id, cJSON * logJSON);
 static int decode_osinfo(char *agent_id, cJSON * logJSON);
 static int decode_hardware(char *agent_id, cJSON * logJSON);

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -247,6 +247,7 @@ int _setlevels(RuleNode *node, int nnode);
 #define SYSCHECK_NEW        "syscheck_new_entry"
 #define SYSCHECK_DEL        "syscheck_deleted"
 #define SYSCOLLECTOR_MOD    "syscollector"
+#define CISCAT_MOD          "ciscat"
 
 /* Global variables */
 extern int _max_freq;

--- a/src/config/wmodules-ciscat.c
+++ b/src/config/wmodules-ciscat.c
@@ -18,6 +18,9 @@ static const char *XML_OVAL = "oval";
 static const char *XML_PATH = "path";
 static const char *XML_TIMEOUT = "timeout";
 static const char *XML_INTERVAL = "interval";
+static const char *XML_SCAN_DAY = "day";
+static const char *XML_SCAN_WDAY = "wday";
+static const char *XML_SCAN_TIME = "time";
 static const char *XML_SCAN_ON_START = "scan-on-start";
 static const char *XML_PROFILE = "profile";
 static const char *XML_JAVA_PATH = "java_path";
@@ -33,6 +36,7 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
     xml_node **children = NULL;
     wm_ciscat *ciscat;
     wm_ciscat_eval *cur_eval = NULL;
+    int month_interval = 0;
 
 
     // Create module
@@ -40,6 +44,8 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
     os_calloc(1, sizeof(wm_ciscat), ciscat);
     ciscat->flags.enabled = 1;
     ciscat->flags.scan_on_start = 1;
+    ciscat->scan_wday = -1;
+    ciscat->scan_time = NULL;
     module->context = &WM_CISCAT_CONTEXT;
     module->data = ciscat;
 
@@ -158,6 +164,13 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             }
 
             switch (*endptr) {
+            case 'M':
+                month_interval = 1;
+                ciscat->interval *= 60; // We can`t calculate seconds of a month
+                break;
+            case 'w':
+                ciscat->interval *= 604800;
+                break;
             case 'd':
                 ciscat->interval *= 86400;
                 break;
@@ -178,6 +191,29 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             if (ciscat->interval < 60) {
                 merror("At module '%s': Interval must be greater than 60 seconds.", WM_CISCAT_CONTEXT.name);
                 return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_SCAN_DAY)) {
+            if (!OS_StrIsNum(nodes[i]->content)) {
+                merror(XML_VALUEERR, nodes[i]->element, nodes[i]->content);
+                return (OS_INVALID);
+            } else {
+                ciscat->scan_day = atoi(nodes[i]->content);
+                if (ciscat->scan_day < 1 || ciscat->scan_day > 31) {
+                    merror(XML_VALUEERR, nodes[i]->element, nodes[i]->content);
+                    return (OS_INVALID);
+                }
+            }
+        } else if (!strcmp(nodes[i]->element, XML_SCAN_WDAY)) {
+            ciscat->scan_wday = w_validate_wday(nodes[i]->content);
+            if (ciscat->scan_wday < 0 || ciscat->scan_wday > 6) {
+                merror(XML_VALUEERR, nodes[i]->element, nodes[i]->content);
+                return (OS_INVALID);
+            }
+        } else if (!strcmp(nodes[i]->element, XML_SCAN_TIME)) {
+            ciscat->scan_time = w_validate_time(nodes[i]->content);
+            if (!ciscat->scan_time) {
+                merror(XML_VALUEERR, nodes[i]->element, nodes[i]->content);
+                return (OS_INVALID);
             }
         } else if (!strcmp(nodes[i]->element, XML_SCAN_ON_START)) {
             if (!strcmp(nodes[i]->content, "yes"))
@@ -207,6 +243,33 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         }
     }
 
+    // Validate scheduled scan parameters and interval value
+
+    if (ciscat->scan_day && (ciscat->scan_wday >= 0)) {
+        merror("At module '%s': 'day' is not compatible with 'wday'.", WM_CISCAT_CONTEXT.name);
+        return OS_INVALID;
+    } else if (ciscat->scan_day) {
+        if (!month_interval) {
+            mwarn("At module '%s': Interval must be a multiple of one month. New interval value: 1M.", WM_CISCAT_CONTEXT.name);
+            ciscat->interval = 60; // 1 month
+        }
+        if (!ciscat->scan_time)
+            ciscat->scan_time = strdup("00:00");
+    } else if (ciscat->scan_wday >= 0) {
+        if (w_validate_interval(ciscat->interval, 1) != 0) {
+            ciscat->interval = 604800;  // 1 week
+            mwarn("At module '%s': Interval must be a multiple of one week. New interval value: 1w.", WM_CISCAT_CONTEXT.name);
+        }
+        if (ciscat->interval == 0)
+            ciscat->interval = 604800;
+        if (!ciscat->scan_time)
+            ciscat->scan_time = strdup("00:00");
+    } else if (ciscat->scan_time) {
+        if (w_validate_interval(ciscat->interval, 0) != 0) {
+            ciscat->interval = WM_DEF_INTERVAL;  // 1 day
+            mwarn("At module '%s': Interval must be a multiple of one day. New interval value: 1d.", WM_CISCAT_CONTEXT.name);
+        }
+    }
     if (!ciscat->interval)
         ciscat->interval = WM_DEF_INTERVAL;
 

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -175,9 +175,6 @@ https://www.gnu.org/licenses/gpl.html\n"
 /* Rootcheck directory */
 #define ROOTCHECK_DIR    "/queue/rootcheck"
 
-/* Syscollector directory */
-#define SYSCOLLECTOR_DIR    "/queue/syscollector"
-
 /* Backup directory for agents */
 #define AGNBACKUP_DIR    "/backup/agents"
 

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -26,6 +26,7 @@
 #define POSTGRESQL_MQ    'b'
 #define AUTH_MQ          'c'
 #define SYSCOLLECTOR_MQ  'd'
+#define CISCAT_MQ        'e'
 
 extern int sock_fail_time;
 

--- a/src/headers/validate_op.h
+++ b/src/headers/validate_op.h
@@ -85,6 +85,17 @@ char *OS_IsValidDay(const char *day_str);
 // Convert a CIDR into string: aaa.bbb.ccc.ddd[/ee]
 int OS_CIDRtoStr(const os_ip * ip, char * string, size_t size);
 
+/* Validate the day of the week set and retrieve its corresponding integer value.
+   If not found, -1 is returned.
+*/
+int w_validate_wday(const char * day_str);
+
+// Acceptable format: hh:mm (24 hour format)
+char * w_validate_time(const char * time_str);
+
+// Validate if the specified interval is multiple of weeks or days
+int w_validate_interval(int interval, int force);
+
 /* Macros */
 
 /* Check if the IP is a single host, not a network with a netmask */

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -802,7 +802,6 @@ int w_validate_wday(const char * day_str) {
 
     /* Must be a valid string */
     if (!day_str) {
-        merror(INVALID_DAY, day_str);
         return -1;
     }
 
@@ -828,7 +827,6 @@ char * w_validate_time(const char * time_str) {
     char * ret_time = NULL;
 
     if (!time_str) {
-        merror(INVALID_TIME, time_str);
         return NULL;
     }
 
@@ -860,7 +858,7 @@ char * w_validate_time(const char * time_str) {
 // Validate if the specified interval is multiple of weeks or days
 int w_validate_interval(int interval, int force) {
 
-    int ret;
+    int ret = -1;
 
     switch(force) {
         case 0:     // Force to be a multiple of a day

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -562,6 +562,7 @@ char *OS_IsValidTime(const char *time_str)
 
     /* Get first hour */
     time_str = __gethour(time_str, first_hour);
+
     if (!time_str) {
         return (NULL);
     }
@@ -599,6 +600,7 @@ char *OS_IsValidTime(const char *time_str)
 
     /* For the normal times */
     snprintf(ret, 12, "%c%s%s", ng == 0 ? '.' : '!', first_hour, second_hour);
+
     return (ret);
 }
 
@@ -780,4 +782,96 @@ int OS_CIDRtoStr(const os_ip * ip, char * string, size_t size) {
         string[size - 1] = '\0';
         return 0;
     }
+}
+
+/* Validate the day of the week set and retrieve its corresponding integer value.
+   If not found, -1 is returned.
+*/
+
+int w_validate_wday(const char * day_str) {
+
+    int i = 0;
+
+    const char *(days[]) = {
+        "sunday", "sun", "monday", "mon", "tuesday", "tue",
+        "wednesday", "wed", "thursday", "thu", "friday",
+        "fri", "saturday", "sat", NULL
+    };
+
+    int days_int[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6};
+
+    /* Must be a valid string */
+    if (!day_str) {
+        merror(INVALID_DAY, day_str);
+        return -1;
+    }
+
+    // Remove spaces
+    RM_WHITE(day_str);
+
+    while((days[i] != NULL)) {
+        if (strncasecmp(day_str, days[i], strlen(days[i])) == 0) {
+            return days_int[i];
+        }
+        i++;
+    }
+
+    merror(INVALID_DAY, day_str);
+    return -1;
+
+}
+
+// Acceptable format: hh:mm (24 hour format)
+char * w_validate_time(const char * time_str) {
+
+    int hour, min;
+    char * ret_time = NULL;
+
+    if (!time_str) {
+        merror(INVALID_TIME, time_str);
+        return NULL;
+    }
+
+    /* Remove spaces */
+    RM_WHITE(time_str);
+
+    if (!strchr(time_str, ':')) {
+        merror(INVALID_TIME, time_str);
+        return NULL;
+    }
+
+    if (sscanf(time_str, "%d:%d", &hour, &min) < 0) {
+        merror(INVALID_TIME, time_str);
+        return NULL;
+    } else {
+        if ((hour < 0 || hour >= 24) || (min < 0 || min >= 60)) {
+            merror(INVALID_TIME, time_str);
+            return NULL;
+        }
+    }
+
+    os_calloc(12, sizeof(char), ret_time);
+    snprintf(ret_time, 12, "%02d:%02d", hour, min);
+
+    return ret_time;
+
+}
+
+// Validate if the specified interval is multiple of weeks or days
+int w_validate_interval(int interval, int force) {
+
+    int ret;
+
+    switch(force) {
+        case 0:     // Force to be a multiple of a day
+            ret = interval % 86400;
+            break;
+        case 1:     // Force to be a multiple of a week
+            ret = interval % 604800;
+            break;
+        default:
+            merror("At validate_interval(): internal error.");
+    }
+
+    return ret;
 }

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -226,6 +226,7 @@ CREATE TABLE IF NOT EXISTS ciscat_results (
     scan_id INTEGER,
     scan_time TEXT,
     benchmark TEXT,
+    profile TEXT,
     pass INTEGER,
     fail INTEGER,
     error INTEGER,

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -234,6 +234,8 @@ CREATE TABLE IF NOT EXISTS ciscat_results (
     score INTEGER
 );
 
+CREATE INDEX IF NOT EXISTS ciscat_id ON ciscat_results (scan_id);
+
 CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
     value TEXT

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -221,6 +221,19 @@ CREATE TABLE IF NOT EXISTS sys_processes (
 
 CREATE INDEX IF NOT EXISTS processes_id ON sys_processes (scan_id);
 
+CREATE TABLE IF NOT EXISTS ciscat_results (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    scan_id INTEGER,
+    scan_time TEXT,
+    benchmark TEXT,
+    pass INTEGER,
+    fail INTEGER,
+    error INTEGER,
+    notchecked INTEGER,
+    unknown INTEGER,
+    score INTEGER
+);
+
 CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
     value TEXT

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -46,7 +46,7 @@ static const char * SQL_STMT[] = {
     "DELETE FROM sys_netiface WHERE scan_id != ?;",
     "DELETE FROM sys_netproto WHERE scan_id != ?;",
     "DELETE FROM sys_netaddr WHERE scan_id != ?;",
-    "INSERT INTO ciscat_results (scan_id, scan_time, benchmark, pass, fail, error, notchecked, unknown, score) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);",
+    "INSERT INTO ciscat_results (scan_id, scan_time, benchmark, profile, pass, fail, error, notchecked, unknown, score) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     "DELETE FROM ciscat_results WHERE scan_id != ?;"
 };
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -45,7 +45,8 @@ static const char * SQL_STMT[] = {
     "INSERT INTO sys_netaddr (id, scan_id, proto, address, netmask, broadcast) VALUES (?, ?, ?, ?, ?, ?);",
     "DELETE FROM sys_netiface WHERE scan_id != ?;",
     "DELETE FROM sys_netproto WHERE scan_id != ?;",
-    "DELETE FROM sys_netaddr WHERE scan_id != ?;"
+    "DELETE FROM sys_netaddr WHERE scan_id != ?;",
+    "INSERT INTO ciscat_results (scan_id, scan_time, benchmark, pass, fail, error, notchecked, unknown, score) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"
 };
 
 sqlite3 *wdb_global = NULL;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -46,7 +46,8 @@ static const char * SQL_STMT[] = {
     "DELETE FROM sys_netiface WHERE scan_id != ?;",
     "DELETE FROM sys_netproto WHERE scan_id != ?;",
     "DELETE FROM sys_netaddr WHERE scan_id != ?;",
-    "INSERT INTO ciscat_results (scan_id, scan_time, benchmark, pass, fail, error, notchecked, unknown, score) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"
+    "INSERT INTO ciscat_results (scan_id, scan_time, benchmark, pass, fail, error, notchecked, unknown, score) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);",
+    "DELETE FROM ciscat_results WHERE scan_id != ?;"
 };
 
 sqlite3 *wdb_global = NULL;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -61,6 +61,7 @@ typedef enum wdb_stmt {
     WDB_STMT_PROTO_DEL,
     WDB_STMT_ADDR_DEL,
     WDB_STMT_CISCAT_INSERT,
+    WDB_STMT_CISCAT_DEL,
     WDB_STMT_SIZE
 } wdb_stmt;
 
@@ -296,6 +297,9 @@ int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, c
 
 // Insert CIS-CAT results tuple. Return 0 on success or -1 on error.
 int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score);
+
+// Delete old information from the 'ciscat_results' table
+int wdb_ciscat_del(wdb_t * wdb, const char * scan_id);
 
 wdb_t * wdb_init(sqlite3 * db, const char * agent_id);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -36,7 +36,6 @@
 #define WDB_ROOTCHECK 2
 #define WDB_AGENTINFO 3
 #define WDB_GROUPS 4
-#define WDB_SYSCOLLECTOR 5
 #define WDB_NETADDR_IPV4 0
 
 typedef enum wdb_stmt {
@@ -61,6 +60,7 @@ typedef enum wdb_stmt {
     WDB_STMT_NETINFO_DEL,
     WDB_STMT_PROTO_DEL,
     WDB_STMT_ADDR_DEL,
+    WDB_STMT_CISCAT_INSERT,
     WDB_STMT_SIZE
 } wdb_stmt;
 
@@ -291,6 +291,12 @@ int wdb_port_save(wdb_t * wdb, const char * scan_id, const char * scan_time, con
 // Delete port info about previous scan from DB.
 int wdb_port_delete(wdb_t * wdb, const char * scan_id);
 
+// Save CIS-CAT scan results.
+int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score);
+
+// Insert CIS-CAT results tuple. Return 0 on success or -1 on error.
+int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score);
+
 wdb_t * wdb_init(sqlite3 * db, const char * agent_id);
 
 void wdb_destroy(wdb_t * wdb);
@@ -334,5 +340,7 @@ int wdb_parse_packages(wdb_t * wdb, char * input, char * output);
 int wdb_parse_ports(wdb_t * wdb, char * input, char * output);
 
 int wdb_parse_processes(wdb_t * wdb, char * input, char * output);
+
+int wdb_parse_ciscat(wdb_t * wdb, char * input, char * output);
 
 #endif

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -293,10 +293,10 @@ int wdb_port_save(wdb_t * wdb, const char * scan_id, const char * scan_time, con
 int wdb_port_delete(wdb_t * wdb, const char * scan_id);
 
 // Save CIS-CAT scan results.
-int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score);
+int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, const char * profile, int pass, int fail, int error, int notchecked, int unknown, int score);
 
 // Insert CIS-CAT results tuple. Return 0 on success or -1 on error.
-int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score);
+int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, const char * profile, int pass, int fail, int error, int notchecked, int unknown, int score);
 
 // Delete old information from the 'ciscat_results' table
 int wdb_ciscat_del(wdb_t * wdb, const char * scan_id);

--- a/src/wazuh_db/wdb_ciscat.c
+++ b/src/wazuh_db/wdb_ciscat.c
@@ -1,0 +1,90 @@
+/*
+ * Wazuh SQLite integration
+ * Copyright (C) 2017 Wazuh Inc.
+ * April 23, 2018.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wdb.h"
+
+// Save CIS-CAT scan results.
+int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score) {
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0){
+        merror("at wdb_ciscat_save(): cannot begin transaction");
+        return -1;
+    }
+
+    if (wdb_ciscat_insert(wdb,
+        scan_id,
+        scan_time,
+        benchmark,
+        pass,
+        fail,
+        error,
+        notchecked,
+        unknown,
+        score) < 0) {
+
+        return -1;
+    }
+
+    return 0;
+}
+
+// Insert CIS-CAT results tuple. Return 0 on success or -1 on error.
+int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score) {
+    sqlite3_stmt *stmt = NULL;
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_CISCAT_INSERT) > 0) {
+        merror("at wdb_ciscat_insert(): cannot cache statement");
+        return -1;
+    }
+
+    stmt = wdb->stmt[WDB_STMT_CISCAT_INSERT];
+
+    sqlite3_bind_text(stmt, 1, scan_id, -1, NULL);
+    sqlite3_bind_text(stmt, 2, scan_time, -1, NULL);
+    sqlite3_bind_text(stmt, 3, benchmark, -1, NULL);
+    if (pass >= 0)
+        sqlite3_bind_int(stmt, 4, pass);
+    else
+        sqlite3_bind_null(stmt, 4);
+
+    if (fail >= 0)
+        sqlite3_bind_int(stmt, 5, fail);
+    else
+        sqlite3_bind_null(stmt, 5);
+
+    if (error >= 0)
+        sqlite3_bind_int(stmt, 6, error);
+    else
+        sqlite3_bind_null(stmt, 6);
+
+    if (notchecked >= 0)
+        sqlite3_bind_int(stmt, 7, notchecked);
+    else
+        sqlite3_bind_null(stmt, 7);
+
+    if (unknown >= 0)
+        sqlite3_bind_int(stmt, 8, unknown);
+    else
+        sqlite3_bind_null(stmt, 8);
+
+    if (score >= 0)
+        sqlite3_bind_int(stmt, 9, score);
+    else
+        sqlite3_bind_null(stmt, 9);
+
+    if (sqlite3_step(stmt) == SQLITE_DONE){
+        return 0;
+    }
+    else {
+        merror("at wdb_ciscat_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        return -1;
+    }
+}

--- a/src/wazuh_db/wdb_ciscat.c
+++ b/src/wazuh_db/wdb_ciscat.c
@@ -12,7 +12,7 @@
 #include "wdb.h"
 
 // Save CIS-CAT scan results.
-int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score) {
+int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, const char * profile, int pass, int fail, int error, int notchecked, int unknown, int score) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
         merror("at wdb_ciscat_save(): cannot begin transaction");
@@ -23,6 +23,7 @@ int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, c
         scan_id,
         scan_time,
         benchmark,
+        profile,
         pass,
         fail,
         error,
@@ -37,7 +38,7 @@ int wdb_ciscat_save(wdb_t * wdb, const char * scan_id, const char * scan_time, c
 }
 
 // Insert CIS-CAT results tuple. Return 0 on success or -1 on error.
-int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, int pass, int fail, int error, int notchecked, int unknown, int score) {
+int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * benchmark, const char * profile, int pass, int fail, int error, int notchecked, int unknown, int score) {
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_CISCAT_INSERT) < 0) {
@@ -50,35 +51,36 @@ int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time,
     sqlite3_bind_text(stmt, 1, scan_id, -1, NULL);
     sqlite3_bind_text(stmt, 2, scan_time, -1, NULL);
     sqlite3_bind_text(stmt, 3, benchmark, -1, NULL);
+    sqlite3_bind_text(stmt, 4, profile, -1, NULL);
     if (pass >= 0)
-        sqlite3_bind_int(stmt, 4, pass);
-    else
-        sqlite3_bind_null(stmt, 4);
-
-    if (fail >= 0)
-        sqlite3_bind_int(stmt, 5, fail);
+        sqlite3_bind_int(stmt, 5, pass);
     else
         sqlite3_bind_null(stmt, 5);
 
-    if (error >= 0)
-        sqlite3_bind_int(stmt, 6, error);
+    if (fail >= 0)
+        sqlite3_bind_int(stmt, 6, fail);
     else
         sqlite3_bind_null(stmt, 6);
 
-    if (notchecked >= 0)
-        sqlite3_bind_int(stmt, 7, notchecked);
+    if (error >= 0)
+        sqlite3_bind_int(stmt, 7, error);
     else
         sqlite3_bind_null(stmt, 7);
 
-    if (unknown >= 0)
-        sqlite3_bind_int(stmt, 8, unknown);
+    if (notchecked >= 0)
+        sqlite3_bind_int(stmt, 8, notchecked);
     else
         sqlite3_bind_null(stmt, 8);
 
-    if (score >= 0)
-        sqlite3_bind_int(stmt, 9, score);
+    if (unknown >= 0)
+        sqlite3_bind_int(stmt, 9, unknown);
     else
         sqlite3_bind_null(stmt, 9);
+
+    if (score >= 0)
+        sqlite3_bind_int(stmt, 10, score);
+    else
+        sqlite3_bind_null(stmt, 10);
 
     if (sqlite3_step(stmt) == SQLITE_DONE){
         if (wdb_ciscat_del(wdb, scan_id) < 0) {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2228,6 +2228,7 @@ int wdb_parse_ciscat(wdb_t * wdb, char * input, char * output) {
     char * scan_id;
     char * scan_time;
     char * benchmark;
+    char * profile;
     int pass, fail, error, notchecked, unknown, score;
     int result;
 
@@ -2290,6 +2291,20 @@ int wdb_parse_ciscat(wdb_t * wdb, char * input, char * output) {
             mdebug1("Invalid CISCAT query syntax.");
             mdebug2("CISCAT query: %s", benchmark);
             snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", benchmark);
+            return -1;
+        }
+
+        profile = curr;
+        *next++ = '\0';
+        curr = next;
+
+        if (!strcmp(profile, "NULL"))
+            profile = NULL;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %s", profile);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", profile);
             return -1;
         }
 
@@ -2364,7 +2379,7 @@ int wdb_parse_ciscat(wdb_t * wdb, char * input, char * output) {
         else
             score = strtol(next,NULL,10);
 
-        if (result = wdb_ciscat_save(wdb, scan_id, scan_time, benchmark, pass, fail, error, notchecked, unknown, score), result < 0) {
+        if (result = wdb_ciscat_save(wdb, scan_id, scan_time, benchmark, profile, pass, fail, error, notchecked, unknown, score), result < 0) {
             mdebug1("Cannot save CISCAT information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save CISCAT information.");
         } else {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -191,6 +191,19 @@ int wdb_parse(char * input, char * output) {
                     merror("Unable to update 'sys_processes' table for agent '%s'", sagent_id);
                 }
             }
+        } else if (strcmp(query, "ciscat") == 0) {
+            if (!next) {
+                mdebug1("Invalid DB query syntax.");
+                mdebug2("DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = -1;
+            } else {
+                if (wdb_parse_ciscat(wdb, next, output) == 0){
+                    mdebug2("Updated 'ciscat_results' table for agent '%s'", sagent_id);
+                } else {
+                    merror("Unable to update 'ciscat_results' table for agent '%s'", sagent_id);
+                }
+            }
         } else if (strcmp(query, "sql") == 0) {
             if (!next) {
                 mdebug1("Invalid DB query syntax.");
@@ -2205,6 +2218,164 @@ int wdb_parse_processes(wdb_t * wdb, char * input, char * output) {
         mdebug1("Invalid Process query syntax.");
         mdebug2("DB query error near: %s", curr);
         snprintf(output, OS_MAXSTR + 1, "err Invalid Process query syntax, near '%.32s'", curr);
+        return -1;
+    }
+}
+
+int wdb_parse_ciscat(wdb_t * wdb, char * input, char * output) {
+    char * curr;
+    char * next;
+    char * scan_id;
+    char * scan_time;
+    char * benchmark;
+    int pass, fail, error, notchecked, unknown, score;
+    int result;
+
+    if (next = strchr(input, ' '), !next) {
+        mdebug1("Invalid CISCAT query syntax.");
+        mdebug2("CISCAT query: %s", input);
+        snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", input);
+        return -1;
+    }
+
+    curr = input;
+    *next++ = '\0';
+
+    if (strcmp(curr, "save") == 0) {
+        curr = next;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %s", curr);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+        scan_id = curr;
+        *next++ = '\0';
+        curr = next;
+
+        if (!strcmp(scan_id, "NULL"))
+            scan_id = NULL;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %s", curr);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+        scan_time = curr;
+        *next++ = '\0';
+        curr = next;
+
+        if (!strcmp(scan_time, "NULL"))
+            scan_time = NULL;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %s", scan_time);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", scan_time);
+            return -1;
+        }
+
+        benchmark = curr;
+        *next++ = '\0';
+        curr = next;
+
+        if (!strcmp(benchmark, "NULL"))
+            benchmark = NULL;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %s", benchmark);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", benchmark);
+            return -1;
+        }
+
+        if (!strncmp(curr, "NULL", 4))
+            pass = -1;
+        else
+            pass = strtol(curr,NULL,10);
+
+        *next++ = '\0';
+        curr = next;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %d", pass);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+        if (!strncmp(curr, "NULL", 4))
+            fail = -1;
+        else
+            fail = strtol(curr,NULL,10);
+
+        *next++ = '\0';
+        curr = next;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %d", fail);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+        if (!strncmp(curr, "NULL", 4))
+            error = -1;
+        else
+            error = strtol(curr,NULL,10);
+
+        *next++ = '\0';
+        curr = next;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %d", error);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+        if (!strncmp(curr, "NULL", 4))
+            notchecked = -1;
+        else
+            notchecked = strtol(curr,NULL,10);
+
+        *next++ = '\0';
+        curr = next;
+
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid CISCAT query syntax.");
+            mdebug2("CISCAT query: %d", notchecked);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+        if (!strncmp(curr, "NULL", 4))
+            unknown = -1;
+        else
+            unknown = strtol(curr,NULL,10);
+
+        *next++ = '\0';
+        if (!strncmp(next, "NULL", 4))
+            score = -1;
+        else
+            score = strtol(next,NULL,10);
+
+        if (result = wdb_ciscat_save(wdb, scan_id, scan_time, benchmark, pass, fail, error, notchecked, unknown, score), result < 0) {
+            mdebug1("Cannot save CISCAT information.");
+            snprintf(output, OS_MAXSTR + 1, "err Cannot save CISCAT information.");
+        } else {
+            snprintf(output, OS_MAXSTR + 1, "ok");
+        }
+
+        return result;
+    } else {
+        mdebug1("Invalid CISCAT query syntax.");
+        mdebug2("DB query error near: %s", curr);
+        snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", curr);
         return -1;
     }
 }

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -1,6 +1,6 @@
 /*
  * Wazuh Module for CIS-CAT
- * Copyright (C) 2016 Wazuh Inc.
+ * Copyright (C) 2017 Wazuh Inc.
  * December, 2017.
  *
  * This program is a free software; you can redistribute it
@@ -21,11 +21,11 @@ static int queue_fd;                                // Output queue file descrip
 static void* wm_ciscat_main(wm_ciscat *ciscat);        // Module main function. It won't return
 static void wm_ciscat_setup(wm_ciscat *_ciscat);       // Setup module
 static void wm_ciscat_check();                       // Check configuration, disable flag
-static void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int ID);      // Run a CIS-CAT policy
+static void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id);      // Run a CIS-CAT policy
 static void wm_ciscat_preparser();                   // Prepare report for the xml parser
 static wm_scan_data* wm_ciscat_txt_parser();        // Parse CIS-CAT csv reports
 static void wm_ciscat_xml_parser();                 // Parse CIS-CAT xml reports
-static void wm_ciscat_send_scan(wm_scan_data *info, int ID);      // Write scan result into JSON events and send them
+static void wm_ciscat_send_scan(wm_scan_data *info, int id);      // Write scan result into JSON events and send them
 static char* wm_ciscat_remove_tags(char* string);    // Remove xml and html tags from a string
 static wm_rule_data* read_group(const OS_XML *xml, XML_NODE node, wm_rule_data *rule_info, char *group);    // Read groups information from the XML report
 static wm_rule_data* read_rule_info(XML_NODE node, wm_rule_data *rule, char *group);      // Read rule information from XML report
@@ -226,19 +226,19 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
             // Set unique ID for each scan
 
         #ifndef WIN32
-            int ID = os_random();
-            if (ID < 0)
-                ID = -ID;
+            int id = os_random();
+            if (id < 0)
+                id = -id;
         #else
-            unsigned int ID1 = os_random();
-            unsigned int ID2 = os_random();
+            unsigned int id1 = os_random();
+            unsigned int id2 = os_random();
 
             char random_id[OS_MAXSTR];
-            snprintf(random_id, OS_MAXSTR - 1, "%u%u", ID1, ID2);
+            snprintf(random_id, OS_MAXSTR - 1, "%u%u", id1, id2);
 
-            int ID = atoi(random_id);
-            if (ID < 0)
-                ID = -ID;
+            int id = atoi(random_id);
+            if (id < 0)
+                id = -id;
         #endif
 
             for (eval = ciscat->evals; eval; eval = eval->next) {
@@ -262,7 +262,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     if (IsFile(eval->path) < 0) {
                         mterror(WM_CISCAT_LOGTAG, "Benchmark file '%s' not found.", eval->path);
                     } else {
-                        wm_ciscat_run(eval, cis_path, ID);
+                        wm_ciscat_run(eval, cis_path, id);
                         ciscat->flags.error = 0;
                     }
                 }
@@ -377,7 +377,7 @@ void wm_ciscat_cleanup() {
 
 #ifdef WIN32
 
-void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int ID) {
+void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id) {
     char *command = NULL;
     int status;
     char *output = NULL;
@@ -487,7 +487,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int ID) {
             wm_ciscat_preparser();
             if (!ciscat->flags.error) {
                 wm_ciscat_xml_parser();
-                wm_ciscat_send_scan(scan_info, ID);
+                wm_ciscat_send_scan(scan_info, id);
             }
         }
     }
@@ -503,7 +503,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int ID) {
 
 // Run a CIS-CAT policy for UNIX systems
 
-void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int ID) {
+void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id) {
 
     char *command = NULL;
     int status, child_status;
@@ -647,7 +647,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int ID) {
             wm_ciscat_preparser();
             if (!ciscat->flags.error) {
                 wm_ciscat_xml_parser();
-                wm_ciscat_send_scan(scan_info, ID);
+                wm_ciscat_send_scan(scan_info, id);
             }
         }
     }
@@ -1320,7 +1320,7 @@ wm_rule_data* read_rule_info(XML_NODE node, wm_rule_data *rule, char *group) {
 }
 
 
-void wm_ciscat_send_scan(wm_scan_data *info, int ID){
+void wm_ciscat_send_scan(wm_scan_data *info, int id){
 
     wm_rule_data *rule;
     wm_rule_data *next_rule;
@@ -1339,7 +1339,7 @@ void wm_ciscat_send_scan(wm_scan_data *info, int ID){
     object = cJSON_CreateObject();
     data = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "scan_info");
-    cJSON_AddNumberToObject(object, "scan_id", ID);
+    cJSON_AddNumberToObject(object, "scan_id", id);
     cJSON_AddItemToObject(object, "cis", data);
     cJSON_AddStringToObject(data, "benchmark", info->benchmark);
     cJSON_AddStringToObject(data, "hostname", info->hostname);
@@ -1358,9 +1358,9 @@ void wm_ciscat_send_scan(wm_scan_data *info, int ID){
     msg = cJSON_PrintUnformatted(object);
     mtdebug2(WM_CISCAT_LOGTAG, "Sending CIS-CAT event: '%s'", msg);
 #ifdef WIN32
-    wm_sendmsg(usec, 0, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
+    wm_sendmsg(usec, 0, msg, WM_CISCAT_LOCATION, CISCAT_MQ);
 #else
-    wm_sendmsg(usec, queue_fd, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
+    wm_sendmsg(usec, queue_fd, msg, WM_CISCAT_LOCATION, CISCAT_MQ);
 #endif
     cJSON_Delete(object);
 
@@ -1378,7 +1378,7 @@ void wm_ciscat_send_scan(wm_scan_data *info, int ID){
         object = cJSON_CreateObject();
         data = cJSON_CreateObject();
         cJSON_AddStringToObject(object, "type", "scan_result");
-        cJSON_AddNumberToObject(object, "scan_id", ID);
+        cJSON_AddNumberToObject(object, "scan_id", id);
         cJSON_AddItemToObject(object, "cis", data);
 
         cJSON_AddStringToObject(data, "rule_id", rule->id);
@@ -1398,9 +1398,9 @@ void wm_ciscat_send_scan(wm_scan_data *info, int ID){
         msg = cJSON_PrintUnformatted(object);
         mtdebug2(WM_CISCAT_LOGTAG, "Sending CIS-CAT event: '%s'", msg);
     #ifdef WIN32
-        wm_sendmsg(usec, 0, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
+        wm_sendmsg(usec, 0, msg, WM_CISCAT_LOCATION, CISCAT_MQ);
     #else
-        wm_sendmsg(usec, queue_fd, msg, WM_CISCAT_LOCATION, LOCALFILE_MQ);
+        wm_sendmsg(usec, queue_fd, msg, WM_CISCAT_LOCATION, CISCAT_MQ);
     #endif
         cJSON_Delete(object);
 

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -181,6 +181,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                 if (status == 0) {
                     time_sleep = get_time_to_hour(ciscat->scan_time);
                 } else {
+                    delay(1000); // Sleep one second to avoid an infinite loop
                     time_sleep = get_time_to_hour("00:00");
                 }
 
@@ -192,7 +193,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
         } else if (ciscat->state.next_time > time_start) {
 
             mtinfo(WM_CISCAT_LOGTAG, "Waiting for turn to evaluate.");
-            mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %d seconds", (int)time_sleep);
+            mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %ld seconds", ciscat->state.next_time - time_start);
             delay(1000 * ciscat->state.next_time - time_start);
 
         } else if (ciscat->scan_wday >= 0) {
@@ -207,7 +208,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
             time_sleep = get_time_to_hour(ciscat->scan_time);
             mtinfo(WM_CISCAT_LOGTAG, "Waiting for turn to evaluate.");
             mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %d seconds", (int)time_sleep);
-            delay (1000 * time_sleep);
+            delay(1000 * time_sleep);
 
         }
     }
@@ -283,9 +284,11 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     time_sleep = get_time_to_hour(ciscat->scan_time);
                     i++;
                 } else {
+                    delay(1000);
                     time_sleep = get_time_to_hour("00:00");     // Sleep until the start of the next day
                 }
 
+                mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %d seconds", (int)time_sleep);
                 delay(1000 * time_sleep);
 
             } while ((status < 0) && (i < interval));

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -191,12 +191,6 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
 
             } while (status < 0);
 
-        } else if (ciscat->state.next_time > time_start) {
-
-            mtinfo(WM_CISCAT_LOGTAG, "Waiting for turn to evaluate.");
-            mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %ld seconds", ciscat->state.next_time - time_start);
-            delay(1000 * ciscat->state.next_time - time_start);
-
         } else if (ciscat->scan_wday >= 0) {
 
             time_sleep = get_time_to_day(ciscat->scan_wday, ciscat->scan_time);
@@ -210,6 +204,12 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
             mtinfo(WM_CISCAT_LOGTAG, "Waiting for turn to evaluate.");
             mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %d seconds", (int)time_sleep);
             delay(1000 * time_sleep);
+
+        } else if (ciscat->state.next_time > time_start) {
+
+            mtinfo(WM_CISCAT_LOGTAG, "Waiting for turn to evaluate.");
+            mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %ld seconds", ciscat->state.next_time - time_start);
+            delay(1000 * ciscat->state.next_time - time_start);
 
         }
     }

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -67,6 +67,9 @@ typedef struct wm_ciscat_state {
 
 typedef struct wm_ciscat {
     unsigned int interval;          // Default time interval between cycles
+    int scan_day;                   // Day of month to run the CIS-CAT scan
+    int scan_wday;                  // Day of the week to run the CIS-CAT scan
+    char *scan_time;                // Time of the day to run the CIS-CAT scan
     unsigned int timeout;           // Default execution time limit (seconds)
     char *java_path;                // Path to Java Runtime Environment
     char *ciscat_path;              // Path to CIS-CAT scanner tool

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -22,6 +22,8 @@
 #define WM_CISCAT_DEFAULT_DIR_WIN "wodles\\ciscat"
 #define WM_CISCAT_REPORTS DEFAULTDIR "/tmp"
 
+#define WM_CISCAT_PROFILE       "<Profile id="
+#define WM_CISCAT_PROFILE2      "<xccdf:Profile id="
 #define WM_CISCAT_GROUP_START   "<Group id="
 #define WM_CISCAT_RESULT_START  "<TestResult"
 #define WM_CISCAT_RULE_START    "<Rule id="
@@ -80,6 +82,7 @@ typedef struct wm_ciscat {
 
 typedef struct wm_scan_data {
     char *benchmark;                // Benchmark evaluated
+    char *profile;                  // Profile evaluated
     char *timestamp;                // Time of scan
     char *hostname;                 // Target of the evaluation
     unsigned int pass;              // Number of checks passed

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -314,3 +314,134 @@ int wm_relative_path(const char * path) {
 
     return 0;
 }
+
+// Get time in seconds to the specified hour in hh:mm
+int get_time_to_hour(const char * hour) {
+
+    time_t curr_time;
+    time_t target_time;
+    struct tm * time_now;
+    double diff;
+    int i;
+
+    char ** parts = OS_StrBreak(':', hour, 2);
+
+    // Get current time
+    curr_time = time(NULL);
+    time_now = localtime(&curr_time);
+
+    struct tm t_target = *time_now;
+
+    // Look for the particular hour
+    t_target.tm_hour = atoi(parts[0]);
+    t_target.tm_min = atoi(parts[1]);
+    t_target.tm_sec = 0;
+
+    // Calculate difference between hours
+    target_time = mktime(&t_target);
+    diff = difftime(target_time, curr_time);
+
+    if (diff < 0) {
+        diff += (24*60*60);
+    }
+
+    for (i=0; parts[i]; i++)
+        free(parts[i]);
+
+    free(parts);
+
+    return (int)diff;
+}
+
+// Get time to reach a particular day of the week and hour
+int get_time_to_day(int wday, const char * hour) {
+
+    time_t curr_time;
+    time_t target_time;
+    struct tm * time_now;
+    double diff;
+    int i, ret;
+
+    // Get exact hour and minute to go to
+    char ** parts = OS_StrBreak(':', hour, 2);
+
+    // Get current time
+    curr_time = time(NULL);
+    time_now = localtime(&curr_time);
+
+    struct tm t_target = *time_now;
+
+    // Look for the particular hour
+    t_target.tm_hour = atoi(parts[0]);
+    t_target.tm_min = atoi(parts[1]);
+    t_target.tm_sec = 0;
+
+    // Calculate difference between hours
+    target_time = mktime(&t_target);
+    diff = difftime(target_time, curr_time);
+
+    if (wday == time_now->tm_wday) {    // We are in the desired day
+
+        if (diff < 0) {
+            diff += (7*24*60*60);   // Seconds of a week
+        }
+
+    } else if (wday > time_now->tm_wday) {  // We are looking for a future day
+
+        while (wday > time_now->tm_wday) {
+            diff += (24*60*60);
+            time_now->tm_wday++;
+        }
+
+    } else if (wday < time_now->tm_wday) { // We have past the desired day
+
+        ret = 7 - (time_now->tm_wday - wday);
+        for (i = 0; i < ret; i++) {
+            diff += (24*60*60);
+        }
+    }
+
+    return (int)diff;
+
+}
+
+// Function to look for the correct day of the month to run a wodle
+int check_day_to_scan(int day, const char *hour) {
+
+    time_t curr_time;
+    time_t target_time;
+    struct tm * time_now;
+    double diff;
+    int i;
+
+    // Get current time
+    curr_time = time(NULL);
+    time_now = localtime(&curr_time);
+
+    if (day == time_now->tm_mday) {    // Day of the scan
+
+        struct tm t_target = *time_now;
+
+        char ** parts = OS_StrBreak(':', hour, 2);
+
+        // Look for the particular hour
+        t_target.tm_hour = atoi(parts[0]);
+        t_target.tm_min = atoi(parts[1]);
+        t_target.tm_sec = 0;
+
+        // Calculate difference between hours
+        target_time = mktime(&t_target);
+        diff = difftime(target_time, curr_time);
+
+        for (i=0; parts[i]; i++)
+            free(parts[i]);
+
+        free(parts);
+
+        if (diff >= 0) {
+            return 0;
+        }
+    }
+
+    return -1;
+}

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -34,6 +34,9 @@
 #define WM_POOL_SIZE    8                           // Child process pool size.
 #define WM_HEADER_SIZE  OS_SIZE_2048
 
+#define DAY_SEC    86400
+#define WEEK_SEC   604800
+
 typedef void* (*wm_routine)(void*);     // Standard routine pointer
 
 // Module context: this should be defined for every module
@@ -137,5 +140,14 @@ int wm_sendmsg(int usec, int queue, const char *message, const char *locmsg, cha
 // Check if a path is relative or absolute.
 // Returns 0 if absolute, 1 if relative or -1 on error.
 int wm_relative_path(const char * path);
+
+// Get time in seconds to the specified hour in hh:mm
+int get_time_to_hour(const char * hour);
+
+// Get time to reach a particular day of the week and hour
+int get_time_to_day(int wday, const char * hour);
+
+// Function to look for the correct day of the month to run a wodle
+int check_day_to_scan(int day, const char *hour);
 
 #endif // W_MODULES


### PR DESCRIPTION
## Description

This PR adds the three following features:

**Parse the evaluated profile**

Extracts the evaluated profile by the CIS-CAT scanner and send it with the rest of the scan information, as well as it is stored in the `ciscat_results` table of the agent databases.

The new alert looks like this one:

```
** Alert 1527084137.116286: - ciscat,
2018 May 23 16:02:17 ubuntu->wodle_cis-cat
Rule: 87422 (level 5) -> 'CIS-CAT Report overview: Score less than 80% (61%)'
{"type":"scan_info","scan_id":1217445549,"cis":{"benchmark":"CIS Ubuntu Linux 16.04 LTS Benchmark","profile":"xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server","hostname":"ubuntu","timestamp":"2018-05-23T16:02:14.539+02:00","pass":93,"fail":60,"error":0,"unknown":0,"notchecked":67,"score":"61%"}}
type: scan_info
scan_id: 1217445549
cis.benchmark: CIS Ubuntu Linux 16.04 LTS Benchmark
cis.profile: xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server
cis.hostname: ubuntu
cis.timestamp: 2018-05-23T16:02:14.539+02:00
cis.pass: 93
cis.fail: 60
cis.error: 0
cis.unknown: 0
cis.notchecked: 67
cis.score: 61%
```

And it can be queried in the database as follows:
```
sqlite> select scan_id,profile from ciscat_results;
1217445549|xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server
```

In this PR is merged the content of the following Pull Requests:
- Schedule scans for the CIS-CAT module: https://github.com/wazuh/wazuh/pull/586
- Store CIS-CAT scan results into the Wazuh DB: https://github.com/wazuh/wazuh/pull/568

**Schedule scans:**

This PR adds a feature that allows to the CIS-CAT wodle to schedule scans setting the day of the month or week that the scan will be launched, and also set a specific time of the day. It has been added three new options to the CIS-CAT wodle configuration:

- **day**: Day of the month to launch the scan. Options: [1..31]
- **wday**: Day of the week to launch the scan. Options: [sunday-sun-monday-mon-tuesday-tue-wednesday-wed-thursday-thu-friday-fri-saturday-sat]
- **time**: Time of the day in 24-hours format. Format: [hh:mm]
- **interval**: We can set the frequency in months [M], weeks [w], days [d], hours [h], min [m] and secs [s].

Here we can see block samples of configuration:
```
<!-- Every 5 minutes from start -->
<interval>5m</interval>
```
```
<!-- 18:00 every day -->
<time>18:00</time>
```
```
<!-- 18:00 every four days -->
<time>5:00</time>
<interval>4d</interval>
```
```
<!-- 00:00 every monday -->
<wday>monday</wday>
```
```
<!-- 18:00 every monday -->
<wday>monday</monday>
<time>18:00</time>
```
```
<!-- 18:00 every wednesday with four weeks of frequency -->
<wday>wednesday</monday>
<time>18:00</time>
<interval>4w</interval>
```
```
<! -- 00:00 every 20th of the month -->
<day>20</day>
```
```
<!-- 18:00 every 20th of the month -->
<day>20</day>
<time>18:00</time>
```
```
<! -- 18:00,  20th every three months -->
<day>20</day>
<time>18:00</time>
<interval>3M</interval>
```

**Store CIS-CAT results into the Wazuh DB:**

It has been added a new table into agent databases to store the CIS-CAT summary information of each scan.

An example of the stored data:
```
sqlite> select * from ciscat_results;
id|scan_id|scan_time|benchmark|pass|fail|error|notchecked|unknown|score
1|253746112|2018-04-23T08:51:36.614-07:00|CIS Ubuntu Linux 16.04 LTS Benchmark|93|60|0|67|0|61
```

## References
**Related issue:** [534](https://github.com/wazuh/wazuh/issues/534)
**Related PR:** [658](https://github.com/wazuh/wazuh/pull/658)
**Branch:** Master
**Documentation:** [240](https://github.com/wazuh/wazuh-documentation/issues/240)

# Unit tests

- [x] Run a CIS-CAT scan and check stored data in the database (`/var/ossec/queue/db/<agent_id>.db`).
- [x] Configure several contents with different profiles checking that are being sent correctly.
- [x] Schedule CIS-CAT scans checking all the parameters (hours, days, weeks, etc.)
- [x] Set incorrect configuration values (mixing parameters like a day of the month with a 5 minutes interval, for example)
- [x] Check backward compatibility with versions 3.X. 