### PR TITLE
Fix SELinux when installing Wazuh into /opt

### DIFF
--- a/src/selinux/wazuh.te
+++ b/src/selinux/wazuh.te
@@ -10,16 +10,25 @@ module wazuh 1.0;
 
 require {
 	type audisp_t;
-        type var_t;
-        class sock_file { create setattr };
-        class dir { remove_name add_name read write };
-        class file { getattr open read };
-        class capability dac_override;
+	type var_t;
+	type usr_t;
+	class sock_file { create setattr };
+	class dir { remove_name add_name read write };
+	class file { getattr open read };
+	class capability dac_override;
 }
 
 #============= audisp_t ==============
 allow audisp_t self: capability dac_override;
+
+allow audisp_t usr_t:dir { remove_name add_name read write };
+allow audisp_t usr_t:file getattr;
+
+allow audisp_t usr_t:sock_file { create setattr };
+allow audisp_t usr_t:file { open read };
+
 allow audisp_t var_t:dir { remove_name add_name read write };
 allow audisp_t var_t:file getattr;
+
 allow audisp_t var_t:sock_file { create setattr };
 allow audisp_t var_t:file { open read };


### PR DESCRIPTION
This PR allows creating the socket when Wazuh is installed into /opt/ossec.