### PR TITLE
Add excluded extensions config to cluster.json

### DIFF
--- a/framework/wazuh/cluster/cluster.json
+++ b/framework/wazuh/cluster/cluster.json
@@ -89,6 +89,13 @@
         "excluded_files": [
             "ar.conf",
             "ossec.conf"
+        ],
+
+        "excluded_extensions": [
+            "~",
+            ".tmp",
+            ".lock",
+            ".swp"
         ]
     },
 


### PR DESCRIPTION
Hello team,

Currently, the cluster has some "extensions to ignore" hardcoded:

https://github.com/wazuh/wazuh/blob/fe3fecf7e3e6613ff36be8e3d5e2cbfff90615a2/framework/wazuh/cluster/cluster.py#L173-L174

Due to #694, I have thought it could be awesome to configure which extensions ignore. This is why I have added the following to the `cluster.json`:

https://github.com/wazuh/wazuh/blob/bd0f94b184bc93c5be693e2a7134a32148fb3558/framework/wazuh/cluster/cluster.json#L94-L99

For example, if I'm editing my rules with vim, the following files will be present in the filesystem:

```
# ls -lah /var/ossec/etc/rules/
total 16K
drwxrwx---. 2 root  ossec  57 May 30 16:50 .
drwxrwx---. 7 ossec ossec 265 May 30 16:49 ..
-rw-r-----. 1 ossec ossec 457 May 30 16:48 local_rules.xml
-rw-r-----. 1 root  root  12K May 30 16:50 .local_rules.xml.swp
```

But the cluster will ignore the `.swp` file since its extension is ignored:

```python
Python 2.7.5 (default, Aug  4 2017, 00:39:18)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-16)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh.cluster import cluster
>>> files = cluster.get_files_status('master')
>>> '/etc/rules/.local_rules.xml.swp' in files
False
```
```python
Python 3.6.5 (default, Apr 10 2018, 17:08:37)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-16)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh.cluster import cluster
>>> files = cluster.get_files_status('master')
>>> '/etc/rules/.local_rules.xml.swp' in files
False
```

Best regards,
Marta