### PR TITLE
Fix for is_sync_group function with Python 3

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2610,7 +2610,7 @@ class Agent:
                 # Check if it has a multigroup
                 if len(agent_info['group']) > 1:
                     multi_group = ','.join(agent_info['group'])
-                    multi_group = hashlib.sha256(multi_group).hexdigest()[:8]
+                    multi_group = hashlib.sha256(multi_group.encode()).hexdigest()[:8]
                     agent_group_merged_path = "{0}/{1}/merged.mg".format(common.multi_groups_path, multi_group)
                 else:
                     agent_group_merged_path = "{0}/{1}/merged.mg".format(common.shared_path, agent_info['group'][0])


### PR DESCRIPTION
Hi team,

`hashlib.sha256()` function needs a `bytes` object to work properly in Python 3:
```bash
File "/tmp/pycharm/wazuh/agent.py", line 2613, in get_sync_group
    multi_group = hashlib.sha256(multi_group).hexdigest()[:8]
TypeError: Unicode-objects must be encoded before hashing
```

I fixed this issue using encode() function over the argument of that function.

Best regards,

Demetrio.