### PR TITLE
 Fix missing fields in agents: key and os_build

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -78,7 +78,9 @@ class Agent:
               'version': 'version', 'manager_host': 'manager_host', 'dateAdd': 'date_add',
               'group': '`group`', 'mergedSum': 'merged_sum', 'configSum': 'config_sum',
               'os.codename': 'os_codename', 'os.major': 'os_major', 'os.minor': 'os_minor',
-              'os.uname': 'os_uname', 'os.arch': 'os_arch', 'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive'}
+              'os.uname': 'os_uname', 'os.arch': 'os_arch', 'os.build':'os_build',
+              'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive', 'key':'key'}
+
 
     def __init__(self, id=None, name=None, ip=None, key=None, force=-1):
         """


### PR DESCRIPTION
Hello team,

this PR fixes the issue https://github.com/wazuh/wazuh/issues/801.

After the refactor done in https://github.com/wazuh/wazuh/pull/743 the agent fields `key` and `os_build` were missing.

Regards!