### PR TITLE
Fix update timestamp in event info struct

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -554,7 +554,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     localtime(&c_time);
     gettime(&local_c_timespec);
     lf->time = local_c_timespec;
-    localtime_r(&local_c_timespec, &p);
+    localtime_r(&lf->time.tv_sec, &p);
 
     /* Assign hour, day, year and month values */
     lf->day = p.tm_mday;

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -26,7 +26,8 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
 {
     size_t loglen;
     char *pieces;
-    struct tm *p;
+    struct tm p;
+    struct timespec local_c_timespec;
 
     /* The message is formated in the following way:
      * id:location:message.
@@ -550,17 +551,19 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     }
 
     /* Set up the event data */
-    lf->time = c_timespec;
-    p = localtime(&c_time);
+    localtime(&c_time);
+    gettime(&local_c_timespec);
+    lf->time = local_c_timespec;
+    localtime_r(&local_c_timespec, &p);
 
     /* Assign hour, day, year and month values */
-    lf->day = p->tm_mday;
-    lf->year = p->tm_year + 1900;
-    strncpy(lf->mon, month[p->tm_mon], 3);
+    lf->day = p.tm_mday;
+    lf->year = p.tm_year + 1900;
+    strncpy(lf->mon, month[p.tm_mon], 3);
     snprintf(lf->hour, 9, "%02d:%02d:%02d",
-             p->tm_hour,
-             p->tm_min,
-             p->tm_sec);
+             p.tm_hour,
+             p.tm_min,
+             p.tm_sec);
 
 #ifdef TESTRULE
     if (!alert_only) {


### PR DESCRIPTION
This PR fix [#1353](https://github.com/wazuh/wazuh/issues/1353)