### PR TITLE
Add reception timeout to Remoted in TCP mode

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -154,6 +154,9 @@ remoted.rlimit_nofile=65536
 # Maximum time waiting for a client response in TCP (seconds) [1..60]
 remoted.recv_timeout=1
 
+# Maximum time waiting for a client delivery in TCP (seconds) [1..60]
+remoted.send_timeout=1
+
 # Merge shared configuration to be broadcasted to agents
 # 0. Disable
 # 1. Enable (default)

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -30,6 +30,7 @@ static void move_netdata(keystore *keys, const keystore *old_keys)
 {
     unsigned int i;
     int keyid;
+    char strsock[16];
 
     for (i = 0; i < old_keys->keysize; i++) {
         keyid = OS_IsAllowedID(keys, old_keys->keyentries[i]->id);
@@ -38,6 +39,9 @@ static void move_netdata(keystore *keys, const keystore *old_keys)
             keys->keyentries[keyid]->rcvd = old_keys->keyentries[i]->rcvd;
             keys->keyentries[keyid]->sock = old_keys->keyentries[i]->sock;
             memcpy(&keys->keyentries[keyid]->peer_info, &old_keys->keyentries[i]->peer_info, sizeof(struct sockaddr_in));
+
+            snprintf(strsock, sizeof(strsock), "%d", keys->keyentries[keyid]->sock);
+            OSHash_Add(keys->keyhash_sock, strsock, keys->keyentries[keyid]);
         }
     }
 }

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -509,6 +509,11 @@ int OS_SetRecvTimeout(int socket, long seconds, long useconds)
     return setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const void *)&tv, sizeof(tv));
 }
 
+int OS_SetSendTimeout(int socket, int seconds)
+{
+    struct timeval tv = { seconds, 0 };
+    return setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, (const void *)&tv, sizeof(tv));
+}
 
 /* Send secure TCP message
  * This function prepends a header containing message size as 4-byte little-endian unsigned integer.

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -80,6 +80,11 @@ int OS_CloseSocket(int socket);
  */
 int OS_SetRecvTimeout(int socket, long seconds, long useconds);
 
+/* Set the delivery timeout for a socket
+ * Returns 0 on success, else -1
+ */
+int OS_SetSendTimeout(int socket, int seconds);
+
 /* Send secure TCP message
  * This function prepends a header containing message size as 4-byte little-endian unsigned integer.
  * Return 0 on success or OS_SOCKTERR on error.

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -915,7 +915,7 @@ static void read_controlmsg(const char *agent_id, char *msg)
                 }
 
                 if (send_file_toagent(agent_id, group, SHAREDCFG_FILENAME, tmp_sum,sharedcfg_dir) < 0) {
-                    merror(SHARED_ERROR, SHAREDCFG_FILENAME, agent_id);
+                    mwarn(SHARED_ERROR, SHAREDCFG_FILENAME, agent_id);
                 }
 
                 mdebug2("End sending file '%s/%s' to agent '%s'.", group, SHAREDCFG_FILENAME, agent_id);
@@ -958,7 +958,7 @@ static void read_controlmsg(const char *agent_id, char *msg)
             }
 
             if (send_file_toagent(agent_id, group, f_sum[i]->name, f_sum[i]->sum,sharedcfg_dir) < 0) {
-                merror(SHARED_ERROR, f_sum[i]->name, agent_id);
+                mwarn(SHARED_ERROR, f_sum[i]->name, agent_id);
             }
         }
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -748,8 +748,7 @@ int send_file_toagent(const char *agent_id, const char *group, const char *name,
     snprintf(buf, OS_SIZE_1024, "%s%s%s %s\n",
              CONTROL_HEADER, FILE_UPDATE_HEADER, sum, name);
 
-    if (send_msg(agent_id, buf, -1) == -1) {
-        merror(SEC_ERROR);
+    if (send_msg(agent_id, buf, -1) < 0) {
         fclose(fp);
         return (-1);
     }
@@ -758,8 +757,7 @@ int send_file_toagent(const char *agent_id, const char *group, const char *name,
     while ((n = fread(buf, 1, 900, fp)) > 0) {
         buf[n] = '\0';
 
-        if (send_msg(agent_id, buf, -1) == -1) {
-            merror(SEC_ERROR);
+        if (send_msg(agent_id, buf, -1) < 0) {
             fclose(fp);
             return (-1);
         }
@@ -777,8 +775,7 @@ int send_file_toagent(const char *agent_id, const char *group, const char *name,
     /* Send the message to close the file */
     snprintf(buf, OS_SIZE_1024, "%s%s", CONTROL_HEADER, FILE_CLOSE_HEADER);
 
-    if (send_msg(agent_id, buf, -1) == -1) {
-        merror(SEC_ERROR);
+    if (send_msg(agent_id, buf, -1) < 0) {
         fclose(fp);
         return (-1);
     }

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -19,15 +19,17 @@
 keystore keys;
 remoted logr;
 char* node_name;
-int timeout;    //timeout in seconds waiting for a client reply
 rlim_t nofile;
 
 /* Handle remote connections */
 void HandleRemote(int uid)
 {
     int position = logr.position;
+    int recv_timeout;    //timeout in seconds waiting for a client reply
+    int send_timeout;
 
-    timeout = getDefine_Int("remoted", "recv_timeout", 1, 60);
+    recv_timeout = getDefine_Int("remoted", "recv_timeout", 1, 60);
+    send_timeout = getDefine_Int("remoted", "send_timeout", 1, 60);
 
     /* If syslog connection and allowips is not defined, exit */
     if (logr.conn[position] == SYSLOG_CONN) {
@@ -61,10 +63,10 @@ void HandleRemote(int uid)
         if ((logr.sock = OS_Bindporttcp(logr.port[position], logr.lip[position], logr.ipv6[position])) < 0) {
             merror_exit(BIND_ERROR, logr.port[position], errno, strerror(errno));
         } else if (logr.conn[position] == SECURE_CONN) {
-            if (OS_SetRecvTimeout(logr.sock, timeout, 0) < 0){
+            if (OS_SetRecvTimeout(logr.sock, recv_timeout, 0) < 0){
                 merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
             }
-            if (OS_SetSendTimeout(logr.sock, timeout) < 0){
+            if (OS_SetSendTimeout(logr.sock, send_timeout) < 0){
                 merror("OS_SetSendTimeout failed with error '%s'", strerror(errno));
             }
         }

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -64,6 +64,9 @@ void HandleRemote(int uid)
             if (OS_SetRecvTimeout(logr.sock, timeout, 0) < 0){
                 merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
             }
+            if (OS_SetSendTimeout(logr.sock, timeout) < 0){
+                merror("OS_SetSendTimeout failed with error '%s'", strerror(errno));
+            }
         }
     } else {
         /* Using UDP. Fast, unreliable... perfect */

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -237,10 +237,10 @@ void * req_dispatch(req_node_t * node) {
             // Try to send message
 
             if (send_msg(agentid, payload, ldata)) {
-                merror("Sending request to agent '%s'.", agentid);
+                mwarn("Sending request to agent '%s'.", agentid);
 
                 if (OS_SendSecureTCP(node->sock, strlen(WR_SEND_ERROR), WR_SEND_ERROR) < 0) {
-                    merror("Couldn't report sending error to client.");
+                    mwarn("Couldn't report sending error to client.");
                 }
                 goto cleanup;
             }
@@ -268,7 +268,7 @@ void * req_dispatch(req_node_t * node) {
             merror("Couldn't send request to agent '%s': number of attempts exceeded.", agentid);
 
             if (OS_SendSecureTCP(node->sock, strlen(WR_ATTEMPT_ERROR), WR_ATTEMPT_ERROR) < 0) {
-                merror("Couldn't report error about number of attempts exceeded to client.");
+                mwarn("Couldn't report error about number of attempts exceeded to client.");
             }
 
             goto cleanup;
@@ -310,9 +310,8 @@ void * req_dispatch(req_node_t * node) {
         mdebug2("Sending response: '%s'", node->buffer);
 
         if (OS_SendSecureTCP(node->sock, node->length, node->buffer) != 0) {
-            merror("At req_dispatch(): OS_SendSecureTCP(): %s", strerror(errno));
+            mwarn("At req_dispatch(): OS_SendSecureTCP(): %s", strerror(errno));
         }
-
     }
 
 cleanup:

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -464,8 +464,10 @@ int _close_sock(keystore * keys, int sock) {
     key_lock_write();
     retval = OS_DeleteSocket(keys, sock);
     key_unlock();
-    close(sock);
-    rem_dec_tcp();
+
+    if (close(sock) == 0) {
+        rem_dec_tcp();
+    }
 
     return retval;
 }

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -106,7 +106,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
             break;
         case EPIPE:
         case EBADF:
-            mdebug1(SEND_ERROR, agent_id, "Agent might got disconnected.");
+            mdebug1(SEND_ERROR, agent_id, "Agent may have disconnected.");
             break;
         case EAGAIN:
 #if EAGAIN != EWOULDBLOCK

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -70,7 +70,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
     /* If we don't have the agent id, ignore it */
     if (keys.keyentries[key_id]->rcvd < (time(0) - DISCON_TIME)) {
         key_unlock();
-        merror(SEND_DISCON, keys.keyentries[key_id]->id);
+        mwarn(SEND_DISCON, keys.keyentries[key_id]->id);
         return (-1);
     }
 

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -56,6 +56,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
     ssize_t msg_size;
     char crypt_msg[OS_MAXSTR + 1];
     int retval = 0;
+    int error;
 
     key_lock_read();
     key_id = OS_IsAllowedID(&keys, agent_id);
@@ -84,9 +85,11 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
     /* Send initial message */
     if (logr.proto[logr.position] == UDP_PROTO) {
         retval = sendto(logr.sock, crypt_msg, msg_size, 0, (struct sockaddr *)&keys.keyentries[key_id]->peer_info, logr.peer_size) == msg_size ? 0 : -1;
+        error = errno;
     } else if (keys.keyentries[key_id]->sock >= 0) {
         w_mutex_lock(&keys.keyentries[key_id]->mutex);
         retval = OS_SendSecureTCP(keys.keyentries[key_id]->sock, msg_size, crypt_msg);
+        error = errno;
         w_mutex_unlock(&keys.keyentries[key_id]->mutex);
     } else {
         key_unlock();
@@ -97,13 +100,22 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
     key_unlock();
 
     if (retval < 0) {
-        switch (errno) {
+        switch (error) {
+        case 0:
+            mwarn(SEND_ERROR, agent_id, "Unknown error.");
+            break;
         case EPIPE:
         case EBADF:
-            mdebug1(SEND_ERROR ". Agent might got disconnected.", agent_id, strerror(errno));
+            mdebug1(SEND_ERROR, agent_id, "Agent might got disconnected.");
+            break;
+        case EAGAIN:
+#if EAGAIN != EWOULDBLOCK
+        case EWOULDBLOCK:
+#endif
+            mwarn(SEND_ERROR, agent_id, "Agent is not responding.");
             break;
         default:
-            merror(SEND_ERROR, agent_id, strerror(errno));
+            merror(SEND_ERROR, agent_id, strerror(error));
         }
     } else {
         rem_inc_msg_sent();


### PR DESCRIPTION
Related issue: #1715.

This PR adds this internal option:

```shell
# Maximum time waiting for a client delivery in TCP (seconds) [1..60]
remoted.send_timeout=1
```

It will prevent Remoted from sticking on sending data to an agent if the network buffer is full.

This PR also fixes a bug in Remoted that loses socket mappings when agents are added or removed.