### PR TITLE
Limit maximum number of items returned by API

### DIFF
--- a/framework/examples/rules2csv.py
+++ b/framework/examples/rules2csv.py
@@ -35,5 +35,5 @@ except Exception as e:
     exit()
 
 print("file;id;description;level;status;groups;pci;details")
-for rule in Rule.get_rules(status='enabled', limit=0, sort={"fields":["file"],"order":"asc"})['items']:
+for rule in Rule.get_rules(status='enabled', limit=None, sort={"fields":["file"],"order":"asc"})['items']:
     print("{0};{1};{2};{3};{4};{5};{6};{7}".format(rule.file, rule.id, rule.description, rule.level, rule.status, rule.groups, rule.pci, rule.details))

--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -56,7 +56,7 @@ def show_group(agent_id):
 
 
 def show_agents_with_group(group_id):
-    agents_data = Agent.get_agent_group(group_id, limit=0)
+    agents_data = Agent.get_agent_group(group_id, limit=None)
 
     if agents_data['totalItems'] == 0:
         print("No agents found in group '{0}'.".format(group_id))

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -281,6 +281,8 @@ class Agent:
             query = query.replace("from {} and".format(table), "from {} where".format(table))
 
         if limit:
+            if limit > common.maximum_database_limit:
+                limit = common.maximum_database_limit
             query += ' limit {} offset {}'.format(limit, offset)
 
         if sort and sort['fields']:
@@ -977,6 +979,8 @@ class Agent:
 
 
         if limit:
+            if limit > common.maximum_database_limit:
+                limit = common.maximum_database_limit
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
@@ -1080,6 +1084,8 @@ class Agent:
 
         # OFFSET - LIMIT
         if limit:
+            if limit > common.maximum_database_limit:
+                limit = common.maximum_database_limit
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
@@ -1372,6 +1378,8 @@ class Agent:
 
         # OFFSET - LIMIT
         if limit:
+            if limit > common.maximum_database_limit:
+                limit = common.maximum_database_limit
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
@@ -1586,6 +1594,8 @@ class Agent:
 
         # OFFSET - LIMIT
         if limit:
+            if limit > common.maximum_database_limit:
+                limit = common.maximum_database_limit
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
@@ -1870,6 +1880,8 @@ class Agent:
 
         # OFFSET - LIMIT
         if limit:
+            if limit > common.maximum_database_limit:
+                limit = common.maximum_database_limit
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -282,7 +282,7 @@ class Agent:
 
         if limit:
             if limit > common.maximum_database_limit:
-                limit = common.maximum_database_limit
+                raise WazuhException(1405, str(limit))
             query += ' limit {} offset {}'.format(limit, offset)
 
         if sort and sort['fields']:
@@ -980,7 +980,7 @@ class Agent:
 
         if limit:
             if limit > common.maximum_database_limit:
-                limit = common.maximum_database_limit
+                raise WazuhException(1405, str(limit))
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
@@ -1085,7 +1085,7 @@ class Agent:
         # OFFSET - LIMIT
         if limit:
             if limit > common.maximum_database_limit:
-                limit = common.maximum_database_limit
+                raise WazuhException(1405, str(limit))
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
@@ -1379,7 +1379,7 @@ class Agent:
         # OFFSET - LIMIT
         if limit:
             if limit > common.maximum_database_limit:
-                limit = common.maximum_database_limit
+                raise WazuhException(1405, str(limit))
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
@@ -1595,7 +1595,7 @@ class Agent:
         # OFFSET - LIMIT
         if limit:
             if limit > common.maximum_database_limit:
-                limit = common.maximum_database_limit
+                raise WazuhException(1405, str(limit))
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
@@ -1881,7 +1881,7 @@ class Agent:
         # OFFSET - LIMIT
         if limit:
             if limit > common.maximum_database_limit:
-                limit = common.maximum_database_limit
+                raise WazuhException(1405, str(limit))
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -284,6 +284,8 @@ class Agent:
             if limit > common.maximum_database_limit:
                 raise WazuhException(1405, str(limit))
             query += ' limit {} offset {}'.format(limit, offset)
+        elif limit == 0:
+            raise WazuhException(1406)
 
         if sort and sort['fields']:
             str_order = "desc" if sort['order'] == 'asc' else "asc"
@@ -984,6 +986,8 @@ class Agent:
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
+        elif limit == 0:
+            raise WazuhException(1406)
 
         conn.execute(query.format(','.join(min_select_fields)), request)
 
@@ -1089,6 +1093,8 @@ class Agent:
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
+        elif limit == 0:
+            raise WazuhException(1406)
 
         conn.execute(query.format(','.join(select)), request)
 
@@ -1383,6 +1389,8 @@ class Agent:
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
+        elif limit == 0:
+            raise WazuhException(1406)
 
         # Data query
         conn.execute(query.format(','.join(select)), request)
@@ -1599,6 +1607,8 @@ class Agent:
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
+        elif limit == 0:
+            raise WazuhException(1406)
 
         if 'group' in select_fields:
             select_fields.remove('group')
@@ -1885,6 +1895,8 @@ class Agent:
             query += ' LIMIT :offset,:limit'
             request['offset'] = offset
             request['limit'] = limit
+        elif limit == 0:
+            raise WazuhException(1406)
 
         # Data query
         conn.execute(query.format(','.join(select)), request)

--- a/framework/wazuh/common.py
+++ b/framework/wazuh/common.py
@@ -90,6 +90,7 @@ agent_info_sleep = 2 # Seconds between retries
 
 # Common variables
 database_limit = 500
+maximum_database_limit = 1000
 
 ossec_uid = getpwnam("ossec").pw_uid
 ossec_gid = getgrnam("ossec").gr_gid

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -428,6 +428,9 @@ def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filenam
     :return: agent.conf as dictionary.
     """
 
+    if limit > common.maximum_database_limit:
+        limit = common.maximum_database_limit
+
     if group_id:
         if not Agent.group_exists(group_id):
             raise WazuhException(1710, group_id)

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -427,10 +427,6 @@ def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filenam
 
     :return: agent.conf as dictionary.
     """
-
-    if limit > common.maximum_database_limit:
-        limit = common.maximum_database_limit
-
     if group_id:
         if not Agent.group_exists(group_id):
             raise WazuhException(1710, group_id)

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -487,14 +487,14 @@ def get_file_conf(filename, group_id=None, type_conf=None):
     if type_conf:
         if type_conf in types:
             if type_conf == 'conf':
-                data = types[type_conf](group_id, limit=0, filename=filename)
+                data = types[type_conf](group_id, limit=None, filename=filename)
             else:
                 data = types[type_conf](file_path)
         else:
             raise WazuhException(1104, "{0}. Valid types: {1}".format(type_conf, types.keys()))
     else:
         if filename == "agent.conf":
-            data = get_agent_conf(group_id, limit=0, filename=filename)
+            data = get_agent_conf(group_id, limit=None, filename=filename)
         elif filename == "rootkit_files.txt":
             data = _rootkit_files2json(file_path)
         elif filename == "rootkit_trojans.txt":

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -172,7 +172,7 @@ class Decoder:
         status = Decoder.__check_status(status)
         all_decoders = []
 
-        for decoder_file in Decoder.get_decoders_files(status=status, limit=0)['items']:
+        for decoder_file in Decoder.get_decoders_files(status=status, limit=None)['items']:
             all_decoders.extend(Decoder.__load_decoders_from_file(decoder_file['file'], decoder_file['path'], decoder_file['status']))
 
         decoders = list(all_decoders)

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -151,6 +151,9 @@ class Decoder:
         else:
             data = sort_array(data, ['file'], 'asc')
 
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
+
         return {'items': cut_array(data, offset, limit), 'totalItems': len(data)}
 
     @staticmethod
@@ -197,6 +200,9 @@ class Decoder:
             decoders = sort_array(decoders, sort['fields'], sort['order'], Decoder.SORT_FIELDS)
         else:
             decoders = sort_array(decoders, ['file', 'position'], 'asc')
+
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
 
         return {'items': cut_array(decoders, offset, limit), 'totalItems': len(decoders)}
 

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -151,9 +151,6 @@ class Decoder:
         else:
             data = sort_array(data, ['file'], 'asc')
 
-        if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
-
         return {'items': cut_array(data, offset, limit), 'totalItems': len(data)}
 
     @staticmethod
@@ -200,9 +197,6 @@ class Decoder:
             decoders = sort_array(decoders, sort['fields'], sort['order'], Decoder.SORT_FIELDS)
         else:
             decoders = sort_array(decoders, ['file', 'position'], 'asc')
-
-        if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
 
         return {'items': cut_array(decoders, offset, limit), 'totalItems': len(decoders)}
 

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -60,6 +60,7 @@ class WazuhException(Exception):
         1403: 'Sort field invalid',  # Also, in DB
         1404: 'A field must be specified to order the data',
         1405: 'Specified limit exceeds maximum allowed (1000)',
+        1406: '0 is not a valid limit',
 
         # Decoders: 1500 - 1599
         1500: 'Error reading decoders from ossec.conf',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -59,6 +59,7 @@ class WazuhException(Exception):
         1402: 'Invalid order. Order must be \'asc\' or \'desc\'',
         1403: 'Sort field invalid',  # Also, in DB
         1404: 'A field must be specified to order the data',
+        1405: 'Specified limit exceeds maximum allowed (1000)',
 
         # Decoders: 1500 - 1599
         1500: 'Error reading decoders from ossec.conf',

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -131,6 +131,9 @@ def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.d
     else:
         logs = sort_array(logs, order='desc', sort_by=['timestamp'])
 
+    if limit > common.maximum_database_limit:
+        limit = common.maximum_database_limit
+
     return {'items': cut_array(logs, offset, limit), 'totalItems': len(logs)}
 
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -131,9 +131,6 @@ def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.d
     else:
         logs = sort_array(logs, order='desc', sort_by=['timestamp'])
 
-    if limit > common.maximum_database_limit:
-        limit = common.maximum_database_limit
-
     return {'items': cut_array(logs, offset, limit), 'totalItems': len(logs)}
 
 

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -176,6 +176,8 @@ def print_db(agent_id=None, status='all', pci=None, cis=None, offset=0, limit=co
         query += ' ORDER BY date_last DESC'
 
     if limit:
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit
@@ -257,6 +259,8 @@ def get_pci(agent_id=None, offset=0, limit=common.database_limit, sort=None, sea
         query += ' ORDER BY pci_dss ASC'
 
     if limit:
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit
@@ -322,6 +326,8 @@ def get_cis(agent_id=None, offset=0, limit=common.database_limit, sort=None, sea
         query += ' ORDER BY cis ASC'
 
     if limit:
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -177,7 +177,7 @@ def print_db(agent_id=None, status='all', pci=None, cis=None, offset=0, limit=co
 
     if limit:
         if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
+            raise WazuhException(1405, str(limit))
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit
@@ -260,7 +260,7 @@ def get_pci(agent_id=None, offset=0, limit=common.database_limit, sort=None, sea
 
     if limit:
         if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
+            raise WazuhException(1405, str(limit))
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit
@@ -327,7 +327,7 @@ def get_cis(agent_id=None, offset=0, limit=common.database_limit, sort=None, sea
 
     if limit:
         if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
+            raise WazuhException(1405, str(limit))
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -181,6 +181,8 @@ def print_db(agent_id=None, status='all', pci=None, cis=None, offset=0, limit=co
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit
+    elif limit == 0:
+        raise WazuhException(1406)
 
     select = ["status", "date_first", "date_last", "log", "pci_dss", "cis"]
 
@@ -264,6 +266,8 @@ def get_pci(agent_id=None, offset=0, limit=common.database_limit, sort=None, sea
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit
+    elif limit == 0:
+        raise WazuhException(1406)
 
 
     conn.execute(query.format('DISTINCT pci_dss'), request)
@@ -331,6 +335,8 @@ def get_cis(agent_id=None, offset=0, limit=common.database_limit, sort=None, sea
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit
+    elif limit == 0:
+        raise WazuhException(1406)
 
 
     conn.execute(query.format('DISTINCT cis'), request)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -255,7 +255,7 @@ class Rule:
             if len(levels) < 0 or len(levels) > 2:
                 raise WazuhException(1203)
 
-        for rule_file in Rule.get_rules_files(status=status, limit=0)['items']:
+        for rule_file in Rule.get_rules_files(status=status, limit=None)['items']:
             all_rules.extend(Rule.__load_rules_from_file(rule_file['file'], rule_file['path'], rule_file['status']))
 
         rules = list(all_rules)
@@ -311,7 +311,7 @@ class Rule:
         """
         groups = set()
 
-        for rule in Rule.get_rules(limit=0)['items']:
+        for rule in Rule.get_rules(limit=None)['items']:
             for group in rule.groups:
                 groups.add(group)
 
@@ -341,7 +341,7 @@ class Rule:
         if requirement != 'pci' and requirement != 'gdpr':
             raise WazuhException(1205, requirement)
 
-        req = list({req for rule in Rule.get_rules(limit=0)['items'] for req in rule.to_dict()[requirement]})
+        req = list({req for rule in Rule.get_rules(limit=None)['items'] for req in rule.to_dict()[requirement]})
 
         if search:
             req = search_array(req, search['value'], search['negation'])

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -226,6 +226,9 @@ class Rule:
         else:
             data = sort_array(data, ['file'], 'asc')
 
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
+
         return {'items': cut_array(data, offset, limit), 'totalItems': len(data)}
 
 
@@ -295,6 +298,9 @@ class Rule:
         else:
             rules = sort_array(rules, ['id'], 'asc')
 
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
+
         return {'items': cut_array(rules, offset, limit), 'totalItems': len(rules)}
 
 
@@ -323,6 +329,9 @@ class Rule:
         else:
             groups = sort_array(groups)
 
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
+
         return {'items': cut_array(groups, offset, limit), 'totalItems': len(groups)}
 
 
@@ -350,6 +359,9 @@ class Rule:
             req = sort_array(req, order=sort['order'])
         else:
             req = sort_array(req)
+
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
 
         return {'items': cut_array(req, offset, limit), 'totalItems': len(req)}
 

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -226,9 +226,6 @@ class Rule:
         else:
             data = sort_array(data, ['file'], 'asc')
 
-        if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
-
         return {'items': cut_array(data, offset, limit), 'totalItems': len(data)}
 
 
@@ -298,9 +295,6 @@ class Rule:
         else:
             rules = sort_array(rules, ['id'], 'asc')
 
-        if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
-
         return {'items': cut_array(rules, offset, limit), 'totalItems': len(rules)}
 
 
@@ -329,9 +323,6 @@ class Rule:
         else:
             groups = sort_array(groups)
 
-        if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
-
         return {'items': cut_array(groups, offset, limit), 'totalItems': len(groups)}
 
 
@@ -359,9 +350,6 @@ class Rule:
             req = sort_array(req, order=sort['order'])
         else:
             req = sort_array(req)
-
-        if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
 
         return {'items': cut_array(req, offset, limit), 'totalItems': len(req)}
 

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -230,6 +230,8 @@ def files(agent_id=None, event=None, filename=None, filetype='file', md5=None, s
         query += ' ORDER BY date DESC'
 
     if limit:
+        if limit > common.maximum_database_limit:
+            limit = common.maximum_database_limit
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -235,6 +235,8 @@ def files(agent_id=None, event=None, filename=None, filetype='file', md5=None, s
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit
+    elif limit == 0:
+        raise WazuhException(1406)
 
     if summary:
         select = ["max(date)", "mtime", "fim_event.type", "path"]

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -231,7 +231,7 @@ def files(agent_id=None, event=None, filename=None, filetype='file', md5=None, s
 
     if limit:
         if limit > common.maximum_database_limit:
-            limit = common.maximum_database_limit
+            raise WazuhException(1405, str(limit))
         query += ' LIMIT :offset,:limit'
         request['offset'] = offset
         request['limit'] = limit

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -12,6 +12,10 @@ from operator import itemgetter
 
 def get_item_agent(agent_id, offset, limit, select, search, sort, filters, valid_select_fields, allowed_sort_fields, table, nested=True, array=False):
     Agent(agent_id).get_basic_information()
+
+    if limit > common.maximum_database_limit:
+        limit = common.maximum_database_limit
+
     if select:
         select_fields = list(set(select['fields']) & set(valid_select_fields))
         if select_fields == []:

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -13,9 +13,6 @@ from operator import itemgetter
 def get_item_agent(agent_id, offset, limit, select, search, sort, filters, valid_select_fields, allowed_sort_fields, table, nested=True, array=False):
     Agent(agent_id).get_basic_information()
 
-    if limit > common.maximum_database_limit:
-        limit = common.maximum_database_limit
-
     if select:
         select_fields = list(set(select['fields']) & set(valid_select_fields))
         if select_fields == []:

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -95,8 +95,10 @@ def cut_array(array, offset, limit):
 
     if limit > common.maximum_database_limit:
         raise WazuhException(1405, str(limit))
+    elif limit == 0:
+        raise WazuhException(1406)
 
-    if not array or limit == 0 or limit == None:
+    if not array or limit == None:
         return array
 
     offset = int(offset)

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -93,6 +93,9 @@ def cut_array(array, offset, limit):
     :return: cut array.
     """
 
+    if limit > common.maximum_database_limit:
+        raise WazuhException(1405, str(limit))
+
     if not array or limit == 0 or limit == None:
         return array
 


### PR DESCRIPTION
Hello team,

This PR fixes https://github.com/wazuh/wazuh/issues/875.

Some examples:
```shellsession
# curl -u foo:bar "localhost:55000/rules?pretty&limit=0"
{
   "error": 1406,
   "message": "0 is not a valid limit."
}
# curl -u foo:bar "localhost:55000/agents?pretty&limit=2000"
{
   "error": 1405,
   "message": "Specified limit exceeds maximum allowed (1000): 2000"
}
# curl -u foo:bar "localhost:55000/rules?pretty&limit=2000"
{
   "error": 1405,
   "message": "Specified limit exceeds maximum allowed (1000): 2000"
}
# curl -u foo:bar "localhost:55000/agents/groups/default?pretty&limit=2000"
{
   "error": 1405,
   "message": "Specified limit exceeds maximum allowed (1000): 2000"
}
```
```python
Python 2.7.5 (default, Apr 11 2018, 07:36:10)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-28)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh.rule import Rule
>>> Rule.get_rules(limit=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "wazuh/rule.py", line 298, in get_rules
    return {'items': cut_array(rules, offset, limit), 'totalItems': len(rules)}
  File "wazuh/utils.py", line 99, in cut_array
    raise WazuhException(1406)
wazuh.exception.WazuhException: Error 1406 - 0 is not a valid limit.
>>> Rule.get_rules(limit=None)
{'totalItems': 1633, 'items': [<wazuh.rule.Rule instance at 0x7f9c47190200>, <wazuh.rule.Rule instance at 0x7f9c47190488>, <wazuh.rule.Rule instance at 0x7f9c471905a8>,.....
```

Best regards,
Marta
