### PR TITLE
Add binary mode to read and write last-entries

### DIFF
--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -204,12 +204,12 @@ static int seechanges_dupfile(const char *old, const char *current)
 
     buf[2048] = '\0';
 
-    fpr = fopen(old, "r");
+    fpr = fopen(old, "rb");
     if (!fpr) {
         return (0);
     }
 
-    fpw = fopen(current, "w");
+    fpw = fopen(current, "wb");
     if (!fpw) {
         fclose(fpr);
         return (0);


### PR DESCRIPTION
This PR solve issue [708](https://github.com/wazuh/wazuh/issues/708). We finally chose the first option.

Allows to read and write in binary mode the files (last-entry) generated with the report_changes option