### PR TITLE
Option to choose the treatment of null fields by the JSON decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [v3.3.2]
+## [v3.3.2]
+
+### Added
+
+- New option for the JSON decoder to choose the treatment of NULL values. ([#677](https://github.com/wazuh/wazuh/pull/677))
 
 ### Fixed
 

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -286,7 +286,7 @@ int ReadDecodeXML(const char *file)
         pi->get_next = 0;
         pi->regex_offset = 0;
         pi->prematch_offset = 0;
-        pi->flags = DISCARD;
+        pi->flags = SHOW_STRING;
 
         regex = NULL;
         prematch = NULL;

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -175,6 +175,7 @@ int ReadDecodeXML(const char *file)
     const char *xml_fts = "fts";
     const char *xml_ftscomment = "ftscomment";
     const char *xml_accumulate = "accumulate";
+    const char *xml_nullfield = "json_null_field";
 
     int i = 0;
     OSDecoderInfo *NULL_Decoder_tmp = NULL;
@@ -285,6 +286,7 @@ int ReadDecodeXML(const char *file)
         pi->get_next = 0;
         pi->regex_offset = 0;
         pi->prematch_offset = 0;
+        pi->flags = DISCARD;
 
         regex = NULL;
         prematch = NULL;
@@ -412,6 +414,19 @@ int ReadDecodeXML(const char *file)
 
                 if (pi->plugin_offset & AFTER_ERROR) {
                     merror_exit(DEC_REGEX_ERROR, pi->name);
+                }
+            }
+
+            else if (strcasecmp(elements[j]->element, xml_nullfield) == 0) {
+                if (strcmp(elements[j]->content, "discard") == 0) {
+                    pi->flags = DISCARD;
+                } else if (strcmp(elements[j]->content, "empty") == 0) {
+                    pi->flags = EMPTY;
+                } else if (strcmp(elements[j]->content, "string") == 0) {
+                    pi->flags = SHOW_STRING;
+                } else {
+                    merror(INVALID_ELEMENT, elements[j]->element, elements[j]->content);
+                    goto cleanup;
                 }
             }
 

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -18,6 +18,11 @@
 #define AFTER_PREVREGEX 0x004   /* 4   */
 #define AFTER_ERROR     0x010
 
+// JSON decoder null treatment
+#define DISCARD     0
+#define EMPTY       1
+#define SHOW_STRING 2
+
 struct _Eventinfo;
 
 /* Decoder structure */
@@ -25,6 +30,7 @@ typedef struct {
     u_int8_t  get_next;
     u_int8_t  type;
     u_int8_t  use_own_name;
+    u_int8_t  flags;
 
     u_int16_t id;
     u_int16_t regex_offset;

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -9,6 +9,7 @@
 */
 
 #include "../plugin_decoders.h"
+#include "../decoder.h"
 
 #include "shared.h"
 #include "eventinfo.h"
@@ -202,6 +203,7 @@ static void readJSON (cJSON *logJSON, char *parent, Eventinfo *lf)
     static const char * VALUE_TRUE = "true";
     static const char * VALUE_FALSE = "false";
     static const char * VALUE_COMMA = ",";
+    static const char * VALUE_EMPTY = "";
 
     cJSON *next, *array;
     char *key = NULL;
@@ -325,7 +327,11 @@ static void readJSON (cJSON *logJSON, char *parent, Eventinfo *lf)
                 break;
 
             case cJSON_NULL:
-                fillData(lf, key, VALUE_NULL);
+                if (lf->decoder_info->flags == EMPTY) {
+                    fillData(lf, key, VALUE_EMPTY);
+                } else if (lf->decoder_info->flags == SHOW_STRING) {
+                    fillData(lf, key, VALUE_NULL);
+                }
                 break;
 
             case cJSON_True:

--- a/src/analysisd/decoders/plugins/pf_decoder.c
+++ b/src/analysisd/decoders/plugins/pf_decoder.c
@@ -173,4 +173,3 @@ void *PF_Decoder_Exec(Eventinfo *lf)
 
     return (NULL);
 }
-

--- a/src/analysisd/decoders/plugins/sonicwall_decoder.c
+++ b/src/analysisd/decoders/plugins/sonicwall_decoder.c
@@ -261,4 +261,3 @@ void *SonicWall_Decoder_Exec(Eventinfo *lf)
 
     return (NULL);
 }
-

--- a/src/analysisd/decoders/plugins/symantecws_decoder.c
+++ b/src/analysisd/decoders/plugins/symantecws_decoder.c
@@ -126,4 +126,3 @@ void *SymantecWS_Decoder_Exec(Eventinfo *lf)
 
     return (NULL);
 }
-


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/669 adding the possibility of choose how to store a null value from a JSON event. It has been added a new option when configuring decoders called `json_null_field`. 

An example is shown using the following decoder definition:

```
<decoder name="testdecoder">
  <program_name>^test_program$</program_name>
  <prematch>^{\s*"</prematch>
  <plugin_decoder>JSON_Decoder</plugin_decoder>
  <json_null_field>discard</json_null_field>
</decoder>
```

The allowed values for this new tag are the following:

- `discard`: this option doesn`t save the null field (is the default value). Alerts look like the following one:
```
** Alert 1527266080.9255: - test
2018 May 25 18:34:40 hostname->/root/test.log
Rule: 100101 (level 10) -> 'This is a test alert'
May 25 00:00:00 hostname test_program[0001]: {"date":"2018-05-25","field1":null,"field2":"string"}
date: 2018-05-25
field2: string
```

- `empty`: this option adds the null field as empty.
```
** Alert 1527266080.9255: - test
2018 May 25 18:34:40 hostname->/root/test.log
Rule: 100101 (level 10) -> 'This is a test alert'
May 25 00:00:00 hostname test_program[0001]: {"date":"2018-05-25","field1":null,"field2":"string"}
date: 2018-05-25
field1:
field2: string
```

- `string`: this was the previous behavior, it casts the null field as the "null" string.
```
** Alert 1527266080.9255: - test
2018 May 25 18:34:40 hostname->/root/test.log
Rule: 100101 (level 10) -> 'This is a test alert'
May 25 00:00:00 hostname test_program[0001]: {"date":"2018-05-25","field1":null,"field2":"string"}
date: 2018-05-25
field1: null
field2: string
```