### PR TITLE
Add an option to disable timeout in distributed API calls

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -33,7 +33,7 @@ try:
 
     # Import cluster
     from wazuh.cluster.cluster import read_config
-    from wazuh.cluster.control import get_nodes, get_healthcheck, get_agents, sync, get_files
+    from wazuh.cluster.control import get_nodes, get_healthcheck, get_agents
 
 except Exception as e:
     print("Error importing 'Wazuh' package.\n\n{0}\n".format(e))
@@ -131,50 +131,6 @@ def __print_table(data, headers, show_header=False):
 
     print (table_str)
 
-#
-# Get
-#
-
-### Get files
-def print_file_status_master(filter_file_list, filter_node_list):
-    files = __execute(my_function=get_files, my_args=(filter_file_list, filter_node_list,))
-    headers = ["Node", "File name", "Modification time", "MD5"]
-
-    node_error = {}
-
-    data = []
-    # Convert JSON data to table format
-    for node_name in sorted(files.keys()):
-
-        if not files[node_name]:
-            continue
-        if not isinstance(files[node_name], dict):
-            node_error[node_name] = files[node_name]
-            continue
-
-        for file_name in sorted(files[node_name].keys()):
-            my_file = [node_name, file_name, files[node_name][file_name]['mod_time'].split('.', 1)[0], files[node_name][file_name]['md5']]
-            data.append(my_file)
-
-    __print_table(data, headers, True)
-
-    if len(node_error) > 0:
-        print ("Error:")
-        for node, error in node_error.items():
-            print (" - {}: {}".format(node, error))
-
-
-def print_file_status_worker(filter_file_list, node_name):
-    my_files = __execute(my_function=get_files, my_args=(filter_file_list, node_name,))
-    headers = ["Node", "File name", "Modification time", "MD5"]
-    data = []
-    for file_name in sorted(my_files.keys()):
-            my_file = [node_name, file_name, my_files[file_name]['mod_time'].split('.', 1)[0], my_files[file_name]['md5']]
-            data.append(my_file)
-
-    __print_table(data, headers, True)
-    print ("(*) Workers only show their own files.")
-
 
 ### Get nodes
 def print_nodes_status(filter_node=None):
@@ -187,15 +143,6 @@ def print_nodes_status(filter_node=None):
 
     if len(response["node_error"]):
         print ("The following nodes could not be found: {}.".format(' ,'.join(response["node_error"])))
-
-
-### Sync
-def sync_master(filter_node):
-    node_response = __execute(my_function=sync, my_args=(filter_node,))
-    headers = ["Node", "Response"]
-    data = [[node, response] for node, response in node_response.items()]
-    __print_table(data, headers, True)
-
 
 ### Get agents
 def print_agents(filter_status, filter_node, is_master):

--- a/framework/wazuh/cluster/control.py
+++ b/framework/wazuh/cluster/control.py
@@ -83,16 +83,6 @@ def get_healthcheck(filter_node=None):
     return execute(request)
 
 
-def sync(filter_node=None):
-    request = "sync {}".format(filter_node) if filter_node else "sync"
-    return execute(request)
-
-
-def get_files(filter_file_list=None, filter_node_list=None):
-    request = "get_files {}".format(filter_file_list) if not filter_node_list else "get_files {}%--%{}".format(filter_file_list, filter_node_list)
-    return execute(request)
-
-
 def get_agents(filter_status, filter_node, is_master):
     filter_status = ["all"] if not filter_status else filter_status
     filter_node = ["all"] if not filter_node else filter_node

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -48,7 +48,7 @@ def distribute_function(input_json, pretty=False, debug=False):
                 (request_type == 'local_master' and node_info['type'] == 'master')   or\
                 (request_type == 'distributed_master' and input_json['from_cluster']):
 
-            del input_json['arguments']['wait_for']  # local requests don't use this parameter
+            del input_json['arguments']['wait_for_complete']  # local requests don't use this parameter
             return execute_local_request(input_json, pretty, debug)
 
         # Second case: forward the request
@@ -136,7 +136,7 @@ def execute_remote_request(input_json, pretty):
     :param pretty: JSON pretty print
     :return: JSON response
     """
-    response = i_s.execute('dapi {}'.format(json.dumps(input_json)), input_json['arguments']['wait_for'])
+    response = i_s.execute('dapi {}'.format(json.dumps(input_json)), input_json['arguments']['wait_for_complete'])
     data, error = __split_response_data(response)
     return print_json(data=data, pretty=pretty, error=error)
 
@@ -172,7 +172,7 @@ def forward_request(input_json, master_name, pretty, debug):
             else:
                 # if it's a worker, forward it
                 response = i_s.execute('{} {}'.format(command, json.dumps(input_json)),
-                                       input_json['arguments']['wait_for'])
+                                       input_json['arguments']['wait_for_complete'])
                 if not isinstance(response, dict):
                     # If there's an error and the flag return_none is not set, return a dictionary with the response.
                     response = {'error':3016, 'message':str(WazuhException(3016,response))} if not return_none else None

--- a/framework/wazuh/cluster/internal_socket.py
+++ b/framework/wazuh/cluster/internal_socket.py
@@ -226,7 +226,7 @@ def check_cluster_status():
         raise WazuhException(3012)
 
 
-def execute(request):
+def execute(request, disable_timeout=False):
     socket_name = "c-internal"
     try:
         # if no exception is raised from function check_cluster_status, the cluster is ok.
@@ -247,7 +247,8 @@ def execute(request):
         # Wait response
         #  Data received will be free when dapi_forward request is received, or when a json/err response is processed.
         logger.debug("Waiting response.")
-        timeout_not_expired = data_received.wait(get_cluster_items_communication_intervals()['timeout_api_request'])
+        timeout_not_expired = data_received.wait(None if disable_timeout else
+                                                 get_cluster_items_communication_intervals()['timeout_api_request'])
 
         if timeout_not_expired:
             response = json.loads(isocket_worker_thread.manager.final_data)


### PR DESCRIPTION
Hello team,

This PR adds framework support to disable timeout in distributed API calls. An example:
```shellsession
# time curl -u foo:bar "localhost:55000/syscollector/001/packages?pretty&wait_for&limit=1"
{
   "error": 0,
   "data": {
      "totalItems": 513,
      "items": [
         {
            "description": "Python interface to libapt-pkg (locales)",
            "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
            "name": "python-apt-common",
            "format": "deb",
            "section": "python",
            "scan": {
               "id": 45095787,
               "time": "2018/10/30 15:44:06"
            },
            "priority": "optional",
            "source": "python-apt",
            "version": "1.6.0",
            "architecture": "all",
            "size": 244
         }
      ]
   }
}

real    0m1.805s
user    0m0.008s
sys     0m0.000s
# time curl -u foo:bar "localhost:55000/syscollector/001/packages?pretty&limit=1"
{
   "error": 1000,
   "message": "Timeout waiting local server."
}

real    0m1.209s
user    0m0.010s
sys     0m0.000s
```

This example has been done setting API timeout to 1:
https://github.com/wazuh/wazuh/blob/44631c3b68a5c4d7069fe044ea78a7129ce9a448/framework/wazuh/cluster/cluster.json#L140

Best regards,
Marta