### PR TITLE
Read reports config in JSON

### DIFF
--- a/src/monitord/moncom.c
+++ b/src/monitord/moncom.c
@@ -55,6 +55,18 @@ size_t moncom_getconfig(const char * section, char ** output) {
         } else {
             goto error;
         }
+    }
+    else if (strcmp(section, "reports") == 0){
+        if (cfg = getReportsOptions(), cfg) {
+            *output = strdup("ok");
+            json_str = cJSON_PrintUnformatted(cfg);
+            wm_strcat(output, json_str, ' ');
+            free(json_str);
+            cJSON_free(cfg);
+            return strlen(*output);
+        } else {
+            goto error;
+        }
     } else {
         goto error;
     }

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -142,3 +142,37 @@ cJSON *getMonitorInternalOptions(void) {
 
     return root;
 }
+
+
+cJSON *getReportsOptions(void) {
+
+    cJSON *root = cJSON_CreateObject();
+    unsigned int i;
+
+    if (mond.reports) {
+        cJSON *arr = cJSON_CreateArray();
+        for (i=0;mond.reports[i];i++) {
+            cJSON *rep = cJSON_CreateObject();
+            if (mond.reports[i]->title) cJSON_AddStringToObject(rep,"title",mond.reports[i]->title);
+            if (mond.reports[i]->r_filter.group) cJSON_AddStringToObject(rep,"group",mond.reports[i]->r_filter.group);
+            if (mond.reports[i]->r_filter.rule) cJSON_AddStringToObject(rep,"rule",mond.reports[i]->r_filter.rule);
+            if (mond.reports[i]->r_filter.level) cJSON_AddStringToObject(rep,"level",mond.reports[i]->r_filter.level);
+            if (mond.reports[i]->r_filter.srcip) cJSON_AddStringToObject(rep,"srcip",mond.reports[i]->r_filter.srcip);
+            if (mond.reports[i]->r_filter.user) cJSON_AddStringToObject(rep,"user",mond.reports[i]->r_filter.user);
+            if (mond.reports[i]->r_filter.show_alerts) cJSON_AddStringToObject(rep,"showlogs","yes"); else cJSON_AddStringToObject(rep,"showlogs","no");
+            if (mond.reports[i]->emailto) {
+                unsigned int j = 0;
+                cJSON *email = cJSON_CreateArray();
+                while (mond.reports[i]->emailto[j]) {
+                    cJSON_AddItemToArray(email, cJSON_CreateString(mond.reports[i]->emailto[j]));
+                    j++;
+                }
+                cJSON_AddItemToObject(rep,"email_to",email);
+            }
+            cJSON_AddItemToArray(arr, rep);
+        }
+        cJSON_AddItemToObject(root,"reports",arr);
+    }
+
+    return root;
+}

--- a/src/monitord/monitord.h
+++ b/src/monitord/monitord.h
@@ -29,6 +29,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
 
 /* Parse readed config into JSON format */
 cJSON *getMonitorInternalOptions(void);
+cJSON *getReportsOptions(void);
 size_t moncom_dispatch(char * command, char ** output);
 size_t moncom_getconfig(const char * section, char ** output);
 void * moncom_main(__attribute__((unused)) void * arg);


### PR DESCRIPTION
This PR adds the function to read the `reports` configuration in JSON.

```
http://192.168.67.17:55000/agents/000/config/monitor/reports
{
    "error": 0,
    "data": {
        "reports": [
            {
                "srcip": "192.168.1.10",
                "email_to": [
                    "recipient@wazuh.com"
                ],
                "group": "authentication_failed-",
                "showlogs": "yes",
                "title": "Auth_Report"
            },
            {
                "srcip": "192.168.1.11",
                "email_to": [
                    "recipient@wazuh.com"
                ],
                "group": "ossec-",
                "showlogs": "yes",
                "title": "Hola_Report"
            }
        ]
    }
}
```