### PR TITLE
Import cryptography.fernet.Fernet unconditionally.

### DIFF
--- a/framework/wazuh/cluster/communication.py
+++ b/framework/wazuh/cluster/communication.py
@@ -34,11 +34,10 @@ else:
         return base64.b64encode(msg.encode())
 
 
-if check_cluster_status():
-    try:
-        from cryptography.fernet import Fernet, InvalidToken, InvalidSignature
-    except ImportError as e:
-        raise ImportError("Could not import cryptography module. Install it using one of the following commands:\n\
+try:
+    from cryptography.fernet import Fernet, InvalidToken, InvalidSignature
+except ImportError as e:
+    raise ImportError("Could not import cryptography module. Install it using one of the following commands:\n\
  - pip install cryptography\n\
  - yum install python-cryptography python-setuptools\n\
  - apt install python-cryptography")


### PR DESCRIPTION
While testing wazuh-cluster in production, I found the following error in `/var/ossec/logs/cluster.log`:

```
2018-10-12 18:27:07,863 ERROR    : [Worker] Exiting. Reason: 'Unknown exception: 'global name 'Fernet' is not defined''.
```

From examination of the code, I believe the fix is to remove the conditional [`if check_cluster_status()`](https://github.com/wazuh/wazuh/blob/master/framework/wazuh/cluster/communication.py#L37) and import the [`cryptography.fernet`](https://github.com/wazuh/wazuh/blob/master/framework/wazuh/cluster/communication.py#L39) modules unconditionally.  Otherwise, when [this code](https://github.com/wazuh/wazuh/blob/master/framework/wazuh/cluster/communication.py#L166) is reached, the cluster will abort with the above-referenced error message.