### PR TITLE
FIM: Change merror to minfo when it is not possible to create the 'last-entry' file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Change errors messages to descriptive warnings in Syscheck when a files is not reachable. ([#1730](https://github.com/wazuh/wazuh/pull/1730))
 - Add default values to global options to let the manager start. ([#1894](https://github.com/wazuh/wazuh/pull/1894))
 - Improve Remoted performance by reducing interaction between threads. ([#1902](https://github.com/wazuh/wazuh/pull/1902))
-
 
 ### Fixed
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -685,13 +685,27 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
 #else
         if (defaultfilesn[di] == NULL) {
 #endif
-            mwarn("Cannot open '%s': %s ", dir_name, strerror(errno));
+            switch (errno) {
+            case ENOENT:
+                mwarn("Cannot open '%s': it was removed during scan.", dir_name);
+                break;
+            default:
+                mwarn("Cannot open '%s': %s ", dir_name, strerror(errno));
+            }
+
         } else {
             free(f_name);
             return 0;
         }
 #else
-        mwarn("Cannot open '%s': %s ", dir_name, strerror(errno));
+        switch (errno) {
+        case ENOENT:
+            mwarn("Cannot open '%s': it was removed during scan.", dir_name);
+            break;
+        default:
+            mwarn("Cannot open '%s': %s ", dir_name, strerror(errno));
+        }
+
 #endif /* WIN32 */
         free(f_name);
         return (-1);

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -324,7 +324,14 @@ char *seechanges_addfile(const char *filename)
     if (OS_MD5_File(old_location, md5sum_old, OS_BINARY) != 0) {
         seechanges_createpath(old_location);
         if (seechanges_dupfile(filename, old_location) != 1) {
-            minfo(RENAME_ERROR, filename, old_location, errno, strerror(errno));
+            switch (errno) {
+                case ENOENT:
+                    minfo(RENAME_ERROR, filename, old_location, errno, strerror(errno));
+                    break;
+                default:
+                    merror(RENAME_ERROR, filename, old_location, errno, strerror(errno));
+                }
+            }
         }
         return (NULL);
     }

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -324,7 +324,7 @@ char *seechanges_addfile(const char *filename)
     if (OS_MD5_File(old_location, md5sum_old, OS_BINARY) != 0) {
         seechanges_createpath(old_location);
         if (seechanges_dupfile(filename, old_location) != 1) {
-            merror(RENAME_ERROR, filename, old_location, errno, strerror(errno));
+            minfo(RENAME_ERROR, filename, old_location, errno, strerror(errno));
         }
         return (NULL);
     }

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -326,11 +326,10 @@ char *seechanges_addfile(const char *filename)
         if (seechanges_dupfile(filename, old_location) != 1) {
             switch (errno) {
                 case ENOENT:
-                    minfo(RENAME_ERROR, filename, old_location, errno, strerror(errno));
+                    mwarn("Cannot create a snapshot of file '%s': it was removed during scan.", filename);
                     break;
                 default:
                     merror(RENAME_ERROR, filename, old_location, errno, strerror(errno));
-                }
             }
         }
         return (NULL);


### PR DESCRIPTION
This is the issue associated: https://github.com/wazuh/wazuh/issues/1236.

The `merror` has been changed to an `minfo` since this temporary files are deleted so quickly that syscheck can't create its `last-entry`.