### PR TITLE
Add syscheck recursive option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.6]
+
+### Added
+
+- Added a recursion level option to Syscheck to set the directory scanning depth. ([#1081](https://github.com/wazuh/wazuh/pull/1081))
+
+### Changed
+
+- The internal option `syscheck.max_depth` has been renamed to `syscheck.default_max_depth`. ([#1081](https://github.com/wazuh/wazuh/pull/1081))
+
+
 ## [v3.5.1]
 
 ### Changed

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -181,7 +181,7 @@ syscheck.max_fd_win_rt=256
 syscheck.max_audit_entries=256
 
 # Maximum level of recursivity allowed [1..320]
-syscheck.max_depth=256
+syscheck.default_max_depth=256
 
 # Rootcheck checking/usage speed. The default is to sleep 50 milliseconds
 # per each PID or suspictious port.

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -512,7 +512,11 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     goto out_free;
                 }
                 recursion_limit = (unsigned int) atoi(*values);
-                if (recursion_limit < 0 || recursion_limit > MAX_DEPTH_ALLOWED) {
+                if (recursion_limit < 0) {
+                    mwarn("Invalid recursion level value: %d. Setting default (%d).", recursion_limit, syscheck->max_depth);
+                    recursion_limit = syscheck->max_depth;
+                } else if (recursion_limit > MAX_DEPTH_ALLOWED) {
+                    mwarn("Recursion level '%d' exceeding limit. Setting %d.", recursion_limit, MAX_DEPTH_ALLOWED);
                     recursion_limit = MAX_DEPTH_ALLOWED;
                 }
             } else {

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -50,6 +50,9 @@
 #define WD_IGNORE_REST      0x0000008
 #endif
 
+//Max allowed value for recursion
+#define MAX_DEPTH_ALLOWED 320
+
 #include <stdio.h>
 #include "os_regex/os_regex.h"
 
@@ -187,6 +190,7 @@ typedef struct _config {
 
     char **dir;                     /* array of directories to be scanned */
     OSMatch **filerestrict;
+    int *recursion_level;
 
     /* Windows only registry checking */
 #ifdef WIN32
@@ -212,7 +216,7 @@ typedef struct _config {
 } syscheck_config;
 
 
-int dump_syscheck_entry(syscheck_config *syscheck, const char *entry, int vals, int reg, const char *restrictfile) __attribute__((nonnull(1, 2)));
+int dump_syscheck_entry(syscheck_config *syscheck, const char *entry, int vals, int reg, const char *restrictfile, int recursion_level) __attribute__((nonnull(1, 2)));
 
 char *syscheck_opts2str(char *buf, int buflen, int opts);
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -173,6 +173,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     syscheck_node *s_node;
     struct stat statbuf;
     char wd_sum[OS_SIZE_6144 + 1];
+    int recursion_limit;
 #ifdef WIN32
     const char *user;
     char *sid = NULL;
@@ -607,7 +608,7 @@ int run_dbcheck()
             }
         }
 #endif
-        read_dir(syscheck.dir[i], i, NULL, syscheck.max_depth);
+        read_dir(syscheck.dir[i], i, NULL, syscheck.recursion_level[i]);
         i++;
     }
 
@@ -679,7 +680,7 @@ int create_db()
     /* Read all available directories */
     __counter = 0;
     do {
-        if (read_dir(syscheck.dir[i], i, NULL, syscheck.max_depth) == 0) {
+        if (read_dir(syscheck.dir[i], i, NULL, syscheck.recursion_level[i]) == 0) {
             mdebug2("Directory loaded from syscheck db: %s", syscheck.dir[i]);
         }
 #ifdef WIN32

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -115,7 +115,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         if (pos >= 0) {
             mdebug1("Scanning new file '%s' with options for directory '%s'.", file_name, syscheck.dir[pos]);
             int diff = fim_find_child_depth(syscheck.dir[pos], file_name);
-            read_dir(file_name, pos, evt, syscheck.max_depth - diff);
+            read_dir(file_name, pos, evt, syscheck.recursion_level[pos] - diff);
         }
 
     }

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -50,8 +50,8 @@ static void read_internal(int debug_level)
     syscheck.tsleep = (unsigned int) getDefine_Int("syscheck", "sleep", 0, 64);
     syscheck.sleep_after = getDefine_Int("syscheck", "sleep_after", 1, 9999);
     syscheck.rt_delay = getDefine_Int("syscheck", "rt_delay", 1, 1000);
-    syscheck.max_depth = getDefine_Int("syscheck", "max_depth", 1, 320);
-    
+    syscheck.max_depth = getDefine_Int("syscheck", "default_max_depth", 1, 320);
+
 #ifndef WIN32
     syscheck.max_audit_entries = getDefine_Int("syscheck", "max_audit_entries", 1, 4096);
 #endif

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -107,7 +107,7 @@ int Start_win32_Syscheck()
         /* Disabled */
         if (!syscheck.dir) {
             minfo(SK_NO_DIR);
-            dump_syscheck_entry(&syscheck, "", 0, 0, NULL);
+            dump_syscheck_entry(&syscheck, "", 0, 0, NULL, 0);
         } else if (!syscheck.dir[0]) {
             minfo(SK_NO_DIR);
         }
@@ -121,7 +121,7 @@ int Start_win32_Syscheck()
         }
 
         if (!syscheck.registry) {
-            dump_syscheck_entry(&syscheck, "", 0, 1, NULL);
+            dump_syscheck_entry(&syscheck, "", 0, 1, NULL, 0);
         }
         syscheck.registry[0].entry = NULL;
 
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
             if (!test_config) {
                 minfo(SK_NO_DIR);
             }
-            dump_syscheck_entry(&syscheck, "", 0, 0, NULL);
+            dump_syscheck_entry(&syscheck, "", 0, 0, NULL, 0);
         } else if (!syscheck.dir[0]) {
             if (!test_config) {
                 minfo(SK_NO_DIR);


### PR DESCRIPTION
This PR solves issue #998. It has been added the possibility to restrict recursion in a directory specifically, through a parameter indicated in directories tag:
```xml
<directories check_all="yes" recursion_level="20">/root/folderwith50level</directories>
```
With this option only get alerts from the first 20 nested directories. The maximum limit of this option is 320.
If the option is not specified, will be set the default value internal option _syscheck.default_max_depth_.