### PR TITLE
Improve configuration parser in API

### DIFF
--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -448,7 +448,7 @@ def load_wazuh_xml(xml_path):
         data = data.replace(comment.group(2), good_comment)
 
     # < characters should be scaped as &lt; unless < is starting a <tag> or a comment
-    data = re.sub(r"<(?!/?.+>|!--)", "&lt;", data)
+    data = re.sub(r"<(?!/?\w+.+>|!--)", "&lt;", data)
 
     # & characters should be scaped if they don't represent an &entity;
     data = re.sub(r"&(?!\w+;)", "&amp;", data)

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -448,7 +448,7 @@ def load_wazuh_xml(xml_path):
         data = data.replace(comment.group(2), good_comment)
 
     # < characters should be scaped as &lt; unless < is starting a <tag> or a comment
-    data = re.sub(r"<(?!/?[\w=\'$,#\"\.@\/_ -:]+>|!--)", "&lt;", data)
+    data = re.sub(r"<(?!/?.+>|!--)", "&lt;", data)
 
     # & characters should be scaped if they don't represent an &entity;
     data = re.sub(r"&(?!\w+;)", "&amp;", data)


### PR DESCRIPTION
Hello @jlruizmlg and @jesuslinares,

The XML parser the framework uses for some API calls and the cluster, has a step where it tries to recognize `<` that don't start a new tag to replace them by `&lt;`. The regex to recognize those `<` is the following:

https://github.com/wazuh/wazuh/blob/8252d5f0974ffbc68b5864989b6f218cb76e9766/framework/wazuh/utils.py#L450-L451

This works well except when characters different than `=`, `\`, `'`, `$`, `,`, `#`, `"`, `.`, `@`, `/`, `_`, ` `, `-` or `:` are used. For example, in https://github.com/wazuh/wazuh-api/issues/85 the `^` character is used, and it makes the API call to fail.

To prevent this parser from failing again, the regex has been changed by the following one:
https://github.com/wazuh/wazuh/blob/5eea8e8e3c74dc23062380437b06b9973fd15b9b/framework/wazuh/utils.py#L450-L451

This regex only searches for `<` that are followed by _any_ character and not ended by a `>`.

[![Regex visualization](https://user-images.githubusercontent.com/8604906/40650309-48319156-6333-11e8-9b2c-e35260e76a07.png)](https://www.debuggex.com/r/FYdGba3aVmQIIZeC)

Best regards,
Marta
