### PR TITLE
Logcollector: define per-target custom output format strings

### DIFF
--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -27,6 +27,16 @@ typedef struct _logsocket {
     time_t last_attempt;
 } logsocket;
 
+typedef struct _outformat {
+    char * target;
+    char * format;
+} outformat;
+
+typedef struct _logtarget {
+    char * format;
+    logsocket * log_socket;
+} logtarget;
+
 /* Logreader config */
 typedef struct _logreader {
     off_t size;
@@ -52,9 +62,9 @@ typedef struct _logreader {
     char *alias;
     char future;
     char *query;
-    char *outformat;
+    outformat ** out_format;
     char **target;
-    logsocket **target_socket;
+    logtarget * log_target;
     int duplicated;
     wlabel_t *labels;
 

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -33,6 +33,6 @@ int StartMQ(const char *key, short int type) __attribute__((nonnull));
 
 int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
 
-int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logsocket **sockets, const char * pattern) __attribute__((nonnull (2, 3, 5)));
+int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logtarget * targets) __attribute__((nonnull (2, 3, 5)));
 
 #endif

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -14,7 +14,7 @@
 #define MAX_HEADER 64
 
 /* Compile message from cache and send through queue */
-static void audit_send_msg(char **cache, int top, const char *file, int drop_it, logsocket **tsockets, const char * pattern) {
+static void audit_send_msg(char **cache, int top, const char *file, int drop_it, logtarget * targets) {
     int i;
     size_t n = 0;
     size_t z;
@@ -37,7 +37,7 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
     if (!drop_it) {
         message[n] = '\0';
 
-        if (SendMSGtoSCK(logr_queue, message, file, LOCALFILE_MQ, tsockets, pattern) < 0) {
+        if (SendMSGtoSCK(logr_queue, message, file, LOCALFILE_MQ, targets) < 0) {
             merror(QUEUE_SEND);
 
             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
@@ -98,7 +98,7 @@ void *read_audit(int pos, int *rc, int drop_it) {
         if (strncmp(id, header, z)) {
             // Current message belongs to another event: send cached messages
             if (icache > 0)
-                audit_send_msg(cache, icache, logff[pos].file, drop_it, logff[pos].target_socket, logff[pos].outformat);
+                audit_send_msg(cache, icache, logff[pos].file, drop_it, logff[pos].log_target);
 
             // Store current event
             *cache = strdup(buffer);
@@ -114,7 +114,7 @@ void *read_audit(int pos, int *rc, int drop_it) {
     }
 
     if (icache > 0)
-        audit_send_msg(cache, icache, logff[pos].file, drop_it, logff[pos].target_socket, logff[pos].outformat);
+        audit_send_msg(cache, icache, logff[pos].file, drop_it, logff[pos].log_target);
 
     mdebug2("Read %d lines from %s", lines, logff[pos].file);
     return NULL;

--- a/src/logcollector/read_command.c
+++ b/src/logcollector/read_command.c
@@ -64,7 +64,7 @@ void *read_command(int pos, int *rc, int drop_it)
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, str,
                         (NULL != logff[pos].alias) ? logff[pos].alias : logff[pos].command,
-                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+                        LOCALFILE_MQ, logff[pos].log_target) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -167,7 +167,7 @@ void *read_djbmultilog(int pos, int *rc, int drop_it)
 
         /* Send message to queue */
         if (drop_it == 0) {
-            if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, MYSQL_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+            if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, MYSQL_MQ, logff[pos].log_target) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_fullcommand.c
+++ b/src/logcollector/read_fullcommand.c
@@ -75,7 +75,7 @@ void *read_fullcommand(int pos, int *rc, int drop_it)
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, strfinal,
                         (NULL != logff[pos].alias) ? logff[pos].alias : logff[pos].command,
-                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+                        LOCALFILE_MQ, logff[pos].log_target) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -87,7 +87,7 @@ void *read_json(int pos, int *rc, int drop_it)
         /* Send message to queue */
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, jsonParsed, logff[pos].file,
-                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+                        LOCALFILE_MQ, logff[pos].log_target) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -18,7 +18,7 @@ static void __send_mssql_msg(int pos, int drop_it, char *buffer)
 {
     mdebug2("Reading MSSQL message: '%s'", buffer);
     if (drop_it == 0) {
-        if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+        if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, LOCALFILE_MQ, logff[pos].log_target) < 0) {
             merror(QUEUE_SEND);
             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -80,7 +80,7 @@ void *read_multiline(int pos, int *rc, int drop_it)
         /* Send message to queue */
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file,
-                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+                        LOCALFILE_MQ, logff[pos].log_target) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -126,7 +126,7 @@ void *read_mysql_log(int pos, int *rc, int drop_it)
 
         /* Send message to queue */
         if (drop_it == 0) {
-            if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, MYSQL_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+            if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, MYSQL_MQ, logff[pos].log_target) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -240,7 +240,7 @@ void *read_nmapg(int pos, int *rc, int drop_it)
         if (drop_it == 0) {
             /* Send message to queue */
             if (SendMSGtoSCK(logr_queue, final_msg, logff[pos].file,
-                        HOSTINFO_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+                        HOSTINFO_MQ, logff[pos].log_target) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -100,7 +100,7 @@ void *read_ossecalert(int pos, __attribute__((unused)) int *rc, int drop_it)
 
     /* Send message to queue */
     if (drop_it == 0) {
-        if (SendMSGtoSCK(logr_queue, syslog_msg, logff[pos].file, LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+        if (SendMSGtoSCK(logr_queue, syslog_msg, logff[pos].file, LOCALFILE_MQ, logff[pos].log_target) < 0) {
             merror(QUEUE_SEND);
             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -18,7 +18,7 @@ static void __send_pgsql_msg(int pos, int drop_it, char *buffer)
 {
     mdebug2("Reading PostgreSQL message: '%s'", buffer);
     if (drop_it == 0) {
-        if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, POSTGRESQL_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+        if (SendMSGtoSCK(logr_queue, buffer, logff[pos].file, POSTGRESQL_MQ, logff[pos].log_target) < 0) {
             merror(QUEUE_SEND);
             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -72,7 +72,7 @@ void *read_snortfull(int pos, int *rc, int drop_it)
                     /* Send the message */
                     if (drop_it == 0) {
                         if (SendMSGtoSCK(logr_queue, f_msg, logff[pos].file,
-                                    LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+                                    LOCALFILE_MQ, logff[pos].log_target) < 0) {
                             merror(QUEUE_SEND);
                             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);
@@ -96,7 +96,7 @@ void *read_snortfull(int pos, int *rc, int drop_it)
                     /* Send the message */
                     if (drop_it == 0) {
                         if (SendMSGtoSCK(logr_queue, f_msg, logff[pos].file,
-                                    LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+                                    LOCALFILE_MQ, logff[pos].log_target) < 0) {
                             merror(QUEUE_SEND);
                             if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                                 merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -72,7 +72,7 @@ void *read_syslog(int pos, int *rc, int drop_it)
         /* Send message to queue */
         if (drop_it == 0) {
             if (SendMSGtoSCK(logr_queue, str, logff[pos].file,
-                        LOCALFILE_MQ, logff[pos].target_socket, logff[pos].outformat) < 0) {
+                        LOCALFILE_MQ, logff[pos].log_target) < 0) {
                 merror(QUEUE_SEND);
                 if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
                     merror_exit(QUEUE_FATAL, DEFAULTQPATH);

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -146,16 +146,18 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc)
 }
 
 /* Send a message to socket */
-int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logsocket **sockets, const char * pattern)
+int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logtarget * targets)
 {
     int __mq_rcode;
     char tmpstr[OS_MAXSTR + 1];
     int i;
     time_t mtime = time(NULL);
-    char * _message = msgsubst(pattern, message, locmsg, mtime);
+    char * _message;
 
-    for (i = 0; sockets[i] && sockets[i]->name; i++) {
-        if (strcmp(sockets[i]->name, "agent") == 0) {
+    for (i = 0; targets[i].log_socket; i++) {
+        _message = msgsubst(targets[i].format, message, locmsg, mtime);
+
+        if (strcmp(targets[i].log_socket->name, "agent") == 0) {
             SendMSG(queue, _message, locmsg, loc);
         }
         else {
@@ -164,7 +166,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
             int sock_type;
             const char * strmode;
 
-            switch (sockets[i]->mode) {
+            switch (targets[i].log_socket->mode) {
             case UDP_PROTO:
                 sock_type = SOCK_DGRAM;
                 strmode = "udp";
@@ -180,72 +182,81 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
             }
 
             // create message and add prefix
-            if (sockets[i]->prefix && *sockets[i]->prefix) {
-                snprintf(tmpstr, OS_MAXSTR, "%s%s", sockets[i]->prefix, _message);
+            if (targets[i].log_socket->prefix && *targets[i].log_socket->prefix) {
+                snprintf(tmpstr, OS_MAXSTR, "%s%s", targets[i].log_socket->prefix, _message);
             } else {
                 snprintf(tmpstr, OS_MAXSTR, "%s", _message);
             }
 
             // Connect to socket if disconnected
-            if (sockets[i]->socket < 0) {
-                if (mtime = time(NULL), mtime > sockets[i]->last_attempt + sock_fail_time) {
-                    if (sockets[i]->socket = OS_ConnectUnixDomain(sockets[i]->location, sock_type, OS_MAXSTR + 256), sockets[i]->socket < 0) {
-                        sockets[i]->last_attempt = mtime;
-                        merror("Unable to connect to socket '%s': %s (%s)", sockets[i]->name, sockets[i]->location, strmode);
+            if (targets[i].log_socket->socket < 0) {
+                if (mtime = time(NULL), mtime > targets[i].log_socket->last_attempt + sock_fail_time) {
+                    if (targets[i].log_socket->socket = OS_ConnectUnixDomain(targets[i].log_socket->location, sock_type, OS_MAXSTR + 256), targets[i].log_socket->socket < 0) {
+                        targets[i].log_socket->last_attempt = mtime;
+                        merror("Unable to connect to socket '%s': %s (%s)", targets[i].log_socket->name, targets[i].log_socket->location, strmode);
                         continue;
                     }
 
-                    mdebug1("Connected to socket '%s' (%s)", sockets[i]->name, sockets[i]->location);
+                    mdebug1("Connected to socket '%s' (%s)", targets[i].log_socket->name, targets[i].log_socket->location);
                 } else {
-                    mdebug2("Discarding event from '%s' due to connection issue with '%s'", locmsg, sockets[i]->name);
+                    mdebug2("Discarding event from '%s' due to connection issue with '%s'", locmsg, targets[i].log_socket->name);
                     continue;
                 }
             }
 
             // Send msg to socket
 
-            if (__mq_rcode = OS_SendUnix(sockets[i]->socket, tmpstr, 0), __mq_rcode < 0) {
+            if (__mq_rcode = OS_SendUnix(targets[i].log_socket->socket, tmpstr, 0), __mq_rcode < 0) {
                 if (__mq_rcode == OS_SOCKTERR) {
-                    if (mtime = time(NULL), mtime > sockets[i]->last_attempt + sock_fail_time) {
-                        close(sockets[i]->socket);
+                    if (mtime = time(NULL), mtime > targets[i].log_socket->last_attempt + sock_fail_time) {
+                        close(targets[i].log_socket->socket);
 
-                        if (sockets[i]->socket = OS_ConnectUnixDomain(sockets[i]->location, sock_type, OS_MAXSTR + 256), sockets[i]->socket < 0) {
-                            merror("Unable to connect to socket '%s': %s (%s)", sockets[i]->name, sockets[i]->location, strmode);
-                            sockets[i]->last_attempt = mtime;
+                        if (targets[i].log_socket->socket = OS_ConnectUnixDomain(targets[i].log_socket->location, sock_type, OS_MAXSTR + 256), targets[i].log_socket->socket < 0) {
+                            merror("Unable to connect to socket '%s': %s (%s)", targets[i].log_socket->name, targets[i].log_socket->location, strmode);
+                            targets[i].log_socket->last_attempt = mtime;
                             continue;
                         }
 
-                        mdebug1("Connected to socket '%s' (%s)", sockets[i]->name, sockets[i]->location);
+                        mdebug1("Connected to socket '%s' (%s)", targets[i].log_socket->name, targets[i].log_socket->location);
 
-                        if (OS_SendUnix(sockets[i]->socket, tmpstr, 0), __mq_rcode < 0) {
-                            merror("Cannot send message to socket '%s'. (Retry)", sockets[i]->name);
+                        if (OS_SendUnix(targets[i].log_socket->socket, tmpstr, 0), __mq_rcode < 0) {
+                            merror("Cannot send message to socket '%s'. (Retry)", targets[i].log_socket->name);
                             SendMSG(queue, "Cannot send message to socket.", "logcollector", LOCALFILE_MQ);
-                            sockets[i]->last_attempt = mtime;
+                            targets[i].log_socket->last_attempt = mtime;
                             continue;
                         }
                     } else {
-                        mdebug2("Discarding event from '%s' due to connection issue with '%s'", locmsg, sockets[i]->name);
+                        mdebug2("Discarding event from '%s' due to connection issue with '%s'", locmsg, targets[i].log_socket->name);
                         continue;
                     }
 
                 } else {
-                    merror("Cannot send message to socket '%s'. (Retry)", sockets[i]->name);
+                    merror("Cannot send message to socket '%s'. (Retry)", targets[i].log_socket->name);
                     SendMSG(queue, "Cannot send message to socket.", "logcollector", LOCALFILE_MQ);
                     continue;
                 }
             }
         }
+
+        free(_message);
     }
 
-    free(_message);
     return (0);
 }
 
 #else
 
-int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, __attribute__((unused)) logsocket **sockets, const char * pattern) {
-    char * _message = msgsubst(pattern, message, locmsg, time(NULL));
-    int retval = SendMSG(queue, _message, locmsg, loc);
+int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logtarget * targets) {
+    char * _message;
+    int retval;
+
+    if (!targets[0].log_socket) {
+        merror("No targets defined for a localfile.");
+        return -1;
+    }
+
+    _message = msgsubst(targets[0].format, message, locmsg, time(NULL));
+    retval = SendMSG(queue, _message, locmsg, loc);
     free(_message);
     return retval;
 }


### PR DESCRIPTION
Related issue: https://github.com/wazuh/wazuh/issues/830

This PR aims to introduce a new option that will allow defining custom output formats for different targets in the same `<localfile>` stanza.

```xml
<localfile>
  <log_format>syslog</log_format>
  <location>/var/log/syslog</location>
  <target>agent,socket</target>
  <out_format target="socket">$(timestamp %Y-%m-%dT%H:%M:%S): $(log)</out_format>
</localfile>
```

## Added options

Attribute `target` for option `<out_format>` in `<localfile>` stanzas.

```xml
<out_format target="custom">custom: $(log)</out_format>
<out_format target="agent">(agent): $(log)</out_format>
```

This attribute is optional. If it is not defined it will affect all the `<target>` stanzas except those that have a custom option `<out_format>` defined.

## Unit tests

- [x] Define `<out_format>` with default target for some localfiles.
- [x] Declare `<out_format>` for the target `"agent"`.
- [x] Create `<out_format>` for a custom socket target.
- [x] Combine `<out_format>` with a default option and another stanza for a custom socket target.
- [x] Use `<out_format>` in _localfile_ stanzas with wildcards (define the option before the location).
- [x] Use `<out_format>` in _localfile_ stanzas with wildcards (define the option after the location).
- [x] Run Logcollector with Valgrind.
- [x] Declare `<out_format>` for a target that does not exist.