### PR TITLE
Add missing debug options to some modules

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -257,10 +257,10 @@ wazuh_command.remote_commands=0
 # Debug 1 -> first level of debug
 # Debug 2 -> full debugging
 
-# Windows debug (used by the windows agent)
+# Windows debug (used by the Windows agent)
 windows.debug=0
 
-# Syscheck (local, server and unix agent)
+# Syscheck (local, server and Unix agent)
 syscheck.debug=0
 
 # Remoted (server debug)
@@ -269,8 +269,20 @@ remoted.debug=0
 # Analysisd (server or local)
 analysisd.debug=0
 
-# Log collector (server, local or unix agent)
+# Auth daemon debug (server)
+authd.debug=0
+
+# Exec daemon debug (server, local or Unix agent)
+execd.debug=0
+
+# Monitor daemon debug (server, local or Unix agent)
+monitord.debug=0
+
+# Log collector (server, local or Unix agent)
 logcollector.debug=0
+
+# Integrator daemon debug (server, local or Unix agent)
+integrator.debug=0
 
 # Unix agentd
 agent.debug=0

--- a/src/monitord/main.c
+++ b/src/monitord/main.c
@@ -50,6 +50,7 @@ int main(int argc, char **argv)
     const char *cfg = DEFAULTCPATH;
     short day_wait = -1;
     char * end;
+    int debug_level = 0;
 
     /* Initialize global variables */
     mond.a_queue = 0;
@@ -67,6 +68,7 @@ int main(int argc, char **argv)
                 break;
             case 'd':
                 nowDebug();
+                debug_level = 1;
                 break;
             case 'f':
                 run_foreground = 1;
@@ -116,6 +118,15 @@ int main(int argc, char **argv)
                 break;
         }
 
+    }
+
+    if (debug_level == 0) {
+        /* Get debug level */
+        debug_level = getDefine_Int("monitord", "debug", 0, 2);
+        while (debug_level != 0) {
+            nowDebug();
+            debug_level--;
+        }
     }
 
     /* Start daemon */

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -86,6 +86,7 @@ int main(int argc, char **argv)
     BIO *sbio;
     bio_err = 0;
     buf[4096] = '\0';
+    int debug_level = 0;
 
 #ifdef WIN32
     WSADATA wsaData;
@@ -103,6 +104,7 @@ int main(int argc, char **argv)
                 help_agent_auth();
                 break;
             case 'd':
+                debug_level = 1;
                 nowDebug();
                 break;
             case 'g':
@@ -177,6 +179,15 @@ int main(int argc, char **argv)
             default:
                 help_agent_auth();
                 break;
+        }
+    }
+
+    if (debug_level == 0) {
+        /* Get debug level */
+        debug_level = getDefine_Int("authd", "debug", 0, 2);
+        while (debug_level != 0) {
+            nowDebug();
+            debug_level--;
         }
     }
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -152,6 +152,7 @@ int main(int argc, char **argv)
 {
     FILE *fp;
     /* Count of pids we are wait()ing on */
+    int debug_level = 0;
     int test_config = 0;
     int status;
     int run_foreground = 0;
@@ -203,6 +204,7 @@ int main(int argc, char **argv)
                     break;
 
                 case 'd':
+                    debug_level = 1;
                     nowDebug();
                     break;
 
@@ -396,6 +398,15 @@ int main(int argc, char **argv)
     if (config.flags.disabled) {
         minfo("Daemon is disabled. Closing.");
         exit(0);
+    }
+
+    if (debug_level == 0) {
+        /* Get debug level */
+        debug_level = getDefine_Int("authd", "debug", 0, 2);
+        while (debug_level != 0) {
+            nowDebug();
+            debug_level--;
+        }
     }
 
     /* Start daemon -- NB: need to double fork and setsid */

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -75,6 +75,7 @@ int main(int argc, char **argv)
     int test_config = 0, run_foreground = 0;
     gid_t gid;
     int m_queue = 0;
+    int debug_level = 0;
 
     const char *group = GROUPGLOBAL;
     const char *cfg = DEFAULTCPATH;
@@ -91,6 +92,7 @@ int main(int argc, char **argv)
                 help_execd();
                 break;
             case 'd':
+                debug_level = 1;
                 nowDebug();
                 break;
             case 'f':
@@ -114,6 +116,15 @@ int main(int argc, char **argv)
             default:
                 help_execd();
                 break;
+        }
+    }
+
+    if (debug_level == 0) {
+        /* Get debug level */
+        debug_level = getDefine_Int("execd", "debug", 0, 2);
+        while (debug_level != 0) {
+            nowDebug();
+            debug_level--;
         }
     }
 

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -40,6 +40,7 @@ int main(int argc, char **argv)
     int uid = 0;
     int gid = 0;
     int run_foreground = 0;
+    int debug_level = 0;
 
     /* Highly recommended not to run as root. However, some integrations
      * may require it. */
@@ -63,6 +64,7 @@ int main(int argc, char **argv)
                 break;
             case 'd':
                 nowDebug();
+                debug_level = 1;
                 break;
             case 'u':
                 if(!optarg)
@@ -83,6 +85,15 @@ int main(int argc, char **argv)
             default:
                 help(ARGV0);
                 break;
+        }
+    }
+
+    if (debug_level == 0) {
+        /* Get debug level */
+        debug_level = getDefine_Int("monitord", "debug", 0, 2);
+        while (debug_level != 0) {
+            nowDebug();
+            debug_level--;
         }
     }
 


### PR DESCRIPTION
This PR adds the debug option to the `internal_options.conf` file for the modules authd, execd, monitord, and integratord.