### PR TITLE
Fix for get manager key

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -355,7 +355,7 @@ class Agent:
         if self.id != "000":
             self.key = self.compute_key()
         else:
-            self.key = ""
+            raise WazuhException(1703)
 
         return self.key
 


### PR DESCRIPTION
Hi team,

API call to get key from manager returned an empty string when should show an error. Now returns this:
```bash
# curl -u foo:bar -GET 'http://localhost:55000/agents/000/key?pretty'
{
   "error": 1703,
   "message": "Action not available for Manager (Agent 000)."
}
```

Best regards,

Demetrio.