### PR TITLE
Delete rm line from update script

### DIFF
--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -132,7 +132,6 @@ UpdateStopOSSEC()
         rm -f $DIRECTORY/queue/syscheck/* > /dev/null 2>&1
         rm -f $DIRECTORY/queue/agent-info/* > /dev/null 2>&1
     fi
-    rm -f $DIRECTORY/queue/syscheck/.* > /dev/null 2>&1
     rm -rf $DIRECTORY/framework/* > /dev/null 2>&1
     rm $DIRECTORY/wodles/aws/aws > /dev/null 2>&1 # this script has been renamed
     rm $DIRECTORY/wodles/aws/aws.py > /dev/null 2>&1 # this script has been renamed


### PR DESCRIPTION
Deleted the line `rm -f $DIRECTORY/queue/syscheck/.* > /dev/null 2>&1` that was removing the _.cpt_ file from the File Integrity Monitoring database.