### PR TITLE
Fix typo in whodata alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Prevent offline agents from generating vulnerability-detector alerts. ([#1292](https://github.com/wazuh/wazuh/pull/1292))
 - Fix empty SHA256 of rotated alerts and log files. ([#1308](https://github.com/wazuh/wazuh/pull/1308))
+- Fix typo in whodata alerts. ([#1242](https://github.com/wazuh/wazuh/issues/1242))
 
 
 ## [v3.6.1] 2018-09-07

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -345,7 +345,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
             cJSON_AddStringToObject(proc, "id", lf->process_id);
             if (lf->process_name) cJSON_AddStringToObject(proc, "name", lf->process_name);
             if (lf->ppid && *lf->ppid != '\0') cJSON_AddStringToObject(proc, "ppid", lf->ppid);
-            cJSON_AddItemToObject(audit, "proccess", proc);
+            cJSON_AddItemToObject(audit, "process", proc);
         }
 
         if (lf->audit_uid && *lf->audit_uid != '\0') {


### PR DESCRIPTION
This PR fix a typo in the process field of whodata alerts.

New view:
```
.
.
.
      "process": {
        "id": "252",
        "name": "C:\\Windows\\System32\\notepad.exe"
      }
.
.
.
```