### PR TITLE
no_full_log option only affecting to JSON alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - Added an internal option for Syscheck to tune the RT alerting delay. ([#434](https://github.com/wazuh/wazuh/pull/434))
 - Added an option `target` to customize output format per-target in Logcollector. ([#863](https://github.com/wazuh/wazuh/pull/863))
 
+### Changed
+
+- Now the no_full_log option only affects JSON alerts. ([#881](https://github.com/wazuh/wazuh/pull/881))
+
 ### Fixed
 
 - Syscheck RT process granularized to make frequency option more accurate. ([#434](https://github.com/wazuh/wazuh/pull/434))

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -346,9 +346,8 @@ void OS_Log(Eventinfo *lf)
 
             lf->dstuser == NULL ? "" : "\nUser: ",
             lf->dstuser == NULL ? "" : lf->dstuser,
-
-            lf->generated_rule->alert_opts & NO_FULL_LOG ? "" : "\n",
-            lf->generated_rule->alert_opts & NO_FULL_LOG ? "" : lf->full_log);
+            "\n",
+            lf->full_log);
 
     /* FIM events */
 


### PR DESCRIPTION
The no_full_log option only affects JSON alerts