### PR TITLE
Fix dapi concurrent calls

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -199,6 +199,10 @@ def sync_master(filter_node):
 
 ### Get agents
 def print_agents(filter_status, filter_node, is_master):
+    if not is_master:
+        print("This option is not available in worker nodes.")
+        exit(0)
+
     agents = get_agents(filter_status, filter_node, is_master)
     try:
         table = ["  ID: {}, Name: {}, IP: {}, Status: {},  Node: {}".format(agent['id'], agent['name'], agent['ip'],

--- a/framework/wazuh/cluster/communication.py
+++ b/framework/wazuh/cluster/communication.py
@@ -584,7 +584,7 @@ class AbstractServer(asyncore.dispatcher):
         self.create_socket(socket_family, socket_type)
         self.set_reuse_addr()
         self.bind(addr)
-        self.listen(5)
+        self.listen(128)  # number of pending connections the queue will hold
         self.interval_file_transfer_send = get_cluster_items_communication_intervals()['file_transfer_send']
         self.interval_string_transfer_send = get_cluster_items_communication_intervals()['string_transfer_send']
 

--- a/framework/wazuh/cluster/internal_socket.py
+++ b/framework/wazuh/cluster/internal_socket.py
@@ -143,9 +143,9 @@ class InternalSocketClient(communication.AbstractClient):
 
     def process_request(self, command, data):
         if command == 'dapi_res':
-            self.string_receiver = FragmentedAPIResponseReceiver(manager_handler=self, stopper=self.stopper)
-            self.string_receiver.start()
-            return 'ok', self.set_worker_thread(command, self.string_receiver)
+            data = data.decode()
+            self.final_response.write(data)
+            return 'ok', 'thanks2'
         elif command == 'err-is':
             data = data.decode()
             logger.debug("{} Cluster has reported an error receiving data: {}".format(self.tag, data))

--- a/framework/wazuh/cluster/internal_socket.py
+++ b/framework/wazuh/cluster/internal_socket.py
@@ -137,11 +137,11 @@ class InternalSocketClient(communication.AbstractClient):
         if command == 'ok' or command == 'ack':
             return False
         if command == 'json':
-            self.final_data = data.decode()
+            self.final_data = data
             self.data_received.set()
             return True
         elif command == 'err':
-            self.final_data = data.decode()
+            self.final_data = data
             self.data_received.set()
             return True
 

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -368,7 +368,7 @@ class FragmentedAPIResponseReceiver(FragmentedStringReceiverMaster):
 
     def __init__(self, manager_handler, stopper, worker_id):
         FragmentedStringReceiverMaster.__init__(self, manager_handler, stopper)
-        self.thread_tag = "[Master ] [{}] [API-R        ]".format(worker_id)
+        self.thread_tag = "[Master ] [{}] [API-R_{}]".format(manager_handler.name, worker_id)
         self.worker_id = worker_id
 
 
@@ -376,7 +376,7 @@ class FragmentedAPIResponseReceiver(FragmentedStringReceiverMaster):
 
         # send request to the worker
 
-
+        logger.debug("{}: Request received. Forwarding it to local client. ({})".format(self.thread_tag, self.worker_id))
         command = "dapi_res"
         data = self.sting_received
         self.manager_handler.isocket_handler.send_request(self.worker_id, command, data)
@@ -552,8 +552,8 @@ class MasterManager(Server):
         logger.debug("[Master ] Creating threads.")
 
         self.threads[MasterManager.Integrity_T] = FileStatusUpdateThread(master=self, interval=self.interval_recalculate_integrity, stopper=self.stopper)
-        self.threads[MasterManager.APIRequests_T] = dapi.APIRequestQueue(server=self, stopper=self.stopper)
         self.threads[MasterManager.ClientStatus_T] = ClientStatusCheckThread(master=self, stopper=self.stopper)
+        self.threads[MasterManager.APIRequests_T] = dapi.APIRequestQueue(server=self, stopper=self.stopper)
 
         for thread in self.threads.values():
             thread.start()

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -372,15 +372,16 @@ class FragmentedAPIResponseReceiver(FragmentedStringReceiverMaster):
         self.worker_id = worker_id
 
     def process_received_data(self):
-        logger.debug("{}: Request received. Forwarding it to local client. ({})".format(self.thread_tag, self.worker_id))
+        logger.debug("{}: Data received. Forwarding it to local client. ({})".format(self.thread_tag, self.worker_id))
 
-        self.manager_handler.isocket_handler.send_request(self.worker_id, "dapi_res", self.sting_received)
+        self.manager_handler.isocket_handler.send_string(self.worker_id, "dapi_res", self.sting_received.decode())
         return True
 
     def process_cmd(self, command, data):
         requests = {'fwd_new':'new_f_r', 'fwd_upd':'update_f_r', 'fwd_end':'end_f_r'}
 
-        data = data.decode() if data is not None else data
+        if data is not None and not isinstance(data, bytes):
+            data = data.decode()
 
         return FragmentedStringReceiverMaster.process_cmd(self, requests[command], data)
 

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -371,15 +371,10 @@ class FragmentedAPIResponseReceiver(FragmentedStringReceiverMaster):
         self.thread_tag = "[Master ] [{}] [API-R_{}]".format(manager_handler.name, worker_id)
         self.worker_id = worker_id
 
-
     def process_received_data(self):
-
-        # send request to the worker
-
         logger.debug("{}: Request received. Forwarding it to local client. ({})".format(self.thread_tag, self.worker_id))
-        command = "dapi_res"
-        data = self.sting_received
-        self.manager_handler.isocket_handler.send_request(self.worker_id, command, data)
+
+        self.manager_handler.isocket_handler.send_request(self.worker_id, "dapi_res", self.sting_received)
         return True
 
     def process_cmd(self, command, data):
@@ -389,12 +384,10 @@ class FragmentedAPIResponseReceiver(FragmentedStringReceiverMaster):
 
         return FragmentedStringReceiverMaster.process_cmd(self, requests[command], data)
 
-
     def unlock_and_stop(self, reason, send_err_request=None):
         if reason == 'error':
             self.manager_handler.isocket_handler.send_request(self.worker_id, 'err-is', send_err_request)
         FragmentedStringReceiverMaster.unlock_and_stop(self, reason, None)
-
 
 
 class ProcessWorker(FragmentedFileReceiver):

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -370,44 +370,24 @@ class FragmentedAPIResponseReceiver(FragmentedStringReceiverMaster):
         FragmentedStringReceiverMaster.__init__(self, manager_handler, stopper)
         self.thread_tag = "[Master ] [{}] [API-R        ]".format(worker_id)
         self.worker_id = worker_id
-        # send request to the worker
-        self.worker_thread_id = self.manager_handler.process_response(self.manager_handler.isocket_handler.send_request(self.worker_id, "dapi_res"))
 
 
     def process_received_data(self):
+
+        # send request to the worker
+
+
+        command = "dapi_res"
+        data = self.sting_received
+        self.manager_handler.isocket_handler.send_request(self.worker_id, command, data)
         return True
-
-
-    def close_reception(self, md5_sum):
-        self.received_all_information = True
-
-
-    def forward_msg(self, command, data):
-        return self.manager_handler.isocket_handler.send_request(self.worker_id, command,
-                                                                 self.worker_thread_id if not data else self.worker_thread_id + ' ' + data)
-
-    def update(self, chunk):
-        self.size_received += len(chunk)
-
 
     def process_cmd(self, command, data):
         requests = {'fwd_new':'new_f_r', 'fwd_upd':'update_f_r', 'fwd_end':'end_f_r'}
 
         data = data.decode() if data is not None else data
 
-        if command == 'fwd_new':
-            self.start_time = time.time()
-            return self.forward_msg(requests[command], data)
-        elif command == 'fwd_upd':
-            self.update(data)
-            return self.forward_msg(requests[command], data)
-        elif command == 'fwd_end':
-            self.close_reception(data)
-            self.end_time = time.time()
-            self.total_time = self.end_time - self.start_time
-            return self.forward_msg(requests[command], data)
-        else:
-            return FragmentedStringReceiverMaster.process_cmd(self, command, data)
+        return FragmentedStringReceiverMaster.process_cmd(self, requests[command], data)
 
 
     def unlock_and_stop(self, reason, send_err_request=None):


### PR DESCRIPTION
Distributed API wasn't working with several calls at the same time.

Fixes:
- The data is forwarded to Unix socket once the data is fully received in the TCP socket.
- The socket queue (_listen_) has changed from 5 to 128.
- The _execute_ function in InternalSocket has been improved.