### PR TITLE
Improve cluster_control to show an error if the status does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
     - Message input buffer in Analysisd to prevent control messages starvation in Remoted.
 - Module to download shared files for agent groups dinamically. ([#519](https://github.com/wazuh/wazuh/pull/519))
 - Option to download the wpk using http in `agent_upgrade`. ([#798](https://github.com/wazuh/wazuh/pull/798))
+- `cluster_control` shows an error if the status does not exist. ([#1002](https://github.com/wazuh/wazuh/pull/1002))
 
 ### Changed
 

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -248,7 +248,6 @@ def sync_master(filter_node):
 ### Get agents
 def print_agents(filter_status=None, filter_node=None):
     total_agents = 0
-    
 
     try:
         gen_agents = get_agents(filter_status, filter_node)
@@ -264,7 +263,6 @@ def print_agents(filter_status=None, filter_node=None):
     except Exception as e:
         print ("{}".format(e))
         exit(1)
-
 
     if filter_status:
         print ("\nFound {} agent(s) with status '{}'.".format(total_agents, filter_status))

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -247,16 +247,24 @@ def sync_master(filter_node):
 
 ### Get agents
 def print_agents(filter_status=None, filter_node=None):
-    gen_agents = get_agents(filter_status, filter_node)
     total_agents = 0
+    
 
-    for agents in gen_agents:
-        table_str = ""
-        total_agents += len(agents['items'])
-        for agent in agents['items']:
-            table_str += "  ID: {}, Name: {}, IP: {}, Status: {},  Node: {}\n".format(agent['id'], agent['name'], agent['ip'], agent['status'], agent['node_name'])
-        stdout.write(table_str)
-        stdout.flush()
+    try:
+        gen_agents = get_agents(filter_status, filter_node)
+
+        for agents in gen_agents:
+            table_str = ""
+            total_agents += len(agents['items'])
+            for agent in agents['items']:
+                table_str += "  ID: {}, Name: {}, IP: {}, Status: {},  Node: {}\n".format(agent['id'], agent['name'], agent['ip'], agent['status'], agent['node_name'])
+            stdout.write(table_str)
+            stdout.flush()
+
+    except Exception as e:
+        print ("{}".format(e))
+        exit(1)
+
 
     if filter_status:
         print ("\nFound {} agent(s) with status '{}'.".format(total_agents, filter_status))


### PR DESCRIPTION
Hi team,

this PR improves `cluster_control -a` to show an error if the agent status does not exist.

### Before
```
$python /var/ossec/bin/cluster_control -a -fs wrong_status

```

### Now
```
$ python /var/ossec/bin/cluster_control -a -fs wrong_status
Error 3008 - Received invalid agent status: 'wrong_status' is not a valid agent status. Try with 'Active', 'Disconnected', 'NeverConnected' or 'Pending'.
```

Regards,
Javi.