### PR TITLE
Remove unreachable code from Read_Global() function.

### DIFF
--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -644,10 +644,6 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                     return OS_INVALID;
                 }
 
-                if (*end) {
-                    merror("Invalid value for option '<%s>'", xml_queue_size);
-                    return OS_INVALID;
-                }
             }
         } else {
             merror(XML_INVELEM, node[i]->element);


### PR DESCRIPTION
The [`Read_Global`](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L121) function has [some code](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L121) that is unreachable and should therefore be removed.