### PR TITLE
Fix bug when using the search parameter in GET/decoders API request

### DIFF
--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -186,7 +186,7 @@ def get_values(o, fields=None):
             if not fields or key in fields:
                 strings.extend(get_values(obj[key]))
     else:
-        strings.append(obj.lower() if isinstance(obj, str) or isinstance(obj, unicode) else obj)
+        strings.append(obj.lower() if isinstance(obj, str) or isinstance(obj, unicode) else str(obj))
 
     return strings
 
@@ -207,8 +207,6 @@ def search_array(array, text, negation=False, fields=None):
     for item in array:
 
         values = get_values(o=item, fields=fields)
-
-        # print("'{0}' in '{1}'?".format(text, values))
 
         if not negation:
             for v in values:


### PR DESCRIPTION
Hello team,

This PR fixes wazuh/wazuh-api#137.

## Testing
### Python 2.7
#### Failed use case
```javascript
# curl -u foo:bar "localhost:55000/decoders?pretty&search=test"
{
   "error": 0,
   "data": {
      "totalItems": 0,
      "items": []
   }
}
```

#### Searching for existing decoders
```javascript
# curl -u foo:bar "localhost:55000/decoders?pretty&search=ssh&limit=3"
{
   "error": 0,
   "data": {
      "totalItems": 25,
      "items": [
         {
            "status": "enabled",
            "name": "sshd",
            "details": {
               "program_name": "^sshd"
            },
            "file": "0310-ssh_decoders.xml",
            "position": 0,
            "path": "/var/ossec/ruleset/decoders"
         },
         {
            "status": "enabled",
            "name": "sshd-success",
            "details": {
               "regex": "^ \\S+ for (\\S+) from (\\S+) port ",
               "fts": "name, user, location",
               "prematch": "^Accepted",
               "parent": "sshd",
               "order": "user, srcip"
            },
            "file": "0310-ssh_decoders.xml",
            "position": 1,
            "path": "/var/ossec/ruleset/decoders"
         },
         {
            "status": "enabled",
            "name": "ssh-denied",
            "details": {
               "regex": "^User (\\S+) from (\\S+) ",
               "prematch": "^User \\S+ from ",
               "parent": "sshd",
               "order": "user, srcip"
            },
            "file": "0310-ssh_decoders.xml",
            "position": 2,
            "path": "/var/ossec/ruleset/decoders"
         }
      ]
   }
}
```

#### Searching in logs with strange characters (wazuh/wazuh-api#100)
```javascript
# curl -u foo:bar "localhost:55000/manager/logs?pretty&search=Intel"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "timestamp": "2018-06-08 11:00:56",
            "tag": "wazuh-db",
            "description": "Executing query: program save 1514944612|2018/06/08 02:00:51|rpm|iwl4965-firmware|CentOS|228.61.2.24-58.el7_4|noarch|Firmware for Intel® PRO/Wireless 4965 A/G/N network adaptors",
            "level": "debug"
         }
      ]
   }
}
```

### Python 3.6

#### Failed use case
```javascript
# curl -u foo:bar "localhost:55000/decoders?pretty&search=test"
{
   "error": 0,
   "data": {
      "items": [],
      "totalItems": 0
   }
}
```

#### Searching for existing decoders
```javascript
# curl -u foo:bar "localhost:55000/decoders?pretty&search=ssh&limit=3"
{
   "error": 0,
   "data": {
      "items": [
         {
            "file": "0310-ssh_decoders.xml",
            "path": "/var/ossec/ruleset/decoders",
            "name": "sshd",
            "position": 0,
            "status": "enabled",
            "details": {
               "program_name": "^sshd"
            }
         },
         {
            "file": "0310-ssh_decoders.xml",
            "path": "/var/ossec/ruleset/decoders",
            "name": "sshd-success",
            "position": 1,
            "status": "enabled",
            "details": {
               "parent": "sshd",
               "prematch": "^Accepted",
               "regex": "^ \\S+ for (\\S+) from (\\S+) port ",
               "order": "user, srcip",
               "fts": "name, user, location"
            }
         },
         {
            "file": "0310-ssh_decoders.xml",
            "path": "/var/ossec/ruleset/decoders",
            "name": "ssh-denied",
            "position": 2,
            "status": "enabled",
            "details": {
               "parent": "sshd",
               "prematch": "^User \\S+ from ",
               "regex": "^User (\\S+) from (\\S+) ",
               "order": "user, srcip"
            }
         }
      ],
      "totalItems": 25
   }
}
```

#### Searching for logs with strange characters (wazuh/wazuh-api#100)
```javascript
# curl -u foo:bar "localhost:55000/manager/logs?pretty&search=Intel"
{
   "error": 0,
   "data": {
      "items": [
         {
            "timestamp": "2018-06-08 11:00:56",
            "tag": "wazuh-db",
            "level": "debug",
            "description": "Executing query: program save 1514944612|2018/06/08 02:00:51|rpm|iwl4965-firmware|CentOS|228.61.2.24-58.el7_4|noarch|Firmware for Intel® PRO/Wireless 4965 A/G/N network adaptors"
         }
      ],
      "totalItems": 1
   }
}
```

Best regards,
Marta