### PR TITLE
Disable agent_groups binary in worker nodes

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -298,14 +298,14 @@ def main():
 if __name__ == "__main__":
 
     try:
-        if read_config()['node_type'] != 'master':
+        if read_config()['node_type'] != 'master' and read_config()['disabled'] == 'no':
             raise WazuhException(3019)
         main()
 
     except WazuhException as e:
         if e.code == 3019:
-            binary_name = argv[0].split('/')[-1]
-            master_ip = read_config()['bind_addr']
+            binary_name = "agent_groups.py"
+            master_ip = read_config()['nodes'][0]
             print("Error {0}: {1}".format(e.code, e.message.format(BINARY_NAME=binary_name, MASTER_IP=master_ip)))
         else:
             print("Error {0}: {1}".format(e.code, e.message))

--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -298,17 +298,15 @@ def main():
 if __name__ == "__main__":
 
     try:
-        if read_config()['node_type'] != 'master' and read_config()['disabled'] == 'no':
-            raise WazuhException(3019)
+        cluster_config = read_config()
+        executable_name = "agent_groups"
+        master_ip = cluster_config['nodes'][0]
+        if cluster_config['node_type'] != 'master' and cluster_config['disabled'] == 'no':
+            raise WazuhException(3019, {"EXECUTABLE_NAME": executable_name, "MASTER_IP": master_ip})
         main()
 
     except WazuhException as e:
-        if e.code == 3019:
-            binary_name = "agent_groups.py"
-            master_ip = read_config()['nodes'][0]
-            print("Error {0}: {1}".format(e.code, e.message.format(BINARY_NAME=binary_name, MASTER_IP=master_ip)))
-        else:
-            print("Error {0}: {1}".format(e.code, e.message))
+        print("Error {0}: {1}".format(e.code, e.message))
         if debug:
             raise
     except Exception as e:

--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -301,8 +301,14 @@ if __name__ == "__main__":
         if read_config()['node_type'] != 'master':
             raise WazuhException(3019)
         main()
+
     except WazuhException as e:
-        print("Error {0}: {1}".format(e.code, e.message))
+        if e.code == 3019:
+            binary_name = argv[0].split('/')[-1]
+            master_ip = read_config()['bind_addr']
+            print("Error {0}: {1}".format(e.code, e.message.format(BINARY_NAME=binary_name, MASTER_IP=master_ip)))
+        else:
+            print("Error {0}: {1}".format(e.code, e.message))
         if debug:
             raise
     except Exception as e:

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -175,9 +175,12 @@ class WazuhException(Exception):
         self.code = code
         if not cmd_error:
             if extra_message:
-                self.message = "{0}: {1}".format(self.ERRORS[code], extra_message)
+                if isinstance(extra_message, dict):
+                    self.message = self.ERRORS[code].format(**extra_message)
+                else:
+                    self.message = "{0}: {1}".format(self.ERRORS[code], extra_message)
             else:
-                self.message = "{0}.".format(self.ERRORS[code])
+                self.message = self.ERRORS[code]
         else:
             self.message = extra_message
 

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -159,7 +159,7 @@ class WazuhException(Exception):
         3016: 'Received an error response',
         3017: 'The agent is not reporting to any manager',
         3018: 'Error sending request',
-        3019: 'Wazuh is running in cluster mode: {BINARY_NAME} is not available in worker nodes. Please, try again in the master node: {MASTER_IP}',
+        3019: 'Wazuh is running in cluster mode: {EXECUTABLE_NAME} is not available in worker nodes. Please, try again in the master node: {MASTER_IP}',
 
         # > 9000: Authd
     }

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -159,7 +159,7 @@ class WazuhException(Exception):
         3016: 'Received an error response',
         3017: 'The agent is not reporting to any manager',
         3018: 'Error sending request',
-        3019: 'Wazuh is running in cluster mode: {EXECUTABLE_NAME} is not available in worker nodes. Please, try again in the master node: {MASTER_IP}',
+        3019: 'This tool is only available for master nodes',
 
         # > 9000: Authd
     }
@@ -175,12 +175,9 @@ class WazuhException(Exception):
         self.code = code
         if not cmd_error:
             if extra_message:
-                if isinstance(extra_message, dict):
-                    self.message = self.ERRORS[code].format(**extra_message)
-                else:
-                    self.message = "{0}: {1}".format(self.ERRORS[code], extra_message)
+                self.message = "{0}: {1}".format(self.ERRORS[code], extra_message)
             else:
-                self.message = self.ERRORS[code]
+                self.message = "{0}.".format(self.ERRORS[code])
         else:
             self.message = extra_message
 

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -159,7 +159,7 @@ class WazuhException(Exception):
         3016: 'Received an error response',
         3017: 'The agent is not reporting to any manager',
         3018: 'Error sending request',
-        3019: 'This tool is only available for master nodes',
+        3019: 'Wazuh is running in cluster mode: {BINARY_NAME} is not available in worker nodes. Please, try again in the master node: {MASTER_IP}',
 
         # > 9000: Authd
     }


### PR DESCRIPTION
Hi team,

This PR improves error message number `3019` (#1775). This error happens when a worker node try to execute a binary that it cannot not execute. Now, if you try to execute `agent_group.py` you'll get:
```bash
# /var/ossec/bin/agent_groups     
Error 3019: Wazuh is running in cluster mode: agent_groups is not available in worker nodes. Please, try again in the master node: 192.168.122.143.
```

Best regards,

Demetrio.