### PR TITLE
Fix Windows path from agent <3.2

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -312,6 +312,9 @@ static int DB_Search(const char *f_name, char *c_sum, char *w_sum, Eventinfo *lf
             saved_name[sn_size] = '\0';
         }
 
+        //Change in Windows paths all slashes for backslashes for compatibility agent<3.4 with manager>=3.4
+        normalize_path(saved_name);
+
         /* If name is different, go to next one */
         if (strcmp(f_name, saved_name) != 0) {
             /* Save current location */
@@ -740,6 +743,9 @@ int DecodeSyscheck(Eventinfo *lf)
     /* Zero to get the check sum */
     *f_name = '\0';
     f_name++;
+
+    //Change in Windows paths all slashes for backslashes for compatibility agent<3.4 with manager>=3.4
+    normalize_path(f_name);
 
     /* Get diff */
     lf->data = strchr(f_name, '\n');

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -157,6 +157,9 @@ void sk_sum_clean(sk_sum_t * sum);
 
 int fim_find_child_depth(const char *parent, const char *child);
 
+//Change in Windows paths all slashes for backslashes for compatibility agent<3.4 with manager>=3.4
+void normalize_path(char *path);
+
 #ifndef WIN32
 
 const char *get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid);

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -418,6 +418,21 @@ int fim_find_child_depth(const char *parent, const char *child) {
     return child_depth;
 }
 
+void normalize_path(char * path) {
+    char *ptname = path;
+
+    if(ptname[1] == ':' && ((ptname[0] >= 'A' && ptname[0] <= 'Z') || (ptname[0] >= 'a' && ptname[0] <= 'z'))) {
+        /* Change forward slashes to backslashes on entry */
+        ptname = strchr(ptname, '/');
+        while (ptname) {
+            *ptname = '\\';
+            ptname++;
+
+            ptname = strchr(ptname, '/');
+        }
+    }
+}
+
 #ifndef WIN32
 
 const char *get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid) {


### PR DESCRIPTION
Avoid reporting alerts from agents smaller than 3.2 because of the path contains slashes