### PR TITLE
Move cluster request timeout to cluster.json

### DIFF
--- a/framework/wazuh/cluster/cluster.json
+++ b/framework/wazuh/cluster/cluster.json
@@ -134,7 +134,10 @@
 
             "max_time_receiving_string": 30,
             "string_transfer_receive": 0.1,
-            "string_transfer_send": 0.1
+            "string_transfer_send": 0.1,
+
+            "timeout_cluster_request": 20,
+            "timeout_api_request": 200
         }
     },
 

--- a/framework/wazuh/cluster/communication.py
+++ b/framework/wazuh/cluster/communication.py
@@ -105,7 +105,7 @@ class Response:
     def __init__(self):
         self.cond = threading.Condition()
         self.data = None
-
+        self.response_timeout = get_cluster_items_communication_intervals()['timeout_cluster_request']
 
     def read(self):
         def frange(start, stop, step):
@@ -116,7 +116,7 @@ class Response:
 
         with self.cond:
             # wait for a response for common.cluster_timeout_msg seconds
-            for _ in frange(1,common.cluster_timeout_msg,0.5):
+            for _ in frange(1,self.response_timeout,0.5):
                 self.cond.wait(timeout=0.5)
                 if self.data is not None:
                     break

--- a/framework/wazuh/cluster/internal_socket.py
+++ b/framework/wazuh/cluster/internal_socket.py
@@ -6,7 +6,8 @@
 from wazuh.cluster import communication
 from wazuh import common
 from wazuh.exception import WazuhException
-from wazuh.cluster.cluster import read_config, check_cluster_config, get_status_json
+from wazuh.cluster.cluster import read_config, check_cluster_config, get_status_json, \
+    get_cluster_items_communication_intervals
 import socket
 import random
 import json
@@ -246,7 +247,7 @@ def execute(request):
         # Wait response
         #  Data received will be free when dapi_forward request is received, or when a json/err response is processed.
         logger.debug("Waiting response.")
-        timeout_not_expired = data_received.wait(25)
+        timeout_not_expired = data_received.wait(get_cluster_items_communication_intervals()['timeout_api_request'])
 
         if timeout_not_expired:
             response = json.loads(isocket_worker_thread.manager.final_data)

--- a/framework/wazuh/common.py
+++ b/framework/wazuh/common.py
@@ -110,7 +110,6 @@ agent_info_sleep = 2 # Seconds between retries
 database_limit = 500
 maximum_database_limit = 1000
 limit_seconds = 1800 # 600*3
-cluster_timeout_msg = 20
 
 ossec_uid = getpwnam("ossec").pw_uid
 ossec_gid = getgrnam("ossec").gr_gid


### PR DESCRIPTION
Hello team,

The current cluster request timeout was defined in `common.py` file. I think that wasn't appropriate since there is a `cluster.json` file which already defines these parameters. This PR moves the cluster request timeout parameter from `common.py` to `cluster.json`.

Best regards,
Marta