### PR TITLE
Fix version comparison in remote upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-### Fixed 
+### Fixed
 
 - Windows prevents agent from renaming file. ([#773](https://github.com/wazuh/wazuh/pull/773))
+- Fix manager-agent version comparison in remote upgrades ([#765](https://github.com/wazuh/wazuh/pull/765))
 
 
 ## [v3.3.0]

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -500,21 +500,22 @@ class WazuhVersion:
     def __ge__(self, new_version):
         if self.__mayor < new_version.__mayor:
             return False
-        elif self.__minor < new_version.__minor:
-            return False
-        elif self.__patch < new_version.__patch:
-            return False
-        elif (self.__dev) and not (new_version.__dev):
-            return False
-        elif (self.__dev) and (new_version.__dev):
-            if ord(self.__dev[0]) < ord(new_version.__dev[0]):
+        elif self.__mayor == new_version.__mayor:
+            if self.__minor < new_version.__minor:
                 return False
-            elif ord(self.__dev[0]) == ord(new_version.__dev[0]) and self.__dev_ver < new_version.__dev_ver:
-                return False
-            else:
-                return True
-        else:
-            return True
+            elif self.__minor == new_version.__minor:
+                if self.__patch < new_version.__patch:
+                    return False
+                elif self.__patch == new_version.__patch:
+                    if (self.__dev) and not (new_version.__dev):
+                        return False
+                    elif (self.__dev) and (new_version.__dev):
+                            if ord(self.__dev[0]) < ord(new_version.__dev[0]):
+                                return False
+                            elif ord(self.__dev[0]) == ord(new_version.__dev[0]) and self.__dev_ver < new_version.__dev_ver:
+                                return False
+
+        return True
 
     def __lt__(self, new_version):
         return not (self >= new_version)


### PR DESCRIPTION
This PR fixes the issue: [#764](https://github.com/wazuh/wazuh/issues/764).



