### PR TITLE
Fix bug when launching osquery from Wazuh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Fix socket error during agent restart due to daemon start/stop order. ([#1221](https://github.com/wazuh/wazuh/issues/1221))
 - Fix bug when checking agent configuration in logcollector. ([#1225](https://github.com/wazuh/wazuh/issues/1225))
 - Fix bug in folder recursion limit count in FIM real-time mode. ([#1226](https://github.com/wazuh/wazuh/issues/1226))
+- Fix bug when launching osquery from Wazuh. ([#1230](https://github.com/wazuh/wazuh/issues/1230))
 
 
 ## [v3.6.0] 2018-08-29

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -16,10 +16,11 @@ cJSON * json_fread(const char * path) {
     cJSON * item = NULL;
     char * buffer = NULL;
     long size;
+    size_t read;
 
     // Load file
 
-    if (fp = fopen(path, "r"), !fp) {
+    if (fp = fopen(path, "rb"), !fp) {
         mdebug1(FOPEN_ERROR, path, errno, strerror(errno));
         return NULL;
     }
@@ -42,8 +43,7 @@ cJSON * json_fread(const char * path) {
     os_malloc(size + 1, buffer);
 
     // Get file and parse into JSON
-    size_t read;
-    if (read = fread(buffer, 1, size, fp), read != (size_t)size) {
+    if (read = fread(buffer, 1, size, fp), read != (size_t)size && (read > (size_t)size || !feof(fp))) {
         mdebug1(FREAD_ERROR, path, errno, strerror(errno));
         goto end;
     }

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -20,7 +20,7 @@ cJSON * json_fread(const char * path) {
 
     // Load file
 
-    if (fp = fopen(path, "rb"), !fp) {
+    if (fp = fopen(path, "r"), !fp) {
         mdebug1(FOPEN_ERROR, path, errno, strerror(errno));
         return NULL;
     }

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -43,7 +43,7 @@ cJSON * json_fread(const char * path) {
     os_malloc(size + 1, buffer);
 
     // Get file and parse into JSON
-    if (read = fread(buffer, 1, size, fp), read != (size_t)size && (read > (size_t)size || !feof(fp))) {
+    if (read = fread(buffer, 1, size, fp), read != (size_t)size && !feof(fp)) {
         mdebug1(FREAD_ERROR, path, errno, strerror(errno));
         goto end;
     }


### PR DESCRIPTION
This bug causes the **run_daemon = yes** does not work by detecting a invalid size of the configuration file.