### PR TITLE
Define interval to retry to update CVE databases

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -90,6 +90,8 @@ int wm_vulnerability_detector_read(xml_node **nodes, wmodule *module) {
     vulnerability_detector->flags.u_flags.update_nvd = 0;
     vulnerability_detector->flags.u_flags.update_ubuntu = 0;
     vulnerability_detector->flags.u_flags.update_redhat = 0;
+    vulnerability_detector->flags.u_flags.attempted_ubuntu = 0;
+    vulnerability_detector->flags.u_flags.attempted_redhat = 0;
     vulnerability_detector->flags.u_flags.precise = 0;
     vulnerability_detector->flags.u_flags.trusty = 0;
     vulnerability_detector->flags.u_flags.xenial = 0;

--- a/src/wazuh_modules/wm_vuln_detector.h
+++ b/src/wazuh_modules/wm_vuln_detector.h
@@ -64,6 +64,8 @@ typedef struct update_flags {
     unsigned int update_nvd:1;
     unsigned int update_ubuntu:1;
     unsigned int update_redhat:1;
+    unsigned int attempted_ubuntu:1;
+    unsigned int attempted_redhat:1;
     // Ubuntu versions
     unsigned int precise:1; // 12.04
     unsigned int trusty:1;  // 14.04


### PR DESCRIPTION
Related to the issue: [#768](https://github.com/wazuh/wazuh/issues/768)

Now when the vulnerability-detector module can't update the CVE databases, it makes another attempt five minutes later. If it also fails, it waits for the defined interval in the configuration for each distribution.

For example, if we define an hour interval for updating the RedHat 7 database:
```
2018/06/13 09:50:55 wazuh-modulesd:vulnerability-detector: INFO: (5461): Starting Red Hat Enterprise Linux 7 DB update...
2018/06/13 09:50:55 wazuh-modulesd:vulnerability-detector: DEBUG: (5450): Downloading RHEL7 database...
2018/06/13 09:50:55 wazuh-modulesd:vulnerability-detector: ERROR: (5400): RHEL7 database could not be fetched.
2018/06/13 09:50:55 wazuh-modulesd:vulnerability-detector: DEBUG: Failed when updating RedHat databases. Retrying in 300 seconds...
2018/06/13 09:50:55 wazuh-modulesd:vulnerability-detector: ERROR: (5426): CVE database could not be updated.

...

2018/06/13 09:55:55 wazuh-modulesd:vulnerability-detector: INFO: (5461): Starting Red Hat Enterprise Linux 7 DB update...
2018/06/13 09:55:55 wazuh-modulesd:vulnerability-detector: DEBUG: (5450): Downloading RHEL7 database...
2018/06/13 09:55:55 wazuh-modulesd:vulnerability-detector: ERROR: (5400): RHEL7 database could not be fetched.
2018/06/13 09:55:55 wazuh-modulesd:vulnerability-detector: DEBUG: Failed when updating RedHat databases. Retrying in 3600 seconds...
2018/06/13 09:55:55 wazuh-modulesd:vulnerability-detector: ERROR: (5426): CVE database could not be updated.
```