### PR TITLE
Fix check_mtime and check_inode view in Syscheck alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed email_alerts configuration for multiple recipients. ([#1193 ](https://github.com/wazuh/wazuh/pull/1193))
 - Fixed manager stopping when no command timeout is allowed. ([#1194](https://github.com/wazuh/wazuh/pull/1194))
 - Fix the cleaning of the temporary folder. ([#1361](https://github.com/wazuh/wazuh/pull/1361))
+- Fix check_mtime and check_inode views in Syscheck alerts. ([#1364](https://github.com/wazuh/wazuh/pull/1364))
 
 
 ## [v3.6.2]

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -503,8 +503,8 @@ static int DB_Search(const char *f_name, char *c_sum, char *w_sum, Eventinfo *lf
                             snprintf(gowner, OS_FLSIZE, "Group ownership was '%s', now it is '%s'\n", oldsum.gid, newsum.gid);
                         }
                         os_strdup(oldsum.gid, lf->gowner_before);
+                    }
                 }
-}
                 /* MD5 message */
                 if (!*newsum.md5 || !*oldsum.md5 || strcmp(newsum.md5, oldsum.md5) == 0) {
                     md5[0] = '\0';
@@ -570,7 +570,7 @@ static int DB_Search(const char *f_name, char *c_sum, char *w_sum, Eventinfo *lf
                 if (oldsum.inode && newsum.inode && oldsum.inode != newsum.inode) {
                     changes = 1;
                     wm_strcat(&lf->fields[SK_CHFIELDS].value, "inode", ',');
-                    snprintf(mtime, OS_FLSIZE, "Old inode was: '%ld', now it is '%ld'\n", oldsum.inode, newsum.inode);
+                    snprintf(inode, OS_FLSIZE, "Old inode was: '%ld', now it is '%ld'\n", oldsum.inode, newsum.inode);
                     lf->inode_before = oldsum.inode;
                 } else {
                     inode[0] = '\0';
@@ -591,9 +591,13 @@ static int DB_Search(const char *f_name, char *c_sum, char *w_sum, Eventinfo *lf
                         "%s"
                         "%s"
                         "%s"
+                        "%s"
+                        "%s"
                         "%s",
                         f_name,
                         size,
+                        mtime,
+                        inode,
                         perm,
                         owner,
                         gowner,


### PR DESCRIPTION
The change of these parameters was not being shown in alerts.log.