### PR TITLE
Ignore whitespaces while reading options from conf files

### DIFF
--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -36,6 +36,7 @@ static char *_read_file(const char *high_name, const char *low_name, const char 
     char *buf_pt;
     char *tmp_buffer;
     char *ret;
+    int i;
 
 #ifndef WIN32
     if (isChroot()) {
@@ -92,14 +93,27 @@ static char *_read_file(const char *high_name, const char *low_name, const char 
             merror(FGETS_ERROR, def_file, buf);
             continue;
         }
-
-        /* Check for the low name */
+        
+        /* Prepare buf_pt to access the value for this option */
         *buf_pt = '\0';
         buf_pt++;
+        
+        /* Remove possible whitespaces between the low name and the equal sign */
+        i = (strlen(tmp_buffer) - 1);
+        while(tmp_buffer[i] == ' ')
+        {
+            tmp_buffer[i] = '\0';
+            i--;
+        }
+        
+        /* Check for the low name */
         if (strcmp(tmp_buffer, low_name) != 0) {
             continue;
         }
-
+        
+        /* Ignore possible whitespaces between the equal sign and the value for this option */
+        while(*buf_pt == ' ') buf_pt++;
+        
         /* Remove newlines or anything that will cause errors */
         tmp_buffer = strrchr(buf_pt, '\n');
         if (tmp_buffer) {


### PR DESCRIPTION
This PR fixes #1653.

Any whitespaces between the low_name for the current option and the equal sign, and between the equal sign and the value for the current option, are ignored with these changes.