### PR TITLE
Added .metadata as sync file

### DIFF
--- a/framework/wazuh/cluster/cluster.json
+++ b/framework/wazuh/cluster/cluster.json
@@ -28,7 +28,7 @@
             "umask": "0o127",
             "source": "master",
             "write_mode": "atomic",
-            "files": ["merged.mg"],
+            "files": [".metadata", "merged.mg"],
             "recursive": true,
             "restart": false,
             "remove_subdirs_if_empty": true,


### PR DESCRIPTION
Related https://github.com/wazuh/wazuh/pull/1695, https://github.com/wazuh/wazuh/pull/1702

Behavior:

- If a worker has no .metadata file the master must push to it
- If a worker has .metadata but not the master, it should remove it