### PR TITLE
Fix parser of file names from Rootcheck events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Fixed filter for `gpg-pubkey` packages in Syscollector. ([#847](https://github.com/wazuh/wazuh/pull/847))
 - Fixed bug in configuration when reading the `repeated_offenders` option in Active Response. ([#873](https://github.com/wazuh/wazuh/pull/873))
 - Fixed variables parser when loading rules. ([#855](https://github.com/wazuh/wazuh/pull/855))
+- Fixed parser files names in the Rootcheck scan. ([#840](https://github.com/wazuh/wazuh/pull/840))
 
 ## [v3.3.1]
 

--- a/src/shared/rootcheck_op.c
+++ b/src/shared/rootcheck_op.c
@@ -52,31 +52,30 @@ char* rk_get_file(const char *log) {
     char *c;
     char *file, *found;
 
-    os_strdup(log, file);
-
-    if ((found = strstr(file, "File: "))) {
+    if ((found = strstr(log, "File: "))) {
         found += 6;
-        file = found;
-        if ((c = strstr(file, ". "))) {
+        os_strdup(found, file);
+
+        if ((c = strstr(file, ". ")) || (c = strstr(file, ".\0"))) {
             *c = '\0';
             return file;
-        } else
-            goto end;
-    } else if ((found = strstr(file, "File '")) || (found = strstr(file, "file '"))) {
+        } else{
+            free(file);
+            return NULL;
+        }
+    } else if ((found = strstr(log, "File '")) || (found = strstr(log, "file '"))) {
         found += 6;
-        file = found;
+        os_strdup(found, file);
 
         if ((c = strstr(file, "' "))) {
             *c = '\0';
             return file;
-        } else
-            goto end;
+        } else {
+            free(file);
+            return NULL;
+        }
+    }
 
-    } else
-        goto end;
-
-end:
-    free(file);
     return NULL;
 }
 

--- a/src/shared/rootcheck_op.c
+++ b/src/shared/rootcheck_op.c
@@ -67,7 +67,7 @@ char* rk_get_file(const char *log) {
         found += 6;
         os_strdup(found, file);
 
-        if ((c = strstr(file, "' "))) {
+        if ((c = strstr(file, "' ")) || (c = strstr(file, "'\0"))) {
             *c = '\0';
             return file;
         } else {

--- a/src/shared/rootcheck_op.c
+++ b/src/shared/rootcheck_op.c
@@ -50,26 +50,34 @@ char* rk_get_title(const char *log) {
 /* Get rootcheck file from log */
 char* rk_get_file(const char *log) {
     char *c;
-    char *file;
+    char *file, *found;
 
-    if ((file = strstr(log, "File: "))) {
-        file += 6;
+    os_strdup(log, file);
 
+    if ((found = strstr(file, "File: "))) {
+        found += 6;
+        file = found;
         if ((c = strstr(file, ". "))) {
             *c = '\0';
-            return strdup(file);
+            return file;
         } else
-            return NULL;
-    } else if ((file = strstr(log, "File '")) || (file = strstr(log, "file '"))) {
-        file += 6;
+            goto end;
+    } else if ((found = strstr(file, "File '")) || (found = strstr(file, "file '"))) {
+        found += 6;
+        file = found;
 
         if ((c = strstr(file, "' "))) {
             *c = '\0';
-            return strdup(file);
+            return file;
         } else
-            return NULL;
+            goto end;
+
     } else
-        return NULL;
+        goto end;
+
+end:
+    free(file);
+    return NULL;
 }
 
 /* Extract time and event from Rootcheck log. It doesn't reserve memory. */


### PR DESCRIPTION
When extracting the file name from the Rootcheck events, the `log` variable was cut by adding a `\0` character at the end of the file name.

This causes that making rules to match with the Rootcheck log coming from agents could fail due to the log is incomplete.

For example, if the log coming from the agent is the following one:

```
File '/etc/logstash/pipelines.yml' is owned by root and has written permissions to anyone.
```
 
The log after the file name parser was:

```
File '/etc/logstash/pipelines.yml
```
