### PR TITLE
Agent name check (limit 128 characters).

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1084,6 +1084,9 @@ class Agent:
         :param force: Remove old agent with same IP if disconnected since <force> seconds.
         :return: Agent ID.
         """
+        # check length of agent name
+        if len(name) > 128:
+            raise WazuhException(1738)
 
         new_agent = Agent(name=name, ip=ip, force=force)
         return {'id': new_agent.id, 'key': new_agent.key}

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -123,6 +123,7 @@ class WazuhException(Exception):
         1735: 'Agent version is not compatible with this feature',
         1736: 'Error getting all groups',
         1737: 'Maximum number of groups per multigroup is 256',
+        1738: 'Agent name is too long. Max length allowed for agent name is 128',
 
         # Manager:
 


### PR DESCRIPTION
Hi team,

I have made this PR for API issue [#173](https://github.com/wazuh/wazuh-api/issues/173). Agent name length is checked now in framework (max 128 characters).

Best regards,

Demetrio.