### PR TITLE
Get hardware information natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to this project will be documented in this file.
 - Add `172.0.0.1` as manager IP when creating `global.db`. ([#970](https://github.com/wazuh/wazuh/pull/970))
 - New requests for Syscollector. ([#728](https://github.com/wazuh/wazuh/pull/728))
 - `cluster_control` shows an error if the status does not exist. ([#1002](https://github.com/wazuh/wazuh/pull/1002))
-
+- Get Windows hardware inventory natively. ([#831](https://github.com/wazuh/wazuh/pull/831))
 
 ### Changed
 

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -773,6 +773,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON) {
         cJSON * cpu_mhz = cJSON_GetObjectItem(inventory, "cpu_mhz");
         cJSON * ram_total = cJSON_GetObjectItem(inventory, "ram_total");
         cJSON * ram_free = cJSON_GetObjectItem(inventory, "ram_free");
+        cJSON * ram_usage = cJSON_GetObjectItem(inventory, "ram_usage");
 
         char * msg = NULL;
         os_calloc(OS_MAXSTR, sizeof(char), msg);
@@ -834,6 +835,14 @@ int decode_hardware(char *agent_id, cJSON * logJSON) {
             char rfree[OS_MAXSTR];
             snprintf(rfree, OS_MAXSTR - 1, "%d", ram_free->valueint);
             wm_strcat(&msg, rfree, '|');
+        } else {
+            wm_strcat(&msg, "NULL", '|');
+        }
+
+        if (ram_usage) {
+            char usage[OS_MAXSTR];
+            snprintf(usage, OS_MAXSTR - 1, "%d", ram_usage->valueint);
+            wm_strcat(&msg, usage, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
         }

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -141,6 +141,7 @@ CREATE TABLE IF NOT EXISTS sys_hwinfo (
     cpu_mhz REAL CHECK (cpu_mhz > 0),
     ram_total INTEGER CHECK (ram_total > 0),
     ram_free INTEGER CHECK (ram_free > 0),
+    ram_usage INTEGER CHECK (ram_usage >= 0 AND ram_usage <= 100),
     PRIMARY KEY (scan_id, board_serial)
 );
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -34,7 +34,7 @@ static const char * SQL_STMT[] = {
     "INSERT INTO sys_programs (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, architecture, multiarch, source, description, location, triaged) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     "DELETE FROM sys_programs WHERE scan_id != ?;",
     "UPDATE SYS_PROGRAMS SET TRIAGED = 1 WHERE SCAN_ID = ? AND EXISTS(SELECT OLD.SCAN_ID FROM SYS_PROGRAMS OLD WHERE OLD.SCAN_ID != SYS_PROGRAMS.SCAN_ID AND OLD.TRIAGED = 1 AND OLD.FORMAT = SYS_PROGRAMS.FORMAT AND OLD.NAME = SYS_PROGRAMS.NAME AND OLD.VENDOR = SYS_PROGRAMS.VENDOR AND OLD.VERSION = SYS_PROGRAMS.VERSION AND OLD.ARCHITECTURE = SYS_PROGRAMS.ARCHITECTURE);",
-    "INSERT INTO sys_hwinfo (scan_id, scan_time, board_serial, cpu_name, cpu_cores, cpu_mhz, ram_total, ram_free) VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
+    "INSERT INTO sys_hwinfo (scan_id, scan_time, board_serial, cpu_name, cpu_cores, cpu_mhz, ram_total, ram_free, ram_usage) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);",
     "DELETE FROM sys_hwinfo;",
     "INSERT INTO sys_ports (scan_id, scan_time, protocol, local_ip, local_port, remote_ip, remote_port, tx_queue, rx_queue, inode, state, PID, process) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     "DELETE FROM sys_ports WHERE scan_id != ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -256,10 +256,10 @@ int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time,
 int wdb_osinfo_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version);
 
 // Insert HW info tuple. Return 0 on success or -1 on error.
-int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free);
+int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free, int ram_usage);
 
 // Save HW info into DB.
-int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free);
+int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free, int ram_usage);
 
 // Insert package info tuple. Return 0 on success or -1 on error.
 int wdb_package_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * format, const char * name, const char * priority, const char * section, long size, const char * vendor, const char * install_time, const char * version, const char * architecture, const char * multiarch, const char * source, const char * description, const char * location, const char triaged);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -1066,6 +1066,7 @@ int wdb_parse_hardware(wdb_t * wdb, char * input, char * output) {
     char * cpu_mhz;
     long ram_total;
     long ram_free;
+    int ram_usage;
     int result;
 
     if (next = strchr(input, ' '), !next) {
@@ -1171,9 +1172,20 @@ int wdb_parse_hardware(wdb_t * wdb, char * input, char * output) {
 
         ram_total = strtol(curr,NULL,10);
         *next++ = '\0';
-        ram_free = strtol(next,NULL,10);
+        curr = next;
 
-        if (result = wdb_hardware_save(wdb, scan_id, scan_time, serial, cpu_name, cpu_cores, cpu_mhz, ram_total, ram_free), result < 0) {
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid HW info query syntax.");
+            mdebug2("HW info query: %ld", ram_total);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid HW info query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+        ram_free = strtol(curr,NULL,10);
+        *next++ = '\0';
+        ram_usage = strtol(next,NULL,10);
+
+        if (result = wdb_hardware_save(wdb, scan_id, scan_time, serial, cpu_name, cpu_cores, cpu_mhz, ram_total, ram_free, ram_usage), result < 0) {
             mdebug1("at wdb_parse_hardware(): Cannot save HW information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save HW information.");
         } else {

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -502,7 +502,7 @@ int wdb_package_delete(wdb_t * wdb, const char * scan_id) {
 }
 
 // Function to save OS info into the DB. Return 0 on success or -1 on error.
-int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free) {
+int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free, int ram_usage) {
 
     sqlite3_stmt *stmt = NULL;
 
@@ -532,7 +532,8 @@ int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time,
         cpu_cores,
         cpu_mhz,
         ram_total,
-        ram_free) < 0) {
+        ram_free,
+        ram_usage) < 0) {
 
         return -1;
     }
@@ -541,7 +542,7 @@ int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time,
 }
 
 // Insert HW info tuple. Return 0 on success or -1 on error.
-int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free) {
+int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free, int ram_usage) {
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_HWINFO_INSERT) < 0) {
@@ -574,6 +575,12 @@ int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_tim
         sqlite3_bind_int(stmt, 8, ram_free);
     } else {
         sqlite3_bind_null(stmt, 8);
+    }
+
+    if (ram_usage > 0) {
+        sqlite3_bind_int(stmt, 9, ram_usage);
+    } else {
+        sqlite3_bind_null(stmt, 9);
     }
 
     if (sqlite3_step(stmt) == SQLITE_DONE){

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -99,6 +99,7 @@ typedef struct hw_info {
     double cpu_MHz;
     int ram_total;  // kB
     int ram_free;   // kB
+    int ram_usage;  // Percentage
 } hw_info;
 
 typedef struct wm_sys_flags_t {

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -509,6 +509,7 @@ void sys_hw_bsd(int queue_fd, const char* LOCATION){
         cJSON_AddNumberToObject(hw_inventory, "ram_free", sys_info->ram_free);
 
         free(sys_info->cpu_name);
+        free(sys_info);
     }
 
     /* Send interface data in JSON format */
@@ -618,6 +619,10 @@ hw_info *get_system_bsd(){
     }else{
         long cpu_free_kb = (vmt.t_free * (u_int64_t)page_size) / 1024;
         info->ram_free = cpu_free_kb;
+
+        if (info->ram_total > 0 && info->ram_free >= 0) {
+            info->ram_usage = 100 - (info->ram_free * 100 / info->ram_total);
+        }
     }
 
 #endif

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -850,6 +850,7 @@ void sys_hw_linux(int queue_fd, const char* LOCATION){
         cJSON_AddNumberToObject(hw_inventory, "cpu_MHz", sys_info->cpu_MHz);
         cJSON_AddNumberToObject(hw_inventory, "ram_total", sys_info->ram_total);
         cJSON_AddNumberToObject(hw_inventory, "ram_free", sys_info->ram_free);
+        cJSON_AddNumberToObject(hw_inventory, "ram_usage", sys_info->ram_usage);
 
         free(sys_info->cpu_name);
         free(sys_info);
@@ -1347,6 +1348,10 @@ hw_info *get_system_linux(){
                 info->ram_free = strtol(aux_string, &end_string, 10);
 
             }
+        }
+
+        if (info->ram_total > 0 && info->ram_free >= 0) {
+            info->ram_usage = 100 - (info->ram_free * 100 / info->ram_total);
         }
         free(aux_string);
         fclose(fp);

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1058,8 +1058,11 @@ void sys_hw_windows(const char* LOCATION){
             cJSON_AddNumberToObject(hw_inventory, "ram_total", sys_info->ram_total);
         if (sys_info->ram_free)
             cJSON_AddNumberToObject(hw_inventory, "ram_free", sys_info->ram_free);
+        if (sys_info->ram_usage)
+            cJSON_AddNumberToObject(hw_inventory, "ram_usage", sys_info->ram_usage);
 
         free(sys_info->cpu_name);
+        free(sys_info);
     }
 
     /* Send interface data in JSON format */
@@ -1282,192 +1285,77 @@ void sys_network_windows(const char* LOCATION){
         mterror(WM_SYS_LOGTAG, "Unable to load syscollector_win_ext.dll: %s (%lu)", messageBuffer, error);
         LocalFree(messageBuffer);
     }
-
 }
 
 hw_info *get_system_windows(){
 
     hw_info *info;
-    char *command;
-    char *end;
-    FILE *output;
-    size_t buf_length = 1024;
-    char read_buff[buf_length];
-    int status;
+    DWORD retVal;
+    HKEY RegistryKey;
+    char subkey[KEY_LENGTH];
+    TCHAR name[MAX_VALUE_NAME];
+    DWORD frequency = 0;
+    DWORD dwCount = MAX_VALUE_NAME;
 
     os_calloc(1,sizeof(hw_info),info);
 
-    memset(read_buff, 0, buf_length);
-    command = "wmic cpu get Name";
-    output = popen(command, "r");
-    if (!output){
-        mtwarn(WM_SYS_LOGTAG, "Unable to execute command '%s'.", command);
+    // Get CPU name and frequency
+
+    snprintf(subkey, KEY_LENGTH - 1, "%s", "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0");
+
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
         info->cpu_name = strdup("unknown");
-    }else{
-        if (fgets(read_buff, buf_length, output)) {
-            if (strncmp(read_buff ,"Name",4) == 0) {
-                if (!fgets(read_buff, buf_length, output)){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get CPU Name.");
-                    info->cpu_name = strdup("unknown");
-                }else if(strstr(read_buff, "Error")){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get CPU Name. Incompatible command.");
-                    info->cpu_name = strdup("unknown");
-                }else if (end = strpbrk(read_buff,"\r\n"), end) {
-                    *end = '\0';
-                    int i = strlen(read_buff) - 1;
-                    while(read_buff[i] == 32){
-                        read_buff[i] = '\0';
-                        i--;
-                    }
-                    info->cpu_name = strdup(read_buff);
-                }else
-                    info->cpu_name = strdup("unknown");
-            }
-        } else {
-            mtdebug1(WM_SYS_LOGTAG, "Unable to get CPU Name (bad header).");
+        mterror(WM_SYS_LOGTAG, SK_REG_OPEN, subkey);
+    } else {
+        retVal = RegQueryValueEx(RegistryKey, TEXT("ProcessorNameString"), NULL, NULL, (LPBYTE)&name, &dwCount);
+        if (retVal != ERROR_SUCCESS) {
             info->cpu_name = strdup("unknown");
-        }
-
-        if (status = pclose(output), status) {
-            mtwarn(WM_SYS_LOGTAG, "Command 'wmic' returned %d getting CPU name.", status);
-        }
-    }
-
-    memset(read_buff, 0, buf_length);
-    char *cores;
-    command = "wmic cpu get NumberOfCores";
-    output = popen(command, "r");
-    if (!output){
-        mtwarn(WM_SYS_LOGTAG, "Unable to execute command '%s'.", command);
-    }else{
-        if (fgets(read_buff, buf_length, output)) {
-            if (strncmp(read_buff, "NumberOfCores",13) == 0) {
-                if (!fgets(read_buff, buf_length, output)){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get number of cores.");
-                }else if(strstr(read_buff, "Error")){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get number of cores. Incompatible command.");
-                }else if (end = strpbrk(read_buff,"\r\n"), end) {
-                    *end = '\0';
-                    int i = strlen(read_buff) - 1;
-                    while(read_buff[i] == 32){
-                        read_buff[i] = '\0';
-                        i--;
-                    }
-                    cores = strdup(read_buff);
-                    info->cpu_cores = atoi(cores);
-                }
-            }
+            mterror(WM_SYS_LOGTAG, "Error reading 'CPU name' from Windows registry. (Error %u)",(unsigned int)retVal);
         } else {
-            mtdebug1(WM_SYS_LOGTAG, "Unable to get number of cores (bad header).");
+            info->cpu_name = strdup(name);
         }
-
-        if (status = pclose(output), status) {
-            mtwarn(WM_SYS_LOGTAG, "Command 'wmic' returned %d getting number of cores.", status);
-        }
-    }
-
-    memset(read_buff, 0, buf_length);
-    char *frec;
-    command = "wmic cpu get CurrentClockSpeed";
-    output = popen(command, "r");
-    if (!output){
-        mtwarn(WM_SYS_LOGTAG, "Unable to execute command '%s'.", command);
-    }else{
-        if (fgets(read_buff, buf_length, output)) {
-            if (strncmp(read_buff, "CurrentClockSpeed",17) == 0) {
-                if (!fgets(read_buff, buf_length, output)){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get CPU clock speed.");
-                }else if(strstr(read_buff, "Error")){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get CPU clock speed. Incompatible command.");
-                }else if (end = strpbrk(read_buff,"\r\n"), end) {
-                    *end = '\0';
-                    int i = strlen(read_buff) - 1;
-                    while(read_buff[i] == 32){
-                        read_buff[i] = '\0';
-                        i--;
-                    }
-                    frec = strdup(read_buff);
-                    info->cpu_MHz = atof(frec);
-                }
-            }
+        retVal = RegQueryValueEx(RegistryKey, TEXT("~MHz"), NULL, NULL, (LPBYTE)&frequency, &dwCount);
+        if (retVal != ERROR_SUCCESS) {
+            mterror(WM_SYS_LOGTAG, "Error reading 'CPU frequency' from Windows registry. (Error %u)",(unsigned int)retVal);
         } else {
-            mtdebug1(WM_SYS_LOGTAG, "Unable to get CPU clock speed (bad header).");
+            info->cpu_MHz = (unsigned int)frequency;
         }
-
-        if (status = pclose(output), status) {
-            mtwarn(WM_SYS_LOGTAG, "Command 'wmic' returned %d getting clock speed.", status);
-        }
+        RegCloseKey(RegistryKey);
     }
 
-    memset(read_buff, 0, buf_length);
-    char *total;
-    command = "wmic computersystem get TotalPhysicalMemory";
-    output = popen(command, "r");
-    if (!output){
-        mtwarn(WM_SYS_LOGTAG, "Unable to execute command '%s'.", command);
-    }else{
-        if (fgets(read_buff, buf_length, output)) {
-            if (strncmp(read_buff, "TotalPhysicalMemory", 19) == 0) {
-                if (!fgets(read_buff, buf_length, output)){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get physical memory information.");
-                }else if(strstr(read_buff, "Error")){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get physical memory information. Incompatible command.");
-                }else if (end = strpbrk(read_buff,"\r\n"), end) {
-                    *end = '\0';
-                    int i = strlen(read_buff) - 1;
-                    while(read_buff[i] == 32){
-                        read_buff[i] = '\0';
-                        i--;
-                    }
-                    total = strdup(read_buff);
-                    info->ram_total = (atof(total)) / 1024;
-                }
-            }
-        } else {
-            mtdebug1(WM_SYS_LOGTAG, "Unable to get physical memory information (bad header).");
-        }
-    }
+    // Get number of cores
 
-    if (status = pclose(output), status) {
-        mtwarn(WM_SYS_LOGTAG, "Command 'wmic' returned %d getting physical memory.", status);
-    }
+    SYSTEM_INFO siSysInfo;
 
-    memset(read_buff, 0, buf_length);
-    char *mem_free;
-    command = "wmic os get FreePhysicalMemory";
-    output = popen(command, "r");
-    if (!output){
-        mtwarn(WM_SYS_LOGTAG, "Unable to execute command '%s'.", command);
-    }else{
-        if (fgets(read_buff, buf_length, output)) {
-            if (strncmp(read_buff, "FreePhysicalMemory", 18) == 0) {
-                if (!fgets(read_buff, buf_length, output)){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get free memory of the system.");
-                }else if(strstr(read_buff, "Error")){
-                    mtdebug1(WM_SYS_LOGTAG, "Unable to get free memory of the system. Incompatible command.");
-                }else if (end = strpbrk(read_buff,"\r\n"), end) {
-                    *end = '\0';
-                    int i = strlen(read_buff) - 1;
-                    while(read_buff[i] == 32){
-                        read_buff[i] = '\0';
-                        i--;
-                    }
-                    mem_free = strdup(read_buff);
-                    info->ram_free = atoi(mem_free);
-                }
-            }
-        } else {
-            mtdebug1(WM_SYS_LOGTAG, "Unable to get free memory of the system (bad header).");
+    GetSystemInfo(&siSysInfo);
+    info->cpu_cores = (int)siSysInfo.dwNumberOfProcessors;
+
+    // RAM memory
+
+    MEMORYSTATUSEX statex;
+    statex.dwLength = sizeof (statex);
+
+    if (!GlobalMemoryStatusEx(&statex)) {
+        DWORD error = GetLastError();
+        LPSTR messageBuffer = NULL;
+        LPSTR end;
+
+        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, error, 0, (LPTSTR) &messageBuffer, 0, NULL);
+
+        if (end = strchr(messageBuffer, '\r'), end) {
+            *end = '\0';
         }
 
-        if (status = pclose(output), status) {
-            mtwarn(WM_SYS_LOGTAG, "Command 'wmic' returned %d getting free memory.", status);
-        }
+        mterror(WM_SYS_LOGTAG, "Unable to call GlobalMemoryStatusEx(): %s (%lu)", messageBuffer, error);
+        LocalFree(messageBuffer);
+    } else {
+        info->ram_total = statex.ullTotalPhys/1024;
+        info->ram_free = statex.ullAvailPhys/1024;
+        info->ram_usage = statex.dwMemoryLoad;
     }
 
     return info;
 }
-
 
 void sys_proc_windows(const char* LOCATION) {
     char *command;


### PR DESCRIPTION
Related to issue: https://github.com/wazuh/wazuh/issues/533

This PR adds a new field to the hardware inventory about the RAM usage.

It also avoids using `wmic` to retrieve the Windows hardware inventory (specifically for the CPU and RAM information).
