### PR TITLE
Fix to detect errors when unmerging files in agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Fixed bug when cluster control or API cannot request the list of nodes to the master. ([#762](https://github.com/wazuh/wazuh/pull/762))
 - Verify WPK with Wazuh CA by default. ([#799](https://github.com/wazuh/wazuh/pull/799))
 - Fixed bug when `agent.conf` received a wrong configuration from manager and made it stop. ([#796](https://github.com/wazuh/wazuh/pull/796))
+- Alert when unmerge files fails on agent. ([#731](https://github.com/wazuh/wazuh/pull/731))
 
 ## [v3.3.0]
 

--- a/etc/rules/0016-wazuh_rules.xml
+++ b/etc/rules/0016-wazuh_rules.xml
@@ -127,4 +127,11 @@
     <group>agent_restarting,configuration_failure,</group>
   </rule>
 
+  <rule id="222" level="7">
+    <if_sid>200</if_sid>
+    <match>^wazuh: Could not unmerge shared file.</match>
+    <description>The agent could not restart due to a error while unmerging files.</description>
+    <group>agent_restarting,configuration_failure,</group>
+  </rule>
+
 </group>

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -119,4 +119,6 @@ extern keystore keys;
 extern agent *agt;
 extern agent_state_t agent_state;
 
+static const char AG_IN_UNMERGE[] = "wazuh: Could not unmerge shared file.";
+
 #endif /* __AGENTD_H */

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -255,9 +255,13 @@ void *receiver_thread(__attribute__((unused)) void *none)
                                         mwarn("Could not clean up shared directory.");
                                     }
 
-                                    UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT);
+                                    if(!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT)){
+                                        char msg_output[OS_MAXSTR];
 
-                                    if (agt->flags.remote_conf && !verifyRemoteConf()) {
+                                        snprintf(msg_output, OS_MAXSTR, "%c:%s:%s:",  LOCALFILE_MQ, "ossec-agent", AG_IN_UNMERGE);
+                                        send_msg(msg_output, -1);
+                                    }
+                                    else if (agt->flags.remote_conf && !verifyRemoteConf()) {
                                         if (agt->flags.auto_restart) {
                                             minfo("Agent is restarting due to shared configuration changes.");
                                             restartAgent();

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -72,9 +72,9 @@ int receive_msg()
                 }else if(length > OS_MAXSTR){
                 	merror("Too big message size from manager.");
                 	return 0;
-                }    
+                }
             }
-            
+
             recv_b = recv(agt->sock, buffer, length, MSG_WAITALL);
 
             if (recv_b != (ssize_t)length) {
@@ -234,9 +234,13 @@ int receive_msg()
                                     mwarn("Could not clean up shared directory.");
                                 }
 
-                                UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT);
+                                if(!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT)){
+                                    char msg_output[OS_MAXSTR];
 
-                                if (agt->flags.remote_conf && !verifyRemoteConf()) {
+                                    snprintf(msg_output, OS_MAXSTR, "%c:%s:%s",  LOCALFILE_MQ, "ossec-agent", AG_IN_UNMERGE);
+                                    send_msg(msg_output, -1);
+                                }
+                                else if (agt->flags.remote_conf && !verifyRemoteConf()) {
                                     if (agt->flags.auto_restart) {
                                         minfo("Agent is restarting due to shared configuration changes.");
                                         restartAgent();


### PR DESCRIPTION
PR imported from this one: [#731](https://github.com/wazuh/wazuh/pull/731) for Wazuh v3.3.1

It includes the following commits:
 
* Fixed unmerge files error detection

* Added rule for triggering alerts

* Updated CHANGELOG

* Fix rule for error on shared file unmerging