### PR TITLE
Fix WPK upgrade with via MSI packages on Windows

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -11,9 +11,10 @@ function install
 {
     kill -processname win32ui -ErrorAction SilentlyContinue -Force
     Remove-Item .\upgrade\upgrade_result -ErrorAction SilentlyContinue
-    $proc = Start-Process "msiexec" -ArgumentList '/i "wazuh-agent-3.4.0-1.msi" /passive /L*V install.log'
+    write-output "$(Get-Date -format u) - Start-Process." >> .\upgrade.log
+	$installer = (Get-Item wazuh-agent*.msi).Basename
+	$proc = Start-Process "msiexec" -ArgumentList "$('/i "' + $($installer) + '.msi" /quiet /L*V install.log')" -Passthru
     $proc.WaitForExit()
-    write-output "$(Get-Date -format u) - Process-Finished." >> .\upgrade.log
 }
 
 function restore
@@ -34,7 +35,6 @@ backup
 # Install
 write-output "$(Get-Date -format u) - Installing" >> .\upgrade.log
 install
-
 write-output "$(Get-Date -format u) - Installation finished." >> .\upgrade.log
 
 # Check process status

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -41,10 +41,10 @@ while($process_id -ne $null -And $counter -gt 0)
 {
     write-output "$(Get-Date -format u) - Trying to stop Wazuh service again. Remaining attempts: $counter." >> .\upgrade.log
     $counter--
-    Get-Service -Name "Wazuh" | Stop-Service 
+    Get-Service -Name "Wazuh" | Stop-Service
     taskkill /pid $process_id /f /T
     Start-Sleep 2
-    $process_id = (Get-Process ossec-agent -ErrorAction SilentlyContinue).id 
+    $process_id = (Get-Process ossec-agent -ErrorAction SilentlyContinue).id
 }
 
 # Install
@@ -54,10 +54,10 @@ write-output "$(Get-Date -format u) - Installation in progress." >> .\upgrade.lo
 # Check new version
 $new_version = (Get-Content VERSION)
 $counter = 10
-while($new_version -eq $current_version)
+while($new_version -eq $current_version -And $counter -gt 0)
 {
     write-output "$(Get-Date -format u) - Waiting for the installation end." >> .\upgrade.log
-    counter --
+    $counter--
     Start-Sleep 2
 }
 

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -11,7 +11,9 @@ function install
 {
     kill -processname win32ui -ErrorAction SilentlyContinue -Force
     Remove-Item .\upgrade\upgrade_result -ErrorAction SilentlyContinue
-    Start-Process -FilePath (Get-ChildItem ".\wazuh-agent*.msi") -ArgumentList '/q /L*V install.log' -Wait
+    $proc = Start-Process "msiexec" -ArgumentList '/i "wazuh-agent-3.4.0-1.msi" /passive /L*V install.log'
+    $proc.WaitForExit()
+    write-output "$(Get-Date -format u) - Process-Finished." >> .\upgrade.log
 }
 
 function restore
@@ -33,16 +35,6 @@ backup
 write-output "$(Get-Date -format u) - Installing" >> .\upgrade.log
 install
 
-# Wait for installation completion
-Start-Sleep 5
-$new_file_date = (Get-Item ".\ossec-agent.exe").LastWriteTime
-$counter = 5
-while($current_file_date -ne $new_file_date -And $counter -gt 0)
-{
-    $counter--
-    Start-Sleep 2
-    $new_file_date = (Get-Item ".\ossec-agent.exe").LastWriteTime
-}
 write-output "$(Get-Date -format u) - Installation finished." >> .\upgrade.log
 
 # Check process status
@@ -83,3 +75,4 @@ Else
     $new_version = (Get-Content VERSION)
     write-output "$(Get-Date -format u) - New version: $($new_version)" >> .\upgrade.log
 }
+

--- a/src/win32/upgrade.bat
+++ b/src/win32/upgrade.bat
@@ -17,5 +17,4 @@ DEL do_upgrade.ps1
 DEL wazuh-agent-*.msi
 DEL upgrade.bat
 
-
 :end

--- a/src/win32/upgrade.bat
+++ b/src/win32/upgrade.bat
@@ -2,11 +2,20 @@
 
 IF "%1"=="B" GOTO background
 
-START /B upgrade\upgrade.bat B
+COPY upgrade\upgrade.bat . > NUL
+COPY upgrade\do_upgrade.ps1 . > NUL
+COPY upgrade\wazuh-agent-*.msi . > NUL
+
+START /B upgrade.bat B
 GOTO end
 
 :background
 SLEEP 5 2> NUL || ping -n 5 127.0.0.1 > NUL
-powershell -ExecutionPolicy ByPass -File upgrade\do_upgrade.ps1
+powershell -ExecutionPolicy ByPass -File do_upgrade.ps1
+
+DEL do_upgrade.ps1
+DEL wazuh-agent-*.msi
+DEL upgrade.bat
+
 
 :end

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -218,35 +218,35 @@
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="QUEUE">
-            <Component Id="CMP_QUEUE" Guid="1CA9BF16-F0B2-4E91-BA09-023518E50624" KeyPath="yes">
+            <Component Id="CMP_QUEUE" Guid="1CA9BF16-F0B2-4E91-BA09-023518E50624" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
                 <RemoveFile Id="purgue_queue" Name="*.*" On="uninstall" />
                 <RemoveFolder Id="purgue_queue_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="DIFF">
-            <Component Id="CMP_DIFF" Guid="AF666E2C-5C12-4355-9BB7-8FA9463ACDF2" KeyPath="yes">
+            <Component Id="CMP_DIFF" Guid="AF666E2C-5C12-4355-9BB7-8FA9463ACDF2" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
                 <RemoveFile Id="purgue_diff" Name="*.*" On="uninstall" />
                 <RemoveFolder Id="purgue_diff_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="BOOKMARKS">
-            <Component Id="CMP_BOOKMARKS" Guid="1A441B10-7735-4507-9DB7-6158CA5D7687" KeyPath="yes">
+            <Component Id="CMP_BOOKMARKS" Guid="1A441B10-7735-4507-9DB7-6158CA5D7687" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
                 <RemoveFile Id="purgue_bookmarks" Name="*.*" On="uninstall" />
                 <RemoveFolder Id="purgue_bookmarks_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="LOGS">
-            <Component Id="CMP_LOGS" Guid="17C9F68D-D1E6-4452-8C3E-992F6D7F0CF1" KeyPath="yes">
+            <Component Id="CMP_LOGS" Guid="17C9F68D-D1E6-4452-8C3E-992F6D7F0CF1" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
                 <RemoveFile Id="purgue_logs" Name="*.*" On="uninstall" />
                 <RemoveFolder Id="purgue_logs_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="WODLES">
-            <Component Id="CMP_WODLES" Guid="A6811CB8-C2E2-4A1A-A2E5-DCE8221828C6" KeyPath="yes">
+            <Component Id="CMP_WODLES" Guid="A6811CB8-C2E2-4A1A-A2E5-DCE8221828C6" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
                 <RemoveFile Id="purgue_wodles" Name="*.*" On="uninstall" />
                 <RemoveFolder Id="purgue_wodles_dir" On="uninstall" />
@@ -255,10 +255,12 @@
         <DirectoryRef Id="RIDS">
             <Component Id="CMP_RIDS" Guid="2052A162-F044-4432-BF50-F89BCD0BC5D1" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
+                <RemoveFile Id="purgue_rids" Name="*.*" On="uninstall" />
+                <RemoveFolder Id="purgue_rids_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="SYSCHECK">
-            <Component Id="CMP_SYSCHECK" Guid="F6841291-B9C5-4B74-82ED-CB9031C85C31" KeyPath="yes">
+            <Component Id="CMP_SYSCHECK" Guid="F6841291-B9C5-4B74-82ED-CB9031C85C31" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
                 <RemoveFile Id="purgue_syscheck" Name="*.*" On="uninstall" />
                 <RemoveFolder Id="purgue_syscheck_dir" On="uninstall" />
@@ -272,12 +274,14 @@
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="UPGRADE">
-            <Component Id="CMP_UPGRADE" Guid="9FB42D24-217F-4E13-9598-01B62040F768" KeyPath="yes">
+            <Component Id="CMP_UPGRADE" Guid="9FB42D24-217F-4E13-9598-01B62040F768" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
+                <RemoveFile Id="purgue_upgrade" Name="*.*" On="uninstall" />
+                <RemoveFolder Id="purgue_upgrade_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="SHARED">
-            <Component Id="CMP_SHARED" Guid="9FB42D24-222F-4E13-9598-01B62040F768" KeyPath="yes">
+            <Component Id="CMP_SHARED" Guid="9FB42D24-222F-4E13-9598-01B62040F768" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
                 <RemoveFile Id="purgue_shared" Name="*.*" On="uninstall" />
                 <RemoveFolder Id="purgue_shared_dir" On="uninstall" />

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -206,10 +206,8 @@
             </Directory>
         </Directory>
         <DirectoryRef Id="ACTIVE_RESPONSE">
-            <Component Id="CMP_ACTIVE_RESPONSE" Guid="EC4352C1-4240-4E6A-9A5E-E31F22702705" KeyPath="yes">
+            <Component Id="CMP_ACTIVE_RESPONSE" Guid="EC4352C1-4240-4E6A-9A5E-E31F22702705" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
-                <RemoveFile Id="purgue_active_response" Name="*.*" On="uninstall" />
-                <RemoveFolder Id="purgue_active_response_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="TMP">
@@ -255,10 +253,8 @@
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="RIDS">
-            <Component Id="CMP_RIDS" Guid="2052A162-F044-4432-BF50-F89BCD0BC5D1" KeyPath="yes">
+            <Component Id="CMP_RIDS" Guid="2052A162-F044-4432-BF50-F89BCD0BC5D1" KeyPath="yes" NeverOverwrite="yes" Permanent="yes">
                 <CreateFolder />
-                <RemoveFile Id="purgue_rids" Name="*.*" On="uninstall" />
-                <RemoveFolder Id="purgue_rids_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="SYSCHECK">
@@ -278,8 +274,6 @@
         <DirectoryRef Id="UPGRADE">
             <Component Id="CMP_UPGRADE" Guid="9FB42D24-217F-4E13-9598-01B62040F768" KeyPath="yes">
                 <CreateFolder />
-                <RemoveFile Id="purgue_upgrade" Name="*.*" On="uninstall" />
-                <RemoveFolder Id="purgue_upgrade_dir" On="uninstall" />
             </Component>
         </DirectoryRef>
         <DirectoryRef Id="SHARED">


### PR DESCRIPTION
The main goal of this PR is to include the MSI package into the remote upgrade procedure for Windows agents instead of the EXE package. This change includes the following advantages among others:

- It has been solved the inconsistencies when upgrading an MSI Wazuh agent with an EXE package, being registered as different packages in the Windows registry.
- Binaries and different programs installed by the MSI package are properly signed and they do not cause false positives by anti-virus such as VirusTotal. This is why the previous procedure (by upgrading to an EXE package) was not a good practice.

## Unit tests

- [x] Windows Server 2008 R2
- [x] Windows 7
- [x] Windows Server 2012
- [x] Windows 10
- [x] Windows Server 2016
- [x] MSI -> MSI
- [x] EXE -> MSI


