### PR TITLE
Fix Mac OS X version detection when unknown codename

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -282,7 +282,7 @@ char *OSX_ReleaseName(const int version) {
     if (version >= 10 && version <= 18)
         return r_names[version%10];
     else
-        return NULL;
+        return "Unknown";
 }
 
 os_info *get_unix_version()


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/1675.

The function which translates the major version to its codename didn't contemplate an unknown value, as the new 18.0.0 Mojave.

This PR adds the codename *unknown* for this case.