### PR TITLE
Fix thread stack size for Mac OS agents

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -38,6 +38,9 @@ static socklen_t us_l = sizeof(n_us);
 
 #endif /* WIN32*/
 
+#define RECV_SOCK 0
+#define SEND_SOCK 1
+
 
 /* Bind a specific port */
 static int OS_Bindport(u_int16_t _port, unsigned int _proto, const char *_ip, int ipv6)
@@ -125,9 +128,7 @@ int OS_Bindportudp(u_int16_t _port, const char *_ip, int ipv6)
 /* Bind to a Unix domain, using DGRAM sockets */
 int OS_BindUnixDomain(const char *path, int type, int max_msg_size)
 {
-    int len;
     int ossock = 0;
-    socklen_t optlen = sizeof(len);
 
     /* Make sure the path isn't there */
     unlink(path);
@@ -156,19 +157,9 @@ int OS_BindUnixDomain(const char *path, int type, int max_msg_size)
         return (OS_SOCKTERR);
     }
 
-    /* Get current maximum size */
-    if (getsockopt(ossock, SOL_SOCKET, SO_RCVBUF, &len, &optlen) == -1) {
-        OS_CloseSocket(ossock);
+    // Set socket maximum size
+    if (OS_SetSocketSize(ossock, RECV_SOCK, max_msg_size) < 0) {
         return (OS_SOCKTERR);
-    }
-
-    /* Set socket opt */
-    if (len < max_msg_size) {
-        len = max_msg_size;
-        if (setsockopt(ossock, SOL_SOCKET, SO_RCVBUF, &len, optlen) < 0) {
-            OS_CloseSocket(ossock);
-            return (OS_SOCKTERR);
-        }
     }
 
     return (ossock);
@@ -179,9 +170,7 @@ int OS_BindUnixDomain(const char *path, int type, int max_msg_size)
  */
 int OS_ConnectUnixDomain(const char *path, int type, int max_msg_size)
 {
-    int len;
     int ossock = 0;
-    socklen_t optlen = sizeof(len);
 
     memset(&n_us, 0, sizeof(n_us));
 
@@ -200,19 +189,9 @@ int OS_ConnectUnixDomain(const char *path, int type, int max_msg_size)
         return (OS_SOCKTERR);
     }
 
-    /* Get current maximum size */
-    if (getsockopt(ossock, SOL_SOCKET, SO_SNDBUF, &len, &optlen) == -1) {
-        OS_CloseSocket(ossock);
+    // Set socket maximum size
+    if (OS_SetSocketSize(ossock, SEND_SOCK, max_msg_size) < 0) {
         return (OS_SOCKTERR);
-    }
-
-    /* Set maximum message size */
-    if (len < max_msg_size) {
-        len = max_msg_size;
-        if (setsockopt(ossock, SOL_SOCKET, SO_SNDBUF, &len, optlen) < 0) {
-            OS_CloseSocket(ossock);
-            return (OS_SOCKTERR);
-        }
     }
 
     return (ossock);
@@ -237,6 +216,7 @@ int OS_getsocketsize(int ossock)
 static int OS_Connect(u_int16_t _port, unsigned int protocol, const char *_ip, int ipv6)
 {
     int ossock;
+    int max_msg_size = OS_MAXSTR + 512;
     struct sockaddr_in server;
 #ifndef WIN32
     struct sockaddr_in6 server6;
@@ -283,6 +263,14 @@ static int OS_Connect(u_int16_t _port, unsigned int protocol, const char *_ip, i
             OS_CloseSocket(ossock);
             return (OS_SOCKTERR);
         }
+    }
+
+    // Set socket maximum size
+    if (OS_SetSocketSize(ossock, RECV_SOCK, max_msg_size) < 0) {
+        return (OS_SOCKTERR);
+    }
+    if (OS_SetSocketSize(ossock, SEND_SOCK, max_msg_size) < 0) {
+        return (OS_SOCKTERR);
     }
 
     return (ossock);
@@ -541,7 +529,7 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
     char * buffer;
     size_t bufsz = size + sizeof(uint32_t);
     uint32_t msgsize;
-    
+
     os_malloc(bufsz, buffer);
     recvval = recv(sock, buffer, bufsz, 0);
 
@@ -551,7 +539,7 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
             free(buffer);
             return recvval;
             break;
-            
+
         case 0:
             free(buffer);
             return recvval;
@@ -559,7 +547,7 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
     }
 
     msgsize = wnet_order(*(uint32_t*)buffer);
-    
+
     if(msgsize > size){
         free(buffer);
         return OS_SOCKTERR;
@@ -568,12 +556,12 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
     if((uint32_t)recvval < msgsize){
         int recvb = recv(sock, buffer + recvval, msgsize-recvval, MSG_WAITALL);
 
-        switch(recvb){ 
+        switch(recvb){
             case -1:
                 free(buffer);
                 return recvb;
                 break;
-                
+
             case 0:
                 free(buffer);
                 return recvb;
@@ -595,4 +583,48 @@ uint32_t wnet_order(uint32_t value) {
 #else
     return value;
 #endif
+}
+
+/* Set the maximum buffer size for the socket */
+int OS_SetSocketSize(int sock, int mode, int max_msg_size) {
+
+    int len;
+    socklen_t optlen = sizeof(len);
+
+    if (mode == RECV_SOCK) {
+
+        /* Get current maximum size */
+        if (getsockopt(sock, SOL_SOCKET, SO_RCVBUF, &len, &optlen) == -1) {
+            OS_CloseSocket(sock);
+            return -1;
+        }
+
+        /* Set maximum message size */
+        if (len < max_msg_size) {
+            len = max_msg_size;
+            if (setsockopt(sock, SOL_SOCKET, SO_RCVBUF, &len, optlen) < 0) {
+                OS_CloseSocket(sock);
+                return -1;
+            }
+        }
+
+    } else if (mode == SEND_SOCK) {
+
+        /* Get current maximum size */
+        if (getsockopt(sock, SOL_SOCKET, SO_SNDBUF, &len, &optlen) == -1) {
+            OS_CloseSocket(sock);
+            return -1;
+        }
+
+        /* Set maximum message size */
+        if (len < max_msg_size) {
+            len = max_msg_size;
+            if (setsockopt(sock, SOL_SOCKET, SO_SNDBUF, &len, optlen) < 0) {
+                OS_CloseSocket(sock);
+                return -1;
+            }
+        }
+    }
+
+    return 0;
 }

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -96,4 +96,7 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size);
 
 uint32_t wnet_order(uint32_t value);
 
+/* Set the maximum buffer size for the socket */
+int OS_SetSocketSize(int sock, int mode, int max_msg_size);
+
 #endif /* __OS_NET_H */

--- a/src/shared/pthreads_op.c
+++ b/src/shared/pthreads_op.c
@@ -11,10 +11,65 @@
 #include "shared.h"
 #include <pthread.h>
 
-
 /* Create a new thread and give the argument passed to the function
  * Returns 0 on success or -1 on error
  */
+
+#if defined(__MACH__)
+
+#include <sys/resource.h>
+
+/* Set the maximum stack limit to new threads on mac OS */
+int CreateThread(void * (*function_pointer)(void *), void *data)
+{
+    pthread_t lthread;
+    pthread_attr_t attr;
+    struct rlimit lim;
+    size_t stacksize = 0;
+    int ret = 0;
+
+    if (getrlimit(RLIMIT_STACK, &lim)) {
+        merror(THREAD_ERROR);
+        return (-1);
+    }
+
+    if (lim.rlim_cur != RLIM_INFINITY && lim.rlim_cur >= PTHREAD_STACK_MIN) {
+
+        if (pthread_attr_init(&attr)) {
+            merror(THREAD_ERROR);
+            return (-1);
+        }
+
+        if (pthread_attr_setstacksize(&attr, lim.rlim_cur)) {
+            merror(THREAD_ERROR);
+            return (-1);
+        }
+
+        if (pthread_attr_getstacksize(&attr, &stacksize)) {
+            merror(THREAD_ERROR);
+            return (-1);
+        }
+        mdebug2("Thread stack size set to: %d", (int)stacksize);
+    }
+
+    ret = pthread_create(&lthread, &attr, function_pointer, (void *)data);
+    if (ret != 0) {
+        merror(THREAD_ERROR);
+        return (-1);
+    }
+
+    if (pthread_detach(lthread) != 0) {
+        merror(THREAD_ERROR);
+        return (-1);
+    }
+
+    pthread_attr_destroy(&attr);
+
+    return (0);
+}
+
+#else
+
 int CreateThread(void * (*function_pointer)(void *), void *data)
 {
     pthread_t lthread;
@@ -34,4 +89,5 @@ int CreateThread(void * (*function_pointer)(void *), void *data)
     return (0);
 }
 
+#endif /* mac OS */
 #endif /* !WIN32 */


### PR DESCRIPTION
On mac OS threads other than the main thread are created with a reduced stack, in particular, 512KB.

This causes the agent daemon crash since large messages ( <= 64KB) are sent to the buffer dispatch thread.

Now, mac OS threads are created by setting the default thread stack size to the allowed limit by the system.

The network sockets functions also include a new one to set the maximum socket size.