### PR TITLE
Delete analysis/rules and analysis/decoders calls

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2429,6 +2429,9 @@ class Agent:
         if component not in components:
             raise WazuhException(1101, "Invalid target")
 
+        if component == "analysis" and (configuration == "rules" or configuration == "decoders"):
+            raise WazuhException(1101, "Could not get requested section")
+
         # checks if agent version is compatible with this feature
         self._load_info_from_DB()
         if self.version is None:


### PR DESCRIPTION
Hi team,

Result of API calls `curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/000/config/analysis/decoders?pretty" ` and  `curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/000/config/analysis/rules?pretty" ` is too big and causes this error:
```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/000/config/analysis/decoders?pretty"
{
   "error": 1014,
   "message": "Error communicating with socket: /var/ossec/queue/ossec/analysis"
}
```
This error appears in `ossec_socket.py` and I caught it before. Now, it is like as other errors that happens when I try to get an invalid configuration section:

```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/000/config/analysis/decoders?pretty"
{
   "error": 1101,
   "message": "Error getting configuration: Could not get requested section"
}
```
```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/000/config/analysis/invalid_section?pretty"
{
   "error": 1101,
   "message": "Error getting configuration: Could not get requested section"
}

```

Best regards,

Demetrio.