### PR TITLE
Remove call to execvpe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Refactor Python framework code to standarize database requests and support API queries ([#921](https://github.com/wazuh/wazuh/pull/921)).
+- Refactor Python framework code to standardize database requests and support API queries. ([#921](https://github.com/wazuh/wazuh/pull/921)).
 - Add support for multigroups ([#1300](https://github.com/wazuh/wazuh/pull/1300) [#1135](https://github.com/wazuh/wazuh/pull/1135)).
+- Replaced the `execvpe` function by `execvp` for the Wazuh modules. ([#1207](https://github.com/wazuh/wazuh/pull/1207))
 
 ## [v3.6.2]
 
@@ -32,7 +33,6 @@ All notable changes to this project will be documented in this file.
 - Fix bug in folder recursion limit count in FIM real-time mode. ([#1226](https://github.com/wazuh/wazuh/issues/1226))
 - Fixed errors when parsing AWS events in Elasticsearch. ([#1229](https://github.com/wazuh/wazuh/issues/1229))
 - Fix bug when launching osquery from Wazuh. ([#1230](https://github.com/wazuh/wazuh/issues/1230))
-
 
 ## [v3.6.0] - 2018-08-29
 

--- a/install.sh
+++ b/install.sh
@@ -107,11 +107,6 @@ Install()
         LIB_FLAG="USE_FRAMEWORK_LIB=yes"
     fi
 
-    # Do not use execvpe() in CentOS 5
-    if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ]) && [ ${DIST_VER} -le 5 ]; then
-        EXEC_FLAG="USE_EXEC_ENVIRON=no"
-    fi
-
     # Makefile
     echo " - ${runningmake}"
     echo ""
@@ -125,7 +120,7 @@ Install()
 
         # Add DATABASE=pgsql or DATABASE=mysql to add support for database
         # alert entry
-        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} ${AUDIT_FLAG} ${LIB_FLAG} ${EXEC_FLAG} -j${THREADS} build
+        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} ${AUDIT_FLAG} ${LIB_FLAG} -j${THREADS} build
 
         if [ $? != 0 ]; then
             cd ../

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,6 @@ USE_GEOIP?=no
 USE_INOTIFY=no
 USE_BIG_ENDIAN=no
 USE_AUDIT=no
-USE_EXEC_ENVIRON=no
 USE_FRAMEWORK_LIB=no
 
 ifneq ($(HAS_CHECKMODULE),)
@@ -83,7 +82,6 @@ ifeq (${uname_S},Linux)
 #		OSSEC_LDFLAGS+=-lmagic
 		CFLAGS+=-Wl,--start-group
 		USE_AUDIT=yes
-		USE_EXEC_ENVIRON=yes
 ifneq (,$(filter ${USE_AUDIT},yes y Y 1))
 		CFLAGS+=-I$(EXTERNAL_AUDIT)lib
 endif
@@ -194,10 +192,6 @@ ifdef DEBUG
 else
 	OFLAGS+=-O2
 endif #DEBUG
-
-ifneq (,$(filter ${USE_EXEC_ENVIRON},yes y Y 1))
-	DEFINES+=-DUSE_EXEC_ENVIRON
-endif
 
 OSSEC_CFLAGS+=${OFLAGS}
 OSSEC_LDFLAGS+=${OFLAGS}
@@ -443,7 +437,6 @@ help: failtarget
 	@echo "   make USE_SELINUX=0           Build with SELinux policies"
 	@echo "   make USE_AUDIT=1             Build with audit service support"
 	@echo "   make USE_FRAMEWORK_LIB=0     Use external SQLite library for the framework"
-	@echo "   make USE_EXEC_ENVIRON=no     Use modern non-standard execvpe in Modulesd"
 	@echo "   make OFLAGS=-Ox              Overrides optimization level"
 	@echo
 	@echo "Database options: "
@@ -492,7 +485,6 @@ settings:
 	@echo "    USE_BIG_ENDIAN:     ${USE_BIG_ENDIAN}"
 	@echo "    USE_SELINUX:        ${USE_SELINUX}"
 	@echo "    USE_AUDIT:          ${USE_AUDIT}"
-	@echo "    USE_EXEC_ENVIRON:   ${USE_EXEC_ENVIRON}"
 	@echo "    USE_FRAMEWORK_LIB:  ${USE_FRAMEWORK_LIB}"
 	@echo "Mysql settings:"
 	@echo "    includes:           ${MI}"

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -477,7 +477,7 @@ size_t wcom_upgrade(const char * package, const char * installer, char ** output
     }
 #endif
 
-    if (wm_exec(installer_j, &out, &status, req_timeout) < 0) {
+    if (wm_exec(installer_j, &out, &status, req_timeout, NULL) < 0) {
         merror("At WCOM upgrade: Error executing command [%s]", installer_j);
         *output = strdup("err Cannot execute installer");
         return strlen(*output);

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -57,7 +57,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
 char *guid_to_string(GUID *guid);
 int set_policies();
 void set_subscription_query(wchar_t *query);
-extern int wm_exec(char *command, char **output, int *exitcode, int secs);
+extern int wm_exec(char *command, char **output, int *exitcode, int secs, const char * add_path);
 int restore_audit_policies();
 void audit_restore();
 int check_object_sacl(char *obj, int is_file);
@@ -421,7 +421,7 @@ int restore_audit_policies() {
         return 1;
     }
     // Get the current policies
-    if (wm_exec(command, &output, &result_code, 5), result_code) {
+    if (wm_exec(command, &output, &result_code, 5, NULL), result_code) {
         merror("Auditpol backup error: '%s'.", output);
         return 1;
     }
@@ -971,7 +971,7 @@ int set_policies() {
     snprintf(command, OS_SIZE_1024, WPOL_BACKUP_COMMAND, WPOL_BACKUP_FILE);
 
     // Get the current policies
-    if (wm_exec(command, &output, &result_code, 5), result_code) {
+    if (wm_exec(command, &output, &result_code, 5, NULL), result_code) {
         retval = 2;
         goto end;
     }
@@ -1002,7 +1002,7 @@ int set_policies() {
     snprintf(command, OS_SIZE_1024, WPOL_RESTORE_COMMAND, WPOL_NEW_FILE);
 
     // Set the new policies
-    if (wm_exec(command, &output, &result_code, 5), result_code) {
+    if (wm_exec(command, &output, &result_code, 5, NULL), result_code) {
         retval = 2;
         goto end;
     }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -293,7 +293,7 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     wm_strcat(&trail_title, " - ", ' ');
 
     mtdebug1(WM_AWS_LOGTAG, "Launching S3 Command: %s", command);
-    switch (wm_exec(command, &output, &status, 0)) {
+    switch (wm_exec(command, &output, &status, 0, NULL)) {
     case 0:
         if (status > 0) {
             mtwarn(WM_AWS_LOGTAG, "%s Returned exit code %d", trail_title, status);

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -234,7 +234,7 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
 
         // Run script
         mtdebug1(WM_AZURE_LOGTAG, "Launching command: %s", command);
-        switch (wm_exec(command, &output, &status, timeout)) {
+        switch (wm_exec(command, &output, &status, timeout, NULL)) {
             case 0:
                 if (status > 0) {
                     mtwarn(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_request->tag, status);
@@ -306,7 +306,7 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
 
         // Run script
         mtdebug1(WM_AZURE_LOGTAG, "Launching command: %s", command);
-        switch (wm_exec(command, &output, &status, timeout)) {
+        switch (wm_exec(command, &output, &status, timeout, NULL)) {
             case 0:
                 if (status > 0) {
                     mtwarn(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_request->tag, status);
@@ -386,7 +386,7 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
 
         // Run script
         mtdebug1(WM_AZURE_LOGTAG, "Launching command: %s", command);
-        switch (wm_exec(command, &output, &status, timeout)) {
+        switch (wm_exec(command, &output, &status, timeout, NULL)) {
             case 0:
                 if (status > 0) {
                     mtwarn(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_container->name, status);

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -175,7 +175,7 @@ void * wm_command_main(wm_command_t * command) {
         // Get time and execute
         time_start = time(NULL);
 
-        switch (wm_exec(command->full_command, command->ignore_output ? NULL : &output, &status, command->timeout)) {
+        switch (wm_exec(command->full_command, command->ignore_output ? NULL : &output, &status, command->timeout, NULL)) {
         case 0:
             if (status > 0) {
                 mtwarn(WM_COMMAND_LOGTAG, "Command '%s' returned exit code %d.", command->tag, status);

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -202,7 +202,7 @@ void wm_oscap_run(wm_oscap_eval *eval) {
 
     mtdebug1(WM_OSCAP_LOGTAG, "Launching command: %s", command);
 
-    switch (wm_exec(command, &output, &status, eval->timeout)) {
+    switch (wm_exec(command, &output, &status, eval->timeout, NULL)) {
     case 0:
         if (status > 0) {
             mtwarn(WM_OSCAP_LOGTAG, "Ignoring content '%s' due to error (%d).", eval->path, status);

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -111,8 +111,9 @@ void wm_module_free(wmodule * config);
  * On success, return 0. On another error, returns -1.
  * If the called program timed-out, returns WM_ERROR_TIMEOUT and output may
  * contain data.
+ * env_path is a pointer to an string to add to the PATH environment variable.
  */
-int wm_exec(char *command, char **output, int *exitcode, int secs);
+int wm_exec(char *command, char **output, int *exitcode, int secs, const char * add_path);
 
 #ifdef WIN32
 // Add process to pool


### PR DESCRIPTION
This PR solves the issue #1188.

The function `execvpe()` was necessary since the CIS-CAT module needs to run a command using the global environment variables. But this function is not standard for OS like CentOS 5.

It has been replaced the function by `execvp()` and now, the needed variables are set in the environment of the child process directly.