### PR TITLE
Warn to restart the manager when updating syscheck/rootcheck databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed active-responses.log definition path on Windows configuration. ([#739](https://github.com/wazuh/wazuh/pull/739))
+- Added warning message when updating Syscheck/Rootcheck database to restart the manager. ([#817](https://github.com/wazuh/wazuh/pull/817))
 
 ## [v3.3.1]
 

--- a/src/util/rootcheck_control.c
+++ b/src/util/rootcheck_control.c
@@ -23,8 +23,10 @@ static void helpmsg()
 {
     printf("\n%s %s: Manages the policy and auditing database.\n",
            __ossec_name, ARGV0);
-    printf("Available options:\n");
+    printf("Available options:\n\n");
     printf("\t-h          This help message.\n");
+    printf("\t-V          Print version.\n");
+    printf("\t-D          Debug mode.\n\n");
     printf("\t-l          List available (active or not) agents.\n");
     printf("\t-lc         List only active agents.\n");
     printf("\t-u <id>     Updates (clear) the database for the agent.\n");
@@ -218,10 +220,10 @@ int main(int argc, char **argv)
 
             if (json_output) {
                 cJSON_AddNumberToObject(json_root, "error", 0);
-                cJSON_AddStringToObject(json_root, "data", "Policy and auditing database updated");
+                cJSON_AddStringToObject(json_root, "data", "Policy and auditing database updated. Restart the manager to apply changes.");
                 printf("%s", cJSON_PrintUnformatted(json_root));
             } else
-                printf("\n** Policy and auditing database updated.\n\n");
+                printf("\n** Policy and auditing database updated. Restart the manager to apply changes.\n\n");
 
             exit(0);
         }
@@ -242,10 +244,10 @@ int main(int argc, char **argv)
 
             if (json_output) {
                 cJSON_AddNumberToObject(json_root, "error", 0);
-                cJSON_AddStringToObject(json_root, "data", "Policy and auditing database updated");
+                cJSON_AddStringToObject(json_root, "data", "Policy and auditing database updated. Restart the manager to apply changes.");
                 printf("%s", cJSON_PrintUnformatted(json_root));
             } else
-                printf("\n** Policy and auditing database updated.\n\n");
+                printf("\n** Policy and auditing database updated. Restart the manager to apply changes.\n\n");
 
             exit(0);
         }
@@ -279,10 +281,10 @@ int main(int argc, char **argv)
 
             if (json_output) {
                  cJSON_AddNumberToObject(json_root, "error", 0);
-                 cJSON_AddStringToObject(json_root, "data", "Policy and auditing database updated");
+                 cJSON_AddStringToObject(json_root, "data", "Policy and auditing database updated. Restart the manager to apply changes.");
                  printf("%s", cJSON_PrintUnformatted(json_root));
             } else
-                printf("\n** Policy and auditing database updated.\n\n");
+                printf("\n** Policy and auditing database updated. Restart the manager to apply changes.\n\n");
 
             exit(0);
         }

--- a/src/util/syscheck_control.c
+++ b/src/util/syscheck_control.c
@@ -22,8 +22,10 @@ static void helpmsg()
 {
     printf("\n%s %s: Manages the integrity checking database.\n",
            __ossec_name, ARGV0);
-    printf("Available options:\n");
+    printf("Available options:\n\n");
     printf("\t-h          This help message.\n");
+    printf("\t-V          Print version.\n");
+    printf("\t-D          Debug mode.\n\n");
     printf("\t-l          List available (active or not) agents.\n");
     printf("\t-lc         List only active agents.\n");
     printf("\t-u <id>     Updates (clear) the database for the agent.\n");
@@ -242,10 +244,10 @@ int main(int argc, char **argv)
 
             if (json_output) {
                 cJSON_AddNumberToObject(json_root, "error", 0);
-                cJSON_AddStringToObject(json_root, "data", "Integrity check database updated");
+                cJSON_AddStringToObject(json_root, "data", "Integrity check database updated. Restart the manager to apply changes.");
                 printf("%s", cJSON_PrintUnformatted(json_root));
             } else
-                printf("\n** Integrity check database updated.\n\n");
+                printf("\n** Integrity check database updated. Restart the manager to apply changes.\n\n");
 
             exit(0);
         }
@@ -276,10 +278,10 @@ int main(int argc, char **argv)
 
             if (json_output) {
                 cJSON_AddNumberToObject(json_root, "error", 0);
-                cJSON_AddStringToObject(json_root, "data", "Integrity check database updated");
+                cJSON_AddStringToObject(json_root, "data", "Integrity check database updated. Restart the manager to apply changes.");
                 printf("%s", cJSON_PrintUnformatted(json_root));
             } else
-                printf("\n** Integrity check database updated.\n\n");
+                printf("\n** Integrity check database updated. Restart the manager to apply changes.\n\n");
 
             exit(0);
         }
@@ -314,10 +316,10 @@ int main(int argc, char **argv)
 
             if (json_output) {
                 cJSON_AddNumberToObject(json_root, "error", 0);
-                cJSON_AddStringToObject(json_root, "data", "Integrity check database updated");
+                cJSON_AddStringToObject(json_root, "data", "Integrity check database updated. Restart the manager to apply changes.");
                 printf("%s", cJSON_PrintUnformatted(json_root));
             } else
-                printf("\n** Integrity check database updated.\n\n");
+                printf("\n** Integrity check database updated. Restart the manager to apply changes.\n\n");
 
             exit(0);
         }

--- a/src/util/syscheck_update.c
+++ b/src/util/syscheck_update.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
         closedir(sys_dir);
         wdb_delete_fim_all();
 
-        printf("\n** Integrity check database updated.\n\n");
+        printf("\n** Integrity check database updated. Restart the manager to apply changes.\n\n");
         exit(0);
     } else {
         printf("\n** Invalid option '%s'.\n", argv[1]);
@@ -169,6 +169,6 @@ int main(int argc, char **argv)
         wdb_delete_fim(atoi(keys.keyentries[i]->id));
     }
 
-    printf("\n** Integrity check database updated.\n\n");
+    printf("\n** Integrity check database updated. Restart the manager to apply changes.\n\n");
     return (0);
 }


### PR DESCRIPTION
This PR is a partial and temporary solution to the issue https://github.com/wazuh/wazuh/issues/815.

It adds a message warning to restart the manager when the Syscheck or Rootcheck database of any agent has been updated by the tools `syscheck_control`, `syscheck_update` and `rootcheck_control`. This step is necessary to apply the changes.