### PR TITLE
Filter null values and remove internal key from GET/agents/:agent_id

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -334,8 +334,9 @@ class Agent:
         Gets public attributes of existing agent.
         """
         self._load_info_from_DB(select)
-        fields = set(self.fields.keys()) & set(select['fields']) if select is not None else self.fields.keys()
-        return {field:getattr(self,field) for field in map(lambda x: x.split('.')[0], fields)}
+        fields = set(self.fields.keys()) & set(select['fields']) if select is not None \
+                                                                 else set(self.fields.keys()) - {'internal_key'}
+        return {field:getattr(self,field) for field in map(lambda x: x.split('.')[0], fields) if getattr(self,field)}
 
 
     def compute_key(self):


### PR DESCRIPTION
Hello team,

This is the current output for never connected agents in `GET/agents/:agent_id` API call:

```javascript
# curl -u foo:bar -X GET "http://localhost:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "status": "Never connected",
      "configSum": null,
      "group": [
         "a.b.c"
      ],
      "name": "pepe",
      "internal_key": "e04541f95e405309f336bd9df9e7253addea677a64b748ed500876931422eec1",
      "mergedSum": null,
      "ip": "any",
      "dateAdd": "2018-10-08 14:06:49",
      "node_name": "unknown",
      "manager": null,
      "version": null,
      "lastKeepAlive": null,
      "os": {},
      "id": "001"
   }
}
```

This PR filters `null` values and removes the internal key field:
```javascript
# curl -u foo:bar -X GET "http://localhost:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "status": "Never connected",
      "group": [
         "a.b.c"
      ],
      "name": "pepe",
      "ip": "any",
      "node_name": "unknown",
      "dateAdd": "2018-10-08 14:06:49",
      "id": "001"
   }
}
```

Best regards,
Marta