### PR TITLE
Fix bug in whodata field extraction for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Fix bug in folder recursion limit count in FIM real-time mode. ([#1226](https://github.com/wazuh/wazuh/issues/1226))
 - Fixed errors when parsing AWS events in Elasticsearch. ([#1229](https://github.com/wazuh/wazuh/issues/1229))
 - Fix bug when launching osquery from Wazuh. ([#1230](https://github.com/wazuh/wazuh/issues/1230))
+- Fix bug in whodata field extraction for Windows. ([#1233](https://github.com/wazuh/wazuh/issues/1233))
 
 
 ## [v3.6.0] 2018-08-29

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -833,7 +833,7 @@ void InsertWhodata(const sk_sum_t * sum) {
     }
 
     /* Whodata process */
-    if(sum->wdata.process_id && *sum->wdata.process_id != '\0') {
+    if(sum->wdata.process_id && *sum->wdata.process_id != '\0' && strcmp(sum->wdata.process_id, "0")) {
         snprintf(sdb.process_id, OS_FLSIZE, "(Audit) Process id: '%s'\n", sum->wdata.process_id);
     } else {
         *sdb.process_id = '\0';

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -329,8 +329,10 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         cJSON* audit = cJSON_CreateObject();
 
         cJSON* user = cJSON_CreateObject();
-        cJSON_AddStringToObject(user, "id", lf->user_id);
-        cJSON_AddStringToObject(user, "name", lf->user_name);
+        if (lf->user_id && *lf->user_id != '\0') {
+            cJSON_AddStringToObject(user, "id", lf->user_id);
+        }
+        cJSON_AddStringToObject(user, "name", lf->user_name); 
         cJSON_AddItemToObject(audit, "user", user);
 
         if (lf->group_id && *lf->group_id != '\0') {
@@ -342,9 +344,15 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
 
         if (lf->process_id) {
             cJSON* proc = cJSON_CreateObject();
-            cJSON_AddStringToObject(proc, "id", lf->process_id);
-            if (lf->process_name) cJSON_AddStringToObject(proc, "name", lf->process_name);
-            if (lf->ppid && *lf->ppid != '\0') cJSON_AddStringToObject(proc, "ppid", lf->ppid);
+            if (strcmp(lf->process_id, "0")) {
+                cJSON_AddStringToObject(proc, "id", lf->process_id);
+            }
+            if (lf->process_name && *lf->process_name != '\0') {
+                cJSON_AddStringToObject(proc, "name", lf->process_name);
+            }
+            if (lf->ppid && *lf->ppid != '\0') {
+                cJSON_AddStringToObject(proc, "ppid", lf->ppid);
+            }
             cJSON_AddItemToObject(audit, "proccess", proc);
         }
 

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -325,52 +325,54 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         cJSON_AddStringToObject(data, "system_name", lf->systemname);
 
     // Whodata fields
-    if (lf->user_id && lf->user_name && file_diff) {
-        cJSON* audit = cJSON_CreateObject();
+    if (file_diff) {
+        cJSON* audit_sect = NULL;
+        cJSON* process_sect = NULL;
+        cJSON* user_sect = NULL;
+        cJSON* group_sect = NULL;
+        cJSON* auser_sect = NULL;
+        cJSON* euser_sect = NULL;
 
-        cJSON* user = cJSON_CreateObject();
-        if (lf->user_id && *lf->user_id != '\0') {
-            cJSON_AddStringToObject(user, "id", lf->user_id);
-        }
-        cJSON_AddStringToObject(user, "name", lf->user_name); 
-        cJSON_AddItemToObject(audit, "user", user);
+        // User section
+        add_json_field(user_sect, "id", lf->user_id, "");
+        add_json_field(user_sect, "name", lf->user_name, "");
 
-        if (lf->group_id && *lf->group_id != '\0') {
-            cJSON* group = cJSON_CreateObject();
-            cJSON_AddStringToObject(group, "id", lf->group_id);
-            if (lf->group_name) cJSON_AddStringToObject(group, "name", lf->group_name);
-            cJSON_AddItemToObject(audit, "group", group);
-        }
+        // Group sect
+        add_json_field(group_sect, "id", lf->group_id, "");
+        add_json_field(group_sect, "name", lf->group_name, "");
 
-        if (lf->process_id) {
-            cJSON* proc = cJSON_CreateObject();
-            if (strcmp(lf->process_id, "0")) {
-                cJSON_AddStringToObject(proc, "id", lf->process_id);
+        // Process section
+        add_json_field(process_sect, "id", lf->process_id, "0");
+        add_json_field(process_sect, "name", lf->process_name, "");
+        add_json_field(process_sect, "ppi", lf->ppid, "");
+
+        // Auser sect
+        add_json_field(auser_sect, "id", lf->audit_uid, "");
+        add_json_field(auser_sect, "name", lf->audit_name, "");
+
+        // Effective user
+        add_json_field(euser_sect, "id", lf->effective_uid, "");
+        add_json_field(euser_sect, "name", lf->effective_name, "");
+
+        if (user_sect || process_sect || group_sect || auser_sect || euser_sect) {
+            audit_sect = cJSON_CreateObject();
+            if (user_sect) {
+                cJSON_AddItemToObject(audit_sect, "user", user_sect);
             }
-            if (lf->process_name && *lf->process_name != '\0') {
-                cJSON_AddStringToObject(proc, "name", lf->process_name);
+            if (process_sect) {
+                cJSON_AddItemToObject(audit_sect, "process", process_sect);
             }
-            if (lf->ppid && *lf->ppid != '\0') {
-                cJSON_AddStringToObject(proc, "ppid", lf->ppid);
+            if (group_sect) {
+                cJSON_AddItemToObject(audit_sect, "group", group_sect);
             }
-            cJSON_AddItemToObject(audit, "proccess", proc);
+            if (auser_sect) {
+                cJSON_AddItemToObject(audit_sect, "login_user", auser_sect);
+            }
+            if (euser_sect) {
+                cJSON_AddItemToObject(audit_sect, "effective_user", euser_sect);
+            }
+            cJSON_AddItemToObject(file_diff, "audit", audit_sect);
         }
-
-        if (lf->audit_uid && *lf->audit_uid != '\0') {
-            cJSON* auser = cJSON_CreateObject();
-            cJSON_AddStringToObject(auser, "id", lf->audit_uid);
-            if (lf->audit_name) cJSON_AddStringToObject(auser, "name", lf->audit_name);
-            cJSON_AddItemToObject(audit, "login_user", auser);
-        }
-
-        if (lf->effective_uid && *lf->effective_uid != '\0') {
-            cJSON* euser = cJSON_CreateObject();
-            cJSON_AddStringToObject(euser, "id", lf->effective_uid);
-            if (lf->effective_name) cJSON_AddStringToObject(euser, "name", lf->effective_name);
-            cJSON_AddItemToObject(audit, "effective_user", euser);
-        }
-
-        cJSON_AddItemToObject(file_diff, "audit", audit);
     }
 
     // DecoderInfo

--- a/src/analysisd/format/to_json.h
+++ b/src/analysisd/format/to_json.h
@@ -11,5 +11,6 @@
 #define __TO_JSON_H__
 
 #include "eventinfo.h"
+#define add_json_field(obj, name, string, filter) if (string && strcmp(string, filter)) { if (!obj) obj = cJSON_CreateObject(); cJSON_AddStringToObject(obj, name, string); }
 char *Eventinfo_to_jsonstr(const Eventinfo *lf);
 #endif /* __TO_JSON_H__ */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -124,6 +124,7 @@
 #define SK_DUP          "(1756): Duplicated directory given: '%s'."
 #define SK_INV_REG      "(1757): Invalid syscheck registry entry: '%s'."
 #define SK_REG_OPEN     "(1758): Unable to open registry key: '%s'."
+#define INV_WDATA_PAR   "Invalid parameter type (%ld) for '%s'."
 
 /* analysisd */
 #define FTS_LIST_ERROR   "(1260): Error initiating FTS list"

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -757,11 +757,11 @@ int extract_whodata_sum(whodata_evt *evt, char *wd_sum, int size) {
         name_esc = wstr_replace(evt->user_name, " ", "\\ ");
 #endif
         if (snprintf(wd_sum, size, "%s:%s:%s:%s:%s:%s:%s:%s:%s:%i:%lli",
-                evt->user_id,
-                name_esc,
+                (evt->user_id)?evt->user_id:"",
+                (name_esc)?name_esc:"",
                 (evt->group_id)?evt->group_id:"",
                 (evt->group_name)?evt->group_name:"",
-                process_esc,
+                (process_esc)?process_esc:"",
                 (evt->audit_uid)?evt->audit_uid:"",
                 (evt->audit_name)?evt->audit_name:"",
                 (evt->effective_uid)?evt->effective_uid:"",

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -469,7 +469,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
         }
 
         if (buffer[0].Type != EvtVarTypeUInt16) {
-            merror("Invalid parameter type (%ld) for 'event_id'.", buffer[0].Type);
+            merror(INV_WDATA_PAR, buffer[0].Type, "event_id");
             goto clean;
         }
         event_id = buffer[0].Int16Val;
@@ -479,7 +479,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
             if (event_id == 4658 || event_id == 4660) {
                 path = NULL;
             } else {
-                merror("Invalid parameter type (%ld) for 'path'.", buffer[2].Type);
+                merror(INV_WDATA_PAR, buffer[2].Type, "path");
                 goto clean;
             }
         }  else {
@@ -492,36 +492,44 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
         }
 
         if (buffer[1].Type != EvtVarTypeString) {
-            merror("Invalid parameter type (%ld) for 'user_name'.", buffer[1].Type);
+            merror(INV_WDATA_PAR, buffer[1].Type, "user_name");
             goto clean;
         }
         user_name = convert_windows_string(buffer[1].XmlVal);
 
         if (buffer[3].Type != EvtVarTypeString) {
-            merror("Invalid parameter type (%ld) for 'process_name'.", buffer[3].Type);
+            merror(INV_WDATA_PAR, buffer[3].Type, "process_name");
             goto clean;
         }
         process_name = convert_windows_string(buffer[3].XmlVal);
 
         // In 32-bit Windows we find EvtVarTypeSizeT
         if (buffer[4].Type != EvtVarTypeHexInt64 && buffer[4].Type !=  EvtVarTypeSizeT) {
-            merror("Invalid parameter type (%ld) for 'process_id'.", buffer[4].Type);
-            goto clean;
+            mwarn(INV_WDATA_PAR, buffer[4].Type, "process_id");
+            process_id = 0;
+        } else {
+            process_id = buffer[4].UInt64Val;
         }
-        process_id = buffer[4].UInt64Val;
 
-        // In 32-bit Windows we find EvtVarTypeSizeT
-        if (buffer[5].Type != EvtVarTypeHexInt64 && buffer[5].Type !=  EvtVarTypeSizeT) {
-            merror("Invalid parameter type (%ld) for 'handle_id'.", buffer[5].Type);
-            goto clean;
+        // In 32-bit Windows we find EvtVarTypeSizeT or EvtVarTypeHexInt32
+        if (buffer[5].Type != EvtVarTypeHexInt64) {
+            if (buffer[5].Type == EvtVarTypeSizeT) {
+                handle_id = (unsigned __int64) buffer[5].SizeTVal;
+            } else if (buffer[5].Type == EvtVarTypeHexInt32) {
+                handle_id = (unsigned __int64) buffer[5].UInt32Val;
+            } else {
+                merror(INV_WDATA_PAR, buffer[5].Type, "handle_id");
+                goto clean;
+            }
+        } else {
+            handle_id = buffer[5].UInt64Val;
         }
-        handle_id = buffer[5].UInt64Val;
 
         if (buffer[6].Type != EvtVarTypeHexInt32) {
             if (event_id == 4658 || event_id == 4660) {
                 mask = 0;
             } else {
-                merror("Invalid parameter type (%ld) for 'mask'.", buffer[6].Type);
+                merror(INV_WDATA_PAR, buffer[6].Type, "mask");
                 goto clean;
             }
         } else {
@@ -529,8 +537,8 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
         }
 
         if (buffer[7].Type != EvtVarTypeSid) {
-            merror("Invalid parameter type (%ld) for 'user_id'.", buffer[7].Type);
-            goto clean;
+            mwarn(INV_WDATA_PAR, buffer[7].Type, "user_id");
+            os_strdup("", user_id);
         } else if (!ConvertSidToStringSid(buffer[7].SidVal, &user_id)) {
             mdebug1("Invalid identifier for user '%s'", user_name);
             goto clean;
@@ -631,7 +639,7 @@ add_whodata_evt:
                             if (w_dir = OSHash_Get_ex(syscheck.wdata.directories, path), w_dir) {
                                 // Get the event time
                                 if (buffer[8].Type != EvtVarTypeFileTime) {
-                                    merror("Invalid parameter type (%ld) for 'event_time'.", buffer[8].Type);
+                                    merror(INV_WDATA_PAR, buffer[8].Type, "event_time");
                                     w_evt->scan_directory = 2;
                                     goto clean;
                                 }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -504,9 +504,15 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
         process_name = convert_windows_string(buffer[3].XmlVal);
 
         // In 32-bit Windows we find EvtVarTypeSizeT
-        if (buffer[4].Type != EvtVarTypeHexInt64 && buffer[4].Type !=  EvtVarTypeSizeT) {
-            mwarn(INV_WDATA_PAR, buffer[4].Type, "process_id");
-            process_id = 0;
+        if (buffer[4].Type != EvtVarTypeHexInt64) {
+            if (buffer[4].Type == EvtVarTypeSizeT) {
+                process_id = (unsigned __int64) buffer[4].SizeTVal;
+            } else if (buffer[4].Type == EvtVarTypeHexInt32) {
+                process_id = (unsigned __int64) buffer[4].UInt32Val;
+            } else {
+                mwarn(INV_WDATA_PAR, buffer[4].Type, "process_id");
+                process_id = 0;
+            }
         } else {
             process_id = buffer[4].UInt64Val;
         }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -492,16 +492,18 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
         }
 
         if (buffer[1].Type != EvtVarTypeString) {
-            merror(INV_WDATA_PAR, buffer[1].Type, "user_name");
-            goto clean;
+            mwarn(INV_WDATA_PAR, buffer[1].Type, "user_name");
+            user_name = NULL;
+        } else {
+            user_name = convert_windows_string(buffer[1].XmlVal);
         }
-        user_name = convert_windows_string(buffer[1].XmlVal);
 
         if (buffer[3].Type != EvtVarTypeString) {
-            merror(INV_WDATA_PAR, buffer[3].Type, "process_name");
-            goto clean;
+            mwarn(INV_WDATA_PAR, buffer[3].Type, "process_name");
+            process_name = NULL;
+        } else {
+            process_name = convert_windows_string(buffer[3].XmlVal);
         }
-        process_name = convert_windows_string(buffer[3].XmlVal);
 
         // In 32-bit Windows we find EvtVarTypeSizeT
         if (buffer[4].Type != EvtVarTypeHexInt64) {
@@ -544,7 +546,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
 
         if (buffer[7].Type != EvtVarTypeSid) {
             mwarn(INV_WDATA_PAR, buffer[7].Type, "user_id");
-            os_strdup("", user_id);
+            user_id = NULL;
         } else if (!ConvertSidToStringSid(buffer[7].SidVal, &user_id)) {
             mdebug1("Invalid identifier for user '%s'", user_name);
             goto clean;


### PR DESCRIPTION
This PR allows whodata events to be sent even if any of them could not be extracted.

Solves: https://groups.google.com/forum/#!topic/wazuh/6pXfEJOL4eQ