### PR TITLE
integratord fixes

### DIFF
--- a/integrations/slack
+++ b/integrations/slack
@@ -109,8 +109,8 @@ if __name__ == "__main__":
         # Read arguments
         bad_arguments = False
         if len(sys.argv) >= 2:
-            alertfile=sys.argv[1]
-            msg = '{0} {1} {2} {3}'.format(now, sys.argv[1], sys.argv[2], sys.argv[3])
+            msg = '{0} {1} {2} {3} {4}'.format(now, sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+            debug_enabled = (sys.argv[4] == 'debug')
         else:
             msg = '{0} Wrong arguments'.format(now)
             bad_arguments = True

--- a/integrations/virustotal
+++ b/integrations/virustotal
@@ -41,8 +41,6 @@ now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 log_file = '{0}/logs/integrations.log'.format(pwd)
 socket_addr = '{0}/queue/ossec/queue'.format(pwd)
 
-
-
 def main(args):
     debug("# Starting")
 
@@ -191,12 +189,11 @@ if __name__ == "__main__":
         # Read arguments
         bad_arguments = False
         if len(sys.argv) >= 2:
-            alertfile=sys.argv[1]
-            msg = '{0} {1} {2} {3}'.format(now, sys.argv[1], sys.argv[2], sys.argv[3])
+            msg = '{0} {1} {2} {3} {4}'.format(now, sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+            debug_enabled = (sys.argv[4] == 'debug')
         else:
             msg = '{0} Wrong arguments'.format(now)
             bad_arguments = True
-
 
         # Logging the call
         f = open(log_file, 'a')

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -74,7 +74,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             if(!integrator_config[s]->hookurl)
             {
                 integrator_config[s]->enabled = 0;
-                merror("Unable to enable integration for: '%s'. Missing hookurl URL.", integrator_config[s]->name);
+                merror("Unable to enable integration for: '%s'. Missing hook URL.", integrator_config[s]->name);
                 s++;
                 continue;
             }
@@ -383,7 +383,10 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
 
             if(temp_file_created == 1)
             {
-                snprintf(exec_full_cmd, 4095, "%s '%s' '%s' '%s' > /dev/null 2>&1", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL?"":integrator_config[s]->apikey, integrator_config[s]->hookurl==NULL?"":integrator_config[s]->hookurl);
+                int dbg_lvl = isDebug();
+                snprintf(exec_full_cmd, 4095, "%s '%s' '%s' '%s' '%s'", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL?"":integrator_config[s]->apikey, integrator_config[s]->hookurl==NULL?"":integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
+                if (dbg_lvl <= 0) strncat(exec_full_cmd, " > /dev/null 2>&1", 17);
+				
                 mdebug2("Running: %s", exec_full_cmd);
                 if(system(exec_full_cmd) != 0)
                 {

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 
     if (debug_level == 0) {
         /* Get debug level */
-        debug_level = getDefine_Int("monitord", "debug", 0, 2);
+        debug_level = getDefine_Int("integrator", "debug", 0, 2);
         while (debug_level != 0) {
             nowDebug();
             debug_level--;
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
         goDaemonLight();
     }
 
-    /* Creating some randoness  */
+    /* Creating some randomness  */
     #ifdef __OpenBSD__
     srandomdev();
     #else


### PR DESCRIPTION
This PR fixes #1246 and #1298.

- Enabled debug logging for integration scripts.
- Fixed debug logging not working when the "integrator.debug" option is set in either local_internal_options.conf or internal_options.conf.