### PR TITLE
Fix type of /cluster/config call

### DIFF
--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -224,7 +224,7 @@ functions = {
     },
     '/cluster/config': {
         'function': cluster.read_config,
-        'type': 'local_master'
+        'type': 'local_any'
     },
     '/cluster/node': {
         'function': cluster.get_node,


### PR DESCRIPTION
Hi team,

Type of `cluster/config` call is `local_any`. I made this change (it was `local_master`).

Best regards,

Demetrio.