### PR TITLE
Improvements and fixes for Syscheck on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Cluster log rotation: set correct permissions and store rotations in /logs/ossec. ([#667](https://github.com/wazuh/wazuh/pull/667))
 - `Distinct` requests don't allow `limit=0` or `limit>maximun_limit`. ([#1007](https://github.com/wazuh/wazuh/pull/1007))
 - Deprecated arguments -i, -F and -r for Authd. ([#1013](https://github.com/wazuh/wazuh/pull/1013))
+- Increase the internal memory for real-time from 12 KiB to 64 KiB. ([#1062](https://github.com/wazuh/wazuh/pull/1062))
 
 ### Fixed
 
@@ -73,6 +74,9 @@ All notable changes to this project will be documented in this file.
 - Stop Syscollector data storage into Wazuh DB when an error appears. ([#674](https://github.com/wazuh/wazuh/pull/674))
 - Fix bug in Syscheck that reported false positive about removed files. ([#1044](https://github.com/wazuh/wazuh/pull/1044))
 - Fix bug in Syscheck that misinterpreted no_diff option. ([#1046](https://github.com/wazuh/wazuh/pull/1046))
+- Fixes in file integrity monitoring for Windows. ([#1062](https://github.com/wazuh/wazuh/pull/1062))
+  - Fix Windows agent crash if FIM fails to extract the file owner.
+  - Prevent FIM real-time mode on Windows from stopping if the internal buffer gets overflowed.
 
 ### Removed
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -175,7 +175,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     char wd_sum[OS_SIZE_6144 + 1];
 #ifdef WIN32
     const char *user;
-    char *sid;
+    char *sid = NULL;
 #endif
 
     opts = syscheck.opts[dir_position];

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -193,10 +193,15 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     if (lstat(file_name, &statbuf) < 0)
 #endif
     {
+        char alert_msg[PATH_MAX + 4];
 
-        if (errno == ENOTDIR) {
+        switch (errno) {
+        case ENOENT:
+            mwarn("Cannot access '%s': it was removed during scan.", file_name);
+            return (-1);
+
+        case ENOTDIR:
             /*Deletion message sending*/
-            char alert_msg[PATH_MAX + 4];
             alert_msg[PATH_MAX + 3] = '\0';
             snprintf(alert_msg, PATH_MAX + 4, "-1 %s", file_name);
             send_syscheck_msg(alert_msg);
@@ -208,8 +213,9 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
 
             return (0);
-        } else {
-            merror("Error accessing '%s'.", file_name);
+
+        default:
+            merror("Error accessing '%s': %s (%d)", file_name, strerror(errno), errno);
             return (-1);
         }
     }
@@ -524,12 +530,12 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
 #else
         if (defaultfilesn[di] == NULL) {
 #endif
-            mwarn("Error opening directory: '%s': %s ", dir_name, strerror(errno));
+            mwarn("Cannot open '%s': %s ", dir_name, strerror(errno));
         } else {
             return 0;
         }
 #else
-        mwarn("Error opening directory: '%s': %s ", dir_name, strerror(errno));
+        mwarn("Cannot open '%s': %s ", dir_name, strerror(errno));
 #endif /* WIN32 */
         return (-1);
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -333,7 +333,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
     os_sha256 sf256_sum;
     syscheck_node *s_node;
 #ifdef WIN32
-    char *sid;
+    char *sid = NULL;
     const char *user;
 #endif
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -320,7 +320,7 @@ typedef struct _win32rtfim {
     OVERLAPPED overlap;
 
     char *dir;
-    TCHAR buffer[12288];
+    TCHAR buffer[65536];
 } win32rtfim;
 
 int realtime_win32read(win32rtfim *rtlocald);


### PR DESCRIPTION
1. A memory violation was detected if FIM failed on extracting the file owner.
2. If the real-time internal memory gets overflowed, it does not work anymore until the agent is restarted (https://github.com/wazuh/wazuh/issues/1034).
3. Increase the internal memory for real-time from 12 KiB to 64 KiB.
4. Change some error messages to make them more descriptive.