### PR TITLE
Fixing update oval in legacy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 - Fix Red Hat vulnerability database update. ([#1127](https://github.com/wazuh/wazuh/pull/1127))
 - Fix allowing more than one wodle command. ([#1128](https://github.com/wazuh/wazuh/pull/1128))
 - Fixed `after_regex` offset for the decoding algorithm. ([#1129](https://github.com/wazuh/wazuh/pull/1129))
+- Fixed legacy configuration for `vulnerability-detector`. ([#1174](https://github.com/wazuh/wazuh/pull/1174))
 
 ### Removed
 

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -410,6 +410,8 @@ int wm_vulnerability_detector_read(const OS_XML *xml, xml_node **nodes, wmodule 
                                     } else {
                                         merror("Invalid Ubuntu version '%s'.", version);
                                     }
+                                    if(precise || trusty || xenial)
+                                        vulnerability_detector->flags.u_flags.update_ubuntu = 1;
                                     version = &version[k] + 1;
                                     k = 0;
                                 }
@@ -494,6 +496,9 @@ int wm_vulnerability_detector_read(const OS_XML *xml, xml_node **nodes, wmodule 
                                     } else {
                                         merror("Invalid RedHat version '%s'.", version);
                                     }
+                                    if(rhel5 || rhel6 || rhel7)
+                                        vulnerability_detector->flags.u_flags.update_redhat = 1;
+
                                     version = &version[k] + 1;
                                     k = 0;
                                 }

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -498,7 +498,6 @@ int wm_vulnerability_detector_read(const OS_XML *xml, xml_node **nodes, wmodule 
                                     }
                                     if(rhel5 || rhel6 || rhel7)
                                         vulnerability_detector->flags.u_flags.update_redhat = 1;
-
                                     version = &version[k] + 1;
                                     k = 0;
                                 }


### PR DESCRIPTION
Fixed legacy configuration for `vulnerability-detector`. 