### PR TITLE
Fix report_changes option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Fix log flooding when restarting agent while the merged file is being receiving. ([#788](https://github.com/wazuh/wazuh/pull/788))
 - Fix issue when overwriting rotated logs in Windows agents. ([#776](https://github.com/wazuh/wazuh/pull/776))
 - Prevent OpenSCAP module from running on Windows agents (incompatible). ([#777](https://github.com/wazuh/wazuh/pull/777))
+- Fix issue in file changes report for FIM on Linux when a directory contains a backslash. ([#775](https://github.com/wazuh/wazuh/pull/775))
 
 
 ## [v3.3.0]

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -151,7 +151,7 @@ static char *gen_diff_alert(const char *filename, time_t alert_diff_time)
     snprintf(path, PATH_MAX, "%s/local/%s/diff.%d",
              DIFF_DIR_PATH, filename + PATH_OFFSET, (int)alert_diff_time);
 
-    fp = fopen(path, "r");
+    fp = fopen(path, "rb");
     if (!fp) {
         merror("Unable to generate diff alert.");
         return (NULL);
@@ -204,12 +204,12 @@ static int seechanges_dupfile(const char *old, const char *current)
 
     buf[2048] = '\0';
 
-    fpr = fopen(old, "r");
+    fpr = fopen(old, "rb");
     if (!fpr) {
         return (0);
     }
 
-    fpw = fopen(current, "w");
+    fpw = fopen(current, "wb");
     if (!fpw) {
         fclose(fpr);
         return (0);
@@ -248,14 +248,22 @@ static int seechanges_createpath(const char *filename)
 
     os_strdup(filename, buffer);
     newdir = buffer;
-    tmpstr = strtok(buffer + PATH_OFFSET, "/\\");
+#ifdef WIN32
+    tmpstr = strtok(buffer + PATH_OFFSET, "\\");
+#else
+    tmpstr = strtok(buffer + PATH_OFFSET, "/");
+#endif
     if (!tmpstr) {
         merror("Invalid path name: '%s'", filename);
         free(buffer);
         return (0);
     }
 
-    while (next = strtok(NULL, "/\\"), next) {
+#ifdef WIN32
+    while (next = strtok(NULL, "\\"), next) {
+#else
+    while (next = strtok(NULL, "/"), next) {
+#endif
         if (IsDir(newdir) != 0) {
 #ifndef WIN32
             if (mkdir(newdir, 0770) == -1)
@@ -370,7 +378,7 @@ char *seechanges_addfile(const char *filename)
         /* Dont leak sensible data with a diff hanging around */
         FILE *fdiff;
         char* nodiff_message = "<Diff truncated because nodiff option>";
-        fdiff = fopen(diff_location, "w");
+        fdiff = fopen(diff_location, "wb");
         if (!fdiff){
             merror("Unable to open file for writing `%s`", diff_location);
             goto cleanup;

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -249,7 +249,7 @@ static int seechanges_createpath(const char *filename)
     os_strdup(filename, buffer);
     newdir = buffer;
 #ifdef WIN32
-    tmpstr = strtok(buffer + PATH_OFFSET, "\\");
+    tmpstr = strtok(buffer + PATH_OFFSET, "/\\");
 #else
     tmpstr = strtok(buffer + PATH_OFFSET, "/");
 #endif
@@ -260,7 +260,7 @@ static int seechanges_createpath(const char *filename)
     }
 
 #ifdef WIN32
-    while (next = strtok(NULL, "\\"), next) {
+    while (next = strtok(NULL, "/\\"), next) {
 #else
     while (next = strtok(NULL, "/"), next) {
 #endif


### PR DESCRIPTION
This PR fixes the error that occurs when monitoring a file containing the character `\` in linux.

Also when generating the `last-entry` copies of binary files they are now opened with the `rb` option to generate a full copy of it.