### PR TITLE
Unified location filter in JSON and plain-text

### DIFF
--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -33,14 +33,13 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
 
     /* Look if location is set */
 
-    //Check if location is headless
-    char * location_headless = strstr(al_data->location,"->");
-
-    if (location_headless){        //If location has head, cut it off
-        location_headless = location_headless + 2;
-    }
-
     if (syslog_config->location) {
+        //Check if location is headless
+        char * location_headless = strstr(al_data->location,"->");
+
+        if (location_headless){        //If location has head, cut it off
+            location_headless = location_headless + 2;
+        }
 
         if (!OSMatch_Execute(location_headless ? location_headless : al_data->location,
                              strlen(al_data->location),


### PR DESCRIPTION
In case the location field has the Agent and the IP because it comes from plain-text, Agent and IP are removed to clean the location field.
