### PR TITLE
Fix SHA256 empty in the checksum file of rotated alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Prevent offline agents from generating vulnerability-detector alerts. ([#1292](https://github.com/wazuh/wazuh/pull/1292))
+- Fix empty SHA256 of rotated alerts and log files. ([#1308](https://github.com/wazuh/wazuh/pull/1308))
 
 
 ## [v3.6.1] 2018-09-07

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -43,6 +43,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     unsigned char md5_digest[16];
     unsigned char md[SHA_DIGEST_LENGTH];
+    unsigned char md256[SHA256_DIGEST_LENGTH];
 
     /* Clear the memory */
     memset(logfilesum, '\0', OS_FLSIZE + 1);
@@ -122,6 +123,14 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
             snprintf(spos, 3, "%02x", md[n]);
             spos += 2;
         }
+
+        SHA256_Final(&(md256[0]), &sha256_ctx);
+        char *sspos = sf256_sum;
+        for (n = 0; n < SHA256_DIGEST_LENGTH; n++) {
+            snprintf(sspos, 3, "%02x", md256[n]);
+            sspos += 2;
+        }
+
     } else {
         strncpy(mf_sum, "none", 6);
         strncpy(sf_sum, "none", 6);


### PR DESCRIPTION
The `ossec-alerts-X.json.sum` file stores the MD5, SHA1, and SHA256 of every rotated and compressed alert and log files. The SHA256 wasn't been calculated correctly so the field was empty:

```
# cat ossec-alerts-13.json.sum
Current checksum:
MD5  (/logs/alerts/2018/Sep/ossec-alerts-14) = 94fa27bf6eb9228165a2434126c7c985
SHA1 (/logs/alerts/2018/Sep/ossec-alerts-14) = 516e11caaaf1e09367d975b273149443282bb6ee

SHA256 (/logs/alerts/2018/Sep/ossec-alerts-14) =

Chained checksum:
MD5  (/logs/alerts/2018/Sep/ossec-alerts-13.json.sum) = 186835e3885132fbd541ffbb0fef40f9
SHA1 (/logs/alerts/2018/Sep/ossec-alerts-13.json.sum) = 84b78f3c7f744681fad2678c445af442e8575aa5

SHA256 (/logs/alerts/2018/Sep/ossec-alerts-13.json.sum) =
```

Now it is calculated and added to the file as follows:

```
# gzip -d ossec-alerts-14.json.gz
# sha256sum ossec-alerts-14.json
3fdc6ae311485f0d0f9f84c438e71dd924cfa7bfdb8addae35106e0dc8d6d69b  ossec-alerts-14.json
# cat ossec-alerts-14.json.sum
Current checksum:
MD5  (/logs/alerts/2018/Sep/ossec-alerts-14) = 94fa27bf6eb9228165a2434126c7c985
SHA1 (/logs/alerts/2018/Sep/ossec-alerts-14) = 516e11caaaf1e09367d975b273149443282bb6ee

SHA256 (/logs/alerts/2018/Sep/ossec-alerts-14) = 3fdc6ae311485f0d0f9f84c438e71dd924cfa7bfdb8addae35106e0dc8d6d69b

Chained checksum:
MD5  (/logs/alerts/2018/Sep/ossec-alerts-13.json.sum) = 186835e3885132fbd541ffbb0fef40f9
SHA1 (/logs/alerts/2018/Sep/ossec-alerts-13.json.sum) = 84b78f3c7f744681fad2678c445af442e8575aa5

SHA256 (/logs/alerts/2018/Sep/ossec-alerts-13.json.sum) = 6baffe0277079ec1630ef484f18afee07e2228513fdb866e292b42bb71105a4f

```