### PR TITLE
Add active-response files to nsi and wxs files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ src/win32/internal_options.conf
 src/win32/restart-ossec.cmd
 src/win32/route-null.cmd
 src/win32/netsh-win-2016.cmd
+src/win32/route-null-2012.cmd
+src/win32/netsh.cmd
 src/win32/VERSION
 src/win32/REVISION
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - Fixed `after_regex` offset for the decoding algorithm. ([#1129](https://github.com/wazuh/wazuh/pull/1129))
 - Prevents some vulnerabilities from not being checked for Debian. ([#1166](https://github.com/wazuh/wazuh/pull/1166))
 - Fixed legacy configuration for `vulnerability-detector`. ([#1174](https://github.com/wazuh/wazuh/pull/1174))
+- Fix active-response scripts installation for Windows. ([#1182](https://github.com/wazuh/wazuh/pull/1182)).
 
 ### Removed
 

--- a/etc/templates/config/generic/ar-commands.template
+++ b/etc/templates/config/generic/ar-commands.template
@@ -40,6 +40,20 @@
   </command>
 
   <command>
+    <name>win_route-null-2012</name>
+    <executable>route-null-2012.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>netsh</name>
+    <executable>netsh.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
     <name>netsh-win-2016</name>
     <executable>netsh-win-2016.cmd</executable>
     <expect>srcip</expect>

--- a/src/Makefile
+++ b/src/Makefile
@@ -585,6 +585,8 @@ winagent: external win32/libwinpthread-1.dll wazuh_modules/syscollector/syscolle
 	cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
 	cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
 	cd win32/ && ./unix2dos.pl ../../active-response/win/route-null.cmd > route-null.cmd
+	cd win32/ && ./unix2dos.pl ../../active-response/win/route-null-2012.cmd > route-null-2012.cmd
+	cd win32/ && ./unix2dos.pl ../../active-response/win/netsh.cmd > netsh.cmd
 	cd win32/ && ./unix2dos.pl ../../active-response/win/netsh-win-2016.cmd > netsh-win-2016.cmd
 	cd win32/ && ./unix2dos.pl ../../active-response/win/restart-ossec.cmd > restart-ossec.cmd
 	cd win32/ && ./unix2dos.pl ../VERSION > VERSION
@@ -1557,6 +1559,8 @@ clean-windows:
 	rm -f win32/default-ossec.conf
 	rm -f win32/restart-ossec.cmd
 	rm -f win32/route-null.cmd
+	rm -f win32/route-null-2012.cmd
+	rm -f win32/netsh.cmd
 	rm -f win32/netsh-win-2016.cmd
 	rm -f ${win32_o} ${win32_ui_o} win32/win_service_rk.o
 	rm -f win32/icon.o win32/resource.o

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -201,7 +201,9 @@ Section "Wazuh Agent (required)" MainSec
     File /oname=help.txt help_win.txt
     File vista_sec.txt
     File /oname=active-response\bin\route-null.cmd route-null.cmd
+    File /oname=active-response\bin\route-null-2012.cmd route-null-2012.cmd
     File /oname=active-response\bin\restart-ossec.cmd restart-ossec.cmd
+    File /oname=active-response\bin\netsh.cmd netsh.cmd
     File /oname=libwinpthread-1.dll libwinpthread-1.dll
 	File agent-auth.exe
     File /oname=wpk_root.pem ../../etc/wpk_root.pem
@@ -228,8 +230,8 @@ Section "Wazuh Agent (required)" MainSec
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "DisplayVersion" "${VERSION}"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "Publisher" "Wazuh, Inc."
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "DisplayIcon" '"$INSTDIR\favicon.ico"'
-    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "HelpLink" "http://wazuh.com"
-    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "URLInfoAbout" "http://wazuh.com"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "HelpLink" "https://wazuh.com"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "URLInfoAbout" "https://wazuh.com"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "UninstallString" '"$INSTDIR\uninstall.exe"'
     ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
     IntFmt $0 "0x%08X" $0
@@ -308,7 +310,7 @@ Section "Wazuh Agent (required)" MainSec
         ClearErrors
 
     ; handle shortcuts
-    ; http://nsis.sourceforge.net/Shortcuts_removal_fails_on_Windows_Vista
+    ; https://nsis.sourceforge.net/Shortcuts_removal_fails_on_Windows_Vista
     SetShellVarContext all
 
     ; remove shortcuts

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -206,7 +206,7 @@ Section "Wazuh Agent (required)" MainSec
     File /oname=active-response\bin\restart-ossec.cmd restart-ossec.cmd
     File /oname=active-response\bin\netsh.cmd netsh.cmd
     File /oname=libwinpthread-1.dll libwinpthread-1.dll
-	  File agent-auth.exe
+    File agent-auth.exe
     File /oname=wpk_root.pem ../../etc/wpk_root.pem
     File ../wazuh_modules/syscollector/syscollector_win_ext.dll
     File /oname=libwazuhext.dll ../libwazuhext.dll

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -157,6 +157,7 @@
                             </Component>
                             <Component Id="NETSH.CMD" DiskId="1" Guid="C59AD066-EB30-4C67-B476-4CFA8D74947D">
                                 <File Id="NETSH.CMD" Name="netsh.cmd" Source="netsh.cmd" />
+                            </Component>
                             <Component Id="NETSH_WIN_2016.CMD" DiskId="1" Guid="B2011FD2-3F82-4FFD-B6C3-32665037C4EA">
                                 <File Id="NETSH_WIN_2016.CMD" Name="netsh-win-2016.cmd" Source="netsh-win-2016.cmd" />
                             </Component>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -152,6 +152,12 @@
                             <Component Id="ROUTE_NULL.CMD" DiskId="1" Guid="249F3287-B69D-46F0-9EB8-3FED24998E07">
                                 <File Id="ROUTE_NULL.CMD" Name="route-null.cmd" Source="route-null.cmd" />
                             </Component>
+                            <Component Id="ROUTE_NULL_2012.CMD" DiskId="1" Guid="C59AD066-EB30-4C67-B476-4CFA8D74947D">
+                                <File Id="ROUTE_NULL_2012.CMD" Name="route-null-2012.cmd" Source="route-null-2012.cmd" />
+                            </Component>
+                            <Component Id="NETSH.CMD" DiskId="1" Guid="C59AD066-EB30-4C67-B476-4CFA8D74947D">
+                                <File Id="NETSH.CMD" Name="netsh.cmd" Source="netsh.cmd" />
+                            </Component>
                         </Directory>
                         <Component Id="ACTIVE_RESPONSES.LOG" DiskId="1" Guid="249F3287-B69D-46F0-8888-3FED24998E07">
                             <File Id="ACTIVE_RESPONSES.LOG" Name="active-responses.log" Source="active-responses.log" />
@@ -297,6 +303,8 @@
             <ComponentRef Id="VISTA_SEC.TXT" />
             <ComponentRef Id="RESTART_OSSEC.CMD" />
             <ComponentRef Id="ROUTE_NULL.CMD" />
+            <ComponentRef Id="ROUTE_NULL_2012.CMD" />
+            <ComponentRef Id="NETSH.CMD" />
             <ComponentRef Id="ACTIVE_RESPONSES.LOG" />
             <ComponentRef Id="ROOTKIT_FILES.TXT" />
             <ComponentRef Id="ROOTKIT_TROJANS.TXT" />

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -155,7 +155,7 @@
                             <Component Id="ROUTE_NULL_2012.CMD" DiskId="1" Guid="C59AD066-EB30-4C67-B476-4CFA8D74947D">
                                 <File Id="ROUTE_NULL_2012.CMD" Name="route-null-2012.cmd" Source="route-null-2012.cmd" />
                             </Component>
-                            <Component Id="NETSH.CMD" DiskId="1" Guid="C59AD066-EB30-4C67-B476-4CFA8D74947D">
+                            <Component Id="NETSH.CMD" DiskId="1" Guid="292E9082-56BE-4258-9224-7F36A59CA433">
                                 <File Id="NETSH.CMD" Name="netsh.cmd" Source="netsh.cmd" />
                             </Component>
                             <Component Id="NETSH_WIN_2016.CMD" DiskId="1" Guid="B2011FD2-3F82-4FFD-B6C3-32665037C4EA">


### PR DESCRIPTION
Hi team,

in this PR I add the missing active-responses files in the Windows installers, msi and nsis. The files are:
- route-null-2012.cmd
- netsh.cmd

Regards,
Braulio.