### PR TITLE
Minor fixes/changes around #510

### DIFF
--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -17,7 +17,7 @@
 #define WM_AWS_LOGTAG ARGV0 ":aws-cloudtrail"
 #define WM_AWS_DEFAULT_INTERVAL 5
 #define WM_AWS_DEFAULT_DIR WM_DEFAULT_DIR "/aws"
-#define WM_AWS_SCRIPT_PATH WM_AWS_DEFAULT_DIR "/aws.py"
+#define WM_AWS_SCRIPT_PATH WM_AWS_DEFAULT_DIR "/aws-cloudtrail.py"
 
 typedef struct wm_aws_state_t {
     time_t next_time;               // Absolute time for next scan


### PR DESCRIPTION
- Nested json for policyDocument in events
- Fix bug with aws_account_id being required (should not be), not parsing correctly when not included
- Reduce msg debug chatter for reformatting
- Rename script and integration (from aws to aws-cloudtrail) to support additional/other AWS integrations