### PR TITLE
Fix scan_id length for processes scan

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1030,16 +1030,15 @@ int decode_process(char *agent_id, cJSON * logJSON) {
 
     int i;
     char * msg = NULL;
-
-    cJSON * inventory;
     cJSON * scan_id;
+
+    if (scan_id = cJSON_GetObjectItem(logJSON, "ID"), !scan_id) {
+        return -1;
+    }
 
     os_calloc(OS_MAXSTR, sizeof(char), msg);
 
-    if (scan_id = cJSON_GetObjectItem(logJSON, "ID"), !scan_id) {
-        free(msg);
-        return -1;
-    }
+    cJSON * inventory;
 
     if (inventory = cJSON_GetObjectItem(logJSON, "process"), inventory) {
         if (error_process) {

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -30,13 +30,13 @@ hw_info *get_system_bsd();    // Get system information
 
 #if defined(__MACH__)
 
-char* sys_parse_pkg(const char * app_folder, const char * timestamp, int ID);
+char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_id);
 
 // Get installed programs inventory
 
 void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -62,8 +62,8 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
     /* Set positive random ID for each event */
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     dr = opendir(MAC_APPS);
 
@@ -79,7 +79,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
             } else if (strstr(de->d_name, ".app")) {
                 snprintf(path, PATH_LENGTH - 1, "%s/%s", MAC_APPS, de->d_name);
                 char * string = NULL;
-                if (string = sys_parse_pkg(path, timestamp, ID), string) {
+                if (string = sys_parse_pkg(path, timestamp, random_id), string) {
 
                     mtdebug2(WM_SYS_LOGTAG, "sys_packages_bsd() sending '%s'", string);
                     wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
@@ -106,7 +106,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
             } else if (strstr(de->d_name, ".app")) {
                 snprintf(path, PATH_LENGTH - 1, "%s/%s", UTILITIES, de->d_name);
                 char * string = NULL;
-                if (string = sys_parse_pkg(path, timestamp, ID), string) {
+                if (string = sys_parse_pkg(path, timestamp, random_id), string) {
 
                     mtdebug2(WM_SYS_LOGTAG, "sys_packages_bsd() sending '%s'", string);
                     wm_sendmsg(usec, queue_fd, string, LOCATION, SYSCOLLECTOR_MQ);
@@ -138,7 +138,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
             cJSON *object = cJSON_CreateObject();
             cJSON *package = cJSON_CreateObject();
             cJSON_AddStringToObject(object, "type", "program");
-            cJSON_AddNumberToObject(object, "ID", ID);
+            cJSON_AddNumberToObject(object, "ID", random_id);
             cJSON_AddStringToObject(object, "timestamp", timestamp);
             cJSON_AddItemToObject(object, "program", package);
             cJSON_AddStringToObject(package, "format", "pkg");
@@ -188,7 +188,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
     cJSON *object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "program_end");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     char *string;
@@ -200,7 +200,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
     free(timestamp);
 }
 
-char* sys_parse_pkg(const char * app_folder, const char * timestamp, int ID) {
+char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_id) {
 
     char read_buff[OS_MAXSTR];
     FILE *fp;
@@ -215,7 +215,7 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int ID) {
         cJSON *object = cJSON_CreateObject();
         cJSON *package = cJSON_CreateObject();
         cJSON_AddStringToObject(object, "type", "program");
-        cJSON_AddNumberToObject(object, "ID", ID);
+        cJSON_AddNumberToObject(object, "ID", random_id);
         cJSON_AddStringToObject(object, "timestamp", timestamp);
         cJSON_AddItemToObject(object, "program", package);
         cJSON_AddStringToObject(package, "format", "pkg");
@@ -309,7 +309,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
     char *command;
     FILE *output;
     int i;
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -331,8 +331,8 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
     /* Set positive random ID for each event */
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     os_calloc(COMMAND_LENGTH, sizeof(char), command);
     snprintf(command, COMMAND_LENGTH - 1, "%s", "pkg query -a '\%n|%m|%v|%q|\%c'");
@@ -346,7 +346,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
             cJSON *object = cJSON_CreateObject();
             cJSON *package = cJSON_CreateObject();
             cJSON_AddStringToObject(object, "type", "program");
-            cJSON_AddNumberToObject(object, "ID", ID);
+            cJSON_AddNumberToObject(object, "ID", random_id);
             cJSON_AddStringToObject(object, "timestamp", timestamp);
             cJSON_AddItemToObject(object, "program", package);
             cJSON_AddStringToObject(package, "format", "pkg");
@@ -391,7 +391,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
     cJSON *object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "program_end");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     char *string;
@@ -410,7 +410,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
 void sys_hw_bsd(int queue_fd, const char* LOCATION){
 
     char *string;
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -424,15 +424,15 @@ void sys_hw_bsd(int queue_fd, const char* LOCATION){
             localtm.tm_year + 1900, localtm.tm_mon + 1,
             localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     mtdebug1(WM_SYS_LOGTAG, "Starting Hardware inventory");
 
     cJSON *object = cJSON_CreateObject();
     cJSON *hw_inventory = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "hardware");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
     cJSON_AddItemToObject(object, "inventory", hw_inventory);
 
@@ -639,7 +639,7 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
     int i = 0, j = 0, found;
     struct ifaddrs *ifaddrs_ptr, *ifa;
     int family;
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -656,8 +656,8 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
             localtm.tm_year + 1900, localtm.tm_mon + 1,
             localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     mtdebug1(WM_SYS_LOGTAG, "Starting network inventory.");
 
@@ -705,7 +705,7 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
         cJSON *object = cJSON_CreateObject();
         cJSON *interface = cJSON_CreateObject();
         cJSON_AddStringToObject(object, "type", "network");
-        cJSON_AddNumberToObject(object, "ID", ID);
+        cJSON_AddNumberToObject(object, "ID", random_id);
         cJSON_AddStringToObject(object, "timestamp", timestamp);
         cJSON_AddItemToObject(object, "iface", interface);
         cJSON_AddStringToObject(interface, "name", ifaces_list[i]);
@@ -947,7 +947,7 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
 
     cJSON *object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "network_end");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     char *string;

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -82,7 +82,7 @@ char* get_port_state(int state){
 
 // Get opened ports related to IPv4 sockets
 
-void get_ipv4_ports(int queue_fd, const char* LOCATION, const char* protocol, int ID, const char* timestamp, int check_all){
+void get_ipv4_ports(int queue_fd, const char* LOCATION, const char* protocol, int random_id, const char* timestamp, int check_all){
 
     unsigned long rxq, txq, time_len, retr, inode;
     int local_port, rem_port, d, state, uid, timer_run, timeout;
@@ -130,7 +130,7 @@ void get_ipv4_ports(int queue_fd, const char* LOCATION, const char* protocol, in
             cJSON *object = cJSON_CreateObject();
             cJSON *port = cJSON_CreateObject();
             cJSON_AddStringToObject(object, "type", "port");
-            cJSON_AddNumberToObject(object, "ID", ID);
+            cJSON_AddNumberToObject(object, "ID", random_id);
             cJSON_AddStringToObject(object, "timestamp", timestamp);
             cJSON_AddItemToObject(object, "port", port);
             cJSON_AddStringToObject(port, "protocol", protocol);
@@ -175,7 +175,7 @@ void get_ipv4_ports(int queue_fd, const char* LOCATION, const char* protocol, in
 
 // Get opened ports related to IPv6 sockets
 
-void get_ipv6_ports(int queue_fd, const char* LOCATION, const char* protocol, int ID, const char * timestamp, int check_all){
+void get_ipv6_ports(int queue_fd, const char* LOCATION, const char* protocol, int random_id, const char * timestamp, int check_all){
 
     unsigned long rxq, txq, time_len, retr, inode;
     int local_port, rem_port, d, state, uid, timer_run, timeout;
@@ -225,7 +225,7 @@ void get_ipv6_ports(int queue_fd, const char* LOCATION, const char* protocol, in
             cJSON *object = cJSON_CreateObject();
             cJSON *port = cJSON_CreateObject();
             cJSON_AddStringToObject(object, "type", "port");
-            cJSON_AddNumberToObject(object, "ID", ID);
+            cJSON_AddNumberToObject(object, "ID", random_id);
             cJSON_AddStringToObject(object, "timestamp", timestamp);
             cJSON_AddItemToObject(object, "port", port);
             cJSON_AddStringToObject(port, "protocol", protocol);
@@ -271,7 +271,7 @@ void get_ipv6_ports(int queue_fd, const char* LOCATION, const char* protocol, in
 void sys_ports_linux(int queue_fd, const char* WM_SYS_LOCATION, int check_all){
 
     char *protocol;
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -285,8 +285,8 @@ void sys_ports_linux(int queue_fd, const char* WM_SYS_LOCATION, int check_all){
             localtm.tm_year + 1900, localtm.tm_mon + 1,
             localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     mtdebug1(WM_SYS_LOGTAG, "Starting ports inventory.");
 
@@ -294,29 +294,29 @@ void sys_ports_linux(int queue_fd, const char* WM_SYS_LOCATION, int check_all){
 
     /* TCP opened ports inventory */
     snprintf(protocol, PROTO_LENGTH, "%s", "tcp");
-    get_ipv4_ports(queue_fd, WM_SYS_LOCATION, protocol, ID, timestamp, check_all);
+    get_ipv4_ports(queue_fd, WM_SYS_LOCATION, protocol, random_id, timestamp, check_all);
 
     if (check_all) {
         /* UDP opened ports inventory */
         snprintf(protocol, PROTO_LENGTH, "%s", "udp");
-        get_ipv4_ports(queue_fd, WM_SYS_LOCATION, protocol, ID, timestamp, check_all);
+        get_ipv4_ports(queue_fd, WM_SYS_LOCATION, protocol, random_id, timestamp, check_all);
     }
 
     /* TCP6 opened ports inventory */
     snprintf(protocol, PROTO_LENGTH, "%s", "tcp6");
-    get_ipv6_ports(queue_fd, WM_SYS_LOCATION, protocol, ID, timestamp, check_all);
+    get_ipv6_ports(queue_fd, WM_SYS_LOCATION, protocol, random_id, timestamp, check_all);
 
     if (check_all) {
         /* UDP6 opened ports inventory */
         snprintf(protocol, PROTO_LENGTH, "%s", "udp6");
-        get_ipv6_ports(queue_fd, WM_SYS_LOCATION, protocol, ID, timestamp, check_all);
+        get_ipv6_ports(queue_fd, WM_SYS_LOCATION, protocol, random_id, timestamp, check_all);
     }
 
     free(protocol);
 
     cJSON *object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "port_end");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     char *string;
@@ -352,7 +352,7 @@ void sys_packages_linux(int queue_fd, const char* LOCATION) {
 int sys_rpm_packages(int queue_fd, const char* LOCATION){
 
     char *format = "rpm";
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -391,8 +391,8 @@ int sys_rpm_packages(int queue_fd, const char* LOCATION){
 
     /* Set positive random ID for each event */
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     if ((ret = db_create(&dbp, NULL, 0)) != 0) {
         mterror(WM_SYS_LOGTAG, "sys_rpm_packages(): failed to initialize the DB handler: %s", db_strerror(ret));
@@ -465,7 +465,7 @@ int sys_rpm_packages(int queue_fd, const char* LOCATION){
         object = cJSON_CreateObject();
         package = cJSON_CreateObject();
         cJSON_AddStringToObject(object, "type", "program");
-        cJSON_AddNumberToObject(object, "ID", ID);
+        cJSON_AddNumberToObject(object, "ID", random_id);
         cJSON_AddStringToObject(object, "timestamp", timestamp);
         cJSON_AddItemToObject(object, "program", package);
         cJSON_AddStringToObject(package, "format", format);
@@ -573,7 +573,7 @@ int sys_rpm_packages(int queue_fd, const char* LOCATION){
 
     object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "program_end");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     char *end_msg;
@@ -596,7 +596,7 @@ int sys_deb_packages(int queue_fd, const char* LOCATION){
     FILE *fp;
     size_t length;
     int i, installed = 1;
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -619,8 +619,8 @@ int sys_deb_packages(int queue_fd, const char* LOCATION){
 
     /* Set positive random ID for each event */
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     memset(read_buff, 0, OS_MAXSTR);
 
@@ -637,7 +637,7 @@ int sys_deb_packages(int queue_fd, const char* LOCATION){
                 object = cJSON_CreateObject();
                 package = cJSON_CreateObject();
                 cJSON_AddStringToObject(object, "type", "program");
-                cJSON_AddNumberToObject(object, "ID", ID);
+                cJSON_AddNumberToObject(object, "ID", random_id);
                 cJSON_AddStringToObject(object, "timestamp", timestamp);
                 cJSON_AddItemToObject(object, "program", package);
                 cJSON_AddStringToObject(package, "format", format);
@@ -790,7 +790,7 @@ int sys_deb_packages(int queue_fd, const char* LOCATION){
 
     object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "program_end");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     char *end_msg;
@@ -810,7 +810,7 @@ int sys_deb_packages(int queue_fd, const char* LOCATION){
 void sys_hw_linux(int queue_fd, const char* LOCATION){
 
     char *string;
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -824,15 +824,15 @@ void sys_hw_linux(int queue_fd, const char* LOCATION){
             localtm.tm_year + 1900, localtm.tm_mon + 1,
             localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     mtdebug1(WM_SYS_LOGTAG, "Starting Hardware inventory.");
 
     cJSON *object = cJSON_CreateObject();
     cJSON *hw_inventory = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "hardware");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
     cJSON_AddItemToObject(object, "inventory", hw_inventory);
 
@@ -874,7 +874,7 @@ void sys_hw_linux(int queue_fd, const char* LOCATION){
 void sys_os_unix(int queue_fd, const char* LOCATION){
 
     char *string;
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -888,14 +888,14 @@ void sys_os_unix(int queue_fd, const char* LOCATION){
             localtm.tm_year + 1900, localtm.tm_mon + 1,
             localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     mtdebug1(WM_SYS_LOGTAG, "Starting Operating System inventory.");
 
     cJSON *object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "OS");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     cJSON *os_inventory = getunameJSON();
@@ -943,7 +943,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
     int i = 0, j = 0, k = 0, found;
     int family = 0;
     struct ifaddrs *ifaddr, *ifa;
-    int ID = os_random();
+    int random_id = os_random();
     char *timestamp;
     time_t now;
     struct tm localtm;
@@ -960,8 +960,8 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
             localtm.tm_year + 1900, localtm.tm_mon + 1,
             localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
 
-    if (ID < 0)
-        ID = -ID;
+    if (random_id < 0)
+        random_id = -random_id;
 
     mtdebug1(WM_SYS_LOGTAG, "Starting network inventory.");
 
@@ -1014,7 +1014,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
         cJSON *object = cJSON_CreateObject();
         cJSON *interface = cJSON_CreateObject();
         cJSON_AddStringToObject(object, "type", "network");
-        cJSON_AddNumberToObject(object, "ID", ID);
+        cJSON_AddNumberToObject(object, "ID", random_id);
         cJSON_AddStringToObject(object, "timestamp", timestamp);
         cJSON_AddItemToObject(object, "iface", interface);
         cJSON_AddStringToObject(interface, "name", ifaces_list[i]);
@@ -1261,7 +1261,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
 
     cJSON *object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "network_end");
-    cJSON_AddNumberToObject(object, "ID", ID);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     char *string;
@@ -1721,6 +1721,10 @@ void sys_proc_linux(int queue_fd, const char* LOCATION) {
     char *timestamp;
     time_t now;
     struct tm localtm;
+    int random_id = os_random();
+
+    if (random_id < 0)
+        random_id = -random_id;
 
     // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
@@ -1745,8 +1749,6 @@ void sys_proc_linux(int queue_fd, const char* LOCATION) {
         return;
     }
 
-    unsigned int random = (unsigned int)os_random();
-
     int i = 0;
     cJSON *item;
     cJSON *proc_array = cJSON_CreateArray();
@@ -1757,7 +1759,7 @@ void sys_proc_linux(int queue_fd, const char* LOCATION) {
         cJSON *object = cJSON_CreateObject();
         cJSON *process = cJSON_CreateObject();
         cJSON_AddStringToObject(object, "type", "process");
-        cJSON_AddNumberToObject(object, "ID", random);
+        cJSON_AddNumberToObject(object, "ID", random_id);
         cJSON_AddStringToObject(object, "timestamp", timestamp);
         cJSON_AddItemToObject(object, "process", process);
         cJSON_AddNumberToObject(process,"pid",proc_info->tid);
@@ -1817,7 +1819,7 @@ void sys_proc_linux(int queue_fd, const char* LOCATION) {
 
     cJSON *object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "process_end");
-    cJSON_AddNumberToObject(object, "ID", random);
+    cJSON_AddNumberToObject(object, "ID", random_id);
     cJSON_AddStringToObject(object, "timestamp", timestamp);
 
     char *end_msg;


### PR DESCRIPTION
The scan_id field was being generated as `unsigned int` for processes events. At the same time, it was stored in the database as `integer`. When a processes scan contained a `scan_id` greater than `MAX_VALUE_INT` it was being stored in the database as 2147483647 (max value integer) so the ID could be repeated between different scans.

It also includes a refactoring for the ID variable.