### PR TITLE
Improvements when Syscheck and Rootcheck starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ All notable changes to this project will be documented in this file.
 - Fix reading of Windows platform for 64 bits systems. ([#832](https://github.com/wazuh/wazuh/pull/832))
 - Fixed Syslog output parser when reading the timestamp from the alerts in JSON format. ([#843](https://github.com/wazuh/wazuh/pull/843))
 - Fixed filter for `gpg-pubkey` packages in Syscollector. ([#847](https://github.com/wazuh/wazuh/pull/847))
-- Improvements  error messages when Rootcheck and Syscheck start.
 
 
 ## [v3.3.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 
 - Delete temporary files when stopping Wazuh. ([#732](https://github.com/wazuh/wazuh/pull/732))
 - Send OpenSCAP checks results to a FIFO queue instead of temporary files. ([#732](https://github.com/wazuh/wazuh/pull/732))
+- Default behavior when starting Syscheck and Rootcheck components. ([#829](https://github.com/wazuh/wazuh/pull/829))
+  - They are disabled if not appear in the configuration.
+  - They can be set up as empty blocks in the configuration, applying their default values.
+  - Improvements of error and information messages when they start.
 
 ### Fixed
 
@@ -22,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Fix reading of Windows platform for 64 bits systems. ([#832](https://github.com/wazuh/wazuh/pull/832))
 - Fixed Syslog output parser when reading the timestamp from the alerts in JSON format. ([#843](https://github.com/wazuh/wazuh/pull/843))
 - Fixed filter for `gpg-pubkey` packages in Syscollector. ([#847](https://github.com/wazuh/wazuh/pull/847))
+- Improvements  error messages when Rootcheck and Syscheck start.
 
 
 ## [v3.3.1]

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -90,14 +90,14 @@ static int read_main_elements(const OS_XML *xml, int modules,
             if ((modules & CRULES) && (Read_Rules(chld_node, d1, d2) < 0)) {
                 goto fail;
             }
-        } else if (chld_node && (strcmp(node[i]->element, ossyscheck) == 0)) {
+        } else if (strcmp(node[i]->element, ossyscheck) == 0) {
             if ((modules & CSYSCHECK) && (Read_Syscheck(chld_node, d1, d2) < 0)) {
                 goto fail;
             }
             if ((modules & CGLOBAL) && (Read_GlobalSK(chld_node, d1, d2) < 0)) {
                 goto fail;
             }
-        } else if (chld_node && (strcmp(node[i]->element, osrootcheck) == 0)) {
+        } else if (strcmp(node[i]->element, osrootcheck) == 0) {
             if ((modules & CROOTCHECK) && (Read_Rootcheck(chld_node, d1, d2) < 0)) {
                 goto fail;
             }

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -40,6 +40,9 @@ int Read_GlobalSK(XML_NODE node, void *configp, __attribute__((unused)) void *ma
         }
     }
 
+    if (!node)
+        return 0;
+
     while (node[i]) {
         if (!node[i]->element) {
             merror(XML_ELEMNULL);

--- a/src/config/rootcheck-config.c
+++ b/src/config/rootcheck-config.c
@@ -60,6 +60,12 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 
     rootcheck = (rkconfig *)configp;
 
+    /* If rootcheck is defined, enable it by default */
+    rootcheck->disabled = 0;
+
+    if (!node)
+        return 0;
+
     while (node[i]) {
         if (!node[i]->element) {
             merror(XML_ELEMNULL);
@@ -109,10 +115,15 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_rootkit_files) == 0) {
+            rootcheck->checks.rc_files = 1;
             os_strdup(node[i]->content, rootcheck->rootkit_files);
         } else if (strcmp(node[i]->element, xml_rootkit_trojans) == 0) {
+            rootcheck->checks.rc_trojans = 1;
             os_strdup(node[i]->content, rootcheck->rootkit_trojans);
         } else if (strcmp(node[i]->element, xml_winaudit) == 0) {
+#ifdef WIN32
+            rootcheck->checks.rc_winaudit = 1;
+#endif
             os_strdup(node[i]->content, rootcheck->winaudit);
         } else if (strcmp(node[i]->element, xml_unixaudit) == 0) {
             unsigned int j = 0;
@@ -125,6 +136,9 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
             rootcheck->unixaudit[j] = NULL;
             rootcheck->unixaudit[j + 1] = NULL;
 
+#ifndef WIN32
+            rootcheck->checks.rc_unixaudit = 1;
+#endif
             os_strdup(node[i]->content, rootcheck->unixaudit[j]);
         } else if (strcmp(node[i]->element, xml_ignore) == 0) {
             unsigned int j = 0;
@@ -139,8 +153,14 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 
             os_strdup(node[i]->content, rootcheck->ignore[j]);
         } else if (strcmp(node[i]->element, xml_winmalware) == 0) {
+#ifdef WIN32
+            rootcheck->checks.rc_winmalware = 1;
+#endif
             os_strdup(node[i]->content, rootcheck->winmalware);
         } else if (strcmp(node[i]->element, xml_winapps) == 0) {
+#ifdef WIN32
+            rootcheck->checks.rc_winapps = 1;
+#endif
             os_strdup(node[i]->content, rootcheck->winapps);
         } else if (strcmp(node[i]->element, xml_base_dir) == 0) {
             os_strdup(node[i]->content, rootcheck->basedir);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -571,6 +571,14 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
     syscheck = (syscheck_config *)configp;
     unsigned int nodiff_size = 0;
 
+    /* If no options are defined, disable it */
+    if (!node) {
+        syscheck->disabled = 1;
+        return 0;
+    } else {
+        syscheck->disabled = 0;
+    }
+
     while (node[i]) {
         if (!node[i]->element) {
             merror(XML_ELEMNULL);

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -185,12 +185,12 @@ int rootcheck_init(int test_config)
         return (1);
     }
 
-    /* Check if Unix audit file is configured */
-    if (!rootcheck.unixaudit) {
 #ifndef WIN32
+    /* Check if Unix audit file is configured */
+    if (rootcheck.checks.rc_unixaudit && !rootcheck.unixaudit) {
         mtferror(ARGV0, "System audit file not configured.");
-#endif
     }
+#endif
 
     /* Set default values */
     if (rootcheck.workdir == NULL) {

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -78,24 +78,24 @@ int rootcheck_init(int test_config)
     rootcheck.notify = QUEUE;
     rootcheck.scanall = 0;
     rootcheck.readall = 0;
-    rootcheck.disabled = 0;
+    rootcheck.disabled = 1;
     rootcheck.skip_nfs = 0;
     rootcheck.alert_msg = NULL;
     rootcheck.time = ROOTCHECK_WAIT;
 
     rootcheck.checks.rc_dev = 1;
-    rootcheck.checks.rc_files = 1;
+    rootcheck.checks.rc_files = 0;
     rootcheck.checks.rc_if = 1;
     rootcheck.checks.rc_pids = 1;
     rootcheck.checks.rc_ports = 1;
     rootcheck.checks.rc_sys = 1;
-    rootcheck.checks.rc_trojans = 1;
+    rootcheck.checks.rc_trojans = 0;
 #ifdef WIN32
-    rootcheck.checks.rc_winaudit = 1;
-    rootcheck.checks.rc_winmalware = 1;
-    rootcheck.checks.rc_winapps = 1;
+    rootcheck.checks.rc_winaudit = 0;
+    rootcheck.checks.rc_winmalware = 0;
+    rootcheck.checks.rc_winapps = 0;
 #else
-    rootcheck.checks.rc_unixaudit = 1;
+    rootcheck.checks.rc_unixaudit = 0;
 #endif
 
     /* We store up to 255 alerts in there */
@@ -181,7 +181,7 @@ int rootcheck_init(int test_config)
 
     /* Return 1 disables rootcheck */
     if (rootcheck.disabled == 1) {
-        mtinfo(ARGV0, "Rootcheck disabled. Exiting.");
+        mtinfo(ARGV0, "Rootcheck disabled.");
         return (1);
     }
 

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -112,7 +112,7 @@ void run_rk_check()
     if (rootcheck.checks.rc_files) {
         if (!rootcheck.rootkit_files) {
 #ifndef WIN32
-            mtinfo(ARGV0, "No rootcheck_files file configured.");
+            mterror(ARGV0, "No rootcheck_files file configured.");
 #endif
         } else {
             fp = fopen(rootcheck.rootkit_files, "r");
@@ -132,7 +132,7 @@ void run_rk_check()
     if (rootcheck.checks.rc_trojans) {
         if (!rootcheck.rootkit_trojans) {
 #ifndef WIN32
-            mtinfo(ARGV0, "No rootcheck_trojans file configured.");
+            mterror(ARGV0, "No rootcheck_trojans file configured.");
 #endif
         } else {
             fp = fopen(rootcheck.rootkit_trojans, "r");

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -24,7 +24,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     modules |= CSYSCHECK;
 
     syscheck.rootcheck      = 0;
-    syscheck.disabled       = 0;
+    syscheck.disabled       = 1;
     syscheck.skip_nfs       = 0;
     syscheck.scan_on_start  = 1;
     syscheck.time           = SYSCHECK_WAIT * 2;

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -115,37 +115,40 @@ int Start_win32_Syscheck()
         syscheck.rootcheck = 0;
     }
 
-    /* Print options */
-    r = 0;
-    while (syscheck.registry[r].entry != NULL) {
-        minfo("Monitoring registry entry: '%s%s'.", syscheck.registry[r].entry, syscheck.registry[r].arch == ARCH_64BIT ? " [x64]" : "");
-        r++;
-    }
+    if (!syscheck.disabled) {
 
-    /* Print directories to be monitored */
-    r = 0;
-    while (syscheck.dir[r] != NULL) {
-	char optstr[ 100 ];
-        minfo("Monitoring directory: '%s', with options %s.", syscheck.dir[r], syscheck_opts2str(optstr, sizeof( optstr ), syscheck.opts[r]));
-        r++;
-    }
-
-    /* Print ignores. */
-    if(syscheck.ignore)
-	for (r = 0; syscheck.ignore[r] != NULL; r++)
-	    minfo("Ignoring: '%s'", syscheck.ignore[r]);
-
-    /* Print files with no diff. */
-    if (syscheck.nodiff){
+        /* Print options */
         r = 0;
-        while (syscheck.nodiff[r] != NULL) {
-            minfo("No diff for file: '%s'", syscheck.nodiff[r]);
+        while (syscheck.registry[r].entry != NULL) {
+            minfo("Monitoring registry entry: '%s%s'.", syscheck.registry[r].entry, syscheck.registry[r].arch == ARCH_64BIT ? " [x64]" : "");
             r++;
         }
-    }
 
-    /* Start up message */
-    minfo(STARTUP_MSG, getpid());
+        /* Print directories to be monitored */
+        r = 0;
+        while (syscheck.dir[r] != NULL) {
+            char optstr[ 100 ];
+            minfo("Monitoring directory: '%s', with options %s.", syscheck.dir[r], syscheck_opts2str(optstr, sizeof( optstr ), syscheck.opts[r]));
+            r++;
+        }
+
+        /* Print ignores. */
+        if(syscheck.ignore)
+            for (r = 0; syscheck.ignore[r] != NULL; r++)
+                minfo("Ignoring: '%s'", syscheck.ignore[r]);
+
+        /* Print files with no diff. */
+        if (syscheck.nodiff){
+            r = 0;
+            while (syscheck.nodiff[r] != NULL) {
+                minfo("No diff for file: '%s'", syscheck.nodiff[r]);
+                r++;
+            }
+        }
+
+        /* Start up message */
+        minfo(STARTUP_MSG, getpid());
+    }
 
     /* Some sync time */
     sleep(syscheck.tsleep + 10);
@@ -309,48 +312,51 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Start up message */
-    minfo(STARTUP_MSG, (int)getpid());
+    if (!syscheck.disabled) {
 
-    if (syscheck.rootcheck) {
-        mtinfo("rootcheck", STARTUP_MSG, (int)getpid());
-    }
+        /* Start up message */
+        minfo(STARTUP_MSG, (int)getpid());
 
-    /* Print directories to be monitored */
-    r = 0;
-    while (syscheck.dir[r] != NULL) {
-	char optstr[ 100 ];
-        minfo("Monitoring directory: '%s', with options %s.", syscheck.dir[r], syscheck_opts2str(optstr, sizeof( optstr ), syscheck.opts[r]));
-        r++;
-    }
-
-    /* Print ignores. */
-    if(syscheck.ignore)
-	for (r = 0; syscheck.ignore[r] != NULL; r++)
-	    minfo("Ignoring: '%s'", syscheck.ignore[r]);
-
-    /* Print files with no diff. */
-    if (syscheck.nodiff){
+        /* Print directories to be monitored */
         r = 0;
-        while (syscheck.nodiff[r] != NULL) {
-            minfo("No diff for file: '%s'", syscheck.nodiff[r]);
+        while (syscheck.dir[r] != NULL) {
+            char optstr[ 100 ];
+            minfo("Monitoring directory: '%s', with options %s.", syscheck.dir[r], syscheck_opts2str(optstr, sizeof( optstr ), syscheck.opts[r]));
+            r++;
+        }
+
+        /* Print ignores. */
+        if(syscheck.ignore)
+            for (r = 0; syscheck.ignore[r] != NULL; r++)
+                minfo("Ignoring: '%s'", syscheck.ignore[r]);
+
+        /* Print files with no diff. */
+        if (syscheck.nodiff){
+            r = 0;
+            while (syscheck.nodiff[r] != NULL) {
+                minfo("No diff for file: '%s'", syscheck.nodiff[r]);
+                r++;
+            }
+        }
+
+        /* Check directories set for real time */
+        r = 0;
+        while (syscheck.dir[r] != NULL) {
+            if (syscheck.opts[r] & CHECK_REALTIME) {
+  #ifdef INOTIFY_ENABLED
+                minfo("Directory set for real time monitoring: '%s'.", syscheck.dir[r]);
+  #elif defined(WIN32)
+                minfo("Directory set for real time monitoring: '%s'.", syscheck.dir[r]);
+  #else
+                mwarn("Ignoring flag for real time monitoring on directory: '%s'.", syscheck.dir[r]);
+  #endif
+            }
             r++;
         }
     }
 
-    /* Check directories set for real time */
-    r = 0;
-    while (syscheck.dir[r] != NULL) {
-        if (syscheck.opts[r] & CHECK_REALTIME) {
-#ifdef INOTIFY_ENABLED
-            minfo("Directory set for real time monitoring: '%s'.", syscheck.dir[r]);
-#elif defined(WIN32)
-            minfo("Directory set for real time monitoring: '%s'.", syscheck.dir[r]);
-#else
-            mwarn("Ignoring flag for real time monitoring on directory: '%s'.", syscheck.dir[r]);
-#endif
-        }
-        r++;
+    if (syscheck.rootcheck) {
+        mtinfo("rootcheck", STARTUP_MSG, (int)getpid());
     }
 
     /* Some sync time */


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/819

Several changes have been included when starting the Syscheck and Rootcheck components:

## Syscheck and Rootcheck

- When `<syscheck>` or `<rootcheck>` are not defined in the configuration, they are disabled now showing an "info" message instead of a "warning".
- When they are defined, but no tag `<disabled>` is set, they are enabled.
- Now, it is possible to set them as empty blocks as follows:

```
<rootcheck/>
<syscheck/>
```

They will load the default values of their configuration. However, Syscheck will be disabled automatically because it doesn't have any directory to monitor.

## Rootcheck only

- The following options are disabled by default if they don't appear in the configuration:

```
<check_files>no</check_files>
<check_trojans>no</check_trojans>

<!-- Linux options -->
<check_unixaudit>no</check_unixaudit>

<!-- Windows options -->
<check_winapps>no</check_winapps>
<check_winaudit>no</check_winaudit>
<check_winmalware>no</check_winmalware>
```

This is why they depend on the definition of particular files to run the checks. This way, we avoid the following errors with an empty configuration:

```
2018/06/20 11:18:28 rootcheck: INFO: No rootcheck_files file configured.
2018/06/20 11:18:28 rootcheck: INFO: No rootcheck_trojans file configured.
```

These messages are defined as "ERROR" now and they appear when the options above are defined but no files have been set.

- When the necessary files to run a specific check are defined, its corresponding check option is enabled internally. For example, if we set the following trojans file:

```
<rootkit_trojans>/var/ossec/etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
```

The option ``check_trojans`` is set to ``yes`` automatically (if it is not defined in the configuration).

Before merging this PR, it is necessary to change the default values in the documentation reference.