### PR TITLE
Check the default-local_internal_options.conf file when upgrading by Windows MSI package

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -145,15 +145,31 @@ If objFSO.fileExists(home_dir & "ossec.conf") Then
     objFile.Close
 
 	If Not objFSO.fileExists(home_dir & "local_internal_options.conf") Then
-		' Reading default-local_internal_options.conf file
-		Set objFile = objFSO.OpenTextFile(home_dir & "default-local_internal_options.conf", ForReading)
-		strText = objFile.ReadAll
-		objFile.Close
 
-		' Writing the local_internal_options.conf file
-		Set objFile = objFSO.CreateTextFile(home_dir & "local_internal_options.conf", ForWriting)
-		objFile.WriteLine strText
-		objFile.Close
+		If objFSO.fileExists(home_dir & "default-local_internal_options.conf") Then
+			' Reading default-local_internal_options.conf file
+			Set objFile = objFSO.OpenTextFile(home_dir & "default-local_internal_options.conf", ForReading)
+			strText = objFile.ReadAll
+			objFile.Close
+
+			' Writing the local_internal_options.conf file
+			Set objFile = objFSO.CreateTextFile(home_dir & "local_internal_options.conf", ForWriting)
+			objFile.WriteLine strText
+			objFile.Close
+		Else
+			Set objFile = objFSO.CreateTextFile(home_dir & "local_internal_options.conf", ForWriting)
+			objFile.WriteLine("# local_internal_options.conf")
+			objFile.WriteLine("#")
+			objFile.WriteLine("# This file should be handled with care. It contains")
+			objFile.WriteLine("# run time modifications that can affect the use")
+			objFile.WriteLine("# of OSSEC. Only change it if you know what you")
+			objFile.WriteLine("# are doing. Look first at ossec.conf")
+			objFile.WriteLine("# for most of the things you want to change.")
+			objFile.WriteLine("#")
+			objFile.WriteLine("# This file will not be overwritten during upgrades")
+			objFile.WriteLine("# but will be removed when the agent is un-installed.")
+			objFile.Close
+		End If
 
 	End If
 


### PR DESCRIPTION
For versions v3.2.0 - v3.2.2 there exists a bug that forbids upgrade to new versions of the Windows agent greater than v3.5.0 directly. This is why the expected `default-local_internal_options.conf` is missing during the upgrade and the `InstallerScript` is not able to copy its content to the `local_internal_options.conf` file.

This PR checks that the file exists, if not, its content is written manually.