### PR TITLE
Prevent wazuh package from crashing if global.db is not created

### DIFF
--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -101,17 +101,21 @@ class Wazuh:
         except:
             raise WazuhException(1005, self.OSSEC_INIT)
 
-        # info DB
-        conn = Connection(common.database_path_global)
+        # info DB if possible
+        try:
+            conn = Connection(common.database_path_global)
 
-        query = "SELECT * FROM info"
-        conn.execute(query)
+            query = "SELECT * FROM info"
+            conn.execute(query)
 
-        for tuple in conn:
-            if tuple[0] == 'max_agents':
-                self.max_agents = tuple[1]
-            elif tuple[0] == 'openssl_support':
-                self.openssl_support = tuple[1]
+            for tuple in conn:
+                if tuple[0] == 'max_agents':
+                    self.max_agents = tuple[1]
+                elif tuple[0] == 'openssl_support':
+                    self.openssl_support = tuple[1]
+        except:
+            self.max_agents = "N/A"
+            self.openssl_support = "N/A"
 
         # Ruleset version
         ruleset_version_file = "{0}/ruleset/VERSION".format(self.path)


### PR DESCRIPTION
Hi team,

This PR closes #1384 and fixes #1476.

Best regards,
Marta