### PR TITLE
Fix wazuh-installer.wxs file and InstallerScripts.vbs

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -30,7 +30,7 @@ address         = Replace(args(1), Chr(34), "") 'ADDRESS
 server_port     = Replace(args(2), Chr(34), "") 'SERVER_PORT
 protocol        = Replace(args(3), Chr(34), "") 'PROTOCOL
 notify_time     = Replace(args(4), Chr(34), "") 'NOTIFY_TIME
-time_reconnect  = Replace(args(5), Chr(34), "") 
+time_reconnect  = Replace(args(5), Chr(34), "")
 ' Only try to set the configuration if variables are setted
 
 Set objFSO = CreateObject("Scripting.FileSystemObject")
@@ -143,6 +143,19 @@ If objFSO.fileExists(home_dir & "ossec.conf") Then
     Set objFile = objFSO.OpenTextFile(home_dir & "ossec.conf", ForWriting)
     objFile.WriteLine strNewText
     objFile.Close
+
+	If Not objFSO.fileExists(home_dir & "local_internal_options.conf") Then
+		' Reading default-local_internal_options.conf file
+		Set objFile = objFSO.OpenTextFile(home_dir & "default-local_internal_options.conf", ForReading)
+		strText = objFile.ReadAll
+		objFile.Close
+
+		' Writing the local_internal_options.conf file
+		Set objFile = objFSO.CreateTextFile(home_dir & "local_internal_options.conf", ForWriting)
+		objFile.WriteLine strText
+		objFile.Close
+
+	End If
 
 End If
 

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -65,14 +65,11 @@
                     <Component Id="AGENT_AUTH.EXE" DiskId="1" Guid="F99FEE7C-A021-4D43-9119-98A8D72EAB65">
                         <File Id="AGENT_AUTH.EXE" Name="agent-auth.exe" Source="agent-auth.exe" />
                     </Component>
-		            <Component Id="SYSCOLLECTOR_DLL" DiskId="1" Guid="3F72347F-1282-44C1-8A97-40BB68CAE4FB">
+                    <Component Id="SYSCOLLECTOR_DLL" DiskId="1" Guid="3F72347F-1282-44C1-8A97-40BB68CAE4FB">
                         <File Id="SYSCOLLECTOR_DLL" Name="syscollector_win_ext.dll" Source="..\wazuh_modules\syscollector\syscollector_win_ext.dll" />
                     </Component>
                     <Component Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" DiskId="1" Guid="10245598-2EE7-4EDB-A114-5398F01A21F9">
-                        <File Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" Name="default-local_internal_options.conf" Source="default-local_internal_options.conf">
-                            <CopyFile Id="LOCAL_INTERNAL_OPTIONS.CONF" DestinationName="default-local_internal_options.conf" />
-                            <CopyFile Id="EMPTY_LOCAL_INTERNAL_OPTIONS.CONF" DestinationName="local_internal_options.conf" />
-                        </File>
+                        <File Id="DEFAULT_LOCAL_INTERNAL_OPTIONS.CONF" Name="default-local_internal_options.conf" Source="default-local_internal_options.conf" />
                     </Component>
                     <Component Id="DEFAULT_OSSEC.CONF" DiskId="1" Guid="26C3265E-EFC8-488D-8D19-397A0C44C071" NeverOverwrite="no">
                         <File Id="DEFAULT_OSSEC.CONF" Name="default-ossec.conf" Source="default-ossec.conf">
@@ -149,6 +146,9 @@
                     <Component Id="WPK_ROOT.PEM" DiskId="1" Guid="EABF8773-57B9-4CD8-A862-87B0E060DBF8">
                         <File Id="WPK_ROOT.PEM" Name="wpk_root.pem" Source="..\..\etc\wpk_root.pem" />
                     </Component>
+                    <Component Id="USER_DEFINED_LOCAL_INTERNAL_OPTIONS.CONF" DiskId="1" Guid="43F9A30D-7C3A-4D7B-884A-D4387F86166E" NeverOverwrite="yes" Permanent="yes" >
+                        <File Id="USER_DEFINED_LOCAL_INTERNAL_OPTIONS.CONF" Name="local_internal_options.conf" Source="default-local_internal_options.conf" />
+                    </Component>
                     <Directory Id="ACTIVE_RESPONSE" Name="active-response">
                         <Directory Id="BIN" Name="bin">
                             <Component Id="RESTART_OSSEC.CMD" DiskId="1" Guid="5A405DD9-F4FF-4313-B242-A28DE03611CA">
@@ -185,7 +185,7 @@
                     </Directory>
                     <Directory Id="BOOKMARKS" Name="bookmarks" />
                     <Directory Id="LOGS" Name="logs" />
-		            <Directory Id="WODLES" Name="wodles" />
+                    <Directory Id="WODLES" Name="wodles" />
                     <Directory Id="RIDS" Name="rids" />
                     <Directory Id="SYSCHECK" Name="syscheck" />
                     <Directory Id="INCOMING" Name="incoming" />
@@ -247,7 +247,6 @@
                 <RemoveFolder Id="purgue_logs_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
-
         <DirectoryRef Id="WODLES">
             <Component Id="CMP_WODLES" Guid="A6811CB8-C2E2-4A1A-A2E5-DCE8221828C6" KeyPath="yes">
                 <CreateFolder />
@@ -255,7 +254,6 @@
                 <RemoveFolder Id="purgue_wodles_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
-
         <DirectoryRef Id="RIDS">
             <Component Id="CMP_RIDS" Guid="2052A162-F044-4432-BF50-F89BCD0BC5D1" KeyPath="yes">
                 <CreateFolder />
@@ -320,7 +318,7 @@
             <ComponentRef Id="CMP_DIFF" />
             <ComponentRef Id="CMP_BOOKMARKS" />
             <ComponentRef Id="CMP_LOGS" />
-	        <ComponentRef Id="CMP_WODLES" />
+            <ComponentRef Id="CMP_WODLES" />
             <ComponentRef Id="CMP_RIDS" />
             <ComponentRef Id="CMP_SYSCHECK" />
             <ComponentRef Id="CMP_INCOMING" />
@@ -331,6 +329,7 @@
             <ComponentRef Id="VERSION" />
             <ComponentRef Id="REVISION" />
             <ComponentRef Id="WPK_ROOT.PEM" />
+            <ComponentRef Id="USER_DEFINED_LOCAL_INTERNAL_OPTIONS.CONF" />
         </Feature>
         <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
     </Product>


### PR DESCRIPTION
Hi team,

in this PR I added some changes to avoid that the `local-internal-options.conf` file gets overwritten when upgrading the wazuh-agent in Windows, 

Now, it has its own `Guid` and the tags `NeverOverwrite="yes"` and `Permanent="yes"` to make it a permanent file and to never overwrite this file.

Also, I made some changes in the `InstallerScripts.vbs` to properly upgrade from previous versions.

Regards,
Braulio.