### PR TITLE
Input message buffer for Analysisd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - New internal option to enable merged file creation by Remoted. ([#603](https://github.com/wazuh/wazuh/pull/603))
 - Created alert item for GDPR and GPG13. ([#608](https://github.com/wazuh/wazuh/pull/608))
 - Add support for Amazon Linux in vulnerability-detector.
+- Created an input queue for Analysisd to prevent Remoted starvation. ([#661](https://github.com/wazuh/wazuh/pull/661))
 
 ### Changed
 

--- a/etc/templates/config/generic/global.template
+++ b/etc/templates/config/generic/global.template
@@ -8,4 +8,5 @@
     <email_from>ossecm@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
+    <queue_size>16384</queue_size>
   </global>

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -57,6 +57,9 @@ int DecodeSyscollector(Eventinfo *lf);
 /* For stats */
 static void DumpLogstats(void);
 
+// Message handler thread
+void * ad_input_main(void * args);
+
 /** Global definitions **/
 int today;
 int thishour;
@@ -79,6 +82,7 @@ static int hourly_events;
 static int hourly_syscheck;
 static int hourly_firewall;
 
+static w_queue_t * input_queue;
 
 /* Print help statement */
 __attribute__((noreturn))
@@ -543,8 +547,7 @@ __attribute__((noreturn))
 void OS_ReadMSG_analysisd(int m_queue)
 #endif
 {
-    int i;
-    char msg[OS_MAXSTR + 1];
+    char * msg = NULL;
     Eventinfo *lf;
 
     RuleInfo *stats_rule = NULL;
@@ -649,9 +652,6 @@ void OS_ReadMSG_analysisd(int m_queue)
         stats_rule->comment = "Excessive number of events (above normal).";
     }
 
-    /* Do some cleanup */
-    memset(msg, '\0', OS_MAXSTR + 1);
-
     /* Initialize the logs */
     {
         os_calloc(1, sizeof(Eventinfo), lf);
@@ -672,6 +672,11 @@ void OS_ReadMSG_analysisd(int m_queue)
     Config.label_cache_maxage = getDefine_Int("analysisd", "label_cache_maxage", 0, 60);
     Config.show_hidden_labels = getDefine_Int("analysisd", "show_hidden_labels", 0, 1);
 
+    // Create input buffer and thread
+
+    input_queue = queue_init(Config.queue_size);
+    w_create_thread(ad_input_main, &m_queue);
+
     mdebug1("Startup completed. Waiting for new messages..");
 
     if (Config.custom_alert_output) {
@@ -682,11 +687,13 @@ void OS_ReadMSG_analysisd(int m_queue)
     while (1) {
         os_calloc(1, sizeof(Eventinfo), lf);
         os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+        free(msg);
+        msg = NULL;
 
         DEBUG_MSG("%s: DEBUG: Waiting for msgs - %d ", ARGV0, (int)time(0));
 
         /* Receive message from queue */
-        if ((i = OS_RecvUnix(m_queue, OS_MAXSTR, msg))) {
+        if (msg = queue_pop_ex(input_queue), msg) {
             RuleNode *rulenode_pt;
 
             /* Get the time we received the event */
@@ -696,7 +703,7 @@ void OS_ReadMSG_analysisd(int m_queue)
             Zero_Eventinfo(lf);
 
             /* Check for a valid message */
-            if (i < 4) {
+            if (strlen(msg) < 4) {
                 merror(IMSG_ERROR, msg);
                 Free_Eventinfo(lf);
                 continue;
@@ -1600,4 +1607,37 @@ static void DumpLogstats()
     hourly_firewall = 0;
 
     fclose(flog);
+}
+
+// Message handler thread
+void * ad_input_main(void * args) {
+    int m_queue = *(int *)args;
+    char buffer[OS_MAXSTR + 1] = "";
+    char * copy;
+    int reported = 0;
+
+    mdebug1("Input message handler thread started.");
+
+    while (1) {
+        if (OS_RecvUnix(m_queue, OS_MAXSTR, buffer)) {
+            w_mutex_lock(&input_queue->mutex);
+
+            if (queue_full(input_queue)) {
+                mdebug2("Discarding input event, head='%c'", buffer[0]);
+
+                if (!reported) {
+                    reported = 1;
+                    mwarn("Input buffer is full (%zu). Events may be lost.", input_queue->size);
+                }
+            } else {
+                os_strdup(buffer, copy);
+                queue_push(input_queue, copy);
+                w_cond_signal(&input_queue->available);
+            }
+
+            w_mutex_unlock(&input_queue->mutex);
+        }
+    }
+
+    return NULL;
 }

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -66,6 +66,7 @@ int GlobalConf(const char *cfgfile)
     Config.rotate_interval = 0;
     Config.min_rotate_interval = 0;
     Config.max_output_size = 0;
+    Config.queue_size = 16384;
 
     os_calloc(1, sizeof(wlabel_t), Config.labels);
 
@@ -95,6 +96,15 @@ int GlobalConf(const char *cfgfile)
     if (Config.max_output_size && (Config.max_output_size < 1000000 || Config.max_output_size > 1099511627776)) {
         merror("Maximum output size must be between 1 MiB and 1 TiB.");
         return (OS_INVALID);
+    }
+
+    if (Config.queue_size < 1) {
+        merror("Queue size is invalid. Review configuration.");
+        return OS_INVALID;
+    }
+
+    if (Config.queue_size > 262144) {
+        mwarn("Queue size is very high. The application may run out of memory.");
     }
 
     return (0);

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -124,6 +124,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     const char *xml_smtpserver = "smtp_server";
     const char *xml_heloserver = "helo_server";
     const char *xml_mailmaxperhour = "email_maxperhour";
+    const char * xml_queue_size = "queue_size";
 
 #ifdef LIBGEOIP_ENABLED
     const char *xml_geoip_db_path = "geoip_db_path";
@@ -600,6 +601,20 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                     merror(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 }
+            }
+        } else if (strcmp(node[i]->element, xml_queue_size) == 0) {
+            char * end;
+
+            Config->queue_size = strtol(node[i]->content, &end, 10);
+
+            if (*end || Config->queue_size < 1) {
+                merror("Invalid value for option '<%s>'", xml_queue_size);
+                return OS_INVALID;
+            }
+
+            if (*end) {
+                merror("Invalid value for option '<%s>'", xml_queue_size);
+                return OS_INVALID;
             }
         } else {
             merror(XML_INVELEM, node[i]->element);

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -106,6 +106,7 @@ typedef struct __Config {
     int rotate_interval;
     int min_rotate_interval;
     ssize_t max_output_size;
+    long queue_size;
 } _Config;
 
 #endif /* _CCONFIG__H */

--- a/src/headers/queue_op.h
+++ b/src/headers/queue_op.h
@@ -12,11 +12,15 @@
 #ifndef QUEUE_OP_H
 #define QUEUE_OP_H
 
+#include <pthread.h>
+
 typedef struct queue_t {
     void ** data;
     size_t begin;
     size_t end;
     size_t size;
+    pthread_mutex_t mutex;
+    pthread_cond_t available;
 } w_queue_t;
 
 w_queue_t * queue_init(size_t n);
@@ -24,6 +28,8 @@ void queue_free(w_queue_t * queue);
 int queue_full(const w_queue_t * queue);
 int queue_empty(const w_queue_t * queue);
 int queue_push(w_queue_t * queue, void * data);
+int queue_push_ex(w_queue_t * queue, void * data);
 void * queue_pop(w_queue_t * queue);
+void * queue_pop_ex(w_queue_t * queue);
 
 #endif // QUEUE_OP_H


### PR DESCRIPTION
This PR adds an input buffer in Analysisd.

```xml
<global>
  <queue_size>16384</queue_size>
</global>
```

#### `queue_size`

Size of the message input buffer in Analysisd (number of events).

Default value: 16384.
Minimum value: 1.
Recommended range: [128..262144]