### PR TITLE
Systemd unit - start after network

### DIFF
--- a/src/systemd/wazuh-agent.service
+++ b/src/systemd/wazuh-agent.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Wazuh agent
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=forking

--- a/src/systemd/wazuh-manager.service
+++ b/src/systemd/wazuh-manager.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Wazuh manager
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Sometimes have issue with wazuh-agent starts before network/resolving, can we add start after network systemd unit ?

```
[Unit]
Wants=network-online.target
After=network.target network-online.target
```

should be sufficient.