### PR TITLE
Build external SQLite library for CentOS 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Fix allowing more than one wodle command. ([#1128](https://github.com/wazuh/wazuh/pull/1128))
 - Fixed `after_regex` offset for the decoding algorithm. ([#1129](https://github.com/wazuh/wazuh/pull/1129))
 - Fix unknown severity in Red Hat systems. ([#1118](https://github.com/wazuh/wazuh/pull/1118))
+- Added a building flag to compile the SQLite library externally for the API. ([#1119](https://github.com/wazuh/wazuh/issues/1119))
 
 ### Removed
 

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -2,27 +2,50 @@
 # Copyright 2017 Wazuh Inc.
 # May 3, 2017
 #
-# Syntax: make [ all | install | examples ]
+# Syntax: make [ all | build | install | examples | clean ]
 
-OSSEC_GROUP  = ossec
-PREFIX       = /var/ossec
+OSSEC_GROUP       = ossec
+PREFIX            = /var/ossec
+USE_FRAMEWORK_LIB = no
 
+CC           = gcc
+CFLAGS       = -pipe -Wall -Wextra
+THREAD_FLAGS = -pthread
+RM_FILE      = rm -f
 INSTALL_DIR  = install -o root -g ${OSSEC_GROUP} -m 0750  -d
 INSTALL_EXEC = install -o root -g ${OSSEC_GROUP} -m 0750
 INSTALL_FILE = install -o root -g ${OSSEC_GROUP} -m 0640
 
-.PHONY: all install examples
+SQLITE_DIR       = ../src/external/sqlite
 
-all:
+BUILD_TARGET     = libsqlite3.so.0
+
+ifdef DEBUG
+	CFLAGS+=-g -I ../src
+	LFLAGS+=-g
+else
+	CFLAGS+=-O2 -I ../src
+	LFLAGS+=-O2
+endif
+
+.PHONY: all build install examples clean
+
+all: build
 
 install:
 	$(INSTALL_DIR) $(PREFIX)/framework
 	$(INSTALL_DIR) $(PREFIX)/framework/wazuh
+ifneq (,$(filter ${USE_FRAMEWORK_LIB},yes y Y 1))
+	$(INSTALL_DIR) $(PREFIX)/framework/lib
+endif
 	$(INSTALL_DIR) $(PREFIX)/framework/wazuh/cluster
 
 	$(INSTALL_FILE) wazuh/*.py ${PREFIX}/framework/wazuh
 	$(INSTALL_FILE) wazuh/cluster/*.json ${PREFIX}/framework/wazuh/cluster
 	$(INSTALL_FILE) wazuh/cluster/*.py ${PREFIX}/framework/wazuh/cluster
+ifneq (,$(filter ${USE_FRAMEWORK_LIB},yes y Y 1))
+	$(INSTALL_FILE) libsqlite3.so.0 ${PREFIX}/framework/lib/
+endif
 
 #	Install scripts/%.py on $(PREFIX)/bin/%
 	$(foreach script,$(wildcard scripts/*),$(INSTALL_EXEC) $(script) $(patsubst scripts/%.py,$(PREFIX)/bin/%,$(script));)
@@ -30,3 +53,13 @@ install:
 examples: install
 	$(INSTALL_DIR) $(PREFIX)/framework/examples
 	$(INSTALL_EXEC) examples/*.py ${PREFIX}/framework/examples
+
+ifneq (,$(filter ${USE_FRAMEWORK_LIB},yes y Y 1))
+build: $(BUILD_TARGET)
+
+libsqlite3.so.0: $(SQLITE_DIR)/sqlite3.o
+	$(CC) $(LFLAGS) -shared -o $@ $^
+endif
+
+clean:
+	$(RM_FILE) $(BUILD_TARGET) *.o *.so.0

--- a/framework/examples/get_agents.py
+++ b/framework/examples/get_agents.py
@@ -17,7 +17,7 @@
 #    - export PATH=$PATH:/opt/rh/python27/root/usr/bin
 #    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rh/python27/root/usr/lib64
 #  - Use the wazuh sqlite lib
-#    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/ossec/lib
+#    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/ossec/framework/lib
 
 from sys import path, exit
 import json

--- a/framework/examples/rules2csv.py
+++ b/framework/examples/rules2csv.py
@@ -17,7 +17,7 @@
 #    - export PATH=$PATH:/opt/rh/python27/root/usr/bin
 #    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rh/python27/root/usr/lib64
 #  - Use the wazuh sqlite lib
-#    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/ossec/lib
+#    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/ossec/framework/lib
 
 from sys import path, exit
 # cwd = /var/ossec/api/framework/examples

--- a/framework/wazuh/database.py
+++ b/framework/wazuh/database.py
@@ -13,7 +13,7 @@ import sqlite3
 if LooseVersion(sqlite3.sqlite_version) < LooseVersion('3.7.0.0'):
     msg = str(sqlite3.sqlite_version)
     msg += "\nTry to export the internal SQLite library:"
-    msg += "\nexport LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{0}/lib".format(common.ossec_path)
+    msg += "\nexport LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{0}/framework/lib".format(common.ossec_path)
     raise WazuhException(2001, msg)
 
 

--- a/install.sh
+++ b/install.sh
@@ -95,13 +95,17 @@ Install()
 
     # On CentOS <= 5 we need to disable syscollector compilation
     OS_VERSION_FOR_SYSC="${DIST_NAME}"
-    if ([ "X${OS_VERSION_FOR_SYSC}" = "Xrhel" ] || [ "X${OS_VERSION_FOR_SYSC}" = "Xcentos" ] || [ "X${OS_VERSION_FOR_SYSC}" = "XCentOS" ]) && [ ${DIST_VER} -le 5 ]; then
+    if ([ "X${OS_VERSION_FOR_SYSC}" = "Xrhel" ] || [ "X${OS_VERSION_FOR_SYSC}" = "Xcentos" ]) && [ ${DIST_VER} -le 5 ]; then
         AUDIT_FLAG="USE_AUDIT=no"
         if [ ${DIST_VER} -lt 5 ]; then
             SYSC_FLAG="DISABLE_SYSC=true"
         fi
     fi
 
+    # Build SQLite library for CentOS 6
+    if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ]) && [ ${DIST_VER} -le 6 ]; then
+        LIB_FLAG="USE_FRAMEWORK_LIB=yes"
+    fi
 
     # Makefile
     echo " - ${runningmake}"
@@ -116,7 +120,7 @@ Install()
 
         # Add DATABASE=pgsql or DATABASE=mysql to add support for database
         # alert entry
-        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} ${AUDIT_FLAG} -j${THREADS} build
+        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} ${AUDIT_FLAG} ${LIB_FLAG} -j${THREADS} build
 
         if [ $? != 0 ]; then
             cd ../

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,6 +39,7 @@ USE_GEOIP?=no
 USE_INOTIFY=no
 USE_BIG_ENDIAN=no
 USE_AUDIT=no
+USE_FRAMEWORK_LIB=no
 
 ifneq ($(HAS_CHECKMODULE),)
 ifneq ($(HAS_SEMODULE_PACKAGE),)
@@ -435,6 +436,7 @@ help: failtarget
 	@echo "   make BIG_ENDIAN=0            Build with big endian support"
 	@echo "   make USE_SELINUX=0           Build with SELinux policies"
 	@echo "   make USE_AUDIT=1             Build with audit service support"
+	@echo "   make USE_FRAMEWORK_LIB=0     Use external SQLite library for the framework"
 	@echo "   make OFLAGS=-Ox              Overrides optimization level"
 	@echo
 	@echo "Database options: "
@@ -459,43 +461,44 @@ help: failtarget
 settings:
 	@echo
 	@echo "General settings:"
-	@echo "    TARGET:           ${TARGET}"
-	@echo "    V:                ${V}"
-	@echo "    DEBUG:            ${DEBUG}"
-	@echo "    DEBUGAD           ${DEBUGAD}"
-	@echo "    PREFIX:           ${PREFIX}"
-	@echo "    MAXAGENTS:        ${MAXAGENTS}"
-	@echo "    REUSE_ID:         ${REUSE_ID}"
-	@echo "    DATABASE:         ${DATABASE}"
-	@echo "    ONEWAY:           ${ONEWAY}"
-	@echo "    CLEANFULL:        ${CLEANFULL}"
-	@echo "    RESOURCES_URL:    ${RESOURCES_URL}"
+	@echo "    TARGET:             ${TARGET}"
+	@echo "    V:                  ${V}"
+	@echo "    DEBUG:              ${DEBUG}"
+	@echo "    DEBUGAD             ${DEBUGAD}"
+	@echo "    PREFIX:             ${PREFIX}"
+	@echo "    MAXAGENTS:          ${MAXAGENTS}"
+	@echo "    REUSE_ID:           ${REUSE_ID}"
+	@echo "    DATABASE:           ${DATABASE}"
+	@echo "    ONEWAY:             ${ONEWAY}"
+	@echo "    CLEANFULL:          ${CLEANFULL}"
+	@echo "    RESOURCES_URL:      ${RESOURCES_URL}"
 	@echo "User settings:"
-	@echo "    OSSEC_GROUP:      ${OSSEC_GROUP}"
-	@echo "    OSSEC_USER:       ${OSSEC_USER}"
-	@echo "    OSSEC_USER_MAIL:  ${OSSEC_USER_MAIL}"
-	@echo "    OSSEC_USER_REM:   ${OSSEC_USER_REM}"
+	@echo "    OSSEC_GROUP:        ${OSSEC_GROUP}"
+	@echo "    OSSEC_USER:         ${OSSEC_USER}"
+	@echo "    OSSEC_USER_MAIL:    ${OSSEC_USER_MAIL}"
+	@echo "    OSSEC_USER_REM:     ${OSSEC_USER_REM}"
 	@echo "USE settings:"
-	@echo "    USE_ZEROMQ:       ${USE_ZEROMQ}"
-	@echo "    USE_GEOIP:        ${USE_GEOIP}"
-	@echo "    USE_PRELUDE:      ${USE_PRELUDE}"
-	@echo "    USE_INOTIFY:      ${USE_INOTIFY}"
-	@echo "    USE_BIG_ENDIAN:   ${USE_BIG_ENDIAN}"
-	@echo "    USE_SELINUX:      ${USE_SELINUX}"
-	@echo "    USE_AUDIT:        ${USE_AUDIT}"
+	@echo "    USE_ZEROMQ:         ${USE_ZEROMQ}"
+	@echo "    USE_GEOIP:          ${USE_GEOIP}"
+	@echo "    USE_PRELUDE:        ${USE_PRELUDE}"
+	@echo "    USE_INOTIFY:        ${USE_INOTIFY}"
+	@echo "    USE_BIG_ENDIAN:     ${USE_BIG_ENDIAN}"
+	@echo "    USE_SELINUX:        ${USE_SELINUX}"
+	@echo "    USE_AUDIT:          ${USE_AUDIT}"
+	@echo "    USE_FRAMEWORK_LIB:  ${USE_FRAMEWORK_LIB}"
 	@echo "Mysql settings:"
-	@echo "    includes:         ${MI}"
-	@echo "    libs:             ${ML}"
+	@echo "    includes:           ${MI}"
+	@echo "    libs:               ${ML}"
 	@echo "Pgsql settings:"
-	@echo "    includes:         ${PI}"
-	@echo "    libs:             ${PL}"
+	@echo "    includes:           ${PI}"
+	@echo "    libs:               ${PL}"
 	@echo "Defines:"
 	@echo "    ${DEFINES}"
 	@echo "Compiler:"
-	@echo "    CFLAGS          ${OSSEC_CFLAGS}"
-	@echo "    LDFLAGS         ${OSSEC_LDFLAGS}"
-	@echo "    CC              ${CC}"
-	@echo "    MAKE            ${MAKE}"
+	@echo "    CFLAGS            ${OSSEC_CFLAGS}"
+	@echo "    LDFLAGS           ${OSSEC_LDFLAGS}"
+	@echo "    CC                ${CC}"
+	@echo "    MAKE              ${MAKE}"
 
 BUILD_SERVER+=ossec-maild -
 BUILD_SERVER+=ossec-csyslogd -
@@ -517,6 +520,9 @@ BUILD_SERVER+=ossec-dbd -
 BUILD_SERVER+=ossec-integratord
 BUILD_SERVER+=wazuh-modulesd
 BUILD_SERVER+=wazuh-db
+ifneq (,$(filter ${USE_FRAMEWORK_LIB},yes y Y 1))
+BUILD_SERVER+=wazuh-framework
+endif
 
 BUILD_AGENT+=ossec-agentd
 BUILD_AGENT+=agent-auth
@@ -1335,6 +1341,12 @@ wmodulesd_o := $(wmodulesd_c:.c=.o)
 wazuh-modulesd: ${wmodulesd_o}
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
+### wazuh-framework ##
+ifneq (,$(filter ${USE_FRAMEWORK_LIB},yes y Y 1))
+wazuh-framework: ${shared_o} ${wdblib_o}
+	${MAKE} -C ../framework build PREFIX=${PREFIX} USE_FRAMEWORK_LIB=${USE_FRAMEWORK_LIB}
+endif
+
 
 ####################
 #### test ##########
@@ -1470,7 +1482,7 @@ win32/agent-auth.exe: win32/win_service_rk.o win32/agent_auth.o addagent/validat
 #### Clean #########
 ####################
 
-clean: clean-test clean-internals clean-external clean-windows clean-config
+clean: clean-test clean-internals clean-external clean-windows clean-framework clean-config
 
 clean-test:
 	rm -f ${test_o} ${test_programs} ossec.test
@@ -1531,6 +1543,9 @@ clean-internals:
 	rm -f ${wdb_o}
 	rm -f ${SELINUX_MODULE}
 	rm -f ${SELINUX_POLICY}
+
+clean-framework:
+	${MAKE} -C ../framework clean
 
 clean-windows:
 	rm -f wazuh_modules/syscollector/syscollector_win_ext.dll

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -826,7 +826,14 @@ InstallLocal(){
     ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} -b ../etc/decoders/*.xml ${PREFIX}/ruleset/decoders
     ${INSTALL} -m 0660 -o root -g ${OSSEC_GROUP} rootcheck/db/*.txt ${PREFIX}/etc/rootcheck
 
-    ${MAKEBIN} --quiet -C ../framework install PREFIX=${PREFIX}
+    # Build SQLite library for CentOS 6
+    if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ]) && [ ${DIST_VER} -le 6 ]; then
+        LIB_FLAG="yes"
+    else
+        LIB_FLAG="no"
+    fi
+
+    ${MAKEBIN} --quiet -C ../framework install PREFIX=${PREFIX} USE_FRAMEWORK_LIB=${LIB_FLAG}
 
     if [ ! -f ${PREFIX}/etc/decoders/local_decoder.xml ]; then
         ${INSTALL} -m 0640 -o ossec -g ${OSSEC_GROUP} -b ../etc/local_decoder.xml ${PREFIX}/etc/decoders/local_decoder.xml


### PR DESCRIPTION
This PR solves the issue: https://github.com/wazuh/wazuh/issues/1119

It has been included a new flag for the Makefile called `USE_FRAMEWORK_LIB` which builds the SQLite shared library for the framework. It is disabled by default except for CentOS 6. 