### PR TITLE
Fix errors when parsing AWS events in elasticsearch

### DIFF
--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -400,8 +400,11 @@ class AWSBucket:
         single_element_list_to_dictionary(event)
 
         # in order to support both old and new index pattern, change data.aws.sourceIPAddress fieldname and parse that one with type ip
-        if 'sourceIPAddress' in event['aws']:
+        # Only add this field if the sourceIPAddress is an IP and not a DNS.
+        if 'sourceIPAddress' in event['aws'] and re.match(r'\d+\.\d+.\d+.\d+', event['aws']['sourceIPAddress']):
             event['aws']['source_ip_address'] = event['aws']['sourceIPAddress']
+        
+        return event
 
 
     def decompress_file(self, log_key):

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -665,6 +665,12 @@ class AWSFirehouseBucket(AWSBucket):
         if event['aws']['source'] == 'macie' and 'trigger' in event['aws']:
             del event['aws']['trigger']
 
+        if 'service' in event['aws'] and 'additionalInfo' in event['aws']['service'] and \
+                'unusual' in event['aws']['service']['additionalInfo'] and \
+                not isinstance(event['aws']['service']['additionalInfo']['unusual'], dict):
+            event['aws']['service']['additionalInfo']['unusual'] = {
+                'value': event['aws']['service']['additionalInfo']['unusual']}
+
         return event
 
     def iter_regions_and_accounts(self, account_id, regions):

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -339,6 +339,13 @@ class AWSBucket:
         )
 
     def get_alert_msg(self, aws_account_id, log_key, event, error_msg=""):
+        def remove_none_fields(event):
+            for key,value in event.items():
+                if isinstance(value, dict):
+                    remove_none_fields(event[key])
+                elif value is None:
+                    del event[key]
+
         # error_msg will only have a value when event is None and vice versa
         msg = {
             'integration': 'aws',
@@ -351,7 +358,8 @@ class AWSBucket:
             }
         }
         if event:
-            msg['aws'].update({key: value for key, value in filter(lambda x: x[1] is not None, event.items())})
+            remove_none_fields(event)
+            msg['aws'].update(event)
         elif error_msg:
             msg['error_msg'] = error_msg
         return msg


### PR DESCRIPTION
Hello team,

This PR fixes #1227 and #1228. Also, field `data.aws.service.additionalInfo.unusual` has been added to `reformat_msg` function since, depending on the event, it could be a dictionary or an integer.

Best regards,
Marta