### PR TITLE
Add error message when trying to manage agents being a worker

### DIFF
--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -190,16 +190,17 @@ int main(int argc, char **argv)
     getuname();
 
     int is_worker = w_is_worker();
+    char *master;
 
-    switch (is_worker){
+    switch (is_worker) {
         case -1:
             merror("Invalid option at cluster configuration");
             return 0;
-            break;
         case 1:
-            merror("manage_agents is not available in worker nodes. Please, try it in the master node.");
+            master = get_master_node();
+            merror("Wazuh is running in cluster mode: %s is not available in worker nodes. Please, try again in the master node: %s.", ARGV0, master);
+            free(master);
             return 0;
-            break;
     }
 
 #ifndef WIN32

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -189,9 +189,17 @@ int main(int argc, char **argv)
     srandom_init();
     getuname();
 
-        if(w_is_worker()){
-        merror("Worker nodes can't manage agents");
-        return 0;
+    int is_worker = w_is_worker();
+
+    switch (is_worker){
+        case -1:
+            merror("Invalid option at cluster configuration");
+            return 0;
+            break;
+        case 1:
+            merror("Worker nodes can't manage agents");
+            return 0;
+            break;
     }
 
 #ifndef WIN32

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
             return 0;
             break;
         case 1:
-            merror("Worker nodes can't manage agents");
+            merror("manage_agents is not available in worker nodes. Please, try it in the master node.");
             return 0;
             break;
     }

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -189,6 +189,11 @@ int main(int argc, char **argv)
     srandom_init();
     getuname();
 
+        if(w_is_worker()){
+        merror("Worker nodes can't manage agents");
+        return 0;
+    }
+
 #ifndef WIN32
     if (gethostname(shost, sizeof(shost) - 1) < 0) {
         strncpy(shost, "localhost", sizeof(shost) - 1);

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -54,6 +54,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             }
             os_strdup(node[i]->content, Config->node_name);
         } else if (!strcmp(node[i]->element, node_type)) {
+            os_strdup(node[i]->content, Config->node_type);
         } else if (!strcmp(node[i]->element, key)) {
         } else if (!strcmp(node[i]->element, socket_timeout)) {
         } else if (!strcmp(node[i]->element, connection_timeout)) {

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -679,3 +679,116 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
 
     return (0);
 }
+
+
+void config_free(_Config *config) {
+
+    if (!config) {
+        return;
+    }
+
+    if (config->prelude_profile) {
+        free(config->prelude_profile);
+    }
+
+    if (config->geoipdb_file) {
+        free(config->geoipdb_file);
+    }
+
+    if (config->zeromq_output_uri) {
+        free(config->zeromq_output_uri);
+    }
+
+    if (config->zeromq_output_server_cert) {
+        free(config->zeromq_output_server_cert);
+    }
+
+    if (config->zeromq_output_client_cert) {
+        free(config->zeromq_output_client_cert);
+    }
+
+    if (config->custom_alert_output_format) {
+        free(config->custom_alert_output_format);
+    }
+
+    if (config->syscheck_ignore) {
+        int i = 0;
+        while (config->syscheck_ignore[i]) {
+            free(config->syscheck_ignore[i]);
+            i++;
+        }
+        free(config->syscheck_ignore);
+    }
+
+    if (config->white_list) {
+        int i = 0;
+        while (config->white_list[i]) {
+            free(config->white_list[i]->ip);
+            i++;
+        }
+        free(config->white_list);
+    }
+
+    if (config->includes) {
+        int i = 0;
+        while (config->includes[i]) {
+            free(config->includes[i]);
+            i++;
+        }
+        free(config->includes);
+    }
+
+    if (config->lists) {
+        int i = 0;
+        while (config->lists[i]) {
+            free(config->lists[i]);
+            i++;
+        }
+        free(config->lists);
+    }
+
+    if (config->decoders) {
+        int i = 0;
+        while (config->decoders[i]) {
+            free(config->decoders[i]);
+            i++;
+        }
+        free(config->decoders);
+    }
+
+    if (config->g_rules_hash) {
+        OSHash_Free(config->g_rules_hash);
+    }
+
+    if (config->hostname_white_list) {
+        int i = 0;
+        while (config->hostname_white_list[i]) {
+            OSMatch_FreePattern(config->hostname_white_list[i]);
+            i++;
+        }
+        free(config->hostname_white_list);
+    }
+
+#ifdef LIBGEOIP_ENABLED
+    if (config->geoip_db_path) {
+        free(config->geoip_db_path);
+    }
+    if (config->geoip6_db_path) {
+        free(config->geoip_db_path);
+    }
+#endif
+
+    labels_free(config->labels); /* null-ended label set */
+
+    // Cluster configuration
+    if (config->cluster_name) {
+        free(config->cluster_name);
+    }
+    if (config->node_name) {
+        free(config->node_name);
+    }
+    if (config->node_type) {
+        free(config->node_type);
+    }
+
+}

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -112,4 +112,7 @@ typedef struct __Config {
     long queue_size;
 } _Config;
 
+
+void config_free(_Config *config);
+
 #endif /* _CCONFIG__H */

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -103,6 +103,7 @@ typedef struct __Config {
     // Cluster configuration
     char *cluster_name;
     char *node_name;
+    char *node_type;
     unsigned char hide_cluster_info;
 
     int rotate_interval;

--- a/src/headers/cluster_utils.h
+++ b/src/headers/cluster_utils.h
@@ -12,6 +12,10 @@
 #ifndef CLUSTER_UTILS_H_
 #define CLUSTER_UTILS_H_
 
-int w_is_worker();
+// Returns 1 if the node is a worker, 0 if it is not and -1 if error.
+int w_is_worker(void);
 
-#endif 
+// Returns the master node or "undefined" if any node is specified.
+char *get_master_node(void);
+
+#endif

--- a/src/headers/cluster_utils.h
+++ b/src/headers/cluster_utils.h
@@ -1,0 +1,17 @@
+/*
+ * URL download support library
+ * Copyright (C) 2018 Wazuh Inc.
+ * April 3, 2018.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef CLUSTER_UTILS_H_
+#define CLUSTER_UTILS_H_
+
+int w_is_worker();
+
+#endif 

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -226,5 +226,6 @@ extern const char *__local_name;
 #include "error_messages/debug_messages.h"
 #include "custom_output_search.h"
 #include "url.h"
+#include "cluster_utils.h"
 
 #endif /* __SHARED_H */

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -351,9 +351,17 @@ int main(int argc, char **argv)
         exit(0);
     }
 
-    if(w_is_worker()){
-        merror("Worker nodes can't run authd");
-        return 0;
+    int is_worker = w_is_worker();
+
+    switch (is_worker) {
+        case -1:
+            merror("Invalid option at cluster configuration");
+            return 0;
+            break;
+        case 1:
+            merror("Worker nodes can't run authd");
+            return 0;
+            break;
     }
 
     /* Exit here if disabled */

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -359,7 +359,7 @@ int main(int argc, char **argv)
             return 0;
             break;
         case 1:
-            merror("Worker nodes can't run authd");
+            merror("authd is not available in worker nodes. Please, try it in the master node.");
             return 0;
             break;
     }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -351,6 +351,11 @@ int main(int argc, char **argv)
         exit(0);
     }
 
+    if(w_is_worker()){
+        merror("Worker nodes can't run authd");
+        return 0;
+    }
+
     /* Exit here if disabled */
     if (config.flags.disabled) {
         minfo("Daemon is disabled. Closing.");

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -352,16 +352,17 @@ int main(int argc, char **argv)
     }
 
     int is_worker = w_is_worker();
+    char *master;
 
     switch (is_worker) {
         case -1:
             merror("Invalid option at cluster configuration");
             return 0;
-            break;
         case 1:
-            merror("authd is not available in worker nodes. Please, try it in the master node.");
+            master = get_master_node();
+            merror("Wazuh is running in cluster mode: %s is not available in worker nodes. Please, try again in the master node: %s.", ARGV0, master);
+            free(master);
             return 0;
-            break;
     }
 
     /* Exit here if disabled */

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -49,10 +49,6 @@ int main(int argc, char **argv)
     int test_config = 0, run_foreground = 0;
     int nocmerged = 0;
 
-    OS_XML xml;
-    const char * xmlf[] = {"ossec_config", "cluster", "disabled", NULL};
-    const char * xmlf2[] = {"ossec_config", "cluster", "node_type", NULL};
-
     const char *cfg = DEFAULTCPATH;
     const char *dir = DEFAULTDIR;
     const char *user = REMUSER;
@@ -135,28 +131,18 @@ int main(int argc, char **argv)
 
     // Don`t create the merged file in worker nodes of the cluster
 
-    if (OS_ReadXML(cfg, &xml) < 0) {
-        mdebug1(XML_ERROR, cfg, xml.err, xml.err_line);
-    } else {
-        // Read the cluster status and the node type from the configuration file
-        char * cl_status = OS_GetOneContentforElement(&xml, xmlf);
-        if (cl_status && cl_status[0] != '\0') {
-            if (!strncmp(cl_status, "no", 2)) {
-                char * cl_type = OS_GetOneContentforElement(&xml, xmlf2);
-                if (cl_type && cl_type[0] != '\0') {
-                    if (!strncmp(cl_type, "client", 6) || !strncmp(cl_type, "worker", 6)) {
-                        mdebug1("Cluster client node: Disabling the merged.mg creation");
-                        logr.nocmerged = 1;
-                    }
-                    free(cl_type);
-                }
-            }
+    // Read the cluster status and the node type from the configuration file
+    int is_worker = w_is_worker();
 
-            free(cl_status);
-        }
-    }
-    OS_ClearXML(&xml);
-
+    switch (is_worker){
+        case -1:
+            merror("Cannot read cluster config %s", strerror(errno));
+            break;
+        case 1:
+            mdebug1("Cluster client node: Disabling the merged.mg creation");
+            logr.nocmerged = 1;
+            break;
+}
 
     /* Exit if test_config is set */
     if (test_config) {

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -14,7 +14,7 @@
 #include "../config/global-config.h"
 
 // Returns 1 if the node is a worker, 0 if it is not and -1 if error.
-int w_is_worker(){
+int w_is_worker(void) {
 
     OS_XML xml;
     const char * xmlf[] = {"ossec_config", "cluster", "disabled", NULL};
@@ -58,4 +58,35 @@ int w_is_worker(){
     OS_ClearXML(&xml);
 
     return is_worker;
+}
+
+
+char *get_master_node(void) {
+
+    OS_XML xml;
+    const char * xmlf[] = {"ossec_config", "cluster", "nodes", "node", NULL};
+    const char *cfgfile = DEFAULTCPATH;
+    _Config cfg;
+    int modules = 0;
+    char *master_node = NULL;
+
+    modules |= CCLUSTER;
+
+    if (ReadConfig(modules, cfgfile, &cfg, NULL) < 0) {
+        master_node = strdup("undefined");
+    }
+
+    if (OS_ReadXML(cfgfile, &xml) < 0) {
+        mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
+    } else {
+        master_node = OS_GetOneContentforElement(&xml, xmlf);
+    }
+
+    OS_ClearXML(&xml);
+
+    if (!master_node) {
+        master_node = strdup("undefined");
+    }
+
+    return master_node;
 }

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -23,6 +23,7 @@ int w_is_worker(void) {
     int modules = 0;
     int is_worker = 0;
     _Config cfg;
+    memset(&cfg, 0, sizeof(_Config));
 
     modules |= CCLUSTER;
 
@@ -56,6 +57,7 @@ int w_is_worker(void) {
         }
     }
     OS_ClearXML(&xml);
+    config_free(&cfg);
 
     return is_worker;
 }
@@ -69,6 +71,7 @@ char *get_master_node(void) {
     _Config cfg;
     int modules = 0;
     char *master_node = NULL;
+    memset(&cfg, 0, sizeof(_Config));
 
     modules |= CCLUSTER;
 
@@ -87,6 +90,8 @@ char *get_master_node(void) {
     if (!master_node) {
         master_node = strdup("undefined");
     }
+
+    config_free(&cfg);
 
     return master_node;
 }

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -1,0 +1,31 @@
+/*
+ * URL download support library
+ * Copyright (C) 2018 Wazuh Inc.
+ * October 26, 2018.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "shared.h"
+#include "../config/config.h"
+#include "../config/global-config.h"
+
+int w_is_worker(){
+
+    const char *cfgfile = DEFAULTCPATH;
+    int modules = 0;
+    int is_worker = 0;
+    _Config cfg;
+
+    modules |= CCLUSTER;
+
+    if (ReadConfig(modules, cfgfile, &cfg, NULL) < 0) {
+        return (OS_INVALID);
+    }
+    is_worker = !strncmp(cfg.node_type, "worker", 6) ? 1 : 0;
+
+    return is_worker;
+}

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -13,8 +13,12 @@
 #include "../config/config.h"
 #include "../config/global-config.h"
 
+// Returns 1 if the node is a worker, 0 if it is not and -1 if error.
 int w_is_worker(){
 
+    OS_XML xml;
+    const char * xmlf[] = {"ossec_config", "cluster", "disabled", NULL};
+    const char * xmlf2[] = {"ossec_config", "cluster", "node_type", NULL};
     const char *cfgfile = DEFAULTCPATH;
     int modules = 0;
     int is_worker = 0;
@@ -25,7 +29,33 @@ int w_is_worker(){
     if (ReadConfig(modules, cfgfile, &cfg, NULL) < 0) {
         return (OS_INVALID);
     }
-    is_worker = !strncmp(cfg.node_type, "worker", 6) ? 1 : 0;
+
+    if (OS_ReadXML(cfgfile, &xml) < 0) {
+        mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
+    } else {
+        char * cl_status = OS_GetOneContentforElement(&xml, xmlf);
+        if (cl_status && cl_status[0] != '\0') {
+            if (!strcmp(cl_status, "no")) {
+                char * cl_type = OS_GetOneContentforElement(&xml, xmlf2);
+                if (cl_type && cl_type[0] != '\0') {
+                    if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
+                        is_worker = 1;
+                    } else if (!strcmp(cl_type, "master")){
+                        is_worker = 0;
+                    } else {
+                        is_worker = -1;
+                    }
+                    free(cl_type);
+                }
+            } else if (strcmp(cl_status, "yes")){
+                is_worker = -1;
+            }
+            free(cl_status);
+        } else {
+            is_worker = -1;
+        }
+    }
+    OS_ClearXML(&xml);
 
     return is_worker;
 }

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -77,6 +77,19 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
+    int is_worker = w_is_worker();
+
+    switch (is_worker) {
+        case -1:
+            merror("Invalid option at cluster configuration");
+            return 0;
+            break;
+        case 1:
+            merror("agent_control is not available in worker nodes. Please, try it in the master node.");
+            return 0;
+            break;
+    }
+
     /* User arguments */
     if (argc < 2) {
         helpmsg();

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -78,16 +78,17 @@ int main(int argc, char **argv)
     OS_SetName(ARGV0);
 
     int is_worker = w_is_worker();
+    char *master;
 
     switch (is_worker) {
         case -1:
             merror("Invalid option at cluster configuration");
             return 0;
-            break;
         case 1:
-            merror("agent_control is not available in worker nodes. Please, try it in the master node.");
+            master = get_master_node();
+            merror("Wazuh is running in cluster mode: %s is not available in worker nodes. Please, try again in the master node: %s.", ARGV0, master);
+            free(master);
             return 0;
-            break;
     }
 
     /* User arguments */


### PR DESCRIPTION
This PR adds an error message when a `worker` node tries to run `manage_agents` or `ossec-authd`, as this is only possible at the server node.