### PR TITLE
Prevent distributed api in workers from crashing if there's no connection with master

### DIFF
--- a/framework/wazuh/cluster/control.py
+++ b/framework/wazuh/cluster/control.py
@@ -107,8 +107,8 @@ def get_agents(filter_status, filter_node, is_master):
 
         request = "dapi {}".format(json.dumps(input_json))
         response = execute(request)
-        if not isinstance(response, dict):
-            raise WazuhException(1000, response)
+        if response.get('err'):
+            raise Exception(response['err'])
 
         if response['error'] == 0:
             return response['data']

--- a/framework/wazuh/cluster/internal_socket.py
+++ b/framework/wazuh/cluster/internal_socket.py
@@ -136,13 +136,8 @@ class InternalSocketClient(communication.AbstractClient):
             self.final_response.write(data)
             return False
         elif command == 'err':
-            try:
-                data = json.loads(data)
-                self.final_response.write(data['err'])
-                return True
-            except ValueError:
-                self.final_response.write(data)
-                return True
+            self.final_response.write(data)
+            return True
 
 
     def process_request(self, command, data):
@@ -238,7 +233,7 @@ def execute(request):
         isocket_worker_thread.manager.final_response.write("ok")
         isocket_worker_thread.manager.handle_close()
         isocket_worker_thread.stop()
-        response = json.loads(response) if not is_error else response
+        response = json.loads(response)
         return response
     except WazuhException as e:
         raise e


### PR DESCRIPTION
Hello team,

This PR fixes #1486.

The API was always expecting JSON responses, even from internal cluster errors:
https://github.com/wazuh/wazuh/blob/7b06a87aa4181b16c31eb0f7ae82f1b7048528c8/framework/wazuh/cluster/dapi/dapi.py#L120-L121

But when an internal error was reported from cluster, it was returned as string causing the upper code snippet to fail:
https://github.com/wazuh/wazuh/blob/7b06a87aa4181b16c31eb0f7ae82f1b7048528c8/framework/wazuh/cluster/internal_socket.py#L138-L145

I think this was done this way because the `cluster_control` was expecting a string:
https://github.com/wazuh/wazuh/blob/7b06a87aa4181b16c31eb0f7ae82f1b7048528c8/framework/wazuh/cluster/control.py#L109-L111

This has been fixed as well.

Best regards,
Marta
