### PR TITLE
Fix inconsistent status of the Wazuh service in CentOS 6

### DIFF
--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -304,6 +304,15 @@ start()
                  continue
              fi
         fi
+        ## If wazuh-clusterd is disabled, don't try to start it.
+        if [ X"$i" = "Xwazuh-clusterd" ]; then
+             start_config="$(grep -n "<cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
+             end_config="$(grep -n "</cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
+             sed -n "${start_config},${end_config}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
+             if [ $? = 0 ]; then
+                 continue
+             fi
+        fi
         if [ $USE_JSON = true ] && [ $first = false ]; then
             echo -n ','
         else

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -308,9 +308,13 @@ start()
         if [ X"$i" = "Xwazuh-clusterd" ]; then
              start_config="$(grep -n "<cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
              end_config="$(grep -n "</cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
-             sed -n "${start_config},${end_config}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
-             if [ $? = 0 ]; then
-                 continue
+             if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
+                sed -n "${start_config},${end_config}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
+                if [ $? = 0 ]; then
+                    continue
+                fi
+             else
+                continue
              fi
         fi
         if [ $USE_JSON = true ] && [ $first = false ]; then


### PR DESCRIPTION
Hi team,

in this PR I fix #943.  Now, the `ossec-control`  will check the configuration of the `wazuh-clusterd`. If it is _disabled_ or its configuration doesn't appear in the `ossec.conf` file, the `ossec-control` will not run it.

* Before:
    ```shellsession
    # service wazuh-manager restart
    Stopping OSSEC:                                          [  OK  ]
    Starting OSSEC:                                          [  FAILED  ]
    # /var/ossec/bin/ossec-control status
    wazuh-clusterd not running...
    ossec-monitord is running...
    ossec-logcollector is running...
    ossec-remoted is running...
    ossec-syscheckd is running...
    ossec-analysisd is running...
    ossec-maild not running...
    ossec-execd is running...
    wazuh-modulesd is running...
    wazuh-db is running...
    ```
    and this was the `wazuh-clusterd` configuration:
    ```xml
    <cluster>
        <name>wazuh</name>
        <node_name>node01</node_name>
        <node_type>master</node_type>
        <key></key>
        <port>1516</port>
        <bind_addr>0.0.0.0</bind_addr>
        <nodes>
            <node>NODE_IP</node>
        </nodes>
        <hidden>no</hidden>
        <disabled>yes</disabled>
    </cluster>
    ```
* Now: 
    ```shellsession
    # service wazuh-manager restart
    Stopping OSSEC:                                            [  OK  ]
    Starting OSSEC:                                            [  OK  ]
    # /var/ossec/bin/ossec-control status
    wazuh-clusterd not running...
    ossec-monitord is running...
    ossec-logcollector is running...
    ossec-remoted is running...
    ossec-syscheckd is running...
    ossec-analysisd is running...
    ossec-maild not running...
    ossec-execd is running...
    wazuh-modulesd is running...
    wazuh-db is running...
    ```

    the `wazuh-clusterd` configuration is the same as before.

Regards,
Braulio.
