### PR TITLE
Fix Slack integration for alerts that not include full_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
 - Allow more than 256 directories in real-time for Windows agent using recursive watchers. ([#540](https://github.com/wazuh/wazuh/pull/540))
 - Fix weird behavior in Syscheck when a modified file returns back to its first state. ([#434](https://github.com/wazuh/wazuh/pull/434))
 - Fix memory leak reading logcollector config. ([#884](https://github.com/wazuh/wazuh/pull/884))
+- Fixed crash in Slack integration for alerts that don't have full log. ([#880](https://github.com/wazuh/wazuh/pull/880))
+
 
 ## [v3.3.1]
 

--- a/integrations/slack
+++ b/integrations/slack
@@ -86,7 +86,7 @@ def generate_msg(alert):
     msg['color'] = color
     msg['pretext'] = "WAZUH Alert"
     msg['title'] = alert['rule']['description']
-    msg['text'] = alert['full_log']
+    msg['text'] = alert.get('full_log')
     agent = { "title":"Agent", "value":"({0}) - {1}".format(alert['agent']['id'],alert['agent']['name']) }
     location = { "title":"Location", "value":alert['location'] }
     rule = { "title":"Rule ID", "value":"{0} _(Level {1})_".format(alert['rule']['id'],level) }


### PR DESCRIPTION
This PR is related to issue https://github.com/wazuh/wazuh/issues/736.

Some alerts, like those coming from Vulnerability Detector, don't include the `full_log` object. This makes the Slack integration crash.

Thanks to @harkylton for proposing this fix.