### PR TITLE
Ignore some Windows Audit events by the default configuration

### DIFF
--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -34,7 +34,8 @@
     <location>Security</location>
     <log_format>eventchannel</log_format>
     <query>Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and
-		   EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660]</query>
+      EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and
+      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907]</query>
   </localfile>
 
   <localfile>


### PR DESCRIPTION
Those Windows events:

> AUDIT_SUCCESS(4907): Auditing settings on object were changed.
> AUDIT_SUCCESS(4703): A token right was adjusted.
> AUDIT_SUCCESS(4670): Permissions on an object were changed.
> AUDIT_SUCCESS(4670): An attempt was made to duplicate a handle to an object.

They may flood the agents when monitoring files in FIM with who-data.