### PR TITLE
Fixes of field sha256

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -438,14 +438,20 @@ static int DB_Search(const char *f_name, char *c_sum, Eventinfo *lf)
                 }
 
                 /* SHA-256 message */
-                if(newsum.sha256 && oldsum.sha256)
+                if(newsum.sha256)
                 {
-                    if (strcmp(newsum.sha256, oldsum.sha256) == 0) {
-                        sdb.sha256[0] = '\0';
+                    if(oldsum.sha256) {
+                        if (strcmp(newsum.sha256, oldsum.sha256) == 0) {
+                            sdb.sha256[0] = '\0';
+                        } else {
+                            snprintf(sdb.sha256, OS_FLSIZE, "Old sha256sum was: '%s'\n"
+                                    "New sha256sum is : '%s'\n",
+                                    oldsum.sha256, newsum.sha256);
+                            os_strdup(oldsum.sha256, lf->sha256_before);
+                        }
                     } else {
-                        snprintf(sdb.sha256, OS_FLSIZE, "Old sha256sum was: '%s'\n"
-                                "New sha256sum is : '%s'\n",
-                                oldsum.sha256, newsum.sha256);
+                        snprintf(sdb.sha256, OS_FLSIZE, "Old sha256sum was: 'n/a'\n"
+                                "New sha256sum is : '%s'\n", newsum.sha256);
                         os_strdup(oldsum.sha256, lf->sha256_before);
                     }
                 }
@@ -482,6 +488,7 @@ static int DB_Search(const char *f_name, char *c_sum, Eventinfo *lf)
                          "%s"
                          "%s"
                          "%s"
+                         "%s"
                          "%s%s",
                          f_name,
                          sdb.size,
@@ -490,6 +497,7 @@ static int DB_Search(const char *f_name, char *c_sum, Eventinfo *lf)
                          sdb.gowner,
                          sdb.md5,
                          sdb.sha1,
+                         sdb.sha256,
                          lf->data ? "What changed:\n" : "",
                          lf->data ? lf->data : ""
                         );

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -179,7 +179,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 alertdump = seechanges_addfile(file_name);
             }
 
-            snprintf(alert_msg, 1172, "%c%c%c%c%c%c%c%c%c%ld:%d:%d:%d:%s:%s:%s:%s:%s:%ld:%ld",
+            snprintf(alert_msg, 1172, "%c%c%c%c%c%c%c%c%c%ld:%d:%d:%d:%s:%s:%s:%s:%ld:%ld:%s",
                      opts & CHECK_SIZE ? '+' : '-',
                      opts & CHECK_PERM ? '+' : '-',
                      opts & CHECK_OWNER ? '+' : '-',
@@ -195,11 +195,11 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                      opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
                      opts & CHECK_MD5SUM ? mf_sum : "xxx",
                      opts & CHECK_SHA1SUM ? sf_sum : "xxx",
-                     opts & CHECK_SHA256SUM ? sf256_sum : "xxx",
                      opts & CHECK_OWNER ? get_user(file_name, statbuf.st_uid) : "",
                      opts & CHECK_GROUP ? get_group(statbuf.st_gid) : "",
                      opts & CHECK_MTIME ? (long)statbuf.st_mtime : 0,
-                     opts & CHECK_INODE ? (long)statbuf.st_ino : 0);
+                     opts & CHECK_INODE ? (long)statbuf.st_ino : 0,
+                     opts & CHECK_SHA256SUM ? sf256_sum : "xxx");
 
             if (OSHash_Add(syscheck.fp, file_name, strdup(alert_msg)) <= 0) {
                 merror("Unable to add file to db: %s", file_name);


### PR DESCRIPTION
Avoid sending _Syscheck_ messages to the manager about changes to a file due to an error in the order of the string _sha256_