### PR TITLE
Limit log sample in Logcollector logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project will be documented in this file.
 - Fixes in file integrity monitoring for Windows. ([#1062](https://github.com/wazuh/wazuh/pull/1062))
   - Fix Windows agent crash if FIM fails to extract the file owner.
   - Prevent FIM real-time mode on Windows from stopping if the internal buffer gets overflowed.
+- Prevent large logs from flooding the log file by Logcollector. ([#1067](https://github.com/wazuh/wazuh/pull/1067))
 
 ### Removed
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -59,6 +59,9 @@ logcollector.max_lines=10000
 # Time to reattempt a socket connection after a failure [1..3600]
 logcollector.sock_fail_time=300
 
+# Sample log length limit for errors about large message [1..4096]
+logcollector.sample_log_length=64
+
 
 # Remoted counter io flush.
 remoted.recv_counter_flush=128

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -27,27 +27,29 @@
 #ifndef WIN32
 #define LOGFILE   "/logs/ossec.log"
 #define LOGJSONFILE "/logs/ossec.json"
+#define _PRINTF_FORMAT printf
 #else
 #define LOGFILE "ossec.log"
 #define LOGJSONFILE "ossec.json"
+#define _PRINTF_FORMAT __MINGW_PRINTF_FORMAT
 #endif
 #endif
 
-void mdebug1(const char *msg, ...) __attribute__((format(printf, 1, 2))) __attribute__((nonnull));
-void mtdebug1(const char *tag, const char *msg, ...) __attribute__((format(printf, 2, 3))) __attribute__((nonnull));
-void mdebug2(const char *msg, ...) __attribute__((format(printf, 1, 2))) __attribute__((nonnull));
-void mtdebug2(const char *tag, const char *msg, ...) __attribute__((format(printf, 2, 3))) __attribute__((nonnull));
-void merror(const char *msg, ...) __attribute__((format(printf, 1, 2))) __attribute__((nonnull));
-void mterror(const char *tag, const char *msg, ...) __attribute__((format(printf, 2, 3))) __attribute__((nonnull));
-void mwarn(const char *msg, ...) __attribute__((format(printf, 1, 2))) __attribute__((nonnull));
-void mtwarn(const char *tag, const char *msg, ...) __attribute__((format(printf, 2, 3))) __attribute__((nonnull));
-void minfo(const char *msg, ...) __attribute__((format(printf, 1, 2))) __attribute__((nonnull));
-void mtinfo(const char *tag, const char *msg, ...) __attribute__((format(printf, 2, 3))) __attribute__((nonnull));
-void print_out(const char *msg, ...) __attribute__((format(printf, 1, 2))) __attribute__((nonnull));
-void mferror(const char *msg, ... ) __attribute__((format(printf, 1, 2))) __attribute__((nonnull));
-void mtferror(const char *tag, const char *msg, ...) __attribute__((format(printf, 2, 3))) __attribute__((nonnull));
-void merror_exit(const char *msg, ...) __attribute__((format(printf, 1, 2))) __attribute__((nonnull)) __attribute__ ((noreturn));
-void mterror_exit(const char *tag, const char *msg, ...) __attribute__((format(printf, 2, 3))) __attribute__((nonnull)) __attribute__ ((noreturn));
+void mdebug1(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
+void mtdebug1(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
+void mdebug2(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
+void mtdebug2(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
+void merror(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
+void mterror(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
+void mwarn(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
+void mtwarn(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
+void minfo(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
+void mtinfo(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
+void print_out(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
+void mferror(const char *msg, ... ) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
+void mtferror(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
+void merror_exit(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull)) __attribute__ ((noreturn));
+void mterror_exit(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull)) __attribute__ ((noreturn));
 
 /* Function to read the logging format configuration */
 void os_logging_config(void);

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -31,6 +31,7 @@ int LogCollectorConfig(const char *cfgfile)
     vcheck_files = getDefine_Int("logcollector", "vcheck_files", 0, 1024);
     maximum_lines = getDefine_Int("logcollector", "max_lines", 0, 1000000);
     sock_fail_time = getDefine_Int("logcollector", "sock_fail_time", 1, 3600);
+    sample_log_length = getDefine_Int("logcollector", "sample_log_length", 1, 4096);
 
     if (maximum_lines > 0 && maximum_lines < 100) {
         merror("Definition 'logcollector.max_lines' must be 0 or 100..1000000.");

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -21,6 +21,7 @@ logreader *logff;
 logsocket *logsk;
 int vcheck_files;
 int maximum_lines;
+int sample_log_length;
 static int _cday = 0;
 logsocket default_agent = { .name = "agent" };
 

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -85,5 +85,6 @@ extern logsocket *logsk;
 extern int vcheck_files;
 extern int maximum_lines;
 extern logsocket default_agent;
+extern int sample_log_length;
 
 #endif /* __LOGREADER_H */

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -99,11 +99,7 @@ void *read_json(int pos, int *rc, int drop_it)
         if (__ms) {
             // strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)
             // truncate str before logging to ossec.log
-#define OUTSIZE 4096
-            char buf[OUTSIZE + 1];
-            buf[OUTSIZE] = '\0';
-            snprintf(buf, OUTSIZE, "%s", str);
-            merror("Large message size(length=%d): '%s...'", (int)strlen(str), buf);
+            merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
             while (fgets(str, OS_MAXSTR - 2, logff[pos].fp) != NULL) {
                 /* Get the last occurrence of \n */
                 if (strrchr(str, '\n') != NULL) {

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -17,6 +17,7 @@
 void *read_json(int pos, int *rc, int drop_it)
 {
     int __ms = 0;
+    int __ms_reported = 0;
     int i;
     char *p, *jsonParsed;
     char str[OS_MAXSTR + 1];
@@ -98,8 +99,14 @@ void *read_json(int pos, int *rc, int drop_it)
         /* Incorrect message size */
         if (__ms) {
             // strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)
-            // truncate str before logging to ossec.log
-            merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+
+            if (!__ms_reported) {
+                merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+                __ms_reported = 1;
+            } else {
+                mdebug2("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+            }
+
             while (fgets(str, OS_MAXSTR - 2, logff[pos].fp) != NULL) {
                 /* Get the last occurrence of \n */
                 if (strrchr(str, '\n') != NULL) {

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -47,7 +47,7 @@ void *read_json(int pos, int *rc, int drop_it)
             __ms = 1;
         } else {
             /* Message not complete. Return. */
-            mdebug1("Message not complete. Trying again: '%s'", str);
+            mdebug1("Message not complete from '%s'. Trying again: '%.*s'%s", logff[pos].file, sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
             fsetpos(logff[pos].fp, &fp_pos);
             break;
         }
@@ -79,11 +79,11 @@ void *read_json(int pos, int *rc, int drop_it)
           cJSON_Delete(obj);
         } else {
           cJSON_Delete(obj);
-          mdebug1("Line '%s' read from '%s' is not a JSON object.", str, logff[pos].file);
+          mdebug1("Line '%.*s'%s read from '%s' is not a JSON object.", sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "", logff[pos].file);
           continue;
         }
 
-        mdebug2("Reading json message: '%s'", jsonParsed);
+        mdebug2("Reading json message: '%.*s'%s", sample_log_length, jsonParsed, strlen(jsonParsed) > (size_t)sample_log_length ? "..." : "");
 
         /* Send message to queue */
         if (drop_it == 0) {

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -93,7 +93,7 @@ void *read_multiline(int pos, int *rc, int drop_it)
 
         /* Incorrect message size */
         if (__ms) {
-            merror("Large message size: '%s'", str);
+            merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
             while (fgets(str, OS_MAXSTR - 2, logff[pos].fp) != NULL) {
                 /* Get the last occurrence of \n */
                 if ((p = strrchr(str, '\n')) != NULL) {

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -50,7 +50,7 @@ void *read_multiline(int pos, int *rc, int drop_it)
             __ms = 1;
         } else {
             /* Message not complete. Return. */
-            mdebug1("Message not complete. Trying again: '%s'", str);
+            mdebug1("Message not complete from '%s'. Trying again: '%.*s'%s", logff[pos].file, sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
             fsetpos(logff[pos].fp, &fp_pos);
             break;
         }
@@ -61,7 +61,7 @@ void *read_multiline(int pos, int *rc, int drop_it)
         }
 #endif
 
-        mdebug2("Reading message: '%s'", str);
+        mdebug2("Reading message: '%.*s'%s", sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
 
         /* Add to buffer */
         buffer_size = strlen(buffer);

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -15,6 +15,7 @@
 void *read_multiline(int pos, int *rc, int drop_it)
 {
     int __ms = 0;
+    int __ms_reported = 0;
     int linesgot = 0;
     size_t buffer_size = 0;
     char *p;
@@ -93,7 +94,13 @@ void *read_multiline(int pos, int *rc, int drop_it)
 
         /* Incorrect message size */
         if (__ms) {
-            merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+            if (!__ms_reported) {
+                merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+                __ms_reported = 1;
+            } else {
+                mdebug2("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+            }
+
             while (fgets(str, OS_MAXSTR - 2, logff[pos].fp) != NULL) {
                 /* Get the last occurrence of \n */
                 if ((p = strrchr(str, '\n')) != NULL) {

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -17,6 +17,7 @@
 void *read_syslog(int pos, int *rc, int drop_it)
 {
     int __ms = 0;
+    int __ms_reported = 0;
     char *p;
     char str[OS_MAXSTR + 1];
     fpos_t fp_pos;
@@ -82,8 +83,14 @@ void *read_syslog(int pos, int *rc, int drop_it)
         /* Incorrect message size */
         if (__ms) {
             // strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)
-            // truncate str before logging to ossec.log
-            merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+
+            if (!__ms_reported) {
+                merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+                __ms_reported = 1;
+            } else {
+                mdebug2("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
+            }
+
             while (fgets(str, OS_MAXSTR - 2, logff[pos].fp) != NULL) {
                 /* Get the last occurrence of \n */
                 if (strrchr(str, '\n') != NULL) {

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -45,7 +45,7 @@ void *read_syslog(int pos, int *rc, int drop_it)
             __ms = 1;
         } else {
             /* Message not complete. Return. */
-            mdebug1("Message not complete. Trying again: '%s'", str);
+            mdebug1("Message not complete from '%s'. Trying again: '%.*s'%s", logff[pos].file, sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
             fsetpos(logff[pos].fp, &fp_pos);
             break;
         }
@@ -68,7 +68,7 @@ void *read_syslog(int pos, int *rc, int drop_it)
         }
 #endif
 
-        mdebug2("Reading syslog message: '%s'", str);
+        mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
 
         /* Send message to queue */
         if (drop_it == 0) {

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -83,11 +83,7 @@ void *read_syslog(int pos, int *rc, int drop_it)
         if (__ms) {
             // strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)
             // truncate str before logging to ossec.log
-#define OUTSIZE 4096
-            char buf[OUTSIZE + 1];
-            buf[OUTSIZE] = '\0';
-            snprintf(buf, OUTSIZE, "%s", str);
-            merror("Large message size(length=%d): '%s...'", (int)strlen(str), buf);
+            merror("Large message size from file '%s' (length = %zu): '%.*s'...", logff[pos].file, strlen(str), sample_log_length, str);
             while (fgets(str, OS_MAXSTR - 2, logff[pos].fp) != NULL) {
                 /* Get the last occurrence of \n */
                 if (strrchr(str, '\n') != NULL) {


### PR DESCRIPTION
This PR aims to fix three related issues:

1. The error about large logs in Logcollector printed up to 4096 bytes per line read.
2. Such message appeared for every line picked from the monitored log.
3. Debug messages had the same problem.

These issues may flood the logs (_ossec.log_ and _ossec.json_) if any log source produced messages larger than 6 KB.