### PR TITLE
Fix centos5 default configuration file

### DIFF
--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -39,9 +39,15 @@ else
 
     # RedHat
     elif [ -r "/etc/redhat-release" ]; then
-        DIST_NAME="rhel"
-        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
-        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.([0-9]{1,2}).*/\1/p' /etc/redhat-release`
+        if [ `grep -ri CentOS /etc/redhat-release` -eq "" ]; then
+            DIST_NAME="rhel"
+            DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
+            DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.([0-9]{1,2}).*/\1/p' /etc/redhat-release`
+        else
+            DIST_NAME="centos"
+            DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
+            DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.([0-9]{1,2}).*/\1/p' /etc/redhat-release`
+        fi
 
     # Ubuntu
     elif [ -r "/etc/lsb-release" ]; then

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -32,7 +32,6 @@ AUTH_TEMPLATE="./etc/templates/config/generic/auth.template"
 CLUSTER_TEMPLATE="./etc/templates/config/generic/cluster.template"
 
 CISCAT_TEMPLATE="./etc/templates/config/generic/wodle-ciscat.template"
-SYSC_TEMPLATE="./etc/templates/config/generic/wodle-syscollector.template"
 VULN_TEMPLATE="./etc/templates/config/generic/wodle-vulnerability-detector.manager.template"
 
 ##########
@@ -141,8 +140,7 @@ WriteCISCAT()
 {
     # Adding to the config file
     CISCAT_TEMPLATE=$(GetTemplate "wodle-ciscat.$1.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
-    if [ "$CISCAT_TEMPLATE" = "ERROR_NOT_FOUND" ]
-    then
+    if [ "$CISCAT_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
         CISCAT_TEMPLATE=$(GetTemplate "wodle-ciscat.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
     fi
     sed -e "s|\${INSTALLDIR}|$INSTALLDIR|g" "${CISCAT_TEMPLATE}" >> $NEWCONFIG


### PR DESCRIPTION
Wazuh interprets the _CentOS 5_ systems as _RHEL 5_ due to the file _"/etc/redhat-release"_, this PR checks the contents of this file, and if it contains the string "CentOS" it applies the configuration for this system.