### PR TITLE
Errors in ReadDecodeXML() function.

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -251,7 +251,7 @@ int ReadDecodeXML(const char *file)
 
         /* Check for additional entries */
         if (node[i]->attributes[1] && node[i]->values[1]) {
-            if (strcasecmp(node[i]->attributes[0], xml_decoder_status) != 0) {
+            if (strcasecmp(node[i]->attributes[1], xml_decoder_status) != 0) {
                 merror(XML_INVELEM, node[i]->element);
                 goto cleanup;
             }
@@ -388,6 +388,7 @@ int ReadDecodeXML(const char *file)
 
             /* Get the FTS comment */
             else if (strcasecmp(elements[j]->element, xml_ftscomment) == 0) {
+                pi->ftscomment = _loadmemory(pi->ftscomment, elements[j]->content);
             }
 
             else if (strcasecmp(elements[j]->element, xml_usename) == 0) {


### PR DESCRIPTION
The [code](https://github.com/wazuh/wazuh/blob/master/src/analysisd/decoders/decode-xml.c#L155) for parsing decoder files such as [`/etc/decoder.xml`](https://github.com/wazuh/wazuh/blob/master/src/analysisd/testrule.c#L215) and [`/etc/local_decoder.xml`](https://github.com/wazuh/wazuh/blob/master/src/analysisd/testrule.c#L220) appears to have some errors:

* It requires that each [`decoder`](https://github.com/wazuh/wazuh/blob/master/src/analysisd/decoders/decode-xml.c#L239) tag have [`name`](https://github.com/wazuh/wazuh/blob/master/src/analysisd/decoders/decode-xml.c#L247) as its first attribute.  An optional second attribute of [`status`](https://github.com/wazuh/wazuh/blob/master/src/analysisd/decoders/decode-xml.c#L254) is allowed, but the code wrongly looks for it in the first attribute `node[i]->attributes[0]` rather than in the second `node[i]->attributes[1]`.
* On the other hand, the `status` attribute value is never assigned anywhere, nor does the [`OSDecoderInfo` struct](https://github.com/wazuh/wazuh/blob/master/src/analysisd/decoders/decoder.h#L28) contain a status field.  Perhaps the corresponding parsing code should be removed?
* The [code](https://github.com/wazuh/wazuh/blob/master/src/analysisd/decoders/decode-xml.c#L389) to "Get the FTS comment" should copy it to the [ftscomment field](https://github.com/wazuh/wazuh/blob/master/src/analysisd/decoders/decoder.h#L44).