### PR TITLE
Fix for encoding msg parameter if it is string

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2459,7 +2459,7 @@ class Agent:
         msg = "{0}".format(command)
 
         # Send message
-        s.send(msg)
+        s.send(msg.encode())
 
         # Receive response
         try:

--- a/framework/wazuh/ossec_socket.py
+++ b/framework/wazuh/ossec_socket.py
@@ -28,8 +28,10 @@ class OssecSocket:
         self.s.close()
 
     def send(self, msg):
+        if isinstance(msg, str):
+            msg = msg.encode()
         try:
-            sent = self.s.send(pack("<I", len(msg)) + msg.encode())
+            sent = self.s.send(pack("<I", len(msg)) + msg)
             if sent == 0:
                 raise WazuhException(1014, self.path)
             return sent

--- a/framework/wazuh/ossec_socket.py
+++ b/framework/wazuh/ossec_socket.py
@@ -58,7 +58,7 @@ class OssecSocketJSON(OssecSocket):
         OssecSocket.__init__(self, path)
 
     def send(self, msg):
-        return OssecSocket.send(self, dumps(msg).encode())
+        return OssecSocket.send(self, dumps(msg))
 
     def receive(self):
         response = loads(OssecSocket.receive(self).decode())

--- a/framework/wazuh/ossec_socket.py
+++ b/framework/wazuh/ossec_socket.py
@@ -27,11 +27,12 @@ class OssecSocket:
     def close(self):
         self.s.close()
 
-    def send(self, msg):
-        if isinstance(msg, str):
-            msg = msg.encode()
+    def send(self, msg_bytes):
+        if not isinstance(msg_bytes, bytes):
+            raise WazuhException(1104, "Type must be bytes")
+
         try:
-            sent = self.s.send(pack("<I", len(msg)) + msg)
+            sent = self.s.send(pack("<I", len(msg_bytes)) + msg_bytes)
             if sent == 0:
                 raise WazuhException(1014, self.path)
             return sent
@@ -58,7 +59,7 @@ class OssecSocketJSON(OssecSocket):
         OssecSocket.__init__(self, path)
 
     def send(self, msg):
-        return OssecSocket.send(self, dumps(msg))
+        return OssecSocket.send(self, dumps(msg).encode())
 
     def receive(self):
         response = loads(OssecSocket.receive(self).decode())


### PR DESCRIPTION
Hi team,

This PR is for fix `send` function in `ossec_socket.py`. This function receives a msg parameter which can be of type string or bytes. It is necessary to apply `.encode` function if this parameter is instance of string.

Best regards,

Demetrio.