### PR TITLE
Fix bug when limiting results in experimental syscollector API calls

### DIFF
--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -176,7 +176,7 @@ def _get_agent_items(func, offset, limit, select, filters, search, sort, array=F
         items = [items] if not array else items['items']
 
         for item in items:
-            if limit > 0 and limit + 1 <= len(result):
+            if 0 < limit <= len(result):
                 break
             item['agent_id'] = agent['id']
             result.append(item)


### PR DESCRIPTION
Hi team,

This PR fixes https://github.com/wazuh/wazuh-api/issues/170.

Some examples:
```javascript
# curl -u foo:bar "localhost:55000/experimental/syscollector/netiface?pretty&limit=1"
{
   "error": 0,
   "data": {
      "totalItems": 4,
      "items": [
         {
            "name": "enp0s3",
            "tx": {
               "packets": 235,
               "errors": 0,
               "bytes": 16155,
               "dropped": 0
            },
            "scan": {
               "id": 318722669,
               "time": "2018/09/26 11:00:55"
            },
            "rx": {
               "packets": 308,
               "errors": 0,
               "bytes": 352209,
               "dropped": 0
            },
            "mac": "08:00:27:51:40:EB",
            "mtu": 1500,
            "state": "up",
            "agent_id": "000",
            "type": "ethernet"
         }
      ]
   }
}
# curl -u foo:bar "localhost:55000/experimental/syscollector/netiface?pretty&limit=2"
{
   "error": 0,
   "data": {
      "totalItems": 4,
      "items": [
         {
            "name": "enp0s3",
            "tx": {
               "packets": 235,
               "errors": 0,
               "bytes": 16155,
               "dropped": 0
            },
            "scan": {
               "id": 318722669,
               "time": "2018/09/26 11:00:55"
            },
            "rx": {
               "packets": 308,
               "errors": 0,
               "bytes": 352209,
               "dropped": 0
            },
            "mac": "08:00:27:51:40:EB",
            "mtu": 1500,
            "state": "up",
            "agent_id": "000",
            "type": "ethernet"
         },
         {
            "name": "enp0s8",
            "tx": {
               "packets": 192,
               "errors": 0,
               "bytes": 31522,
               "dropped": 0
            },
            "scan": {
               "id": 318722669,
               "time": "2018/09/26 11:00:55"
            },
            "rx": {
               "packets": 164,
               "errors": 0,
               "bytes": 17028,
               "dropped": 0
            },
            "mac": "08:00:27:00:69:88",
            "mtu": 1500,
            "state": "up",
            "agent_id": "000",
            "type": "ethernet"
         }
      ]
   }
}
# curl -u foo:bar "localhost:55000/experimental/syscollector/netiface?pretty&limit=2&offset=1"
{
   "error": 0,
   "data": {
      "totalItems": 4,
      "items": [
         {
            "name": "enp0s8",
            "tx": {
               "packets": 192,
               "errors": 0,
               "bytes": 31522,
               "dropped": 0
            },
            "scan": {
               "id": 318722669,
               "time": "2018/09/26 11:00:55"
            },
            "rx": {
               "packets": 164,
               "errors": 0,
               "bytes": 17028,
               "dropped": 0
            },
            "mac": "08:00:27:00:69:88",
            "mtu": 1500,
            "state": "up",
            "agent_id": "000",
            "type": "ethernet"
         },
         {
            "name": "enp0s8",
            "tx": {
               "packets": 25,
               "errors": 0,
               "bytes": 3130,
               "dropped": 0
            },
            "scan": {
               "id": 1623645291,
               "time": "2018/09/26 04:02:02"
            },
            "rx": {
               "packets": 11,
               "errors": 0,
               "bytes": 3381,
               "dropped": 0
            },
            "mac": "08:00:27:99:57:22",
            "mtu": 1500,
            "state": "up",
            "agent_id": "001",
            "type": "ethernet"
         }
      ]
   }
}
```

Best regards,
Marta