### PR TITLE
Full re-work of AWS wodle as per wazuh/wazuh#510

### DIFF
--- a/extensions/logstash/01-wazuh-local.conf
+++ b/extensions/logstash/01-wazuh-local.conf
@@ -13,9 +13,27 @@ filter {
             add_field => [ "@src_ip", "%{[data][srcip]}" ]
         }
     }
-    if [data][aws][sourceIPAddress] {
+    # if AWS, add IP for Geo-Tagging
+    if [data][aws][cloudtrail][event][sourceIPAddress] {
         mutate {
-            add_field => [ "@src_ip", "%{[data][aws][sourceIPAddress]}" ]
+            add_field => [ "@src_ip", "%{[data][aws][cloudtrail][event][sourceIPAddress]}" ]
+        }
+    }
+    # if AWS event with timestamp, use that for ES @timestamp instead of ossec timestamp
+    if [data][aws][cloudtrail][event][eventTime] {
+        # Copy timestamp to ossec.timestamp
+        mutate {
+            copy => { "timestamp" => "[data][aws][cloudtrail][ossec_timestamp]" }
+        }
+        # If AWS timestamp in correct format, overwrite ossec timestamp
+        date {
+            match => ["[data][aws][cloudtrail][event][eventTime]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ss'Z'"]
+            target => "@timestamp"
+        }
+    } else {
+        date {
+            match => ["timestamp", "ISO8601"]
+            target => "@timestamp"
         }
     }
 }
@@ -24,10 +42,6 @@ filter {
         source => "@src_ip"
         target => "GeoLocation"
         fields => ["city_name", "country_name", "region_name", "location"]
-    }
-    date {
-        match => ["timestamp", "ISO8601"]
-        target => "@timestamp"
     }
     mutate {
         remove_field => [ "timestamp", "beat", "input_type", "tags", "count", "@version", "log", "offset", "type","@src_ip"]

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -18,13 +18,29 @@ static const char *XML_ACCESS_KEY = "access_key";
 static const char *XML_SECRET_KEY = "secret_key";
 static const char *XML_RUN_ON_START = "run_on_start";
 static const char *XML_REMOVE_FORM_BUCKET = "remove_from_bucket";
+static const char *XML_SKIP_ON_ERROR = "skip_on_error";
+static const char *XML_AWS_CLOUDTRAIL = "cloudtrail";
+static const char *XML_AWS_PROFILE = "aws_profile";
+static const char *XML_IAM_ROLE_ARN = "iam_role_arn";
+static const char *XML_AWS_ACCOUNT_ID = "aws_account_id";
+static const char *XML_AWS_ACCOUNT_ALIAS = "aws_account_alias";
+static const char *XML_TRAIL_PREFIX = "trail_prefix";
+static const char *XML_ONLY_LOGS_AFTER = "only_logs_after";
+static const char *XML_REGION = "regions";
+
+static const char *LEGACY_AWS_ACCOUNT_ID = "";
+static const char *LEGACY_AWS_ACCOUNT_ALIAS = "LEGACY";
 
 // Parse XML
 
-int wm_aws_read(xml_node **nodes, wmodule *module, int agent_cfg)
+int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
 {
-    int i;
-    wm_aws_t * config;
+    int i = 0;
+    int j = 0;
+    xml_node **children = NULL;
+    wm_aws *aws_config;
+    os_calloc(1, sizeof(wm_aws), aws_config);
+    wm_aws_cloudtrail *cur_cloudtrail = NULL;
 
     if (!nodes) {
         mwarn("Tag <%s> not found at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);
@@ -33,14 +49,13 @@ int wm_aws_read(xml_node **nodes, wmodule *module, int agent_cfg)
 
     // Create module
 
-    os_calloc(1, sizeof(wm_aws_t), config);
-    config->enabled = 1;
-    config->run_on_start = 1;
-    config->remove_from_bucket = 0;
-    config->interval = WM_AWS_DEFAULT_INTERVAL;
-    config->agent_cfg = agent_cfg;
+    os_calloc(1, sizeof(wm_aws), aws_config);
+    aws_config->enabled = 1;
+    aws_config->run_on_start = 1;
+    aws_config->remove_from_bucket = 0;
+    aws_config->interval = WM_AWS_DEFAULT_INTERVAL;
     module->context = &WM_AWS_CONTEXT;
-    module->data = config;
+    module->data = aws_config;
 
     // Iterate over module subelements
 
@@ -50,31 +65,31 @@ int wm_aws_read(xml_node **nodes, wmodule *module, int agent_cfg)
             return OS_INVALID;
         } else if (!strcmp(nodes[i]->element, XML_DISABLED)) {
             if (!strcmp(nodes[i]->content, "yes"))
-                config->enabled = 0;
+                aws_config->enabled = 0;
             else if (!strcmp(nodes[i]->content, "no"))
-                config->enabled = 1;
+                aws_config->enabled = 1;
             else {
                 merror("Invalid content for tag '%s' at module '%s'.", XML_DISABLED, WM_AWS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_INTERVAL)) {
             char *endptr;
-            config->interval = strtoul(nodes[i]->content, &endptr, 0);
+            aws_config->interval = strtoul(nodes[i]->content, &endptr, 0);
 
-            if ((config->interval == 0 && endptr == nodes[i]->content) || config->interval == ULONG_MAX) {
+            if ((aws_config->interval == 0 && endptr == nodes[i]->content) || aws_config->interval == ULONG_MAX) {
                 merror("Invalid interval at module '%s'", WM_AWS_CONTEXT.name);
                 return OS_INVALID;
             }
 
             switch (*endptr) {
             case 'd':
-                config->interval *= 86400;
+                aws_config->interval *= 86400;
                 break;
             case 'h':
-                config->interval *= 3600;
+                aws_config->interval *= 3600;
                 break;
             case 'm':
-                config->interval *= 60;
+                aws_config->interval *= 60;
                 break;
             case 's':
             case '\0':
@@ -85,31 +100,49 @@ int wm_aws_read(xml_node **nodes, wmodule *module, int agent_cfg)
             }
         } else if (!strcmp(nodes[i]->element, XML_RUN_ON_START)) {
             if (!strcmp(nodes[i]->content, "yes"))
-                config->run_on_start = 1;
+                aws_config->run_on_start = 1;
             else if (!strcmp(nodes[i]->content, "no"))
-                config->run_on_start = 0;
+                aws_config->run_on_start = 0;
             else {
                 merror("Invalid content for tag '%s' at module '%s'.", XML_RUN_ON_START, WM_AWS_CONTEXT.name);
                 return OS_INVALID;
             }
+        } else if (!strcmp(nodes[i]->element, XML_SKIP_ON_ERROR)) {
+            if (!strcmp(nodes[i]->content, "yes"))
+                aws_config->skip_on_error = 1;
+            else if (!strcmp(nodes[i]->content, "no"))
+                aws_config->skip_on_error = 0;
+            else {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_SKIP_ON_ERROR, WM_AWS_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_SKIP_ON_ERROR)) {
+            if (!strcmp(nodes[i]->content, "yes"))
+                aws_config->skip_on_error = 1;
+            else if (!strcmp(nodes[i]->content, "no"))
+                aws_config->skip_on_error = 0;
+            else {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_SKIP_ON_ERROR, WM_AWS_CONTEXT.name);
+                return OS_INVALID;
+            }
         } else if (!strcmp(nodes[i]->element, XML_REMOVE_FORM_BUCKET)) {
             if (!strcmp(nodes[i]->content, "yes"))
-                config->remove_from_bucket = 1;
+                aws_config->remove_from_bucket = 1;
             else if (!strcmp(nodes[i]->content, "no"))
-                config->remove_from_bucket = 0;
+                aws_config->remove_from_bucket = 0;
             else {
                 merror("Invalid content for tag '%s' at module '%s'.", XML_REMOVE_FORM_BUCKET, WM_AWS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_ACCESS_KEY)) {
             if (strlen(nodes[i]->content) != 0) {
-                free(config->access_key);
-                os_strdup(nodes[i]->content, config->access_key);
+                free(aws_config->access_key);
+                os_strdup(nodes[i]->content, aws_config->access_key);
             }
         } else if (!strcmp(nodes[i]->element, XML_SECRET_KEY)) {
             if (strlen(nodes[i]->content) != 0) {
-                free(config->secret_key);
-                os_strdup(nodes[i]->content, config->secret_key);
+                free(aws_config->secret_key);
+                os_strdup(nodes[i]->content, aws_config->secret_key);
             }
         } else if (!strcmp(nodes[i]->element, XML_BUCKET)) {
             if (strlen(nodes[i]->content) == 0) {
@@ -117,16 +150,163 @@ int wm_aws_read(xml_node **nodes, wmodule *module, int agent_cfg)
                 return OS_INVALID;
             }
 
-            free(config->bucket);
-            os_strdup(nodes[i]->content, config->bucket);
+            free(aws_config->bucket);
+            os_strdup(nodes[i]->content, aws_config->bucket);
+        } else if (!strcmp(nodes[i]->element, XML_AWS_CLOUDTRAIL)) {
+            mtdebug2(WM_AWS_LOGTAG, "Found a cloudtrail tag");
+
+            // Create cloudtrail node
+            if (cur_cloudtrail) {
+                os_calloc(1, sizeof(wm_aws_cloudtrail), cur_cloudtrail->next);
+                cur_cloudtrail = cur_cloudtrail->next;
+                mtdebug2(WM_AWS_LOGTAG, "Creating another cloudtrail structure");
+            } else {
+                // First cloudtrail
+                os_calloc(1, sizeof(wm_aws_cloudtrail), cur_cloudtrail);
+                aws_config->cloudtrails = cur_cloudtrail;
+                mtdebug2(WM_AWS_LOGTAG, "Creating first cloudtrail structure");
+            }
+
+            // Expand CloudTrail Child Nodes
+
+            if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
+                continue;
+            }
+
+            mtdebug2(WM_AWS_LOGTAG, "Loop thru child nodes");
+            for (j = 0; children[j]; j++) {
+
+                mtdebug2(WM_AWS_LOGTAG, "Parse child node: %s", children[j]->element);
+
+                if (!children[j]->element) {
+                    merror(XML_ELEMNULL);
+                    OS_ClearNode(children);
+                    return OS_INVALID;
+                }
+
+                // Start
+                if (!strcmp(children[j]->element, XML_BUCKET)) {
+                    if (strlen(children[j]->content) == 0) {
+                        merror("Empty content for tag '%s' at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);
+                        return OS_INVALID;
+                    }
+                    free(cur_cloudtrail->bucket);
+                    os_strdup(children[j]->content, cur_cloudtrail->bucket);
+                } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ID)) {
+                    if (strlen(children[j]->content) == 0) {
+                        merror("Empty content for tag '%s' at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);
+                        return OS_INVALID;
+                    }
+                    free(cur_cloudtrail->aws_account_id);
+                    os_strdup(children[j]->content, cur_cloudtrail->aws_account_id);
+                } else if (!strcmp(children[j]->element, XML_REMOVE_FORM_BUCKET)) {
+                    if (strcmp(children[j]->content, "yes")) {
+                        cur_cloudtrail->remove_from_bucket = 1;
+                    } else if (strcmp(children[j]->content, "no")) {
+                        cur_cloudtrail->remove_from_bucket = 0;
+                    } else {
+                        merror("Invalid content for tag '%s' at module '%s'.", XML_REMOVE_FORM_BUCKET, WM_AWS_CONTEXT.name);
+                        return OS_INVALID;
+                    }
+                } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_cloudtrail->access_key);
+                        os_strdup(children[j]->content, cur_cloudtrail->access_key);
+                    }
+                } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ALIAS)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_cloudtrail->aws_account_alias);
+                        os_strdup(children[j]->content, cur_cloudtrail->aws_account_alias);
+                    }
+                } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_cloudtrail->secret_key);
+                        os_strdup(children[j]->content, cur_cloudtrail->secret_key);
+                    }
+                } else if (!strcmp(children[j]->element, XML_AWS_PROFILE)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_cloudtrail->aws_profile);
+                        os_strdup(children[j]->content, cur_cloudtrail->aws_profile);
+                    }
+                } else if (!strcmp(children[j]->element, XML_IAM_ROLE_ARN)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_cloudtrail->iam_role_arn);
+                        os_strdup(children[j]->content, cur_cloudtrail->iam_role_arn);
+                    }
+                } else if (!strcmp(children[j]->element, XML_TRAIL_PREFIX)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_cloudtrail->trail_prefix);
+                        os_strdup(children[j]->content, cur_cloudtrail->trail_prefix);
+                    }
+                } else if (!strcmp(children[j]->element, XML_ONLY_LOGS_AFTER)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_cloudtrail->only_logs_after);
+                        os_strdup(children[j]->content, cur_cloudtrail->only_logs_after);
+                    }
+                } else if (!strcmp(children[j]->element, XML_REGION)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_cloudtrail->regions);
+                        os_strdup(children[j]->content, cur_cloudtrail->regions);
+                    }
+                } else {
+                    merror("No such child tag '%s' of cloudtrail at module '%s'.", children[j]->element, WM_AWS_CONTEXT.name);
+                    OS_ClearNode(children);
+                    return OS_INVALID;
+                }
+            }
+
+            OS_ClearNode(children);
+
         } else {
             merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_AWS_CONTEXT.name);
             return OS_INVALID;
         }
     }
 
-    if (!config->bucket) {
-        mwarn("Tag <%s> not found at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);
+    // Support legacy config
+    if (aws_config->bucket) {
+        mtwarn(WM_AWS_LOGTAG, "Deprecated CloudTrail config defined; please use current config definition at module '%s'.", WM_AWS_CONTEXT.name);
+
+        // Create cloudtrail node
+        if (cur_cloudtrail) {
+            os_calloc(1, sizeof(wm_aws_cloudtrail), cur_cloudtrail->next);
+            cur_cloudtrail = cur_cloudtrail->next;
+        } else {
+            // First cloudtrail
+            os_calloc(1, sizeof(wm_aws_cloudtrail), cur_cloudtrail);
+            aws_config->cloudtrails = cur_cloudtrail;
+        }
+
+        if (aws_config->bucket) {
+            if (strlen(aws_config->bucket) != 0) {
+                free(cur_cloudtrail->bucket);
+                os_strdup(aws_config->bucket, cur_cloudtrail->bucket);
+            }
+        }
+        if (aws_config->secret_key) {
+            if (strlen(aws_config->secret_key) != 0) {
+                free(cur_cloudtrail->secret_key);
+                os_strdup(aws_config->secret_key, cur_cloudtrail->secret_key);
+            }
+        }
+        if (aws_config->access_key) {
+            if (strlen(aws_config->access_key) != 0) {
+                free(cur_cloudtrail->access_key);
+                os_strdup(aws_config->access_key, cur_cloudtrail->access_key);
+            }
+        } else if (aws_config->remove_from_bucket) {
+            cur_cloudtrail->remove_from_bucket = aws_config->remove_from_bucket;
+        }
+
+        // Hard code LEGACY references
+        free(cur_cloudtrail->aws_account_id);
+        os_strdup(LEGACY_AWS_ACCOUNT_ID, cur_cloudtrail->aws_account_id);
+        free(cur_cloudtrail->aws_account_alias);
+        os_strdup(LEGACY_AWS_ACCOUNT_ALIAS, cur_cloudtrail->aws_account_alias);
+    }
+
+    if (!aws_config->cloudtrails) {
+        mtwarn("No CloudTrails definitions found at module '%s'.", WM_AWS_CONTEXT.name);
         return OS_INVALID;
     }
 

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -116,15 +116,6 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 merror("Invalid content for tag '%s' at module '%s'.", XML_SKIP_ON_ERROR, WM_AWS_CONTEXT.name);
                 return OS_INVALID;
             }
-        } else if (!strcmp(nodes[i]->element, XML_SKIP_ON_ERROR)) {
-            if (!strcmp(nodes[i]->content, "yes"))
-                aws_config->skip_on_error = 1;
-            else if (!strcmp(nodes[i]->content, "no"))
-                aws_config->skip_on_error = 0;
-            else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_SKIP_ON_ERROR, WM_AWS_CONTEXT.name);
-                return OS_INVALID;
-            }
         } else if (!strcmp(nodes[i]->element, XML_REMOVE_FORM_BUCKET)) {
             if (!strcmp(nodes[i]->content, "yes"))
                 aws_config->remove_from_bucket = 1;

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -54,7 +54,15 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 
     // Select module by name
 
-    if (!strcmp(node->values[0], WM_OSCAP_CONTEXT.name)) {
+    //osQuery monitor module
+    if (!strcmp(node->values[0], WM_OSQUERYMONITOR_CONTEXT.name)) {
+        if (wm_osquery_monitor_read(children, cur_wmodule) < 0) {
+            OS_ClearNode(children);
+            return OS_INVALID;
+        }
+    }
+
+    else if (!strcmp(node->values[0], WM_OSCAP_CONTEXT.name)) {
         if (wm_oscap_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
@@ -91,7 +99,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     }
 #ifndef CLIENT
     else if (!strcmp(node->values[0], WM_VULNDETECTOR_CONTEXT.name)) {
-        if (wm_vulnerability_detector_read(children, cur_wmodule) < 0) {
+        if (wm_vulnerability_detector_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -54,15 +54,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 
     // Select module by name
 
-   //osQuery monitor module
-    if (!strcmp(node->values[0], WM_OSQUERYMONITOR_CONTEXT.name)) {
-        if (wm_osquery_monitor_read(children, cur_wmodule) < 0) {
-            OS_ClearNode(children);
-            return OS_INVALID;
-        }
-    }
-
-    else if (!strcmp(node->values[0], WM_OSCAP_CONTEXT.name)) {
+    if (!strcmp(node->values[0], WM_OSCAP_CONTEXT.name)) {
         if (wm_oscap_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
@@ -92,14 +84,14 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 #endif
 #ifndef WIN32
     else if (!strcmp(node->values[0], WM_AWS_CONTEXT.name)) {
-        if (wm_aws_read(children, cur_wmodule, agent_cfg) < 0) {
+        if (wm_aws_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }
     }
 #ifndef CLIENT
     else if (!strcmp(node->values[0], WM_VULNDETECTOR_CONTEXT.name)) {
-        if (wm_vulnerability_detector_read(xml, children, cur_wmodule) < 0) {
+        if (wm_vulnerability_detector_read(children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -3,6 +3,8 @@
  * Copyright (C) 2017 Wazuh Inc.
  * January 08, 2018.
  *
+ * Updated by Jeremy Phillips <jeremy@uranusbytes.com>
+ *
  * This program is a free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
@@ -11,8 +13,15 @@
 
 #include "wmodules.h"
 
-static void * wm_aws_main(wm_aws_t * config);    // Module main function. It won't return
-static void wm_aws_destroy(wm_aws_t * config);   // Destroy data
+static wm_aws *aws_config;                              // Pointer to aws_configuration
+static int queue_fd;                                    // Output queue file descriptor
+
+static void* wm_aws_main(wm_aws *aws_config);           // Module main function. It won't return
+static void wm_aws_setup(wm_aws *_aws_config);          // Setup module
+static void wm_aws_cleanup();                           // Cleanup function, doesn't overwrite wm_cleanup
+static void wm_aws_check();                             // Check configuration, disable flag
+static void wm_aws_run_cloudtrail(wm_aws_cloudtrail *exec_cloudtrail);   // Run a CloudTrail
+static void wm_aws_destroy(wm_aws *aws_config);         // Destroy data
 
 // Command module context definition
 
@@ -24,116 +33,59 @@ const wm_context WM_AWS_CONTEXT = {
 
 // Module module main function. It won't return.
 
-void * wm_aws_main(wm_aws_t * config) {
+void* wm_aws_main(wm_aws *aws_config) {
+    wm_aws_cloudtrail *cur_cloudtrail;
     time_t time_start;
     time_t time_sleep = 0;
 
-    // Define time to sleep between messages sent
-    int usec = 1000000 / wm_max_eps;
-
-    if (!config->enabled) {
-        mtwarn(WM_AWS_LOGTAG, "Module AWS-CloudTrail is disabled. Exiting.");
-        pthread_exit(0);
-    }
-
-    mtinfo(WM_AWS_LOGTAG, "Module AWS-CloudTrail started");
-
-    // Connect to socket
-
-    int i;
-
-    for (i = 0; config->queue_fd = StartMQ(DEFAULTQPATH, WRITE), config->queue_fd < 0 && i < WM_MAX_ATTEMPTS; i++) {
-        sleep(WM_MAX_WAIT);
-    }
-
-    if (i == WM_MAX_ATTEMPTS) {
-        mterror(WM_AWS_LOGTAG, "Can't connect to queue.");
-        pthread_exit(NULL);
-    }
+    wm_aws_setup(aws_config);
+    mtinfo(WM_AWS_LOGTAG, "Module AWS started");
 
     // First sleeping
 
-    if (!config->run_on_start) {
+    if (!aws_config->run_on_start) {
         time_start = time(NULL);
 
-        if (config->state.next_time > time_start) {
+        if (aws_config->state.next_time > time_start) {
             mtinfo(WM_AWS_LOGTAG, "Waiting interval to start fetching.");
-            sleep(config->state.next_time - time_start);
+            sleep(aws_config->state.next_time - time_start);
         }
     }
 
+    // Main loop
+
     while (1) {
-        int status;
-        char * output = NULL;
-        char *command = NULL;
 
-        // Create arguments
-
-        wm_strcat(&command, WM_AWS_SCRIPT_PATH, '\0');
-        wm_strcat(&command, "--bucket", ' ');
-        wm_strcat(&command, config->bucket, ' ');
-
-        if (config->remove_from_bucket) {
-            wm_strcat(&command, "--remove", ' ');
-        }
-        if (config->access_key) {
-            wm_strcat(&command, "--access_key", ' ');
-            wm_strcat(&command, config->access_key, ' ');
-        }
-        if (config->secret_key) {
-            wm_strcat(&command, "--secret_key", ' ');
-            wm_strcat(&command, config->secret_key, ' ');
-        }
-        if (wm_state_io(WM_AWS_CONTEXT.name, WM_IO_READ, &config->state, sizeof(config->state)) < 0) {
-            memset(&config->state, 0, sizeof(config->state));
-        }
-
-        mtinfo(WM_AWS_LOGTAG, "Fetching logs started");
+        mtinfo(WM_AWS_LOGTAG, "Starting fetching of logs.");
 
         // Get time and execute
         time_start = time(NULL);
 
-        switch (wm_exec(command, &output, &status, 0)) {
-        case 0:
-            if (status > 0) {
-                mtwarn(WM_AWS_LOGTAG, "Returned exit code %d.", status);
-                if(status == 3)
-                    mtwarn(WM_AWS_LOGTAG, "Invalid credentials to access S3 Bucket");
-                if(status == 4)
-                    mtwarn(WM_AWS_LOGTAG, "boto3 module is required.");
-                mtdebug2(WM_AWS_LOGTAG, "OUTPUT: %s", output);
+        for (cur_cloudtrail = aws_config->cloudtrails; cur_cloudtrail; cur_cloudtrail = cur_cloudtrail->next) {
+            if (cur_cloudtrail->aws_account_id && cur_cloudtrail->aws_account_alias) {
+                mtdebug1(WM_AWS_LOGTAG, "Executing CloudTrail: %s (%s)", cur_cloudtrail->aws_account_alias, cur_cloudtrail->aws_account_id);
+            } else if (cur_cloudtrail->aws_account_id) {
+                mtdebug1(WM_AWS_LOGTAG, "Executing CloudTrail: %s", cur_cloudtrail->aws_account_id);
+            } else {
+                mtdebug1(WM_AWS_LOGTAG, "Executing CloudTrail: LEGACY - %s", cur_cloudtrail->bucket);
             }
-
-            break;
-
-        default:
-            mterror(WM_AWS_LOGTAG, "Internal calling. Exiting...");
-            pthread_exit(NULL);
+            wm_aws_run_cloudtrail(cur_cloudtrail);
         }
-
-        char * line;
-
-        for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
-            wm_sendmsg(usec, config->queue_fd, line, WM_AWS_CONTEXT.name, LOCALFILE_MQ);
-        }
-
-        free(output);
-        free(command);
 
         mtinfo(WM_AWS_LOGTAG, "Fetching logs finished.");
 
-        if (config->interval) {
+        if (aws_config->interval) {
             time_sleep = time(NULL) - time_start;
 
-            if ((time_t)config->interval >= time_sleep) {
-                time_sleep = config->interval - time_sleep;
-                config->state.next_time = config->interval + time_start;
+            if ((time_t)aws_config->interval >= time_sleep) {
+                time_sleep = aws_config->interval - time_sleep;
+                aws_config->state.next_time = aws_config->interval + time_start;
             } else {
                 mtwarn(WM_AWS_LOGTAG, "Interval overtaken.");
-                time_sleep = config->state.next_time = 0;
+                time_sleep = aws_config->state.next_time = 0;
             }
 
-            if (wm_state_io(WM_AWS_CONTEXT.name, WM_IO_WRITE, &config->state, sizeof(config->state)) < 0)
+            if (wm_state_io(WM_AWS_CONTEXT.name, WM_IO_WRITE, &aws_config->state, sizeof(aws_config->state)) < 0)
                 mterror(WM_AWS_LOGTAG, "Couldn't save running state.");
         }
 
@@ -146,6 +98,200 @@ void * wm_aws_main(wm_aws_t * config) {
 
 // Destroy data
 
-void wm_aws_destroy(wm_aws_t * config) {
-    free(config);
+void wm_aws_destroy(wm_aws *aws_config) {
+    free(aws_config);
+}
+
+// Setup module
+
+void wm_aws_setup(wm_aws *_aws_config) {
+    int i;
+
+    aws_config = _aws_config;
+    wm_aws_check();
+
+    // Read running state
+
+    if (wm_state_io(WM_AWS_CONTEXT.name, WM_IO_READ, &aws_config->state, sizeof(aws_config->state)) < 0)
+        memset(&aws_config->state, 0, sizeof(aws_config->state));
+
+    // Connect to socket
+
+    for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
+        sleep(WM_MAX_WAIT);
+
+    if (i == WM_MAX_ATTEMPTS) {
+        mterror(WM_AWS_LOGTAG, "Can't connect to queue.");
+        pthread_exit(NULL);
+    }
+
+    // Cleanup exiting
+
+    atexit(wm_aws_cleanup);
+}
+
+
+// Check configuration
+
+void wm_aws_check() {
+    // Check if disabled
+
+    if (!aws_config->enabled) {
+        mtinfo(WM_AWS_LOGTAG, "Module AWS is disabled. Exiting...");
+        pthread_exit(NULL);
+    }
+
+    // Check if cloudtrails defines
+
+    if (!aws_config->cloudtrails) {
+        mtwarn(WM_AWS_LOGTAG, "No AWS CloudTrails defined. Exiting...");
+        pthread_exit(NULL);
+    }
+
+    // Check if interval defined; otherwise set default
+
+    if (!aws_config->interval)
+        aws_config->interval = WM_AWS_DEFAULT_INTERVAL;
+
+}
+
+// Cleanup function, doesn't overwrite wm_cleanup
+
+void wm_aws_cleanup() {
+    close(queue_fd);
+    mtinfo(WM_AWS_LOGTAG, "Module AWS finished.");
+}
+
+// Run a CloudTrail parsing
+
+void wm_aws_run_cloudtrail(wm_aws_cloudtrail *exec_cloudtrail) {
+    int status;
+    char *output = NULL;
+    char *command = NULL;
+
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
+    // Create arguments
+    mtdebug2(WM_AWS_LOGTAG, "Create argument list");
+
+    wm_strcat(&command, WM_AWS_SCRIPT_PATH, '\0');
+    wm_strcat(&command, "--bucket", ' ');
+    wm_strcat(&command, exec_cloudtrail->bucket, ' ');
+
+    if (exec_cloudtrail->remove_from_bucket) {
+        wm_strcat(&command, "--remove", ' ');
+    }
+    if (exec_cloudtrail->access_key) {
+        wm_strcat(&command, "--access_key", ' ');
+        wm_strcat(&command, exec_cloudtrail->access_key, ' ');
+    }
+    if (exec_cloudtrail->secret_key) {
+        wm_strcat(&command, "--secret_key", ' ');
+        wm_strcat(&command, exec_cloudtrail->secret_key, ' ');
+    }
+    if (exec_cloudtrail->aws_profile) {
+        wm_strcat(&command, "--aws_profile", ' ');
+        wm_strcat(&command, exec_cloudtrail->aws_profile, ' ');
+    }
+    if (exec_cloudtrail->iam_role_arn) {
+        wm_strcat(&command, "--iam_role_arn", ' ');
+        wm_strcat(&command, exec_cloudtrail->iam_role_arn, ' ');
+    }
+    if (exec_cloudtrail->aws_account_id) {
+        wm_strcat(&command, "--aws_account_id", ' ');
+        wm_strcat(&command, exec_cloudtrail->aws_account_id, ' ');
+    }
+    if (exec_cloudtrail->aws_account_alias) {
+        wm_strcat(&command, "--aws_account_alias", ' ');
+        wm_strcat(&command, exec_cloudtrail->aws_account_alias, ' ');
+    }
+    if (exec_cloudtrail->trail_prefix) {
+        wm_strcat(&command, "--trail_prefix", ' ');
+        wm_strcat(&command, exec_cloudtrail->trail_prefix, ' ');
+    }
+    if (exec_cloudtrail->only_logs_after) {
+        wm_strcat(&command, "--only_logs_after", ' ');
+        wm_strcat(&command, exec_cloudtrail->only_logs_after, ' ');
+    }
+    if (exec_cloudtrail->regions) {
+        wm_strcat(&command, "--regions", ' ');
+        wm_strcat(&command, exec_cloudtrail->regions, ' ');
+    }
+    if (isDebug()) {
+        wm_strcat(&command, "--debug", ' ');
+        if (isDebug() > 2) {
+            wm_strcat(&command, "3", ' ');
+        } else if (isDebug() > 1) {
+            wm_strcat(&command, "2", ' ');
+        } else {
+            wm_strcat(&command, "1", ' ');
+        }
+    }
+    if (aws_config->skip_on_error) {
+        wm_strcat(&command, "--skip_on_error", ' ');
+    }
+    if (wm_state_io(WM_AWS_CONTEXT.name, WM_IO_READ, &aws_config->state, sizeof(aws_config->state)) < 0) {
+        memset(&aws_config->state, 0, sizeof(aws_config->state));
+    }
+
+    // Execute
+
+    char *trail_title = NULL;
+    wm_strcat(&trail_title, "CloudTrail:", ' ');
+    wm_strcat(&trail_title, exec_cloudtrail->aws_account_id, ' ');
+    if(exec_cloudtrail->aws_account_alias){
+        wm_strcat(&trail_title, "(", '\0');
+        wm_strcat(&trail_title, exec_cloudtrail->aws_account_alias, '\0');
+        wm_strcat(&trail_title, ")", '\0');
+    }
+    wm_strcat(&trail_title, " - ", ' ');
+
+    mtdebug1(WM_AWS_LOGTAG, "Launching CloudTrail Command: %s", command);
+    switch (wm_exec(command, &output, &status, 0)) {
+    case 0:
+        if (status > 0) {
+            mtwarn(WM_AWS_LOGTAG, "%s Returned exit code %d", trail_title, status);
+            if(status == 1)
+                mtwarn(WM_AWS_LOGTAG, "%s Unknown error", trail_title);
+            else if(status == 2)
+                mtwarn(WM_AWS_LOGTAG, "%s SIGINT received", trail_title);
+            else if(status == 3)
+                mtwarn(WM_AWS_LOGTAG, "%s Invalid credentials to access S3 Bucket", trail_title);
+            else if(status == 4)
+                mtwarn(WM_AWS_LOGTAG, "%s boto3 module is required.", trail_title);
+            else if(status == 5)
+                mtwarn(WM_AWS_LOGTAG, "%s Unexpected error accessing SQLite DB.", trail_title);
+            else if(status == 6)
+                mtwarn(WM_AWS_LOGTAG, "%s Unable to create SQLite DB.", trail_title);
+            else if(status == 7)
+                mtwarn(WM_AWS_LOGTAG, "%s Unexpected error querying/working with objects in S3.", trail_title);
+            else if(status == 8)
+                mtwarn(WM_AWS_LOGTAG, "%s Failed to decompress file.", trail_title);
+            else if(status == 9)
+                mtwarn(WM_AWS_LOGTAG, "%s Failed to parse file.", trail_title);
+            else if(status == 10)
+                mtwarn(WM_AWS_LOGTAG, "%s Failed to execute DB cleanup.", trail_title);
+            else if(status == 11)
+                mtwarn(WM_AWS_LOGTAG, "%s Unable to connect to Wazuh", trail_title);
+            else
+                mtdebug1(WM_AWS_LOGTAG, "%s OUTPUT: %s", trail_title, output);
+        } else {
+            mtdebug2(WM_AWS_LOGTAG, "%s OUTPUT: %s", trail_title, output);
+        }
+        break;
+
+    default:
+        mterror(WM_AWS_LOGTAG, "Internal calling. Exiting...");
+        pthread_exit(NULL);
+    }
+    char * line;
+
+    for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
+        wm_sendmsg(usec, queue_fd, line, WM_AWS_CONTEXT.name, LOCALFILE_MQ);
+    }
+    free(line);
+    free(trail_title);
+    free(output);
+    free(command);
 }

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -3,6 +3,8 @@
  * Copyright (C) 2017 Wazuh Inc.
  * January 08, 2018.
  *
+ * Updated by Jeremy Phillips <jeremy@uranusbytes.com>
+ *
  * This program is a free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
@@ -21,22 +23,38 @@ typedef struct wm_aws_state_t {
     time_t next_time;               // Absolute time for next scan
 } wm_aws_state_t;
 
-typedef struct wm_aws_t {
-    char * bucket;
-    char * access_key;
-    char * secret_key;
+typedef struct wm_aws_cloudtrail {
+    char *bucket;                       // S3 bucket
+    char *access_key;                   // IAM access key
+    char *secret_key;                   // IAM secret key
+    char *aws_profile;                  // AWS credentials profile
+    char *iam_role_arn;                 // IAM role
+    char *aws_account_id;               // AWS account ID(s)
+    char *aws_account_alias;            // AWS account alias
+    char *trail_prefix;                 // Trail prefix
+    char *only_logs_after;              // Date (YYYY-MMM-DD) to only parse logs after
+    char *regions;                       // CSV of regions to parse
+    unsigned int remove_from_bucket:1;  // Remove the logs from the bucket
+    struct wm_aws_cloudtrail *next;     // Pointer to next
+} wm_aws_cloudtrail;
+
+typedef struct wm_aws {
+    char *bucket;                       // DEPRECATE
+    char *access_key;                   // DEPRECATE
+    char *secret_key;                   // DEPRECATE
     unsigned long interval;
     int queue_fd;
-    wm_aws_state_t state;
     unsigned int enabled:1;
     unsigned int run_on_start:1;
-    unsigned int remove_from_bucket:1;
-    unsigned int agent_cfg:1;
-} wm_aws_t;
+    unsigned int remove_from_bucket:1;  // DEPRECATE
+    unsigned int skip_on_error:1;
+    wm_aws_state_t state;
+    wm_aws_cloudtrail *cloudtrails;      // CloudTrails (linked list)
+} wm_aws;
 
 extern const wm_context WM_AWS_CONTEXT;   // Context
 
 // Parse XML
-int wm_aws_read(xml_node **nodes, wmodule *module, int agent_cfg);
+int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module);
 
 #endif // WM_AWS_H

--- a/wodles/aws/aws.py
+++ b/wodles/aws/aws.py
@@ -5,163 +5,542 @@
 # Author: Wazuh, Inc.
 # Copyright: GPLv3
 #
+# Full re-work of AWS wodle as per #510
+# - Scalability and functional enhancements for parsing of CloudTrail
+# - Support for existing config params
+# - Upgrade to a granular object key addressing to support multiple CloudTrails in S3 bucket
+# - Support granular parsing by account id, region, prefix
+# - Support only parsing logs after a given date
+# - Support IAM credential profiles, IAM roles
+# - Only look for new logs/objects since last iteration
+# - Skip digest files altogether (only look at logs)
+# - Move from downloading object and working with file on filesystem to byte stream
+# - Inherit debug from modulesd
+# - Add bounds checks for msg against socket buffer size; truncate fields if too big (wazuh/wazuh#733)
+# - Support multiple debug levels
+# - Move connect error so not confused with general error
+# - If fail to parse log, and skip_on_error, attempt to send me msg to wazuh
+# - Support existing configurations by migrating data, inferring other required params
 #
+# Future
+# ToDo: Integrity check logs against digest
+# ToDo: Escape special characters in arguments?  Needed?
+#     Valid values for AWS Keys
+#     Alphanumeric characters [0-9a-zA-Z]
+#     Special characters !, -, _, ., *, ', (, and )
+#
+# Error Codes:
+#   1 - Unknown
+#   2 - SIGINT
+#   3 - Invalid credentials to access S3 bucket
+#   4 - boto3 module missing
+#   5 - Unexpected error accessing SQLite DB
+#   6 - Unable to create SQLite DB
+#   7 - Unexpected error querying/working with objects in S3
+#   8 - Failed to decompress file
+#   9 - Failed to parse file
+#   10 - Failed to execute DB cleanup
+#   11 - Unable to connect to Wazuh
 
-import os
-import re
 import signal
 import sys
 import sqlite3
 import argparse
+
 from socket import socket, AF_UNIX, SOCK_DGRAM
+
 try:
     import boto3
 except ImportError:
-    print('Error: No module found boto3.')
+    print('ERROR: No module found boto3.')
     sys.exit(4)
 import botocore
-import gzip
 import json
+import zlib
+from datetime import datetime
+
+# Retain last X log processed records for each account/region; only last record is used; rest are for history/knowledge
+retain_db_records = 100
+
+# Message header
+msg_header = '1:Wazuh-AWS:'
 
 # Enable/disable debug mode
-enable_debug = False
+debug_level = 0
 # Wazuh installation path
 wazuh_path = open('/etc/ossec-init.conf').readline().split('"')[1]
 # Wazuh queue
 wazuh_queue = '{0}/queue/ossec/queue'.format(wazuh_path)
-# Wazuh tmp folder
-wazuh_tmp = '{0}/tmp'.format(wazuh_path)
 # Wazuh wodle path
 wazuh_wodle = '{0}/wodles/aws'.format(wazuh_path)
 
-def send_msg(wazuh_queue, header, msg):
-    formatted = {}
-    formatted['integration'] = 'aws'
-    formatted['aws'] = msg
-    debug(json.dumps(formatted, indent=4))
-    formatted = '{0}{1}'.format(header, json.dumps(formatted))
+
+def send_msg(wazuh_queue, queue_buffer, msg):
+    formatted = {
+        'integration': 'aws',
+        'aws': msg
+    }
+    debug(json.dumps(formatted, indent=4), 3)
+    formatted = '{0}{1}'.format(msg_header, json.dumps(formatted))
+    formatted = formatted.encode()
+    # if msg too large to send to socket
+    for shrink in ['requestParameters', 'responseElements']:
+        if len(formatted) > queue_buffer:
+            debug('++ Message truncated because too large; removing {shrink}'.format(shrink=shrink), 2)
+            msg[shrink] = 'Value truncated because too large for socket buffer'
+            formatted = {
+                'integration': 'aws',
+                'aws': msg
+            }
+            formatted = '{0}{1}'.format(msg_header, json.dumps(formatted))
+            formatted.encode()
+        else:
+            # Message not too large; skip out
+            break
+
     s = socket(AF_UNIX, SOCK_DGRAM)
     try:
         s.connect(wazuh_queue)
     except:
-        print('Error: Wazuh must be running.')
-        sys.exit(1)
-    s.send(formatted.encode())
+        print('ERROR: Wazuh must be running.')
+        sys.exit(11)
+    s.send(formatted)
     s.close()
 
-def handler(signal, frame):
-    print "SIGINT received, bye!"
-    sys.exit(1)
 
-def already_processed(downloaded_file, db_connector):
+def handler(signal, frame):
+    print "ERROR: SIGINT received, bye!"
+    sys.exit(2)
+
+
+def already_processed(downloaded_file, aws_account_id, aws_region, db_connector):
     if db_connector:
-        cursor = db_connector.execute('select count(*) from log_progress where log_name="{log_name}"'.format(log_name=downloaded_file))
-        if cursor.fetchall()[0][0]:
+        cursor = db_connector.execute(
+            """
+              SELECT
+                count(*) 
+              FROM 
+                trail_progress 
+              WHERE 
+                aws_account_id='{aws_account_id}' AND 
+                aws_region='{aws_region}' AND 
+                log_key='{log_name}'""".format(aws_account_id=aws_account_id,
+                                               aws_region=aws_region,
+                                               log_name=downloaded_file))
+        if cursor.fetchone()[0]:
             return True
     return False
 
-def mark_complete(downloaded_file, db_connector):
+
+def mark_complete(aws_account_id, aws_region, log_key, db_connector):
     if db_connector:
-        db_connector.execute("insert into log_progress (log_name, processed_date) values ('{log_name}', DATE('now'))".format(log_name=downloaded_file))
+        db_connector.execute(
+            """
+              INSERT INTO trail_progress (
+                aws_account_id, 
+                aws_region, 
+                log_key, 
+                processed_date) VALUES (
+                '{aws_account_id}', 
+                '{aws_region}', 
+                '{log_key}', 
+                DATETIME('now'))""".format(aws_account_id=aws_account_id,
+                                           aws_region=aws_region,
+                                           log_key=log_key))
+        debug('+++ Mark log complete: {log_key}'.format(log_key=log_key), 2)
         db_connector.commit()
 
-def debug(msg):
-    if enable_debug:
-        print(msg)
+
+def debug(msg, msg_level):
+    if debug_level >= msg_level:
+        print('DEBUG: {debug_msg}'.format(debug_msg=msg))
+
+
+def arg_valid_date(arg_string):
+    try:
+        parsed_date = datetime.strptime(arg_string, "%Y-%b-%d")
+        # Return int created from date in YYYYMMDD format
+        return int(parsed_date.strftime('%Y%m%d'))
+    except ValueError:
+        raise argparse.ArgumentTypeError("Argument not a valid date in format YYYY-MMM-DD: '{0}'.".format(arg_string))
+
+
+def arg_valid_prefix(arg_string):
+    if arg_string and arg_string[-1:] != '/':
+        return '{arg_string}/'.format(arg_string=arg_string)
+    return arg_string
+
+
+def arg_valid_accountid(arg_string):
+    if not arg_string:
+        return []
+    account_ids = arg_string.split(',')
+    for account in account_ids:
+        if not account.strip().isdigit() and len(account) != 12:
+            raise argparse.ArgumentTypeError(
+                "Not valid AWS account ID (numeric digits only): '{0}'.".format(arg_string))
+
+    return account_ids
+
+
+def arg_valid_regions(arg_string):
+    if not arg_string:
+        return []
+    final_regions = []
+    regions = arg_string.split(',')
+    for arg_region in regions:
+        if arg_region.strip():
+            final_regions.append(arg_region.strip())
+    return final_regions
+
+
+def get_s3_client(options):
+    conn_args = {}
+    if options.access_key is not None and options.secret_key is not None:
+        conn_args['aws_access_key_id'] = options.access_key
+        conn_args['aws_secret_access_key'] = options.secret_key
+    if options.aws_profile is not None:
+        conn_args['profile_name'] = options.aws_profile
+
+    boto_session = boto3.Session(**conn_args)
+
+    # If using a role, create session using that
+    if options.iam_role_arn:
+        sts_client = boto_session.client('sts')
+        sts_role_assumption = sts_client.assume_role(RoleArn=options.iam_role_arn,
+                                                     RoleSessionName='WazuhCloudTrailLogParsing')
+        sts_session = boto3.Session(aws_access_key_id=sts_role_assumption['Credentials']['AccessKeyId'],
+                                    aws_secret_access_key=sts_role_assumption['Credentials']['SecretAccessKey'],
+                                    aws_session_token=sts_role_assumption['Credentials']['SessionToken'])
+        s3_client = sts_session.client(service_name='s3')
+    else:
+        s3_client = boto_session.client(service_name='s3')
+    try:
+        s3_client.head_bucket(Bucket=options.logBucket)
+    except botocore.exceptions.ClientError as e:
+        print "ERROR: Bucket %s access error: %s" % (options.logBucket, e)
+        sys.exit(3)
+    return s3_client
+
+
+def marker_only_logs_after(options, aws_account_id, aws_region):
+    only_logs_after = datetime.strptime(str(options.only_logs_after), "%Y%m%d")
+    filter_marker = '{trail_prefix}AWSLogs/{aws_account_id}/CloudTrail/{aws_region}/{only_logs_after}'.format(
+        trail_prefix=options.trail_prefix,
+        aws_account_id=aws_account_id,
+        aws_region=aws_region,
+        only_logs_after=only_logs_after.strftime('%Y/%m/%d'))
+    return filter_marker
+
+
+def migrate_legacy_table(db_connector):
+    debug('++ Query legacy table records', 1)
+    query_results = db_connector.execute("""
+                                           SELECT 
+                                             log_name,
+                                             processed_date 
+                                           FROM 
+                                             log_progress;""")
+    for row in query_results:
+        if row[0] != '':
+            try:
+                debug('++ Parse arguments from log file name', 2)
+                filename_parts = row[0].split('_')
+                aws_account_id = filename_parts[0]
+                aws_region = filename_parts[2]
+                log_timestamp = datetime.strptime(filename_parts[3].split('.')[0], '%Y%m%dT%H%M%SZ')
+                log_key = 'AWSLogs/{aws_account_id}/CloudTrail/{aws_region}/{date_path}/{log_filename}'.format(
+                    aws_account_id=aws_account_id,
+                    aws_region=aws_region,
+                    date_path=datetime.strftime(log_timestamp,'%Y/%m/%d'),
+                    log_filename=row[0]
+                )
+                mark_complete(aws_account_id, aws_region, log_key, db_connector)
+            except:
+                debug('++ Error parsing log file name: {}'.format(row[0]), 1)
+
+    # Rename legacy table
+    debug('+++ Rename legacy table', 1)
+    db_connector.execute(
+        """
+          ALTER TABLE trail_progress
+            RENAME TO legacy_trail_progress;""")
+    db_connector.commit()
+
+    debug('+++ Finished legacy table migration', 1)
+    return
+
 
 def main(argv):
-    # Message header
-    header = '1:Wazuh-AWS:'
-
     # Parse arguments
-    parser = argparse.ArgumentParser(usage="usage: %prog [options]", version="%prog 1.0")
-    parser.add_argument('-b', '--bucket', dest='logBucket', help='Specify the S3 bucket containing AWS logs')
-    parser.add_argument('-d', '--debug', action='store_true', dest='debug', help='Increase verbosity')
-    parser.add_argument('-a', '--access_key', dest='access_key', help='S3 Access key credential')
-    parser.add_argument('-k', '--secret_key', dest='secret_key', help='S3 Secrety key credential')
-    #Beware, once you delete history it's gone.
-    parser.add_argument('-R', '--remove', action='store_true', dest='deleteFile', help='Remove processed files from the AWS S3 bucket')
+    parser = argparse.ArgumentParser(usage="usage: %(prog)s [options]",
+                                     version="%(prog)s 1.1",
+                                     description="Wazuh wodle for monitoring of AWS CloudTrail logs in S3 bucket",
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('-b', '--bucket', dest='logBucket', help='Specify the S3 bucket containing AWS CloudTrail logs',
+                        action='store', required=True)
+    parser.add_argument('-c', '--aws_account_id', dest='aws_account_id',
+                        help='AWS Account ID for CloudTrail logs', required=True,
+                        type=arg_valid_accountid)
+    parser.add_argument('-d', '--debug', action='store', dest='debug', default=0, help='Enable debu')
+    parser.add_argument('-a', '--access_key', dest='access_key', help='S3 Access key credential', default=None)
+    parser.add_argument('-k', '--secret_key', dest='secret_key', help='S3 Secrety key credential', default=None)
+    # Beware, once you delete history it's gone.
+    parser.add_argument('-R', '--remove', action='store_true', dest='deleteFile',
+                        help='Remove processed files from the AWS S3 bucket', default=False)
+    parser.add_argument('-p', '--aws_profile', dest='aws_profile', help='The name of credneitla profile to use',
+                        default=None)
+    parser.add_argument('-i', '--iam_role_arn', dest='iam_role_arn',
+                        help='ARN of IAM role to assume for access to S3 bucket',
+                        default=None)
+    parser.add_argument('-n', '--aws_account_alias', dest='aws_account_alias',
+                        help='AWS Account ID Alias', default='')
+    parser.add_argument('-l', '--trail_prefix', dest='trail_prefix',
+                        help='Log prefix for S3 key',
+                        default='', type=arg_valid_prefix)
+    parser.add_argument('-s', '--only_logs_after', dest='only_logs_after',
+                        help='Only parse logs after this date - format YYYY-MMM-DD', default='1970-JAN-01',
+                        type=arg_valid_date)
+    parser.add_argument('-r', '--regions', dest='regions', help='Comma delimited list of AWS regions to parse logs',
+                        default='', type=arg_valid_regions)
+    parser.add_argument('-e', '--skip_on_error', action='store_true', dest='skip_on_error',
+                        help='If fail to parse a file, error out instead of skipping the file', default=True)
     options = parser.parse_args()
+
     db_connector = None
 
-    if options.debug:
-        global enable_debug
-        enable_debug = True
-        debug('+++ Debug mode on')
+    # Get socket buffer size
+    with open('/proc/sys/net/core/rmem_max', 'r') as kernel_param:
+        queue_buffer = int(kernel_param.read().strip())
 
-    if options.logBucket == None:
-        print 'ERROR: Missing an AWS S3 bucket! (-b flag)'
-        sys.exit(1)
+    if int(options.debug) > 0:
+        global debug_level
+        debug_level = int(options.debug)
+        debug('+++ Debug mode on - Level: {debug}'.format(debug=options.debug), 1)
 
     # Create or connect SQLite DB
-    debug('+++ Create or connect SQLite DB')
+    debug('+++ Connect SQLite DB', 1)
+    legacy_table_exists = False
+    table_exists = False
     try:
         db_connector = sqlite3.connect("{0}/s3_cloudtrail.db".format(wazuh_wodle))
-        db_connector.execute("select count(*) from log_progress")
+        query_results = db_connector.execute("""
+                                               SELECT 
+                                                 tbl_name 
+                                               FROM 
+                                                 sqlite_master 
+                                               WHERE 
+                                                 type='table';""")
+        for row in query_results:
+            if row[0] == 'log_progress':
+                legacy_table_exists = True
+            elif row[0] == 'trail_progress':
+                table_exists = True
+        if not table_exists:
+            raise sqlite3.OperationalError
+        db_exists = True
     except sqlite3.OperationalError:
-        db_connector.execute("create table log_progress  (log_name 'text' primary key, processed_date 'TEXT')")
+        db_exists = False
+    except:
+        print "ERROR: Unexpected error accessing SQLite DB"
+        sys.exit(5)
 
-    
+    # DB does exist yet
+    if not db_exists:
+        try:
+            debug('+++ Table does not exist; create', 1)
+            db_connector.execute(
+                """
+                  CREATE TABLE
+                    trail_progress (
+                      aws_account_id 'text' NOT NULL, 
+                      aws_region 'text' NOT NULL, 
+                      log_key 'text' NOT NULL, 
+                      processed_date 'text' NOT NULL, 
+                      PRIMARY KEY (aws_account_id, aws_region, log_key));""")
+            db_connector.commit()
+        except:
+            print "ERROR: Unable to create SQLite DB"
+            sys.exit(6)
+
+    # Legacy table exists; migrate progress to new table
+    if legacy_table_exists:
+        debug('+++ Migrate legacy table data', 1)
+        migrate_legacy_table(db_connector)
+
     # Connect to Amazon S3 Bucket
-    debug('+++ Connecting to Amazon S3')
+    s3_client = get_s3_client(options)
+    debug('+++ Connecting to Amazon S3', 1)
 
-    if options.access_key != None and options.secret_key != None:
-        s3 = boto3.resource(
-            's3',
-            aws_access_key_id=options.access_key,
-            aws_secret_access_key=options.secret_key
-        )
-    else:
-        s3 = boto3.resource('s3')
+    # No accounts provided, so find which exist in s3 bucket
+    if not options.aws_account_id:
+        for common_prefix in s3_client.list_objects_v2(Bucket=options.logBucket,
+                                                       Prefix='{trail_prefix}AWSLogs/'.format(
+                                                           trail_prefix=options.trail_prefix),
+                                                       Delimiter='/')['CommonPrefixes']:
+            if common_prefix['Prefix'].split('/')[-2].isdigit():
+                options.aws_account_id.append(common_prefix['Prefix'].split('/')[-2])
 
-    my_bucket = s3.Bucket(options.logBucket)
-    try:
-        s3.meta.client.head_bucket(Bucket=options.logBucket)
-    except botocore.exceptions.ClientError as e:
-        print "Bucket %s access error: %s" % (options.logBucket, e)
-        sys.exit(3)
-
-    for bucket_file in my_bucket.objects.all():
-        downloaded_file = os.path.basename(str(bucket_file.key))
-        downloaded_file_path = '{0}/{1}'.format(wazuh_tmp,downloaded_file)
-        if re.match('.+_CloudTrail-Digest_.+', downloaded_file):
-            debug('Skipping digest file: %s' % downloaded_file)
-            continue
-        if downloaded_file != "":
-            if already_processed(downloaded_file, db_connector):
-                debug("++ Skipping previously seen file {file}".format(file=downloaded_file))
+    for aws_account_id in options.aws_account_id:
+        # No regions provided, so find which exist for this AWS account
+        if options.regions:
+            aws_account_regions = options.regions
+        else:
+            aws_account_regions = []
+            regions_in_s3 = s3_client.list_objects_v2(Bucket=options.logBucket,
+                                                           Prefix='{trail_prefix}AWSLogs/{aws_account_id}/CloudTrail/'.format(
+                                                               trail_prefix=options.trail_prefix,
+                                                               aws_account_id=aws_account_id),
+                                                           Delimiter='/')
+            if 'CommonPrefixes' in regions_in_s3:
+                for common_prefix in regions_in_s3['CommonPrefixes']:
+                    aws_account_regions.append(common_prefix['Prefix'].split('/')[-2])
+            else:
+                debug('+++ No regions found for AWS account: {aws_account_id}'.format(aws_account_id=aws_account_id), 1)
                 continue
-            debug("++ Found new log: {0}".format(downloaded_file))
-            my_bucket.download_file(bucket_file.key,downloaded_file_path)
-            data = gzip.open(downloaded_file_path, 'rb')
 
-            # Format JSON for Wazuh ingestion
-            j = json.load(data)
-            if "Records" not in j:
-                continue
-            for json_event in j["Records"]:
-                aws_log = {}
-                for key in json_event:
-                    if json_event[key]:
-                        aws_log[key] = json_event[key]
-                aws_log['log_file'] = downloaded_file
-                send_msg(wazuh_queue, header, aws_log)
+        for aws_region in aws_account_regions:
+            debug('+++ Working on {aws_account_id} - {aws_region}'.format(aws_account_id=aws_account_id,
+                                                                          aws_region=aws_region), 1)
+            # Where did we end last run thru on this account/region?
+            query_results = db_connector.execute(
+                """
+                  SELECT 
+                    log_key 
+                  FROM 
+                    trail_progress 
+                  WHERE 
+                    aws_account_id='{aws_account_id}' AND 
+                    aws_region = '{aws_region}' 
+                  ORDER BY 
+                    ROWID DESC 
+                  LIMIT 1;""".format(aws_account_id=aws_account_id,
+                                     aws_region=aws_region))
+            try:
+                filter_marker = query_results.fetchone()[0]
+                # Existing logs processed, but older than only_logs_after
+                if int(filter_marker.split('/')[-1].split('_')[-2].split('T')[0]) < options.only_logs_after:
+                    filter_marker = marker_only_logs_after(options, aws_account_id, aws_region)
+            except TypeError:
+                # No logs processed for this account/region, but if only_logs_after has been set
+                if options.only_logs_after:
+                    filter_marker = marker_only_logs_after(options, aws_account_id, aws_region)
+                else:
+                    filter_marker = ''
 
-            # Remove temporal file
-            debug("+++ Removing temporal file: {0}".format(downloaded_file))
+            filter_args = {
+                'Bucket': options.logBucket,
+                'MaxKeys': 1000,
+                'Prefix': '{trail_prefix}AWSLogs/{aws_account_id}/CloudTrail/{aws_region}/'.format(
+                    trail_prefix=options.trail_prefix, aws_account_id=aws_account_id, aws_region=aws_region)
+            }
+            if filter_marker:
+                filter_args['StartAfter'] = filter_marker
+                debug('+++ Marker: {0}'.format(filter_marker))
 
             try:
-                os.remove(downloaded_file_path)
-            except IOError as e:
-                print "ERROR: Cannot delete %s (%s)" % (downloaded_file_path, e.strerror)
+                bucket_files = s3_client.list_objects_v2(**filter_args)
+                if 'Contents' not in bucket_files:
+                    debug('+++ No logs to process: {aws_account_id}/{aws_region}'.format(aws_account_id=aws_account_id,
+                                                                                         aws_region=aws_region), 1)
+                    continue
 
-            # Remove file from S3 Bucket
-            if options.deleteFile:
-                debug("+++ Remove file from S3 Bucket:{0}".format(downloaded_file))
-                s3.Object(options.logBucket, bucket_file.key).delete()
-            mark_complete(downloaded_file, db_connector)
+                for bucket_file in s3_client.list_objects_v2(**filter_args)['Contents']:
+                    if bucket_file['Key'] != "":
+                        # Fail safe in case an older log gets thru StartAfter; probably redundant
+                        if int(bucket_file['Key'].split('/')[-1].split('_')[-2].split('T')[0]) < options.only_logs_after:
+                            debug("++ Skipping file dated before only_logs_after: {file}".format(file=bucket_file['Key']), 1)
+                            mark_complete(aws_account_id, aws_region, bucket_file['Key'], db_connector)
+                            continue
+                        if already_processed(bucket_file['Key'], aws_account_id, aws_region, db_connector):
+                            debug("++ Skipping previously processed file {file}".format(file=bucket_file['Key']), 1)
+                            continue
+                        debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
+
+                        try:
+                            raw_gz_object = s3_client.get_object(Bucket=options.logBucket, Key=bucket_file['Key'])['Body']
+                            uncompressed_object = zlib.decompress(raw_gz_object.read(), 16 + zlib.MAX_WBITS)
+                        except:
+                            if options.skip_on_error:
+                                debug("++ Failed to decompress file; skipping...", 1)
+                                try:
+                                    error_msg = {
+                                        'eventSource'
+                                    }
+                                    send_msg(wazuh_queue, queue_buffer, aws_log)
+                                except:
+                                    debug("++ Failed to send message to Wazuh", 1)
+                            else:
+                                print "ERROR: Failed to decompress file: {0}".format(bucket_file['Key'])
+                                sys.exit(8)
+
+                        try:
+                            j = json.loads(uncompressed_object)
+                        except:
+                            if options.skip_on_error:
+                                debug("++ Unable to parse file {0}; skipping...".format(bucket_file['Key']), 1)
+                                try:
+                                    error_msg = {}
+                                    send_msg(wazuh_queue, queue_buffer, aws_log)
+                                except:
+                                    debug("++ Failed to send message to Wazuh", 1)
+                            else:
+                                print "ERROR: Failed to parse file: {0}".format(bucket_file['Key'])
+                                sys.exit(9)
+                        if "Records" not in j:
+                            continue
+                        for cloudtrail_event in j["Records"]:
+                            # Parse out all the values of 'None'
+                            aws_log = dict((key, value) for key, value in cloudtrail_event.iteritems() if value)
+                            aws_log['log_file'] = bucket_file['Key']
+                            aws_log['aws_account_alias'] = options.aws_account_alias
+                            send_msg(wazuh_queue, queue_buffer, aws_log)
+
+                        # Remove file from S3 Bucket
+                        if options.deleteFile:
+                            debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
+                            s3_client.delete_object(Bucket=options.logBucket, Key=bucket_file['Key'])
+                        mark_complete(aws_account_id, aws_region, bucket_file['Key'], db_connector)
+            except SystemExit:
+                raise
+            except:
+                print "ERROR: Unexpected error querying/working with objects in S3"
+                sys.exit(7)
+
+            debug("+++ DB Maintenance", 1)
+            # Delete all the older log processed records for account/region
+            try:
+                db_connector.execute(
+                    """DELETE
+                       FROM 
+                         trail_progress 
+                       WHERE
+                         aws_account_id='{aws_account_id}' AND 
+                         aws_region='{aws_region}' AND 
+                         rowid NOT IN 
+                           (SELECT ROWID 
+                            FROM 
+                              trail_progress
+                            WHERE 
+                              aws_account_id='{aws_account_id}' AND 
+                              aws_region='{aws_region}'
+                            ORDER BY
+                              ROWID DESC
+                            LIMIT {retain_db_records})""".format(aws_account_id=aws_account_id,
+                                                                 aws_region=aws_region,
+                                                                 retain_db_records=retain_db_records))
+                db_connector.commit()
+            except:
+                print "ERROR: Failed to execute DB cleanup - AWS Account ID: {aws_account_id}  Region: {aws_region}".format(aws_account_id=aws_account_id,
+                                                                 aws_region=aws_region)
+                sys.exit(10)
+
+    db_connector.execute('PRAGMA optimize;')
+    db_connector.close()
+
 
 if __name__ == '__main__':
+    debug('Args: {args}'.format(args=str(sys.argv)), 2)
     signal.signal(signal.SIGINT, handler)
     main(sys.argv[1:])
     sys.exit(0)

--- a/wodles/aws/aws.py
+++ b/wodles/aws/aws.py
@@ -296,7 +296,7 @@ def main(argv):
     parser.add_argument('-e', '--skip_on_error', action='store_true', dest='skip_on_error',
                         help='If fail to parse a file, error out instead of skipping the file', default=True)
     parser.add_argument('-o', '--reparse', action='store_true', dest='reparse',
-                        help='Parse the log file, even if its been parsed before', default=True)
+                        help='Parse the log file, even if its been parsed before', default=False)
     options = parser.parse_args()
 
     db_connector = None

--- a/wodles/aws/aws.py
+++ b/wodles/aws/aws.py
@@ -5,6 +5,7 @@
 # Author: Wazuh, Inc.
 # Copyright: GPLv3
 #
+# Updated by Jeremy Phillips <jeremy@uranusbytes.com>
 # Full re-work of AWS wodle as per #510
 # - Scalability and functional enhancements for parsing of CloudTrail
 # - Support for existing config params
@@ -284,11 +285,11 @@ def main(argv):
                         type=arg_valid_accountid)
     parser.add_argument('-d', '--debug', action='store', dest='debug', default=0, help='Enable debu')
     parser.add_argument('-a', '--access_key', dest='access_key', help='S3 Access key credential', default=None)
-    parser.add_argument('-k', '--secret_key', dest='secret_key', help='S3 Secrety key credential', default=None)
+    parser.add_argument('-k', '--secret_key', dest='secret_key', help='S3 Secret key credential', default=None)
     # Beware, once you delete history it's gone.
     parser.add_argument('-R', '--remove', action='store_true', dest='deleteFile',
                         help='Remove processed files from the AWS S3 bucket', default=False)
-    parser.add_argument('-p', '--aws_profile', dest='aws_profile', help='The name of credneitla profile to use',
+    parser.add_argument('-p', '--aws_profile', dest='aws_profile', help='The name of credential profile to use',
                         default=None)
     parser.add_argument('-i', '--iam_role_arn', dest='iam_role_arn',
                         help='ARN of IAM role to assume for access to S3 bucket',
@@ -436,7 +437,7 @@ def main(argv):
             }
             if filter_marker:
                 filter_args['StartAfter'] = filter_marker
-                debug('+++ Marker: {0}'.format(filter_marker))
+                debug('+++ Marker: {0}'.format(filter_marker), 2)
 
             try:
                 bucket_files = s3_client.list_objects_v2(**filter_args)

--- a/wodles/aws/aws.py
+++ b/wodles/aws/aws.py
@@ -263,8 +263,8 @@ def migrate_legacy_table(db_connector):
     debug('+++ Rename legacy table', 1)
     db_connector.execute(
         """
-          ALTER TABLE trail_progress
-            RENAME TO legacy_trail_progress;""")
+          ALTER TABLE log_progress
+            RENAME TO legacy_log_progress;""")
     db_connector.commit()
 
     debug('+++ Finished legacy table migration', 1)

--- a/wodles/aws/aws.py
+++ b/wodles/aws/aws.py
@@ -62,6 +62,10 @@ import json
 import zlib
 from datetime import datetime
 
+
+# Constants
+###############################################################################
+
 # Retain last X log processed records for each account/region; only last record is used; rest are for history/knowledge
 retain_db_records = 100
 
@@ -77,6 +81,87 @@ wazuh_queue = '{0}/queue/ossec/queue'.format(wazuh_path)
 # Wazuh wodle path
 wazuh_wodle = '{0}/wodles/aws'.format(wazuh_path)
 
+# DB Query SQL
+sql_already_processed = """
+                          SELECT
+                            count(*) 
+                          FROM 
+                            trail_progress 
+                          WHERE 
+                            aws_account_id='{aws_account_id}' AND 
+                            aws_region='{aws_region}' AND 
+                            log_key='{log_name}'"""
+
+sql_mark_complete = """
+                      INSERT INTO trail_progress (
+                        aws_account_id, 
+                        aws_region, 
+                        log_key, 
+                        processed_date) VALUES (
+                        '{aws_account_id}', 
+                        '{aws_region}', 
+                        '{log_key}', 
+                        DATETIME('now'))"""
+
+sql_select_migrate_legacy = """
+                               SELECT 
+                                 log_name,
+                                 processed_date 
+                               FROM 
+                                 log_progress;"""
+
+sql_rename_migrate_legacy = """
+                              ALTER TABLE log_progress
+                                RENAME TO legacy_log_progress;"""
+
+sql_find_table_names = """
+                           SELECT 
+                             tbl_name 
+                           FROM 
+                             sqlite_master 
+                           WHERE 
+                             type='table';"""
+
+sql_create_table = """
+                      CREATE TABLE
+                        trail_progress (
+                          aws_account_id 'text' NOT NULL, 
+                          aws_region 'text' NOT NULL, 
+                          log_key 'text' NOT NULL, 
+                          processed_date 'text' NOT NULL, 
+                          PRIMARY KEY (aws_account_id, aws_region, log_key));"""
+
+sql_find_last_log_processed = """
+                                  SELECT 
+                                    log_key 
+                                  FROM 
+                                    trail_progress 
+                                  WHERE 
+                                    aws_account_id='{aws_account_id}' AND 
+                                    aws_region = '{aws_region}' 
+                                  ORDER BY 
+                                    ROWID DESC 
+                                  LIMIT 1;"""
+
+sql_db_maintenance = """DELETE
+                       FROM 
+                         trail_progress 
+                       WHERE
+                         aws_account_id='{aws_account_id}' AND 
+                         aws_region='{aws_region}' AND 
+                         rowid NOT IN 
+                           (SELECT ROWID 
+                            FROM 
+                              trail_progress
+                            WHERE 
+                              aws_account_id='{aws_account_id}' AND 
+                              aws_region='{aws_region}'
+                            ORDER BY
+                              ROWID DESC
+                            LIMIT {retain_db_records})"""
+
+sql_db_optimize = "PRAGMA optimize;"
+
 
 def send_msg(wazuh_queue, msg):
     try:
@@ -84,7 +169,8 @@ def send_msg(wazuh_queue, msg):
         debug(msg, 3)
         s = socket(AF_UNIX, SOCK_DGRAM)
         s.connect(wazuh_queue)
-        s.send("{header}{msg}".format(header=ossec_header, msg=json.dumps(msg).encode()))
+        s.send("{header}{msg}".format(header=ossec_header,
+                                      msg=json.dumps(msg).encode()))
         s.close()
     except:
         print('ERROR: Wazuh must be running.')
@@ -98,18 +184,9 @@ def handler(signal, frame):
 
 def already_processed(downloaded_file, aws_account_id, aws_region, db_connector):
     if db_connector:
-        cursor = db_connector.execute(
-            """
-              SELECT
-                count(*) 
-              FROM 
-                trail_progress 
-              WHERE 
-                aws_account_id='{aws_account_id}' AND 
-                aws_region='{aws_region}' AND 
-                log_key='{log_name}'""".format(aws_account_id=aws_account_id,
-                                               aws_region=aws_region,
-                                               log_name=downloaded_file))
+        cursor = db_connector.execute(sql_already_processed.format(aws_account_id=aws_account_id,
+                                                                   aws_region=aws_region,
+                                                                   log_name=downloaded_file))
         if cursor.fetchone()[0]:
             return True
     return False
@@ -121,19 +198,9 @@ def mark_complete(aws_account_id, aws_region, log_key, db_connector, options):
             debug('+++ File already marked complete, but reparse flag set: {log_key}'.format(log_key=log_key), 2)
             return
     try:
-        db_connector.execute(
-            """
-              INSERT INTO trail_progress (
-                aws_account_id, 
-                aws_region, 
-                log_key, 
-                processed_date) VALUES (
-                '{aws_account_id}', 
-                '{aws_region}', 
-                '{log_key}', 
-                DATETIME('now'))""".format(aws_account_id=aws_account_id,
-                                           aws_region=aws_region,
-                                           log_key=log_key))
+        db_connector.execute(sql_mark_complete.format(aws_account_id=aws_account_id,
+                                                      aws_region=aws_region,
+                                                      log_key=log_key))
         debug('+++ Mark log complete: {log_key}'.format(log_key=log_key), 2)
         db_connector.commit()
     except:
@@ -225,12 +292,7 @@ def marker_only_logs_after(options, aws_account_id, aws_region):
 
 def migrate_legacy_table(db_connector, options):
     debug('++ Query legacy table records', 1)
-    query_results = db_connector.execute("""
-                                           SELECT 
-                                             log_name,
-                                             processed_date 
-                                           FROM 
-                                             log_progress;""")
+    query_results = db_connector.execute(sql_select_migrate_legacy)
     for row in query_results:
         if row[0] != '':
             try:
@@ -242,7 +304,7 @@ def migrate_legacy_table(db_connector, options):
                 log_key = 'AWSLogs/{aws_account_id}/CloudTrail/{aws_region}/{date_path}/{log_filename}'.format(
                     aws_account_id=aws_account_id,
                     aws_region=aws_region,
-                    date_path=datetime.strftime(log_timestamp,'%Y/%m/%d'),
+                    date_path=datetime.strftime(log_timestamp, '%Y/%m/%d'),
                     log_filename=row[0]
                 )
                 mark_complete(aws_account_id, aws_region, log_key, db_connector, options)
@@ -251,18 +313,14 @@ def migrate_legacy_table(db_connector, options):
 
     # Rename legacy table
     debug('+++ Rename legacy table', 1)
-    db_connector.execute(
-        """
-          ALTER TABLE log_progress
-            RENAME TO legacy_log_progress;""")
+    db_connector.execute(sql_rename_migrate_legacy)
     db_connector.commit()
 
     debug('+++ Finished legacy table migration', 1)
     return
 
 
-def main(argv):
-    # Parse arguments
+def get_script_arguments():
     parser = argparse.ArgumentParser(usage="usage: %(prog)s [options]",
                                      version="%(prog)s 1.1",
                                      description="Wazuh wodle for monitoring of AWS CloudTrail logs in S3 bucket",
@@ -297,13 +355,148 @@ def main(argv):
                         help='If fail to parse a file, error out instead of skipping the file', default=True)
     parser.add_argument('-o', '--reparse', action='store_true', dest='reparse',
                         help='Parse the log file, even if its been parsed before', default=False)
-    options = parser.parse_args()
+    return parser.parse_args()
+
+
+def get_alert_msg(aws_account_id, aws_account_alias, log_key, s3_bucket):
+    msg = {
+        'integration': 'aws',
+        'aws': {
+            'cloudtrail': {
+                'aws_account_id': aws_account_id,
+                'aws_account_alias': aws_account_alias,
+                'log_file': log_key,
+                's3bucket': s3_bucket
+            }
+        }
+    }
+    return msg
+
+
+def build_s3_filter_args(options, db_connector, aws_account_id, aws_region):
+    filter_marker = ''
+    # If reparse flag set
+    if options.reparse:
+        if options.only_logs_after:
+            filter_marker = marker_only_logs_after(options, aws_account_id, aws_region)
+    else:
+        # Where did we end last run thru on this account/region?
+        query_results = db_connector.execute(sql_find_last_log_processed.format(aws_account_id=aws_account_id,
+                                                                                aws_region=aws_region))
+        try:
+            filter_marker = query_results.fetchone()[0]
+            # Existing logs processed, but older than only_logs_after
+            if int(filter_marker.split('/')[-1].split('_')[-2].split('T')[0]) < options.only_logs_after:
+                filter_marker = marker_only_logs_after(options, aws_account_id, aws_region)
+        except TypeError:
+            # No logs processed for this account/region, but if only_logs_after has been set
+            if options.only_logs_after:
+                filter_marker = marker_only_logs_after(options, aws_account_id, aws_region)
+
+    filter_args = {
+        'Bucket': options.logBucket,
+        'MaxKeys': 1000,
+        'Prefix': '{trail_prefix}AWSLogs/{aws_account_id}/CloudTrail/{aws_region}/'.format(
+            trail_prefix=options.trail_prefix,
+            aws_account_id=aws_account_id,
+            aws_region=aws_region)
+    }
+    if filter_marker:
+        filter_args['StartAfter'] = filter_marker
+        debug('+++ Marker: {0}'.format(filter_marker), 2)
+    return filter_args
+
+
+def reformat_msg(event_msg, max_queue_buffer):
+    debug('++ Reformat message', 2)
+    # Some fields in CloudTrail are dynamic in nature, which causes problems for ES mapping
+    for field_to_str in ['additionalEventData', 'responseElements', 'requestParameters']:
+        if field_to_str in event_msg['aws']['cloudtrail']['event']:
+            try:
+                debug('++ Reformat field: {}'.format(field_to_str), 2)
+                event_msg['aws']['cloudtrail']['event'][field_to_str] = json.dumps(
+                    event_msg['aws']['cloudtrail']['event'][field_to_str],
+                    ensure_ascii=True,
+                    indent=2,
+                    sort_keys=True)
+            except:
+                debug('++ Failed to convert field to string: {}'.format(field_to_str), 2)
+                event_msg['aws']['cloudtrail']['event'][
+                    field_to_str] = 'Unable to convert field to string: {field}'.format(field=field_to_str)
+
+    debug('++ Shrink message', 2)
+    # If msg too large, start truncating
+    for field_to_shrink in ['additionalEventData', 'responseElements', 'requestParameters']:
+        if field_to_shrink not in event_msg['aws']['cloudtrail']['event']:
+            continue
+        if event_msg['aws']['cloudtrail']['event'][
+            field_to_shrink] == 'Unable to convert field to string: {field}'.format(field=field_to_shrink):
+            continue
+
+        if len(json.dumps(event_msg).encode()) > max_queue_buffer:
+            debug('++ Message too large; truncating {field}'.format(field=field_to_shrink), 2)
+            event_msg['aws']['cloudtrail']['event'][
+                field_to_shrink] = 'Value truncated because event msg too large for socket buffer'
+        else:
+            debug('++ Message not too large; skip out', 2)
+            break
+    return event_msg
+
+
+def get_log_file(s3_client, options, aws_account_id, log_key):
+    try:
+        raw_gz_object = s3_client.get_object(Bucket=options.logBucket, Key=log_key)['Body']
+        uncompressed_object = zlib.decompress(raw_gz_object.read(), 16 + zlib.MAX_WBITS)
+    except:
+        if options.skip_on_error:
+            debug("++ Failed to decompress file; skipping...", 1)
+            try:
+                error_msg = get_alert_msg(aws_account_id,
+                                          options.aws_account_alias,
+                                          log_key,
+                                          options.logBucket)
+                error_msg['error_msg'] = 'Failed to decompress file; skipping...'
+                send_msg(wazuh_queue, error_msg)
+            except:
+                debug("++ Failed to send message to Wazuh", 1)
+        else:
+            print "ERROR: Failed to decompress file: {0}".format(log_key)
+            sys.exit(8)
+
+    # Parse the log json
+    try:
+        log_json = json.loads(uncompressed_object)
+    except:
+        if options.skip_on_error:
+            debug("++ Unable to parse file {0}; skipping...".format(log_key), 1)
+            try:
+                error_msg = get_alert_msg(aws_account_id,
+                                          options.aws_account_alias,
+                                          log_key,
+                                          options.logBucket)
+                error_msg['error_msg'] = 'Unable to parse log file contents; skipping...'
+                send_msg(wazuh_queue, error_msg)
+            except:
+                debug("++ Failed to send message to Wazuh", 1)
+        else:
+            print "ERROR: Failed to parse file: {0}".format(log_key)
+            sys.exit(9)
+    return log_json
+
+
+# Main
+###############################################################################
+
+
+def main(argv):
+    # Parse arguments
+    options = get_script_arguments()
 
     db_connector = None
 
     # Get socket buffer size
     with open('/proc/sys/net/core/rmem_max', 'r') as kernel_param:
-        queue_buffer = int(kernel_param.read().strip())
+        max_queue_buffer = int(kernel_param.read().strip())
 
     if int(options.debug) > 0:
         global debug_level
@@ -316,13 +509,7 @@ def main(argv):
     table_exists = False
     try:
         db_connector = sqlite3.connect("{0}/s3_cloudtrail.db".format(wazuh_wodle))
-        query_results = db_connector.execute("""
-                                               SELECT 
-                                                 tbl_name 
-                                               FROM 
-                                                 sqlite_master 
-                                               WHERE 
-                                                 type='table';""")
+        query_results = db_connector.execute(sql_find_table_names)
         for row in query_results:
             if row[0] == 'log_progress':
                 legacy_table_exists = True
@@ -341,15 +528,7 @@ def main(argv):
     if not db_exists:
         try:
             debug('+++ Table does not exist; create', 1)
-            db_connector.execute(
-                """
-                  CREATE TABLE
-                    trail_progress (
-                      aws_account_id 'text' NOT NULL, 
-                      aws_region 'text' NOT NULL, 
-                      log_key 'text' NOT NULL, 
-                      processed_date 'text' NOT NULL, 
-                      PRIMARY KEY (aws_account_id, aws_region, log_key));""")
+            db_connector.execute(sql_create_table)
             db_connector.commit()
         except:
             print "ERROR: Unable to create SQLite DB"
@@ -380,10 +559,10 @@ def main(argv):
         else:
             aws_account_regions = []
             regions_in_s3 = s3_client.list_objects_v2(Bucket=options.logBucket,
-                                                           Prefix='{trail_prefix}AWSLogs/{aws_account_id}/CloudTrail/'.format(
-                                                               trail_prefix=options.trail_prefix,
-                                                               aws_account_id=aws_account_id),
-                                                           Delimiter='/')
+                                                      Prefix='{trail_prefix}AWSLogs/{aws_account_id}/CloudTrail/'.format(
+                                                          trail_prefix=options.trail_prefix,
+                                                          aws_account_id=aws_account_id),
+                                                      Delimiter='/')
             if 'CommonPrefixes' in regions_in_s3:
                 for common_prefix in regions_in_s3['CommonPrefixes']:
                     aws_account_regions.append(common_prefix['Prefix'].split('/')[-2])
@@ -394,57 +573,17 @@ def main(argv):
         for aws_region in aws_account_regions:
             debug('+++ Working on {aws_account_id} - {aws_region}'.format(aws_account_id=aws_account_id,
                                                                           aws_region=aws_region), 1)
-            # If reparse flag set
-            if options.reparse:
-                if options.only_logs_after:
-                    filter_marker = marker_only_logs_after(options, aws_account_id, aws_region)
-                else:
-                    filter_marker = ''
-            else:
-                # Where did we end last run thru on this account/region?
-                query_results = db_connector.execute(
-                    """
-                      SELECT 
-                        log_key 
-                      FROM 
-                        trail_progress 
-                      WHERE 
-                        aws_account_id='{aws_account_id}' AND 
-                        aws_region = '{aws_region}' 
-                      ORDER BY 
-                        ROWID DESC 
-                      LIMIT 1;""".format(aws_account_id=aws_account_id,
-                                         aws_region=aws_region))
-                try:
-                    filter_marker = query_results.fetchone()[0]
-                    # Existing logs processed, but older than only_logs_after
-                    if int(filter_marker.split('/')[-1].split('_')[-2].split('T')[0]) < options.only_logs_after:
-                        filter_marker = marker_only_logs_after(options, aws_account_id, aws_region)
-                except TypeError:
-                    # No logs processed for this account/region, but if only_logs_after has been set
-                    if options.only_logs_after:
-                        filter_marker = marker_only_logs_after(options, aws_account_id, aws_region)
-                    else:
-                        filter_marker = ''
-
-            filter_args = {
-                'Bucket': options.logBucket,
-                'MaxKeys': 1000,
-                'Prefix': '{trail_prefix}AWSLogs/{aws_account_id}/CloudTrail/{aws_region}/'.format(
-                    trail_prefix=options.trail_prefix, aws_account_id=aws_account_id, aws_region=aws_region)
-            }
-            if filter_marker:
-                filter_args['StartAfter'] = filter_marker
-                debug('+++ Marker: {0}'.format(filter_marker), 2)
-
+            
+            s3_filter_args = build_s3_filter_args(options, db_connector, aws_account_id, aws_region)
+            
             try:
-                bucket_files = s3_client.list_objects_v2(**filter_args)
+                bucket_files = s3_client.list_objects_v2(**s3_filter_args)
                 if 'Contents' not in bucket_files:
-                    debug('+++ No logs to process: {aws_account_id}/{aws_region}'.format(aws_account_id=aws_account_id,
-                                                                                         aws_region=aws_region), 1)
+                    debug('+++ No logs to process in bucket: {aws_account_id}/{aws_region}'.format(aws_account_id=aws_account_id,
+                                                                                                   aws_region=aws_region), 1)
                     continue
 
-                for bucket_file in s3_client.list_objects_v2(**filter_args)['Contents']:
+                for bucket_file in s3_client.list_objects_v2(**s3_filter_args)['Contents']:
                     if bucket_file['Key'] != "":
                         # Fail safe in case an older log gets thru StartAfter; probably redundant
                         if int(bucket_file['Key'].split('/')[-1].split('_')[-2].split('T')[0]) < options.only_logs_after:
@@ -458,99 +597,22 @@ def main(argv):
                                 debug("++ Skipping previously processed file: {file}".format(file=bucket_file['Key']), 1)
                                 continue
                         debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
-
-                        try:
-                            raw_gz_object = s3_client.get_object(Bucket=options.logBucket, Key=bucket_file['Key'])['Body']
-                            uncompressed_object = zlib.decompress(raw_gz_object.read(), 16 + zlib.MAX_WBITS)
-                        except:
-                            if options.skip_on_error:
-                                debug("++ Failed to decompress file; skipping...", 1)
-                                try:
-                                    error_msg = {
-                                        'integration': 'aws',
-                                        'aws': {
-                                            'cloudtrail': {
-                                                'aws_account_id': aws_account_id,
-                                                'aws_account_alias': options.aws_account_alias,
-                                                'log_file': bucket_file['Key'],
-                                                'error_msg': 'Failed to decompress file; skipping...',
-                                                's3bucket': options.logBucket
-                                            }
-                                        }
-                                    }
-                                    send_msg(wazuh_queue, error_msg)
-                                except:
-                                    debug("++ Failed to send message to Wazuh", 1)
-                            else:
-                                print "ERROR: Failed to decompress file: {0}".format(bucket_file['Key'])
-                                sys.exit(8)
-
-                        try:
-                            log_json = json.loads(uncompressed_object)
-                        except:
-                            if options.skip_on_error:
-                                debug("++ Unable to parse file {0}; skipping...".format(bucket_file['Key']), 1)
-                                try:
-                                    error_msg = {
-                                        'integration': 'aws',
-                                        'aws': {
-                                            'cloudtrail': {
-                                                'aws_account_id': aws_account_id,
-                                                'aws_account_alias': options.aws_account_alias,
-                                                'log_file': bucket_file['Key'],
-                                                'error_msg': 'Unable to parse file; skipping...',
-                                                's3bucket': options.logBucket
-                                            }
-                                        }
-                                    }
-                                    send_msg(wazuh_queue, error_msg)
-                                except:
-                                    debug("++ Failed to send message to Wazuh", 1)
-                            else:
-                                print "ERROR: Failed to parse file: {0}".format(bucket_file['Key'])
-                                sys.exit(9)
+                        # Get the log file from S3 and decompress it
+                        log_json = get_log_file(s3_client, options, aws_account_id, bucket_file['Key'])
                         if "Records" not in log_json:
                             continue
+                        # Loop thru all the events in log
                         for cloudtrail_event in log_json["Records"]:
+
                             # Parse out all the values of 'None'
-                            event_msg = {
-                                'integration': 'aws',
-                                'aws': {
-                                    'cloudtrail': {
-                                        'aws_account_id': aws_account_id,
-                                        'aws_account_alias': options.aws_account_alias,
-                                        'log_file': bucket_file['Key'],
-                                        'event': dict((key, value) for key, value in cloudtrail_event.iteritems() if value),
-                                        's3bucket': options.logBucket
-                                    }
-                                }
-                            }
-
-                            # Some fields in CloudTrail are dynamic in nature, which causes problems for ES mapping
-                            for field_to_str in ['additionalEventData', 'responseElements', 'requestParameters']:
-                                if field_to_str in event_msg['aws']['cloudtrail']['event']:
-                                    try:
-                                        event_msg['aws']['cloudtrail']['event'][field_to_str] = json.dumps(event_msg['aws']['cloudtrail']['event'][field_to_str],
-                                                                           ensure_ascii=True,
-                                                                           indent=2,
-                                                                           sort_keys=True)
-                                    except:
-                                        event_msg['aws']['cloudtrail']['event'][field_to_str] = 'Unable to convert field to string: {field}'.format(field=field_to_str)
-
-                            # If msg too large, start truncating
-                            for field_to_shrink in ['additionalEventData', 'responseElements', 'requestParameters']:
-                                if field_to_shrink not in event_msg['aws']['cloudtrail']['event']:
-                                    continue
-                                if event_msg['aws']['cloudtrail']['event'][field_to_shrink] == 'Unable to convert field to string: {field}'.format(field=field_to_shrink):
-                                    continue
-
-                                if len(json.dumps(event_msg).encode()) > queue_buffer:
-                                    debug('++ Message too large; truncating {field}'.format(field=field_to_shrink), 2)
-                                    event_msg['aws']['cloudtrail']['event'][field_to_shrink] = 'Value truncated because event msg too large for socket buffer'
-                                else:
-                                    # Message not too large; skip out
-                                    break
-
+                            event_msg = get_alert_msg(aws_account_id,
+                                                      options.aws_account_alias,
+                                                      bucket_file['Key'],
+                                                      options.logBucket)
+                            # Parse out all the values of 'None'
+                            event_msg['aws']['cloudtrail']['event'] = dict((key, value) for key, value in cloudtrail_event.iteritems() if value)
+                            # Change dynamic fields to strings; truncate values as needed
+                            event_msg = reformat_msg(event_msg, max_queue_buffer)
                             # Send the message
                             send_msg(wazuh_queue, event_msg)
 
@@ -562,39 +624,27 @@ def main(argv):
             except SystemExit:
                 raise
             except Exception as err:
-                debug("+++ Unexpected error: {}".format(err), 2)
+                if hasattr(err, 'message'):
+                    debug("+++ Unexpected error: {}".format(err.message), 2)
+                else:
+                    debug("+++ Unexpected error: {}".format(err), 2)
                 print "ERROR: Unexpected error querying/working with objects in S3"
                 sys.exit(7)
 
             debug("+++ DB Maintenance", 1)
             # Delete all the older log processed records for account/region
             try:
-                db_connector.execute(
-                    """DELETE
-                       FROM 
-                         trail_progress 
-                       WHERE
-                         aws_account_id='{aws_account_id}' AND 
-                         aws_region='{aws_region}' AND 
-                         rowid NOT IN 
-                           (SELECT ROWID 
-                            FROM 
-                              trail_progress
-                            WHERE 
-                              aws_account_id='{aws_account_id}' AND 
-                              aws_region='{aws_region}'
-                            ORDER BY
-                              ROWID DESC
-                            LIMIT {retain_db_records})""".format(aws_account_id=aws_account_id,
-                                                                 aws_region=aws_region,
-                                                                 retain_db_records=retain_db_records))
+                db_connector.execute(sql_db_maintenance.format(aws_account_id=aws_account_id,
+                                                               aws_region=aws_region,
+                                                               retain_db_records=retain_db_records))
                 db_connector.commit()
             except:
-                print "ERROR: Failed to execute DB cleanup - AWS Account ID: {aws_account_id}  Region: {aws_region}".format(aws_account_id=aws_account_id,
-                                                                 aws_region=aws_region)
+                print "ERROR: Failed to execute DB cleanup - AWS Account ID: {aws_account_id}  Region: {aws_region}".format(
+                    aws_account_id=aws_account_id,
+                    aws_region=aws_region)
                 sys.exit(10)
 
-    db_connector.execute('PRAGMA optimize;')
+    db_connector.execute(sql_db_optimize)
     db_connector.close()
 
 


### PR DESCRIPTION
Full re-work of AWS wodle as per wazuh/wazuh#510
- Scalability and functional enhancements for parsing of CloudTrail
- Support for existing config params
- Upgrade to a granular object key addressing to support multiple CloudTrails in S3 bucket
- Support granular parsing by account id, region, prefix
- Support only parsing logs after a given date
- Support IAM credential profiles, IAM roles
- Only look for new logs/objects since last iteration
- Skip digest files altogether (only look at logs)
- Move from downloading object and working with file on filesystem to byte stream
- Inherit debug from modulesd
- Add bounds checks for msg against socket buffer size; truncate fields if too big (wazuh/wazuh#733)
- Support multiple debug levels
- Move connect error so not confused with general error
- If fail to parse log, and skip_on_error, attempt to send me msg to wazuh
- Support existing configurations by migrating data, inferring other required params

Associated documentation updates covered in wazuh/wazuh-documentation#274