### PR TITLE
Fix using the uninitialized hash table mutex on Windows systems

### DIFF
--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -418,6 +418,7 @@ OSHash *OSHash_Duplicate(const OSHash *hash) {
     self->initial_seed = hash->initial_seed;
     self->constant = hash->constant;
     os_calloc(self->rows + 1, sizeof(OSHashNode*), self->table);
+    self->mutex = (pthread_rwlock_t)PTHREAD_RWLOCK_INITIALIZER;
 
     for (i = 0; i <= self->rows; i++) {
         next_addr = &self->table[i];


### PR DESCRIPTION
Using the function to duplicate a hash table did not initialize the mutex variable causing an error in Windows systems.
```
At pthread_rwlock_rdlock(): invalid argument
```