### PR TITLE
Fix variable size

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -240,7 +240,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum) {
             char *file_url;
             char *file_name;
             char destination_path[PATH_MAX + 1];
-            char download_path[PATH_MAX];
+            char download_path[PATH_MAX + 1];
             int downloaded;
 
             // Check if we have merged.mg file in this group


### PR DESCRIPTION
This fix solves the following error:

```
In file included from /usr/include/stdio.h:862:0,
                 from ./headers/shared.h:61,
                 from remoted/manager.c:10:
In function ‘snprintf’,
    inlined from ‘c_group’ at remoted/manager.c:284:25,
    inlined from ‘c_files’ at remoted/manager.c:465:9:]
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: warning: ‘__builtin___snprintf_chk’: specified bound 4097 exceeds the size 4096 of the destination [-Wstringop-overflow=]
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

`snprintf(download_path, PATH_MAX + 1, "%s/%s", DOWNLOAD_DIR, file_name);`