### PR TITLE
Fix for delete multiple groups

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1519,48 +1519,56 @@ class Agent:
 
 
     @staticmethod
-    def remove_multi_group(group_id):
+    def remove_multi_group(groups_id):
+        """
+        Removes groups by IDs.
 
-        if group_id.lower() == "default":
+        :param groups_id: list with Groups ID.
+        """
+
+        for group in groups_id:
+            if group.lower() == "default":
                 raise WazuhException(1712)
 
         for filename in listdir("{0}".format(common.groups_path)):
-            file = open("{0}/{1}".format(common.groups_path,filename),"r")
-            agent_id = filename
-            agent_group = file.read()
-            agent_group = agent_group.strip()
-            file.close()
+            for group in groups_id:
+                file = open("{0}/{1}".format(common.groups_path, filename), "r")
+                agent_id = filename
+                agent_group = file.read()
+                agent_group = agent_group.strip()
+                file.close()
 
-            if agent_group.find(group_id) >= 0:
+                if agent_group.find(group) >= 0:
 
-                group_list = agent_group.split(',')
-                # remove the group
-                group_list.remove(group_id)
-                if len(group_list) > 1:
-                    # create new multigroup
-                    new_group = ','.join(group_list)
-                    if not Agent.multi_group_exists(new_group):
-                        Agent.create_multi_group(new_group)
-                else:
-                    new_group = 'default' if not group_list else group_list[0]
-                
-                # Add multigroup
-                agent_file = open("{0}/{1}".format(common.groups_path,agent_id),"w")
-                agent_file.write("{0}\n".format(new_group))
-                agent_file.close()
+                    group_list = agent_group.split(',')
+                    # remove the group
+                    group_list.remove(group)
+                    if len(group_list) > 1:
+                        # create new multigroup
+                        new_group = ','.join(group_list)
+                        if not Agent.multi_group_exists(new_group):
+                            Agent.create_multi_group(new_group)
+                    else:
+                        new_group = 'default' if not group_list else group_list[0]
+
+                    # Add multigroup
+                    agent_file = open("{0}/{1}".format(common.groups_path, agent_id), "w")
+                    agent_file.write("{0}\n".format(new_group))
+                    agent_file.close()
 
         multi_group_metadata = Agent().get_multigroups_metadata()
         multi_group_metadata_copy = multi_group_metadata[:]
 
         try:
             for multi_group in multi_group_metadata:
-                if group_id in multi_group.split(','):
-                    try:
-                        multi_group_metadata_copy.remove(multi_group)
-                        folder = hashlib.sha256(multi_group).hexdigest()[:8]
-                        rmtree("{}/{}".format(common.multi_groups_path,folder))
-                    except Exception:
-                        pass
+                for group in groups_id:
+                    if group in multi_group.split(','):
+                        try:
+                            multi_group_metadata_copy.remove(multi_group)
+                            folder = hashlib.sha256(multi_group).hexdigest()[:8]
+                            rmtree("{}/{}".format(common.multi_groups_path, folder))
+                        except Exception:
+                            pass
 
         except Exception:
             pass

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1526,6 +1526,9 @@ class Agent:
         :param groups_id: list with Groups ID.
         """
 
+        if not isinstance(groups_id, list):
+            raise WazuhException(1104, "Input must be a list")
+
         for group in groups_id:
             if group.lower() == "default":
                 raise WazuhException(1712)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1494,18 +1494,8 @@ class Agent:
         :param group_id: Group ID.
         :return: Confirmation message.
         """
-        # Input Validation of group_id
-        #if not InputValidator().group(group_id):
-        #    raise WazuhException(1722)
-
-        group_list = group_id.split(',')
-        # remove the group
-        try:
-            group_list.remove(group_id)
-        except Exception:
-            pass
-        
-        if len(group_list) == 0:
+        if ',' not in group_id:
+            # if there's not , in the group_id, then it isn't a multigroup and therefore the function does nothing
             return
 
         # Create group in /var/multigroups
@@ -1549,24 +1539,18 @@ class Agent:
             with open("{0}/{1}".format(common.groups_path, agent_id), "w") as agent_file:
                 agent_file.write("{0}\n".format(new_group))
 
-        multi_group_metadata = Agent().get_multigroups_metadata()
-        multi_group_metadata_copy = multi_group_metadata[:]
+        multigroups_to_remove = list(filter(lambda mg: groups_id & set(mg.split(',')) != set(),
+                                       Agent().get_multigroups_metadata()))
 
-        try:
-            for multi_group in multi_group_metadata:
-                for group in groups_id:
-                    if group in multi_group.split(','):
-                        try:
-                            multi_group_metadata_copy.remove(multi_group)
-                            folder = hashlib.sha256(multi_group).hexdigest()[:8]
-                            rmtree("{}/{}".format(common.multi_groups_path, folder))
-                        except Exception:
-                            pass
-        except Exception:
-            pass
+        for multi_group in multigroups_to_remove:
+            try:
+                folder = hashlib.sha256(multi_group).hexdigest()[:8]
+                rmtree("{}/{}".format(common.multi_groups_path, folder))
+            except Exception:
+                pass
 
-        multi_group_metadata = multi_group_metadata_copy[:]
-        Agent().write_multigroups_metadata(multi_group_metadata)
+        Agent().write_multigroups_metadata(multigroups_to_remove)
+
 
     @staticmethod
     def remove_group(group_id):
@@ -1766,19 +1750,11 @@ class Agent:
     def check_multigroup_limit(agent_id):
         # Check if multigroup limit is reached
         agent_group_path = "{0}/{1}".format(common.groups_path, agent_id)
-        limit_reached = False
 
-        try:
-            f_group = open(agent_group_path, 'r')
-            group_readed = f_group.read()
-            f_group.close()
-            
-            if (len(group_readed.split(',')) + 1) > common.max_groups_per_multigroup:
-                limit_reached = True
-        except Exception:
-            pass       
+        with open(agent_group_path) as f_group:
+            group_read = f_group.read()
 
-        return limit_reached
+        return len(group_read.split(',')) >= common.max_groups_per_multigroup
 
     @staticmethod
     def unset_group(agent_id, group_id=None, force=False):
@@ -2542,13 +2518,8 @@ class Agent:
 
         :return: readed multigroups list.
         """
-        multi_groups_list = []
-        try:
-            with open(common.multi_groups_path + "/.metadata") as f:
-                for line in f:
-                    multi_groups_list.append(line.strip())
-        except Exception:
-            pass
+        with open(common.multi_groups_path + "/.metadata") as f:
+            multi_groups_list = [line.strip() for line in f.readlines()]
         
         return multi_groups_list
 


### PR DESCRIPTION
Hi team,

This PR is for issue [189](https://github.com/wazuh/wazuh-api/issues/189). Two or more groups can be deleted now.

I had to change permissions in `/var/ossec/var/multigroups/.metadata` to `ossec:ossec` because I got this error:

```bash
# curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["webserver","database"]}' "http://127.0.0.1:55000/agents/groups?pretty"
{
   "error": 1000,
   "message": "[Errno 13] Permission denied: '/var/ossec/var/multigroups/.metadata'"
}
```
Fixed this, here there are the output of this call:

```bash
# curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["webserver","database"]}' "http://127.0.0.1:55000/agents/groups?pretty"
{
   "error": 0,
   "data": {
      "msg": "All selected groups were removed",
      "ids": [
         "webserver",
         "database"
      ],
      "affected_agents": []
   }
}
```

Best regards,

Demetrio.