### PR TITLE
Fix for error getting remote configuration in inactive agents

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2495,7 +2495,13 @@ class Agent:
         if not component or not configuration:
             raise WazuhException(1307)
 
-        return Agent(agent_id).getconfig(component=component, configuration=configuration)
+        my_agent = Agent(agent_id)
+        my_agent._load_info_from_DB()
+
+        if my_agent.status != "Active":
+            raise WazuhException(1740)
+
+        return my_agent.getconfig(component=component, configuration=configuration)
 
     @staticmethod
     def get_multigroups_metadata():

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -125,6 +125,7 @@ class WazuhException(Exception):
         1737: 'Maximum number of groups per multigroup is 256',
         1738: 'Agent name is too long. Max length allowed for agent name is 128',
         1739: "Error getting agent's group sync",
+        1740: 'Action only available for active agents',
 
         # Manager:
 


### PR DESCRIPTION
Hi team,

I made changes to show this error when you try to get the remote configuration of an inactive agent:
```bash
# curl -u foo:bar -XGET 'http://localhost:55000/agents/003/config/logcollector/localfile?pretty'
{
   "error": 1740,
   "message": "Action only available for active agents."
}
```

Best regards,

Demetrio.