### PR TITLE
Fix agent ID zero-padding in alerts coming from Vuln Detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix agent ID zero-padding in alerts coming from Vulnerability Detector. ([#1083](https://github.com/wazuh/wazuh/pull/1083))
 - Fixed minor issues in the Makefile and the sources installer on HP-UX, Solaris on SPARC and AIX systems. ([#1089](https://github.com/wazuh/wazuh/pull/1089))
 
 ### Removed

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -662,7 +662,7 @@ int wm_vulnerability_detector_report_agent_vulnerabilities(agent_software *agent
 
             // Send an alert as a manager if there is no IP assigned
             if (agents_it->agent_ip) {
-                snprintf(header, OS_SIZE_256, VU_ALERT_HEADER, agents_it->agent_id, agents_it->agent_name, agents_it->agent_ip);
+                snprintf(header, OS_SIZE_256, VU_ALERT_HEADER, atoi(agents_it->agent_id), agents_it->agent_name, agents_it->agent_ip);
                 snprintf(alert_msg, OS_MAXSTR, VU_ALERT_JSON, str_json);
                 send_queue = SECURE_MQ;
             } else {

--- a/src/wazuh_modules/wm_vuln_detector.h
+++ b/src/wazuh_modules/wm_vuln_detector.h
@@ -46,7 +46,7 @@
 #define VU_MAX_WAZUH_DB_ATTEMPS 5
 #define VU_MAX_TIMESTAMP_ATTEMPS 4
 #define VU_AGENT_REQUEST_LIMIT   0
-#define VU_ALERT_HEADER "[%s] (%s) %s"
+#define VU_ALERT_HEADER "[%03d] (%s) %s"
 #define VU_ALERT_JSON "1:" VU_WM_NAME ":%s"
 #define VU_MODERATE   "Moderate"
 #define VU_MEDIUM     "Medium"


### PR DESCRIPTION
This PR fixes issue https://github.com/wazuh/wazuh/issues/1082.

Alerts from Vulnerability Detector show the agent ID without zero-padding:

```json
{ 
  "agent": {
    "id": "001",
    "name": "centos",
    "ip": "192.168.33.11"
  }
}
```

This is a problem when indexing agent data. This PR will fix it.