### PR TITLE
Fix the communication between manage_agents and ossec-authd

### DIFF
--- a/framework/wazuh/ossec_socket.py
+++ b/framework/wazuh/ossec_socket.py
@@ -30,7 +30,7 @@ class OssecSocket:
     def send(self, msg):
         try:
             payload = dumps(msg)
-            sent = self.s.send(pack("<I", len(msg)) + payload.encode())
+            sent = self.s.send(pack("<I", len(payload)) + payload.encode())
             if sent == 0:
                 raise WazuhException(1014, self.path)
             return sent

--- a/src/addagent/auth_client.c
+++ b/src/addagent/auth_client.c
@@ -52,14 +52,14 @@ int auth_add_agent(int sock, char *id, const char *name, const char *ip, int for
 
     output = cJSON_PrintUnformatted(request);
 
-    if (send(sock, output, strlen(output), 0) < 0) {
+    if (OS_SendSecureTCP(sock, strlen(output), output) < 0) {
         merror_exit("send(): %s", strerror(errno));
     }
 
     cJSON_Delete(request);
     free(output);
 
-    switch (length = recv(sock, buffer, OS_MAXSTR, 0), length) {
+    switch (length = OS_RecvSecureTCP(sock, buffer, OS_MAXSTR), length) {
     case -1:
         merror_exit("recv(): %s", strerror(errno));
         break;

--- a/src/addagent/auth_client.c
+++ b/src/addagent/auth_client.c
@@ -53,7 +53,7 @@ int auth_add_agent(int sock, char *id, const char *name, const char *ip, int for
     output = cJSON_PrintUnformatted(request);
 
     if (OS_SendSecureTCP(sock, strlen(output), output) < 0) {
-        merror_exit("send(): %s", strerror(errno));
+        merror_exit("OS_SendSecureTCP(): %s", strerror(errno));
     }
 
     cJSON_Delete(request);
@@ -61,7 +61,7 @@ int auth_add_agent(int sock, char *id, const char *name, const char *ip, int for
 
     switch (length = OS_RecvSecureTCP(sock, buffer, OS_MAXSTR), length) {
     case -1:
-        merror_exit("recv(): %s", strerror(errno));
+        merror_exit("OS_RecvSecureTCP(): %s", strerror(errno));
         break;
 
     case 0:
@@ -128,16 +128,16 @@ int auth_remove_agent(int sock, const char *id, int json_format) {
 
     output = cJSON_PrintUnformatted(request);
 
-    if (send(sock, output, strlen(output), 0) < 0) {
-        merror_exit("send(): %s", strerror(errno));
+    if (OS_SendSecureTCP(sock, strlen(output), output) < 0) {
+        merror_exit("OS_SendSecureTCP(): %s", strerror(errno));
     }
 
     cJSON_Delete(request);
     free(output);
 
-    switch (length = recv(sock, buffer, OS_MAXSTR, 0), length) {
+    switch (length = OS_RecvSecureTCP(sock, buffer, OS_MAXSTR), length) {
     case -1:
-        merror_exit("recv(): %s", strerror(errno));
+        merror_exit("OS_RecvSecureTCP(): %s", strerror(errno));
         break;
 
     case 0:

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -108,6 +108,10 @@ void* run_local_server(__attribute__((unused)) void *arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            mwarn("OS_RecvSecureTCP(): Got a message with invalid length.");
+            break;
+
         case -1:
             merror("OS_RecvSecureTCP(): %s", strerror(errno));
             break;
@@ -127,8 +131,9 @@ void* run_local_server(__attribute__((unused)) void *arg) {
                 OS_SendSecureTCP(peer, strlen(response), response);
                 free(response);
             }
-            close(peer);
         }
+
+        close(peer);
         free(buffer);
     }
 

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -432,7 +432,7 @@ int OS_RecvUnix(int socket, int sizet, char *ret)
 {
     ssize_t recvd;
     ret[sizet] = '\0';
-    
+
     if ((recvd = recvfrom(socket, ret, sizet - 1, 0,
                           (struct sockaddr *)&n_us, &us_l)) < 0) {
         return (0);
@@ -534,55 +534,34 @@ int OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
  * Return recvval on success or OS_SOCKTERR on error.
  */
 int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
-    int recvval;
-    char * buffer;
-    size_t bufsz = size + sizeof(uint32_t);
+    ssize_t recvval, recvb;
     uint32_t msgsize;
 
-    os_malloc(bufsz, buffer);
-    recvval = recv(sock, buffer, bufsz, 0);
+    recvval = recv(sock, &msgsize, sizeof(msgsize), 0);
 
-    switch(recvval){
-
+    switch(recvval) {
         case -1:
-            free(buffer);
             return recvval;
             break;
 
         case 0:
-            free(buffer);
             return recvval;
             break;
     }
 
-    msgsize = wnet_order(*(uint32_t*)buffer);
+    msgsize = wnet_order(msgsize);
 
     if(msgsize > size){
-        free(buffer);
         return OS_SOCKTERR;
     }
 
-    if((uint32_t)recvval < msgsize){
-        int recvb = recv(sock, buffer + recvval, msgsize-recvval, MSG_WAITALL);
+    recvb = recv(sock, ret, msgsize, MSG_WAITALL);
 
-        switch(recvb){
-            case -1:
-                free(buffer);
-                return recvb;
-                break;
-
-            case 0:
-                free(buffer);
-                return recvb;
-                break;
-        }
-        recvval+=recvb;
+    if (recvb == msgsize && msgsize < size) {
+        ret[msgsize] = '\0';
     }
 
-    memcpy(ret, buffer + sizeof(uint32_t), recvval - sizeof(uint32_t));
-    ret[recvval - sizeof(uint32_t)] = '\0';
-    free(buffer);
-    return recvval - sizeof(uint32_t);
+    return msgsize;
 }
 
 


### PR DESCRIPTION
Manage_agents didn't work while ossec-authd was running because it didn't send the information with the correct format.
Reference issue: #1262 