### PR TITLE
Change  'node_name' to 'node'

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -206,7 +206,7 @@ class Agent:
               'group': '`group`', 'mergedSum': 'merged_sum', 'configSum': 'config_sum',
               'os.codename': 'os_codename', 'os.major': 'os_major', 'os.minor': 'os_minor',
               'os.uname': 'os_uname', 'os.arch': 'os_arch', 'os.build':'os_build',
-              'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive', 'internal_key':'internal_key'}
+              'node': 'node_name', 'lastKeepAlive': 'last_keepalive', 'internal_key':'internal_key'}
 
 
     def __init__(self, id=None, name=None, ip=None, key=None, force=-1):

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -232,7 +232,7 @@ class Agent:
         self.mergedSum     = None
         self.group         = None
         self.manager       = None
-        self.node_name     = None
+        self.node          = None
 
         # if the method has only been called with an ID parameter, no new agent should be added.
         # Otherwise, a new agent must be added
@@ -246,7 +246,7 @@ class Agent:
         dictionary = {'id': self.id, 'name': self.name, 'ip': self.ip, 'internal_key': self.internal_key, 'os': self.os,
                       'version': self.version, 'dateAdd': self.dateAdd, 'lastKeepAlive': self.lastKeepAlive,
                       'status': self.status, 'key': self.key, 'configSum': self.configSum, 'mergedSum': self.mergedSum,
-                      'group': self.group, 'manager': self.manager, 'node_name': self.node_name }
+                      'group': self.group, 'manager': self.manager, 'node': self.node }
 
         return dictionary
 

--- a/framework/wazuh/cluster/control.py
+++ b/framework/wazuh/cluster/control.py
@@ -99,11 +99,11 @@ def get_agents(filter_status, filter_node, is_master):
 
     if is_master:
         return Agent.get_agents_overview(limit=None, filters={'status': ','.join(filter_status), 'node_name':','.join(filter_node)},
-                                         select={'fields':['id','ip','name','status','node_name']})
+                                         select={'fields':['id','ip','name','status','node']})
     else:
         input_json = {'function': '/agents', 'from_cluster': False,
                       'arguments': {'filters': {'status': ','.join(filter_status), 'node_name': ','.join(filter_node)}, 'limit': None,
-                                    'select': {'fields': ['id', 'ip', 'name', 'status', 'node_name']}}}
+                                    'select': {'fields': ['id', 'ip', 'name', 'status', 'node']}}}
 
         request = "dapi {}".format(json.dumps(input_json))
         response = execute(request)

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -216,13 +216,13 @@ def get_solver_node(input_json, master_name):
     :param master_name: name of the master node
     :return: node name and whether the result is list or not
     """
-    select_node = {'fields':['node_name']}
+    select_node = {'fields':['node']}
     if 'agent_id' in input_json['arguments']:
         # the request is for multiple agents
         if isinstance(input_json['arguments']['agent_id'], list):
             agents = Agent.get_agents_overview(select=select_node, limit=None, filters={'id':input_json['arguments']['agent_id']},
-                                                  sort={'fields':['node_name'], 'order':'desc'})['items']
-            node_name = {k:list(map(itemgetter('id'), g)) for k,g in groupby(agents, key=itemgetter('node_name'))}
+                                                  sort={'fields':['node'], 'order':'desc'})['items']
+            node_name = {k:list(map(itemgetter('id'), g)) for k,g in groupby(agents, key=itemgetter('node'))}
 
             # add non existing ids in the master's dictionary entry
             non_existent_ids = list(set(input_json['arguments']['agent_id']) - set(map(itemgetter('id'), agents)))
@@ -236,7 +236,7 @@ def get_solver_node(input_json, master_name):
         # if the request is only for one agent
         else:
             # Get the node where the agent 'agent_id' is reporting
-            node_name = Agent.get_agent(input_json['arguments']['agent_id'], select=select_node)['node_name']
+            node_name = Agent.get_agent(input_json['arguments']['agent_id'], select=select_node)['node']
             return node_name, False
 
     elif 'node_id' in input_json['arguments']:
@@ -246,8 +246,8 @@ def get_solver_node(input_json, master_name):
 
     else: # agents, syscheck, rootcheck and syscollector
         # API calls that affect all agents. For example, PUT/agents/restart, DELETE/rootcheck, etc...
-        agents = Agent.get_agents_overview(select=select_node, limit=None, sort={'fields': ['node_name'], 'order': 'desc'})['items']
-        node_name = {k:[] for k, _ in groupby(agents, key=itemgetter('node_name'))}
+        agents = Agent.get_agents_overview(select=select_node, limit=None, sort={'fields': ['node'], 'order': 'desc'})['items']
+        node_name = {k:[] for k, _ in groupby(agents, key=itemgetter('node'))}
         return node_name, True
 
 

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -644,7 +644,7 @@ class MasterManager(Server):
 
         # Get active agents by node and format last keep alive date format
         for node_name in workers_info.keys():
-            workers_info[node_name]["info"]["n_active_agents"]=Agent.get_agents_overview(filters={'status': 'Active', 'node_name': node_name})['totalItems']
+            workers_info[node_name]["info"]["n_active_agents"]=Agent.get_agents_overview(filters={'status': 'Active', 'node': node_name})['totalItems']
             if workers_info[node_name]['info']['type'] != 'master' and isinstance(workers_info[node_name]['status']['last_keep_alive'], float):
                 workers_info[node_name]['status']['last_keep_alive'] = str(datetime.fromtimestamp(workers_info[node_name]['status']['last_keep_alive']))
 


### PR DESCRIPTION
Hi team,

This PR is an alternative to [#215](https://github.com/wazuh/wazuh-api/pull/215). With the changes of this PR we can use this API call:
```bash
curl -u foo:bar "localhost:55000/agents?node=master&select=name&pretty" 
{
   "error": 0,
   "data": {
      "totalItems": 3,
      "items": [
         {
            "id": "000",
            "name": "localhost.localdomain"
         },
         {
            "id": "001",
            "name": "agent001"
         },
         {
            "id": "002",
            "name": "agent002"
         }
      ]
   }
}
```
It isn't necessary to do something in API with these changes, but the field `node_name` is now `node`:
```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 3,
      "items": [
         {
            "status": "Active",
            "node": "master",
            "name": "localhost.localdomain",
            "ip": "127.0.0.1",
            "manager": "localhost.localdomain",
            "dateAdd": "2018-10-24 12:41:34",
            "version": "Wazuh v3.7.0",
            "lastKeepAlive": "9999-12-31 23:59:59",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "000"
         },
         {
            "status": "Active",
            "node": "master",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": [
               "default"
            ],
            "name": "agent001",
            "mergedSum": "bcb219b9b009801f3b29eb9e00a6a88d",
            "ip": "192.168.122.58",
            "manager": "localhost.localdomain",
            "dateAdd": "2018-10-24 12:41:34",
            "version": "Wazuh v3.6.1",
            "lastKeepAlive": "2018-10-24 12:56:25",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "001"
         },
         {
            "status": "Active",
            "node": "master",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": [
               "default"
            ],
            "name": "agent002",
            "mergedSum": "bcb219b9b009801f3b29eb9e00a6a88d",
            "ip": "192.168.122.19",
            "manager": "localhost.localdomain",
            "dateAdd": "2018-10-24 12:41:34",
            "version": "Wazuh v3.7.0",
            "lastKeepAlive": "2018-10-24 12:56:25",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "002"
         }
      ]
   }
}
```
Before, the call which I made before, was the next:
```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 3,
      "items": [
         {
            "status": "Active",
            "name": "localhost.localdomain",
            "ip": "127.0.0.1",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "dateAdd": "2018-10-24 12:59:48",
            "version": "Wazuh v3.7.0",
            "lastKeepAlive": "9999-12-31 23:59:59",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "000"
         },
         {
            "status": "Active",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": [
               "default"
            ],
            "name": "agent001",
            "mergedSum": "bcb219b9b009801f3b29eb9e00a6a88d",
            "ip": "192.168.122.58",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "dateAdd": "2018-10-24 12:59:48",
            "version": "Wazuh v3.6.1",
            "lastKeepAlive": "2018-10-24 13:00:05",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "001"
         },
         {
            "status": "Active",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": [
               "default"
            ],
            "name": "agent002",
            "mergedSum": "bcb219b9b009801f3b29eb9e00a6a88d",
            "ip": "192.168.122.19",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "dateAdd": "2018-10-24 12:59:49",
            "version": "Wazuh v3.7.0",
            "lastKeepAlive": "2018-10-24 13:00:05",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "002"
         }
      ]
   }
}
```

I'm aware that this PR could cause troubles to `app` team

Best regards,

Demetrio.