### PR TITLE
Deleting functionalities from old databases of syscheck

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -275,7 +275,7 @@ wazuh_modules.kill_timeout=10
 # Synchronize agent database with client.keys
 wazuh_database.sync_agents=1
 
-# Synchronize file integrity monitoring data with Syscheck database
+# DEPRECATED Synchronize file integrity monitoring data with Syscheck database
 wazuh_database.sync_syscheck=0
 
 # Synchronize policy monitoring data with Rootcheck database

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -652,23 +652,6 @@ void OS_BackupAgentInfo(const char *id, const char *name, const char *ip)
     snprintf(path_dst, OS_FLSIZE, "%s/agent-info", path_backup);
     status += link(path_src, path_dst);
 
-    /* syscheck */
-    snprintf(path_src, OS_FLSIZE, "%s/(%s) %s->syscheck", SYSCHECK_DIR, name, ip);
-    snprintf(path_dst, OS_FLSIZE, "%s/syscheck", path_backup);
-    status += link(path_src, path_dst);
-
-    snprintf(path_src, OS_FLSIZE, "%s/.(%s) %s->syscheck.cpt", SYSCHECK_DIR, name, ip);
-    snprintf(path_dst, OS_FLSIZE, "%s/syscheck.cpt", path_backup);
-    status += link(path_src, path_dst);
-
-    snprintf(path_src, OS_FLSIZE, "%s/(%s) %s->syscheck-registry", SYSCHECK_DIR, name, ip);
-    snprintf(path_dst, OS_FLSIZE, "%s/syscheck-registry", path_backup);
-    status += link(path_src, path_dst);
-
-    snprintf(path_src, OS_FLSIZE, "%s/.(%s) %s->syscheck-registry.cpt", SYSCHECK_DIR, name, ip);
-    snprintf(path_dst, OS_FLSIZE, "%s/syscheck-registry.cpt", path_backup);
-    status += link(path_src, path_dst);
-
     /* rootcheck */
     snprintf(path_src, OS_FLSIZE, "%s/(%s) %s->rootcheck", ROOTCHECK_DIR, name, ip);
     snprintf(path_dst, OS_FLSIZE, "%s/rootcheck", path_backup);

--- a/src/util/syscheck_control.c
+++ b/src/util/syscheck_control.c
@@ -20,25 +20,24 @@ static void helpmsg(void) __attribute__((noreturn));
 
 static void helpmsg()
 {
-    printf("\n%s %s: Manages the integrity checking database.\n",
+    printf("\n%s %s: This binary it's deprecated, use API calls related below instead\n",
            __ossec_name, ARGV0);
     printf("Available options:\n\n");
     printf("\t-h          This help message.\n");
     printf("\t-V          Print version.\n");
     printf("\t-D          Debug mode.\n\n");
-    printf("\t-l          List available (active or not) agents.\n");
-    printf("\t-lc         List only active agents.\n");
-    printf("\t-ln         List only disconnected agents.\n");
-    printf("\t-u <id>     Updates (clear) the database for the agent.\n");
-    printf("\t-u all      Updates (clear) the database for all agents.\n");
-    printf("\t-i <id>     List modified files for the agent.\n");
-    printf("\t-r -i <id>  List modified registry entries for the agent "
-           "(Windows only).\n");
-    printf("\t-f <file>   Prints information about a modified file.\n");
-    printf("\t-z          Used with the -f, zeroes the auto-ignore counter.\n");
-    printf("\t-d          Used with the -f, ignores that file.\n");
-    printf("\t-s          Changes the output to CSV (comma delimited).\n");
-    printf("\t-j          Changes the output to JSON.\n");
+    printf("\t-l          List available (active or not) agents. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#get-all-agents filtering by status.\n");
+    printf("\t-lc         List only active agents. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#get-all-agents filtering by status.\n");
+    printf("\t-ln         List only disconnected agents. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#get-all-agents filtering by status.\n");
+    printf("\t-u <id>     Updates (clear) the database for the agent. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#clear-syscheck-database-of-an-agent.\n");
+    printf("\t-u all      Updates (clear) the database for all agents. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#clear-syscheck-database.\n");
+    printf("\t-i <id>     List modified files for the agent. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#get-syscheck-files to print last modified of all files.\n");
+    printf("\t-r -i <id>  List modified registry entries (Windows) for the agent. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#get-syscheck-files filtering by event.\n");
+    printf("\t-f <file>   Prints information about a modified file. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#get-syscheck-files filtering by event.\n");
+    printf("\t-z          Used with the -f, zeroes the auto-ignore counter. Deprecated since 3.4 version.\n");
+    printf("\t-d          Used with the -f, ignores that file. Deprecated since version 3.4.\n");
+    printf("\t-s          Changes the output to CSV (comma delimited).Deprecated.\n");
+    printf("\t-j          Changes the output to JSON. Using API calls all data comes in Json.\n");
     exit(1);
 }
 
@@ -63,6 +62,9 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    //This binary its deprecated, use RestFull API instead
+    helpmsg();
 
     /* User arguments */
     if (argc < 2) {

--- a/src/util/syscheck_update.c
+++ b/src/util/syscheck_update.c
@@ -20,13 +20,13 @@ static void helpmsg(void) __attribute__((noreturn));
 
 static void helpmsg()
 {
-    printf("\n%s %s: Updates (clears) the integrity check database.\n", __ossec_name, ARGV0);
+    printf("\n%s %s: This binary it's deprecated, use API calls related below instead.\n", __ossec_name, ARGV0);
     printf("Available options:\n");
     printf("\t-h       This help message.\n");
-    printf("\t-l       List available agents.\n");
-    printf("\t-a       Update (clear) syscheck database for all agents.\n");
-    printf("\t-u <id>  Update (clear) syscheck database for a specific agent.\n");
-    printf("\t-u local Update (clear) syscheck database locally.\n\n");
+    printf("\t-l       List available agents. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#get-all-agents filtering by status.\n");
+    printf("\t-a       Update (clear) syscheck database for all agents. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#clear-syscheck-database.\n");
+    printf("\t-u <id>  Update (clear) syscheck database for a specific agent. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#clear-syscheck-database-of-an-agent.\n");
+    printf("\t-u local Update (clear) syscheck database locally. Use https://documentation.wazuh.com/current/user-manual/api/reference.html#clear-syscheck-database-of-an-agent with id 0.\n\n");
     exit(1);
 }
 
@@ -37,6 +37,9 @@ int main(int argc, char **argv)
     const char *user = USER;
     gid_t gid;
     uid_t uid;
+
+    //This binary its deprecated, use RestFull API instead
+    helpmsg();
 
     /* Set the name */
     OS_SetName(ARGV0);

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -1202,7 +1202,7 @@ wmodule* wm_database_read() {
     wmodule *module = NULL;
 
     data.sync_agents = getDefine_Int("wazuh_database", "sync_agents", 0, 1);
-    data.sync_syscheck = getDefine_Int("wazuh_database", "sync_syscheck", 0, 1);
+    data.sync_syscheck = 0; //getDefine_Int("wazuh_database", "sync_syscheck", 0, 1);
     data.sync_rootcheck = getDefine_Int("wazuh_database", "sync_rootcheck", 0, 1);
     data.full_sync = getDefine_Int("wazuh_database", "full_sync", 0, 1);
     data.real_time = getDefine_Int("wazuh_database", "real_time", 0, 1);


### PR DESCRIPTION
There are two binaries with Syscheck funcionalities over old databases that are been mark as deprecated. The RestFul API should now be used.
