### PR TITLE
Error in recv function

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -537,7 +537,7 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
     ssize_t recvval, recvb;
     uint32_t msgsize;
 
-    recvval = recv(sock, (char *) &msgsize, sizeof(msgsize), 0);
+    recvval = recv(sock, (char *) &msgsize, sizeof(msgsize), MSG_WAITALL);
 
     switch(recvval) {
         case -1:
@@ -561,7 +561,7 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
         ret[msgsize] = '\0';
     }
 
-    return msgsize;
+    return recvb;
 }
 
 


### PR DESCRIPTION
A bug has been detected in the 'recvSecure' function. First, we get the size of the message sent in the first 4 Bytes of the message. In the 'recv' call, the waiting time equal to 0 was passed as a parameter, which did not allow to receive the complete message returning OS_SOCKTERR, causing a failure in any call to this function.

This PR solves issues [#1382](https://github.com/wazuh/wazuh/issues/1382) and [1375](https://github.com/wazuh/wazuh/issues/1375)