### PR TITLE
Add new options to Syscheck default documentation

### DIFF
--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -7,12 +7,6 @@
 
     <scan_on_start>yes</scan_on_start>
 
-    <!-- Generate alert when new file detected -->
-    <alert_new_files>yes</alert_new_files>
-
-    <!-- Don't ignore files that change more than 'frequency' times -->
-    <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
-
     <!-- Directories to check  (perform all possible verifications) -->
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
     <directories check_all="yes">/bin,/sbin,/boot</directories>
@@ -40,7 +34,4 @@
 
     <!-- Remove not monitorized files -->
     <remove_old_diff>yes</remove_old_diff>
-
-    <!-- Allow the system to restart Auditd after installing the plugin -->
-    <restart_audit>yes</restart_audit>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -40,7 +40,4 @@
 
     <!-- Remove not monitorized files -->
     <remove_old_diff>yes</remove_old_diff>
-
-    <!-- Allow the system to restart Auditd after installing the plugin -->
-    <restart_audit>yes</restart_audit>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -34,4 +34,7 @@
 
     <!-- Remove not monitorized files -->
     <remove_old_diff>yes</remove_old_diff>
+
+    <!-- Allow the system to restart Auditd after installing the plugin -->
+    <restart_audit>yes</restart_audit>
   </syscheck>

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -155,6 +155,9 @@
 
     <!-- Remove not monitorized files -->
     <remove_old_diff>yes</remove_old_diff>
+
+    <!-- Frequency for ACL checking (seconds) -->
+    <windows_audit_interval>300</windows_audit_interval>
   </syscheck>
 
   <!-- CIS policies evaluation -->


### PR DESCRIPTION
- `restart_audit` (Linux)
- `windows_audit_interval` (Windows)