### PR TITLE
Fix socket connection between authd and manage_agents

### DIFF
--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -126,6 +126,8 @@ int add_agent(int json_output, int no_limit)
         /* Set time 2 */
         time2 = time(0);
         rand1 = os_random();
+    } else {
+        close(sock);
     }
 
     if (!json_output)
@@ -365,6 +367,16 @@ int add_agent(int json_output, int no_limit)
                 free(file.name);
                 OS_AddAgentTimestamp(id, name, ip, time3);
             } else {
+                if (sock = auth_connect(), sock < 0) {
+                    if (json_output) {
+                        cJSON *json_root = cJSON_CreateObject();
+                        cJSON_AddNumberToObject(json_root, "error", 80);
+                        cJSON_AddStringToObject(json_root, "message", "Lost authd socket connection.");
+                        printf("%s", cJSON_PrintUnformatted(json_root));
+                        exit(1);
+                    } else
+                        merror_exit("Lost authd socket connection.");
+                }
                 if (auth_add_agent(sock, id, name, ip, env_remove_dup ? force_antiquity : -1, json_output) < 0) {
                     break;
                 }
@@ -411,6 +423,7 @@ int remove_agent(int json_output)
     // Create socket
 
     sock = auth_connect();
+    auth_close(sock);
 
     do {
         if (!json_output) {
@@ -506,6 +519,16 @@ int remove_agent(int json_output)
                 free(full_name);
                 full_name = NULL;
             } else {
+                if (sock = auth_connect(), sock < 0) {
+                    if (json_output) {
+                        cJSON *json_root = cJSON_CreateObject();
+                        cJSON_AddNumberToObject(json_root, "error", 80);
+                        cJSON_AddStringToObject(json_root, "message", "Lost authd socket connection.");
+                        printf("%s", cJSON_PrintUnformatted(json_root));
+                        exit(1);
+                    } else
+                        merror_exit("Lost authd socket connection.");
+                }
                 if (auth_remove_agent(sock, u_id, json_output) < 0) {
                     break;
                 }

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -129,7 +129,7 @@ void* run_local_server(__attribute__((unused)) void *arg) {
             break;
 
         case 0:
-            mdebug1("Empty message from local client.");
+            mdebug2("Empty message from local client.");
             close(peer);
             break;
 


### PR DESCRIPTION
This PR solves the issue #1434.

Since the `authd` socket is blocking and have a timeout of a second by default to receive data, when registering or removing an agent manually by the `manage_agents` tool the timeout was reached always due to the connection to the socket was established before data is entered.

Now, `manage_agents` connects to the socket for the first time to know if `authd` is up. After that, it closes the connection and reopens it when sending the final request.