### PR TITLE
Fixed /agents/outdated call. Now, this call returns only outdated age…

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1806,7 +1806,7 @@ class Agent:
 
         select = {'fields':['version','id','name']} if select is None else select
         db_query = WazuhDBQueryAgents(offset=offset, limit=limit, sort=sort, search=search, select=select,
-                                      query="version!={};id!=0".format(manager.version) + ('' if not q else ';'+q),
+                                      query="version<{};id!=0".format(manager.version) + ('' if not q else ';'+q),
                                       get_data=True, count=True)
         return db_query.run()
 


### PR DESCRIPTION
Hi team,

This PR is for issue [#135](https://github.com/wazuh/wazuh-api/issues/135). Now *GET /agents/outdated* call returns only outdated agents respect to the manager.

Best regards,

Demetrio.