### PR TITLE
Prevent Remoted from downloading shared files if option '-m' is enabled

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -220,6 +220,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum) {
     char merged[PATH_MAX + 1];
     char file[PATH_MAX + 1];
     unsigned int i;
+    remote_files_group *r_group;
 
     /* Create merged file */
     os_calloc(2, sizeof(file_sum *), f_sum);
@@ -232,8 +233,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum) {
 
     snprintf(merged, PATH_MAX + 1, "%s/%s/%s", SHAREDCFG_DIR, group, SHAREDCFG_FILENAME);
 
-    remote_files_group *r_group = w_parser_get_group(group);
-    if(r_group){
+    if (!logr.nocmerged && (r_group = w_parser_get_group(group), r_group)) {
         if(r_group->current_polling_time <= 0){
             r_group->current_polling_time = r_group->poll;
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -220,7 +220,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum) {
     char merged[PATH_MAX + 1];
     char file[PATH_MAX + 1];
     unsigned int i;
-    remote_files_group *r_group;
+    remote_files_group *r_group = NULL;
 
     /* Create merged file */
     os_calloc(2, sizeof(file_sum *), f_sum);


### PR DESCRIPTION
The option `-m` for Remoted prevents it from updating the file _merged.mg_. In other words, that option makes shared files read-only artifacts.

If _etc/shared/files.yml_ exists, Remoted is parsing it and downloading the shared files no matter if option `-m` is activated.

This PR aims to make `-m` prevent Remoted from downloading shared files event if they are declared in the _files.yml_.