### PR TITLE
Fix 0 value at check options from Syscheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix 0 value at check options from Syscheck. ([1209](https://github.com/wazuh/wazuh/pull/1209))
 - Prevent offline agents from generating vulnerability-detector alerts. ([#1292](https://github.com/wazuh/wazuh/pull/1292))
 - Fix empty SHA256 of rotated alerts and log files. ([#1308](https://github.com/wazuh/wazuh/pull/1308))
 - Fix typo in whodata alerts. ([#1242](https://github.com/wazuh/wazuh/issues/1242))
@@ -78,6 +79,7 @@ All notable changes to this project will be documented in this file.
 - Prevents some vulnerabilities from not being checked for Debian. ([#1166](https://github.com/wazuh/wazuh/pull/1166))
 - Fixed legacy configuration for `vulnerability-detector`. ([#1174](https://github.com/wazuh/wazuh/pull/1174))
 - Fix active-response scripts installation for Windows. ([#1182](https://github.com/wazuh/wazuh/pull/1182)).
+
 
 ### Removed
 

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -183,7 +183,7 @@ void OS_LogOutput(Eventinfo *lf)
     if (lf->filename && lf->event_type != FIM_DELETED) {
         printf("Attributes:\n");
 
-        if (lf->size_after){
+        if (lf->size_after && *lf->size_after != '\0'){
             printf(" - Size: %s\n", lf->size_after);
         }
 
@@ -346,7 +346,7 @@ void OS_Log(Eventinfo *lf)
     if (lf->filename && lf->event_type != FIM_DELETED) {
         fprintf(_aflog, "Attributes:\n");
 
-        if (lf->size_after){
+        if (lf->size_after && *lf->size_after != '\0'){
             fprintf(_aflog, " - Size: %s\n", lf->size_after);
         }
 

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -409,35 +409,39 @@ static int DB_Search(const char *f_name, char *c_sum, char *w_sum, Eventinfo *lf
                 sk_fill_event(lf, f_name, &newsum);
 
                 /* Generate size message */
-                if (strcmp(oldsum.size, newsum.size) == 0) {
-                    sdb.size[0] = '\0';
-                } else {
-                    changes = 1;
-                    wm_strcat(&lf->fields[SK_CHFIELDS].value, "size", ',');
-                    snprintf(sdb.size, OS_FLSIZE,
-                             "Size changed from '%s' to '%s'\n",
-                             oldsum.size, newsum.size);
+                if (oldsum.size && newsum.size) {
+                    if (strcmp(oldsum.size, newsum.size) == 0) {
+                        sdb.size[0] = '\0';
+                    } else {
+                        changes = 1;
+                        wm_strcat(&lf->fields[SK_CHFIELDS].value, "size", ',');
+                        snprintf(sdb.size, OS_FLSIZE,
+                                "Size changed from '%s' to '%s'\n",
+                                oldsum.size, newsum.size);
 
-                    os_strdup(oldsum.size, lf->size_before);
+                        os_strdup(oldsum.size, lf->size_before);
+                    }
                 }
 
                 /* Permission message */
-                if (oldsum.perm == newsum.perm) {
-                    sdb.perm[0] = '\0';
-                } else if (oldsum.perm > 0 && newsum.perm > 0) {
-                    changes = 1;
-                    wm_strcat(&lf->fields[SK_CHFIELDS].value, "perm", ',');
-                    char opstr[10];
-                    char npstr[10];
+                if (oldsum.perm && newsum.perm){
+                    if (oldsum.perm == newsum.perm) {
+                        sdb.perm[0] = '\0';
+                    } else if (oldsum.perm > 0 && newsum.perm > 0) {
+                        changes = 1;
+                        wm_strcat(&lf->fields[SK_CHFIELDS].value, "perm", ',');
+                        char opstr[10];
+                        char npstr[10];
 
-                    strncpy(opstr, agent_file_perm(oldsum.perm), sizeof(opstr) - 1);
-                    strncpy(npstr, agent_file_perm(newsum.perm), sizeof(npstr) - 1);
-                    opstr[9] = npstr[9] = '\0';
+                        strncpy(opstr, agent_file_perm(oldsum.perm), sizeof(opstr) - 1);
+                        strncpy(npstr, agent_file_perm(newsum.perm), sizeof(npstr) - 1);
+                        opstr[9] = npstr[9] = '\0';
 
-                    snprintf(sdb.perm, OS_FLSIZE, "Permissions changed from "
-                             "'%9.9s' to '%9.9s'\n", opstr, npstr);
+                        snprintf(sdb.perm, OS_FLSIZE, "Permissions changed from "
+                                "'%9.9s' to '%9.9s'\n", opstr, npstr);
 
-                    lf->perm_before = oldsum.perm;
+                        lf->perm_before = oldsum.perm;
+                    }
                 }
 
                 /* Ownership message */

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -334,6 +334,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
     os_sha1 sf_sum;
     os_sha256 sf256_sum;
     syscheck_node *s_node;
+    char str_size[50], str_perm[50], str_owner[50], str_group[50], str_mtime[50], str_inode[50];
 #ifdef WIN32
     char *sid = NULL;
     const char *user;
@@ -463,31 +464,92 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             }
         }
     }
-    snprintf(newsum, OS_MAXSTR, "%ld:%d:%d:%d:%s:%s:%s:%s:%ld:%ld:%s",
-        size == 0 ? 0 : (long)statbuf.st_size,
-        perm == 0 ? 0 : (int)statbuf.st_mode,
-        owner == 0 ? 0 : (int)statbuf.st_uid,
-        group == 0 ? 0 : (int)statbuf.st_gid,
+
+    if (size == 0){
+        *str_size = '\0';
+    } else {
+        sprintf(str_size, "%ld", (long)statbuf.st_size);
+    }
+
+    if (perm == 0){
+        *str_perm = '\0';
+    } else {
+        sprintf(str_perm, "%ld", (long)statbuf.st_mode);
+    }
+
+    if (owner == 0){
+        *str_owner = '\0';
+    } else {
+        sprintf(str_owner, "%ld", (long)statbuf.st_uid);
+    }
+
+    if (group == 0){
+        *str_group = '\0';
+    } else {
+        sprintf(str_group, "%ld", (long)statbuf.st_gid);
+    }
+
+    if (mtime == 0){
+        *str_mtime = '\0';
+    } else {
+        sprintf(str_mtime, "%ld", (long)statbuf.st_gid);
+    }
+
+    if (inode == 0){
+        *str_inode = '\0';
+    } else {
+        sprintf(str_inode, "%ld", (long)statbuf.st_gid);
+    }
+
+    snprintf(newsum, OS_MAXSTR, "%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
+        str_size,
+        str_perm,
+        str_owner,
+        str_group,
         md5sum   == 0 ? "" : mf_sum,
         sha1sum  == 0 ? "" : sf_sum,
         owner == 0 ? "" : get_user(file_name, statbuf.st_uid, NULL),
         group == 0 ? "" : get_group(statbuf.st_gid),
-        mtime ? (long)statbuf.st_mtime : 0,
-        inode ? (long)statbuf.st_ino : 0,
+        str_mtime,
+        str_inode,
         sha256sum  == 0 ? "" : sf256_sum);
 #else
     user = get_user(file_name, statbuf.st_uid, &sid);
 
-    snprintf(newsum, OS_MAXSTR, "%ld:%d:%s::%s:%s:%s:%s:%ld:%ld:%s",
-        size == 0 ? 0 : (long)statbuf.st_size,
-        perm == 0 ? 0 : (int)statbuf.st_mode,
+    if (size == 0){
+        *str_size = '\0';
+    } else {
+        sprintf(str_size, "%ld", (long)statbuf.st_size);
+    }
+
+    if (perm == 0){
+        *str_perm = '\0';
+    } else {
+        sprintf(str_perm, "%ld", (long)statbuf.st_mode);
+    }
+
+    if (mtime == 0){
+        *str_mtime = '\0';
+    } else {
+        sprintf(str_mtime, "%ld", (long)statbuf.st_gid);
+    }
+
+    if (inode == 0){
+        *str_inode = '\0';
+    } else {
+        sprintf(str_inode, "%ld", (long)statbuf.st_gid);
+    }
+
+    snprintf(newsum, OS_MAXSTR, "%s:%s:%s::%s:%s:%s:%s:%s:%s:%s",
+        str_size,
+        str_perm,
         (owner == 0) && sid ? "" : sid,
         md5sum   == 0 ? "" : mf_sum,
         sha1sum  == 0 ? "" : sf_sum,
         owner == 0 ? "" : user,
         group == 0 ? "" : get_group(statbuf.st_gid),
-        mtime ? (long)statbuf.st_mtime : 0,
-        inode ? (long)statbuf.st_ino : 0,
+        str_mtime,
+        str_inode,
         sha256sum  == 0 ? "" : sf256_sum);
 
         if (sid) {


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/952, as well as the options `check_owner`, `check_group`, `check_inode`, `check_mtime` and `check_perm`.