### PR TITLE
Fix hash type selector in GET/agents/groups

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1435,8 +1435,8 @@ class Agent:
             conn.execute(query.format('COUNT(*)'), request)
 
             # merged.mg and agent.conf sum
-            merged_sum = get_hash(entry + "/merged.mg")
-            conf_sum   = get_hash(entry + "/agent.conf")
+            merged_sum = get_hash(entry + "/merged.mg", hash_algorithm)
+            conf_sum   = get_hash(entry + "/agent.conf", hash_algorithm)
 
             item = {'count':conn.fetch()[0], 'name': entry}
 


### PR DESCRIPTION
Hello team,

this PR fixes the hash type selector in `GET/agents/groups`.

## Sample:

#### Before:

```
$ curl -u foo:bar "http://127.0.0.1:55000/agents/groups?pretty&hash=TestingHash"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "count": 1,
            "conf_sum": "ab73af41699f13fdd81903b5f23d8d00",
            "merged_sum": "d9835ca466a5f6ede52e0684537f76bd",
            "name": "default"
         }
      ]
   }
}
```

#### Now:

```
$ curl -u foo:bar "http://127.0.0.1:55000/agents/groups?pretty&hash=TestingHash"
{
   "error": 1723,
   "message": "Hash algorithm not available: Available algorithms are set(['SHA1', 'SHA224', 'SHA', 'SHA384', 'ecdsa-with-SHA1', 'SHA256', 'SHA512', 'md4', 'md5', 'sha1', 'dsaWithSHA', 'DSA-SHA', 'sha224', 'dsaEncryption', 'DSA', 'RIPEMD160', 'sha', 'MD5', 'MD4', 'sha384', 'sha256', 'sha512', 'ripemd160', 'whirlpool'])."
}

$ curl -u foo:bar "http://127.0.0.1:55000/agents/groups?pretty&hash=DSA"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "count": 1,
            "conf_sum": "9f21e83145c551fc5db520ebbc8094589acbffc9",
            "merged_sum": "ed206f7aceac5e63d08d57670f947149c1b7f675",
            "name": "default"
         }
      ]
}
```

Regards!
