### PR TITLE
Fix bug which only appears using Python 3 when agent data is loaded.

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -261,7 +261,7 @@ class Agent:
         except IndexError:
             raise WazuhException(1701, self.id)
 
-        map(lambda x: setattr(self, x[0], x[1]), data.items())
+        list(map(lambda x: setattr(self, x[0], x[1]), data.items()))
 
 
     def _load_info_from_agent_db(self, table, select, filters={}, count=False, offset=0, limit=common.database_limit, sort={}, search={}):


### PR DESCRIPTION
Hi team,

I fixed a bug which appears only in Python 3 when the agent data are loading.

Best regards,

Demetrio.