### PR TITLE
Fix OssecSocketJSON implementation

### DIFF
--- a/framework/wazuh/ossec_socket.py
+++ b/framework/wazuh/ossec_socket.py
@@ -53,17 +53,13 @@ class OssecSocketJSON(OssecSocket):
     MAX_SIZE = 65536
 
     def __init__(self, path):
-        super().__init__(path)
+        OssecSocket.__init__(self, path)
 
     def send(self, msg):
-        return super().send(dumps(msg).encode())
+        return OssecSocket.send(self, dumps(msg).encode())
 
     def receive(self):
-        try:
-            chunk = super().receive().decode()
-            response = loads(super().receive().decode())
-        except:
-            raise WazuhException(1014, self.path)
+        response = loads(OssecSocket.receive(self).decode())
 
         if 'error' in response.keys():
             if response['error'] != 0:


### PR DESCRIPTION
Hello team,

The following error was shown when using the API to register or delete agents with authd activated:
```json
{
    "message": "super() takes at least 1 argument (0 given)", 
    "error": 1000
}
```
I have fixed the implementation in the `OssecSocketJSON` class, responsible of sending these requests to authd.

Best regards,
Marta