### PR TITLE
Improve ip_address_regex

### DIFF
--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -417,8 +417,8 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
 #ifndef WIN32
 
             const char *ip_address_regex =
-                "^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}/?"
-                "([0-9]{0,2}|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})$";
+                "^!?\\d{1,3}(\\.\\d{1,3}){3}"
+                "(/\\d{1,2}(\\d(\\.\\d{1,3}){3})?)?$";
 
             if (Config && OS_PRegex(node[i]->content, ip_address_regex)) {
                 white_size++;


### PR DESCRIPTION
The existing regex for matching ip_address netblocks is poorly designed. It allows invalid values such as `123.123.123.12345` and `123.123.123.123123.123.123.123`

The proposed replacement, while not perfect, is both more restrictive and more compact.