### PR TITLE
Fix bug when filtering by multiple statuses in GET/agents API call

### DIFF
--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -737,7 +737,7 @@ class WazuhDBQuery(object):
         Parses legacy filters.
         """
         legacy_filters_as_list = {name: value.split(',') if isinstance(value, unicode) or isinstance(value,str) else value for name, value in self.legacy_filters.items()}
-        self.query_filters += [{'value': None if subvalue == "null" else subvalue, 'field': '{}${}'.format(name,i), 'operator': '=', 'separator': 'OR' if ',' in value else 'AND', 'level': 0}
+        self.query_filters += [{'value': None if subvalue == "null" else subvalue, 'field': '{}${}'.format(name,i), 'operator': '=', 'separator': 'OR' if len(value) > 1 else 'AND', 'level': 0}
                                for name, value in legacy_filters_as_list.items() for subvalue,i in zip(value, range(len(value))) if not self._pass_filter(subvalue)]
         if not self.q and self.query_filters:
             # if only traditional filters have been defined, remove last AND from the query.

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -739,9 +739,9 @@ class WazuhDBQuery(object):
         legacy_filters_as_list = {name: value.split(',') if isinstance(value, unicode) or isinstance(value,str) else value for name, value in self.legacy_filters.items()}
         self.query_filters += [{'value': None if subvalue == "null" else subvalue, 'field': '{}${}'.format(name,i), 'operator': '=', 'separator': 'OR' if len(value) > 1 else 'AND', 'level': 0}
                                for name, value in legacy_filters_as_list.items() for subvalue,i in zip(value, range(len(value))) if not self._pass_filter(subvalue)]
-        if not self.q and self.query_filters:
+        if self.query_filters:
             # if only traditional filters have been defined, remove last AND from the query.
-            self.query_filters[-1]['separator'] = ''
+            self.query_filters[-1]['separator'] = '' if not self.q else 'AND'
 
 
     def _parse_filters(self):


### PR DESCRIPTION
Hello team,

This PR fixes a bug when using the `status` filter to filter by multiple statuses in the `GET/agents` API call.

The problem was caused because it was using an `AND` instead of an `OR` to join the conditions defined by each status, and no agents meet the conditions.

Best regards,
Marta