### PR TITLE
Fix for return JSON instead string with an error happens

### DIFF
--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -820,8 +820,8 @@ class MasterInternalSocketHandler(InternalSocketHandler):
 
         elif command == 'dapi_forward':
             worker_id, node_name, input_json = data.split(' ', 2)
-            response = self.server.manager.send_request(worker_name=node_name, command='dapi', data=worker_id + ' ' + input_json)
-            return response.split(' ',1)
+            res_cmd, res = self.server.manager.send_request(worker_name=node_name, command='dapi', data=worker_id + ' ' + input_json).split(' ', 1)
+            return res_cmd, res if res_cmd != 'err' else json.dumps({'err': res})
 
         else:
             return InternalSocketHandler.process_request(self,command,data)

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -156,7 +156,7 @@ class WazuhException(Exception):
         3015: 'Cannot access directory',
         3016: 'Received an error response',
         3017: 'The agent is not reporting to any manager',
-        3018: 'Error sending request to the master'
+        3018: 'Error sending request',
 
         # > 9000: Authd
     }


### PR DESCRIPTION
Hi team,

This PR is for #1684. I made changes to send the error message properly when you try to get information about an unexisting node (`curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/unexisting_node/stats?pretty"`).

Best regards,

Demetrio.