### PR TITLE
Fix getting ram inventory for Mac OS X and FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Fixed service startup on error. ([#1324](https://github.com/wazuh/wazuh/pull/1324))
 - Fix stack overflow when monitoring deep files. ([#1239](https://github.com/wazuh/wazuh/pull/1239))
 - Fix bug when running quick commands with timeout of 1 second. ([#1259](https://github.com/wazuh/wazuh/pull/1259))
+- Fixed getting RAM memory information from mac OS X and FreeBSD agents. ([#1203](https://github.com/wazuh/wazuh/pull/1203))
 
 
 ## [v3.6.1] 2018-09-07

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -636,8 +636,8 @@ hw_info *get_system_bsd(){
 
 #elif defined(__MACH__)
 
-    u_int page_size;
-    uint64_t free_pages;
+    u_int page_size = 0;
+    uint64_t free_pages = 0;
 
     len = sizeof(page_size);
 
@@ -648,6 +648,11 @@ hw_info *get_system_bsd(){
 
             uint64_t cpu_free_kb = (free_pages * (uint64_t)page_size) / 1024;
             info->ram_free = cpu_free_kb;
+
+            if (info->ram_free > info->ram_total) {
+                mwarn("Failed reading free memory RAM.");
+                info->ram_free = info->ram_total;
+            }
 
             if (info->ram_total > 0) {
                 info->ram_usage = 100 - (info->ram_free * 100 / info->ram_total);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -507,6 +507,7 @@ void sys_hw_bsd(int queue_fd, const char* LOCATION){
         cJSON_AddNumberToObject(hw_inventory, "cpu_MHz", sys_info->cpu_MHz);
         cJSON_AddNumberToObject(hw_inventory, "ram_total", sys_info->ram_total);
         cJSON_AddNumberToObject(hw_inventory, "ram_free", sys_info->ram_free);
+        cJSON_AddNumberToObject(hw_inventory, "ram_usage", sys_info->ram_usage);
 
         free(sys_info->cpu_name);
         free(sys_info);
@@ -590,18 +591,24 @@ hw_info *get_system_bsd(){
 #endif
 
     /* Total memory RAM */
-    long cpu_ram;
+    uint64_t cpu_ram;
     mib[0] = CTL_HW;
+
+#if defined(__MACH__)
+    mib[1] = HW_MEMSIZE;
+#else
     mib[1] = HW_PHYSMEM;
+#endif
+
     len = sizeof(cpu_ram);
     if (!sysctl(mib, 2, &cpu_ram, &len, NULL, 0)){
-        int cpu_ram_kb = cpu_ram / 1024;
+        uint64_t cpu_ram_kb = cpu_ram / 1024;
         info->ram_total = cpu_ram_kb;
     }else{
         mtdebug1(WM_SYS_LOGTAG, "sysctl failed getting total RAM due to (%s)", strerror(errno));
     }
 
-    /* Free memory RAM */
+    /* Free memory RAM and usage */
 #if defined(__FreeBSD__)
 
     u_int page_size;
@@ -617,12 +624,36 @@ hw_info *get_system_bsd(){
     if (!sysctlbyname("vm.stats.vm.v_page_size", &page_size, &len, NULL, 0)){
         mtdebug1(WM_SYS_LOGTAG, "sysctl failed getting free memory due to (%s)", strerror(errno));
     }else{
-        long cpu_free_kb = (vmt.t_free * (uint64_t)page_size) / 1024;
+        uint64_t cpu_free_kb = (vmt.t_free * (uint64_t)page_size) / 1024;
         info->ram_free = cpu_free_kb;
 
-        if (info->ram_total > 0 && info->ram_free >= 0) {
+        if (info->ram_total > 0) {
             info->ram_usage = 100 - (info->ram_free * 100 / info->ram_total);
         }
+    }
+
+#elif defined(__MACH__)
+
+    u_int page_size;
+    uint64_t free_pages;
+
+    len = sizeof(page_size);
+
+    if (!sysctlbyname("vm.pagesize", &page_size, &len, NULL, 0)) {
+        if (!sysctlbyname("vm.page_free_count", &free_pages, &len, NULL, 0)) {
+
+            uint64_t cpu_free_kb = (free_pages * (uint64_t)page_size) / 1024;
+            info->ram_free = cpu_free_kb;
+
+            if (info->ram_total > 0) {
+                info->ram_usage = 100 - (info->ram_free * 100 / info->ram_total);
+            }
+
+        } else {
+            mtdebug1(WM_SYS_LOGTAG, "sysctl failed getting free pages due to (%s)", strerror(errno));
+        }
+    } else {
+        mtdebug1(WM_SYS_LOGTAG, "sysctl failed getting pages size due to (%s)", strerror(errno));
     }
 
 #endif


### PR DESCRIPTION
This PR solves partially the issue https://github.com/wazuh/wazuh/issues/1190

It includes the fields `ram_free` and `ram_usage` to the mac and FreeBSD hardware inventory.
