### PR TITLE
Improve output DELETE/agents when no agents were removed

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1252,7 +1252,7 @@ class Agent:
                     failed_ids.append(create_exception_dic(id, e))
 
         if not failed_ids:
-            message = 'All selected agents were removed'
+            message = 'All selected agents were removed' if affected_agents else "No agents were removed"
         else:
             message = 'Some agents were not removed'
 


### PR DESCRIPTION
Hi team,

this PR fixes https://github.com/wazuh/wazuh-api/issues/113.

## Sample

```
$ curl -u foo:bar -k -X DELETE "http://127.0.0.1:55000/agents?pretty&older_than=1s&status=neverconnected"
{
   "error": 0,
   "data": {
      "msg": "No agents were removed",
      "older_than": "1s",
      "affected_agents": [],
      "total_affected_agents": 0
   }
}

```

Best regards,
Javi.