### PR TITLE
Fix timestamp parser by the syslog output daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
   - Check that the PID file was created and written.
   - This would prevent service from running multiple processes of the same daemon.
 - Fix reading of Windows platform for 64 bits systems. ([#832](https://github.com/wazuh/wazuh/pull/832))
-
+- Fixed Syslog output parser when reading the timestamp from the alerts in JSON format. ([#843](https://github.com/wazuh/wazuh/pull/843))
 
 ## [v3.3.1]
 

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -364,7 +364,10 @@ int OS_Alert_SendSyslog_JSON(cJSON *json_data, const SyslogConfig *syslog_config
     now = time(NULL);
     localtime_r(&now, &tm);
 
-    if (end = strptime(timestamp->valuestring, "%FT%T%z", &tm), !end || *end) {
+    if (end = strchr(timestamp->valuestring, '.'), end)
+        *end = '\0';
+
+    if (end = strptime(timestamp->valuestring, "%FT%T", &tm), !end || *end) {
         merror("Could not parse timestamp '%s'.", timestamp->valuestring);
     }
 


### PR DESCRIPTION
This PR fixes the issue https://github.com/wazuh/wazuh/issues/841.

Since #467 the alerts in JSON format include millisecond timing in the timestamps. That millisecond field was not recognized by the Syslog output daemon when parsing the timestamps.

It has been removed the millisecond field before parsing it. Despite this, no information is lost due to the complete JSON read is contained in the forwarded log.