### PR TITLE
Output messages FIM configuration

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -202,7 +202,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     restriction = syscheck.filerestrict[dir_position];
 
     if (fim_check_ignore (file_name) == 1) {
-        mdebug1("Ignoring file '%s', continuing...", file_name);
         free(wd_sum);
         return (0);
     }
@@ -955,6 +954,7 @@ int fim_check_ignore (const char *file_name) {
         int i = 0;
         while (syscheck.ignore[i] != NULL) {
             if (strncasecmp(syscheck.ignore[i], file_name, strlen(syscheck.ignore[i])) == 0) {
+                mdebug1("Ignoring file '%s' ignore '%s', continuing...", file_name, syscheck.ignore[i]);
                 return (1);
             }
             i++;
@@ -966,6 +966,7 @@ int fim_check_ignore (const char *file_name) {
         int i = 0;
         while (syscheck.ignore_regex[i] != NULL) {
             if (OSMatch_Execute(file_name, strlen(file_name), syscheck.ignore_regex[i])) {
+                mdebug1("Ignoring file '%s' sregex '%s', continuing...", file_name, syscheck.ignore_regex[i]->raw);
                 return (1);
             }
             i++;

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -176,7 +176,12 @@ int Start_win32_Syscheck()
         /* Print ignores. */
         if(syscheck.ignore)
             for (r = 0; syscheck.ignore[r] != NULL; r++)
-                minfo("Ignoring: '%s'", syscheck.ignore[r]);
+                minfo("Ignoring: '%s'", syscheck.ignore[r]->raw);
+
+        /* Print sregex ignores. */
+        if(syscheck.ignore_regex)
+            for (r = 0; syscheck.ignore_regex[r] != NULL; r++)
+                minfo("Ignoring sregex: '%s'", syscheck.ignore_regex[r]->raw);
 
         /* Print files with no diff. */
         if (syscheck.nodiff){
@@ -392,6 +397,11 @@ int main(int argc, char **argv)
         if(syscheck.ignore)
             for (r = 0; syscheck.ignore[r] != NULL; r++)
                 minfo("Ignoring: '%s'", syscheck.ignore[r]);
+
+        /* Print sregex ignores. */
+        if(syscheck.ignore_regex)
+            for (r = 0; syscheck.ignore_regex[r] != NULL; r++)
+                minfo("Ignoring sregex: '%s'", syscheck.ignore_regex[r]->raw);
 
         /* Print files with no diff. */
         if (syscheck.nodiff){

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -176,12 +176,22 @@ int Start_win32_Syscheck()
         /* Print ignores. */
         if(syscheck.ignore)
             for (r = 0; syscheck.ignore[r] != NULL; r++)
-                minfo("Ignoring: '%s'", syscheck.ignore[r]->raw);
+                minfo("Ignoring: '%s'", syscheck.ignore[r]);
 
         /* Print sregex ignores. */
         if(syscheck.ignore_regex)
             for (r = 0; syscheck.ignore_regex[r] != NULL; r++)
                 minfo("Ignoring sregex: '%s'", syscheck.ignore_regex[r]->raw);
+
+        /* Print registry ignores. */
+        if(syscheck.registry_ignore)
+            for (r = 0; syscheck.registry_ignore[r].entry != NULL; r++)
+                minfo("Ignoring registry: '%s'", syscheck.registry_ignore[r].entry);
+
+        /* Print sregex registry ignores. */
+        if(syscheck.registry_ignore_regex)
+            for (r = 0; syscheck.registry_ignore_regex[r].regex != NULL; r++)
+                minfo("Ignoring registry sregex: '%s'", syscheck.registry_ignore_regex[r].regex->raw);
 
         /* Print files with no diff. */
         if (syscheck.nodiff){

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -329,6 +329,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch, const char *
     if (fullkey_name && syscheck.registry_ignore) {
         while (syscheck.registry_ignore[i].entry != NULL) {
             if (syscheck.registry_ignore[i].arch == arch && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0) {
+                mdebug1("Ignoring registry '%s' ignore '%s', continuing...", fullkey_name, syscheck.registry_ignore[i].entry);
                 return;
             }
             i++;
@@ -339,6 +340,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch, const char *
             if (syscheck.registry_ignore[i].arch == arch &&
                 OSMatch_Execute(fullkey_name, strlen(fullkey_name),
                                 syscheck.registry_ignore_regex[i].regex)) {
+                mdebug1("Ignoring registry '%s' ignore '%s', continuing...", fullkey_name, syscheck.registry_ignore_regex[i].regex->raw);
                 return;
             }
             i++;


### PR DESCRIPTION
Add output messages when configure ignore tags with _sregex_ type. Issue [#1290](https://github.com/wazuh/wazuh/issues/1290)