### PR TITLE
Filter select fields in distinct requests

### DIFF
--- a/framework/wazuh/distinct.py
+++ b/framework/wazuh/distinct.py
@@ -89,12 +89,18 @@ def _get_distinct_items(valid_select_fields, table, select={}, offset=0, limit=c
     if select:
         incorrect_fields = map(lambda x: str(x), set(select['fields']) - set(valid_select_fields.keys()))
         if incorrect_fields:
-            raise WazuhException(1724, "Allowed select fields: {0}. Fields {1}".\
+            raise WazuhException(1724, "Allowed fields: {0}. Fields {1}".\
                 format(', '.join(valid_select_fields.keys()), ','.join(incorrect_fields)))
 
         select_fields = {field:valid_select_fields[field] for field in select['fields'] if field in valid_select_fields.keys()}
     else:
         select_fields = valid_select_fields
+
+    if filter_fields:
+        incorrect_fields = map(lambda x: str(x), set(filter_fields['fields']) - set(valid_select_fields.keys()))
+        if incorrect_fields:
+            raise WazuhException(1724, "Allowed select fields: {0}. Fields {1}".\
+                format(', '.join(valid_select_fields.keys()), ','.join(incorrect_fields)))
 
     if sort:
         if not set(sort.get('fields')).issubset(select_fields.keys()):


### PR DESCRIPTION
Hi team,

this PR fixes the issue https://github.com/wazuh/wazuh/issues/1008.

### Sample
```
$ curl -u foo:bar -k "http://127.0.0.1:55000/agents/stats/distinct?pretty&select=wrong"
{
   "error": 1724,
   "message": "Not a valid select field: Allowed select fields: os.major, os.version, os.arch, os.codename, os.minor, os.name, os.platform, group, os.uname, os.build, node_name, version, manager_host. Fields wrong"
}

$ curl -u foo:bar -k "http://127.0.0.1:55000/agents/stats/distinct?pretty&fields=wrong"
{
   "error": 1724,
   "message": "Not a valid select field: Allowed fields: os.major, os.version, os.arch, os.codename, os.minor, os.name, os.platform, group, os.uname, os.build, node_name, version, manager_host. Fields wrong"
}

$ curl -u foo:bar -k "http://127.0.0.1:55000/agents/stats/distinct?pretty&fields=os.minor,group&select=group"
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "group": null
         },
         {
            "group": "default"
         }
      ]
   }
}
```

Regards,
Javi.