### PR TITLE
Fix for cast msg to bytes with Python 3

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -27,6 +27,7 @@ import hashlib
 import re
 import fcntl
 from json import loads, dumps
+from functools import reduce
 import struct
 
 try:

--- a/framework/wazuh/ossec_socket.py
+++ b/framework/wazuh/ossec_socket.py
@@ -29,7 +29,7 @@ class OssecSocket:
 
     def send(self, msg):
         try:
-            sent = self.s.send(pack("<I", len(msg)) + msg)
+            sent = self.s.send(pack("<I", len(msg)) + msg.encode())
             if sent == 0:
                 raise WazuhException(1014, self.path)
             return sent


### PR DESCRIPTION
Hi team,

This PR fixes remote config calls with Python 3. There was a bug in line 32 of `ossec_socket.py` that I solved casting msg (string) to bytes.

Best regards,

Demetrio.