### PR TITLE
Fix variable length when collecting ram stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Fixed empty configuration blocks for Wazuh modules. ([#1101](https://github.com/wazuh/wazuh/pull/1101))
 - Fix broken pipe error in Wazuh DB by Vulnerability Detector. ([#1111](https://github.com/wazuh/wazuh/pull/1111))
 - Restored firewall-drop AR script for Linux. ([#1114](https://github.com/wazuh/wazuh/pull/1114))
+- Fixed variables length when storing RAM information by Syscollector. ([#1124](https://github.com/wazuh/wazuh/pull/1124))
 
 ### Removed
 

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -826,7 +826,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON) {
 
         if (ram_total) {
             char total[OS_MAXSTR];
-            snprintf(total, OS_MAXSTR - 1, "%d", ram_total->valueint);
+            snprintf(total, OS_MAXSTR - 1, "%f", ram_total->valuedouble);
             wm_strcat(&msg, total, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -834,7 +834,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON) {
 
         if (ram_free) {
             char rfree[OS_MAXSTR];
-            snprintf(rfree, OS_MAXSTR - 1, "%d", ram_free->valueint);
+            snprintf(rfree, OS_MAXSTR - 1, "%f", ram_free->valuedouble);
             wm_strcat(&msg, rfree, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -257,10 +257,10 @@ int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time,
 int wdb_osinfo_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version);
 
 // Insert HW info tuple. Return 0 on success or -1 on error.
-int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free, int ram_usage);
+int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, u_int64_t ram_total, u_int64_t ram_free, int ram_usage);
 
 // Save HW info into DB.
-int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free, int ram_usage);
+int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, u_int64_t ram_total, u_int64_t ram_free, int ram_usage);
 
 // Insert package info tuple. Return 0 on success or -1 on error.
 int wdb_package_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * format, const char * name, const char * priority, const char * section, long size, const char * vendor, const char * install_time, const char * version, const char * architecture, const char * multiarch, const char * source, const char * description, const char * location, const char triaged);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -1077,8 +1077,8 @@ int wdb_parse_hardware(wdb_t * wdb, char * input, char * output) {
     char * cpu_name;
     int cpu_cores;
     char * cpu_mhz;
-    long ram_total;
-    long ram_free;
+    u_int64_t ram_total;
+    u_int64_t ram_free;
     int ram_usage;
     int result;
 

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -502,7 +502,7 @@ int wdb_package_delete(wdb_t * wdb, const char * scan_id) {
 }
 
 // Function to save OS info into the DB. Return 0 on success or -1 on error.
-int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free, int ram_usage) {
+int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, u_int64_t ram_total, u_int64_t ram_free, int ram_usage) {
 
     sqlite3_stmt *stmt = NULL;
 
@@ -542,7 +542,7 @@ int wdb_hardware_save(wdb_t * wdb, const char * scan_id, const char * scan_time,
 }
 
 // Insert HW info tuple. Return 0 on success or -1 on error.
-int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, long ram_total, long ram_free, int ram_usage) {
+int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * serial, const char * cpu_name, int cpu_cores, const char * cpu_mhz, u_int64_t ram_total, u_int64_t ram_free, int ram_usage) {
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_HWINFO_INSERT) < 0) {
@@ -566,13 +566,13 @@ int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_tim
     sqlite3_bind_text(stmt, 6, cpu_mhz, -1, NULL);
 
     if (ram_total > 0) {
-        sqlite3_bind_int(stmt, 7, ram_total);
+        sqlite3_bind_int64(stmt, 7, ram_total);
     } else {
         sqlite3_bind_null(stmt, 7);
     }
 
     if (ram_free > 0) {
-        sqlite3_bind_int(stmt, 8, ram_free);
+        sqlite3_bind_int64(stmt, 8, ram_free);
     } else {
         sqlite3_bind_null(stmt, 8);
     }

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -97,8 +97,8 @@ typedef struct hw_info {
     char *cpu_name;
     int cpu_cores;
     double cpu_MHz;
-    int ram_total;  // kB
-    int ram_free;   // kB
+    u_int64_t ram_total;  // kB
+    u_int64_t ram_free;   // kB
     int ram_usage;  // Percentage
 } hw_info;
 

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -1351,7 +1351,7 @@ hw_info *get_system_linux(){
             }
         }
 
-        if (info->ram_total > 0 && info->ram_free >= 0) {
+        if (info->ram_total > 0) {
             info->ram_usage = 100 - (info->ram_free * 100 / info->ram_total);
         }
         free(aux_string);


### PR DESCRIPTION
This PR fixed the issue #1099.

When calculating the ram usage, the value of free memory ram is multiplicated by 100, which causes that the maximum value of the integer variable is reached. That's why the returned value is not correct.

It has been fixed by increasing the implicated variables size from `32bits integer` to `unsigned 64 bits integer`.

This way we avoid the following error:

```
2018/08/20 11:31:09 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2018/08/20 11:31:09 wazuh-db: DEBUG: TEST: RAM_TOTAL = 32780836001
2018/08/20 11:31:09 wazuh-db: ERROR: at wdb_hardware_insert(): sqlite3_step(): CHECK constraint failed: sys_hwinfo
2018/08/20 11:31:09 wazuh-db: ERROR: Unable to update 'sys_hwinfo' table for agent '000'
2018/08/20 11:31:09 ossec-analysisd: ERROR: at sc_send_db(): received: 'err Cannot save HW information.'
```

And the new `ram_total` is stored correctly in the database:

```
sqlite> select ram_total from sys_hwinfo;
32780836001
```