### PR TITLE
Prevent Authd from quitting if the agent selects an invalid IP

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -765,6 +765,17 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                 /* If IP: != 'src' overwrite the srcip */
                 if(strncmp(client_source_ip,"src",3) != 0)
                 {
+                    if (!OS_IsValidIP(client_source_ip, NULL)) {
+                        merror("Invalid IP: '%s'", client_source_ip);
+                        snprintf(response, 2048, "ERROR: Invalid IP: %s\n\n", client_source_ip);
+                        SSL_write(ssl, response, strlen(response));
+                        snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
+                        SSL_write(ssl, response, strlen(response));
+                        SSL_free(ssl);
+                        close(client.socket);
+                        continue;
+                    }
+
                     memcpy(srcip,client_source_ip,IPSIZE);
                 }
 


### PR DESCRIPTION
When an agent requests a key via Auth with an invalid source IP:
```sh
agent-auth -I 19x.168.a.b -m 192.168.33.10
```

The manager logs this critical error and quits:
```
2018/08/02 12:42:27 ossec-authd: CRITICAL: (1237): Invalid ip address: '19x.168.a.b'.
```

This PR aims to let Authd report this condition to the agent and continue working:
```
2018/08/02 14:14:46 ossec-authd: ERROR: Invalid IP: '19x.168.a.b'
```

This is the agent's log:
```
2018/08/02 02:42:58 agent-auth: INFO: Started (pid: 14728).
WARN: No authentication password provided.
INFO: Connected to 192.168.33.10:1515
INFO: Using agent name as: centos
INFO: Send request to manager. Waiting for reply.
ERROR: Invalid IP: 19x.168.a.b (from manager)
ERROR: Unable to add agent. (from manager)
ERROR: Unable to create key. Either wrong password or connection not accepted by the manager.
INFO: Connection closed.
```