### PR TITLE
Make agent show protocol used when connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - Include the file owner SID in Syscheck alerts.
 - Change no previous checksum error message to information log. ([#897](https://github.com/wazuh/wazuh/pull/897))
 - Changed default Syscheck scan speed: 100 files per second. ([#975](https://github.com/wazuh/wazuh/pull/975))
+- Show network protocol used by the agent when connecting to the manager. ([#980](https://github.com/wazuh/wazuh/pull/980))
 
 ### Fixed
 

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -34,9 +34,10 @@ int connect_server(int initial_id)
         agt->sock = -1;
 
         if (agt->server[1].rip) {
-            minfo("Closing connection to server (%s:%d).",
+            minfo("Closing connection to server (%s:%d/%s).",
                     agt->server[rc].rip,
-                    agt->server[rc].port);
+                    agt->server[rc].port,
+                    agt->server[rc].protocol == UDP_PROTO ? "udp" : "tcp");
         }
     }
 
@@ -77,9 +78,10 @@ int connect_server(int initial_id)
             tmp_str = agt->server[rc].rip;
         }
 
-        minfo("Trying to connect to server (%s:%d).",
+        minfo("Trying to connect to server (%s:%d/%s).",
                 agt->server[rc].rip,
-                agt->server[rc].port);
+                agt->server[rc].port,
+                agt->server[rc].protocol == UDP_PROTO ? "udp" : "tcp");
 
         if (agt->server[rc].protocol == UDP_PROTO) {
             agt->sock = OS_ConnectUDP(agt->server[rc].port, tmp_str, strchr(tmp_str, ':') != NULL);
@@ -213,7 +215,7 @@ void start_agent(int is_startup)
                     available_server = time(0);
 
                     minfo(AG_CONNECTED, agt->server[agt->rip_id].rip,
-                            agt->server[agt->rip_id].port);
+                            agt->server[agt->rip_id].port, agt->server[agt->rip_id].protocol == UDP_PROTO ? "udp" : "tcp");
 
                     if (is_startup) {
                         /* Send log message about start up */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -231,7 +231,7 @@
 
 /* Agent errors */
 #define AG_WAIT_SERVER  "(4101): Waiting for server reply (not started). Tried: '%s'."
-#define AG_CONNECTED    "(4102): Connected to the server (%s:%d)."
+#define AG_CONNECTED    "(4102): Connected to the server (%s:%d/%s)."
 #define AG_USINGIP      "(4103): Server IP address already set. Trying that before the hostname."
 #define AG_INV_HOST     "(4104): Invalid hostname: '%s'."
 #define AG_INV_IP       "(4105): No valid server IP found."

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -444,7 +444,7 @@ int SendMSG(__attribute__((unused)) int queue, const char *message, const char *
                     }
                 }
 
-                minfo(AG_CONNECTED, agt->server[agt->rip_id].rip, agt->server[agt->rip_id].port);
+                minfo(AG_CONNECTED, agt->server[agt->rip_id].rip, agt->server[agt->rip_id].port, agt->server[agt->rip_id].protocol == UDP_PROTO ? "udp" : "tcp");
                 minfo(SERVER_UP);
                 update_status(GA_STATUS_ACTIVE);
             }


### PR DESCRIPTION
The agent will show the network protocol when connecting to the manager:

> 2018/07/22 14:00:11 ossec-agentd: INFO: Started (pid: 6431).
> 2018/07/22 14:00:11 ossec-agentd: INFO: Server IP Address: 192.168.33.10
> 2018/07/22 14:00:11 ossec-agentd: INFO: Trying to connect to server (192.168.33.10:1514/tcp).
> 2018/07/22 14:00:11 ossec-agentd: INFO: (4102): Connected to the server (192.168.33.10:1514/tcp).
