### PR TITLE
Decrease agent upgrade failure rule level

### DIFF
--- a/etc/rules/0016-wazuh_rules.xml
+++ b/etc/rules/0016-wazuh_rules.xml
@@ -92,14 +92,14 @@
     <group>upgrade,upgrade_success,</group>
   </rule>
 
-  <rule id="215" level="7">
+  <rule id="215" level="6">
     <if_sid>210</if_sid>
     <status>failed</status>
     <description>Remote upgrade failed. Agent restored to previous version.</description>
     <group>upgrade,upgrade_failure,</group>
   </rule>
 
-  <rule id="216" level="15">
+  <rule id="216" level="7">
     <if_sid>210</if_sid>
     <status>lost</status>
     <description>Remote upgrade failed. Agent disconnected.</description>


### PR DESCRIPTION
This PR decreases the level of the following rules:
- 215 (Remote upgrade failed. Agent restored to the previous version): from 7 to 6.
- 216 (Remote upgrade failed. Agent disconnected): from 15 to 7.