### PR TITLE
Fix Remoted connection failed warning in TCP mode due to timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to this project will be documented in this file.
 - Fix CA verification with more than one 'ca_store' definitions. ([#927](https://github.com/wazuh/wazuh/pull/927))
 - Fix error in syscollector API calls when Wazuh is installed in a directory different than `/var/ossec`. ([#942](https://github.com/wazuh/wazuh/pull/942)).
 - Fix error in CentOS 6 when `wazuh-cluster` is disabled. ([#944](https://github.com/wazuh/wazuh/pull/944)).
+- Fix Remoted connection failed warning in TCP mode due to timeout. ([#958](https://github.com/wazuh/wazuh/pull/958))
 
 
 ## [v3.3.1]

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -60,7 +60,7 @@ void HandleRemote(int uid)
     if (logr.proto[position] == TCP_PROTO) {
         if ((logr.sock = OS_Bindporttcp(logr.port[position], logr.lip[position], logr.ipv6[position])) < 0) {
             merror_exit(BIND_ERROR, logr.port[position], errno, strerror(errno));
-        }else{
+        } else if (logr.conn[position] == SECURE_CONN) {
             if (OS_SetRecvTimeout(logr.sock, timeout) < 0){
                 merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
             }

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -172,7 +172,7 @@ void HandleSyslogTCP()
         /* Accept new connections */
         int client_socket = OS_AcceptTCP(logr.sock, srcip, IPSIZE);
         if (client_socket < 0) {
-            mwarn("Accepting tcp connection from client failed.");
+            mwarn("Accepting tcp connection from client failed: %s (%d)", strerror(errno), errno);
             continue;
         }
 


### PR DESCRIPTION
This PR aims to prevent this message from appearing in the log:

> ossec-remoted: WARNING: Accepting tcp connection from client failed.

Remoted enables timeout in the TCP sockets, but it should do it for secure connections (no syslog) only.