### PR TITLE
Fix CA verification with several 'ca_store' definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to this project will be documented in this file.
 - Fix network unreachable error when cluster starts. ([#800](https://github.com/wazuh/wazuh/pull/800))
 - Fix empty rules and decoders file check. ([#887](https://github.com/wazuh/wazuh/pull/887))
 - Prevent to access an unexisting hash table from 'whodata' thread. ([#911](https://github.com/wazuh/wazuh/pull/911))
+- Fix CA verification with more than one 'ca_store' definitions. ([#927](https://github.com/wazuh/wazuh/pull/927))
 
 
 ## [v3.3.1]


### PR DESCRIPTION
This PR solves the issue #890.

The X509 functions provided by the OpenSSL library didn't store correctly more than one CA certification in the verification process. This algorithm has been modified to make a single verification for each defined CA root certificate against the target one.