### PR TITLE
Revert avoiding DB_NOTFOUND warning 

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -420,14 +420,13 @@ int sys_rpm_packages(int queue_fd, const char* LOCATION){
     memset(&key, 0, sizeof(DBT));
     memset(&data, 0, sizeof(DBT));
 
-    int j = 0;
+    int j;
 
-    while((ret = cursor->c_get(cursor, &key, &data, DB_NEXT)) == 0) {
+    for (j = 0; ret = cursor->c_get(cursor, &key, &data, DB_NEXT), ret == 0; j++) {
 
         // First header is not a package
 
         if (j == 0) {
-            j++;
             continue;
         }
 
@@ -553,8 +552,6 @@ int sys_rpm_packages(int queue_fd, const char* LOCATION){
             free(string);
         }
 
-        j++;
-
         // Free resources
 
         for (info = head; info; info = next_info) {
@@ -562,6 +559,10 @@ int sys_rpm_packages(int queue_fd, const char* LOCATION){
             free(info->tag);
             free(info);
         }
+    }
+
+    if (ret == DB_NOTFOUND && j <= 1) {
+        mtwarn(WM_SYS_LOGTAG, "sys_rpm_packages(): Not found any record in database '%s'", RPM_DATABASE);
     }
 
     cursor->c_close(cursor);

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -422,12 +422,7 @@ int sys_rpm_packages(int queue_fd, const char* LOCATION){
 
     int j = 0;
 
-    ret = cursor->c_get(cursor, &key, &data, DB_NEXT);
-    if (ret == DB_NOTFOUND){
-        mtwarn(WM_SYS_LOGTAG, "sys_rpm_packages(): Not found any record in database '%s'", RPM_DATABASE);
-    }
-
-    while(ret == 0) {
+    while((ret = cursor->c_get(cursor, &key, &data, DB_NEXT)) == 0) {
 
         // First header is not a package
 
@@ -567,8 +562,6 @@ int sys_rpm_packages(int queue_fd, const char* LOCATION){
             free(info->tag);
             free(info);
         }
-
-        ret = cursor->c_get(cursor, &key, &data, DB_NEXT);
     }
 
     cursor->c_close(cursor);


### PR DESCRIPTION
The PR https://github.com/wazuh/wazuh/pull/1051 could cause a SegFault due to the reading of the first pair key:value from the RPM Packages DB was not reading the desired data. 

This PR avoid that situation reading the correct data from the DB.