### PR TITLE
Add node_name to the valid search fields in GET/agents

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -908,7 +908,8 @@ class Agent:
 
         valid_select_fields = set(Agent.fields.values()) | {'status'}
         # at least, we should retrieve those fields since other fields depending on those
-        search_fields = {"id", "name", "ip", "os_name", "os_version", "os_platform", "manager_host", "version", "`group`"}
+        search_fields = {"id", "name", "ip", "os_name", "os_version", "os_platform", "manager_host", "version",
+                         "`group`", "node_name"}
         request = {}
         if select:
             select['fields'] = list(map(lambda x: Agent.fields[x] if x in Agent.fields else x, select['fields']))


### PR DESCRIPTION
Hello,

this PR adds `node_name` to the valid search fields in `GET/agents`.

## Sample:

#### Before
```
$ curl -u foo:bar "http://127.0.0.1:55000/agents?pretty&node=unknown"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "status": "Never connected",
            "dateAdd": "2018-06-08 10:23:56",
            "name": "agent002",
            "ip": "any",
            "id": "002",
            "node_name": "unknown"
         }
      ]
   }
}

$ curl -u foo:bar "http://127.0.0.1:55000/agents?pretty&search=unknown"
{
   "error": 0,
   "data": {
      "totalItems": 0,
      "items": []
   }
}
```

#### Now
```
$ curl -u foo:bar "http://127.0.0.1:55000/agents?pretty&search=unknown"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "status": "Never connected",
            "dateAdd": "2018-06-08 10:23:56",
            "name": "agent002",
            "ip": "any",
            "id": "002",
            "node_name": "unknown"
         }
      ]
   }
}
```

Regards!