### PR TITLE
try/exception for unicode errors with python3

### DIFF
--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -140,9 +140,14 @@ def check_cluster_status():
     """
     Function to check if cluster is enabled
     """
-    with open("/etc/ossec-init.conf") as f:
-        # the osec directory is the first line of ossec-init.conf
-        directory = f.readline().split("=")[1][:-1].replace('"', "")
+    # for python 2/3 compatibility
+    # the osec directory is the first line of ossec-init.conf
+    try:
+        with open("/etc/ossec-init.conf") as f:
+            directory = f.readline().split("=")[1][:-1].replace('"', "")
+    except UnicodeDecodeError:
+        with open("/etc/ossec-init.conf", encoding='utf-8') as f:
+            directory = f.readline().split("=")[1][:-1].replace('"', "")
 
     try:
         # wrap the data


### PR DESCRIPTION
Hi team,

I got this error in my IDE executing requests with a `Python 3` interpreter:

```bash
File "/tmp/pycharm/wazuh/cluster/cluster.py", line 145, in check_cluster_status
    directory = f.readline().split("=")[1][:-1].replace('"', "")
 File "/opt/rh/rh-python36/root/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
```

I made this PR to avoid future errors by reading files with `Python 3`.

Best regards,

Demetrio.