### PR TITLE
Fix whodata in Linux 

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -212,6 +212,7 @@ typedef struct _config {
     OSHash *fp;
     OSHash *last_check;
     OSHash *local_hash;
+    OSHash *inode_hash;
 
     rtfim *realtime;
 

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -81,6 +81,7 @@ typedef struct whodata_evt {
     char *audit_name;  // Linux
     char *effective_uid;  // Linux
     char *effective_name;  // Linux
+    char *inode;  // Linux
     int ppid;  // Linux
 #ifndef WIN32
     unsigned int process_id;

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -126,6 +126,7 @@ void free_whodata_event(whodata_evt *w_evt) {
     if (w_evt->group_id) free(w_evt->group_id);
     if (w_evt->path) free(w_evt->path);
     if (w_evt->process_name) free(w_evt->process_name);
+    if (w_evt->inode) free(w_evt->inode);
     free(w_evt);
 }
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -702,6 +702,7 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
     }
     else if (evt) {
         free(f_name);
+        closedir(dp);
         return (0);
     }
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -184,6 +184,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     os_calloc(OS_SIZE_6144 + 1, sizeof(char), wd_sum);
 #ifndef WIN32
     char str_owner[50], str_group[50];
+    char *hash_file_name;
 #else
     const char *user;
     char *sid = NULL;
@@ -430,7 +431,9 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 merror("Unable to add file to db: %s", file_name);
             }
 #ifndef WIN32
-            if (OSHash_Add_ex(syscheck.inode_hash, str_inode, strdup(file_name)) <= 0) {
+            hash_file_name = strdup(file_name);
+            if (OSHash_Add_ex(syscheck.inode_hash, str_inode, hash_file_name) != 2) {
+                free(hash_file_name);
                 mwarn("Unable to add inode to db: %s (%s) ", file_name, str_inode);
             }
 #endif

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -701,6 +701,7 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
         return (-1);
     }
     else if (evt) {
+        free(f_name);
         return (0);
     }
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -429,11 +429,11 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 free(s_node);
                 merror("Unable to add file to db: %s", file_name);
             }
-
+#ifndef WIN32
             if (OSHash_Add_ex(syscheck.inode_hash, str_inode, strdup(file_name)) <= 0) {
                 mwarn("Unable to add inode to db: %s (%s) ", file_name, str_inode);
             }
-
+#endif
             /* Send the new checksum to the analysis server */
             alert_msg[OS_MAXSTR] = '\0';
 
@@ -846,10 +846,12 @@ int create_db()
         merror(LIST_ERROR);
         return (0);
     }
+#ifndef WIN32
     if (!OSHash_setSize(syscheck.inode_hash, 2048)) {
         merror(LIST_ERROR);
         return (0);
     }
+#endif
 
     if ((syscheck.dir == NULL) || (syscheck.dir[0] == NULL)) {
         merror("No directories to check.");

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -430,6 +430,10 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 merror("Unable to add file to db: %s", file_name);
             }
 
+            if (OSHash_Add_ex(syscheck.inode_hash, str_inode, strdup(file_name)) <= 0) {
+                mwarn("Unable to add inode to db: %s (%s) ", file_name, str_inode);
+            }
+
             /* Send the new checksum to the analysis server */
             alert_msg[OS_MAXSTR] = '\0';
 
@@ -691,10 +695,13 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
             return 0;
         }
 #else
-        mwarn("Cannot open '%s': %s ", dir_name, strerror(errno));
+        mdebug2("Cannot open '%s': %s ", dir_name, strerror(errno));
 #endif /* WIN32 */
         free(f_name);
         return (-1);
+    }
+    else if (evt) {
+        return (0);
     }
 
     /* Check for real time flag */
@@ -834,6 +841,10 @@ int create_db()
         return (0);
     }
     if (!OSHash_setSize(syscheck.local_hash, 2048)) {
+        merror(LIST_ERROR);
+        return (0);
+    }
+    if (!OSHash_setSize(syscheck.inode_hash, 2048)) {
         merror(LIST_ERROR);
         return (0);
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -89,6 +89,7 @@ static void send_sk_db(int first_start)
     /* Send end scan control message */
     if(first_start) {
         send_syscheck_msg(HC_FIM_DB_EFS);
+        w_cond_signal(&audit_db_consistency);
     } else {
         send_syscheck_msg(HC_FIM_DB_ES);
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -89,7 +89,9 @@ static void send_sk_db(int first_start)
     /* Send end scan control message */
     if(first_start) {
         send_syscheck_msg(HC_FIM_DB_EFS);
+#ifndef WIN32
         w_cond_signal(&audit_db_consistency);
+#endif
     } else {
         send_syscheck_msg(HC_FIM_DB_ES);
     }
@@ -361,9 +363,11 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             free(s_node->checksum);
             free(s_node);
         }
+#ifndef WIN32
         if (s_node = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), s_node) {
             free(s_node);
         }
+#endif
         struct timeval timeout = {0, syscheck.rt_delay * 1000};
         select(0, NULL, NULL, NULL, &timeout);
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -321,6 +321,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
     os_sha1 sf_sum;
     os_sha256 sf256_sum;
     syscheck_node *s_node;
+    char *w_inode;
     char str_size[50], str_perm[50], str_mtime[50], str_inode[50];
 #ifndef WIN32
     char str_owner[50], str_group[50];
@@ -364,8 +365,8 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             free(s_node);
         }
 #ifndef WIN32
-        if (s_node = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), s_node) {
-            free(s_node);
+        if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), w_inode) {
+            free(w_inode);
         }
 #endif
         struct timeval timeout = {0, syscheck.rt_delay * 1000};

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -361,6 +361,9 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             free(s_node->checksum);
             free(s_node);
         }
+        if (s_node = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), s_node) {
+            free(s_node);
+        }
         struct timeval timeout = {0, syscheck.rt_delay * 1000};
         select(0, NULL, NULL, NULL, &timeout);
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -19,6 +19,7 @@
 #include "syscheck.h"
 
 volatile int audit_thread_active;
+volatile int whodata_alerts;
 
 #ifdef INOTIFY_ENABLED
 #include <sys/inotify.h>

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -78,8 +78,9 @@ int fim_initialize() {
     /* Create store data */
     syscheck.fp = OSHash_Create();
     syscheck.local_hash = OSHash_Create();
+#ifndef WIN32
     syscheck.inode_hash = OSHash_Create();
-
+#endif
     // Duplicate hash table to check for deleted files
     syscheck.last_check = OSHash_Create();
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -18,6 +18,7 @@
 // Global variables
 syscheck_config syscheck;
 pthread_cond_t audit_thread_started;
+pthread_cond_t audit_db_consistency;
 int sys_debug_level;
 
 #ifdef USE_MAGIC
@@ -77,6 +78,7 @@ int fim_initialize() {
     /* Create store data */
     syscheck.fp = OSHash_Create();
     syscheck.local_hash = OSHash_Create();
+    syscheck.inode_hash = OSHash_Create();
 
     // Duplicate hash table to check for deleted files
     syscheck.last_check = OSHash_Create();
@@ -210,9 +212,6 @@ int Start_win32_Syscheck()
     sleep(syscheck.tsleep * 5);
     fim_initialize();
 
-    if(syscheck.enable_whodata && ! syscheck.scan_on_start)
-        create_db();
-
     /* Wait if agent started properly */
     os_wait();
 
@@ -252,6 +251,7 @@ int main(int argc, char **argv)
     const char *group = GROUPGLOBAL;
 #ifdef ENABLE_AUDIT
     audit_thread_active = 0;
+    whodata_alerts = 0;
 #endif
 
     /* Set the name */

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -97,8 +97,10 @@ void *audit_main(int *audit_sock);
 void clean_rules(void);
 extern W_Vector *audit_added_dirs;
 extern volatile int audit_thread_active;
+extern volatile int whodata_alerts;
 extern pthread_mutex_t audit_mutex;
 extern pthread_cond_t audit_thread_started;
+extern pthread_cond_t audit_db_consistency;
 #elif WIN32
 int whodata_audit_start();
 int set_winsacl(const char *dir, int position);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -398,7 +398,7 @@ int init_regex(void) {
         return -1;
     }
     // static const char *pattern_inode = " inode=([0-9]*) ";
-    static const char *pattern_inode = " item=[1-9] name=.* inode=([0-9]*)";
+    static const char *pattern_inode = " item=[0-9] name=.* inode=([0-9]*)";
     if (regcomp(&regexCompiled_inode, pattern_inode, REG_EXTENDED)) {
         merror("Cannot compile inode regular expression.");
         return -1;
@@ -762,10 +762,13 @@ void audit_parse(char *buffer) {
                                 (w_evt->inode)?w_evt->inode:"",
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
-                            if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp){
-                                realtime_checksumfile(inode_temp, w_evt);
-                            } else {
-                                realtime_checksumfile(w_evt->path, w_evt);
+
+                            if(w_evt->inode){
+                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp){
+                                    realtime_checksumfile(inode_temp, w_evt);
+                                } else {
+                                    realtime_checksumfile(w_evt->path, w_evt);
+                                }
                             }
                         }
                     }
@@ -784,12 +787,14 @@ void audit_parse(char *buffer) {
                                 (w_evt->inode)?w_evt->inode:"",
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
-                            if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp){
-                                realtime_checksumfile(inode_temp, w_evt);
-                            } else {
-                                realtime_checksumfile(w_evt->path, w_evt);
-                            }
 
+                            if(w_evt->inode){
+                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp){
+                                    realtime_checksumfile(inode_temp, w_evt);
+                                } else {
+                                    realtime_checksumfile(w_evt->path, w_evt);
+                                }
+                            }
                         }
                     }
                     break;
@@ -822,10 +827,12 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
-                            if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp){
-                                realtime_checksumfile(inode_temp, w_evt);
-                            } else {
-                                realtime_checksumfile(w_evt->path, w_evt);
+                            if(w_evt->inode){
+                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp){
+                                    realtime_checksumfile(inode_temp, w_evt);
+                                } else {
+                                    realtime_checksumfile(w_evt->path, w_evt);
+                                }
                             }
 
                             free(file_path1);
@@ -847,10 +854,12 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
-                            if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp){
-                                realtime_checksumfile(inode_temp, w_evt);
-                            } else {
-                                realtime_checksumfile(w_evt->path, w_evt);
+                            if(w_evt->inode){
+                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp){
+                                    realtime_checksumfile(inode_temp, w_evt);
+                                } else {
+                                    realtime_checksumfile(w_evt->path, w_evt);
+                                }
                             }
                         }
                     }

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -861,7 +861,6 @@ void audit_parse(char *buffer) {
             free(cwd);
             free(path0);
             free(path1);
-
             free_whodata_event(w_evt);
         }
     }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -962,6 +962,10 @@ void send_whodata_del(whodata_evt *w_evt) {
     if (s_node = OSHash_Delete_ex(syscheck.fp, w_evt->path), !s_node) {
         return;
     }
+    if (s_node = OSHash_Delete_ex(syscheck.inode_hash, w_evt->inode), !s_node) {
+        return;
+    }
+
     free(s_node->checksum);
     free(s_node);
 

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -727,7 +727,7 @@ add_whodata_evt:
                             if (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA, 1), pos >= 0) {
                                 int diff = fim_find_child_depth(syscheck.dir[pos], w_evt->path);
                                 int depth = syscheck.recursion_level[pos] - diff;
-                                read_dir(w_evt->path, pos, w_evt, depth);
+                                read_dir(w_evt->path, pos, NULL, depth);
                             }
 
                             mdebug1("The '%s' directory has been scanned after detecting event of new files.", w_evt->path);
@@ -960,9 +960,6 @@ void send_whodata_del(whodata_evt *w_evt) {
 
     // Remove the file from the syscheck hash table
     if (s_node = OSHash_Delete_ex(syscheck.fp, w_evt->path), !s_node) {
-        return;
-    }
-    if (s_node = OSHash_Delete_ex(syscheck.inode_hash, w_evt->inode), !s_node) {
         return;
     }
 


### PR DESCRIPTION
Hi team,

The main purpose of this pull request is to fix the following scenarios:

- Previously, `whodata` was able to start before the _first sycheck scan_ was finished. This generated an inconsistency as the DB was not initialized correctly and any deletion generated an error as it tried to delete a nonexistent file in the DB. To solve this problem, we have decided to start whodata once the first scan is finished, which guarantees data consistency.

- Until now, there was no `whodata` alert for deleted files inside a folder (#1714) in Linux. The problem was related to an `auditd` failure, which did not generate the paths correctly if the call was recursive. 

Best regards,
Cerv1.