### PR TITLE
Rename merge sum and config sum in GET/agents/groups

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1441,10 +1441,10 @@ class Agent:
             item = {'count':conn.fetch()[0], 'name': entry}
 
             if merged_sum:
-                item['merged_sum'] = merged_sum
+                item['mergedSum'] = merged_sum
 
             if conf_sum:
-                item['conf_sum'] = conf_sum
+                item['configSum'] = conf_sum
 
             data.append(item)
 


### PR DESCRIPTION
Hi team,

this PR changes the output of `GET/agents/groups` according to the attribute names in `GET/agents`.

### Sample
#### Before:
```
$ curl -u foo:bar "http://127.0.0.1:55000/agents/groups/?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 4,
      "items": [
         {
            "count": 7,
            "conf_sum": "ab73af41699f13fdd81903b5f23d8d00",
            "merged_sum": "d9835ca466a5f6ede52e0684537f76bd",
            "name": "default"
         },
         {
            "count": 0,
            "conf_sum": "ab73af41699f13fdd81903b5f23d8d00",
            "merged_sum": "1837f0ff126169022108d4d1414f7479",
            "name": "test_group"
         },
         {
            "count": 0,
            "conf_sum": "ab73af41699f13fdd81903b5f23d8d00",
            "merged_sum": "cbb55029feea03c07636760186fa8ba5",
            "name": "test_group2"
         },
         {
            "count": 0,
            "name": "testing"
         }
      ]
   }
}
```
#### Now:
```
$ curl -u foo:bar "http://127.0.0.1:55000/agents/groups/?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 4,
      "items": [
         {
            "count": 7,
            "mergedSum": "d9835ca466a5f6ede52e0684537f76bd",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "name": "default"
         },
         {
            "count": 0,
            "mergedSum": "1837f0ff126169022108d4d1414f7479",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "name": "test_group"
         },
         {
            "count": 0,
            "mergedSum": "cbb55029feea03c07636760186fa8ba5",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "name": "test_group2"
         },
         {
            "count": 0,
            "name": "testing"
         }
      ]
   }
}
```

Regards!
