### PR TITLE
Add tags for FIM directories and registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   - Periodically rescan of new files.
   - New options have been added to internal_options.conf file.
 - Added a recursion level option to Syscheck to set the directory scanning depth. ([#1081](https://github.com/wazuh/wazuh/pull/1081))
+- Added custom tags to FIM directories and registries. ([#1096](https://github.com/wazuh/wazuh/pull/1096))
+
 
 ### Changed
 
@@ -42,7 +44,6 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - The 'T' multiplier has been removed from option `max_output_size`. ([#1089](https://github.com/wazuh/wazuh/pull/1089))
-
 
 ## [v3.5.0] 2018-08-10
 

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -180,7 +180,7 @@ void OS_LogOutput(Eventinfo *lf)
 
     /* FIM events */
 
-    if (lf->filename) {
+    if (lf->filename && lf->event_type != FIM_DELETED) {
         printf("Attributes:\n");
 
         if (lf->size_after){
@@ -224,9 +224,16 @@ void OS_LogOutput(Eventinfo *lf)
             }
         }
 
-        if (lf->sk_tag) {
-            if (strcmp(lf->sk_tag, "") != 0) {
-                fprintf(_aflog, " - Tags: %s\n", lf->sk_tag);
+    }
+
+    if (lf->filename && lf->sk_tag) {
+        if (strcmp(lf->sk_tag, "") != 0) {
+            printf("\nTags:\n");
+            char * tag;
+            tag = strtok(lf->sk_tag, ",");
+            while (tag != NULL) {
+                printf(" - %s\n", tag);
+                tag = strtok(NULL, ",");
             }
         }
     }
@@ -380,10 +387,20 @@ void OS_Log(Eventinfo *lf)
             }
         }
 
-        if (lf->sk_tag) {
-            if (strcmp(lf->sk_tag, "") != 0) {
-                fprintf(_aflog, " - Tags: %s\n", lf->sk_tag);
+    }
+
+    if (lf->filename && lf->sk_tag) {
+        if (strcmp(lf->sk_tag, "") != 0) {
+            char * tags;
+            os_strdup(lf->sk_tag, tags);
+            fprintf(_aflog, "\nTags:\n");
+            char * tag;
+            tag = strtok(tags, ",");
+            while (tag != NULL) {
+                fprintf(_aflog, " - %s\n", tag);
+                tag = strtok(NULL, ",");
             }
+            free(tags);
         }
     }
 

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -211,7 +211,7 @@ void OS_LogOutput(Eventinfo *lf)
                 printf(" - MD5: %s\n", lf->md5_after);
             }
         }
-        
+
         if (lf->sha1_after) {
             if (strcmp(lf->sha1_after, "xxx") != 0 && strcmp(lf->sha1_after, "") != 0) {
                 printf(" - SHA1: %s\n", lf->sha1_after);
@@ -221,6 +221,12 @@ void OS_LogOutput(Eventinfo *lf)
         if (lf->sha256_after) {
             if (strcmp(lf->sha256_after, "xxx") != 0 && strcmp(lf->sha256_after, "") != 0) {
                 printf(" - SHA256: %s\n", lf->sha256_after);
+            }
+        }
+
+        if (lf->sk_tag) {
+            if (strcmp(lf->sk_tag, "") != 0) {
+                fprintf(_aflog, " - Tags: %s\n", lf->sk_tag);
             }
         }
     }
@@ -361,7 +367,7 @@ void OS_Log(Eventinfo *lf)
                 fprintf(_aflog, " - MD5: %s\n", lf->md5_after);
             }
         }
-        
+
         if (lf->sha1_after) {
             if (strcmp(lf->sha1_after, "xxx") != 0 && strcmp(lf->sha1_after, "") != 0) {
                 fprintf(_aflog, " - SHA1: %s\n", lf->sha1_after);
@@ -371,6 +377,12 @@ void OS_Log(Eventinfo *lf)
         if (lf->sha256_after) {
             if (strcmp(lf->sha256_after, "xxx") != 0 && strcmp(lf->sha256_after, "") != 0) {
                 fprintf(_aflog, " - SHA256: %s\n", lf->sha256_after);
+            }
+        }
+
+        if (lf->sk_tag) {
+            if (strcmp(lf->sk_tag, "") != 0) {
+                fprintf(_aflog, " - Tags: %s\n", lf->sk_tag);
             }
         }
     }

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -751,7 +751,7 @@ int DecodeSyscheck(Eventinfo *lf)
     if (tag = wstr_chr(f_name, '!'), tag) {
         *tag = '\0';
         tag++;
-        lf->sk_tag = tag;
+        os_strdup(tag, lf->sk_tag);
     }
 
     //Change in Windows paths all slashes for backslashes for compatibility agent<3.4 with manager>=3.4

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -722,11 +722,12 @@ int DecodeSyscheck(Eventinfo *lf)
     char *c_sum;
     char *w_sum;
     char *f_name;
+    char *tag;
 
     /* Every syscheck message must be in the following format:
-     * checksum filename
+     * checksum filename<!optional_tag>
      * or
-     * checksum!whodatasum filename
+     * checksum!whodatasum filename<!optional_tag>
      */
     f_name = wstr_chr(lf->log, ' ');
     if (f_name == NULL) {
@@ -745,6 +746,13 @@ int DecodeSyscheck(Eventinfo *lf)
     /* Zero to get the check sum */
     *f_name = '\0';
     f_name++;
+
+    /* Look for a defined tag */
+    if (tag = wstr_chr(f_name, '!'), tag) {
+        *tag = '\0';
+        tag++;
+        lf->sk_tag = tag;
+    }
 
     //Change in Windows paths all slashes for backslashes for compatibility agent<3.4 with manager>=3.4
     normalize_path(f_name);
@@ -776,6 +784,7 @@ int DecodeSyscheck(Eventinfo *lf)
     c_sum = lf->log;
 
     /* Get w_sum */
+
     if (w_sum = strchr(c_sum, '!'), w_sum) {
         *(w_sum++) = '\0';
     }

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -91,6 +91,7 @@ void SyscheckInit()
     sdb.syscheck_dec->fields[SK_EFFECTIVE_NAME] = "effective_name";
     sdb.syscheck_dec->fields[SK_PPID] = "ppid";
     sdb.syscheck_dec->fields[SK_PROC_ID] = "process_id";
+    sdb.syscheck_dec->fields[SK_TAG] = "tag";
 
     sdb.id1 = getDecoderfromlist(SYSCHECK_MOD);
     sdb.id2 = getDecoderfromlist(SYSCHECK_MOD2);
@@ -722,12 +723,11 @@ int DecodeSyscheck(Eventinfo *lf)
     char *c_sum;
     char *w_sum;
     char *f_name;
-    char *tag;
 
     /* Every syscheck message must be in the following format:
-     * checksum filename<!optional_tag>
+     * checksum filename
      * or
-     * checksum!whodatasum filename<!optional_tag>
+     * checksum!whodatasum filename
      */
     f_name = wstr_chr(lf->log, ' ');
     if (f_name == NULL) {
@@ -746,13 +746,6 @@ int DecodeSyscheck(Eventinfo *lf)
     /* Zero to get the check sum */
     *f_name = '\0';
     f_name++;
-
-    /* Look for a defined tag */
-    if (tag = wstr_chr(f_name, '!'), tag) {
-        *tag = '\0';
-        tag++;
-        os_strdup(tag, lf->sk_tag);
-    }
 
     //Change in Windows paths all slashes for backslashes for compatibility agent<3.4 with manager>=3.4
     normalize_path(f_name);
@@ -784,7 +777,6 @@ int DecodeSyscheck(Eventinfo *lf)
     c_sum = lf->log;
 
     /* Get w_sum */
-
     if (w_sum = strchr(c_sum, '!'), w_sum) {
         *(w_sum++) = '\0';
     }

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -532,6 +532,7 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->diff = NULL;
     lf->previous = NULL;
     lf->labels = NULL;
+    lf->sk_tag = NULL;
 
     lf->user_id = NULL;
     lf->user_name = NULL;
@@ -643,6 +644,9 @@ void Free_Eventinfo(Eventinfo *lf)
 
     if (lf->filename) {
         free(lf->filename);
+    }
+    if (lf->sk_tag) {
+        free(lf->sk_tag);
     }
     if (lf->md5_before) {
         free(lf->md5_before);

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -79,6 +79,7 @@ typedef struct _Eventinfo {
     /* SYSCHECK Results variables */
     syscheck_event_t event_type;
     char *filename;
+    char *sk_tag;
     int perm_before;
     int perm_after;
     char *md5_before;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -263,7 +263,17 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         }
         if(lf->sk_tag) {
             if (strcmp(lf->sk_tag, "") != 0) {
-                cJSON_AddStringToObject(file_diff, "tag", lf->sk_tag);
+                cJSON *tags = cJSON_CreateArray();
+                cJSON_AddItemToObject(file_diff, "tags", tags);
+                char * tag;
+                char * aux_tags;
+                os_strdup(lf->sk_tag, aux_tags);
+                tag = strtok(aux_tags, ",");
+                while (tag != NULL) {
+                    cJSON_AddItemToArray(tags, cJSON_CreateString(tag));
+                    tag = strtok(NULL, ",");
+                }
+                free(aux_tags);
             }
         }
 

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -261,6 +261,11 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
                 cJSON_AddStringToObject(file_diff, "diff", lf->diff);
             }
         }
+        if(lf->sk_tag) {
+            if (strcmp(lf->sk_tag, "") != 0) {
+                cJSON_AddStringToObject(file_diff, "tag", lf->sk_tag);
+            }
+        }
 
         switch (lf->event_type) {
         case FIM_ADDED:

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -592,6 +592,14 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             if (clean_tag = os_strip_char(tag, '!'), !clean_tag) {
                 merror("Processing tag '%s'.", tag);
                 goto out_free;
+            } else {
+                free(tag);
+                tag = NULL;
+                os_strdup(clean_tag, tag);
+            }
+            if (clean_tag = os_strip_char(tag, ':'), !clean_tag) {
+                merror("Processing tag '%s'.", tag);
+                goto out_free;
             }
         }
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -581,8 +581,18 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         /* Remove spaces from tag */
 
         if (tag) {
-            if (clean_tag = os_strip_char(tag, ' '), !clean_tag)
+            if (clean_tag = os_strip_char(tag, ' '), !clean_tag) {
                 merror("Processing tag '%s'.", tag);
+                goto out_free;
+            } else {
+                free(tag);
+                tag = NULL;
+                os_strdup(clean_tag, tag);
+            }
+            if (clean_tag = os_strip_char(tag, '!'), !clean_tag) {
+                merror("Processing tag '%s'.", tag);
+                goto out_free;
+            }
         }
 
         /* Add directory - look for the last available */
@@ -663,8 +673,12 @@ out_free:
 
     free(dir_org);
     free(restrictfile);
-    free(tag);
-    free(clean_tag);
+    if (tag) {
+        free(tag);
+    }
+    if (clean_tag) {
+        free(clean_tag);
+    }
 
     return ret;
 }

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -192,6 +192,8 @@ typedef struct _config {
     OSMatch **filerestrict;
     int *recursion_level;
 
+    char **tag;                     /* array of tags for each directory */
+
     /* Windows only registry checking */
 #ifdef WIN32
     registry *registry_ignore;                  /* list of registry entries to ignore */
@@ -216,7 +218,7 @@ typedef struct _config {
 } syscheck_config;
 
 
-int dump_syscheck_entry(syscheck_config *syscheck, const char *entry, int vals, int reg, const char *restrictfile, int recursion_level) __attribute__((nonnull(1, 2)));
+int dump_syscheck_entry(syscheck_config *syscheck, const char *entry, int vals, int reg, const char *restrictfile, int recursion_level, const char *tag) __attribute__((nonnull(1, 2)));
 
 char *syscheck_opts2str(char *buf, int buflen, int opts);
 

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -141,6 +141,7 @@ typedef struct whodata {
 typedef struct registry {
     char *entry;
     int arch;
+    char *tag;
 } registry;
 
 typedef struct registry_regex {

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -56,6 +56,7 @@ typedef enum sk_syscheck {
     SK_EFFECTIVE_NAME,
     SK_PPID,
     SK_PROC_ID,
+    SK_TAG,
     SK_NFIELDS
 } sk_syscheck;
 
@@ -134,6 +135,7 @@ typedef struct sk_sum_t {
     char *gname;
     long mtime;
     long inode;
+    char *tag;
     sk_sum_wdata wdata;
 } sk_sum_t;
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -32,11 +32,6 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
 
     if (c_sum[0] == '-' && c_sum[1] == '1') {
         retval = 1;
-        /* Look for a defined tag */
-        if (tag = strchr(c_sum, ':'), tag) {
-            *(tag++) = '\0';
-            sum->tag = tag;
-        }
     } else {
         sum->size = c_sum;
 
@@ -102,7 +97,7 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
         }
     }
 
-    // Get whodata
+    // Get extra data wdata+tags(optional)
     if (w_sum) {
         sum->wdata.user_id = w_sum;
 
@@ -164,6 +159,13 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
             *(sum->wdata.process_id++) = '\0';
         } else {
             return -1;
+        }
+
+        /* Look for a defined tag */
+        if (sum->tag = wstr_chr(sum->wdata.process_id, ':'), sum->tag) {
+            *(sum->tag++) = '\0';
+        } else {
+            sum->tag = NULL;
         }
 
         sum->wdata.user_name = unescape_whodata_sum(sum->wdata.user_name);
@@ -253,11 +255,6 @@ void sk_fill_event(Eventinfo *lf, const char *f_name, const sk_sum_t *sum) {
         os_strdup(sum->sha256, lf->fields[SK_SHA256].value);
     }
 
-    if(sum->tag) {
-        os_strdup(sum->tag, lf->sk_tag);
-        os_strdup(sum->tag, lf->fields[SK_TAG].value);
-    }
-
     if(sum->wdata.user_id) {
         os_strdup(sum->wdata.user_id, lf->user_id);
         os_strdup(sum->wdata.user_id, lf->fields[SK_USER_ID].value);
@@ -311,6 +308,11 @@ void sk_fill_event(Eventinfo *lf, const char *f_name, const sk_sum_t *sum) {
     if(sum->wdata.process_id) {
         os_strdup(sum->wdata.process_id, lf->process_id);
         os_strdup(sum->wdata.process_id, lf->fields[SK_PROC_ID].value);
+    }
+
+    if(sum->tag) {
+        os_strdup(sum->tag, lf->sk_tag);
+        os_strdup(sum->tag, lf->fields[SK_TAG].value);
     }
 
     /* Fields */

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -25,12 +25,18 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
     char *c_perm;
     char *c_mtime;
     char *c_inode;
+    char *tag;
     int retval = 0;
 
     memset(sum, 0, sizeof(sk_sum_t));
 
     if (c_sum[0] == '-' && c_sum[1] == '1') {
         retval = 1;
+        /* Look for a defined tag */
+        if (tag = strchr(c_sum, ':'), tag) {
+            *(tag++) = '\0';
+            sum->tag = tag;
+        }
     } else {
         sum->size = c_sum;
 
@@ -84,6 +90,12 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
 
             if ((sum->sha256 = strchr(c_inode, ':')))
                 *(sum->sha256++) = '\0';
+
+            /* Look for a defined tag */
+            if (tag = strchr(sum->sha256, ':'), tag) {
+                *(tag++) = '\0';
+                sum->tag = tag;
+            }
 
             sum->mtime = atol(c_mtime);
             sum->inode = atol(c_inode);
@@ -239,6 +251,11 @@ void sk_fill_event(Eventinfo *lf, const char *f_name, const sk_sum_t *sum) {
     if(sum->sha256) {
         os_strdup(sum->sha256, lf->sha256_after);
         os_strdup(sum->sha256, lf->fields[SK_SHA256].value);
+    }
+
+    if(sum->tag) {
+        os_strdup(sum->tag, lf->sk_tag);
+        os_strdup(sum->tag, lf->fields[SK_TAG].value);
     }
 
     if(sum->wdata.user_id) {

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -13,7 +13,7 @@
 
 #ifdef WIN32
 static char *SYSCHECK_EMPTY[] = { NULL };
-static registry REGISTRY_EMPTY[] = { { NULL, 0 } };
+static registry REGISTRY_EMPTY[] = { { NULL, 0, NULL } };
 #endif
 
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -204,7 +204,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
         case ENOTDIR:
             /*Deletion message sending*/
             alert_msg[OS_SIZE_6144 - 1] = '\0';
-            snprintf(alert_msg, OS_SIZE_6144, "-1:%s %s", syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", file_name);
+            snprintf(alert_msg, OS_SIZE_6144, "-1!:::::::::::%s %s", syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", file_name);
             send_syscheck_msg(alert_msg);
 
             // Delete from hash table
@@ -357,12 +357,11 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             /* Extract the whodata sum here to not include it in the hash table */
             if (extract_whodata_sum(evt, wd_sum, OS_SIZE_6144)) {
                 merror("The whodata sum for '%s' file could not be included in the alert as it is too large.", file_name);
-                *wd_sum = '\0';
             }
 
 #ifdef WIN32
             user = get_user(file_name, statbuf.st_uid, &sid);
-            snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%s::%s:%s:%s:%s:%ld:%ld:%s:%s!%s %s%s%s",
+            snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%s::%s:%s:%s:%s:%ld:%ld:%s!%s:%s %s%s%s",
                 opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
                 opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
                 (opts & CHECK_OWNER) && sid ? sid : "",
@@ -373,8 +372,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 opts & CHECK_MTIME ? (long)statbuf.st_mtime : 0,
                 opts & CHECK_INODE ? (long)statbuf.st_ino : 0,
                 opts & CHECK_SHA256SUM ? sf256_sum : "",
-                syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "",
                 wd_sum,
+                syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "",
                 file_name,
                 alertdump ? "\n" : "",
                 alertdump ? alertdump : "");
@@ -382,7 +381,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 LocalFree(sid);
             }
 #else
-            snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%d:%d:%s:%s:%s:%s:%ld:%ld:%s:%s!%s %s%s%s",
+            snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%d:%d:%s:%s:%s:%s:%ld:%ld:%s!%s:%s %s%s%s",
                 opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
                 opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
                 opts & CHECK_OWNER ? (int)statbuf.st_uid : 0,
@@ -394,8 +393,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 opts & CHECK_MTIME ? (long)statbuf.st_mtime : 0,
                 opts & CHECK_INODE ? (long)statbuf.st_ino : 0,
                 opts & CHECK_SHA256SUM ? sf256_sum : "",
-                syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "",
                 wd_sum,
+                syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "",
                 file_name,
                 alertdump ? "\n" : "",
                 alertdump ? alertdump : "");
@@ -427,7 +426,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 // Extract the whodata sum here to not include it in the hash table
                 if (extract_whodata_sum(evt, wd_sum, OS_SIZE_6144)) {
                     merror("The whodata sum for '%s' file could not be included in the alert as it is too large.", file_name);
-                    *wd_sum = '\0';
                 }
                 // Update database
                 snprintf(alert_msg, sizeof(alert_msg), "%.*s%.*s", SK_DB_NATTR, buf, (int)strcspn(c_sum, " "), c_sum);
@@ -439,17 +437,17 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 if (buf[9] == '+') {
                     fullalert = seechanges_addfile(file_name);
                     if (fullalert) {
-                        snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s\n%s",
-                                c_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", wd_sum, file_name, fullalert);
+                        snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s\n%s",
+                                c_sum, wd_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", file_name, fullalert);
                         free(fullalert);
                         fullalert = NULL;
                     } else {
-                        snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s",
-                                c_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", wd_sum, file_name);
+                        snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s",
+                                c_sum, wd_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", file_name);
                     }
                 } else {
-                    snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s",
-                            c_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", wd_sum, file_name);
+                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s",
+                            c_sum, wd_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", file_name);
                 }
                 free(buf);
                 send_syscheck_msg(alert_msg);
@@ -634,7 +632,7 @@ int run_dbcheck()
 
                 pos = find_dir_pos(curr_node->key, 1, 0, 0);
                 mdebug2("Sending delete msg for file: %s", curr_node->key);
-                snprintf(alert_msg, OS_SIZE_6144 - 1, "-1:%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", curr_node->key);
+                snprintf(alert_msg, OS_SIZE_6144 - 1, "-1!:::::::::::%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", curr_node->key);
                 send_syscheck_msg(alert_msg);
                 OSHash_Delete_ex(syscheck.last_check, curr_node->key);
                 if (data = OSHash_Delete_ex(syscheck.fp, curr_node->key), data) {
@@ -773,6 +771,7 @@ int extract_whodata_sum(whodata_evt *evt, char *wd_sum, int size) {
                 (long long unsigned int) evt->process_id
             ) >= size) {
             retval = 1;
+            snprintf(wd_sum, size, "::::::::::");
         }
 
 #ifdef WIN32

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -173,7 +173,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     syscheck_node *s_node;
     struct stat statbuf;
     char wd_sum[OS_SIZE_6144 + 1];
-    int recursion_limit;
 #ifdef WIN32
     const char *user;
     char *sid = NULL;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -204,7 +204,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
         case ENOTDIR:
             /*Deletion message sending*/
             alert_msg[OS_SIZE_6144 - 1] = '\0';
-            snprintf(alert_msg, OS_SIZE_6144, "-1 %s!%s", file_name, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "");
+            snprintf(alert_msg, OS_SIZE_6144, "-1:%s %s", syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", file_name);
             send_syscheck_msg(alert_msg);
 
             // Delete from hash table
@@ -362,7 +362,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
 
 #ifdef WIN32
             user = get_user(file_name, statbuf.st_uid, &sid);
-            snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%s::%s:%s:%s:%s:%ld:%ld:%s!%s %s!%s%s%s",
+            snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%s::%s:%s:%s:%s:%ld:%ld:%s:%s!%s %s%s%s",
                 opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
                 opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
                 (opts & CHECK_OWNER) && sid ? sid : "",
@@ -373,16 +373,16 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 opts & CHECK_MTIME ? (long)statbuf.st_mtime : 0,
                 opts & CHECK_INODE ? (long)statbuf.st_ino : 0,
                 opts & CHECK_SHA256SUM ? sf256_sum : "",
+                syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "",
                 wd_sum,
                 file_name,
-                syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "",
                 alertdump ? "\n" : "",
                 alertdump ? alertdump : "");
             if (sid) {
                 LocalFree(sid);
             }
 #else
-            snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%d:%d:%s:%s:%s:%s:%ld:%ld:%s!%s %s!%s%s%s",
+            snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%d:%d:%s:%s:%s:%s:%ld:%ld:%s:%s!%s %s%s%s",
                 opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
                 opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
                 opts & CHECK_OWNER ? (int)statbuf.st_uid : 0,
@@ -394,9 +394,9 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 opts & CHECK_MTIME ? (long)statbuf.st_mtime : 0,
                 opts & CHECK_INODE ? (long)statbuf.st_ino : 0,
                 opts & CHECK_SHA256SUM ? sf256_sum : "",
+                syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "",
                 wd_sum,
                 file_name,
-                syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "",
                 alertdump ? "\n" : "",
                 alertdump ? alertdump : "");
 #endif
@@ -439,14 +439,17 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 if (buf[9] == '+') {
                     fullalert = seechanges_addfile(file_name);
                     if (fullalert) {
-                        snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s\n%s", c_sum, wd_sum, file_name, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", fullalert);
+                        snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s\n%s",
+                                c_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", wd_sum, file_name, fullalert);
                         free(fullalert);
                         fullalert = NULL;
                     } else {
-                        snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s", c_sum, wd_sum, file_name, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "");
+                        snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s",
+                                c_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", wd_sum, file_name);
                     }
                 } else {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s", c_sum, wd_sum, file_name, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "");
+                    snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s",
+                            c_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", wd_sum, file_name);
                 }
                 free(buf);
                 send_syscheck_msg(alert_msg);
@@ -631,7 +634,7 @@ int run_dbcheck()
 
                 pos = find_dir_pos(curr_node->key, 1, 0, 0);
                 mdebug2("Sending delete msg for file: %s", curr_node->key);
-                snprintf(alert_msg, OS_SIZE_6144 - 1, "-1 %s!%s", curr_node->key, syscheck.tag[pos] ? syscheck.tag[pos] : "");
+                snprintf(alert_msg, OS_SIZE_6144 - 1, "-1:%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", curr_node->key);
                 send_syscheck_msg(alert_msg);
                 OSHash_Delete_ex(syscheck.last_check, curr_node->key);
                 if (data = OSHash_Delete_ex(syscheck.fp, curr_node->key), data) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -364,7 +364,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
         int pos = find_dir_pos(file_name, 1, 0, 0);
 
         //Alert for deleted file
-        snprintf(alert_msg, sizeof(alert_msg), "-1!%s %s!%s", wd_sum, file_name, syscheck.tag[pos] ? syscheck.tag[pos] : "");
+        snprintf(alert_msg, sizeof(alert_msg), "-1:%s!%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, file_name);
         send_syscheck_msg(alert_msg);
 
         // Delete from hash table

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -360,8 +360,11 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             *wd_sum = '\0';
         }
 
+        /* Find tag position for the evaluated file name */
+        int pos = find_dir_pos(file_name, 1, 0, 0);
+
         //Alert for deleted file
-        snprintf(alert_msg, sizeof(alert_msg), "-1!%s %s", wd_sum, file_name);
+        snprintf(alert_msg, sizeof(alert_msg), "-1!%s %s!%s", wd_sum, file_name, syscheck.tag[pos] ? syscheck.tag[pos] : "");
         send_syscheck_msg(alert_msg);
 
         // Delete from hash table
@@ -441,6 +444,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             }
         }
     }
+
 #ifndef WIN32
     /* If it is a link, check if the actual file is valid */
     else if (S_ISLNK(statbuf.st_mode)) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -357,14 +357,13 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
         // Extract the whodata sum here to not include it in the hash table
         if (extract_whodata_sum(evt, wd_sum, OS_SIZE_6144)) {
             merror("The whodata sum for '%s' file could not be included in the alert as it is too large.", file_name);
-            *wd_sum = '\0';
         }
 
         /* Find tag position for the evaluated file name */
         int pos = find_dir_pos(file_name, 1, 0, 0);
 
         //Alert for deleted file
-        snprintf(alert_msg, sizeof(alert_msg), "-1:%s!%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, file_name);
+        snprintf(alert_msg, sizeof(alert_msg), "-1!%s:%s %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
         send_syscheck_msg(alert_msg);
 
         // Delete from hash table

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -66,7 +66,6 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             // Extract the whodata sum here to not include it in the hash table
             if (extract_whodata_sum(evt, wd_sum, OS_SIZE_6144)) {
                 merror("The whodata sum for '%s' file could not be included in the alert as it is too large.", file_name);
-                *wd_sum = '\0';
             }
 
             /* Find tag position for the evaluated file name */
@@ -82,14 +81,14 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             if (buf[9] == '+') {
                 fullalert = seechanges_addfile(file_name);
                 if (fullalert) {
-                    snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s\n%s", c_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, file_name, fullalert);
+                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s\n%s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name, fullalert);
                     free(fullalert);
                     fullalert = NULL;
                 } else {
-                    snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s", c_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, file_name);
+                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
                 }
             } else {
-                snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s", c_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, file_name);
+                snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
             }
 
             send_syscheck_msg(alert_msg);

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -82,14 +82,14 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             if (buf[9] == '+') {
                 fullalert = seechanges_addfile(file_name);
                 if (fullalert) {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s\n%s", c_sum, wd_sum, file_name, syscheck.tag[pos] ? syscheck.tag[pos] : "", fullalert);
+                    snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s\n%s", c_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, file_name, fullalert);
                     free(fullalert);
                     fullalert = NULL;
                 } else {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s", c_sum, wd_sum, file_name, syscheck.tag[pos] ? syscheck.tag[pos] : "");
+                    snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s", c_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, file_name);
                 }
             } else {
-                snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s", c_sum, wd_sum, file_name, syscheck.tag[pos] ? syscheck.tag[pos] : "");
+                snprintf(alert_msg, OS_MAXSTR, "%s:%s!%s %s", c_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, file_name);
             }
 
             send_syscheck_msg(alert_msg);

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -69,6 +69,9 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
                 *wd_sum = '\0';
             }
 
+            /* Find tag position for the evaluated file name */
+            int pos = find_dir_pos(file_name, 1, 0, 0);
+
             // Update database
             snprintf(alert_msg, sizeof(alert_msg), "%.*s%.*s", SK_DB_NATTR, buf, (int)strcspn(c_sum, " "), c_sum);
             s_node->checksum = strdup(alert_msg);
@@ -79,15 +82,16 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             if (buf[9] == '+') {
                 fullalert = seechanges_addfile(file_name);
                 if (fullalert) {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s %s\n%s", c_sum, wd_sum, file_name, fullalert);
+                    snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s\n%s", c_sum, wd_sum, file_name, syscheck.tag[pos] ? syscheck.tag[pos] : "", fullalert);
                     free(fullalert);
                     fullalert = NULL;
                 } else {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s %s", c_sum, wd_sum, file_name);
+                    snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s", c_sum, wd_sum, file_name, syscheck.tag[pos] ? syscheck.tag[pos] : "");
                 }
             } else {
-                snprintf(alert_msg, OS_MAXSTR, "%s!%s %s", c_sum, wd_sum, file_name);
+                snprintf(alert_msg, OS_MAXSTR, "%s!%s %s!%s", c_sum, wd_sum, file_name, syscheck.tag[pos] ? syscheck.tag[pos] : "");
             }
+
             send_syscheck_msg(alert_msg);
             struct timeval timeout = {0, syscheck.rt_delay * 1000};
             select(0, NULL, NULL, NULL, &timeout);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -107,7 +107,7 @@ int Start_win32_Syscheck()
         /* Disabled */
         if (!syscheck.dir) {
             minfo(SK_NO_DIR);
-            dump_syscheck_entry(&syscheck, "", 0, 0, NULL, 0);
+            dump_syscheck_entry(&syscheck, "", 0, 0, NULL, 0, NULL);
         } else if (!syscheck.dir[0]) {
             minfo(SK_NO_DIR);
         }
@@ -121,7 +121,7 @@ int Start_win32_Syscheck()
         }
 
         if (!syscheck.registry) {
-            dump_syscheck_entry(&syscheck, "", 0, 1, NULL, 0);
+            dump_syscheck_entry(&syscheck, "", 0, 1, NULL, 0, NULL);
         }
         syscheck.registry[0].entry = NULL;
 
@@ -166,6 +166,8 @@ int Start_win32_Syscheck()
         while (syscheck.dir[r] != NULL) {
             char optstr[ 1024 ];
             minfo("Monitoring directory: '%s', with options %s.", syscheck.dir[r], syscheck_opts2str(optstr, sizeof( optstr ), syscheck.opts[r]));
+            if (syscheck.tag[r] != NULL)
+                mdebug1("Adding tag '%s' to directory '%s'.", syscheck.tag[r], syscheck.dir[r]);
             r++;
         }
 
@@ -281,7 +283,7 @@ int main(int argc, char **argv)
             if (!test_config) {
                 minfo(SK_NO_DIR);
             }
-            dump_syscheck_entry(&syscheck, "", 0, 0, NULL, 0);
+            dump_syscheck_entry(&syscheck, "", 0, 0, NULL, 0, NULL);
         } else if (!syscheck.dir[0]) {
             if (!test_config) {
                 minfo(SK_NO_DIR);
@@ -363,6 +365,8 @@ int main(int argc, char **argv)
         while (syscheck.dir[r] != NULL) {
             char optstr[ 1024 ];
             minfo("Monitoring directory: '%s', with options %s.", syscheck.dir[r], syscheck_opts2str(optstr, sizeof( optstr ), syscheck.opts[r]));
+            if (syscheck.tag[r] != NULL)
+                mdebug1("Adding tag '%s' to directory '%s'.", syscheck.tag[r], syscheck.dir[r]);
             r++;
         }
 

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -30,7 +30,7 @@ int ig_count = 0;
 int run_count = 0;
 
 /* Prototypes */
-void os_winreg_open_key(char *subkey, char *fullkey_name, int arch);
+void os_winreg_open_key(char *subkey, char *fullkey_name, int arch, const char * tag);
 
 
 int os_winreg_changed(char *key, char *md5, char *sha1, int arch)
@@ -146,7 +146,7 @@ char *os_winreg_sethkey(char *reg_entry)
 }
 
 /* Query the key and get all its values */
-void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int arch)
+void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int arch, const char * tag)
 {
     int rc;
     DWORD i, j;
@@ -216,7 +216,7 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int arch)
                 }
 
                 /* Open subkey */
-                os_winreg_open_key(new_key, new_key_full, arch);
+                os_winreg_open_key(new_key, new_key_full, arch, tag);
             }
         }
     }
@@ -301,8 +301,8 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int arch)
         /* Look for p_key on the reg db */
         if (os_winreg_changed(full_key_name, mf_sum, sf_sum, arch)) {
             char reg_changed[MAX_LINE + 1];
-            snprintf(reg_changed, MAX_LINE, "0:0:0:0:%s:%s %s%s",
-                     mf_sum, sf_sum, arch == ARCH_64BIT ? "[x64] " : "", full_key_name);
+            snprintf(reg_changed, MAX_LINE, "0:0:0:0:%s:%s %s%s!%s",
+                     mf_sum, sf_sum, arch == ARCH_64BIT ? "[x64] " : "", full_key_name, tag ? tag : "");
 
             /* Notify server */
             notify_registry(reg_changed, 0);
@@ -313,7 +313,7 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int arch)
 }
 
 /* Open the registry key */
-void os_winreg_open_key(char *subkey, char *fullkey_name, int arch)
+void os_winreg_open_key(char *subkey, char *fullkey_name, int arch, const char *tag)
 {
     int i = 0;
     HKEY oshkey;
@@ -350,7 +350,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch)
         return;
     }
 
-    os_winreg_querykey(oshkey, subkey, fullkey_name, arch);
+    os_winreg_querykey(oshkey, subkey, fullkey_name, arch, tag);
     RegCloseKey(oshkey);
     return;
 }
@@ -398,7 +398,7 @@ void os_winreg_check()
             continue;
         }
 
-        os_winreg_open_key(rk, syscheck.registry[i].entry, syscheck.registry[i].arch);
+        os_winreg_open_key(rk, syscheck.registry[i].entry, syscheck.registry[i].arch, syscheck.registry[i].tag);
         i++;
     }
 

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -301,8 +301,8 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int arch, c
         /* Look for p_key on the reg db */
         if (os_winreg_changed(full_key_name, mf_sum, sf_sum, arch)) {
             char reg_changed[MAX_LINE + 1];
-            snprintf(reg_changed, MAX_LINE, "0:0:0:0:%s:%s %s%s!%s",
-                     mf_sum, sf_sum, arch == ARCH_64BIT ? "[x64] " : "", full_key_name, tag ? tag : "");
+            snprintf(reg_changed, MAX_LINE, "0:0:0:0:%s:%s!:::::::::::%s %s%s",
+                     mf_sum, sf_sum, tag ? tag : "", arch == ARCH_64BIT ? "[x64] " : "", full_key_name);
 
             /* Notify server */
             notify_registry(reg_changed, 0);

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -949,7 +949,7 @@ void send_whodata_del(whodata_evt *w_evt) {
     /* Find tag if defined for this file */
     pos = find_dir_pos(w_evt->path, 1, 0, 0);
 
-    snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s %s!%s", wd_sum, w_evt->path, syscheck.tag[pos] ? syscheck.tag[pos] : "");
+    snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1:%s!%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, w_evt->path);
     send_syscheck_msg(del_msg);
 }
 

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -943,13 +943,12 @@ void send_whodata_del(whodata_evt *w_evt) {
 
     if (extract_whodata_sum(w_evt, wd_sum, OS_SIZE_6144)) {
         merror("The whodata sum for '%s' file could not be included in the alert as it is too large.", w_evt->path);
-        *wd_sum = '\0';
     }
 
     /* Find tag if defined for this file */
     pos = find_dir_pos(w_evt->path, 1, 0, 0);
 
-    snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1:%s!%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", wd_sum, w_evt->path);
+    snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s:%s %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", w_evt->path);
     send_syscheck_msg(del_msg);
 }
 

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -947,7 +947,7 @@ void send_whodata_del(whodata_evt *w_evt) {
     }
 
     /* Find tag if defined for this file */
-    pos = find_dir_pos(curr_node->key, 1, 0, 0);
+    pos = find_dir_pos(w_evt->path, 1, 0, 0);
 
     snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s %s!%s", wd_sum, w_evt->path, syscheck.tag[pos] ? syscheck.tag[pos] : "");
     send_syscheck_msg(del_msg);

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -932,6 +932,7 @@ void send_whodata_del(whodata_evt *w_evt) {
     static char del_msg[PATH_MAX + OS_SIZE_6144 + 6];
     static char wd_sum[OS_SIZE_6144 + 1];
     syscheck_node *s_node;
+    int pos;
 
     // Remove the file from the syscheck hash table
     if (s_node = OSHash_Delete_ex(syscheck.fp, w_evt->path), !s_node) {
@@ -945,7 +946,10 @@ void send_whodata_del(whodata_evt *w_evt) {
         *wd_sum = '\0';
     }
 
-    snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s %s", wd_sum, w_evt->path);
+    /* Find tag if defined for this file */
+    pos = find_dir_pos(curr_node->key, 1, 0, 0);
+
+    snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s %s!%s", wd_sum, w_evt->path, syscheck.tag[pos] ? syscheck.tag[pos] : "");
     send_syscheck_msg(del_msg);
 }
 


### PR DESCRIPTION
This PR adds a new attribute called `tags` for monitored directories and registries as follows:

```
<!-- Directories -->
<directories check_all="yes" whodata="yes" tags="whodata-folder, test_tag">/root/whodata-syscheck</directories>

<!-- Windows registry -->
<windows_registry tags="services-registry">HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services</windows_registry>
```

These tags are separated by commas, and they are included in the alert fields:

## Plain alert

```
** Alert 1534149464.85834: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2018 Aug 13 10:37:44 ubuntu18->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
Integrity checksum changed for: '/root/whodata-syscheck/file'
Size changed from '0' to '5'
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : 'd8e8fca2dc0f896fd7cb4cb0031ba249'
Old sha1sum was: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
New sha1sum is : '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83'
Old sha256sum was: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
New sha256sum is : 'f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2'
(Audit) User: 'root (0)'
(Audit) Login user: 'root (0)'
(Audit) Effective user: 'root (0)'
(Audit) Group: 'root (0)'
(Audit) Process id: '1881'
(Audit) Process name: '/bin/bash'

Attributes:
 - Size: 5
 - Permissions: 100644
 - Date: Mon Aug 13 10:37:43 2018
 - Inode: 1180095
 - User: root (0)
 - Group: root (0)
 - MD5: d8e8fca2dc0f896fd7cb4cb0031ba249
 - SHA1: 4e1243bd22c66e76c2ba9eddc1f91394e57f9f83
 - SHA256: f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2

Tags:
 - whodata-folder
 - test_tag
```

## JSON alert

```
...
"syscheck": {
    "path": "/root/whodata-syscheck/file",
    "size_before": "0",
    "size_after": "5",
    "perm_after": "100644",
    "uid_after": "0",
    "gid_after": "0",
    "md5_before": "d41d8cd98f00b204e9800998ecf8427e",
    "md5_after": "d8e8fca2dc0f896fd7cb4cb0031ba249",
    "sha1_before": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
    "sha1_after": "4e1243bd22c66e76c2ba9eddc1f91394e57f9f83",
    "sha256_before": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
    "sha256_after": "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
    "uname_after": "root",
    "gname_after": "root",
    "mtime_before": "2018-08-10T16:02:27",
    "mtime_after": "2018-08-13T10:37:43",
    "inode_after": 1180095,
    "tags": [
      "whodata-folder",
      "test_tag"
    ],
    "event": "modified",
    "audit": {
      "user": {
        "id": "0",
        "name": "root"
      },
      "group": {
        "id": "0",
        "name": "root"
      },
      "proccess": {
        "id": "1881",
        "name": "/bin/bash",
        "ppid": "1808"
      }
...
```

It is necessary to include the new attribute in the `Syscheck` reference before merging this PR.