### PR TITLE
Add vulnerability detector configuration to GET/manager/configuration API call

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -76,6 +76,11 @@ conf_sections = {
     'cluster': {
         'type': 'last',
         'list_options': ['nodes']
+    },
+
+    'vulnerability-detector': {
+        'type': 'merge',
+        'list_options': ['feed']
     }
 }
 

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -164,9 +164,14 @@ def _read_option(section_name, opt):
     else:
         if opt.attrib:
             opt_value = {}
-            opt_value['item'] = opt.text
             for a in opt.attrib:
                 opt_value[a] = opt.attrib[a]
+            if opt._children:
+                for child in opt:
+                    child_section, child_config = _read_option(child.tag.lower(),child)
+                    opt_value[child_section] = child_config
+            else:
+                opt_value['item'] = opt.text
         else:
             opt_value = opt.text
 


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh-api/issues/149.

This is an example of an output configuration:
```javascript
# curl -u foo:bar "localhost:55000/manager/configuration?pretty&section=vulnerability-detector"
{
   "error": 0,
   "data": {
      "disabled": "yes",
      "run_on_start": "yes",
      "interval": "1m",
      "feed": [
         {
            "disabled": "yes",
            "update_interval": "1h",
            "name": "ubuntu-18"
         },
         {
            "disabled": "yes",
            "update_interval": "1h",
            "name": "redhat-7"
         },
         {
            "disabled": "yes",
            "update_interval": "1h",
            "name": "debian-9"
         }
      ]
   }
}
```
Best regards,
Marta