### PR TITLE
Fix bug that prevents the agent from restarting

### DIFF
--- a/src/client-agent/restart_agent.c
+++ b/src/client-agent/restart_agent.c
@@ -49,7 +49,7 @@ void * restartAgent() {
 			merror("At restartAgent(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
 		}
 	} else {
-		if (send(sock, req, length, 0) != length) {
+		if (OS_SendSecureTCP(sock, length, req) != length) {
 			merror("send(): %s", strerror(errno));
 		}
 


### PR DESCRIPTION
The issue was due to the fact that agentd for Linux was sending the restart request to execd using send() instead of OS_SendSecureTCP(). This only affects 3.7 because from this version OS_RecvSecureTCP() is used to receive requests in wcom().

This PR solves https://github.com/wazuh/wazuh/issues/1251.