### PR TITLE
Do not allow limit=0 or limit>maximun in distinct requests

### DIFF
--- a/framework/wazuh/distinct.py
+++ b/framework/wazuh/distinct.py
@@ -85,6 +85,11 @@ def _get_distinct_items(valid_select_fields, table, select={}, offset=0, limit=c
                         search={}, sort={}, nest=[], filter_fields={}):
     offset = int(offset)
     limit = int(limit)
+    if limit:
+        if limit > common.maximum_database_limit:
+            raise WazuhException(1405, str(limit))
+    elif limit == 0:
+        raise WazuhException(1406)
 
     if select:
         incorrect_fields = map(lambda x: str(x), set(select['fields']) - set(valid_select_fields.keys()))


### PR DESCRIPTION
Hi,

this PR fixes the issue https://github.com/wazuh/wazuh/issues/1006.

### Sample

```
$ curl -u foo:bar -k "http://127.0.0.1:55000/agents/stats/distinct?pretty&limit=10000"
{
   "error": 1405,
   "message": "Specified limit exceeds maximum allowed (1000): 10000"
}

$ curl -u foo:bar -k "http://127.0.0.1:55000/agents/stats/distinct?pretty&limit=0"
{
   "error": 1406,
   "message": "0 is not a valid limit."
}

$ curl -u foo:bar -k "http://127.0.0.1:55000/agents/stats/distinct?pretty&limit=1"
{
   "error": 0,
   "data": {
      "totalItems": 4,
      "items": [
         {
            "count": 1,
            "version": "Wazuh v3.5.0",
            "group": null,
            "manager_host": "manager",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |manager |3.10.0-693.21.1.el7.x86_64 |#1 SMP Wed Mar 7 19:03:37 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "build": null,
               "codename": "Core",
               "arch": "x86_64",
               "minor": null
            },
            "node_name": "node01"
         }
      ]
   }
}
```

Regards,
Javi.