### PR TITLE
Add a command to test cluster's data transfer speed

### DIFF
--- a/framework/tests/test_cluster_transfer.py
+++ b/framework/tests/test_cluster_transfer.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+import logging
+import argparse
+
+sys.path.insert(0, os.path.abspath('..'))
+from wazuh.cluster import internal_socket
+
+if __name__ == '__main__':
+    # Parse args
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', help="Enable debug messages", action='store_true')
+    parser.add_argument('-n', help="Number of MB to transfer", type=int, required=True)
+    args = parser.parse_args()
+
+    logger = logging.getLogger(__name__)
+    logging.basicConfig(level=logging.INFO)
+
+    response = internal_socket.execute('transfertest {}'.format(args.n))
+    print(response)

--- a/framework/wazuh/cluster/communication.py
+++ b/framework/wazuh/cluster/communication.py
@@ -211,12 +211,12 @@ class Handler(asyncore.dispatcher_with_send):
                 del self.worker_threads[worker_thread_id]
 
 
-    def get_worker_thread(self, data):
+    def get_worker_thread(self, data, command):
         # the worker_thread worker_thread_id will be the first element spliting the data by spaces
         worker_thread_id = data.split(b' ', 1)[0].decode()
         with self.worker_threads_lock:
             if worker_thread_id in self.worker_threads:
-                return self.worker_threads[worker_thread_id], 'ack', 'Command received for {}'.format(worker_thread_id)
+                return self.worker_threads[worker_thread_id], 'ack', "Command '{}' received for {}".format(command, worker_thread_id)
             else:
                 return None, 'err', 'Worker {} not found. Please, send me the reason first'.format(worker_thread_id)
 
@@ -481,7 +481,7 @@ class Handler(asyncore.dispatcher_with_send):
             return 'ok ', data.decode()
         elif command in fragmented_requests_commands:
             # At this moment, the thread should exists
-            worker_thread, cmd, message = self.get_worker_thread(data)
+            worker_thread, cmd, message = self.get_worker_thread(data, command)
             if worker_thread:
                 worker_thread.set_command(command, data)
             return cmd, message
@@ -1125,4 +1125,26 @@ class FragmentedStringReceiverWorker(FragmentedStringReceiver):
             self.sleep(2)
             return False
 
+        return True
+
+
+class TransferTester(FragmentedStringReceiverWorker):
+
+    def __init__(self, manager_handler, stopper, request_id):
+        FragmentedStringReceiverWorker.__init__(self, manager_handler, stopper)
+        self.thread_tag = "[Worker] [{0}] [String-R     ]".format(self.manager_handler.name)
+        self.n_updates = 0
+        self.request_id = request_id
+
+
+    def update(self, chunk):
+        self.n_updates += 1
+        FragmentedStringReceiverWorker.update(self, chunk)
+
+
+    def process_received_data(self):
+        self.manager_handler.send_string(reason='dapi_res', string_data=json.dumps({'n_updates':self.n_updates,
+                                                                                    'total_time':self.total_time,
+                                                                                    'total_data':self.size_received}),
+                                                extra_data=self.request_id, new_req='fwd_new', upd_req='fwd_upd', end_req='fwd_end')
         return True

--- a/framework/wazuh/cluster/internal_socket.py
+++ b/framework/wazuh/cluster/internal_socket.py
@@ -189,7 +189,7 @@ class FragmentedAPIResponseReceiver(communication.FragmentedStringReceiverWorker
 
     def unlock_and_stop(self, reason, send_err_request=None):
         if reason=='error':
-            self.manager_handler.final_response.write(send_err_request)
+            self.manager_handler.final_response.write(json.dumps({'error':1000,'message':'Wazuh Python Internal Error: ' + send_err_request}))
         communication.FragmentedStringReceiverWorker.unlock_and_stop(self,reason,None)
 
 

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -777,5 +777,13 @@ class MasterInternalSocketHandler(InternalSocketHandler):
             response = self.server.manager.send_request(worker_name=node_name, command='dapi', data=worker_id + ' ' + input_json)
             return response.split(' ',1)
 
+        elif command == 'transfertest':
+            first_worker_node = self.server.manager.get_connected_workers().keys()[0]
+            request_id, bytes_to_send = data.split(' ',1)
+            response = self.server.manager.send_string(worker_name=first_worker_node,
+                                                       string_to_send='a'*int(bytes_to_send), reason='transfertest',
+                                                       extra_data=request_id)
+            return response.split(' ',1)
+
         else:
             return InternalSocketHandler.process_request(self,command,data)

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -17,7 +17,7 @@ from wazuh.cluster.cluster import get_cluster_items, _update_file, compress_file
     decompress_files, get_files_status, get_cluster_items_worker_intervals, unmerge_agent_info, merge_agent_info
 from wazuh import common
 from wazuh.utils import mkdir_with_mode
-from wazuh.cluster.communication import WorkerHandler, ClusterThread, FragmentedFileReceiver, FragmentedStringReceiverWorker
+from wazuh.cluster.communication import WorkerHandler, ClusterThread, FragmentedFileReceiver, FragmentedStringReceiverWorker, TransferTester
 from wazuh.cluster.internal_socket import InternalSocketHandler
 from wazuh.cluster.dapi import dapi
 
@@ -69,6 +69,10 @@ class WorkerManagerHandler(WorkerHandler):
             return 'json', json.dumps(files)
         elif command == 'string':
             string_sender_thread = FragmentedStringReceiverWorker(manager_handler=self, stopper=self.stopper)
+            string_sender_thread.start()
+            return 'ack', self.set_worker_thread(command, string_sender_thread)
+        elif command == 'transfertest':
+            string_sender_thread = TransferTester(manager_handler=self, stopper=self.stopper, request_id=data)
             string_sender_thread.start()
             return 'ack', self.set_worker_thread(command, string_sender_thread)
         elif command == 'dapi':


### PR DESCRIPTION
Hello team,

Built on top of #885, this PR adds a script to test cluster's data transfer speed:

```shellsession
# python test_cluster_transfer.py  -n 1000000
INFO:wazuh.cluster.communication:[InternalSocket-Worker] [700788307] Connected.
INFO:wazuh.cluster.communication:[APIResponseReceiver]: Start.
INFO:wazuh.cluster.communication:[APIResponseReceiver]: Reception completed: Time: 0.20s.
INFO:wazuh.cluster.communication:[APIResponseReceiver]: Result: Successfully.
INFO:wazuh.cluster.communication:[InternalSocket-Worker] [700788307] Disconnected.
{u'total_time': 0.9115231037139893, u'n_updates': 2, u'total_data': 1000000}
```

Best regards,
Marta