### PR TITLE
Return correctly formatted key when inserting a new agent

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1550,8 +1550,9 @@ class Agent:
                 else:
                     new_group = 'default' if not group_list else group_list[0]
 
-            # Add multigroup
-            Agent.set_agent_group_file(agent_id, new_group)
+            if new_group:
+                # Add multigroup
+                Agent.set_agent_group_file(agent_id, new_group)
 
         for multi_group in groups_to_remove:
             Agent.remove_multi_group_directory(multi_group)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1194,7 +1194,7 @@ class Agent:
         """
 
         new_agent = Agent(name=name, ip=ip, id=id, key=key, force=force)
-        return {'id': new_agent.id, 'key': key}
+        return {'id': new_agent.id, 'key': new_agent.compute_key()}
 
 
     @staticmethod

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -106,10 +106,6 @@ functions = {
         'function': Agent.insert_agent,
         'type': 'local_master'
     },
-    'DELETE/agents/groups': {
-        'function': Agent.remove_group,
-        'type': 'local_master'
-    },
     'DELETE/agents/:agent_id': {
         'function': Agent.remove_agent,
         'type': 'local_master'


### PR DESCRIPTION
Hello team,

This PR fixes https://github.com/wazuh/wazuh-api/issues/195.

This is the output right now:
```javascript
# curl -u foo:bar -k -X POST -d '{"name":"NewHost_3","ip":"10.0.10.11","id":"124","key":"1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64"}' -H 'Content-Type:application/json' "https://127.0.0.1:55000/agents/insert?pretty"
{
   "error": 0,
   "data": {
      "id": "124",
      "key": "MTI0IE5ld0hvc3RfMyAxMC4wLjEwLjExIDFhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpNjQ="
   }
}
```

Best regards,
Marta