### PR TITLE
Fix undefined client waiting in Authd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - Fix bug in whodata field extraction for Windows. ([#1233](https://github.com/wazuh/wazuh/issues/1233))
 - Fixed service startup on error. ([#1324](https://github.com/wazuh/wazuh/pull/1324))
 - Fix stack overflow when monitoring deep files. ([#1239](https://github.com/wazuh/wazuh/pull/1239))
-
+- Set connection timeout for Auth server ([#1336](https://github.com/wazuh/wazuh/pull/1336))
 
 ## [v3.6.1] 2018-09-07
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -284,6 +284,11 @@ wazuh_db.open_db_limit=64
 wazuh_command.remote_commands=0
 
 
+# Network timeout for Authd clients
+auth.timeout_seconds=1
+auth.timeout_microseconds=0
+
+
 # Debug options.
 # Debug 0 -> no debug
 # Debug 1 -> first level of debug

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -112,7 +112,7 @@ int connect_server(int initial_id)
             }
         } else {
             if (agt->server[rc].protocol == TCP_PROTO) {
-                if (OS_SetRecvTimeout(agt->sock, timeout) < 0){
+                if (OS_SetRecvTimeout(agt->sock, timeout, 0) < 0){
                     merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
                 }
             }

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -28,4 +28,6 @@ typedef struct authd_config_t {
     char *agent_ca;
     char *manager_cert;
     char *manager_key;
+    long timeout_sec;
+    long timeout_usec;
 } authd_config_t;

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -33,5 +33,8 @@ int authd_read_config(const char *path) {
         config.ciphers = strdup(DEFAULT_CIPHERS);
     }
 
+    config.timeout_sec = getDefine_Int("auth", "timeout_seconds", 0, INT_MAX);
+    config.timeout_usec = getDefine_Int("auth", "timeout_microseconds", 0, 999999);
+
     return 0;
 }

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -68,7 +68,7 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg)
             return (socket);
         }
 
-        if (OS_SetRecvTimeout(socket, SOCK_RECV_TIME0) < 0) {
+        if (OS_SetRecvTimeout(socket, SOCK_RECV_TIME0, 0) < 0) {
             merror("Couldn't set receiving timeout for socket.");
         }
 
@@ -321,7 +321,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
             return (socket);
         }
 
-        if (OS_SetRecvTimeout(socket, SOCK_RECV_TIME0) < 0) {
+        if (OS_SetRecvTimeout(socket, SOCK_RECV_TIME0, 0) < 0) {
             merror("Couldn't set receiving timeout for socket.");
         }
 

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -500,9 +500,9 @@ int OS_CloseSocket(int socket)
 #endif /* WIN32 */
 }
 
-int OS_SetRecvTimeout(int socket, int seconds)
+int OS_SetRecvTimeout(int socket, long seconds, long useconds)
 {
-    struct timeval tv = { seconds, 0 };
+    struct timeval tv = { seconds, useconds };
     return setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const void *)&tv, sizeof(tv));
 }
 

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -78,7 +78,7 @@ int OS_CloseSocket(int socket);
 /* Set the receiving timeout for a socket
  * Returns 0 on success, else -1
  */
-int OS_SetRecvTimeout(int socket, int seconds);
+int OS_SetRecvTimeout(int socket, long seconds, long useconds);
 
 /* Send secure TCP message
  * This function prepends a header containing message size as 4-byte little-endian unsigned integer.

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -61,7 +61,7 @@ void HandleRemote(int uid)
         if ((logr.sock = OS_Bindporttcp(logr.port[position], logr.lip[position], logr.ipv6[position])) < 0) {
             merror_exit(BIND_ERROR, logr.port[position], errno, strerror(errno));
         } else if (logr.conn[position] == SECURE_CONN) {
-            if (OS_SetRecvTimeout(logr.sock, timeout) < 0){
+            if (OS_SetRecvTimeout(logr.sock, timeout, 0) < 0){
                 merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
             }
         }


### PR DESCRIPTION
This issue may occur if any client connects to Authd but does not send data.

**Proposed fix:** Add a timeout to the client sockets. If a client takes more than the selected time to respond, the server shall close the connection.

Related issue: https://github.com/wazuh/wazuh/issues/1243

## New internal options:

### `auth.timeout_seconds`

Network timeout (seconds).
Allowed values: 0 to 2147483647.
Default value: 1.

### `auth.timeout_microseconds`

Network timeout (µseconds).
Allowed values: 0 to 999999.
Default value: 0.

## Example log

### 1-second timeout in network client
```
2018/09/10 19:12:04 ossec-authd: INFO: New connection from 127.0.0.1
2018/09/10 19:12:05 ossec-authd: INFO: Client was disconnected, or network timeout.
```

### 1-second timeout in local-socket
```
2018/09/10 19:17:02 ossec-authd: DEBUG: Local connection timeout.
```