### PR TITLE
Add error message when configuring vuln-detector on agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Let hostname field be the name of the agent, without the location part. ([#1080](https://github.com/wazuh/wazuh/pull/1080))
+- Show error message when configuring vulnerability-detector for an agent. ([#1130](https://github.com/wazuh/wazuh/pull/1130))
 
 ### Fixed
 

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -108,8 +108,13 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     }
 #endif
 #endif
+
     else {
-        merror("Unknown module '%s'", node->values[0]);
+        if(!strcmp(node->values[0], "vulnerability-detector")){
+            merror("The '%s' module only works for the manager", node->values[0]);
+        } else {
+            merror("Unknown module '%s'", node->values[0]);
+        }
     }
 
     OS_ClearNode(children);


### PR DESCRIPTION
A new error message for the agent configuration when vulnerability-detector is set has been added.