### PR TITLE
Fix sending alert to syslog filtering by 'rule_id'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ All notable changes to this project will be documented in this file.
 - Added support for unified WPK. ([#865](https://github.com/wazuh/wazuh/pull/865))
 - Added missing debug options for modules in the internal options file. ([#901](https://github.com/wazuh/wazuh/pull/901))
 
-
 ### Changed
 
 - Renamed cluster _client_ node type to ___worker___ ([#850](https://github.com/wazuh/wazuh/pull/850)).
@@ -77,7 +76,7 @@ All notable changes to this project will be documented in this file.
 - Fix error in syscollector API calls when Wazuh is installed in a directory different than `/var/ossec`. ([#942](https://github.com/wazuh/wazuh/pull/942)).
 - Fix error in CentOS 6 when `wazuh-cluster` is disabled. ([#944](https://github.com/wazuh/wazuh/pull/944)).
 - Fix Remoted connection failed warning in TCP mode due to timeout. ([#958](https://github.com/wazuh/wazuh/pull/958))
-
+- Fix option 'rule_id' in syslog client. ([#979](https://github.com/wazuh/wazuh/pull/979))
 
 ## [v3.3.1] 2018-06-18
 

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -345,7 +345,7 @@ int OS_Alert_SendSyslog_JSON(cJSON *json_data, const SyslogConfig *syslog_config
             return 0;
         }
 
-        for (i = 0; syslog_config->rule_id[i] && (int)syslog_config->rule_id[i] != item->valueint; i++);
+        for (i = 0; syslog_config->rule_id[i] && (int)syslog_config->rule_id[i] != atoi(item->valuestring); i++);
 
         /* If we found, id is going to be a valid rule */
 


### PR DESCRIPTION
This PR solve [#965](https://github.com/wazuh/wazuh/issues/965)

Fix Syslog output filtering by rule_id