### PR TITLE
Fixed oscap error with files in tmp folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 
 - New option for the JSON decoder to choose the treatment of NULL values. ([#677](https://github.com/wazuh/wazuh/pull/677))
 
+### Changed
+
+- Delete temporary files when stopping Wazuh. ([#732](https://github.com/wazuh/wazuh/pull/732))
+- Send OpenSCAP checks results to a FIFO queue instead of temporary files. ([#732](https://github.com/wazuh/wazuh/pull/732))
+
 ### Fixed
 
 - Fixed active-responses.log definition path on Windows configuration. ([#739](https://github.com/wazuh/wazuh/pull/739))
@@ -17,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fix reading of Windows platform for 64 bits systems. ([#832](https://github.com/wazuh/wazuh/pull/832))
 - Fixed Syslog output parser when reading the timestamp from the alerts in JSON format. ([#843](https://github.com/wazuh/wazuh/pull/843))
 - Fixed filter for `gpg-pubkey` packages in Syscollector. ([#847](https://github.com/wazuh/wazuh/pull/847))
+
 
 ## [v3.3.1]
 

--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -125,6 +125,10 @@ start()
 
     echo "Starting $NAME $VERSION (maintained by $AUTHOR)..."
     checkpid;
+    
+    # Delete all files in temporary folder
+    TO_DELETE="$DIR/tmp/*"
+    rm -f $TO_DELETE
 
     # We actually start them now.
     for i in ${SDAEMONS}; do

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -213,6 +213,11 @@ start()
 
     checkpid;
 
+    # Delete all files in temporary folder
+    TO_DELETE="$DIR/tmp/*"
+    rm -f $TO_DELETE
+
+
     # We actually start them now.
     for i in ${SDAEMONS}; do
         pstatus ${i};

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -286,6 +286,10 @@ start()
     fi
 
     checkpid;
+    
+    # Delete all files in temporary folder
+    TO_DELETE="$DIR/tmp/*"
+    rm -f $TO_DELETE
 
     # We actually start them now.
     first=true

--- a/wodles/oscap/oscap.py
+++ b/wodles/oscap/oscap.py
@@ -14,7 +14,6 @@ from getopt import getopt, GetoptError
 from signal import signal, SIGINT
 from random import randrange
 from time import time
-import tempfile
 
 OSCAP_BIN = "oscap"
 XSLT_BIN = "xsltproc"
@@ -26,8 +25,6 @@ TEMPLATE_XCCDF = "wodles/oscap/template_xccdf.xsl"
 TEMPLATE_OVAL = "wodles/oscap/template_oval.xsl"
 CONTENT_PATH = "wodles/oscap/content"
 FIFO_PATH = "wodles/oscap/oscap.fifo"
-
-tempfile.tempdir = "tmp"
 
 def check_installed(arguments, stdin=None, stderr=None, shell=False):
 

--- a/wodles/oscap/oscap.py
+++ b/wodles/oscap/oscap.py
@@ -8,16 +8,13 @@
 from re import compile
 from sys import argv, exit, version_info
 from os.path import isfile, isdir
-from xml.etree import ElementTree
-from os import remove, close as close, pipe, fork, mkfifo
-from subprocess import call, CalledProcessError, STDOUT, Popen, PIPE
+from os import mkfifo, unlink
+from subprocess import CalledProcessError, STDOUT, Popen, PIPE
 from getopt import getopt, GetoptError
 from signal import signal, SIGINT
 from random import randrange
-from time import time, sleep
+from time import time
 import tempfile
-import string
-import os, sys
 
 OSCAP_BIN = "oscap"
 XSLT_BIN = "xsltproc"
@@ -103,12 +100,12 @@ def oscap(profile=None):
 
     # If FIFO exists, delete it
     try:
-        os.unlink(FIFO_PATH)
+        unlink(FIFO_PATH)
     except OSError:
         pass
     
     # Create an unique FIFO file
-    os.mkfifo(FIFO_PATH, 0666)
+    mkfifo(FIFO_PATH, 0666)
 
     try:
         cmd = [OSCAP_BIN, arg_module, 'eval', '--fetch-remote-resources', '--results', FIFO_PATH]
@@ -141,7 +138,7 @@ def oscap(profile=None):
             # output = error.output
             print("{0} Executing profile \"{1}\" of file \"{2}\": Return Code: \"{3}\" Error: \"{4}\".".format(OSCAP_LOG_ERROR, profile, arg_file, error.returncode,
                                                                                                                error.output.replace('\r', '').split("\n")[0]))
-            os.unlink(FIFO_PATH)
+            unlink(FIFO_PATH)
             return
 
     try:
@@ -238,7 +235,7 @@ def oscap(profile=None):
         print("{0} Formatting data for profile \"{1}\" of file \"{2}\": Return Code: \"{3}\" Error: \"{4}\".".format(OSCAP_LOG_ERROR, profile, arg_file, error.returncode,
                                                                                                            error.output.replace('\r', '').split("\n")[0]))
 
-    os.unlink(FIFO_PATH)
+    unlink(FIFO_PATH)
 
 def signal_handler(n_signal, frame):
     print("\nExiting...({0})".format(n_signal))

--- a/wodles/oscap/oscap.py
+++ b/wodles/oscap/oscap.py
@@ -32,10 +32,10 @@ FIFO_PATH = "wodles/oscap/oscap.fifo"
 
 tempfile.tempdir = "tmp"
 
-def execute_xsltproc(arguments, stdin=None, stderr=None, shell=False):
+def check_installed(arguments, stdin=None, stderr=None, shell=False):
 
-    ps = Popen(arguments,shell=shell, stdin=FIFO_PATH, stdout=PIPE, stderr=STDOUT)
-    cmd_output = ps.communicate(stdin)
+    ps = Popen(arguments,shell=shell, stdin=None, stdout=PIPE, stderr=STDOUT)
+    cmd_output = ps.communicate()[0]
     returncode = ps.returncode
 
     if returncode != 0:

--- a/wodles/oscap/oscap.py
+++ b/wodles/oscap/oscap.py
@@ -105,7 +105,7 @@ def oscap(profile=None):
     mkfifo(FIFO_PATH, 0666)
 
     try:
-        cmd = [OSCAP_BIN, arg_module, 'eval', '--fetch-remote-resources', '--results', FIFO_PATH]
+        cmd = [OSCAP_BIN, arg_module, 'eval', '--results', FIFO_PATH]
 
         if profile:
             cmd.extend(["--profile", profile])
@@ -156,16 +156,19 @@ def oscap(profile=None):
 
         if arg_module == 'xccdf':
 
-            ps_xsltproc = Popen([XSLT_BIN, TEMPLATE_XCCDF, FIFO_PATH],stdin=None, stdout=PIPE, stderr=STDOUT)
+            ps_xsltproc = Popen([XSLT_BIN, TEMPLATE_XCCDF, FIFO_PATH], stdin=None, stdout=None, stderr=STDOUT)
             ps.wait()
             output = ps.communicate()[0]
-            returncode = ps.returncode
+            ps_xsltproc.wait()
+            returncode = ps_xsltproc.returncode
+
 
             if returncode != 0:
                 error_cmd = CalledProcessError(returncode, [XSLT_BIN, TEMPLATE_XCCDF, FIFO_PATH])
                 error_cmd.output = output
                 raise error_cmd
             else:
+                unlink(FIFO_PATH)
                 return output
                 
             if version_info[0] >= 3:


### PR DESCRIPTION
Now `oscap.py` doesn't create any temporary files. Instead, it creates a FIFO file named `oscap.fifo` under `wodles/oscap` folder.

Furthermore, agents, managers and locals now delete the content of the `tmp` folder when starting.

Fixes #704 