### PR TITLE
 Fix memory bug in regex when getting empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 - Set connection timeout for Auth server ([#1336](https://github.com/wazuh/wazuh/pull/1336))
 - Fix the cleaning of the temporary folder. ([#1361](https://github.com/wazuh/wazuh/pull/1361))
 - Fix check_mtime and check_inode views in Syscheck alerts. ([#1364](https://github.com/wazuh/wazuh/pull/1364))
-
+- Fixed a memory bug in regex when getting empty strings. ([#1430](https://github.com/wazuh/wazuh/pull/1430)) 
 
 ## [v3.6.1] 2018-09-07
 

--- a/src/os_regex/os_regex_compile.c
+++ b/src/os_regex/os_regex_compile.c
@@ -76,7 +76,7 @@ int OSRegex_Compile(const char *pattern, OSRegex *reg, int flags)
     pt = new_str;
 
     /* Get the number of sub patterns */
-    do {
+    while (*pt != '\0') {
         if (*pt == BACKSLASH) {
             pt++;
             /* Give the new values for each regex */
@@ -164,7 +164,7 @@ int OSRegex_Compile(const char *pattern, OSRegex *reg, int flags)
             count++;
         }
         pt++;
-    } while (*pt != '\0');
+    }
 
     /* After the whole pattern is read, the parentheses must all be closed */
     if (parenthesis != 0) {
@@ -225,7 +225,7 @@ int OSRegex_Compile(const char *pattern, OSRegex *reg, int flags)
             }
 
             /* If string ends with $, set the END_SET flag */
-            if (*(pt - 1) == ENDREGEX) {
+            if (pt > new_str && *(pt - 1) == ENDREGEX) {
                 *(pt - 1) = '\0';
                 reg->flags[i] |= END_SET;
             }

--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -128,7 +128,7 @@ static const char *_OS_Regex(const char *pattern, const char *str, const char **
     const char *pt_error_str[4] = {NULL, NULL, NULL, NULL};
 
     /* Will loop the whole string, trying to find a match */
-    do {
+    for (st = str; *st != '\0'; ++st) {
         switch (*pt) {
             case '\0':
                 if (!(flags & END_SET) || ((flags & END_SET) && (*st == '\0'))) {
@@ -373,7 +373,7 @@ static const char *_OS_Regex(const char *pattern, const char *str, const char **
         pt = pattern;
         r_code = NULL;
 
-    } while (*(++st) != '\0');
+    }
 
     /* Match for a possible last parenthesis */
     if (prts_closure) {
@@ -421,4 +421,3 @@ static const char *_OS_Regex(const char *pattern, const char *str, const char **
 
     return (NULL);
 }
-

--- a/src/util/ossec-regex.c
+++ b/src/util/ossec-regex.c
@@ -25,6 +25,7 @@ static void helpmsg()
 int main(int argc, char **argv)
 {
     const char *pattern;
+    char * string;
 
     char msg[OS_MAXSTR + 1];
     memset(msg, '\0', OS_MAXSTR + 1);
@@ -62,34 +63,33 @@ int main(int argc, char **argv)
             msg[strlen(msg) - 1] = '\0';
         }
 
-        /* Make sure we ignore blank lines */
-        if (strlen(msg) < 2) {
-            continue;
-        }
+        string = strdup(msg);
 
-        if (OSRegex_Execute(msg, &regex)) {
-            printf("+OSRegex_Execute: %s\n", msg);
+        if (OSRegex_Execute(string, &regex)) {
+            printf("+OSRegex_Execute: %s\n", string);
         }
         /*
         else
             printf("-OSRegex_Execute: \n");
          */
 
-        if (OS_Regex(pattern, msg)) {
-            printf("+OS_Regex       : %s\n", msg);
+        if (OS_Regex(pattern, string)) {
+            printf("+OS_Regex       : %s\n", string);
         }
         /*
         else
             printf("-OS_Regex: \n");
          */
 
-        if (OSMatch_Execute(msg, strlen(msg), &matcher)) {
-            printf("+OSMatch_Compile: %s\n", msg);
+        if (OSMatch_Execute(string, strlen(string), &matcher)) {
+            printf("+OSMatch_Compile: %s\n", string);
         }
 
-        if (OS_Match2(pattern, msg)) {
-            printf("+OS_Match2      : %s\n", msg);
+        if (OS_Match2(pattern, string)) {
+            printf("+OS_Match2      : %s\n", string);
         }
+
+        free(string);
     }
     return (0);
 }


### PR DESCRIPTION
OSSEC regexes are not compatible with empty strings. This may lead to memory errors if:
- A user creates an empty regex in some field (syscheck/decoder/rule).
- A multi regex decoder gets an empty input string because the previous sibling decoder matched the full string.

This PR:
1. Lets the regex library compile an empty regex.
2. Allows a regex match an empty string.
3. Makes `ossec-regex` tool accept empty input strings.

Related issues:
- Valgrind report: #216 
- Particular crash case: #1317 
