### PR TITLE
Multiple fixes for the AWS integration

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -620,13 +620,21 @@
                   "type": "date",
                   "doc_values": "true"
                 },
-                "sourceIPAddress": {
+                "source_ip_address": {
                   "type": "ip",
                   "doc_values": "true"
                 },
-                "resource.instanceDetails.networkInterfaces.privateIpAddress": {
-                  "type": "ip",
-                  "doc_values": "true"
+                "resource.instanceDetails.networkInterfaces": {
+                  "properties": {
+                    "privateIpAddress": {
+                      "type": "ip",
+                      "doc_values": "true"
+                    },
+                    "publicIp": {
+                      "type": "ip",
+                      "doc_values": "true"
+                    }
+                  }
                 },
                 "service": {
                   "properties": {

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -371,7 +371,7 @@ class AWSBucket:
             try:
                 created_date = query_results.fetchone()[0]
                 # Existing logs processed, but older than only_logs_after
-                if int(created_date) > int(self.only_logs_after.strftime('%Y%m%d')):
+                if created_date > int(self.only_logs_after.strftime('%Y%m%d')):
                     self.only_logs_after = datetime.strptime(str(created_date), '%Y%m%d')
                 filter_marker = self.marker_only_logs_after(aws_region, aws_account_id)
             except TypeError as e:

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -399,6 +399,10 @@ class AWSBucket:
         # turn some list fields into dictionaries
         single_element_list_to_dictionary(event)
 
+        # in order to support both old and new index pattern, change data.aws.sourceIPAddress fieldname and parse that one with type ip
+        if 'sourceIPAddress' in event['aws']:
+            event['aws']['source_ip_address'] = event['aws']['sourceIPAddress']
+
 
     def decompress_file(self, log_key):
         def decompress_gzip(raw_object):


### PR DESCRIPTION
Hi team,

This PR fixes the following bugs for our AWS integration:
* `additionalData`, `responseElements` and `requestParameters` fields must be cast to object instead of being cast to string. Some of their subfields are necessary for the ruleset.
* Return single element lists as dictionaries in CloudTrail alerts.
* Fix error which made some logs to be processed multiple times and the same alert to be raised multiple times.
* In order to have a retro-compatible elasticsearch template, keep `sourceIPAddress` as string and add `source_ip_address` with the same value but with IP type.

Best regards,
Marta