### PR TITLE
Duplicated syscheck remote config thread

### DIFF
--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -203,11 +203,6 @@ void start_daemon()
         }
     }
 
-#ifndef WIN32
-    // Start com request thread
-    w_create_thread(syscom_main, NULL);
-#endif
-
     /* Check every SYSCHECK_WAIT */
     while (1) {
         int run_now = 0;


### PR DESCRIPTION
This PR solves https://github.com/wazuh/wazuh/issues/1738

Thread initialization was duplicated here https://github.com/wazuh/wazuh/blob/3.7/src/syscheckd/syscheck.c#L365