### PR TITLE
Fix error control in Virustotal integration

### DIFF
--- a/integrations/virustotal
+++ b/integrations/virustotal
@@ -20,7 +20,7 @@ try:
     from requests.auth import HTTPBasicAuth
 except Exception as e:
     print("No module 'requests' found. Install: pip install requests")
-    sys.exit()
+    sys.exit(1)
 
 # ossec.conf configuration:
 #  <integration>


### PR DESCRIPTION
If python-requests was not installed, the integration failed silently because the exception returned a 0 value, which is processed as a successful execution.
