### PR TITLE
API calls cluster/stats/remoted and cluster/stats/analysisd

### DIFF
--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -224,7 +224,7 @@ functions = {
     },
     '/cluster/config': {
         'function': cluster.read_config,
-        'type': 'local_master'
+        'type': 'local_any'
     },
     '/cluster/node': {
         'function': cluster.get_node,

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -267,11 +267,11 @@ functions = {
         'type': 'distributed_master'
     },
     '/cluster/:node_id/stats/analysisd': {
-        'function': stats.totals,
+        'function': stats.analysisd,
         'type': 'distributed_master'
     },
     '/cluster/:node_id/stats/remoted': {
-        'function': stats.totals,
+        'function': stats.remoted,
         'type': 'distributed_master'
     },
     '/cluster/:node_id/logs/summary': {

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -224,7 +224,7 @@ functions = {
     },
     '/cluster/config': {
         'function': cluster.read_config,
-        'type': 'local_any'
+        'type': 'local_master'
     },
     '/cluster/node': {
         'function': cluster.get_node,
@@ -264,6 +264,14 @@ functions = {
     },
     '/cluster/:node_id/stats/weekly': {
         'function': stats.weekly,
+        'type': 'distributed_master'
+    },
+    '/cluster/:node_id/stats/analysisd': {
+        'function': stats.totals,
+        'type': 'distributed_master'
+    },
+    '/cluster/:node_id/stats/remoted': {
+        'function': stats.totals,
         'type': 'distributed_master'
     },
     '/cluster/:node_id/logs/summary': {


### PR DESCRIPTION
Hi team,

This PR is for giving support to API calls `curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/client/stats/analysisd?pretty"` and `curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/client/stats/remoted?pretty"`[#213](https://github.com/wazuh/wazuh-api/pull/213).

Best regards,

Demetrio.