### PR TITLE
Fix error in ossec-control that wasn't starting wazuh-clusterd

### DIFF
--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -36,13 +36,13 @@ USE_JSON=false
 INITCONF="/etc/ossec-init.conf"
 DAEMONS="wazuh-modulesd ossec-monitord ossec-logcollector ossec-remoted ossec-syscheckd ossec-analysisd ossec-maild ossec-execd wazuh-db ${DB_DAEMON} ${CSYSLOG_DAEMON} ${AGENTLESS_DAEMON} ${INTEGRATOR_DAEMON} ${AUTH_DAEMON}"
 
-# Reverse order of daemons
-SDAEMONS=$(echo $DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
-
 if ! is_rhel_le_5
 then
     DAEMONS="wazuh-clusterd $DAEMONS"
 fi
+
+# Reverse order of daemons
+SDAEMONS=$(echo $DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
 
 [ -f ${INITCONF} ] && . ${INITCONF}  || echo "ERROR: No such file ${INITCONF}"
 
@@ -246,6 +246,9 @@ testconfig()
 {
     # We first loop to check the config.
     for i in ${SDAEMONS}; do
+        if [ X"$i" = "Xwazuh-clusterd" ]; then
+            continue
+        fi
         ${DIR}/bin/${i} -t ${DEBUG_CLI};
         if [ $? != 0 ]; then
             if [ $USE_JSON = true ]; then


### PR DESCRIPTION
Hello team,

This PR fixes #1378.

The bug was caused because the `SDAEMONS` variable, which is used in `start()` function was declared before the cluster was added to the daemons list.

Also, I've removed cluster configuration testing because if the global database is not created, the cluster won't be able to start and therefore, wazuh won't start as well.

Best regards,
Marta