### PR TITLE
Fix FIM path depth

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -639,8 +639,11 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
         return (-1);
     }
 
+    /* Open the directory given */
+    dp = opendir(dir_name);
+
     /* Should we check for NFS? */
-    if (syscheck.skip_nfs)
+    if (syscheck.skip_nfs && dp)
     {
         is_nfs = IsNFS(dir_name);
         if (is_nfs != 0)
@@ -651,8 +654,6 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
         }
     }
 
-    /* Open the directory given */
-    dp = opendir(dir_name);
     if (!dp) {
         if (errno == ENOTDIR) {
             if (read_file(dir_name, dir_position, evt, max_depth) == 0) {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -116,7 +116,12 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         if (pos >= 0) {
             mdebug1("Scanning new file '%s' with options for directory '%s'.", file_name, syscheck.dir[pos]);
             int diff = fim_find_child_depth(syscheck.dir[pos], file_name);
-            read_dir(file_name, pos, evt, syscheck.recursion_level[pos] - diff+1);
+            int depth = syscheck.recursion_level[pos] - diff+1;
+
+            if(check_path_type(file_name) == 2){
+                depth = depth - 1;
+            }
+            read_dir(file_name, pos, evt, depth);
         }
 
     }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -723,13 +723,11 @@ add_whodata_evt:
                         // Check that a new file has been added
                         if ((mask & FILE_WRITE_DATA) && w_evt->path && (w_dir = OSHash_Get(syscheck.wdata.directories, w_evt->path))) {
                             GetSystemTime(&w_dir->timestamp);
-                            int pos = w_evt->dir_position;
-                            if (pos >= 0) {
+                            int pos;
+                            if (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA, 1), pos >= 0) {
                                 int diff = fim_find_child_depth(syscheck.dir[pos], w_evt->path);
-                                int depth = syscheck.recursion_level[pos] - diff+1;
-                                if (depth >= 0) {
-                                    read_dir(w_evt->path, pos, w_evt, depth);
-                                }
+                                int depth = syscheck.recursion_level[pos] - diff;
+                                read_dir(w_evt->path, pos, w_evt, depth);
                             }
 
                             mdebug1("The '%s' directory has been scanned after detecting event of new files.", w_evt->path);


### PR DESCRIPTION
With a recursion level of 3, alerts were generating when adding or removing 4 files in depth, but not when modifying the one in the 4th depth. This was caused because when adding or removing the file, the path used was the folder's one being a recursion level of 3 generating the alert. When the file was modified, the path was the file's one, being level 4 and not reporting the alert, as it should be.
This PR solves that issue checking if the path is from a folder or a file.