### PR TITLE
Fix error with older C compilers

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -15,7 +15,7 @@
 os_info *get_win_version()
 {
     os_info *info;
-
+    unsigned int i;
     char temp[1024];
     DWORD dwRet;
     HKEY RegistryKey;
@@ -130,7 +130,7 @@ os_info *get_win_version()
                 char ** parts = OS_StrBreak('.', winver, 2);
                 info->os_major = strdup(parts[0]);
                 info->os_minor = strdup(parts[1]);
-                for (int i = 0; parts[i]; i++){
+                for (i = 0; parts[i]; i++){
                     free(parts[i]);
                 }
                 free(parts);


### PR DESCRIPTION
This fix solves the following compilation error:

```
shared/version_op.c: In function 'get_win_version':
shared/version_op.c:133:17: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
                 for (int i = 0; parts[i]; i++){
                 ^
shared/version_op.c:133:17: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
    CC shared/notify_op.o
make[1]: *** [shared/version_op.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory `/var/lib/jenkins/workspace/nigthly/src'
make: *** [winagent] Error 2
```