### PR TITLE
Fix getting destination address and type of PPP interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@ All notable changes to this project will be documented in this file.
 - Set connection timeout for Auth server ([#1336](https://github.com/wazuh/wazuh/pull/1336))
 - Fix the cleaning of the temporary folder. ([#1361](https://github.com/wazuh/wazuh/pull/1361))
 - Fix check_mtime and check_inode views in Syscheck alerts. ([#1364](https://github.com/wazuh/wazuh/pull/1364))
-- Fixed a memory bug in regex when getting empty strings. ([#1430](https://github.com/wazuh/wazuh/pull/1430)) 
+- Fixed the reading of the destination address and type for PPP interfaces. ([#1405](https://github.com/wazuh/wazuh/pull/1405))
+- Fixed a memory bug in regex when getting empty strings. ([#1430](https://github.com/wazuh/wazuh/pull/1430))
+
 
 ## [v3.6.1] 2018-09-07
 

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -1077,16 +1077,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
                         }
 
                         /* Get broadcast address (or destination address in a Point to Point connection) */
-                        if ((host[0] != '\0') && (netmask[0] != '\0')) {
-                            char * broadaddr;
-                            broadaddr = get_broadcast_addr(host, netmask);
-                            if (strncmp(broadaddr, "unknown", 7)) {
-                                cJSON_AddItemToArray(ipv4_broadcast, cJSON_CreateString(broadaddr));
-                            } else {
-                                mterror(WM_SYS_LOGTAG, "Failed getting broadcast addr for '%s'", host);
-                            }
-                            free(broadaddr);
-                        } else if (ifa->ifa_ifu.ifu_broadaddr != NULL){
+                        if (ifa->ifa_ifu.ifu_broadaddr != NULL){
                             char broadaddr[NI_MAXHOST];
                             result = getnameinfo(ifa->ifa_ifu.ifu_broadaddr,
                                 sizeof(struct sockaddr_in),
@@ -1098,6 +1089,15 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
                             } else {
                                 mterror(WM_SYS_LOGTAG, "getnameinfo() failed: %s\n", gai_strerror(result));
                             }
+                        } else if ((host[0] != '\0') && (netmask[0] != '\0')) {
+                            char * broadaddr;
+                            broadaddr = get_broadcast_addr(host, netmask);
+                            if (strncmp(broadaddr, "unknown", 7)) {
+                                cJSON_AddItemToArray(ipv4_broadcast, cJSON_CreateString(broadaddr));
+                            } else {
+                                mterror(WM_SYS_LOGTAG, "Failed getting broadcast addr for '%s'", host);
+                            }
+                            free(broadaddr);
                         }
                     }
 
@@ -1234,7 +1234,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
         dhcp_status = check_dhcp(ifaces_list[i], AF_INET);
         cJSON_AddStringToObject(ipv4, "DHCP", dhcp_status);
         free(dhcp_status);
-        
+
         /* Get DHCP status for IPv6 */
         dhcp_status = check_dhcp(ifaces_list[i], AF_INET6);
         cJSON_AddStringToObject(ipv6, "DHCP", dhcp_status);
@@ -1397,7 +1397,7 @@ char* get_if_type(char *ifa_name){
     char file[PATH_LENGTH];
 
     FILE *fp;
-    char type_str[3];
+    char type_str[6];
     int type_int;
     char * type;
     os_calloc(TYPE_LENGTH + 1, sizeof(char), type);
@@ -1406,7 +1406,7 @@ char* get_if_type(char *ifa_name){
     snprintf(file, PATH_LENGTH - 1, "%s%s/%s", WM_SYS_IFDATA_DIR, ifa_name, "type");
 
     if((fp = fopen(file, "r"))){
-        if (fgets(type_str, 3, fp) != NULL){
+        if (fgets(type_str, 6, fp) != NULL){
 
             type_int = atoi(type_str);
 


### PR DESCRIPTION
This PR solves the issue #1393.

The broadcast field should include the destination address in a "point-to-point" interface, however, it wasn't be collected properly.

It also has been fixed the reading of the interface type, which failed due to a length variable issue.

The reading of the state is working fine, the problem is that the own agent doesn't know the state of that interface:

```
# ifconfig ppp0
ppp0: flags=4305<UP,POINTOPOINT,RUNNING,NOARP,MULTICAST>  mtu 1496
        inet 172.16.40.236  netmask 255.255.255.255  destination 172.16.40.1
        ppp  txqueuelen 3  (Point-to-Point Protocol)
        RX packets 9  bytes 336 (336.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 96  bytes 5478 (5.4 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

# cat /sys/class/net/ppp0/operstate
unknown
```

Here is the fixed event for the PPP interface:
```
{
  "timestamp": "2018/09/24 03:22:19",
  "type": "network",
  "ID": 891660950,
  "iface": {
    "name": "ppp0",
    "type": "point-to-point",
    "state": "unknown",
    "IPv4": {
      "address": [
        "172.16.40.236"
      ],
      "netmask": [
        "255.255.255.255"
      ],
      "broadcast": [
        "172.16.40.1"
      ],
      "gateway": "unknown",
      "DHCP": "enabled"
    }
  }
}
```

