### PR TITLE
Fix showing changes of sha256 when it is missing

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -495,7 +495,7 @@ static int DB_Search(const char *f_name, char *c_sum, char *w_sum, Eventinfo *lf
                 }
 
                 /* SHA-256 message */
-                if(newsum.sha256 && *newsum.sha256)
+                if(newsum.sha256 && newsum.sha256[0] != '\0')
                 {
                     if(oldsum.sha256) {
                         if (strcmp(newsum.sha256, oldsum.sha256) == 0) {
@@ -512,6 +512,8 @@ static int DB_Search(const char *f_name, char *c_sum, char *w_sum, Eventinfo *lf
                         wm_strcat(&lf->fields[SK_CHFIELDS].value, "sha256", ',');
                         snprintf(sdb.sha256, OS_FLSIZE, "New sha256sum is : '%s'\n", newsum.sha256);
                     }
+                } else {
+                    sdb.sha256[0] = '\0';
                 }
 
                 /* Modification time message */


### PR DESCRIPTION
When the Syscheck decoder was evaluating a new entry without the option `check_sha256sum` enabled, it was being taken the corresponding sha256 changes message of the previous alert so it was showing false data about the old and new sha256:

```
** Alert 1534237734.28670: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2018 Aug 14 11:08:54 debian9->(debian9) 192.168.1.65->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
Integrity checksum changed for: '/var/ossec/etc/ossec.conf'
Size changed from '3927' to '3825'
Old md5sum was: '965715ca15ef108fb7e9ab2950c83508'
New md5sum is : 'b78eedd22136f446f06a9247a4def304'
Old sha1sum was: 'e4a72f5e31d62e49e50008f0d5fe6ac1a809a65c'
New sha1sum is : '56677394e08f3111b5c9c818fafaca153bdc3a83'
Old sha256sum was: 'fd53d33f8068c7d0bf1b85903657e97cdfdf3b622eed1a628579d356bfa50290'
New sha256sum is : '45c4498f9e63a4bfcbc8f7d59a7623ee234d9d090c548488c60ebe8c9ce708a1'

Attributes:
 - Size: 3825
 - Permissions: 100640
 - Date: Tue Aug 14 11:08:30 2018
 - Inode: 651930
 - MD5: b78eedd22136f446f06a9247a4def304
 - SHA1: 56677394e08f3111b5c9c818fafaca153bdc3a83
 - SHA256: 45c4498f9e63a4bfcbc8f7d59a7623ee234d9d090c548488c60ebe8c9ce708a1

** Alert 1534237754.29627: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2018 Aug 14 11:09:14 debian9->(debian9) 192.168.1.65->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
Integrity checksum changed for: '/root/realtime-syscheck/file'
Size changed from '16' to '20'
Old md5sum was: 'cba4c6a799a43bb6a9a483d55d3bf01c'
New md5sum is : '3deebac51d161443371c251fa384b788'
Old sha256sum was: 'fd53d33f8068c7d0bf1b85903657e97cdfdf3b622eed1a628579d356bfa50290'
New sha256sum is : '45c4498f9e63a4bfcbc8f7d59a7623ee234d9d090c548488c60ebe8c9ce708a1'

Attributes:
 - Size: 20
 - Permissions: 100644
 - Date: Tue Aug 14 11:09:13 2018
 - Inode: 531265
 - User: root (0)
 - Group: root (0)
 - MD5: 3deebac51d161443371c251fa384b788
```

This PR fixes that behavior.