### PR TITLE
Change default Syscheck scan speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Improve output of `DELETE/agents` when no agents were removed. ([#868](https://github.com/wazuh/wazuh/pull/868))
 - Include the file owner SID in Syscheck alerts.
 - Change no previous checksum error message to information log. ([#897](https://github.com/wazuh/wazuh/pull/897))
+- Changed default Syscheck scan speed: 100 files per second. ([#975](https://github.com/wazuh/wazuh/pull/975))
 
 ### Fixed
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -154,10 +154,10 @@ monitord.daily_rotations=12
 
 # Syscheck checking/usage speed. To avoid large cpu/memory
 # usage, you can specify how much to sleep after generating
-# the checksum of X files. The default is to sleep 2 seconds
-# after reading 15 files.
-syscheck.sleep=2
-syscheck.sleep_after=15
+# the checksum of X files. The default is to sleep one second
+# per 100 files read.
+syscheck.sleep=1
+syscheck.sleep_after=100
 
 # Syscheck perform a delay when dispatching real-time notifications so it avoids
 # triggering on some temporary files like vim edits. (ms) [1..1000]


### PR DESCRIPTION
Sleep one second per 100 files read by default.