### PR TITLE
3.7 fix Suse

### DIFF
--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -65,7 +65,7 @@ else
         DIST_NAME="suse"
         DIST_VER=`sed -rn 's/.*VERSION = ([0-9]{1,2}).*/\1/p' /etc/SuSE-release`
         DIST_SUBVER=`sed -rn 's/.*PATCHLEVEL = ([0-9]{1,2}).*/\1/p' /etc/SuSE-release`
-        if ["$DIST_SUBVER" = ""]; then #openSuse
+        if [ "$DIST_SUBVER" = "" ]; then #openSuse
           DIST_SUBVER=`sed -rn 's/.*VERSION = ([0-9]{1,2})\.([0-9]{1,2}).*/\1/p' /etc/SuSE-release`
         fi
 


### PR DESCRIPTION
Hello team

  This PR solve the check on script `dist-detect.sh`. Due to this typo, the Suse package installation (and source) could be not successful, if the OS doesn't have the `/etc/os-release` file. 

Best regards, 