### PR TITLE
Set thread stack size as internal option for Unix systems

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -283,6 +283,9 @@ wazuh_db.open_db_limit=64
 # Wazuh Command Module - If it should accept remote commands from the manager
 wazuh_command.remote_commands=0
 
+# Wazuh default stack size for child threads in KiB (2048..65536)
+wazuh.thread_stack_size=8192
+
 
 # Debug options.
 # Debug 0 -> no debug

--- a/src/headers/pthreads_op.h
+++ b/src/headers/pthreads_op.h
@@ -23,6 +23,7 @@
 
 #ifndef WIN32
 int CreateThread(void * (*function_pointer)(void *), void * data) __attribute__((nonnull(1)));
+int CreateThreadJoinable(pthread_t *lthread, void * (*function_pointer)(void *), void *data);
 #endif
 
 #endif

--- a/src/shared/pthreads_op.c
+++ b/src/shared/pthreads_op.c
@@ -19,40 +19,29 @@
 int CreateThreadJoinable(pthread_t *lthread, void * (*function_pointer)(void *), void *data)
 {
     pthread_attr_t attr;
-    struct rlimit lim;
     size_t read_size = 0;
     size_t stacksize = 0;
     int ret = 0;
 
-    if (getrlimit(RLIMIT_STACK, &lim)) {
-        merror_exit("At getrlimit(RLIMIT_STACK): %s (%d)", strerror(errno), errno);
+    if (pthread_attr_init(&attr)) {
+        merror(THREAD_ERROR);
+        return -1;
     }
 
-    if (lim.rlim_cur != RLIM_INFINITY && lim.rlim_cur >= PTHREAD_STACK_MIN) {
-        if (pthread_attr_init(&attr)) {
-            merror(THREAD_ERROR);
-            return -1;
-        }
+    read_size = 1024 * (size_t)getDefine_Int("wazuh", "thread_stack_size", 2048, 65536);
 
-        read_size = 1024 * (size_t)getDefine_Int("wazuh", "thread_stack_size", 2048, 65536);
-
-        if (lim.rlim_cur < read_size) {
-            read_size = lim.rlim_cur;
-        }
-
-        /* Set the maximum stack limit to new threads */
-        if (pthread_attr_setstacksize(&attr, read_size)) {
-            merror(THREAD_ERROR);
-            return -1;
-        }
-
-        if (pthread_attr_getstacksize(&attr, &stacksize)) {
-            merror(THREAD_ERROR);
-            return -1;
-        }
-
-        mdebug2("Thread stack size set to: %d", (int)stacksize);
+    /* Set the maximum stack limit to new threads */
+    if (pthread_attr_setstacksize(&attr, read_size)) {
+        merror(THREAD_ERROR);
+        return -1;
     }
+
+    if (pthread_attr_getstacksize(&attr, &stacksize)) {
+        merror(THREAD_ERROR);
+        return -1;
+    }
+
+    mdebug2("Thread stack size set to: %d KiB", (int)stacksize / 1024);
 
     ret = pthread_create(lthread, &attr, function_pointer, (void *)data);
     if (ret != 0) {

--- a/src/shared/pthreads_op.c
+++ b/src/shared/pthreads_op.c
@@ -10,19 +10,14 @@
 #ifndef WIN32
 #include "shared.h"
 #include <pthread.h>
+#include <sys/resource.h>
 
 /* Create a new thread and give the argument passed to the function
  * Returns 0 on success or -1 on error
  */
 
-#if defined(__MACH__) || defined(AIX) || defined(HPUX)
-
-#include <sys/resource.h>
-
-/* Set the maximum stack limit to new threads on mac OS */
-int CreateThread(void * (*function_pointer)(void *), void *data)
+int CreateThreadJoinable(pthread_t *lthread, void * (*function_pointer)(void *), void *data)
 {
-    pthread_t lthread;
     pthread_attr_t attr;
     struct rlimit lim;
     size_t stacksize = 0;
@@ -36,30 +31,26 @@ int CreateThread(void * (*function_pointer)(void *), void *data)
 
         if (pthread_attr_init(&attr)) {
             merror(THREAD_ERROR);
-            return (-1);
+            return -1;
         }
 
+        /* Set the maximum stack limit to new threads */
         if (pthread_attr_setstacksize(&attr, lim.rlim_cur)) {
             merror(THREAD_ERROR);
-            return (-1);
+            return -1;
         }
 
         if (pthread_attr_getstacksize(&attr, &stacksize)) {
             merror(THREAD_ERROR);
-            return (-1);
+            return -1;
         }
         mdebug2("Thread stack size set to: %d", (int)stacksize);
     }
 
-    ret = pthread_create(&lthread, &attr, function_pointer, (void *)data);
+    ret = pthread_create(lthread, &attr, function_pointer, (void *)data);
     if (ret != 0) {
         merror(THREAD_ERROR);
-        return (-1);
-    }
-
-    if (pthread_detach(lthread) != 0) {
-        merror(THREAD_ERROR);
-        return (-1);
+        return -1;
     }
 
     pthread_attr_destroy(&attr);
@@ -67,26 +58,21 @@ int CreateThread(void * (*function_pointer)(void *), void *data)
     return (0);
 }
 
-#else
-
 int CreateThread(void * (*function_pointer)(void *), void *data)
 {
     pthread_t lthread;
-    int ret = 0;
 
-    ret = pthread_create(&lthread, NULL, function_pointer, (void *)data);
-    if (ret != 0) {
+    if (CreateThreadJoinable(&lthread, function_pointer, data) < 0) {
         merror(THREAD_ERROR);
-        return (-1);
+        return -1;
     }
 
     if (pthread_detach(lthread) != 0) {
         merror(THREAD_ERROR);
-        return (-1);
+        return -1;
     }
 
     return (0);
 }
 
-#endif /* mac OS */
 #endif /* !WIN32 */

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -77,10 +77,10 @@ int main(int argc, char **argv)
     // Run modules
 
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
-        int error = pthread_create(&cur_module->thread, NULL, cur_module->context->start, cur_module->data);
-
-        if (error)
-            merror_exit("pthread_create(): %s", strerror(error));
+        if (CreateThreadJoinable(&cur_module->thread, cur_module->context->start, cur_module->data) < 0) {
+            merror_exit("CreateThreadJoinable() for '%s': %s", cur_module->tag, strerror(errno));
+        }
+        mdebug2("Created new thread for the '%s' module.", cur_module->tag);
     }
 
     // Wait for threads


### PR DESCRIPTION
This PR sets the stack size of the created child threads to 8 MiB on Unix. This parameter is configurable by the internal option: `wazuh.thread_stack_size` from 2 MiB to 64 MiB.

This way, we avoid unexpected crashes due to the lack of memory for some modules, as well as the inordinate default stack size of some systems like FreeBSD, which sets it to 512 MiB per thread.