### PR TITLE
Make UNIX version of agent-auth multi-platform for use on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Increased AWS S3 database entry limit to 5000 to prevent reprocessing repeated events. ([#1391](https://github.com/wazuh/wazuh/pull/1391))
 - Increased the limit of concurrent agent requests: 1024 by default, configurable up to 4096. ([#1473](https://github.com/wazuh/wazuh/pull/1473))
 - Change the default vulnerability-detector interval from 1 to 5 minutes. ([#1729](https://github.com/wazuh/wazuh/pull/1729))
+- Modified the UNIX version of agent-auth to be compatible with Windows.
 
 ### Fixed
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1481,8 +1481,8 @@ win32/resource.o: win32/ui/win32ui.rc
 win32/os_win32ui.exe: win32/resource.o win32/win_service_rk.o ${win32_ui_o} addagent/b64.o
 	${OSSEC_CCBIN} -DARGV0=\"ossec-win32ui\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -mwindows -o $@
 
-win32/agent-auth.exe: win32/win_service_rk.o win32/agent_auth.o addagent/validate.o
-	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -lshlwapi -lwsock32 -lsecur32 -flto -o $@
+win32/agent-auth.exe: win32/win_service_rk.o os_auth/main-client.o os_auth/ssl.o os_auth/main-client.o os_auth/check_cert.o addagent/validate.o
+	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -lshlwapi -lwsock32 -lsecur32 -lws2_32 -flto -o $@
 
 ####################
 #### Clean #########

--- a/src/os_auth/check_cert.c
+++ b/src/os_auth/check_cert.c
@@ -190,6 +190,13 @@ int check_ipaddr(const ASN1_STRING *cert_astr, const char *manager)
     memset(&iptest, 0, sizeof(iptest));
     memset(&iptest6, 0, sizeof(iptest6));
 
+#ifdef WIN32
+    iptest.sin_addr.s_addr = inet_addr(manager);
+
+    if (cert_astr->length == 4 && !memcmp(cert_astr->data, (const void *)&iptest.sin_addr, 4)) {
+        return VERIFY_TRUE;
+    }
+#else
     if (inet_pton(AF_INET, manager, &iptest.sin_addr) == 1) {
         if (cert_astr->length == 4 && !memcmp(cert_astr->data, (const void *)&iptest.sin_addr, 4)) {
             return VERIFY_TRUE;
@@ -199,6 +206,7 @@ int check_ipaddr(const ASN1_STRING *cert_astr, const char *manager)
             return VERIFY_TRUE;
         }
     }
+#endif
 
     return VERIFY_FALSE;
 }

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -43,8 +43,10 @@ static void help_agent_auth()
     print_out("                can be specified multiple times");
     print_out("                to increase the debug level.");
     print_out("    -t          Test configuration");
+#ifndef WIN32
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
     print_out("    -D <dir>    Directory to chroot into (default: %s)", DEFAULTDIR);
+#endif
     print_out("    -m <addr>   Manager IP address");
     print_out("    -p <port>   Manager port (default: %d)", DEFAULT_PORT);
     print_out("    -A <name>   Agent name (default: hostname)");
@@ -69,12 +71,12 @@ int main(int argc, char **argv)
     int auto_method = 0;
 #ifndef WIN32
     gid_t gid = 0;
+    const char *group = GROUPGLOBAL;
 #endif
 
     int sock = 0, port = DEFAULT_PORT, ret = 0;
     char *ciphers = DEFAULT_CIPHERS;
     const char *dir = DEFAULTDIR;
-    const char *group = GROUPGLOBAL;
     char *authpass = NULL;
     const char *manager = NULL;
     const char *ipaddress = NULL;
@@ -100,7 +102,11 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    while ((c = getopt(argc, argv, "VdhtgG:m:p:A:c:v:x:k:D:P:a:I:i")) != -1) {
+    while ((c = getopt(argc, argv, "VdhtG:m:p:A:c:v:x:k:D:P:a:I:i"
+#ifndef WIN32
+    "g:D:"
+#endif
+    )) != -1) {
         switch (c) {
             case 'V':
                 print_version();
@@ -112,6 +118,7 @@ int main(int argc, char **argv)
                 debug_level = 1;
                 nowDebug();
                 break;
+#ifndef WIN32
             case 'g':
                 if (!optarg) {
                     merror_exit("-g needs an argument");
@@ -119,11 +126,12 @@ int main(int argc, char **argv)
                 group = optarg;
                 break;
             case 'D':
-            if (!optarg) {
-                merror_exit("-g needs an argument");
-            }
-            dir = optarg;
-            break;
+                if (!optarg) {
+                    merror_exit("-g needs an argument");
+                }
+                dir = optarg;
+                break;
+#endif
             case 't':
                 test_config = 1;
                 break;
@@ -211,6 +219,16 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Exit here if test config is set */
+    if (test_config) {
+        exit(0);
+    }
+
+    if (sender_ip && use_src_ip) {
+        merror("Options '-I' and '-i' are uncompatible.");
+        exit(1);
+    }
+
     /* Start daemon */
     mdebug1(STARTED_MSG);
 
@@ -219,16 +237,6 @@ int main(int argc, char **argv)
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
         merror_exit(USER_ERROR, "", group);
-    }
-
-    if (sender_ip && use_src_ip) {
-        merror("Options '-I' and '-i' are uncompatible.");
-        exit(1);
-    }
-
-    /* Exit here if test config is set */
-    if (test_config) {
-        exit(0);
     }
 
     /* Privilege separation */


### PR DESCRIPTION
Related issues: #1452 and #852.

This PR aims to port the UNIX version of _agent-auth_ tool for Windows agents.