### PR TITLE
Proper error msg for missing oscap / xsltproc installation

### DIFF
--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -205,8 +205,13 @@ void wm_oscap_run(wm_oscap_eval *eval) {
     switch (wm_exec(command, &output, &status, eval->timeout, NULL)) {
     case 0:
         if (status > 0) {
-            mtwarn(WM_OSCAP_LOGTAG, "Ignoring content '%s' due to error (%d).", eval->path, status);
-            mtdebug2(WM_OSCAP_LOGTAG, "OUTPUT: %s", output);
+            if (status != 2) {
+                mtwarn(WM_OSCAP_LOGTAG, "Ignoring content '%s' due to error (%d).", eval->path, status);
+                mtdebug2(WM_OSCAP_LOGTAG, "OUTPUT: %s", output);
+            } else {
+                mterror(WM_OSCAP_LOGTAG, "OUTPUT: %s", output);
+                pthread_exit(NULL);
+            }
             eval->flags.error = 1;
         }
 

--- a/wodles/oscap/oscap.py
+++ b/wodles/oscap/oscap.py
@@ -349,7 +349,7 @@ if __name__ == "__main__":
         else:
             print("{0} Impossible to execute OpenSCAP. Details: {1}.".format(OSCAP_LOG_ERROR, e))
 
-        exit(1)
+        exit(2)
 
     # Check xsltproc installed
     try:
@@ -360,7 +360,7 @@ if __name__ == "__main__":
             print("{0} xsltproc not installed. Details: {1}.".format(OSCAP_LOG_ERROR, e))
         else:
             print("{0} Impossible to execute xsltproc. Details: {1}.".format(OSCAP_LOG_ERROR, e))
-        exit(1)
+        exit(2)
 
 
     # Check policy


### PR DESCRIPTION
This PR fixes #1175 and #1343 by making the oscap.py script exit with status code 2 when either oscap or xsltproc is not installed or can't be executed.