### PR TITLE
Fix bug when installing framework package

### DIFF
--- a/framework/setup.py
+++ b/framework/setup.py
@@ -3,7 +3,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # Install the package locally: python setup.py install
 # Install the package dev: python setup.py develop
@@ -15,6 +15,6 @@ setup(name='wazuh',
       author='Wazuh',
       author_email='hello@wazuh.com',
       license='GPLv2',
-      packages=['wazuh'],
+      packages=find_packages(),
       install_requires=[],
       zip_safe=False)


### PR DESCRIPTION
Hello team,

This PR fixes #976. 

Basically, the `wazuh.cluster` package was not installed when running `python setup.py install`.

It has been tested in both python2 and python3.

Best regards,
Marta