### PR TITLE
Copy default-firewall-drop.sh *before* installing active-response/*.sh…

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -762,6 +762,7 @@ InstallCommon(){
 
   ${INSTALL} -d -m 0700 -o root -g ${OSSEC_GROUP} ${PREFIX}/.ssh
 
+  ./init/fw-check.sh execute
   ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../active-response/*.sh ${PREFIX}/active-response/bin/
   ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../active-response/*.py ${PREFIX}/active-response/bin/
   ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../active-response/firewalls/*.sh ${PREFIX}/active-response/bin/
@@ -779,7 +780,6 @@ InstallCommon(){
 
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/backup
 
-  ./init/fw-check.sh execute
 }
 
 InstallLocal(){


### PR DESCRIPTION
Problem: The script firewall-drop.sh is not present when Wazuh is installed from an installation package (rpm or deb, for example). Nevertheless, it is present in the active-response directory after compiling from source.
It turns out that when the installation package is created (for Linux, for example), the copy from default-firewall-drop.sh is done, but after the files in the active-response directory are copied/installed to the directory used to create the package. Thus, firewall-drop.sh is not copied/installed.

Fix: Move the copy-renaming of default-firewall-drop.sh to firewall-drop.sh *before* the files are copied/installed to the package directory tree.
