### PR TITLE
Prevent Logcollector from null-terminating socket output messages

### DIFF
--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -177,7 +177,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
 
         // Send msg to socket
 
-        if (__mq_rcode = OS_SendUnix(target->log_socket->socket, tmpstr, 0), __mq_rcode < 0) {
+        if (__mq_rcode = OS_SendUnix(target->log_socket->socket, tmpstr, strlen(tmpstr)), __mq_rcode < 0) {
             if (__mq_rcode == OS_SOCKTERR) {
                 if (mtime = time(NULL), mtime > target->log_socket->last_attempt + sock_fail_time) {
                     close(target->log_socket->socket);
@@ -188,7 +188,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
                     } else {
                         mdebug1("Connected to socket '%s' (%s)", target->log_socket->name, target->log_socket->location);
 
-                        if (OS_SendUnix(target->log_socket->socket, tmpstr, 0), __mq_rcode < 0) {
+                        if (OS_SendUnix(target->log_socket->socket, tmpstr, strlen(tmpstr)), __mq_rcode < 0) {
                             merror("Cannot send message to socket '%s'. (Retry)", target->log_socket->name);
                             SendMSG(queue, "Cannot send message to socket.", "logcollector", LOCALFILE_MQ);
                             target->log_socket->last_attempt = mtime;


### PR DESCRIPTION
Logcollector adds an extra `\0` byte at the end of every string for Analysisd and Agentd.
However, it should not modify external message payloads.

Related issue: #1530 

Please **do not delete this branch yet**.