### PR TITLE
Improve input validation of group names

### DIFF
--- a/framework/wazuh/InputValidator.py
+++ b/framework/wazuh/InputValidator.py
@@ -47,8 +47,7 @@ class InputValidator:
         group_name: name of the group to be validated
         """
         def check_single_group_name(group_name):
-            return self.check_length(group_name) and \
-                   self.check_name(group_name, regex_str=r'[A-Za-z0-9\.;:\-_=\+!@\(\)][A-Za-z0-9;:\-_=\+!@\(\)]{0,254}')
+            return self.check_length(group_name) and self.check_name(group_name, regex_str=r'[A-Za-z0-9.\-_]+')
 
         if isinstance(group_name, list):
             return reduce(operator.mul, map(lambda x: check_single_group_name(x), group_name))

--- a/framework/wazuh/InputValidator.py
+++ b/framework/wazuh/InputValidator.py
@@ -6,15 +6,20 @@
 import re
 import operator
 from functools import reduce
-from wazuh import common
-from wazuh.exception import WazuhException
+
 
 class InputValidator:
     """
     Class to do Input Validation
     """
 
-    def check_name(self, name, regex_str="[A-Za-z0-9\.;:\-_=\+!@\(\)][A-Za-z0-9;:\-_=\+!@\(\)]{0,254}"):
+    def check_name(self, name, regex_str=r"\w+"):
+        """
+        Abstract function to check a name matches a regex (\w+ by default)
+        :param name: Name to check
+        :param regex_str: Regular expression to do the matching
+        :return: True if it matched, False otherwise.
+        """
         regex = re.compile(regex_str)
         matching = regex.match(name)
         if matching:
@@ -22,8 +27,17 @@ class InputValidator:
         else: 
             return False
 
+
     def check_length(self, name, length=255, func=operator.le):
+        """
+        Function to compare the length of a string.
+        :param name: String to check.
+        :param length: Length used to do the comparison. By default, 255.
+        :param func: Operator to do the comparison with. By default, <.
+        :return: True or False.
+        """
         return func(len(name), length)
+
 
     def group(self, group_name):
         """
@@ -33,10 +47,10 @@ class InputValidator:
         group_name: name of the group to be validated
         """
         def check_single_group_name(group_name):
-            return self.check_length(group_name) and self.check_name(group_name)
+            return self.check_length(group_name) and \
+                   self.check_name(group_name, regex_str=r'[A-Za-z0-9\.;:\-_=\+!@\(\)][A-Za-z0-9;:\-_=\+!@\(\)]{0,254}')
 
         if isinstance(group_name, list):
             return reduce(operator.mul, map(lambda x: check_single_group_name(x), group_name))
         else:
             return check_single_group_name(group_name)
-            

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -107,7 +107,7 @@ class WazuhException(Exception):
         1719: 'Remote upgrade is not available for this agent version',
         1720: 'Agent disconnected',
         1721: 'Remote upgrade is not available for this agent OS version',
-        1722: 'Incorrect format for group_id. Characters supported  a-z, A-Z, 0-9, -.=!() Max length is 255',
+        1722: 'Incorrect format for group_id. Characters supported  a-z, A-Z, 0-9, ., _ and -. Max length is 255',
         1723: 'Hash algorithm not available',
         1724: 'Not a valid select field',
         1725: 'Error registering a new agent',


### PR DESCRIPTION
Hello team,

This PR fixes #1579, #1571 and https://github.com/wazuh/wazuh-api/issues/181.

The regex used to validate a group name is now the same as the regex [used in the API](https://github.com/wazuh/wazuh-api/blob/3.7/helpers/input_validation.js#L26-L28):
```javascript
 /^[a-zA-Z0-9_\-\.]+$/
```

Also, some code comments have been added.

Best regards,
Marta