### PR TITLE
Fix bug in Analysisd when reconnecting to the Wazuh DB

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -452,7 +452,7 @@ int send_query_wazuhdb(char *wazuhdb_query, char **output, _sdb *sdb) {
                 return (-2);
             }
 
-            if (!OS_SendSecureTCP(sdb->socket, size + 1, wazuhdb_query)) {
+            if (OS_SendSecureTCP(sdb->socket, size + 1, wazuhdb_query)) {
                 mterror(ARGV0, "FIM decoder: in send reattempt (%d) '%s'.", errno, strerror(errno));
                 return (-2);
             }

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1388,7 +1388,7 @@ int sc_send_db(char *msg, int *sock) {
                 goto end;
             }
 
-            if (!OS_SendSecureTCP(*sock, size + 1, msg)) {
+            if (OS_SendSecureTCP(*sock, size + 1, msg)) {
                 merror("at sc_send_db(): at OS_SendSecureTCP() (retry): %s (%d)", strerror(errno), errno);
                 goto end;
             }


### PR DESCRIPTION
There is a typo in the Syscheck and Syscollector decoders that could lead Analysisd to crash if Wazuh DB is restarted.

When Analysisd detects a broken connection with Wazuh DB, it restarts the connection and sends the request again. Due to a logic error, Analysisd detects a false error in the delivery. When the same thread executes a new query, it successes to send the message, but the actual response is that of the previous query. This bug can produce a string parsing error and lead Analysisd to crash.

This PR aims to fix that typo in the message delivery procedure.