### PR TITLE
Add a logging handler in agent_groups binary

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -7,6 +7,7 @@ from sys import exit, path, argv
 from os.path import dirname, basename
 from getopt import GetoptError, getopt
 from signal import signal, SIGINT
+import logging
 
 # Set framework path
 path.append(dirname(argv[0]) + '/../framework')  # It is necessary to import Wazuh package
@@ -296,6 +297,7 @@ def main():
 
 
 if __name__ == "__main__":
+    logger = logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
     try:
         cluster_config = read_config()


### PR DESCRIPTION
Hello team,

There was no logging handler in `agent_groups` binary, this made errors like the following one appear when using it:

```shellsession
# /var/ossec/bin/agent_groups -ld
No handlers could be found for logger "wazuh.cluster.cluster"
[...]
```

After adding a logging handler, the output is:
```shellsession
# /var/ossec/bin/agent_groups -ld
WARNING: Deprecated node type 'client'. Using 'worker' instead.
[...]
```

Best regards,
Marta
