### PR TITLE
Hide the ossec user in MacOS X

### DIFF
--- a/src/init/osx105-addusers.sh
+++ b/src/init/osx105-addusers.sh
@@ -107,3 +107,7 @@ for U in ${NEWUSERS}; do
 
     i=$[i+1]
 done
+
+sudo ${DSCL} . create /Users/ossec IsHidden 1
+sudo ${DSCL} . create /Users/ossecm IsHidden 1
+sudo ${DSCL} . create /Users/ossecr IsHidden 1


### PR DESCRIPTION
This feature will hide ossec users from the login screen in MacOS X.