### PR TITLE
Fix comparing path with no_diff option

### DIFF
--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -120,7 +120,7 @@ int is_nodiff(const char *filename){
         int i;
         for (i = 0; syscheck.nodiff[i] != NULL; i++){
             if (strncasecmp(syscheck.nodiff[i], filename,
-                            strlen(filename)) == 0) {
+                            strlen(syscheck.nodiff[i])) == 0) {
                 return (TRUE);
             }
         }


### PR DESCRIPTION
When the option <no_diff> is set to not show differences in alerts, the file paths are compared with the _strncasecmp_ function. To this function is passed the number of characters to be compared, the problem comes when the paths are equal to the size of the monitored file, for example:

file -> `/root/syscheck/file`
no_diff option -> `/root/syscheck/file001`

The function returns that the paths are the same and discards showing the differences for the file that is not configured to not show differences.