### PR TITLE
Fix empty configuration blocks for Wazuh modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Fix multiple warnings when agent is offline. ([#1086](https://github.com/wazuh/wazuh/pull/1086))
 - Fixed minor issues in the Makefile and the sources installer on HP-UX, Solaris on SPARC and AIX systems. ([#1089](https://github.com/wazuh/wazuh/pull/1089))
 - Fixed SHA256 changes messages in alerts when it is disabled. ([#1100](https://github.com/wazuh/wazuh/pull/1100))
+- Fixed empty configuration blocks for Wazuh modules. ([#1101](https://github.com/wazuh/wazuh/pull/1101))
 - Restored firewall-drop AR script for Linux. ([#1114](https://github.com/wazuh/wazuh/pull/1114))
 
 ### Removed

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -51,7 +51,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     // Get children
 
     if (children = OS_GetElementsbyNode(xml, node), !children) {
-        return 0;
+        mdebug1("Empty configuration for module '%s'.", node->values[0]);
     }
 
     // Select module by name

--- a/src/config/wmodules-osquery-monitor.c
+++ b/src/config/wmodules-osquery-monitor.c
@@ -40,6 +40,9 @@ int wm_osquery_monitor_read(xml_node **nodes, wmodule *module)
     os_strdup("/etc/osquery/osquery.conf", osquery_monitor->config_path);
 #endif
 
+    if (!nodes)
+        return 0;
+
     for(i = 0; nodes[i]; i++)
     {
         if(!nodes[i]->element)


### PR DESCRIPTION
Fixed the possibility of set empty blocks in the configuration file for Wodles as follows:

```
<wodle name="syscollector"/>
<wodle name="osquery"/>
<wodle name="vulnerability-detector"/>
...
```
