### PR TITLE
Set the minimum vulnerability-detector timeout to 1 second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 - Let hostname field be the name of the agent, without the location part. ([#1080](https://github.com/wazuh/wazuh/pull/1080))
 - Show error message when configuring vulnerability-detector for an agent. ([#1130](https://github.com/wazuh/wazuh/pull/1130))
+- Increase the minimum waiting time from 0 to 1 seconds in Vulnerability-Detector. ([#1132](https://github.com/wazuh/wazuh/pull/1132))
 
 ### Fixed
 

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -2335,8 +2335,8 @@ void * wm_vulnerability_detector_main(wm_vulnerability_detector_t * vulnerabilit
 
         time_t t_now = time(NULL);
         time_sleep = (vulnerability_detector->last_detection + vulnerability_detector->detection_interval) - t_now;
-        if (time_sleep < 0) {
-            time_sleep = 0;
+        if (time_sleep <= 0) {
+            time_sleep = 1;
             i = OS_SUPP_SIZE;
         } else {
             i = 0;
@@ -2347,8 +2347,8 @@ void * wm_vulnerability_detector_main(wm_vulnerability_detector_t * vulnerabilit
             if (updates[i]) {
                 time_t t_diff = (updates[i]->last_update + updates[i]->interval) - t_now;
                 // Stop checking if we have any pending updates
-                if (t_diff < 0) {
-                    time_sleep = 0;
+                if (t_diff <= 0) {
+                    time_sleep = 1;
                     break;
                 } else if (t_diff < time_sleep) {
                     time_sleep = t_diff;


### PR DESCRIPTION
This will avoid unnecessary iterations.