### PR TITLE
Avoid error in Wazuh-DB at clean exit

### DIFF
--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -263,7 +263,11 @@ void * run_worker(__attribute__((unused)) void * args) {
 
         switch (wnotify_wait(notify_queue, 1000)) {
         case -1:
-            merror_exit("at run_worker(): wnotify_wait(): %s", strerror(errno));
+            if (!running) {
+                w_mutex_unlock(&queue_mutex);
+                continue;
+            }
+            merror("at run_worker(): wnotify_wait(): %s", strerror(errno));
             w_mutex_unlock(&queue_mutex);
             continue;
 


### PR DESCRIPTION
This PR solves the issue #1433.

When Wazuh-DB receives a `SIGTERM` signal, the `wnotify_wait()` function exits with the result -1. In this case, it should not throw an error message.

On the other hand, if any error happens while a worker thread is waiting for events, the `merror_exit()` function closed the entire program. This behavior has been changed to show an error and continue the loop waiting for another valid incoming event.