### PR TITLE
Remove offset of frequency rules

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1683,7 +1683,12 @@ static int getattributes(char **attributes, char **values,
         /* Get frequency */
         else if (strcasecmp(attributes[k], xml_frequency) == 0) {
             if (OS_StrIsNum(values[k])) {
-                sscanf(values[k], "%4d", frequency);
+                *frequency = atoi(values[k]);
+                if (*frequency < 2 || *frequency > 9999) {
+                    merror("rules_op: Invalid frequency: %d. Must be higher than 1 and lower than 10000.", *frequency);
+                    return (-1);
+                }
+                *frequency = *frequency - 2;
             } else {
                 merror("rules_op: Invalid frequency: %s. "
                        "Must be integer" ,


### PR DESCRIPTION
Related to the issue https://github.com/wazuh/wazuh/issues/818.

Previously there was a +2 offset in the frequency option due to design reasons. After evaluating several options to disable the current offset, we think the least impactful option is to correct that offset when reading the rules from the XML files.

It also set the limit of the offset between 2 and 9999.