### PR TITLE
Fixes in unit tests

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -570,6 +570,7 @@ $(SELINUX_POLICY): $(SELINUX_MODULE)
 $(SELINUX_MODULE): $(SELINUX_ENFORCEMENT)
 	checkmodule -M -m -o $@ $?
 
+test_programs = test_os_zlib test_os_xml test_os_regex test_os_crypto test_os_net test_shared
 
 WINDOWS_BINS:=win32/ossec-agent.exe win32/ossec-agent-eventchannel.exe win32/ossec-rootcheck.exe win32/manage_agents.exe win32/setup-windows.exe win32/setup-syscheck.exe win32/setup-iis.exe win32/add-localfile.exe win32/os_win32ui.exe win32/agent-auth.exe
 
@@ -802,7 +803,7 @@ WAZUHEXT_LIB = libwazuhext.$(SHARED)
 BUILD_LIBS = libwazuh.a $(WAZUHEXT_LIB)
 endif
 
-$(BUILD_SERVER) $(BUILD_AGENT) $(WINDOWS_BINS): $(BUILD_LIBS)
+$(BUILD_SERVER) $(BUILD_AGENT) $(WINDOWS_BINS) $(test_programs): $(BUILD_LIBS)
 
 #### os_xml ########
 
@@ -1360,14 +1361,13 @@ endif
 
 CFLAGS_TEST = -g -O0 --coverage
 
-LDFLAGS_TEST = -lcheck -lm -pthread -lrt -lsubunit
+LIBS_TEST = -lcheck -lm -lrt -lsubunit
 
 ifdef TEST
 	OSSEC_CFLAGS+=${CFLAGS_TEST}
-	OSSEC_LDFLAGS+=${LDFLAGS_TEST}
+	OSSEC_LDFLAGS+=${CFLAGS_TEST}
+	OSSEC_LIBS+=${LIBS_TEST}
 endif #TEST
-
-test_programs = test_os_zlib test_os_xml test_os_regex test_os_crypto test_os_net test_shared
 
 .PHONY: test run_tests build_tests test_valgrind test_coverage
 
@@ -1396,10 +1396,10 @@ test_os_regex: tests/test_os_regex.c ${os_regex_o}
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_os_crypto: tests/test_os_crypto.c ${crypto_o} ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o}
-	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_os_net: tests/test_os_net.c ${os_net_o} ${shared_o} ${os_regex_o} ${os_xml_o}
-	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_shared: tests/test_shared.c ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o}
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@

--- a/src/os_regex/os_regex_free_pattern.c
+++ b/src/os_regex/os_regex_free_pattern.c
@@ -64,7 +64,9 @@ void OSRegex_FreePattern(OSRegex *reg)
         w_FreeArray(reg->d_sub_strings);
         free(reg->d_sub_strings);
         reg->d_sub_strings = NULL;
-}
+    }
+
+    free(reg->d_size.prts_str_size);
 
     w_mutex_unlock((pthread_mutex_t *)&reg->mutex);
     return;

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -113,17 +113,7 @@ int OS_ReadXML(const char *file, OS_XML *_lxml)
     FILE *fp;
 
     /* Initialize xml structure */
-    _lxml->cur = 0;
-    _lxml->fol = 0;
-    _lxml->el = NULL;
-    _lxml->ct = NULL;
-    _lxml->tp = NULL;
-    _lxml->rl = NULL;
-    _lxml->ck = NULL;
-    _lxml->ln = NULL;
-
-    _lxml->err_line = 0;
-    memset(_lxml->err, '\0', XML_ERR_LENGTH);
+    memset(_lxml, 0, sizeof(OS_XML));
 
     fp = fopen(file, "r");
     if (!fp) {

--- a/src/tests/test_os_regex.c
+++ b/src/tests/test_os_regex.c
@@ -391,7 +391,7 @@ START_TEST(test_regexextraction)
 
 
 
-        char **result = reg.sub_strings;
+        char **result = reg.d_sub_strings;
 
         int j;
         int k;

--- a/src/util/ossec-regex.c
+++ b/src/util/ossec-regex.c
@@ -87,5 +87,9 @@ int main(int argc, char **argv)
         w_FreeArray(regex.d_sub_strings);
         free(string);
     }
+
+    OSRegex_FreePattern(&regex);
+    OSMatch_FreePattern(&matcher);
+
     return (0);
 }


### PR DESCRIPTION
This PR fixes an issue in the Makefile that prevented unit tests from compiling.

Then, we fixed two issues detected by the unit tests:
- If the XML library fails on opening a file, the variable containing the file line number is not initialized.
- There was a memory leak in the regex pattern freeing function.

Related issue: #1288.