### PR TITLE
Fix crash in Remoted due to legacy request protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ All notable changes to this project will be documented in this file.
   - Extract the pack name into a new field.
   - Include the query name in the alert description.
   - Minor fixes.
-- Increased AWS S3 database entry limit to 5000 to prevent reprocessing repeated events ([#1391](https://github.com/wazuh/wazuh/pull/1391)).
+- Increased AWS S3 database entry limit to 5000 to prevent reprocessing repeated events. ([#1391](https://github.com/wazuh/wazuh/pull/1391))
+- Increased the limit of concurrent agent requests: 1024 by default, configurable up to 4096. ([#1473](https://github.com/wazuh/wazuh/pull/1473))
 
 ### Fixed
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -124,8 +124,8 @@ remoted.pass_empty_keyfile=1
 # Number of shared file sender threads
 remoted.sender_pool=8
 
-# Number of parallel request dispatchers
-remoted.request_pool=8
+# Limit of parallel request dispatchers [1..4096]
+remoted.request_pool=1024
 
 # Timeout to reject a new request (seconds) [1..600]
 remoted.request_timeout=10

--- a/framework/wazuh/common.py
+++ b/framework/wazuh/common.py
@@ -86,6 +86,9 @@ def set_paths_based_on_ossec(o_path='/var/ossec'):
     global AUTHD_SOCKET
     AUTHD_SOCKET = "{0}/queue/ossec/auth".format(ossec_path)
 
+    global REQUEST_SOCKET
+    REQUEST_SOCKET = "{0}/queue/ossec/request".format(ossec_path)
+
 # Agent upgrading variables
 wpk_repo_url = "packages.wazuh.com/wpk/"
 

--- a/src/client-agent/request.c
+++ b/src/client-agent/request.c
@@ -42,7 +42,7 @@ static OSHash * allowed_sockets;
 void req_init() {
     // Get values from internal options
 
-    request_pool = getDefine_Int("remoted", "request_pool", 1, 64);
+    request_pool = getDefine_Int("remoted", "request_pool", 1, 4096);
     rto_sec = getDefine_Int("remoted", "request_rto_sec", 0, 60);
     rto_msec = getDefine_Int("remoted", "request_rto_msec", 0, 999);
     max_attempts = getDefine_Int("remoted", "max_attempts", 1, 16);

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -55,7 +55,7 @@ void * req_main(__attribute__((unused)) void * arg) {
 
     // Get values from internal options
 
-    request_pool = getDefine_Int("remoted", "request_pool", 1, 64);
+    request_pool = getDefine_Int("remoted", "request_pool", 1, 4096);
     request_timeout = getDefine_Int("remoted", "request_timeout", 1, 600);
     response_timeout = getDefine_Int("remoted", "response_timeout", 1, 3600);
     rto_sec = getDefine_Int("remoted", "request_rto_sec", 0, 60);

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -120,10 +120,12 @@ void * req_main(__attribute__((unused)) void * arg) {
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case -1:
             merror("OS_RecvSecureTCP(): %s", strerror(errno));
+            free(buffer);
             break;
 
         case 0:
             mdebug1("Empty message from local client.");
+            free(buffer);
             break;
 
         default:
@@ -134,6 +136,7 @@ void * req_main(__attribute__((unused)) void * arg) {
 
             snprintf(counter_s, COUNTER_LENGTH, "%x", counter++);
             node = req_create(peer, counter_s, target, buffer, length);
+            free(buffer);
 
             w_mutex_lock(&mutex_table);
             error = OSHash_Add(req_table, counter_s, node);

--- a/src/shared/pthreads_op.c
+++ b/src/shared/pthreads_op.c
@@ -24,7 +24,7 @@ int CreateThreadJoinable(pthread_t *lthread, void * (*function_pointer)(void *),
     int ret = 0;
 
     if (pthread_attr_init(&attr)) {
-        merror(THREAD_ERROR);
+        merror(THREAD_ERROR " Cannot initialize attributes.");
         return -1;
     }
 
@@ -32,12 +32,12 @@ int CreateThreadJoinable(pthread_t *lthread, void * (*function_pointer)(void *),
 
     /* Set the maximum stack limit to new threads */
     if (pthread_attr_setstacksize(&attr, read_size)) {
-        merror(THREAD_ERROR);
+        merror(THREAD_ERROR " Cannot set stack size to %d KB.", (int)read_size);
         return -1;
     }
 
     if (pthread_attr_getstacksize(&attr, &stacksize)) {
-        merror(THREAD_ERROR);
+        merror(THREAD_ERROR " Cannot confirm stack size setting.");
         return -1;
     }
 
@@ -45,7 +45,7 @@ int CreateThreadJoinable(pthread_t *lthread, void * (*function_pointer)(void *),
 
     ret = pthread_create(lthread, &attr, function_pointer, (void *)data);
     if (ret != 0) {
-        merror(THREAD_ERROR);
+        merror(THREAD_ERROR " %s (%d)", strerror(ret), ret);
         return -1;
     }
 
@@ -59,12 +59,11 @@ int CreateThread(void * (*function_pointer)(void *), void *data)
     pthread_t lthread;
 
     if (CreateThreadJoinable(&lthread, function_pointer, data) < 0) {
-        merror(THREAD_ERROR);
         return -1;
     }
 
     if (pthread_detach(lthread) != 0) {
-        merror(THREAD_ERROR);
+        merror(THREAD_ERROR " Cannot detach thread.");
         return -1;
     }
 


### PR DESCRIPTION
This PR aims to apply 4 changes:
- Port the request client (Framework) to the new protocol (add a 4-byte header).
- Fix a memory leak in Remoted when opening new request sessions.
- Make thread creation errors more descriptive.
- Increase the request protocol limit:
  - Soft limit of 1024 concurrent sessions.
  - Hard limit of 4096 concurrent sessions.

Related issue: #1467 