### PR TITLE
Let Authd log the client IP on timeout

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -658,14 +658,15 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
 
         buf[0] = '\0';
         ret = SSL_read(ssl, buf, OS_SIZE_65536 + OS_SIZE_4096);
-        if (ssl_error(ssl, ret)) {
-            merror("SSL Error (%d)", ret);
-            SSL_free(ssl);
-            close(client.socket);
-            free(buf);
-            continue;
-        } else if (ret <= 0) {
-            minfo("Client was disconnected, or network timeout.");
+        if (ret <= 0) {
+            switch (ssl_error(ssl, ret)) {
+            case 0:
+                minfo("Client timeout from %s", srcip);
+                break;
+            default:
+                merror("SSL Error (%d)", ret);
+            }
+
             SSL_free(ssl);
             close(client.socket);
             free(buf);


### PR DESCRIPTION
This PR improves client timeout detection and shows a log like this on timeout:

```
2018/10/30 12:14:40 ossec-authd: INFO: Started (pid: 5719).
2018/10/30 12:14:40 ossec-authd: INFO: Accepting connections on port 1515. No password required.
2018/10/30 12:14:40 ossec-authd: INFO: Setting network timeout to 5.000000 sec.
2018/10/30 12:14:42 ossec-authd: INFO: New connection from 192.168.33.12
2018/10/30 12:14:47 ossec-authd: INFO: Client timeout from 192.168.33.12
```