### PR TITLE
Remove agent's debugging log about buffer empty

### DIFF
--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -134,7 +134,6 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
         pthread_mutex_lock(&mutex_lock);
 
         while(empty(i, j)){
-            mdebug2("Agent buffer empty.");
             pthread_cond_wait(&cond_no_empty, &mutex_lock);
         }
         /* Check if buffer usage reaches any lower level */


### PR DESCRIPTION
This PR removes this debugging log:
```
ossec-agentd: DEBUG: Agent buffer empty.
```

This is useless nowadays and may flood a log.