### PR TITLE
Fix some bugs in Analysisd

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1404,7 +1404,10 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
     w_mutex_lock(&hourly_alert_mutex);
     hourly_alerts++;
     w_mutex_unlock(&hourly_alert_mutex);
+    w_mutex_lock(&rule->mutex);
     rule->firedtimes++;
+    lf->r_firedtimes = rule->firedtimes;
+    w_mutex_unlock(&rule->mutex);
     return (rule); /* Matched */
 }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1361,8 +1361,8 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
     if (rule->context == 1) {
         if (!(rule->context_opts & SAME_DODIFF)) {
             if (rule->event_search) {
-                w_FreeArray(lf->last_events);
                 if (!rule->event_search(lf, rule, rule_match)) {
+                    w_FreeArray(lf->last_events);
                     return (NULL);
                 }
             }
@@ -2246,7 +2246,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
         } while ((rulenode_pt = rulenode_pt->next) != NULL);
 
         w_inc_processed_events();
-        
+
         if (Config.logall || Config.logall_json){
             if (!lf_logall) {
                 os_calloc(1, sizeof(Eventinfo), lf_logall);

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -69,4 +69,7 @@ void w_init_queues();
 OSHash *fim_agentinfo;
 extern int num_rule_matching_threads;
 
+#define FIM_MAX_WAZUH_DB_ATTEMPS 5
+#define SYS_MAX_WAZUH_DB_ATTEMPS 5
+
 #endif /* _LOGAUDIT__H */

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1340,57 +1340,58 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
     return 0;
 }
 
-int sc_send_db(char * msg,int *sock) {
-    char response[OS_MAXSTR];
+int sc_send_db(char *msg, int *sock) {
+    char response[OS_SIZE_128 + 1];
     ssize_t length;
     fd_set fdset;
     struct timeval timeout = {0, 1000};
     int size = strlen(msg);
     int retval = -1;
-    static time_t last_attempt = 0;
-    time_t mtime;
+    int attempts;
 
     // Connect to socket if disconnected
     if (*sock < 0) {
-        if (mtime = time(NULL), mtime > last_attempt + 10) {
-            if (*sock = OS_ConnectUnixDomain(WDB_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), *sock < 0) {
-                last_attempt = mtime;
-                merror("Unable to connect to socket '%s': %s (%d)", WDB_LOCAL_SOCK, strerror(errno), errno);
-                goto end;
+        for (attempts = 1; attempts <= SYS_MAX_WAZUH_DB_ATTEMPS && (*sock = OS_ConnectUnixDomain(WDB_LOCAL_SOCK, SOCK_STREAM, OS_SIZE_128)) < 0; attempts++) {
+            switch (errno) {
+            case ENOENT:
+                mtinfo(ARGV0, "at sc_send_db(): Cannot find '%s'. Waiting %d seconds to reconnect.", WDB_LOCAL_SOCK, attempts);
+                break;
+            default:
+                mtinfo(ARGV0, "at sc_send_db(): Cannot connect to '%s': %s (%d). Waiting %d seconds to reconnect.", WDB_LOCAL_SOCK, strerror(errno), errno, attempts);
             }
-        } else {
-            // Return silently
+            sleep(attempts);
+        }
+
+        if (*sock < 0) {
+            mterror(ARGV0, "at sc_send_db(): Unable to connect to socket '%s'.", WDB_LOCAL_SOCK);
             goto end;
         }
     }
 
     // Send msg to Wazuh DB
-
     if (OS_SendSecureTCP(*sock, size + 1, msg) != 0) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             merror("at sc_send_db(): database socket is full");
         } else if (errno == EPIPE) {
-            if (mtime = time(NULL), mtime > last_attempt + 10) {
-                // Retry to connect
-                merror("at sc_send_db(): Connection with wazuh-db lost. Reconnecting.");
-                close(*sock);
+            // Retry to connect
+            merror("at sc_send_db(): Connection with wazuh-db lost. Reconnecting.");
+            close(*sock);
 
-                if (*sock = OS_ConnectUnixDomain(WDB_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), *sock < 0) {
-                    last_attempt = mtime;
-                    merror("Unable to connect to socket '%s': %s (%d)", WDB_LOCAL_SOCK, strerror(errno), errno);
-                    goto end;
+            if (*sock = OS_ConnectUnixDomain(WDB_LOCAL_SOCK, SOCK_STREAM, OS_SIZE_128), *sock < 0) {
+                switch (errno) {
+                case ENOENT:
+                    mterror(ARGV0, "at sc_send_db(): Cannot find '%s'.", WDB_LOCAL_SOCK);
+                    break;
+                default:
+                    mterror(ARGV0, "at sc_send_db(): Cannot connect to '%s': %s (%d).", WDB_LOCAL_SOCK, strerror(errno), errno);
                 }
-
-                if (!OS_SendSecureTCP(*sock, size + 1, msg)) {
-                    last_attempt = mtime;
-                    merror("at sc_send_db(): at OS_SendSecureTCP() (retry): %s (%d)", strerror(errno), errno);
-                    goto end;
-                }
-            } else {
-                // Return silently
                 goto end;
             }
 
+            if (!OS_SendSecureTCP(*sock, size + 1, msg)) {
+                merror("at sc_send_db(): at OS_SendSecureTCP() (retry): %s (%d)", strerror(errno), errno);
+                goto end;
+            }
         } else {
             merror("at sc_send_db(): at OS_SendSecureTCP(): %s (%d)", strerror(errno), errno);
             goto end;
@@ -1398,7 +1399,6 @@ int sc_send_db(char * msg,int *sock) {
     }
 
     // Wait for socket
-
     FD_ZERO(&fdset);
     FD_SET(*sock, &fdset);
 
@@ -1408,7 +1408,7 @@ int sc_send_db(char * msg,int *sock) {
     }
 
     // Receive response from socket
-    length = OS_RecvSecureTCP(*sock,response,OS_MAXSTR);
+    length = OS_RecvSecureTCP(*sock, response, OS_SIZE_128);
     switch (length) {
         case -1:
             merror("at sc_send_db(): at OS_RecvSecureTCP(): %s (%d)", strerror(errno), errno);

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -664,7 +664,7 @@ void Free_Eventinfo(Eventinfo *lf)
             i = 0;
             // Remove the node from all lists
             while (i < lf->generated_rule->group_prev_matched_sz) {
-                while (lf->generated_rule->group_prev_matched[i]->count);
+                while (lf->generated_rule->group_prev_matched[i]->count > 0);
                 OSList_DeleteThisNode(lf->generated_rule->group_prev_matched[i],
                                         lf->group_node_to_delete[i]);
                 // Unblock the list

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -606,6 +606,7 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->process_id = NULL;
     lf->is_a_copy = 0;
     lf->last_events = NULL;
+    lf->r_firedtimes = -1;
     lf->queue_added = 0;
     lf->rootcheck_fts = 0;
     lf->decoder_syscheck_id = 0;
@@ -1237,6 +1238,7 @@ void w_copy_event_for_log(Eventinfo *lf,Eventinfo *lf_cpy){
     lf_cpy->mtime_after = lf->mtime_after;
     lf_cpy->inode_before = lf->inode_before;
     lf_cpy->inode_after = lf->inode_after;
+    lf_cpy->r_firedtimes = lf->r_firedtimes;
 
 
     if(lf->diff){

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -200,6 +200,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
 {
     Eventinfo *lf = NULL;
     OSListNode *lf_node;
+    Eventinfo *first_lf;
     int frequency_count = 0;
     OSList *list = rule->group_search;
 
@@ -228,6 +229,9 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         lf = NULL;
         goto end;
     }
+
+    first_lf = (Eventinfo *)lf_node->data;
+
     do {
         lf = (Eventinfo *)lf_node->data;
 
@@ -349,6 +353,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         /* If reached here, we matched */
         my_lf->matched = rule->level;
         lf->matched = rule->level;
+        first_lf->matched = rule->level;
         goto end;
     } while ((lf_node = lf_node->prev) != NULL);
 

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -138,7 +138,7 @@ typedef struct _Eventinfo {
 struct _EventNode {
     Eventinfo *event;
     pthread_mutex_t mutex;
-    int count;
+    volatile int count;
     EventNode *next;
     EventNode *prev;
 };

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -126,6 +126,7 @@ typedef struct _Eventinfo {
     int rootcheck_fts;
     int is_a_copy;
     char **last_events;
+    int r_firedtimes;
     int queue_added;
     // Node reference
     EventNode *node;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -95,8 +95,8 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         if(lf->generated_rule->frequency){
             cJSON_AddNumberToObject(rule, "frequency", lf->generated_rule->frequency);
         }
-        if(lf->generated_rule->firedtimes && !(lf->generated_rule->alert_opts & NO_COUNTER)) {
-            cJSON_AddNumberToObject(rule, "firedtimes", lf->generated_rule->firedtimes);
+        if(lf->r_firedtimes != -1 && !(lf->generated_rule->alert_opts & NO_COUNTER)) {
+            cJSON_AddNumberToObject(rule, "firedtimes", lf->r_firedtimes);
         }
         cJSON_AddItemToObject(rule, "mail", cJSON_CreateBool(lf->generated_rule->alert_opts & DO_MAILALERT));
 

--- a/src/headers/list_op.h
+++ b/src/headers/list_op.h
@@ -25,8 +25,8 @@ typedef struct _OSList {
 
     int currently_size;
     int max_size;
-    int count;
-    int pending_remove;
+    volatile int count;
+    volatile int pending_remove;
 
     void (*free_data_function)(void *data);
     pthread_rwlock_t wr_mutex;


### PR DESCRIPTION
This PR aims to fix some issues that appeared in Analysisd during the testing stage:

- Spurious previous outputs in alerts with candidate correlation rules. 72fd42243
- Race condition in the _fired_times_ counter. 7b3090d
- Invalid frequency counter in rules with `<if_matched_group>`. 85f5e39df