### PR TITLE
Prevent MSI package from removing configuration files on upgrade

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -71,10 +71,10 @@
                     <Component Id="LIBWAZUHEXT_DLL" DiskId="1" Guid="31F7B5FA-9678-427B-9536-88AAA897A82A">
                         <File Id="LIBWAZUHEXT_DLL" Name="libwazuhext.dll" Source="..\libwazuhext.dll" />
                     </Component>
-                    <Component Id="LOCAL_INTERNAL_OPTIONS.CONF" DiskId="1" Guid="10245598-2EE7-4EDB-A114-5398F01A21F9">
+                    <Component Id="LOCAL_INTERNAL_OPTIONS.CONF" DiskId="1" Guid="*" NeverOverwrite="yes" Permanent="yes">
                         <File Id="LOCAL_INTERNAL_OPTIONS.CONF" Name="local_internal_options.conf" Source="default-local_internal_options.conf" />
                     </Component>
-                    <Component Id="OSSEC.CONF" DiskId="1" Guid="B9291C46-4C38-4E1F-9EED-A141985C03DA" NeverOverwrite="yes">
+                    <Component Id="OSSEC.CONF" DiskId="1" Guid="*" NeverOverwrite="yes" Permanent="yes">
                         <File Id="OSSEC.CONF" Name="ossec.conf" Source="default-ossec.conf">
                             <util:PermissionEx User="Everyone" GenericRead="yes" GenericWrite="yes" />
                         </File>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -74,7 +74,7 @@
                     <Component Id="LOCAL_INTERNAL_OPTIONS.CONF" DiskId="1" Guid="10245598-2EE7-4EDB-A114-5398F01A21F9">
                         <File Id="LOCAL_INTERNAL_OPTIONS.CONF" Name="local_internal_options.conf" Source="default-local_internal_options.conf" />
                     </Component>
-                    <Component Id="OSSEC.CONF" DiskId="1" Guid="26C3265E-EFC8-488D-8D19-397A0C44C071" NeverOverwrite="yes">
+                    <Component Id="OSSEC.CONF" DiskId="1" Guid="B9291C46-4C38-4E1F-9EED-A141985C03DA" NeverOverwrite="yes">
                         <File Id="OSSEC.CONF" Name="ossec.conf" Source="default-ossec.conf">
                             <util:PermissionEx User="Everyone" GenericRead="yes" GenericWrite="yes" />
                         </File>


### PR DESCRIPTION
Upgrading Windows agents to Wazuh v3.6.0 via MSI packages would delete the file _ossec.conf_ and reset _local_internal_options.conf_.

This PR aims to fix it.
Related issue: https://github.com/wazuh/wazuh/issues/1211