### PR TITLE
Fixed SELinux socket creation on CentOS and Fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ src/analysisd/compiled_rules/compiled_rules.h
 etc/ossec.mc
 src/Config.OS
 src/external/zlib/ztest*
+src/selinux/*.mod
+src/selinux/*.pp
 
 # Compiled programs
 src/agent-auth

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,8 @@
 # TODO: mysql and postgresql?
 
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+HAS_CHECKMODULE = $(shell which checkmodule)
+HAS_SEMODULE_PACKAGE = $(shell which semodule_package)
 
 EXTERNAL_JSON=external/cJSON/
 EXTERNAL_LUA=external/lua-5.2.3/
@@ -23,12 +25,25 @@ OSSEC_GROUP?=ossec
 OSSEC_USER?=ossec
 OSSEC_USER_MAIL?=ossecm
 OSSEC_USER_REM?=ossecr
+SELINUX_MODULE=selinux/wazuh.mod
+SELINUX_ENFORCEMENT=selinux/wazuh.te
+SELINUX_POLICY=selinux/wazuh.pp
 
 USE_PRELUDE?=no
 USE_ZEROMQ?=no
 USE_GEOIP?=no
 USE_INOTIFY=no
 USE_BIG_ENDIAN=no
+
+ifneq ($(HAS_CHECKMODULE),)
+ifneq ($(HAS_SEMODULE_PACKAGE),)
+USE_SELINUX=yes
+else
+USE_SELINUX=no
+endif
+else
+USE_SELINUX=no
+endif
 
 ONEWAY?=no
 CLEANFULL?=no
@@ -412,6 +427,7 @@ settings:
 	@echo "    USE_PRELUDE:      ${USE_PRELUDE}"
 	@echo "    USE_INOTIFY:      ${USE_INOTIFY}"
 	@echo "    USE_BIG_ENDIAN:   ${USE_BIG_ENDIAN}"
+	@echo "    USE_SELINUX:      ${USE_SELINUX}"
 	@echo "Mysql settings:"
 	@echo "    includes:         ${MI}"
 	@echo "    libs:             ${ML}"
@@ -425,7 +441,6 @@ settings:
 	@echo "    LDFLAGS         ${OSSEC_LDFLAGS}"
 	@echo "    CC              ${CC}"
 	@echo "    MAKE            ${MAKE}"
-
 
 BUILD_SERVER+=ossec-maild
 BUILD_SERVER+=ossec-csyslogd
@@ -457,7 +472,8 @@ BUILD_AGENT+=ossec-execd
 BUILD_AGENT+=manage_agents
 BUILD_AGENT+=wazuh-modulesd
 
-.PHONY: server local hybrid agent
+.PHONY: server local hybrid agent selinux
+
 ifeq (${MAKECMDGOALS},server)
 $(error Do not use 'server' directly, use 'TARGET=server')
 endif
@@ -481,6 +497,18 @@ $(error Do not use 'agent' directly, use 'TARGET=agent')
 endif
 agent: external
 	${MAKE} ${BUILD_AGENT}
+
+ifneq (,$(filter ${USE_SELINUX},yes y Y 1))
+server local hybrid agent: selinux
+endif
+
+selinux: $(SELINUX_POLICY)
+
+$(SELINUX_POLICY): $(SELINUX_MODULE)
+	semodule_package -o $@ -m $?
+
+$(SELINUX_MODULE): $(SELINUX_ENFORCEMENT)
+	checkmodule -M -m -o $@ $?
 
 
 WINDOWS_BINS:=win32/ossec-agent.exe win32/ossec-agent-eventchannel.exe win32/ossec-rootcheck.exe win32/manage_agents.exe win32/setup-windows.exe win32/setup-syscheck.exe win32/setup-iis.exe win32/add-localfile.exe win32/os_win32ui.exe win32/agent-auth.exe
@@ -1346,6 +1374,8 @@ clean-internals:
 	rm -f ${integrator_o} ossec-integratord
 	rm -f ${wmodulesd_o} ${wmodules_o} wazuh-modulesd wmodules.a
 	rm -f ${wdb_o} wazuh-db
+	rm -f ${SELINUX_MODULE}
+	rm -f ${SELINUX_POLICY}
 
 clean-framework:
 	${MAKE} -C ../framework clean

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -731,6 +731,7 @@ InstallCommon(){
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/backup
 
   ./init/fw-check.sh execute
+  InstallSELinuxPolicyPackage
 }
 
 InstallLocal(){

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -11,14 +11,18 @@ WazuhSetup(){
 
 InstallSELinuxPolicyPackage(){
 
-    if which semodule > /dev/null; then
+    if which semodule > /dev/null && which getenforce > /dev/null; then
         if [ -f selinux/wazuh.pp ]; then
-            if ! (semodule -l | grep wazuh > /dev/null); then
-                echo "Installing Wazuh policy for SELinux."
-                semodule -i selinux/wazuh.pp
-                semodule -e wazuh
+            if [ $(getenforce) != "Disabled" ]; then
+                if ! (semodule -l | grep wazuh > /dev/null); then
+                    echo "Installing Wazuh policy for SELinux."
+                    semodule -i selinux/wazuh.pp
+                    semodule -e wazuh
+                else
+                    echo "Skipping installation of Wazuh policy for SELinux: module already installed."
+                fi
             else
-                echo "Skipping installation of Wazuh policy for SELinux: module already installed."
+                echo "Skipping installation of Wazuh policy: SELinux is disabled."
             fi
         else
             echo "WARN: Could not install Wazuh policy for SELinux: the module was not compiled."

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -13,7 +13,7 @@ InstallSELinuxPolicyPackage(){
 
     if which semodule > /dev/null; then
         if [ -f selinux/wazuh.pp ]; then
-            if [[ ! $(semodule -l | grep wazuh) ]]; then
+            if ! (semodule -l | grep wazuh > /dev/null); then
                 echo "Installing Wazuh policy for SELinux."
                 semodule -i selinux/wazuh.pp
                 semodule -e wazuh

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -9,6 +9,23 @@ WazuhSetup(){
     patch_version
 }
 
+InstallSELinuxPolicyPackage(){
+
+    if which semodule > /dev/null; then
+        if [ -f selinux/wazuh.pp ]; then
+            if [[ ! $(semodule -l | grep wazuh) ]]; then
+                echo "Installing Wazuh policy for SELinux."
+                semodule -i selinux/wazuh.pp
+                semodule -e wazuh
+            else
+                echo "Skipping installation of Wazuh policy for SELinux: module already installed."
+            fi
+        else
+            echo "WARN: Could not install Wazuh policy for SELinux: the module was not compiled."
+        fi
+    fi
+}
+
 WazuhUpgrade()
 {
     # Encode Agentd passlist if not encoded

--- a/src/selinux/wazuh.te
+++ b/src/selinux/wazuh.te
@@ -1,0 +1,22 @@
+module wazuh 1.0;
+
+require {
+	type audisp_t;
+        type var_t;
+        class sock_file { create setattr };
+        class dir { remove_name add_name read write };
+        class file { getattr open read };
+        class capability dac_override;
+}
+
+#============= audisp_t ==============
+allow audisp_t self: capability dac_override;
+
+#!!!! This avc is allowed in the current policy
+allow audisp_t var_t:dir { remove_name add_name read write };
+allow audisp_t var_t:file getattr;
+
+allow audisp_t var_t:sock_file { create setattr };
+#!!!! This avc is allowed in the current policy
+allow audisp_t var_t:file { open read };
+


### PR DESCRIPTION
This PR allows the auditd daemon creating the socket needed on CentOS and Fedora.