### PR TITLE
Fix reading fields when querying the remote configuration section

### DIFF
--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -21,6 +21,7 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     unsigned int allow_size = 1;
     unsigned int deny_size = 1;
     remoted *logr;
+    int defined_queue_size = 0;
 
     /*** XML Definitions ***/
 
@@ -206,6 +207,7 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 merror("Invalid value for option '<%s>'", xml_queue_size);
                 return OS_INVALID;
             }
+            defined_queue_size = 1;
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);
@@ -231,6 +233,12 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     /* Set default protocol */
     if (logr->proto[pl] == 0) {
         logr->proto[pl] = UDP_PROTO;
+    }
+
+    /* Queue_size is only for secure connections */
+    if (logr->conn[pl] == SYSLOG_CONN && defined_queue_size) {
+        merror("Invalid option <%s> for Syslog remote connection.", xml_queue_size);
+        return OS_INVALID;
     }
 
     return (0);

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -88,13 +88,13 @@ cJSON *getRemoteConfig(void) {
             else if (logr.conn[i] == SECURE_CONN) cJSON_AddStringToObject(conn,"connection","secure");
             if (logr.ipv6 && logr.ipv6[i]) cJSON_AddStringToObject(conn,"ipv6","yes"); else cJSON_AddStringToObject(conn,"ipv6","no");
             if (logr.lip && logr.lip[i]) cJSON_AddStringToObject(conn,"local_ip",logr.lip[i]);
-            if (logr.proto && logr.proto[logr.position] == UDP_PROTO) cJSON_AddStringToObject(conn,"protocol","udp");
-            else if (logr.proto && logr.proto[logr.position] == TCP_PROTO) cJSON_AddStringToObject(conn,"protocol","tcp");
-            if (logr.port && logr.port[logr.position]){
-                sprintf(port,"%d",logr.port[logr.position]);
+            if (logr.proto && logr.proto[i] == UDP_PROTO) cJSON_AddStringToObject(conn,"protocol","udp");
+            else if (logr.proto && logr.proto[i] == TCP_PROTO) cJSON_AddStringToObject(conn,"protocol","tcp");
+            if (logr.port && logr.port[i]){
+                sprintf(port,"%d",logr.port[i]);
                 cJSON_AddStringToObject(conn,"port",port);
             }
-            if (logr.queue_size) {
+            if (logr.queue_size && (logr.conn[i] == SECURE_CONN)) {
                 sprintf(queue_size,"%ld",logr.queue_size);
                 cJSON_AddStringToObject(conn,"queue_size",queue_size); };
             if (logr.allowips && (int)i!=logr.position) {


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/1646.

Several fields were being overwritten when reading the configuration of the `remote` section.

It also has been added a check to not allow to set the `queue_size` field to `syslog` connections, it only applies to the `secure` connection between agents and the manager, and a configuration like this one:

```
<remote>
  <connection>secure</connection>
  <port>1514</port>
  <protocol>udp</protocol>
  <queue_size>131072</queue_size>
</remote>

<remote>
  <connection>syslog</connection>
  <port>514</port>
  <protocol>tcp</protocol>
 <queue_size>16107</queue_size>
  <allowed-ips>192.168.1.0/24</allowed-ips>
  <local_ip>192.168.1.5</local_ip>
</remote>
```

was overwriting the correct value by the last one read.

Now, with the following configuration:

```
<remote>
    <connection>syslog</connection>
    <port>511</port>
    <protocol>udp</protocol>
    <denied-ips>10.10.0.1</denied-ips>
  </remote>

  <remote>
    <connection>secure</connection>
    <port>1514</port>
    <protocol>udp</protocol>
    <local_ip>192.168.1.222</local_ip>
    <queue_size>131072</queue_size>
  </remote>

  <remote>
    <connection>syslog</connection>
    <port>1212</port>
    <protocol>udp</protocol>
    <local_ip>192.168.1.222</local_ip>
    <allowed-ips>10.10.10.10/23</allowed-ips>
  </remote>

  <remote>
    <connection>syslog</connection>
    <port>514</port>
    <protocol>tcp</protocol>
    <allowed-ips>192.168.0.1/24</allowed-ips>
    <allowed-ips>10.10.10.10/23</allowed-ips>
  </remote>
```

The API reads it as follow

```
{
   "error": 0,
   "data": {
      "remote": [
         {
            "denied-ips": [
               "10.10.0.1"
            ],
            "protocol": "udp",
            "allowed-ips": [
               "10.10.10.10/23",
               "192.168.0.1/24",
               "10.10.10.10/23"
            ],
            "connection": "syslog",
            "ipv6": "no",
            "port": "511"
         },
         {
            "protocol": "udp",
            "local_ip": "192.168.1.222",
            "queue_size": "131072",
            "connection": "secure",
            "ipv6": "no",
            "port": "1514"
         },
         {
            "denied-ips": [
               "10.10.0.1"
            ],
            "protocol": "udp",
            "allowed-ips": [
               "10.10.10.10/23",
               "192.168.0.1/24",
               "10.10.10.10/23"
            ],
            "local_ip": "192.168.1.222",
            "connection": "syslog",
            "ipv6": "no",
            "port": "1212"
         },
         {
            "denied-ips": [
               "10.10.0.1"
            ],
            "protocol": "tcp",
            "allowed-ips": [
               "10.10.10.10/23",
               "192.168.0.1/24",
               "10.10.10.10/23"
            ],
            "connection": "syslog",
            "ipv6": "no",
            "port": "514"
         }
      ]
   }
}
```
