### PR TITLE
Let hostname field be the name of the agent, without the location part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.5.1]
 
+### Changed
+
+- Let hostname field be the name of the agent, without the location part. ([#1080](https://github.com/wazuh/wazuh/pull/1080))
+
 ### Fixed
 
 - Fix agent ID zero-padding in alerts coming from Vulnerability Detector. ([#1083](https://github.com/wazuh/wazuh/pull/1083))

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -528,13 +528,24 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
         *lf->location = '\0';
         os_strdup(lf->agent_id, lf->agent_id);
         os_strdup(lf->location + 2, lf->location);
-        lf->hostname = lf->location;
-        free(orig);
-    } else {
-        if (lf->hostname == NULL) {
-            lf->hostname = __shost;
+
+        if (lf->location[0] == '(') {
+            char * end;
+
+            os_strdup(lf->location + 1, lf->hostname);
+
+            if (end = strchr(lf->hostname, ')'), end) {
+                *end = '\0';
+            } else {
+                lf->hostname[0] = '\0';
+            }
+        } else {
+            os_strdup("", lf->hostname);
         }
 
+        free(orig);
+    } else {
+        os_strdup(lf->hostname ? lf->hostname : __shost, lf->hostname);
         lf->agent_id = strdup("000");
     }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -571,6 +571,10 @@ void Free_Eventinfo(Eventinfo *lf)
         free(lf->location);
     }
 
+    if (lf->hostname) {
+        free(lf->hostname);
+    }
+
     if (lf->srcip) {
         free(lf->srcip);
     }


### PR DESCRIPTION
This PR aims to fix issue https://github.com/wazuh/wazuh/issues/1073.

The _hostname_ field should not be the complete _location_ field, but only the name of the agent, or the hostname of the manager.