### PR TITLE
Fix logcollector multi-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Prevent command injection in Agentless daemon. ([#600](https://github.com/wazuh/wazuh/pull/600))
 - Fixed bug getting the agents in cluster control. ([#741](https://github.com/wazuh/wazuh/pull/741))
 - Prevent Logcollector from reporting an error when a path with wildcards matches no files.
+- Fixes the feature to group with the option multi-line. ([#754](https://github.com/wazuh/wazuh/pull/754))
 
 ## [v3.2.4]
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -214,7 +214,7 @@ void LogCollectorStart()
                     logff[i].file = NULL;
                 }
                 logff[i].read = read_djbmultilog;
-            } else if (logff[i].logformat[0] >= '0' && logff[i].logformat[0] <= '9') {
+            } else if (strstr(logff[i].logformat, "multi-line:")) {
                 logff[i].read = read_multiline;
             } else if (strcmp("audit", logff[i].logformat) == 0) {
                 logff[i].read = read_audit;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -214,7 +214,7 @@ void LogCollectorStart()
                     logff[i].file = NULL;
                 }
                 logff[i].read = read_djbmultilog;
-            } else if (strstr(logff[i].logformat, "multi-line:")) {
+            } else if (strncmp(logff[i].logformat, "multi-line:", 10) == 0) {
                 logff[i].read = read_multiline;
             } else if (strcmp("audit", logff[i].logformat) == 0) {
                 logff[i].read = read_audit;

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -75,6 +75,8 @@ void *read_multiline(int pos, int *rc, int drop_it)
             continue;
         }
 
+        linesgot = 0;
+
         /* Send message to queue */
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file,


### PR DESCRIPTION
Fixes the feature to group with the option `multi-line` in logcollector.

With configuration:
```
  <localfile>
    <log_format>multi-line:3</log_format>
    <location>/logcollector/test.log</location>
  </localfile>
```

The log receive nexts lines:
```
Test line 1
Test line 2
Test line 3
Test line 4
Test line 5
Test line 6
Test line 7
```

Logcollector generate the output:
```
(ag-ubu16) any->/logcollector/test.log Test line 1 Test line 2 Test line 3
(ag-ubu16) any->/logcollector/test.log Test line 4 Test line 5 Test line 6
```