### PR TITLE
Fix errors in framework running Python 3

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -156,7 +156,7 @@ def __print_table(data, headers, show_header=False):
         """
         For each column of the table, return the size of the biggest element
         """
-        return map(lambda x: max(map(lambda y: len(y)+2, x)), map(list, zip(*l)))
+        return list(map(lambda x: max(map(lambda y: len(y)+2, x)), map(list, zip(*l))))
 
     if show_header:
         table = list(chain.from_iterable([[headers], data]))

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -155,7 +155,7 @@ class Agent:
         # Select
         if select:
             if not set(select['fields']).issubset(valid_select_fields):
-                incorrect_fields = map(lambda x: str(x), set(select['fields']) - valid_select_fields)
+                incorrect_fields = list(map(lambda x: str(x), set(select['fields']) - valid_select_fields))
                 raise WazuhException(1724, "Allowed select fields: {0}. Fields {1}".\
                         format(valid_select_fields, incorrect_fields))
             select_fields |= set(select['fields'])
@@ -380,7 +380,7 @@ class Agent:
             with open(common.api_config_path) as f:
                 data = f.readlines()
 
-            use_only_authd = filter(lambda x: x.strip().startswith('config.use_only_authd'), data)
+            use_only_authd = list(filter(lambda x: x.strip().startswith('config.use_only_authd'), data))
 
             return loads(use_only_authd[0][:-2].strip().split(' = ')[1]) if use_only_authd != [] else False
         except IOError:
@@ -590,6 +590,7 @@ class Agent:
         self.internal_key = data['key']
         self.key = self.compute_key()
 
+
     def _add_manual(self, name, ip, id=None, key=None, force=-1):
         """
         Adds an agent to OSSEC manually.
@@ -716,7 +717,7 @@ class Agent:
             except Exception as ex:
                 fcntl.lockf(lock_file, fcntl.LOCK_UN)
                 lock_file.close()
-                raise WazuhException(1725, str(e))
+                raise WazuhException(1725, str(ex))
 
 
             fcntl.lockf(lock_file, fcntl.LOCK_UN)
@@ -725,6 +726,7 @@ class Agent:
         self.id = agent_id
         self.internal_key = agent_key
         self.key = self.compute_key()
+
 
     def _remove_single_group(self, group_id):
         """
@@ -842,7 +844,7 @@ class Agent:
         request = {}
         if select:
             if not set(select['fields']).issubset(valid_select_fields):
-                incorrect_fields = map(lambda x: str(x), set(select['fields']) - valid_select_fields)
+                incorrect_fields = list(map(lambda x: str(x), set(select['fields']) - valid_select_fields))
                 raise WazuhException(1724, "Allowed select fields: {0}. Fields {1}".\
                                     format(valid_select_fields, incorrect_fields))
             select_fields_set = set(select['fields'])
@@ -1577,11 +1579,11 @@ class Agent:
                 in zip(db_select_fields, tuple) if tuple_elem} for tuple in conn]
 
         if 'id' in select_fields:
-            map(lambda x: setitem(x, 'id', str(x['id']).zfill(3)), non_nested)
+            list(map(lambda x: setitem(x, 'id', str(x['id']).zfill(3)), non_nested))
 
         if 'status' in select_fields:
             try:
-                map(lambda x: setitem(x, 'status', Agent.calculate_status(x['last_keepalive'], x['version'] == None)), non_nested)
+                list(map(lambda x: setitem(x, 'status', Agent.calculate_status(x['last_keepalive'], x['version'] == None)), non_nested))
             except KeyError:
                 pass
 
@@ -1683,11 +1685,11 @@ class Agent:
                 in zip(db_select_fields, tuple) if tuple_elem} for tuple in conn]
 
         if 'id' in select_fields:
-            map(lambda x: setitem(x, 'id', str(x['id']).zfill(3)), non_nested)
+            list(map(lambda x: setitem(x, 'id', str(x['id']).zfill(3)), non_nested))
 
         if 'status' in select_fields:
             try:
-                map(lambda x: setitem(x, 'status', Agent.calculate_status(x['last_keepalive'], x['version'] == None)), non_nested)
+                list(map(lambda x: setitem(x, 'status', Agent.calculate_status(x['last_keepalive'], x['version'] == None)), non_nested))
             except KeyError:
                 pass
 

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -81,7 +81,7 @@ def check_cluster_config(config):
 def get_cluster_items():
     try:
         cluster_items = json.load(open('{0}/framework/wazuh/cluster/cluster.json'.format(common.ossec_path)))
-        map(lambda x: setitem(x, 'umask', int(x['umask'], base=0)), filter(lambda x: 'umask' in x, cluster_items['files'].values()))
+        list(map(lambda x: setitem(x, 'umask', int(x['umask'], base=0)), filter(lambda x: 'umask' in x, cluster_items['files'].values())))
         return cluster_items
     except Exception as e:
         raise WazuhException(3005, str(e))

--- a/framework/wazuh/pyDaemonModule.py
+++ b/framework/wazuh/pyDaemonModule.py
@@ -41,9 +41,9 @@ def pyDaemon():
     # Redirect standard file descriptors
     sys.stdout.flush()
     sys.stderr.flush()
-    si = file('/dev/null', 'r')
-    so = file('/dev/null', 'a+')
-    se = file('/dev/null', 'a+', 0)
+    si = open('/dev/null', 'r')
+    so = open('/dev/null', 'a+')
+    se = open('/dev/null', 'ab+', 0)
     os.dup2(si.fileno(), sys.stdin.fileno())
     os.dup2(so.fileno(), sys.stdout.fileno())
     os.dup2(se.fileno(), sys.stderr.fileno())

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -166,7 +166,7 @@ def print_db(agent_id=None, status='all', pci=None, cis=None, offset=0, limit=co
             allowed_sort_fields = fields.keys()
             # Check if every element in sort['fields'] is in allowed_sort_fields
             if not set(sort['fields']).issubset(allowed_sort_fields):
-                uncorrect_fields = map(lambda x: str(x), set(sort['fields']) - set(allowed_sort_fields))
+                uncorrect_fields = list(map(lambda x: str(x), set(sort['fields']) - set(allowed_sort_fields)))
                 raise WazuhException(1403, 'Allowed sort fields: {0}. Fields: {1}'.format(allowed_sort_fields, uncorrect_fields))
                 
             query += ' ORDER BY ' + ','.join(['{0} {1}'.format(fields[i], sort['order']) for i in sort['fields']])
@@ -247,7 +247,7 @@ def get_pci(agent_id=None, offset=0, limit=common.database_limit, sort=None, sea
             allowed_sort_fields = fields.keys()
             # Check if every element in sort['fields'] is in allowed_sort_fields
             if not set(sort['fields']).issubset(allowed_sort_fields):
-                uncorrect_fields = map(lambda x: str(x), set(sort['fields']) - set(allowed_sort_fields))
+                uncorrect_fields = list(map(lambda x: str(x), set(sort['fields']) - set(allowed_sort_fields)))
                 raise WazuhException(1403, 'Allowed sort fields: {0}. Fields: {1}'.format(allowed_sort_fields, uncorrect_fields))
 
             query += ' ORDER BY pci_dss ' + sort['order']

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -220,7 +220,7 @@ def files(agent_id=None, event=None, filename=None, filetype='file', md5=None, s
             allowed_sort_fields = fields.keys()
              # Check if every element in sort['fields'] is in allowed_sort_fields
             if not set(sort['fields']).issubset(allowed_sort_fields):
-                uncorrect_fields = map(lambda x: str(x), set(sort['fields']) - set(allowed_sort_fields))
+                uncorrect_fields = list(map(lambda x: str(x), set(sort['fields']) - set(allowed_sort_fields)))
                 raise WazuhException(1403, 'Allowed sort fields: {0}. Fields: {1}'.format(allowed_sort_fields, uncorrect_fields))
 
             query += ' ORDER BY ' + ','.join(['{0} {1}'.format(fields[i], sort['order']) for i in sort['fields']])


### PR DESCRIPTION
Hello team,

As explained in #700, there were some bugs in the framework when it was run using Python 3.6:

* **Generators vs lists**:  Both `map` and `filter` functions return a generator in Python3 but a list in Python2. This caused several errors that have been fixed forcing both functions to return a list. Bellow, there's an example of this fix:
    https://github.com/wazuh/wazuh/blob/cce4b2d9ffc99400086e31c48606a30510f80e15/framework/scripts/cluster_control.py#L159
* **`file` function**: When the cluster was run in background mode, it used the built-in `file` function to do the UNIX double-fork. This function was removed in Python3 so the cluster couldn't start:
    https://github.com/wazuh/wazuh/blob/cce4b2d9ffc99400086e31c48606a30510f80e15/framework/wazuh/pyDaemonModule.py#L44-L46

Also, syntax errors have been fixed.

Best regards,
Marta