### PR TITLE
agent-auth: added a simple regex to avoid invalid client IP addresses

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -26,7 +26,6 @@
 #include "check_cert.h"
 #include <openssl/ssl.h>
 #include "auth.h"
-#include "os_regex/os_regex.h"
 
 #undef ARGV0
 #define ARGV0 "agent-auth"
@@ -369,7 +368,7 @@ int main(int argc, char **argv)
 
     if(sender_ip){
 		/* Check if this is strictly an IP address using a regex */
-		if (OS_Regex("^\\d+.\\d+.\\d+.\\d+$", sender_ip))
+		if (OS_IsValidIP(sender_ip, NULL))
 		{
 			char opt_buf[256] = {0};
 			snprintf(opt_buf,254," IP:'%s'",sender_ip);
@@ -429,7 +428,7 @@ int main(int argc, char **argv)
                     *tmpstr = '\0';
                     entry = OS_StrBreak(' ', key, 4);
                     if (!OS_IsValidID(entry[0]) || !OS_IsValidName(entry[1]) ||
-                            !OS_IsValidName(entry[2]) || !OS_IsValidName(entry[3])) {
+                            !OS_IsValidIP(entry[2], NULL) || !OS_IsValidName(entry[3])) {
                         printf("ERROR: Invalid key received (2). Closing connection.\n");
                         free(buf);
                         exit(1);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -26,6 +26,7 @@
 #include "check_cert.h"
 #include <openssl/ssl.h>
 #include "auth.h"
+#include "os_regex/os_regex.h"
 
 #undef ARGV0
 #define ARGV0 "agent-auth"
@@ -36,7 +37,7 @@ static void help_agent_auth(void) __attribute__((noreturn));
 static void help_agent_auth()
 {
     print_header();
-    print_out("  %s: -[VhdtI] [-g group] [-D dir] [-m IP address] [-p port] [-A name] [-c ciphers] [-v path] [-x path] [-k path] [-P pass] [-G group] [-i IP address]", ARGV0);
+    print_out("  %s: -[Vhdti] [-g group] [-D dir] [-m IP address] [-p port] [-A name] [-c ciphers] [-v path] [-x path] [-k path] [-P pass] [-G group] [-I IP address]", ARGV0);
     print_out("    -V          Version and license message");
     print_out("    -h          This help message");
     print_out("    -d          Execute in debug mode. This parameter");
@@ -367,9 +368,17 @@ int main(int argc, char **argv)
     }
 
     if(sender_ip){
-        char opt_buf[256] = {0};
-        snprintf(opt_buf,254," IP:'%s'",sender_ip);
-        strncat(buf,opt_buf,254);
+		/* Check if this is strictly an IP address using a regex */
+		if (OS_Regex("^\\d+.\\d+.\\d+.\\d+$", sender_ip))
+		{
+			char opt_buf[256] = {0};
+			snprintf(opt_buf,254," IP:'%s'",sender_ip);
+			strncat(buf,opt_buf,254);
+		} else {
+			merror("Invalid IP address provided with '-I' option.");
+			free(buf);
+			exit(1);
+		}
     }
 
     if(use_src_ip)


### PR DESCRIPTION
This fixes #1480.