### PR TITLE
Change no previous checksum error message to information log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
   - Improvements of error and information messages when they start.
 - Improve output of `DELETE/agents` when no agents were removed. ([#868](https://github.com/wazuh/wazuh/pull/868))
 - Include the file owner SID in Syscheck alerts.
+- Change no previous checksum error message to information log. ([#897](https://github.com/wazuh/wazuh/pull/897))
 
 ### Fixed
 

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -61,21 +61,21 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     /* Generate MD5 of the old file */
     if (OS_MD5_File(logfilesum_old, mf_sum_old, OS_TEXT) < 0) {
-        merror("No previous md5 checksum found: '%s'. "
+        minfo("No previous md5 checksum found: '%s'. "
                "Starting over.", logfilesum_old);
         strncpy(mf_sum_old, "none", 6);
     }
 
     /* Generate SHA-1 of the old file  */
     if (OS_SHA1_File(logfilesum_old, sf_sum_old, OS_TEXT) < 0) {
-        merror("No previous sha1 checksum found: '%s'. "
+        minfo("No previous sha1 checksum found: '%s'. "
                "Starting over.", logfilesum_old);
         strncpy(sf_sum_old, "none", 6);
     }
 
     /* Generate SHA-256 of the old file  */
     if (OS_SHA256_File(logfilesum_old, sf256_sum_old, OS_TEXT) < 0) {
-        merror("No previous sha256 checksum found: '%s'. "
+        minfo("No previous sha256 checksum found: '%s'. "
                "Starting over.", logfilesum_old);
         strncpy(sf256_sum_old, "none", 6);
     }


### PR DESCRIPTION
These errors:

```
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous md5 checksum found: '/logs/archives/2018/Jul/ossec-archive-04.log.sum'. Starting over.
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous sha1 checksum found: '/logs/archives/2018/Jul/ossec-archive-04.log.sum'. Starting over.
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous sha256 checksum found: '/logs/archives/2018/Jul/ossec-archive-04.log.sum'. Starting over.
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous md5 checksum found: '/logs/archives/2018/Jul/ossec-archive-04.json.sum'. Starting over.
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous sha1 checksum found: '/logs/archives/2018/Jul/ossec-archive-04.json.sum'. Starting over.
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous sha256 checksum found: '/logs/archives/2018/Jul/ossec-archive-04.json.sum'. Starting over.
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous md5 checksum found: '/logs/alerts/2018/Jul/ossec-alerts-04.log.sum'. Starting over.
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous sha1 checksum found: '/logs/alerts/2018/Jul/ossec-alerts-04.log.sum'. Starting over.
2018/07/05 07:59:06 ossec-monitord: ERROR: No previous sha256 checksum found: '/logs/alerts/2018/Jul/ossec-alerts-04.log.sum'. Starting over.
2018/07/05 07:59:07 ossec-monitord: ERROR: No previous md5 checksum found: '/logs/alerts/2018/Jul/ossec-alerts-04.json.sum'. Starting over.
2018/07/05 07:59:07 ossec-monitord: ERROR: No previous sha1 checksum found: '/logs/alerts/2018/Jul/ossec-alerts-04.json.sum'. Starting over.
2018/07/05 07:59:07 ossec-monitord: ERROR: No previous sha256 checksum found: '/logs/alerts/2018/Jul/ossec-alerts-04.json.sum'. Starting over.
```

They always appear the first time the manager rotates the alerts, after installing or after purging the alert files.

They should not be error messages but information logs.