### PR TITLE
Update source installer for new FIM behavior

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -695,7 +695,6 @@ InstallCommon(){
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/alerts
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/ossec
-  ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/syscheck
   ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/diff
   ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/agents
 

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -57,10 +57,16 @@ WazuhUpgrade()
     rm -f $DIRECTORY/var/db/.template.db*
     rm -f $DIRECTORY/var/db/agents/*
 
-    # Remove existing SQLite databases for Wazuh DB
+    # Remove existing SQLite databases for Wazuh DB, only if upgrading from 3.2..3.6
 
-    rm -f $DIRECTORY/queue/db/*.db*
-    rm -f $DIRECTORY/queue/db/.template.db
+    MAJOR=$(echo $USER_OLD_VERSION | cut -dv -f2 | cut -d. -f1)
+    MINOR=$(echo $USER_OLD_VERSION | cut -d. -f2)
+
+    if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ]
+    then
+        rm -f $DIRECTORY/queue/db/*.db*
+        rm -f $DIRECTORY/queue/db/.template.db
+    fi
 
     # Remove existing SQLite databases for vulnerability-detector
 


### PR DESCRIPTION
- Prevent installer from erasing Wazuh DB's artifacts on upgrade from 3.7 #1549
- Do not install Syscheck DB folder on new installation #1553