### PR TITLE
Fixed path for active-responses.log on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.3.2]
+
+### Fixed
+
+- Fixed active-responses.log definition path on Windows configuration. ([#739](https://github.com/wazuh/wazuh/pull/739))
+
 ## [v3.3.1]
 
 ### Added
@@ -61,6 +67,7 @@ All notable changes to this project will be documented in this file.
 - Fixed bug getting the agents in cluster control. ([#741](https://github.com/wazuh/wazuh/pull/741))
 - Prevent Logcollector from reporting an error when a path with wildcards matches no files.
 - Fixes the feature to group with the option multi-line. ([#754](https://github.com/wazuh/wazuh/pull/754))
+
 
 ## [v3.2.4]
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -39,7 +39,7 @@
   </localfile>
 
   <localfile>
-    <location>C:\Program Files (x86)\ossec-agent\active-response\active-responses.log</location>
+    <location>active-response\active-responses.log</location>
     <log_format>syslog</log_format>
   </localfile>
 


### PR DESCRIPTION
This PR fixes the `active-responses.log` path on all versions of Windows.

