### PR TITLE
Fix reading of Windows platform in 64 bits systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Fix PID file creation checking. ([#822](https://github.com/wazuh/wazuh/pull/822))
   - Check that the PID file was created and written.
   - This would prevent service from running multiple processes of the same daemon.
+- Fix reading of Windows platform for 64 bits systems. ([#832](https://github.com/wazuh/wazuh/pull/832))
 
 
 ## [v3.3.1]

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1375,7 +1375,7 @@ const char *getuname()
                 DWORD dwCount = size;
                 add_infoEx = 0;
 
-                if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+                if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ | KEY_WOW64_64KEY , &RegistryKey) != ERROR_SUCCESS) {
                     merror("Error opening Windows registry.");
                 }
 
@@ -1594,7 +1594,7 @@ const char *getuname()
                 DWORD dwCount = size;
                 unsigned long type=REG_DWORD;
 
-                if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+                if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ | KEY_WOW64_64KEY, &RegistryKey) != ERROR_SUCCESS) {
                     merror("Error opening Windows registry.");
                 }
 


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/825.

The Windows agent reads the OS information from the registry when it starts, sending the data to the manager and Kibana later.

By default, it was being read the 32 bits registry, even if the Windows is a 64 bits system. 

The root cause of that issue is that in 64 bits Windows 10 Pro, there exists an inconsistency in both registry views. In the 32 bits registry, the `ProductName` key read from `HKLM\Software\ Wow6432Node\Microsoft\WindowsNT\CurrentVersion` contains the value **Windows 10 Enterprise**, while the equivalent value for the 64 bits view is **Windows 10 Pro**.

It has been added a flag when opening the registry to read the 64 bits registry on 64 bits Operating Systems. This is the new information retrieved by the Wazuh agent:

```
 2018/06/22 15:49:34 ossec-agent: INFO: Windows version is 6.0 or newer. (Microsoft Windows 10 Pro [Ver: 10.0.17134] - Wazuh v3.3.2).
```

Regards.