### PR TITLE
Fix segmentation fault when the agent version is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.6.1]
+
+## Added
+
+### Changed
+
+### Fixed
+
+- Fix segmentation fault when the agent version is empty in Vulnerability Detector. ([#1191](https://github.com/wazuh/wazuh/pull/1191))
+
+
 ## [v3.6.0]
 
 ## Added

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -49,6 +49,7 @@
 #define VU_INS_TEST_SEC       "(5484): Inserting test section..."
 #define VU_SYS_CHECKED        "(5485): The last package inventory for the agent %s (ID: %s) has already been checked. The vulnerability search is omitted."
 #define VU_AGENT_START        "(5486): Starting vulnerability assessment for agent %s."
-#define VU_AGENT_FINISH       "(5486): Finished vulnerability assessment for agent %s."
+#define VU_AGENT_FINISH       "(5487): Finished vulnerability assessment for agent %s."
+#define VU_AG_NEVER_CON       "(5488): Agent '%s' hasn has never connected."
 
 #endif

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -50,6 +50,6 @@
 #define VU_SYS_CHECKED        "(5485): The last package inventory for the agent %s (ID: %s) has already been checked. The vulnerability search is omitted."
 #define VU_AGENT_START        "(5486): Starting vulnerability assessment for agent %s."
 #define VU_AGENT_FINISH       "(5487): Finished vulnerability assessment for agent %s."
-#define VU_AG_NEVER_CON       "(5488): Agent '%s' hasn has never connected."
+#define VU_AG_NEVER_CON       "(5488): Agent '%s' never connected."
 
 #endif

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -650,6 +650,9 @@ os_info *get_unix_version()
                 snprintf(info->os_version, len, "%s (%s)", info->os_version, info->os_codename);
             }
         }
+    } else {
+        // Empty version
+        info->os_version = strdup("0.0");
     }
 
     return info;

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -2414,7 +2414,12 @@ int wm_vunlnerability_detector_set_agents_info(agent_software **agents_software,
         name = (char *) sqlite3_column_text(stmt, 2);
 
         if (!os_name) {
-            // The agent has never connected
+            if (name) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_NEVER_CON, name);
+            }
+            continue;
+        } else if (!os_version) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, name);
             continue;
         }
 


### PR DESCRIPTION
A segmentation fault was occurring when the agent versions were empty in **global.db**.

Issue: https://groups.google.com/forum/#!topic/wazuh/L-hfb4YmZnE 
