### PR TITLE
Some fixes for Syscollector DB

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -21,8 +21,6 @@
 #include "string_op.h"
 #include <time.h>
 
-#define SYSCOLLECTOR_DIR    "/queue/syscollector"
-
 static int error_package = 0;
 static int prev_package_id = 0;
 static int error_port = 0;
@@ -56,9 +54,6 @@ int DecodeSyscollector(Eventinfo *lf)
 {
     cJSON *logJSON;
     char *msg_type = NULL;
-
-    // Decoding JSON
-    JSON_Decoder_Exec(lf);
 
     lf->decoder_info = sysc_decoder;
 

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -85,47 +85,55 @@ int DecodeSyscollector(Eventinfo *lf)
     msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
     if (!msg_type) {
         mdebug1("Invalid message. Type not found.");
+        cJSON_Delete (logJSON);
         return (0);
     }
 
     if (strcmp(msg_type, "port") == 0 || strcmp(msg_type, "port_end") == 0) {
         if (decode_port(lf->agent_id, logJSON) < 0) {
             mdebug1("Unable to send ports information to Wazuh DB.");
+            cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "program") == 0 || strcmp(msg_type, "program_end") == 0) {
         if (decode_package(lf->agent_id, logJSON) < 0) {
             mdebug1("Unable to send packages information to Wazuh DB.");
+            cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "hardware") == 0) {
         if (decode_hardware(lf->agent_id, logJSON) < 0) {
             mdebug1("Unable to send hardware information to Wazuh DB.");
+            cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "OS") == 0) {
         if (decode_osinfo(lf->agent_id, logJSON) < 0) {
             mdebug1("Unable to send osinfo message to Wazuh DB.");
+            cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "network") == 0 || strcmp(msg_type, "network_end") == 0) {
         if (decode_netinfo(lf->agent_id, logJSON) < 0) {
             merror("Unable to send netinfo message to Wazuh DB.");
+            cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "process") == 0 || strcmp(msg_type, "process_end") == 0) {
         if (decode_process(lf->agent_id, logJSON) < 0) {
             mdebug1("Unable to send processes information to Wazuh DB.");
+            cJSON_Delete (logJSON);
             return (0);
         }
     }
     else {
         mdebug1("Invalid message type: %s.", msg_type);
+        cJSON_Delete (logJSON);
         return (0);
     }
 
@@ -1030,7 +1038,7 @@ int decode_process(char *agent_id, cJSON * logJSON) {
             }
         }
         cJSON * scan_time = cJSON_GetObjectItem(logJSON, "timestamp");
-        cJSON * pid = cJSON_GetObjectItem(logJSON, "pid");
+        cJSON * pid = cJSON_GetObjectItem(inventory, "pid");
         cJSON * name = cJSON_GetObjectItem(inventory, "name");
         cJSON * state = cJSON_GetObjectItem(inventory, "state");
         cJSON * ppid = cJSON_GetObjectItem(inventory, "ppid");

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -23,6 +23,13 @@
 
 #define SYSCOLLECTOR_DIR    "/queue/syscollector"
 
+static int error_package = 0;
+static int prev_package_id = 0;
+static int error_port = 0;
+static int prev_port_id = 0;
+static int error_process = 0;
+static int prev_process_id = 0;
+
 static int sc_send_db(char * msg);
 static int decode_netinfo(char *agent_id, cJSON * logJSON);
 static int decode_osinfo(char *agent_id, cJSON * logJSON);
@@ -591,6 +598,14 @@ int decode_port(char *agent_id, cJSON * logJSON) {
 
     if (inventory = cJSON_GetObjectItem(logJSON, "port"), inventory) {
         cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
+        if (error_port) {
+            if (scan_id->valueint == prev_port_id) {
+                free(msg);
+                return 0;
+            } else {
+                error_port = 0;
+            }
+        }
         cJSON * scan_time = cJSON_GetObjectItem(logJSON, "timestamp");
         cJSON * protocol = cJSON_GetObjectItem(inventory, "protocol");
         cJSON * local_ip = cJSON_GetObjectItem(inventory, "local_ip");
@@ -699,6 +714,8 @@ int decode_port(char *agent_id, cJSON * logJSON) {
         }
 
         if (sc_send_db(msg) < 0) {
+            error_port = 1;
+            prev_port_id = scan_id->valueint;
             return -1;
         }
 
@@ -715,9 +732,21 @@ int decode_port(char *agent_id, cJSON * logJSON) {
         } else if (strcmp(msg_type, "port_end") == 0) {
 
             cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
+
+            if (error_port) {
+                if (scan_id->valueint == prev_port_id) {
+                    free(msg);
+                    return 0;
+                } else {
+                    error_port = 0;
+                }
+            }
+
             snprintf(msg, OS_MAXSTR - 1, "agent %s port del %d", agent_id, scan_id->valueint);
 
             if (sc_send_db(msg) < 0) {
+                error_port = 1;
+                prev_port_id = scan_id->valueint;
                 return -1;
             }
         } else {
@@ -823,6 +852,14 @@ int decode_package(char *agent_id, cJSON * logJSON) {
 
     if (package = cJSON_GetObjectItem(logJSON, "program"), package) {
         cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
+        if (error_package) {
+            if (scan_id->valueint == prev_package_id) {
+                free(msg);
+                return 0;
+            } else {
+                error_package = 0;
+            }
+        }
         cJSON * scan_time = cJSON_GetObjectItem(logJSON, "timestamp");
         cJSON * format = cJSON_GetObjectItem(package, "format");
         cJSON * name = cJSON_GetObjectItem(package, "name");
@@ -935,6 +972,8 @@ int decode_package(char *agent_id, cJSON * logJSON) {
         }
 
         if (sc_send_db(msg) < 0) {
+            error_package = 1;
+            prev_package_id = scan_id->valueint;
             return -1;
         }
 
@@ -952,9 +991,21 @@ int decode_package(char *agent_id, cJSON * logJSON) {
         } else if (strcmp(msg_type, "program_end") == 0) {
 
             cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
+
+            if (error_package) {
+                if (scan_id->valueint == prev_package_id) {
+                    free(msg);
+                    return 0;
+                } else {
+                    error_package = 0;
+                }
+            }
+
             snprintf(msg, OS_MAXSTR - 1, "agent %s package del %d", agent_id, scan_id->valueint);
 
             if (sc_send_db(msg) < 0) {
+                error_package = 1;
+                prev_package_id = scan_id->valueint;
                 return -1;
             }
         } else {
@@ -975,6 +1026,14 @@ int decode_process(char *agent_id, cJSON * logJSON) {
 
     if (inventory = cJSON_GetObjectItem(logJSON, "process"), inventory) {
         cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
+        if (error_process) {
+            if (scan_id->valueint == prev_process_id) {
+                free(msg);
+                return 0;
+            } else {
+                error_process = 0;
+            }
+        }
         cJSON * scan_time = cJSON_GetObjectItem(logJSON, "timestamp");
         cJSON * pid = cJSON_GetObjectItem(logJSON, "pid");
         cJSON * name = cJSON_GetObjectItem(inventory, "name");
@@ -1228,6 +1287,8 @@ int decode_process(char *agent_id, cJSON * logJSON) {
         }
 
         if (sc_send_db(msg) < 0) {
+            error_process = 1;
+            prev_process_id = scan_id->valueint;
             return -1;
         }
 
@@ -1244,9 +1305,21 @@ int decode_process(char *agent_id, cJSON * logJSON) {
         } else if (strcmp(msg_type, "process_end") == 0) {
 
             cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
+
+            if (error_process) {
+                if (scan_id->valueint == prev_process_id) {
+                    free(msg);
+                    return 0;
+                } else {
+                    error_process = 0;
+                }
+            }
+
             snprintf(msg, OS_MAXSTR - 1, "agent %s process del %d", agent_id, scan_id->valueint);
 
             if (sc_send_db(msg) < 0) {
+                error_process = 1;
+                prev_process_id = scan_id->valueint;
                 return -1;
             }
         } else {

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -770,7 +770,7 @@ int wdb_stmt_cache(wdb_t * wdb, int index) {
             return -1;
         }
     } else if (sqlite3_reset(wdb->stmt[index]) != SQLITE_OK) {
-        merror("at wdb_stmt_cache(): at sqlite3_reset(): %s", sqlite3_errmsg(wdb->db));
+        mdebug1("at wdb_stmt_cache(): at sqlite3_reset(): %s", sqlite3_errmsg(wdb->db));
 
         // Retry to prepare
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -591,7 +591,7 @@ int wdb_parse_netinfo(wdb_t * wdb, char * input, char * output) {
             rx_dropped = strtol(next,NULL,10);
 
         if (result = wdb_netinfo_save(wdb, scan_id, scan_time, name, adapter, type, state, mtu, mac, tx_packets, rx_packets, tx_bytes, rx_bytes, tx_errors, rx_errors, tx_dropped, rx_dropped), result < 0) {
-            mdebug1("Cannot save Network information.");
+            mdebug1("at wdb_parse_netinfo(): Cannot save Network information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save Network information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -609,7 +609,7 @@ int wdb_parse_netinfo(wdb_t * wdb, char * input, char * output) {
             scan_id = next;
 
         if (result = wdb_netinfo_delete(wdb, scan_id), result < 0) {
-            mdebug1("Cannot delete old network information.");
+            mdebug1("at wdb_parse_netinfo(): Cannot delete old network information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot delete old network information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -707,7 +707,7 @@ int wdb_parse_netproto(wdb_t * wdb, char * input, char * output) {
             dhcp = next;
 
         if (result = wdb_netproto_save(wdb, scan_id, iface, type, gateway, dhcp), result < 0) {
-            mdebug1("Cannot save netproto information.");
+            mdebug1("at wdb_parse_netproto(): Cannot save netproto information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save netproto information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -805,7 +805,7 @@ int wdb_parse_netaddr(wdb_t * wdb, char * input, char * output) {
             broadcast = next;
 
         if (result = wdb_netaddr_save(wdb, scan_id, proto, address, netmask, broadcast), result < 0) {
-            mdebug1("Cannot save netaddr information.");
+            mdebug1("at wdb_parse_netaddr(): Cannot save netaddr information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save netaddr information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -1040,7 +1040,7 @@ int wdb_parse_osinfo(wdb_t * wdb, char * input, char * output) {
             version = next;
 
         if (result = wdb_osinfo_save(wdb, scan_id, scan_time, hostname, architecture, os_name, os_version, os_codename, os_major, os_minor, os_build, os_platform, sysname, release, version), result < 0) {
-            mdebug1("Cannot save OS information.");
+            mdebug1("at wdb_parse_osinfo(): Cannot save OS information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save OS information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -1174,7 +1174,7 @@ int wdb_parse_hardware(wdb_t * wdb, char * input, char * output) {
         ram_free = strtol(next,NULL,10);
 
         if (result = wdb_hardware_save(wdb, scan_id, scan_time, serial, cpu_name, cpu_cores, cpu_mhz, ram_total, ram_free), result < 0) {
-            mdebug1("Cannot save HW information.");
+            mdebug1("at wdb_parse_hardware(): Cannot save HW information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save HW information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -1398,7 +1398,7 @@ int wdb_parse_ports(wdb_t * wdb, char * input, char * output) {
             process = next;
 
         if (result = wdb_port_save(wdb, scan_id, scan_time, protocol, local_ip, local_port, remote_ip, remote_port, tx_queue, rx_queue, inode, state, pid, process), result < 0) {
-            mdebug1("Cannot save Port information.");
+            mdebug1("at wdb_parse_ports(): Cannot save Port information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save Port information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -1415,7 +1415,7 @@ int wdb_parse_ports(wdb_t * wdb, char * input, char * output) {
             scan_id = next;
 
         if (result = wdb_port_delete(wdb, scan_id), result < 0) {
-            mdebug1("Cannot delete old Port information.");
+            mdebug1("at wdb_parse_ports(): Cannot delete old Port information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot delete old Port information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -1667,7 +1667,7 @@ int wdb_parse_packages(wdb_t * wdb, char * input, char * output) {
             location = next;
 
         if (result = wdb_package_save(wdb, scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, architecture, multiarch, source, description, location), result < 0) {
-            mdebug1("Cannot save Package information.");
+            mdebug1("at wdb_parse_packages(): Cannot save Package information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save Package information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -1685,12 +1685,12 @@ int wdb_parse_packages(wdb_t * wdb, char * input, char * output) {
             scan_id = next;
 
         if (result = wdb_package_update(wdb, scan_id), result < 0) {
-            mdebug1("Cannot save scanned packages before delete old Package information.");
+            mdebug1("at wdb_parse_packages(): Cannot update scanned packages.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save scanned packages before delete old Package information.");
         }
 
         if (result = wdb_package_delete(wdb, scan_id), result < 0) {
-            mdebug1("Cannot delete old Package information.");
+            mdebug1("at wdb_parse_packages(): Cannot delete old Package information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot delete old Package information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -2164,7 +2164,7 @@ int wdb_parse_processes(wdb_t * wdb, char * input, char * output) {
             processor = strtol(next,NULL,10);
 
         if (result = wdb_process_save(wdb, scan_id, scan_time, pid, name, state, ppid, utime, stime, cmd, argvs, euser, ruser, suser, egroup, rgroup, sgroup, fgroup, priority, nice, size, vm_size, resident, share, start_time, pgrp, session, nlwp, tgid, tty, processor), result < 0) {
-            mdebug1("Cannot save Process information.");
+            mdebug1("at wdb_parse_processes(): Cannot save Process information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save Process information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
@@ -2181,7 +2181,7 @@ int wdb_parse_processes(wdb_t * wdb, char * input, char * output) {
             scan_id = next;
 
         if (result = wdb_process_delete(wdb, scan_id), result < 0) {
-            mdebug1("Cannot delete old Process information.");
+            mdebug1("at wdb_parse_processes(): Cannot delete old Process information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot delete old Process information.");
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -17,7 +17,7 @@ static int iface_id = 0;
 int wdb_netinfo_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * name, const char * adapter, const char * type, const char * state, int mtu, const char * mac, long tx_packets, long rx_packets, long tx_bytes, long rx_bytes, long tx_errors, long rx_errors, long tx_dropped, long rx_dropped) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_netinfo_save(): cannot begin transaction");
+        mdebug1("at wdb_netinfo_save(): cannot begin transaction");
         return -1;
     }
 
@@ -49,8 +49,8 @@ int wdb_netinfo_save(wdb_t * wdb, const char * scan_id, const char * scan_time, 
 int wdb_netinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * name, const char * adapter, const char * type, const char * state, int mtu, const char * mac, long tx_packets, long rx_packets, long tx_bytes, long rx_bytes, long tx_errors, long rx_errors, long tx_dropped, long rx_dropped) {
     sqlite3_stmt *stmt = NULL;
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_NETINFO_INSERT) > 0) {
-        merror("at wdb_netinfo_insert(): cannot cache statement");
+    if (wdb_stmt_cache(wdb, WDB_STMT_NETINFO_INSERT) < 0) {
+        mdebug1("at wdb_netinfo_insert(): cannot cache statement");
         return -1;
     }
 
@@ -117,7 +117,7 @@ int wdb_netinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time
         return 0;
     }
     else {
-        mdebug1("at wdb_netinfo_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        merror("at wdb_netinfo_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 }
@@ -126,7 +126,7 @@ int wdb_netinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time
 int wdb_netproto_save(wdb_t * wdb, const char * scan_id, const char * iface, int type, const char * gateway, const char * dhcp) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_netproto_save(): cannot begin transaction");
+        mdebug1("at wdb_netproto_save(): cannot begin transaction");
         return -1;
     }
 
@@ -148,8 +148,8 @@ int wdb_netproto_insert(wdb_t * wdb, const char * scan_id, const char * iface, i
 
     sqlite3_stmt *stmt = NULL;
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_PROTO_INSERT) > 0) {
-        merror("at wdb_netproto_insert(): cannot cache statement");
+    if (wdb_stmt_cache(wdb, WDB_STMT_PROTO_INSERT) < 0) {
+        mdebug1("at wdb_netproto_insert(): cannot cache statement");
         return -1;
     }
 
@@ -171,7 +171,7 @@ int wdb_netproto_insert(wdb_t * wdb, const char * scan_id, const char * iface, i
         return 0;
     }
     else {
-        mdebug1("at wdb_netproto_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        merror("at wdb_netproto_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 }
@@ -180,7 +180,7 @@ int wdb_netproto_insert(wdb_t * wdb, const char * scan_id, const char * iface, i
 int wdb_netaddr_save(wdb_t * wdb, const char * scan_id, int proto, const char * address, const char * netmask, const char * broadcast) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_netaddr_save(): cannot begin transaction");
+        mdebug1("at wdb_netaddr_save(): cannot begin transaction");
         return -1;
     }
 
@@ -202,8 +202,8 @@ int wdb_netaddr_insert(wdb_t * wdb, const char * scan_id, int proto, const char 
 
     sqlite3_stmt *stmt = NULL;
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_ADDR_INSERT) > 0) {
-        merror("at wdb_netaddr_insert(): cannot cache statement");
+    if (wdb_stmt_cache(wdb, WDB_STMT_ADDR_INSERT) < 0) {
+        mdebug1("at wdb_netaddr_insert(): cannot cache statement");
         return -1;
     }
 
@@ -225,7 +225,7 @@ int wdb_netaddr_insert(wdb_t * wdb, const char * scan_id, int proto, const char 
         return 0;
     }
     else {
-        mdebug1("at wdb_netaddr_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        merror("at wdb_netaddr_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 }
@@ -236,49 +236,49 @@ int wdb_netinfo_delete(wdb_t * wdb, const char * scan_id) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_netinfo_delete(): cannot begin transaction");
+        mdebug1("at wdb_netinfo_delete(): cannot begin transaction");
         return -1;
     }
 
     // Delete 'sys_netiface' table
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_NETINFO_DEL) > 0) {
-        merror("at wdb_netinfo_delete(): cannot cache statement");
+    if (wdb_stmt_cache(wdb, WDB_STMT_NETINFO_DEL) < 0) {
+        mdebug1("at wdb_netinfo_delete(): cannot cache statement");
         return -1;
     }
     stmt = wdb->stmt[WDB_STMT_NETINFO_DEL];
     sqlite3_bind_text(stmt, 1, scan_id, -1, NULL);
 
     if (sqlite3_step(stmt) != SQLITE_DONE) {
-        merror("Unable to delete old information from 'sys_netiface' table: %s", sqlite3_errmsg(wdb->db));
+        merror("Deleting old information from 'sys_netiface' table: %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 
     // Delete 'sys_netproto' table
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_PROTO_DEL) > 0) {
-        merror("at wdb_netinfo_delete(): cannot cache statement");
+    if (wdb_stmt_cache(wdb, WDB_STMT_PROTO_DEL) < 0) {
+        mdebug1("at wdb_netinfo_delete(): cannot cache statement");
         return -1;
     }
     stmt = wdb->stmt[WDB_STMT_PROTO_DEL];
     sqlite3_bind_text(stmt, 1, scan_id, -1, NULL);
 
     if (sqlite3_step(stmt) != SQLITE_DONE) {
-        merror("Unable to delete old information from 'sys_netproto' table: %s", sqlite3_errmsg(wdb->db));
+        merror("Deleting old information from 'sys_netproto' table: %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 
     // Delete 'sys_netaddr' table
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_ADDR_DEL) > 0) {
-        merror("at wdb_netinfo_delete(): cannot cache statement");
+    if (wdb_stmt_cache(wdb, WDB_STMT_ADDR_DEL) < 0) {
+        mdebug1("at wdb_netinfo_delete(): cannot cache statement");
         return -1;
     }
     stmt = wdb->stmt[WDB_STMT_ADDR_DEL];
     sqlite3_bind_text(stmt, 1, scan_id, -1, NULL);
 
     if (sqlite3_step(stmt) != SQLITE_DONE) {
-        merror("Unable to delete old information from 'sys_netaddr' table: %s", sqlite3_errmsg(wdb->db));
+        merror("Deleting old information from 'sys_netaddr' table: %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 
@@ -291,13 +291,13 @@ int wdb_osinfo_save(wdb_t * wdb, const char * scan_id, const char * scan_time, c
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_osinfo_save(): cannot begin transaction");
+        mdebug1("at wdb_osinfo_save(): cannot begin transaction");
         return -1;
     }
 
     /* Delete old OS information before insert the new scan */
     if (wdb_stmt_cache(wdb, WDB_STMT_OSINFO_DEL) < 0) {
-        merror("at wdb_osinfo_save(): cannot cache statement");
+        mdebug1("at wdb_osinfo_save(): cannot cache statement");
         return -1;
     }
 
@@ -335,7 +335,7 @@ int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time,
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_OSINFO_INSERT) < 0) {
-        merror("at wdb_osinfo_insert(): cannot cache statement");
+        mdebug1("at wdb_osinfo_insert(): cannot cache statement");
         return -1;
     }
 
@@ -370,7 +370,7 @@ int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time,
 int wdb_package_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * format, const char * name, const char * priority, const char * section, long size, const char * vendor, const char * install_time, const char * version, const char * architecture, const char * multiarch, const char * source, const char * description, const char * location) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_package_save(): cannot begin transaction");
+        mdebug1("at wdb_package_save(): cannot begin transaction");
         return -1;
     }
 
@@ -403,7 +403,7 @@ int wdb_package_insert(wdb_t * wdb, const char * scan_id, const char * scan_time
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_PROGRAM_INSERT) < 0) {
-        merror("at wdb_package_insert(): cannot cache statement");
+        mdebug1("at wdb_package_insert(): cannot cache statement");
         return -1;
     }
 
@@ -430,15 +430,21 @@ int wdb_package_insert(wdb_t * wdb, const char * scan_id, const char * scan_time
     sqlite3_bind_text(stmt, 15, location, -1, NULL);
     sqlite3_bind_int(stmt, 16, triaged);
 
-
-    if (sqlite3_step(stmt) == SQLITE_DONE){
-        return 0;
+    switch (sqlite3_step(stmt)) {
+        case SQLITE_DONE:
+            return 0;
+        case SQLITE_CONSTRAINT:
+            if (!strncmp(sqlite3_errmsg(wdb->db), "UNIQUE", 6)) {
+                mdebug1("at wdb_package_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+                return 0;
+            } else {
+                merror("at wdb_package_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+                return -1;
+            }
+        default:
+            merror("at wdb_package_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+            return -1;
     }
-    else {
-        mdebug1("at wdb_package_insert(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
-        return -1;
-    }
-
 }
 
 // Function to update old Package information from DB. Return 0 on success or -1 on error.
@@ -447,12 +453,12 @@ int wdb_package_update(wdb_t * wdb, const char * scan_id) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_package_update(): cannot begin transaction");
+        mdebug1("at wdb_package_update(): cannot begin transaction");
         return -1;
     }
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_PROGRAM_UPD) > 0) {
-        merror("at wdb_package_update(): cannot cache statement");
+    if (wdb_stmt_cache(wdb, WDB_STMT_PROGRAM_UPD) < 0) {
+        mdebug1("at wdb_package_update(): cannot cache statement");
         return -1;
     }
 
@@ -461,7 +467,7 @@ int wdb_package_update(wdb_t * wdb, const char * scan_id) {
     sqlite3_bind_text(stmt, 1, scan_id, -1, NULL);
 
     if (sqlite3_step(stmt) != SQLITE_DONE) {
-        merror("Unable to update the new information from 'sys_programs' table: %s", sqlite3_errmsg(wdb->db));
+        merror("Unable to update the 'sys_programs' table: %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 
@@ -474,12 +480,12 @@ int wdb_package_delete(wdb_t * wdb, const char * scan_id) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_package_delete(): cannot begin transaction");
+        mdebug1("at wdb_package_delete(): cannot begin transaction");
         return -1;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_PROGRAM_DEL) < 0) {
-        merror("at wdb_package_delete(): cannot cache statement");
+        mdebug1("at wdb_package_delete(): cannot cache statement");
         return -1;
     }
 
@@ -501,13 +507,13 @@ int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time,
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_hardware_save(): cannot begin transaction");
+        mdebug1("at wdb_hardware_save(): cannot begin transaction");
         return -1;
     }
 
     /* Delete old OS information before insert the new scan */
     if (wdb_stmt_cache(wdb, WDB_STMT_HWINFO_DEL) < 0) {
-        merror("at wdb_hardware_save(): cannot cache statement");
+        mdebug1("at wdb_hardware_save(): cannot cache statement");
         return -1;
     }
 
@@ -539,7 +545,7 @@ int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_tim
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_HWINFO_INSERT) < 0) {
-        merror("at wdb_hardware_insert(): cannot cache statement");
+        mdebug1("at wdb_hardware_insert(): cannot cache statement");
         return -1;
     }
 
@@ -583,7 +589,7 @@ int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_tim
 int wdb_port_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, int inode, const char * state, int pid, const char * process) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_port_save(): cannot begin transaction");
+        mdebug1("at wdb_port_save(): cannot begin transaction");
         return -1;
     }
 
@@ -613,7 +619,7 @@ int wdb_port_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, c
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_PORT_INSERT) < 0) {
-        merror("at wdb_port_insert(): cannot cache statement");
+        mdebug1("at wdb_port_insert(): cannot cache statement");
         return -1;
     }
 
@@ -679,12 +685,12 @@ int wdb_port_delete(wdb_t * wdb, const char * scan_id) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_port_delete(): cannot begin transaction");
+        mdebug1("at wdb_port_delete(): cannot begin transaction");
         return -1;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_PORT_DEL) < 0) {
-        merror("at wdb_port_delete(): cannot cache statement");
+        mdebug1("at wdb_port_delete(): cannot cache statement");
         return -1;
     }
 
@@ -704,7 +710,7 @@ int wdb_port_delete(wdb_t * wdb, const char * scan_id) {
 int wdb_process_save(wdb_t * wdb, const char * scan_id, const char * scan_time, int pid, const char * name, const char * state, int ppid, int utime, int stime, const char * cmd, const char * argvs, const char * euser, const char * ruser, const char * suser, const char * egroup, const char * rgroup, const char * sgroup, const char * fgroup, int priority, int nice, int size, int vm_size, int resident, int share, int start_time, int pgrp, int session, int nlwp, int tgid, int tty, int processor) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_process_save(): cannot begin transaction");
+        mdebug1("at wdb_process_save(): cannot begin transaction");
         return -1;
     }
 
@@ -751,7 +757,7 @@ int wdb_process_insert(wdb_t * wdb, const char * scan_id, const char * scan_time
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_PROC_INSERT) < 0) {
-        merror("at wdb_process_insert(): cannot cache statement");
+        mdebug1("at wdb_process_insert(): cannot cache statement");
         return -1;
     }
 
@@ -854,12 +860,12 @@ int wdb_process_delete(wdb_t * wdb, const char * scan_id) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        merror("at wdb_process_delete(): cannot begin transaction");
+        mdebug1("at wdb_process_delete(): cannot begin transaction");
         return -1;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_PROC_DEL) < 0) {
-        merror("at wdb_process_delete(): cannot cache statement");
+        mdebug1("at wdb_process_delete(): cannot cache statement");
         return -1;
     }
 


### PR DESCRIPTION
This PR adds the following improvements in the process of storing the collected inventory into the agents DBs:

- If any error appears when a particular scan is being stored in the DB, we don`t store the rest of the data belonging to that scan. This way, we avoid useless queries to the DB wasting its resources and flooding the logs with many error messages.
- When reading Windows programs inventory from the registry, some programs could be repeated triggering an error from the DB. Now, we skip that program without stopping the programs scan.
- Syscollector events were being processed by the JSON decoder. This is useless since the Syscollector decoder exists so we avoid parsing syscollector events by the JSON decoder.