### PR TITLE
Fix id format in json output log.

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -45,9 +45,9 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
 
     if ( lf->time.tv_sec ) {
 
-        char alert_id[19];
-        alert_id[18] = '\0';
-        if((snprintf(alert_id, 18, "%ld.%ld", (long int)lf->time.tv_sec, __crt_ftell)) < 0) {
+        char alert_id[23];
+        alert_id[22] = '\0';
+        if((snprintf(alert_id, 22, "%ld.%ld", (long int)lf->time.tv_sec, __crt_ftell)) < 0) {
             merror("snprintf failed");
         }
 


### PR DESCRIPTION
When writing rule id in json alerts file, the id is truncated and can be non unique, on intensive alerts generation. 
This is due snprintf buffer size which is too small to  store id. Indeed id is composed of two long int (timestamp and log offset) then the size can be to 21 characters (10 digits for both timestamp and offset + the dot)
The fix set id buffer to the correct size, and snprintf max size.