### PR TITLE
Improve osquery integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ All notable changes to this project will be documented in this file.
 - Fim data is stored in SQLite using Wazuh-DB. ([#1333](https://github.com/wazuh/wazuh/pull/1333))
 - Make Syscheck case insensitive. ([#1349](https://github.com/wazuh/wazuh/pull/1349))
 - Avoid conflicts with the size of time_t variable in wazuh-db. ([#1366](https://github.com/wazuh/wazuh/pull/1366))
+- Osquery integration updated: ([#1369](https://github.com/wazuh/wazuh/pull/1369))
+  - Nest the result data into a "osquery" object.
+  - Extract the pack name into a new field.
+  - Include the query name in the alert description.
+  - Minor fixes.
 
 ### Fixed
 

--- a/etc/rules/0545-osquery_rules.xml
+++ b/etc/rules/0545-osquery_rules.xml
@@ -26,7 +26,7 @@
   <rule id="24010" level="3">
     <if_sid>24000</if_sid>
     <decoded_as>json</decoded_as>
-    <description>osquery event: $(name)</description>
+    <description>osquery: result for '$(name)' query</description>
   </rule>
 
   <rule id="24011" level="4">
@@ -55,65 +55,65 @@
 
   <rule id="24020" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_osquery-monitoring</field>
-    <description>osquery event: $(name)</description>
-    <group>osquery_monitoring</group>
+    <field name="pack">^osquery-monitoring$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>osquery_monitoring,</group>
   </rule>
 
   <rule id="24030" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_incident-response</field>
-    <description>osquery event: $(name)</description>
-    <group>incident_response</group>
+    <field name="pack">^incident-response$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>incident_response,</group>
   </rule>
 
   <rule id="24040" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_it-compliance</field>
-    <description>osquery event: $(name)</description>
-    <group>it_compliance</group>
+    <field name="pack">^it-compliance$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>it_compliance,</group>
   </rule>
 
   <rule id="24050" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_osx-attacks</field>
-    <description>osquery event: $(name)</description>
-    <group>osx_attacks</group>
+    <field name="pack">^osx-attacks$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>osx_attacks,</group>
   </rule>
 
   <rule id="24060" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_vuln-management</field>
-    <description>osquery event: $(name)</description>
-    <group>vuln_management</group>
+    <field name="pack">^vuln-management$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>vuln_management,</group>
   </rule>
 
   <rule id="24070" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_hardware-monitoring</field>
-    <description>osquery event: $(name)</description>
-    <group>hardware_monitoring</group>
+    <field name="pack">^hardware-monitoring$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>hardware_monitoring,</group>
   </rule>
 
   <rule id="24080" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_ossec-rootkit</field>
-    <description>osquery event: $(name)</description>
-    <group>ossec_rootkit</group>
+    <field name="pack">^ossec-rootkit$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>ossec_rootkit,</group>
   </rule>
 
   <rule id="24090" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_windows-hardening</field>
-    <description>osquery event: $(name)</description>
-    <group>windows_hardening</group>
+    <field name="pack">^windows-hardening$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>windows_hardening,</group>
   </rule>
 
   <rule id="24100" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">^pack_windows-attacks</field>
-    <description>osquery event: $(name)</description>
-    <group>windows_attacks</group>
+    <field name="pack">^windows-attacks$</field>
+    <description>osquery: result for '$(name)' query</description>
+    <group>windows_attacks,</group>
   </rule>
 
 </group>

--- a/etc/rules/0545-osquery_rules.xml
+++ b/etc/rules/0545-osquery_rules.xml
@@ -26,7 +26,7 @@
   <rule id="24010" level="3">
     <if_sid>24000</if_sid>
     <decoded_as>json</decoded_as>
-    <description>osquery data grouped</description>
+    <description>osquery event: $(name)</description>
   </rule>
 
   <rule id="24011" level="4">

--- a/etc/rules/0545-osquery_rules.xml
+++ b/etc/rules/0545-osquery_rules.xml
@@ -26,7 +26,7 @@
   <rule id="24010" level="3">
     <if_sid>24000</if_sid>
     <decoded_as>json</decoded_as>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
   </rule>
 
   <rule id="24011" level="4">
@@ -56,63 +56,63 @@
   <rule id="24020" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^osquery-monitoring$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>osquery_monitoring,</group>
   </rule>
 
   <rule id="24030" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^incident-response$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>incident_response,</group>
   </rule>
 
   <rule id="24040" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^it-compliance$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>it_compliance,</group>
   </rule>
 
   <rule id="24050" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^osx-attacks$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>osx_attacks,</group>
   </rule>
 
   <rule id="24060" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^vuln-management$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>vuln_management,</group>
   </rule>
 
   <rule id="24070" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^hardware-monitoring$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>hardware_monitoring,</group>
   </rule>
 
   <rule id="24080" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^ossec-rootkit$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>ossec_rootkit,</group>
   </rule>
 
   <rule id="24090" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^windows-hardening$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>windows_hardening,</group>
   </rule>
 
   <rule id="24100" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^windows-attacks$</field>
-    <description>osquery: result for '$(osquery.name)' query</description>
+    <description>osquery: $(osquery.name) query result</description>
     <group>windows_attacks,</group>
   </rule>
 

--- a/etc/rules/0545-osquery_rules.xml
+++ b/etc/rules/0545-osquery_rules.xml
@@ -53,4 +53,67 @@
     <description>Disk busy time is over $(columns.threshold)</description>
   </rule>
 
+  <rule id="24020" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_osquery-monitoring</field>
+    <description>osquery event: $(name)</description>
+    <group>osquery_monitoring</group>
+  </rule>
+
+  <rule id="24030" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_incident-response</field>
+    <description>osquery event: $(name)</description>
+    <group>incident_response</group>
+  </rule>
+
+  <rule id="24040" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_it-compliance</field>
+    <description>osquery event: $(name)</description>
+    <group>it_compliance</group>
+  </rule>
+
+  <rule id="24050" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_osx-attacks</field>
+    <description>osquery event: $(name)</description>
+    <group>osx_attacks</group>
+  </rule>
+
+  <rule id="24060" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_vuln-management</field>
+    <description>osquery event: $(name)</description>
+    <group>vuln_management</group>
+  </rule>
+
+  <rule id="24070" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_hardware-monitoring</field>
+    <description>osquery event: $(name)</description>
+    <group>hardware_monitoring</group>
+  </rule>
+
+  <rule id="24080" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_ossec-rootkit</field>
+    <description>osquery event: $(name)</description>
+    <group>ossec_rootkit</group>
+  </rule>
+
+  <rule id="24090" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_windows-hardening</field>
+    <description>osquery event: $(name)</description>
+    <group>windows_hardening</group>
+  </rule>
+
+  <rule id="24100" level="4">
+    <if_sid>24010</if_sid>
+    <field name="name">^pack_windows-attacks</field>
+    <description>osquery event: $(name)</description>
+    <group>windows_attacks</group>
+  </rule>
+
 </group>

--- a/etc/rules/0545-osquery_rules.xml
+++ b/etc/rules/0545-osquery_rules.xml
@@ -26,93 +26,93 @@
   <rule id="24010" level="3">
     <if_sid>24000</if_sid>
     <decoded_as>json</decoded_as>
-    <description>osquery: result for '$(name)' query</description>
+    <description>osquery: result for '$(osquery.name)' query</description>
   </rule>
 
   <rule id="24011" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">high_load_average</field>
+    <field name="osquery.name">high_load_average</field>
     <description>System memory is under $(columns.threshold)</description>
   </rule>
 
   <rule id="24012" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">low_free_memory</field>
+    <field name="osquery.name">low_free_memory</field>
     <description>System memory is under $(columns.threshold)</description>
   </rule>
 
   <rule id="24013" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">low_disk_space</field>
+    <field name="osquery.name">low_disk_space</field>
     <description>Free disk space is under $(columns.threshold)</description>
   </rule>
 
   <rule id="24014" level="4">
     <if_sid>24010</if_sid>
-    <field name="name">disk_time_busy</field>
+    <field name="osquery.name">disk_time_busy</field>
     <description>Disk busy time is over $(columns.threshold)</description>
   </rule>
 
   <rule id="24020" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^osquery-monitoring$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^osquery-monitoring$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>osquery_monitoring,</group>
   </rule>
 
   <rule id="24030" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^incident-response$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^incident-response$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>incident_response,</group>
   </rule>
 
   <rule id="24040" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^it-compliance$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^it-compliance$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>it_compliance,</group>
   </rule>
 
   <rule id="24050" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^osx-attacks$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^osx-attacks$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>osx_attacks,</group>
   </rule>
 
   <rule id="24060" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^vuln-management$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^vuln-management$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>vuln_management,</group>
   </rule>
 
   <rule id="24070" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^hardware-monitoring$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^hardware-monitoring$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>hardware_monitoring,</group>
   </rule>
 
   <rule id="24080" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^ossec-rootkit$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^ossec-rootkit$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>ossec_rootkit,</group>
   </rule>
 
   <rule id="24090" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^windows-hardening$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^windows-hardening$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>windows_hardening,</group>
   </rule>
 
   <rule id="24100" level="4">
     <if_sid>24010</if_sid>
-    <field name="pack">^windows-attacks$</field>
-    <description>osquery: result for '$(name)' query</description>
+    <field name="osquery.pack">^windows-attacks$</field>
+    <description>osquery: result for '$(osquery.name)' query</description>
     <group>windows_attacks,</group>
   </rule>
 

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -92,7 +92,7 @@ void OS_Store(const Eventinfo *lf)
             lf->location[0] != '(' ? "->" : "",
             lf->location,
             lf->full_log);
-            
+
     return;
 }
 
@@ -243,7 +243,7 @@ void OS_LogOutput(Eventinfo *lf)
     // Dynamic fields, except for syscheck events
     if (lf->fields && !lf->filename) {
         for (i = 0; i < lf->nfields; i++) {
-            if (lf->fields[i].value) {
+            if (lf->fields[i].value && *lf->fields[i].value) {
                 printf("%s: %s\n", lf->fields[i].key, lf->fields[i].value);
             }
         }
@@ -410,7 +410,7 @@ void OS_Log(Eventinfo *lf)
     // Dynamic fields, except for syscheck events
     if (lf->fields && !lf->filename) {
         for (i = 0; i < lf->nfields; i++) {
-            if (lf->fields[i].value) {
+            if (lf->fields[i].value && *lf->fields[i].value) {
                 fprintf(_aflog, "%s: %s\n", lf->fields[i].key, lf->fields[i].value);
             }
         }

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -383,7 +383,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         // Dynamic fields, except for syscheck events
         if (lf->fields && !lf->filename) {
             for (i = 0; i < lf->nfields; i++) {
-                if (lf->fields[i].value) {
+                if (lf->fields[i].value && *lf->fields[i].value) {
                     W_JSON_AddField(data, lf->fields[i].key, lf->fields[i].value);
                 }
             }

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -64,7 +64,10 @@ void *Read_Log(wm_osquery_monitor_t * osquery)
         }
 
         if (!active) {
-            fclose(result_log);
+            if (result_log) {
+                fclose(result_log);
+            }
+
             break;
         }
 

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -59,8 +59,9 @@ void *Read_Log(wm_osquery_monitor_t * osquery)
         // Wait to open log file
 
         while (result_log = wfopen(osquery->log_path, "r"), !result_log && active) {
-            mwarn("Results file '%s' not available: %s (%d)", osquery->log_path, strerror(errno), errno);
-            sleep((i < 60 ? ++i : 60));
+            i += i < 60;
+            mwarn("Results file '%s' not available: %s (%d). Retrying in %d sec.", osquery->log_path, strerror(errno), errno, i);
+            sleep(i);
         }
 
         if (!active) {
@@ -70,6 +71,8 @@ void *Read_Log(wm_osquery_monitor_t * osquery)
 
             break;
         }
+
+        minfo("Following osquery results file '%s'.", osquery->log_path);
 
         // Move to end of the file
 


### PR DESCRIPTION
Related issue: #1348.

## osquery-monitoring pack example

```json
{
  "timestamp": "2018-09-20T17:22:31.841+0200",
  "rule": {
    "level": 4,
    "description": "osquery: pack_osquery-monitoring_schedule query result",
    "id": "24020",
    "mail": false,
    "groups": [
      "osquery",
      "osquery_monitoring"
    ]
  },
  "agent": {
    "id": "000",
    "name": "stretch"
  },
  "manager": {
    "name": "stretch"
  },
  "id": "1537456951.5934738",
  "full_log": "{\"osquery\":{\"name\":\"pack_osquery-monitoring_schedule\",\"hostIdentifier\":\"stretch\",\"calendarTime\":\"Thu Sep 20 15:22:30 2018 UTC\",\"unixTime\":1537456950,\"epoch\":0,\"counter\":0,\"decorations\":{\"host_uuid\":\"6AF93292-17E0-44F5-B321-35EA577BCC3F\",\"username\":\"root\"},\"columns\":{\"average_memory\":\"0\",\"avg_system_time\":\"\",\"avg_user_time\":\"\",\"executions\":\"0\",\"interval\":\"3600\",\"last_executed\":\"0\",\"name\":\"pack_ossec-rootkit_zarwt_rootkit\",\"output_size\":\"0\",\"wall_time\":\"0\"},\"action\":\"added\",\"pack\":\"osquery-monitoring\"}}",
  "data": {
    "osquery": {
      "name": "pack_osquery-monitoring_schedule",
      "hostIdentifier": "stretch",
      "calendarTime": "Thu Sep 20 15:22:30 2018 UTC",
      "unixTime": "1537456950",
      "epoch": "0",
      "counter": "0",
      "decorations": {
        "host_uuid": "6AF93292-17E0-44F5-B321-35EA577BCC3F",
        "username": "root"
      },
      "columns": {
        "name": "pack_ossec-rootkit_zarwt_rootkit",
        "average_memory": "0",
        "executions": "0",
        "interval": "3600",
        "last_executed": "0",
        "output_size": "0",
        "wall_time": "0"
      },
      "action": "added",
      "pack": "osquery-monitoring"
    }
  },
  "location": "osquery",
  "decoder": {
    "name": "json"
  }
}
```

## Global query example

This alert comes from a custom query named "packages":

```json
{
  "timestamp": "2018-09-20T17:31:05.155+0200",
  "rule": {
    "level": 3,
    "description": "osquery: packages query result",
    "id": "24010",
    "mail": false,
    "groups": [
      "osquery"
    ]
  },
  "agent": {
    "id": "000",
    "name": "stretch"
  },
  "manager": {
    "name": "stretch"
  },
  "id": "1537457465.6481323",
  "full_log": "{\"osquery\":{\"name\":\"packages\",\"hostIdentifier\":\"stretch\",\"calendarTime\":\"Thu Sep 20 15:30:54 2018 UTC\",\"unixTime\":1537457454,\"epoch\":0,\"counter\":0,\"decorations\":{\"host_uuid\":\"6AF93292-17E0-44F5-B321-35EA577BCC3F\",\"username\":\"root\"},\"columns\":{\"arch\":\"amd64\",\"name\":\"zlib1g\",\"revision\":\"5\",\"size\":\"156\",\"source\":\"zlib\",\"version\":\"1:1.2.8.dfsg-5\"},\"action\":\"added\"}}",
  "data": {
    "osquery": {
      "name": "packages",
      "hostIdentifier": "stretch",
      "calendarTime": "Thu Sep 20 15:30:54 2018 UTC",
      "unixTime": "1537457454",
      "epoch": "0",
      "counter": "0",
      "decorations": {
        "host_uuid": "6AF93292-17E0-44F5-B321-35EA577BCC3F",
        "username": "root"
      },
      "columns": {
        "arch": "amd64",
        "name": "zlib1g",
        "revision": "5",
        "size": "156",
        "source": "zlib",
        "version": "1:1.2.8.dfsg-5"
      },
      "action": "added"
    }
  },
  "location": "osquery",
  "decoder": {
    "name": "json"
  }
}
```