### PR TITLE
Fix for getting labels config

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -78,15 +78,17 @@ conf_sections = {
         'type': 'last',
         'list_options': ['nodes']
     },
-
     'vulnerability-detector': {
         'type': 'merge',
         'list_options': ['feed']
     },
-
     'osquery': {
         'type': 'merge',
         'list_options': []
+    },
+    'labels': {
+        'type': 'duplicate',
+        'list_options': ['label']
     }
 }
 
@@ -172,6 +174,10 @@ def _read_option(section_name, opt):
             opt_value.append(json_path)
     elif section_name == 'cluster' and opt_name == 'nodes':
         opt_value = [child.text for child in opt]
+    elif section_name == 'labels' and opt_name == 'label':
+        opt_value = {'value': opt.text}
+        for a in opt.attrib:
+            opt_value[a] = opt.attrib[a]
     else:
         if opt.attrib:
             opt_value = {}


### PR DESCRIPTION
Hi team,

This fix is for API issue [#219](https://github.com/wazuh/wazuh-api/issues/219). I added a configuration section for `labels`:
```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/groups/dmz/files/agent.conf?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "config": {
               "labels": [
                  {
                     "label": [
                        {
                           "key": "aws.instance-id",
                           "value": "i-xxxxx"
                        },
                        {
                           "key": "aws.sec-group",
                           "value": "sg-xxxx"
                        },
                        {
                           "key": "network.ip",
                           "value": "172.xxx"
                        },
                        {
                           "key": "network.mac",
                           "value": "02xxxxx"
                        },
                        {
                           "hidden": "yes",
                           "key": "installation",
                           "value": "January 1st, 2017"
                        }
                     ]
                  }
               ]
            },
            "filters": {}
         }
      ]
   }
}

```

Best regards,

Demetrio.