### PR TITLE
Fix type of cluster/config call

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2495,7 +2495,13 @@ class Agent:
         if not component or not configuration:
             raise WazuhException(1307)
 
-        return Agent(agent_id).getconfig(component=component, configuration=configuration)
+        my_agent = Agent(agent_id)
+        my_agent._load_info_from_DB()
+
+        if my_agent.status != "Active":
+            raise WazuhException(1740)
+
+        return my_agent.getconfig(component=component, configuration=configuration)
 
     @staticmethod
     def get_multigroups_metadata():

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -224,7 +224,7 @@ functions = {
     },
     '/cluster/config': {
         'function': cluster.read_config,
-        'type': 'local_master'
+        'type': 'local_any'
     },
     '/cluster/node': {
         'function': cluster.get_node,

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -125,6 +125,7 @@ class WazuhException(Exception):
         1737: 'Maximum number of groups per multigroup is 256',
         1738: 'Agent name is too long. Max length allowed for agent name is 128',
         1739: "Error getting agent's group sync",
+        1740: 'Action only available for active agents',
 
         # Manager:
 


### PR DESCRIPTION
Hi team,

Type of API call `cluster/config` is `local_any`, not `local_master`.

Best regards,

Demetrio.