### PR TITLE
Fix for last scan in syscheck and rootcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,18 @@ All notable changes to this project will be documented in this file.
 - **Boost Analysisd performance with multithreading.** ([#1039](https://github.com/wazuh/wazuh/pull/1039))
 - Adding feature to **let agents belong to multiple groups.** ([#1135](https://github.com/wazuh/wazuh/pull/1135))
   - API support for multiple groups. ([#1300](https://github.com/wazuh/wazuh/pull/1300) [#1135](https://github.com/wazuh/wazuh/pull/1135))
-- Added statistical data for Analysisd. ([#1297](https://github.com/wazuh/wazuh/pull/1297))
-  - Added API call `GET/manager/stats/analysisd` to query Analysisd statistics.
-  - Added API call `GET/manager/stats/remoted` to query Remoted statistics.
 - **Boost FIM decoding performance** by storing data into Wazuh DB using SQLite databases. ([#1333](https://github.com/wazuh/wazuh/pull/1333))
   - FIM database is cleaned after restarting agent 3 times, deleting all entries that left being monitored.
   - Added script to migrate older Syscheck databases to WazuhDB. ([#1504](https://github.com/wazuh/wazuh/pull/1504)) ([#1333](https://github.com/wazuh/wazuh/pull/1333))
 - Added rule testing output when restarting manager. ([#1196](https://github.com/wazuh/wazuh/pull/1196))
 - New wodle for **Azure environment log and process collection.** ([#1306](https://github.com/wazuh/wazuh/pull/1306))
 - New wodle for **Docker container monitoring.** ([#1368](https://github.com/wazuh/wazuh/pull/1368))
+- Disconnect manager nodes in cluster if no keep alive is received or sent during two minutes. ([#1482](https://github.com/wazuh/wazuh/pull/1482))
+- API requests are forwarded to the proper manager node in cluster. ([#885](https://github.com/wazuh/wazuh/pull/885))
 
 ### Changed
 
-- Refactor Python framework code to standardize database requests and support API queries. ([#921](https://github.com/wazuh/wazuh/pull/921))
-
+- Refactor Python framework code to standardize database requests and support queries. ([#921](https://github.com/wazuh/wazuh/pull/921))
 - Replaced the `execvpe` function by `execvp` for the Wazuh modules. ([#1207](https://github.com/wazuh/wazuh/pull/1207))
 - Avoid the use of reference ID in Syscollector network tables. ([#1315](https://github.com/wazuh/wazuh/pull/1315))
 - Make Syscheck case insensitive on Windows agent. ([#1349](https://github.com/wazuh/wazuh/pull/1349))
@@ -55,7 +53,8 @@ All notable changes to this project will be documented in this file.
 - Fixed the reading of the destination address and type for PPP interfaces. ([#1405](https://github.com/wazuh/wazuh/pull/1405))
 - Fixed a memory bug in regex when getting empty strings. ([#1430](https://github.com/wazuh/wazuh/pull/1430))
 - Fixed report_changes with a big ammount of files. ([#1465](https://github.com/wazuh/wazuh/pull/1465))
-- Prevent Logcollector from null-terminating socket output messages. (#1465)
+- Prevent Logcollector from null-terminating socket output messages. ([#1547](https://github.com/wazuh/wazuh/pull/1547))
+- Prevent service from crashing if _global.db_ is not created. ([#1485](https://github.com/wazuh/wazuh/pull/1485))
 
 
 ## [v3.6.1] 2018-09-07

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -245,12 +245,12 @@ def last_scan(agent_id):
     query = "SELECT max(date_last) FROM pm_event WHERE log = 'Ending rootcheck scan.'"
     conn.execute(query)
     for tuple in conn:
-        data['end'] = tuple[0]
+        data['end'] = tuple[0] if tuple[0] is not None else "ND"
 
     # start time
     query = "SELECT max(date_last) FROM pm_event WHERE log = 'Starting rootcheck scan.'"
     conn.execute(query)
     for tuple in conn:
-        data['start'] = tuple[0]
+        data['start'] = tuple[0] if tuple[0] is not None else "ND"
 
     return data

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -100,12 +100,14 @@ def last_scan(agent_id):
         # end time
         query = "SELECT date_last, log FROM pm_event WHERE log LIKE '% syscheck scan.'"
         conn.execute(query)
+
         return {'end' if log.startswith('End') else 'start': date_last for date_last, log in conn}
     else:
         fim_scan_info = my_agent._load_info_from_agent_db(table='scan_info', select={'end_scan', 'start_scan'},
                                                           filters={'module': 'fim'})[0]
         end = 'ND' if not fim_scan_info['end_scan'] else datetime.fromtimestamp(float(fim_scan_info['end_scan'])).strftime('%Y-%m-%d %H:%M:%S')
         start = 'ND' if not fim_scan_info['start_scan'] else datetime.fromtimestamp(float(fim_scan_info['start_scan'])).strftime('%Y-%m-%d %H:%M:%S')
+        # returns 'end': ND' ever if start == 'ND'
         return {'start': start, 'end': 'ND' if start == 'ND' else end}
 
 

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -84,9 +84,13 @@ def last_scan(agent_id):
     :return: Dictionary: end, start.
     """
     my_agent = Agent(agent_id)
-    agent_version = my_agent.get_basic_information(select={'fields': ['version']})['version']
+    # if agent status is never connected, a KeyError happens
+    try:
+        agent_version = my_agent.get_basic_information(select={'fields': ['version']})['version']
+    except KeyError:
+        agent_version = 'ND'
 
-    if agent_version < 'Wazuh v3.7.0':
+    if agent_version < 'Wazuh v3.7.0' and agent_version != 'ND':
         db_agent = glob('{0}/{1}-*.db'.format(common.database_path_agents, agent_id))
         if not db_agent:
             raise WazuhException(1600)


### PR DESCRIPTION
Hi team,

This PR is for issue #1248. Before I made this PR, I got this with an agent with status `never connected`:
```
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/syscheck/003/last_scan?pretty"
{
   "error": 1000,
   "message": "'version'"
}
```
When `rootcheck` didn't run:
```
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/rootcheck/003/last_scan?pretty"
{
   "error": 0,
   "data": {
      "start": null,
      "end": null
   }
}
```
Now, I obtain this:
```
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/syscheck/003/last_scan?pretty"
{
   "error": 0,
   "data": {
      "start": "ND",
      "end": "ND"
   }
}
```
```
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/rootcheck/003/last_scan?pretty"
{
   "error": 0,
   "data": {
      "start": "ND",
      "end": "ND"
   }
}
```