### PR TITLE
Fix log rotation in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Windows prevents agent from renaming file. ([#773](https://github.com/wazuh/wazuh/pull/773))
 - Fix manager-agent version comparison in remote upgrades. ([#765](https://github.com/wazuh/wazuh/pull/765))
 - Fix log flooding when restarting agent while the merged file is being receiving. ([#788](https://github.com/wazuh/wazuh/pull/788))
+- Fix issue when overwriting rotated logs in Windows agents. ([#776](https://github.com/wazuh/wazuh/pull/776))
 
 
 ## [v3.3.0]

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -116,7 +116,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                 snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-001.log.gz", month_dir, tm.tm_mday);
                 counter = 1;
                 while (counter < daily_rotations) {
-                    if (rename(old_rename_path, rename_path) != 0) {
+                    if (rename_ex(old_rename_path, rename_path) != 0) {
                         merror("Couldn't rename compressed log '%s' to '%s': '%s'", old_rename_path, rename_path, strerror(errno));
                         return;
                     }
@@ -129,7 +129,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
         }
 
         if (!IsFile(old_path)) {
-            if (rename(old_path, new_path) == 0) {
+            if (rename_ex(old_path, new_path) == 0) {
                 if (compress) {
                     OS_CompressLog(new_path);
                 }
@@ -160,7 +160,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                 snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-001.json.gz", month_dir, tm.tm_mday);
                 counter = 1;
                 while (counter < daily_rotations) {
-                    if (rename(old_rename_path, rename_path) != 0) {
+                    if (rename_ex(old_rename_path, rename_path) != 0) {
                         merror("Couldn't rename compressed log '%s' to '%s': '%s'", old_rename_path, rename_path, strerror(errno));
                         return;
                     }
@@ -173,7 +173,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
         }
 
         if (!IsFile(old_path_json)) {
-            if (rename(old_path_json, new_path_json) == 0) {
+            if (rename_ex(old_path_json, new_path_json) == 0) {
                 if (compress) {
                     OS_CompressLog(new_path_json);
                 }


### PR DESCRIPTION
The rename function in Windows cannot change the name of a file if it already exists. Therefore, when the maximum limit of rotations for that day is reached, you must overwrite the first one. Failure to rename an existing file causes the error.

From https://msdn.microsoft.com/en-us/library/zw5t957f.aspx: 
> The rename function renames the file or directory specified by oldname to the name given by newname. The old name must be the path of an existing file or directory. The new name must not be the name of an existing file or directory.