### PR TITLE
Fix error in the synchronization of nonexistent agents

### DIFF
--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -805,6 +805,10 @@ int wm_sync_file(const char *dirname, const char *fname) {
             return -1;
         }
 
+        if (wdb_get_agent_status(id_agent) < 0) {
+            return -1;
+        }
+
         break;
 
      case WDB_SHARED_GROUPS:


### PR DESCRIPTION
Fix the following error:

```
2018/11/05 19:32:14 wazuh-modulesd:database: ERROR: Couldn't sync agent '027' group.
```