### PR TITLE
Add error description in socket operations

### DIFF
--- a/src/agentlessd/lessdcom.c
+++ b/src/agentlessd/lessdcom.c
@@ -77,7 +77,7 @@ void * lessdcom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(DEFAULTDIR LESSD_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s'. Closing local server.", LESSD_LOCAL_SOCK);
+        merror("Unable to bind to socket '%s': (%d) %s.", LESSD_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -690,7 +690,7 @@ int main_analysisd(int argc, char **argv)
     minfo(STARTUP_MSG, (int)getpid());
 
     // Start com request thread
-    w_create_thread(syscom_main, NULL);
+    w_create_thread(asyscom_main, NULL);
 
     /* Going to main loop */
     OS_ReadMSG(m_queue);

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -42,9 +42,9 @@ extern EventList *last_events_list;
 extern time_t current_time;
 
 // Com request thread dispatcher
-void * syscom_main(__attribute__((unused)) void * arg) ;
-size_t syscom_dispatch(char * command, char ** output);
-size_t syscom_getconfig(const char * section, char ** output);
+void * asyscom_main(__attribute__((unused)) void * arg) ;
+size_t asyscom_dispatch(char * command, char ** output);
+size_t asyscom_getconfig(const char * section, char ** output);
 
 #define WM_ANALYSISD_LOGTAG ARGV0 "" // Tag for log messages
 

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -100,7 +100,7 @@ void * lccom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(DEFAULTDIR LC_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s'. Closing local server.", LC_LOCAL_SOCK);
+        merror("Unable to bind to socket '%s': (%d) %s.", LC_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/monitord/moncom.c
+++ b/src/monitord/moncom.c
@@ -88,7 +88,7 @@ void * moncom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(MON_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s'. Closing local server: %s (%d)", MON_LOCAL_SOCK,strerror(errno),errno);
+        merror("Unable to bind to socket '%s': (%d) %s.", MON_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/os_csyslogd/csyscom.c
+++ b/src/os_csyslogd/csyscom.c
@@ -76,7 +76,7 @@ void * csyscom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(CSYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s'. Closing local server.", CSYS_LOCAL_SOCK);
+        merror("Unable to bind to socket '%s': (%d) %s.", CSYS_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -646,7 +646,7 @@ void * wcom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(DEFAULTDIR COM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s': '%s'. Closing local server.", COM_LOCAL_SOCK, strerror(errno));
+        merror("Unable to bind to socket '%s': (%d) %s.", COM_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/os_integrator/intgcom.c
+++ b/src/os_integrator/intgcom.c
@@ -76,7 +76,7 @@ void * intgcom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(DEFAULTDIR INTG_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s'. Closing local server.", INTG_LOCAL_SOCK);
+        merror("Unable to bind to socket '%s': (%d) %s.", INTG_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/os_maild/mailcom.c
+++ b/src/os_maild/mailcom.c
@@ -106,7 +106,7 @@ void * mailcom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(socket_path, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s'. Closing local server.", MAIL_LOCAL_SOCK);
+        merror("Unable to bind to socket '%s': (%d) %s.", MAIL_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/syscheckd/syscom.c
+++ b/src/syscheckd/syscom.c
@@ -101,7 +101,7 @@ void * syscom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(DEFAULTDIR SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s'. Closing local server.", SYS_LOCAL_SOCK);
+        merror("Unable to bind to socket '%s': (%d) %s.", SYS_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -87,7 +87,7 @@ void * wmcom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(DEFAULTDIR WM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s'. Closing local server.", WM_LOCAL_SOCK);
+        merror("Unable to bind to socket '%s': (%d) %s.", WM_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
 


### PR DESCRIPTION
Added error number and description in socket operations:

```
merror("Unable to bind to socket '%s': (%d) %s.", ANLSYS_LOCAL_SOCK, errno, strerror(errno));
```

Renamed analysisd `syscom` functions to `asyscom`