### PR TITLE
Fix error when distributed API client disconnects before its final response reaches the server

### DIFF
--- a/framework/wazuh/cluster/communication.py
+++ b/framework/wazuh/cluster/communication.py
@@ -419,7 +419,15 @@ class Handler(asyncore.dispatcher_with_send):
     def handle_close(self):
         self.close()
 
-        for response in self.box.values():
+        # before closing all responses, wait to let the response be written.
+        n_retries = 0
+        while len(self.box) > 0 and n_retries < 5:
+            logger.debug("{}: There are {} pending responses. Waiting 0.1s.".format(self.tag, len(self.box)))
+            time.sleep(0.1)
+            n_retries += 1
+
+        for response_id, response in self.box.items():
+            logger.debug("{}: Closing pending response with id {}.".format(self.tag, response_id))
             response.write(None)
 
 

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -207,9 +207,9 @@ class MasterManagerHandler(ServerHandler):
         if sum(n_errors['warnings'].values()) > 0:
             for key, value in n_errors['warnings'].items():
                 if key == '/queue/agent-info/':
-                    logger.warning("Received {} agent statuses for non-existent agents. Skipping.".format(value))
+                    logger.debug2("Received {} agent statuses for non-existent agents. Skipping.".format(value))
                 elif key == '/queue/agent-groups/':
-                    logger.warning("Received {} group assignments for non-existent agents. Skipping.".format(value))
+                    logger.debug2("Received {} group assignments for non-existent agents. Skipping.".format(value))
 
         # Save info for healthcheck
         self.manager.set_worker_status(worker_id=self.name, key=cluster_control_key, subkey=cluster_control_subkey, status=n_merged_files)


### PR DESCRIPTION
Hello team,

This PR fixes #1778.

This is a log sample of the fix:
```
2018-10-31 18:05:00,851 DEBUG   : [Master ] [node02] [API-R_399537519]: Data received. Forwarding it to local client. (399537519)
2018-10-31 18:05:01,231 DEBUG   : [Cluster] [LocalServer  ] Cleaning handler threads. Start.
2018-10-31 18:05:01,232 DEBUG   : [Cluster] [LocalServer  ] Cleaning handler threads. End.
2018-10-31 18:05:01,232 INFO    : [Cluster] [LocalServer  ] [399537519]: Disconnected.
2018-10-31 18:05:01,232 DEBUG   : [Cluster] [LocalServer  ]: There are 1 pending responses. Waiting 0.1s.
2018-10-31 18:05:01,333 DEBUG   : [Cluster] [LocalServer  ]: There are 1 pending responses. Waiting 0.1s.
2018-10-31 18:05:01,434 DEBUG   : [Cluster] [LocalServer  ]: There are 1 pending responses. Waiting 0.1s.
2018-10-31 18:05:01,464 INFO    : [Master ] [node02] [API-R_399537519]: Result: Successfully.
2018-10-31 18:05:01,574 INFO    : [Master ] [node02] [API-R_399537519]: End.
```

There is a pending response when the connection is closed, waiting 0.3s to get it fixes the error described in #1778.

This PR also changes log level of two messages, from warning to debug2.

Best regards,
Marta