### PR TITLE
Inconsistency in sort/select fields in API

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -75,8 +75,8 @@ class Agent:
 
     fields = {'id': 'id', 'name': 'name', 'ip': 'ip', 'status': 'status',
               'os.name': 'os_name', 'os.version': 'os_version', 'os.platform': 'os_platform',
-              'version': 'version', 'manager_host': 'manager_host', 'date_add': 'date_add',
-              'group': 'group', 'merged_sum': 'merged_sum', 'config_sum': 'config_sum',
+              'version': 'version', 'manager_host': 'manager_host', 'dateAdd': 'date_add',
+              'group': '`group`', 'mergedSum': 'merged_sum', 'configSum': 'config_sum',
               'os.codename': 'os_codename', 'os.major': 'os_major', 'os.uname': 'os_uname',
               'os.arch': 'os_arch', 'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive'}
 
@@ -785,24 +785,21 @@ class Agent:
 
     @staticmethod
     def get_agents_dict(conn, select_fields, user_select_fields):
-        select_fields = list(map(lambda x: x.replace('`',''), select_fields))
-        db_api_name = {name:name for name in select_fields}
-        db_api_name.update({"date_add":"dateAdd", "last_keepalive":"lastKeepAlive",'config_sum':'configSum','merged_sum':'mergedSum'})
-        fields_to_nest, non_nested = get_fields_to_nest(db_api_name.values(), ['os'])
+        db_api_name = {v:k for k,v in Agent.fields.items()}
+        fields_to_nest, non_nested = get_fields_to_nest(db_api_name.values(), ['os'], '.')
 
-        agent_items = [{field:value for field,value in zip(select_fields, db_tuple) if value is not None} for db_tuple in conn]
+        agent_items = [{db_api_name[field]:value for field,value in zip(select_fields, db_tuple) if value is not None} for db_tuple in conn]
 
         if 'status' in user_select_fields:
             today = datetime.today()
-            agent_items = [dict(item, id=str(item['id']).zfill(3), status=Agent.calculate_status(item.get('last_keepalive'), item.get('version') is None, today)) for item in agent_items]
+            agent_items = [dict(item, id=str(item['id']).zfill(3), status=Agent.calculate_status(item.get('lastKeepAlive'), item.get('version') is None, today)) for item in agent_items]
         else:
             agent_items = [dict(item, id=str(item['id']).zfill(3)) for item in agent_items]
 
         if len(agent_items) > 0 and agent_items[0]['id'] == '000' and 'ip' in user_select_fields:
             agent_items[0]['ip'] = '127.0.0.1'
 
-        agent_items = [{db_api_name[key]:value for key,value in agent.items() if key in user_select_fields} for agent in agent_items]
-        agent_items = [plain_dict_to_nested_dict(d, fields_to_nest, non_nested, ['os']) for d in agent_items]
+        agent_items = [plain_dict_to_nested_dict(d, fields_to_nest, non_nested, ['os'], '.') for d in agent_items]
 
         return agent_items
 
@@ -950,7 +947,7 @@ class Agent:
         # Sorting
         if sort:
             if sort['fields']:
-                allowed_sort_fields = Agent.fields.keys()
+                allowed_sort_fields = set(Agent.fields.keys())
                 # Check if every element in sort['fields'] is in allowed_sort_fields.
                 if not set(sort['fields']).issubset(allowed_sort_fields):
                     raise WazuhException(1403, 'Allowed sort fields: {0}. Fields: {1}'.format(allowed_sort_fields, sort['fields']))
@@ -980,10 +977,6 @@ class Agent:
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
-
-        if 'group' in min_select_fields:
-            min_select_fields.remove('group')
-            min_select_fields.add('`group`')
 
         conn.execute(query.format(','.join(min_select_fields)), request)
 
@@ -1572,13 +1565,13 @@ class Agent:
         # Sorting
         if sort:
             if sort['fields']:
-                allowed_sort_fields = Agent.fields.keys()
+                allowed_sort_fields = set(Agent.fields.keys())
                 # Check if every element in sort['fields'] is in allowed_sort_fields.
                 if not set(sort['fields']).issubset(allowed_sort_fields):
                     raise WazuhException(1403, 'Allowed sort fields: {0}. Fields: {1}'.\
                         format(allowed_sort_fields, sort['fields']))
 
-                order_str_fields = ['{0} {1}'.format(i, sort['order']) for i in sort['fields']]
+                order_str_fields = ['{0} {1}'.format(Agent.fields[i], sort['order']) for i in sort['fields']]
                 query += ' ORDER BY ' + ','.join(order_str_fields)
             else:
                 query += ' ORDER BY id {0}'.format(sort['order'])

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -362,17 +362,17 @@ def md5(fname):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 
-def get_fields_to_nest(fields, force_fields=[]):
+def get_fields_to_nest(fields, force_fields=[], split_character="_"):
     nest = {k:set(filter(lambda x: x != k, chain.from_iterable(g)))
-             for k,g in groupby(map(lambda x: x.split('_'), sorted(fields)),
+             for k,g in groupby(map(lambda x: x.split(split_character), sorted(fields)),
              key=lambda x:x[0])}
     nested = filter(lambda x: len(x[1]) > 1 or x[0] in force_fields, nest.items())
-    nested = [(field,{(subfield, '_'.join([field,subfield])) for subfield in subfields}) for field, subfields in nested]
-    non_nested = set(filter(lambda x: x.split('_')[0] not in map(itemgetter(0), nested), fields))
+    nested = [(field,{(subfield, split_character.join([field,subfield])) for subfield in subfields}) for field, subfields in nested]
+    non_nested = set(filter(lambda x: x.split(split_character)[0] not in map(itemgetter(0), nested), fields))
     return nested, non_nested
 
 
-def plain_dict_to_nested_dict(data, nested=None, non_nested=None, force_fields=[]):
+def plain_dict_to_nested_dict(data, nested=None, non_nested=None, force_fields=[], split_character='_'):
     """
     Turns an input dictionary with "nested" fields in form
                 field_subfield
@@ -407,7 +407,7 @@ def plain_dict_to_nested_dict(data, nested=None, non_nested=None, force_fields=[
     # separate fields and subfields:
     # nested = {'board': ['serial'], 'cpu': ['cores', 'mhz', 'name'], 'ram': ['free', 'total']}
     nested = {k:list(filter(lambda x: x != k, chain.from_iterable(g)))
-             for k,g in groupby(map(lambda x: x.split('_'), sorted(data.keys())),
+             for k,g in groupby(map(lambda x: x.split(split_character), sorted(data.keys())),
              key=lambda x:x[0])}
 
     # create a nested dictionary with those fields that have subfields
@@ -423,12 +423,12 @@ def plain_dict_to_nested_dict(data, nested=None, non_nested=None, force_fields=[
     #           'total': '2045956'
     #       }
     #    }
-    nested_dict = {f:{sf:data['{0}_{1}'.format(f,sf)] for sf in sfl} for f,sfl
+    nested_dict = {f:{sf:data['{0}{2}{1}'.format(f,sf,split_character)] for sf in sfl} for f,sfl
                   in nested.items() if len(sfl) > 1 or f in force_fields}
 
     # create a dictionary with the non nested fields
     # non_nested_dict = {'board_serial': 'BSS-0123456789'}
-    non_nested_dict = {f:data[f] for f in data.keys() if f.split('_')[0]
+    non_nested_dict = {f:data[f] for f in data.keys() if f.split(split_character)[0]
                        not in nested_dict.keys()}
 
     # append both dictonaries


### PR DESCRIPTION
Hello team,

Selecting or sorting by some fields such as `dateAdd` or `configSum` ends up in errors like these:
```javascript
# curl -u foo:bar "localhost:55000/agents?pretty&sort=dateAdd"
{
   "error": 1403,
   "message": "Sort field invalid: Allowed sort fields: ['status', 'date_add', 'merged_sum', 'os.arch', 'group', 'name', 'os.uname', 'ip', 'os.version', 'os.major', 'os.codename', 'node_name', 'version', 'manager_host', 'config_sum', 'os.name', 'lastKeepAlive', 'id', 'os.platform']. Fields: [u'dateAdd']"
}
# curl -u foo:bar "localhost:55000/agents/groups/default?pretty&select=configSum"
{
   "error": 1724,
   "message": "Not a valid select field: Allowed select fields: status, date_add, merged_sum, os_name, last_keepalive, ip, config_sum, os_platform, id, group, name, os_uname, os_major, os_arch, node_name, os_version, version, os_codename, manager_host. Fields configSum"
}
```

The user has to use `date_add` field but the API returns it as `dateAdd`. The same with `configSum` and many other. This PR aims to fix that:
```javascript
# curl -u foo:bar "localhost:55000/agents/groups/webserver?pretty&select=configSum&sort=dateAdd"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "id": "001"
         }
      ]
   }
}
```

Best regards,
Marta