### PR TITLE
Update time global variables before create the logs directories

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -787,7 +787,8 @@ void OS_ReadMSG_analysisd(int m_queue)
 
     /* Get current time before starting */
     gettime(&c_timespec);
-
+    Start_Time();
+    
     /* Start the hourly/weekly stats directories*/
     if(Init_Stats_Directories() < 0) {
         Config.stats = 0;

--- a/src/analysisd/stats.c
+++ b/src/analysisd/stats.c
@@ -386,7 +386,6 @@ int Init_Stats_Directories(){
 /* Start hourly stats and other necessary variables */
 int Start_Hour(int t_id, int threads_number)
 {
-    struct tm *p;
 
     w_mutex_lock(&msg_mutex);
     if (!_lastmsg) {
@@ -467,6 +466,8 @@ void LastMsg_Change(const char *log, int t_id)
 }
 
 void Start_Time(){
+    struct tm *p;
+    
     /* Current time */
     p = localtime(&c_time);
 

--- a/src/analysisd/stats.c
+++ b/src/analysisd/stats.c
@@ -396,18 +396,7 @@ int Start_Hour(int t_id, int threads_number)
     }
     w_mutex_unlock(&msg_mutex);
 
-    /* Current time */
-    p = localtime(&c_time);
-
-    /* Other global variables */
-    _fired = 0;
-    _cignorehour = 0;
-
-    today = p->tm_mday;
-    thishour = p->tm_hour;
-    prev_year = p->tm_year + 1900;
-    strncpy(prev_month, l_month[p->tm_mon], 3);
-    prev_month[3] = '\0';
+    Start_Time();
 
     /* Clear some memory */
     memset(__stats_comment, '\0', 192);
@@ -475,4 +464,20 @@ void LastMsg_Change(const char *log, int t_id)
 
     os_strdup(log, _lastmsg[t_id]);
     return;
+}
+
+void Start_Time(){
+    /* Current time */
+    p = localtime(&c_time);
+
+    /* Other global variables */
+    _fired = 0;
+    _cignorehour = 0;
+
+    today = p->tm_mday;
+    thishour = p->tm_hour;
+    prev_year = p->tm_year + 1900;
+    strncpy(prev_month, l_month[p->tm_mon], 3);
+    prev_month[3] = '\0';
+
 }

--- a/src/analysisd/stats.h
+++ b/src/analysisd/stats.h
@@ -22,5 +22,5 @@ extern int percent_diff;
 void Update_Hour(void);
 int Check_Hour(void);
 int Start_Hour(int t_id, int threads_number);
-
+void Start_Time();
 #endif /* _STAT__H */


### PR DESCRIPTION
This PR encapsulate the function to initialize the global functions of time to use it before creating the directories where the logs rotate to avoid create the directory of the year 0.