### PR TITLE
Fix filter for 'gpg-pubkey' packages in Syscollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   - This would prevent service from running multiple processes of the same daemon.
 - Fix reading of Windows platform for 64 bits systems. ([#832](https://github.com/wazuh/wazuh/pull/832))
 - Fixed Syslog output parser when reading the timestamp from the alerts in JSON format. ([#843](https://github.com/wazuh/wazuh/pull/843))
+- Fixed filter for `gpg-pubkey` packages in Syscollector. ([#847](https://github.com/wazuh/wazuh/pull/847))
 
 ## [v3.3.1]
 

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -465,7 +465,7 @@ void sys_programs_linux(int queue_fd, const char* LOCATION){
 
         while(fgets(read_buff, OS_MAXSTR, output)){
 
-            if (!strcmp(read_buff, "gpg-pubkey"))
+            if (!strncmp(read_buff, "gpg-pubkey", 10))
                 continue;
 
             cJSON *object = cJSON_CreateObject();
@@ -482,7 +482,9 @@ void sys_programs_linux(int queue_fd, const char* LOCATION){
             parts = OS_StrBreak('|', read_buff, 5);
 
             cJSON_AddStringToObject(program, "name", parts[0]);
-            cJSON_AddStringToObject(program, "vendor", parts[1]);
+            if (strncmp(parts[1], "(none)", 6))
+                cJSON_AddStringToObject(program, "vendor", parts[1]);
+
             if (!strncmp(parts[2], "(none):", 7)) {
                 char ** epoch = NULL;
                 epoch = OS_StrBreak(':', parts[2], 2);
@@ -494,7 +496,9 @@ void sys_programs_linux(int queue_fd, const char* LOCATION){
             } else {
                 cJSON_AddStringToObject(program, "version", parts[2]);
             }
-            cJSON_AddStringToObject(program, "architecture", parts[3]);
+
+            if (strncmp(parts[1], "(none)", 6))
+                cJSON_AddStringToObject(program, "architecture", parts[3]);
 
             char ** description = NULL;
             description = OS_StrBreak('\n', parts[4], 2);

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -497,7 +497,7 @@ void sys_programs_linux(int queue_fd, const char* LOCATION){
                 cJSON_AddStringToObject(program, "version", parts[2]);
             }
 
-            if (strncmp(parts[1], "(none)", 6))
+            if (strncmp(parts[3], "(none)", 6))
                 cJSON_AddStringToObject(program, "architecture", parts[3]);
 
             char ** description = NULL;


### PR DESCRIPTION
The filter to ignore packages called 'gpg-pubkey' was broken.

It also has been added a filter to ignore `architecture` and `vendor` fields which `none` as content.