### PR TITLE
Fix inconsistencies when showing the firedtimes value

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1404,7 +1404,10 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
     w_mutex_lock(&hourly_alert_mutex);
     hourly_alerts++;
     w_mutex_unlock(&hourly_alert_mutex);
+    w_mutex_lock(&rule->mutex);
     rule->firedtimes++;
+    lf->r_firedtimes = rule->firedtimes;
+    w_mutex_unlock(&rule->mutex);
     return (rule); /* Matched */
 }
 
@@ -2246,7 +2249,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
         } while ((rulenode_pt = rulenode_pt->next) != NULL);
 
         w_inc_processed_events();
-        
+
         if (Config.logall || Config.logall_json){
             if (!lf_logall) {
                 os_calloc(1, sizeof(Eventinfo), lf_logall);

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -606,6 +606,7 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->process_id = NULL;
     lf->is_a_copy = 0;
     lf->last_events = NULL;
+    lf->r_firedtimes = -1;
     lf->queue_added = 0;
     lf->rootcheck_fts = 0;
     lf->decoder_syscheck_id = 0;
@@ -1237,6 +1238,7 @@ void w_copy_event_for_log(Eventinfo *lf,Eventinfo *lf_cpy){
     lf_cpy->mtime_after = lf->mtime_after;
     lf_cpy->inode_before = lf->inode_before;
     lf_cpy->inode_after = lf->inode_after;
+    lf_cpy->r_firedtimes = lf->r_firedtimes;
 
 
     if(lf->diff){

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -126,6 +126,7 @@ typedef struct _Eventinfo {
     int rootcheck_fts;
     int is_a_copy;
     char **last_events;
+    int r_firedtimes;
     int queue_added;
     // Node reference
     EventNode *node;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -95,8 +95,8 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         if(lf->generated_rule->frequency){
             cJSON_AddNumberToObject(rule, "frequency", lf->generated_rule->frequency);
         }
-        if(lf->generated_rule->firedtimes && !(lf->generated_rule->alert_opts & NO_COUNTER)) {
-            cJSON_AddNumberToObject(rule, "firedtimes", lf->generated_rule->firedtimes);
+        if(lf->r_firedtimes != -1 && !(lf->generated_rule->alert_opts & NO_COUNTER)) {
+            cJSON_AddNumberToObject(rule, "firedtimes", lf->r_firedtimes);
         }
         cJSON_AddItemToObject(rule, "mail", cJSON_CreateBool(lf->generated_rule->alert_opts & DO_MAILALERT));
 


### PR DESCRIPTION
Each time a rule matches, its firedtimes value is increased. When generating an alert, the last value of that variable was taken into account to show the fired times, instead of showing the value it had at the time of generating the alert.

This PR solves it.