### PR TITLE
Fix call to sleep function inside a locked section

### DIFF
--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -70,14 +70,13 @@ static void read_internal(int debug_level)
     return;
 }
 
-/* Initialize syscheck variables */
-int fim_initilize() {
-
+// Initialize syscheck variables
+int fim_initialize() {
     /* Create store data */
     syscheck.fp = OSHash_Create();
     syscheck.local_hash = OSHash_Create();
 
-    /* Duplicate hash table to check for deleted files */
+    // Duplicate hash table to check for deleted files
     syscheck.last_check = OSHash_Create();
 
     return 0;
@@ -190,7 +189,7 @@ int Start_win32_Syscheck()
 
     /* Some sync time */
     sleep(syscheck.tsleep * 5);
-    fim_initilize();
+    fim_initialize();
 
     /* Wait if agent started properly */
     os_wait();
@@ -403,7 +402,7 @@ int main(int argc, char **argv)
 
     /* Some sync time */
     sleep(syscheck.tsleep * 5);
-    fim_initilize();
+    fim_initialize();
 
     // Audit events thread
     if (syscheck.enable_whodata) {


### PR DESCRIPTION
When monitoring files to detect and send deletion messages is checked within a critical section to avoid overlaps with the _whodata_ thread. The delete message is removed from the critical section because it contains a sleep.