### PR TITLE
Check that PID files were created and written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 - Fixed active-responses.log definition path on Windows configuration. ([#739](https://github.com/wazuh/wazuh/pull/739))
 - Added warning message when updating Syscheck/Rootcheck database to restart the manager. ([#817](https://github.com/wazuh/wazuh/pull/817))
+- Fix PID file creation checking. ([#822](https://github.com/wazuh/wazuh/pull/822))
+  - Check that the PID file was created and written.
+  - This would prevent service from running multiple processes of the same daemon.
+
 
 ## [v3.3.1]
 

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -201,29 +201,6 @@ int rootcheck_init(int test_config)
     /* Start up message */
 #ifdef WIN32
     mtinfo(ARGV0, STARTUP_MSG, getpid());
-#else
-
-    /* Connect to the queue if configured to do so */
-    if (rootcheck.notify == QUEUE) {
-        mtdebug1(ARGV0, "Starting queue ...");
-
-        /* Start the queue */
-        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
-            mterror(ARGV0, QUEUE_ERROR, DEFAULTQPATH, strerror(errno));
-
-            /* 5 seconds to see if the agent starts */
-            sleep(5);
-            if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
-                /* Wait 10 more seconds */
-                mterror(ARGV0, QUEUE_ERROR, DEFAULTQPATH, strerror(errno));
-                sleep(10);
-                if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
-                    mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQPATH);
-                }
-            }
-        }
-    }
-
 #endif /* WIN32 */
 
 #endif /* OSSECHIDS */
@@ -241,6 +218,7 @@ int rootcheck_init(int test_config)
 #ifndef WIN32
     /* Start signal handling */
     StartSIG(ARGV0);
+    rootcheck_connect();
 #endif
     mtdebug1(ARGV0, "Running run_rk_check");
     run_rk_check();
@@ -248,4 +226,18 @@ int rootcheck_init(int test_config)
     mtdebug1(ARGV0, "Leaving...");
 #endif /* OSSECHIDS */
     return (0);
+}
+
+void rootcheck_connect() {
+#ifndef WIN32
+    /* Connect to the queue if configured to do so */
+    if (rootcheck.notify == QUEUE) {
+        mtdebug1(ARGV0, "Starting queue ...");
+
+        /* Start the queue */
+        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+            mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQPATH);
+        }
+    }
+#endif
 }

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -85,6 +85,9 @@ int notify_rk(int rk_type, const char *msg);
 /* Start the rootcheck externally */
 int rootcheck_init(int test_config);
 
+/* Connect Rootcheck queue */
+void rootcheck_connect();
+
 /* run_rk_check: checks the integrity of the files against the
  * saved database
  */
@@ -126,4 +129,3 @@ typedef struct _Proc_Info {
 } Proc_Info;
 
 #endif /* __ROOTCHECK_H */
-

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -446,11 +446,15 @@ int CreatePID(const char *name, int pid)
     fprintf(fp, "%d\n", pid);
 
     if (chmod(file, 0640) != 0) {
+        merror(CHMOD_ERROR, file, errno, strerror(errno));
         fclose(fp);
         return (-1);
     }
 
-    fclose(fp);
+    if (fclose(fp)) {
+        merror("Could not write PID file '%s': %s (%d)", file, strerror(errno), errno);
+        return -1;
+    }
 
     return (0);
 }

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -287,6 +287,10 @@ int main(int argc, char **argv)
         merror_exit(PID_ERROR);
     }
 
+    if (syscheck.rootcheck) {
+        rootcheck_connect();
+    }
+
     /* Initial time to settle */
     sleep(syscheck.tsleep + 2);
 

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -135,11 +135,6 @@ void wm_setup()
         exit(EXIT_SUCCESS);
     }
 
-    // Create PID file
-
-    if (CreatePID(ARGV0, getpid()) < 0)
-        merror_exit("Couldn't create PID file: (%s)", strerror(errno));
-
     // Signal management
 
     atexit(wm_cleanup);
@@ -149,6 +144,11 @@ void wm_setup()
         sigaction(SIGHUP, &action, NULL);
         sigaction(SIGINT, &action, NULL);
     }
+
+    // Create PID file
+
+    if (CreatePID(ARGV0, getpid()) < 0)
+        merror_exit("Couldn't create PID file: (%s)", strerror(errno));
 }
 
 // Cleanup function, called on exiting.


### PR DESCRIPTION
When each component gets started, it must create a PID file. This lets `ossec-control` kill that process when stopping the service.

The function `CreatePID()` checks that the PID file is created but does not check whether the file is written (`fclose()`). So the application may leave a PID file empty and continue running, in this case `ossec-control` would not stop it.

This PR aims to check that the PID file was created and written. Otherwise it would log an error and make the application quit.

Example of error:
```
2018/06/20 13:22:45 ossec-analysisd: ERROR: Could not write PID file '/var/run/ossec-analysisd-4818.pid': No space left on device (28)
2018/06/20 13:22:45 ossec-analysisd: CRITICAL: (1212): Unable to create PID file.
```

Related issue: https://github.com/wazuh/wazuh/issues/821