### PR TITLE
Add support for unified WPK 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - New option for the JSON decoder to choose the treatment of NULL values. ([#677](https://github.com/wazuh/wazuh/pull/677))
 - Remove old snapshot files for FIM. ([#872](https://github.com/wazuh/wazuh/pull/872))
 - Distinct operation in agents. ([#920](https://github.com/wazuh/wazuh/pull/920))
+- Added support for unified WPK. ([#865](https://github.com/wazuh/wazuh/pull/865))
 
 
 ### Changed

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -71,9 +71,10 @@ def main():
         raise WazuhException(1720)
 
     # Evaluate if the version is correct
-    pattern = re.compile("v[0-9]+\.[0-9]+\.[0-9]+")
-    if not pattern.match(args.version):
-        raise WazuhException(1733, "Version received: {0}".format(args.version))
+    if args.version is not None:
+        pattern = re.compile("v[0-9]+\.[0-9]+\.[0-9]+")
+        if not pattern.match(args.version):
+            raise WazuhException(1733, "Version received: {0}".format(args.version))
 
     # Custom WPK file
     if args.file:

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -9,6 +9,7 @@ from signal import signal, SIGINT
 from time import sleep
 import argparse
 import os
+import re
 
 # Set framework path
 path.append(dirname(argv[0]) + '/../framework')  # It is necessary to import Wazuh package
@@ -68,6 +69,11 @@ def main():
     agent_info = "{0}/queue/agent-info/{1}-{2}".format(common.ossec_path, agent.name, agent.ip)
     if not os.path.isfile(agent_info):
         raise WazuhException(1720)
+
+    # Evaluate if the version is correct
+    pattern = re.compile("v[0-9]+\.[0-9]+\.[0-9]+")
+    if not pattern.match(args.version):
+        raise WazuhException(1733, "Version received: {0}".format(args.version))
 
     # Custom WPK file
     if args.file:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1924,6 +1924,12 @@ class Agent:
         """
         Generates a list of available versions for its distribution and version.
         """
+        invalid_platforms = ["darwin", "solaris", "aix", "hpux"]
+
+        if self.os['platform'] in invalid_platforms or self.os['platform'] = "sles" and self.os['major'] == 11:
+            error = "The WPK for this platform is not available."
+            raise WazuhException(1713, error)
+
         if (desired_version is None or desired_version[:4] >= "v3.4") and self.os['platform'] != "windows":
             versions_url = wpk_repo + "linux/" + self.os['arch'] + "/versions"
         else:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1924,7 +1924,7 @@ class Agent:
         """
         Generates a list of available versions for its distribution and version.
         """
-        invalid_platforms = ["darwin", "solaris", "aix", "hpux"]
+        invalid_platforms = ["darwin", "solaris", "aix", "hpux", "bsd"]
         not_valid_versions = [("sles", 11), ("rhel", 5), ("centos", 5)]
 
         if self.os['platform'] in invalid_platforms or (self.os['platform'], self.os['major']) in not_valid_versions:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1924,7 +1924,7 @@ class Agent:
         """
         Generates a list of available versions for its distribution and version.
         """
-        if desired_version is None or desired_version[:4] >= "v3.4" and self.os['platform'] != "windows":
+        if (desired_version is None or desired_version[:4] >= "v3.4") and self.os['platform'] != "windows":
             versions_url = wpk_repo + "linux/" + self.os['arch'] + "/versions"
         else:
             if self.os['platform']=="windows":
@@ -1999,7 +1999,7 @@ class Agent:
         if self.os['platform']=="windows":
             wpk_file = "wazuh_agent_{0}_{1}.wpk".format(agent_new_ver, self.os['platform'])
             wpk_url = wpk_repo + "windows/" + wpk_file
-            
+
         else:
             if version is None or version[:4] >= "v3.4":
                 wpk_file = "wazuh_agent_{0}_linux_{1}.wpk".format(agent_new_ver, self.os['arch'])

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1925,8 +1925,9 @@ class Agent:
         Generates a list of available versions for its distribution and version.
         """
         invalid_platforms = ["darwin", "solaris", "aix", "hpux"]
+        not_valid_versions = [("sles", 11), ("rhel", 5), ("centos", 5)]
 
-        if self.os['platform'] in invalid_platforms or self.os['platform'] = "sles" and self.os['major'] == 11:
+        if self.os['platform'] in invalid_platforms or (self.os['platform'], self.os['major']) in not_valid_versions:
             error = "The WPK for this platform is not available."
             raise WazuhException(1713, error)
 

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -105,7 +105,7 @@ class WazuhException(Exception):
         1730: 'Node does not exist',
         1731: 'Agent is not eligible for removal',
         1732: 'No agents selected',
-
+        1733: 'Bad formatted version. Version must follow this pattern: vX.Y.Z .',
         # Manager:
 
         # Database:

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -477,12 +477,16 @@ size_t wcom_upgrade_result(char *output){
 #ifndef WIN32
     const char * PATH = isChroot() ? UPGRADE_DIR "/upgrade_result" : DEFAULTDIR UPGRADE_DIR "/upgrade_result";
 #else
-    const char * PATH = UPGRADE_DIR "/upgrade_result";
+    const char * PATH = UPGRADE_DIR "\\upgrade_result";
 #endif
 
     FILE * result_file;
 
+#ifndef WIN32
     if (result_file = fopen(PATH, "r"), result_file) {
+#else
+    if (result_file = fopen(PATH, "rb"), result_file) {
+#endif
         if (fgets(buffer,20,result_file)){
             snprintf(output, OS_MAXSTR, "ok %s", buffer);
             fclose(result_file);
@@ -491,7 +495,7 @@ size_t wcom_upgrade_result(char *output){
         fclose(result_file);
     }
     strcpy(output, "err Cannot read upgrade_result file.");
-    merror("At WCOM upgrade_result: Cannot read file '%s'.", PATH);
+    mdebug1("At WCOM upgrade_result: Cannot read file '%s'.", PATH);
     return strlen(output);
 }
 


### PR DESCRIPTION
Hi team,

this PR fix #864. The `agent_upgrade` now can upgrade an agent using the unified WPK to the last version and also supports the downgrade to previous versions using the previous WPKs.

Regards,
Braulio.