### PR TITLE
Verify WPK with Wazuh CA by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
     - Sockets were not closing properly.
 - Cluster exits showing an error when an error occurs. ([#790](https://github.com/wazuh/wazuh/pull/790))
 - Fixed bug when cluster control or API cannot request the list of nodes to the master. ([#762](https://github.com/wazuh/wazuh/pull/762))
-- Verify WPK with Wazuh CA by default.
+- Verify WPK with Wazuh CA by default. ([#799](https://github.com/wazuh/wazuh/pull/799))
 
 ## [v3.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ All notable changes to this project will be documented in this file.
 - Prevent OpenSCAP module from running on Windows agents (incompatible). ([#777](https://github.com/wazuh/wazuh/pull/777))
 - Fix issue in file changes report for FIM on Linux when a directory contains a backslash. ([#775](https://github.com/wazuh/wazuh/pull/775))
 - Fixed missing "minor" field in agent data managed by the framework. ([#771](https://github.com/wazuh/wazuh/pull/771))
-- Fixed several bugs in upgrade agents ([#784](https://github.com/wazuh/wazuh/pull/784)): 
+- Fixed several bugs in upgrade agents ([#784](https://github.com/wazuh/wazuh/pull/784)):
     - Error upgrading an agent with status `Never Connected`.
     - Fixed API support.
     - Sockets were not closing properly.
 - Cluster exits showing an error when an error occurs. ([#790](https://github.com/wazuh/wazuh/pull/790))
 - Fixed bug when cluster control or API cannot request the list of nodes to the master. ([#762](https://github.com/wazuh/wazuh/pull/762))
+- Verify WPK with Wazuh CA by default.
 
 ## [v3.3.0]
 

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -134,11 +134,13 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define AR_BINDIR       "/active-response/bin"
 #define AGENTCONFIGINT  "/etc/shared/agent.conf"
 #define AGENTCONFIG     DEFAULTDIR "/etc/shared/agent.conf"
+#define DEF_CA_STORE    DEFAULTDIR "/etc/wpk_root.pem"
 #else
 #define DEFAULTAR       "shared/" DEFAULTAR_FILE
 #define AR_BINDIR       "active-response/bin"
 #define AGENTCONFIG     "shared/agent.conf"
 #define AGENTCONFIGINT  "shared/agent.conf"
+#define DEF_CA_STORE    "wpk_root.pem"
 #endif
 
 /* Exec queue */

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -356,6 +356,7 @@ WriteAgent()
         echo "    <ca_store>${CA_STORE}</ca_store>" >> $NEWCONFIG
     fi
 
+    echo "    <ca_verification>yes</ca_verification>" >> $NEWCONFIG
     echo "  </active-response>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 

--- a/src/os_crypto/signature/signature.c
+++ b/src/os_crypto/signature/signature.c
@@ -240,6 +240,12 @@ int wpk_verify_cert(X509 * cert, const char ** ca_store) {
     for (i = 0; ca_store[i]; i++) {
         int r;
 
+        // If empty string, ignore
+
+        if (ca_store[i][0] == '\0') {
+            continue;
+        }
+
         if (stat(ca_store[i], &statbuf) < 0) {
             merror(FSTAT_ERROR, ca_store[i], errno, strerror(errno));
             continue;

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -11,6 +11,7 @@
 #include "execd.h"
 
 char ** wcom_ca_store;
+static int enable_ca_verification = 1;
 
 /* Read the config file */
 int ExecdConfig(const char *cfgfile)
@@ -25,7 +26,6 @@ int ExecdConfig(const char *cfgfile)
     char *repeated_t;
     char **repeated_a;
     char ** ca_verification;
-    int enable_ca_verification = 1;
     int i;
 
     OS_XML xml;
@@ -116,7 +116,17 @@ int ExecdConfig(const char *cfgfile)
             for (i = 0; wcom_ca_store[i]; i++) {
                 mdebug1("Added CA store '%s'.", wcom_ca_store[i]);
             }
-        } else {
+        }
+    }
+
+    OS_ClearXML(&xml);
+
+    return (is_disabled);
+}
+
+void CheckExecConfig() {
+    if (enable_ca_verification) {
+        if (!wcom_ca_store) {
             minfo("No CA store defined. Using Wazuh default CA (%s).", DEF_CA_STORE);
             os_calloc(2, sizeof(char *), wcom_ca_store);
             os_strdup(DEF_CA_STORE, wcom_ca_store[0]);
@@ -124,8 +134,4 @@ int ExecdConfig(const char *cfgfile)
     } else {
         minfo("WPK verification with CA is disabled.");
     }
-
-    OS_ClearXML(&xml);
-
-    return (is_disabled);
 }

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -127,7 +127,7 @@ int ExecdConfig(const char *cfgfile)
 void CheckExecConfig() {
     if (enable_ca_verification) {
         if (!wcom_ca_store) {
-            minfo("No CA store defined. Using Wazuh default CA (%s).", DEF_CA_STORE);
+            minfo("No option <ca_store> defined. Using Wazuh default CA (%s).", DEF_CA_STORE);
             os_calloc(2, sizeof(char *), wcom_ca_store);
             os_strdup(DEF_CA_STORE, wcom_ca_store[0]);
         }

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -20,9 +20,12 @@ int ExecdConfig(const char *cfgfile)
     const char *(xmlf[]) = {"ossec_config", "active-response", "disabled", NULL};
     const char *(blocks[]) = {"ossec_config", "active-response", "repeated_offenders", NULL};
     const char *(castore[]) = {"ossec_config", "active-response", "ca_store", NULL};
+    const char *(caverify[]) = {"ossec_config", "active-response", "ca_verification", NULL};
     char *disable_entry;
     char *repeated_t;
     char **repeated_a;
+    char ** ca_verification;
+    int enable_ca_verification = 1;
     int i;
 
     OS_XML xml;
@@ -94,12 +97,32 @@ int ExecdConfig(const char *cfgfile)
         free(repeated_a);
     }
 
-    if (wcom_ca_store = OS_GetContents(&xml, castore), wcom_ca_store) {
-        for (i = 0; wcom_ca_store[i]; i++) {
-            mdebug1("Added CA store '%s'.", wcom_ca_store[i]);
+    if (ca_verification = OS_GetContents(&xml, caverify), ca_verification) {
+        for (i = 0; ca_verification[i]; ++i) {
+            if (strcasecmp(ca_verification[i], "yes") == 0) {
+                enable_ca_verification = 1;
+            } else if (strcasecmp(ca_verification[i], "no") == 0) {
+                enable_ca_verification = 0;
+            } else {
+                mwarn("Invalid content for tag <%s>: '%s'", caverify[2], ca_verification[i]);
+            }
+        }
+
+        free_strarray(ca_verification);
+    }
+
+    if (enable_ca_verification) {
+        if (wcom_ca_store = OS_GetContents(&xml, castore), wcom_ca_store) {
+            for (i = 0; wcom_ca_store[i]; i++) {
+                mdebug1("Added CA store '%s'.", wcom_ca_store[i]);
+            }
+        } else {
+            minfo("No CA store defined. Using Wazuh default CA (%s).", DEF_CA_STORE);
+            os_calloc(2, sizeof(char *), wcom_ca_store);
+            os_strdup(DEF_CA_STORE, wcom_ca_store[0]);
         }
     } else {
-        mdebug1("No CA store defined.");
+        minfo("WPK verification with CA is disabled.");
     }
 
     OS_ClearXML(&xml);

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -114,7 +114,9 @@ int ExecdConfig(const char *cfgfile)
     if (enable_ca_verification) {
         if (wcom_ca_store = OS_GetContents(&xml, castore), wcom_ca_store) {
             for (i = 0; wcom_ca_store[i]; i++) {
-                mdebug1("Added CA store '%s'.", wcom_ca_store[i]);
+                if (wcom_ca_store[i][0]) {
+                    mdebug1("Added CA store '%s'.", wcom_ca_store[i]);
+                }
             }
         }
     }

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -158,6 +158,8 @@ int main(int argc, char **argv)
         merror_exit(PID_ERROR);
     }
 
+    CheckExecConfig();
+
     /* Start exec queue */
     if ((m_queue = StartMQ(EXECQUEUEPATH, READ)) < 0) {
         merror_exit(QUEUE_ERROR, EXECQUEUEPATH, strerror(errno));

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -35,6 +35,7 @@ extern time_t pending_upg;
 
 void WinExecdRun(char *exec_msg);
 int ReadExecConfig(void);
+void CheckExecConfig();
 char *GetCommandbyName(const char *name, int *timeout) __attribute__((nonnull));
 void ExecCmd(char *const *cmd) __attribute__((nonnull));
 void ExecCmd_Win32(char *cmd);

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -48,6 +48,8 @@ int WinExecd_Start()
         return (0);
     }
 
+    CheckExecConfig();
+
     /* Create list for timeout */
     timeout_list = OSList_Create();
     if (!timeout_list) {

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -164,6 +164,7 @@
   <active-response>
     <disabled>no</disabled>
     <ca_store>wpk_root.pem</ca_store>
+    <ca_verification>yes</ca_verification>
   </active-response>
 
   <!-- Choose between plain or json format (or both) for internal logs -->


### PR DESCRIPTION
Related issue: https://github.com/wazuh/wazuh/issues/758

This PR makes the agent use the default root CA "wpk_root.pem" if no such `<ca_store>` is defined in the `<active-response>` section.

This way, the agent forces to verify every WPK file that the manager sends it. On the other hand, a new option has been introduced to disable explicitly the verification with CA:

```xml
<active-response>
  <ca_verification>no</ca_verification>
</active-response>
```

If the root CA settings is not present in the configuration, this message appears:

```
ossec-execd: INFO: No option <ca_store> defined. Using Wazuh default CA (/var/ossec/etc/wpk_root.pem).
```

This message appears in the log if the WPK validation with CA is disabled:
```
ossec-execd: INFO: WPK verification with CA is disabled.
```

We have added another improvement: if the option `<ca_store>` is empty, its value is ignored.