### PR TITLE
Add total_affected_agents and total_failed_ids to API request DELETE/agents

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1255,9 +1255,12 @@ class Agent:
             message = 'Some agents were not removed'
 
         if failed_ids:
-            final_dict = {'msg': message, 'affected_agents': affected_agents, 'failed_ids': failed_ids, 'older_than': older_than}
+            final_dict = {'msg': message, 'affected_agents': affected_agents, 'failed_ids': failed_ids,
+                          'older_than': older_than, 'total_affected_agents':len(affected_agents),
+                          'total_failed_ids':len(failed_ids)}
         else:
-            final_dict = {'msg': message, 'affected_agents': affected_agents, 'older_than': older_than}
+            final_dict = {'msg': message, 'affected_agents': affected_agents, 'older_than': older_than,
+                          'total_affected_agents':len(affected_agents)}
 
         return final_dict
 


### PR DESCRIPTION
Hello team,

this PR fixes https://github.com/wazuh/wazuh/issues/791.

Attributes `total_affected_agents` and `total_failed_ids`  added to the output of DELETE/agents.

### Sample:

```
$ curl -u foo:bar -k -X DELETE "http://127.0.0.1:55000/agents?pretty&older_than=1s&status=Active"
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "total_affected_agents": 901,
      "older_than": "1s",
      "affected_agents": [
         "100",
         "101",
         "102",
         "103",
         "104",
         "105",
         "106",
         "107",
         "108",
         "109",
          ...
      ]
   }
}
```

Regards!