### PR TITLE
Fixing open-scap deadlock when opening large files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project will be documented in this file.
 - Prevents some vulnerabilities from not being checked for Debian. ([#1166](https://github.com/wazuh/wazuh/pull/1166))
 - Fixed legacy configuration for `vulnerability-detector`. ([#1174](https://github.com/wazuh/wazuh/pull/1174))
 - Fix active-response scripts installation for Windows. ([#1182](https://github.com/wazuh/wazuh/pull/1182)).
+- Fixed `open-scap` deadlock when opening large files. ([#1206](https://github.com/wazuh/wazuh/pull/1206)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ All notable changes to this project will be documented in this file.
 - Prevents some vulnerabilities from not being checked for Debian. ([#1166](https://github.com/wazuh/wazuh/pull/1166))
 - Fixed legacy configuration for `vulnerability-detector`. ([#1174](https://github.com/wazuh/wazuh/pull/1174))
 - Fix active-response scripts installation for Windows. ([#1182](https://github.com/wazuh/wazuh/pull/1182)).
-- Fixed `open-scap` deadlock when opening large files. ([#1206](https://github.com/wazuh/wazuh/pull/1206)).
+- Fixed `open-scap` deadlock when opening large files. ([#1206](https://github.com/wazuh/wazuh/pull/1206)). Thanks to @juergenc for detecting this issue.
 
 ### Removed
 

--- a/wodles/oscap/oscap.py
+++ b/wodles/oscap/oscap.py
@@ -8,7 +8,7 @@
 from re import compile
 from sys import argv, exit, version_info
 from os.path import isfile, isdir
-from os import mkfifo, unlink
+from os import mkfifo, unlink, devnull
 from subprocess import CalledProcessError, STDOUT, Popen, PIPE
 from getopt import getopt, GetoptError
 from signal import signal, SIGINT
@@ -126,7 +126,8 @@ def oscap(profile=None):
         if debug:
             print("\nCMD: '{0}'".format(' '.join(cmd)))
 
-        ps = Popen(cmd, shell=False, stdout=PIPE, stderr=STDOUT)
+        DEVNULL = open(devnull, 'wb')
+        ps = Popen(cmd, shell=False, stdout=DEVNULL, stderr=None)
 
     except CalledProcessError as error:
 


### PR DESCRIPTION
`oscap` filled up the system buffer and it sopped reading. Therefore, `xsltproc` was never executed and `open-scap` timed out.  

Related issue: #1134.