### PR TITLE
Fix for check if nodes have children

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -177,7 +177,7 @@ def _read_option(section_name, opt):
             opt_value = {}
             for a in opt.attrib:
                 opt_value[a] = opt.attrib[a]
-            if opt._children:
+            if list(opt):
                 for child in opt:
                     child_section, child_config = _read_option(child.tag.lower(),child)
                     opt_value[child_section] = child_config


### PR DESCRIPTION
Hi team,

I discovered this bug when passing mocha test with Python 3. Most of tests fail if this bug is present.

This is an example of a call using Python 3:
```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty"
{
   "error": 3006,
   "message": "Error reading cluster configuration: Error getting configuration: 'xml.etree.ElementTree.Element' object has no attribute '_children'"
}
```

Now, this is the output after fix it:

```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty"
{
   "error": 0,
   "data": {
      "items": [
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "version": "7"
            },
            "status": "Active",
            "ip": "127.0.0.1",
            "manager": "localhost.localdomain",
            "name": "localhost.localdomain",
            "dateAdd": "2018-10-15 15:15:26",
            "node_name": "master",
            "lastKeepAlive": "9999-12-31 23:59:59",
            "version": "Wazuh v3.7.0",
            "id": "000"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "version": "7"
            },
            "mergedSum": "7ba5f1b48d59dbb8d7443993a878edb3",
            "status": "Active",
            "ip": "192.168.122.58",
            "manager": "localhost.localdomain",
            "name": "agent001",
            "group": [
               "default"
            ],
            "dateAdd": "2018-10-15 15:15:26",
            "node_name": "master",
            "lastKeepAlive": "2018-10-15 15:42:34",
            "version": "Wazuh v3.6.1",
            "id": "001",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
               "version": "7"
            },
            "mergedSum": "7ba5f1b48d59dbb8d7443993a878edb3",
            "status": "Active",
            "ip": "192.168.122.19",
            "manager": "localhost.localdomain",
            "name": "agent002",
            "group": [
               "default"
            ],
            "dateAdd": "2018-10-15 15:15:26",
            "node_name": "master",
            "lastKeepAlive": "2018-10-15 15:42:34",
            "version": "Wazuh v3.7.0",
            "id": "002",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         }
      ],
      "totalItems": 3
   }
}

```

Best regards,

Demetrio.