### PR TITLE
Add labels to manager configuration in JSON

### DIFF
--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -318,3 +318,21 @@ cJSON *getRulesConfig(void) {
 
     return root;
 }
+
+
+cJSON *getManagerLabelsConfig(void) {
+
+    unsigned int i;
+    cJSON *root = cJSON_CreateObject();
+    cJSON *labels = cJSON_CreateObject();
+
+    if (Config.labels) {
+        for (i=0;Config.labels[i].key;i++) {
+            cJSON_AddStringToObject(labels,Config.labels[i].key,Config.labels[i].value);
+        }
+    }
+
+    cJSON_AddItemToObject(root,"labels",labels);
+
+    return root;
+}

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -40,5 +40,6 @@ void _getDecodersListJSON(OSDecoderNode *list, cJSON *array);
 cJSON *getRulesConfig(void);
 void _getRulesListJSON(RuleNode *list, cJSON *array);
 cJSON *getAnalysisInternalOptions(void);
+cJSON *getManagerLabelsConfig(void);
 
 #endif /* _CONFIG__H */

--- a/src/analysisd/syscom.c
+++ b/src/analysisd/syscom.c
@@ -128,6 +128,18 @@ size_t syscom_getconfig(const char * section, char ** output) {
         } else {
             goto error;
         }
+    }
+    else if (strcmp(section, "labels") == 0){
+        if (cfg = getManagerLabelsConfig(), cfg) {
+            *output = strdup("ok");
+            json_str = cJSON_PrintUnformatted(cfg);
+            wm_strcat(output, json_str, ' ');
+            free(json_str);
+            cJSON_free(cfg);
+            return strlen(*output);
+        } else {
+            goto error;
+        }
     } else {
         goto error;
     }


### PR DESCRIPTION
This PR add the ability to read the labels configuration from the manager.

```
http://localhost:55000/agents/000/config/analysis/labels
{
    "error": 0,
    "data": {
        "labels": {
            "network.ip": "172.17.0.0",
            "network.mac": "02:42:ac:11:00:02",
            "aws.instance-id": "i-052a1838c",
            "installation": "January 1st, 2017",
            "aws.sec-group": "sg-1103"
        }
    }
}
```
