### PR TITLE
Check version of python in cluster control

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -7,7 +7,7 @@ from sys import argv, exit, path, stdout, version_info
 
 if version_info[0] == 2 and version_info[1] < 7:
     print("Error: Minimal Python version required is 2.7. Found version is {0}.{1}.".format(version_info[0], version_info[1]))
-    exit()
+    exit(1)
 
 from os.path import dirname, basename
 from itertools import chain

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -3,8 +3,13 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+from sys import argv, exit, path, stdout, version_info
+
+if version_info[0] == 2 and version_info[1] < 7:
+    print("Error: Minimal Python version required is 2.7. Found version is {0}.{1}.".format(version_info[0], version_info[1]))
+    exit()
+
 from os.path import dirname, basename
-from sys import argv, exit, path, stdout
 from itertools import chain
 import argparse
 import logging


### PR DESCRIPTION
Hi team,

this PR fixes https://github.com/wazuh/wazuh/issues/759.

### Sample:

```
$ /var/ossec/bin/cluster_control
Error: Minimal Python version required is 2.7. Found version is 2.6.
```

Regards!