### PR TITLE
Fix _get_versions function when comparing input version

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1924,7 +1924,7 @@ class Agent:
 
         return protocol
 
-    def _get_versions(self, wpk_repo=common.wpk_repo_url, desired_version=None, use_http=False):
+    def _get_versions(self, wpk_repo=common.wpk_repo_url, version=None, use_http=False):
         """
         Generates a list of available versions for its distribution and version.
         """
@@ -1936,7 +1936,7 @@ class Agent:
             raise WazuhException(1713, error)
 
         protocol = self._get_protocol(wpk_repo, use_http)
-        if (desired_version is None or desired_version[:4] >= "v3.4") and self.os['platform'] != "windows":
+        if (version is None or version[:4] >= "v3.4") and self.os['platform'] != "windows":
             versions_url = protocol + wpk_repo + "linux/" + self.os['arch'] + "/versions"
         else:
             if self.os['platform']=="windows":
@@ -1975,7 +1975,7 @@ class Agent:
         Searchs latest Wazuh WPK file for its distribution and version. Downloads the WPK if it is not in the upgrade folder.
         """
         agent_new_ver = None
-        versions = self._get_versions(wpk_repo, use_http)
+        versions = self._get_versions(wpk_repo=wpk_repo, version=version, use_http=use_http)
         if not version:
             agent_new_ver = versions[0][0]
             agent_new_shasum = versions[0][1]


### PR DESCRIPTION
When getting the list of available WPK versions from the online repository, it was being used the wrong variable whose content was always `False`.

The following error was shown:

```
root@ubuntu1710:~/wazuh# /var/ossec/bin/agent_upgrade -a 001
Internal error: 'bool' object has no attribute '__getitem__'
```

And enabling the debug messages:

```
root@ubuntu1710:~/wazuh# /var/ossec/bin/agent_upgrade -a 001 -d
Internal error: 'bool' object has no attribute '__getitem__'
Traceback (most recent call last):
  File "/var/ossec/bin/agent_upgrade", line 165, in <module>
    main()
  File "/var/ossec/bin/agent_upgrade", line 119, in main
    rl_timeout=-1 if args.timeout == None else args.timeout, use_http=use_http)
  File "/var/ossec/bin/../framework/wazuh/agent.py", line 2222, in upgrade
    show_progress=show_progress, chunk_size=chunk_size, rl_timeout=rl_timeout, use_http=use_http)
  File "/var/ossec/bin/../framework/wazuh/agent.py", line 2082, in _send_wpk_file
    _get_wpk = self._get_wpk_file(wpk_repo=wpk_repo, debug=debug, version=version, force=force, use_http=use_http)
  File "/var/ossec/bin/../framework/wazuh/agent.py", line 1979, in _get_wpk_file
    versions = self._get_versions(wpk_repo, use_http)
  File "/var/ossec/bin/../framework/wazuh/agent.py", line 1940, in _get_versions
    if (desired_version is None or desired_version[:4] >= "v3.4") and self.os['platform'] != "windows":
TypeError: 'bool' object has no attribute '__getitem__'
```

Now it compares the correct version variable. Here we have some example outputs:

```
root@localhost /var/ossec » agent_upgrade -a 001 -v v3.3.0
Error 1716: Error upgrading agent: Agent ver: v3.4.0 / Agent new ver: v3.3.0

root@localhost /var/ossec » agent_upgrade -a 002 -d                                                                                
Manager version: v3.5.0
Agent version: v3.3.1
Agent new version: v3.4.0
WPK file already downloaded: /var/ossec/var/upgrade/wazuh_agent_v3.4.0_windows.wpk - SHA1SUM: b6f42d7c909c3c2393901654b8f559e127c3a957
Upgrade PKG: wazuh_agent_v3.4.0_windows.wpk (3193 KB)
MSG SENT: 002 com open wb wazuh_agent_v3.4.0_windows.wpk
RESPONSE: ok
MSG SENT: 002 com lock_restart -1
RESPONSE: ok
Chunk size: 512 bytes
Sending: /var/ossec/var/upgrade/wazuh_agent_v3.4.0_windows.wpk
...

root@localhost /var/ossec » agent_upgrade -a 001 -v v3.5.0
Error 1718: Version not available: v3.5.0
```