### PR TITLE
Prevent subprocesses from trying to delete PID file

### DIFF
--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -566,7 +566,8 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
 
             if (chdir(path) < 0) {
                 ciscat->flags.error = 1;
-                mterror_exit(WM_CISCAT_LOGTAG, "Unable to change working directory: %s", strerror(errno));
+                mterror(WM_CISCAT_LOGTAG, "Unable to change working directory: %s", strerror(errno));
+                _exit(EXIT_FAILURE);
             } else
                 mtdebug2(WM_CISCAT_LOGTAG, "Changing working directory to %s", path);
 
@@ -577,7 +578,8 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
                     if (status > 0) {
                         ciscat->flags.error = 1;
                         mterror(WM_CISCAT_LOGTAG, "Ignoring content '%s' due to error (%d).", eval->path, status);
-                        mterror_exit(WM_CISCAT_LOGTAG, "OUTPUT: %s", output);
+                        mterror(WM_CISCAT_LOGTAG, "OUTPUT: %s", output);
+                        _exit(EXIT_FAILURE);
                     }
 
                     mtinfo(WM_CISCAT_LOGTAG, "Scan finished successfully. File: %s", eval->path);
@@ -594,8 +596,8 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
 
                 default:
                     ciscat->flags.error = 1;
-                    mterror_exit(WM_CISCAT_LOGTAG, "Internal calling. Exiting...");
-                    pthread_exit(NULL);
+                    mterror(WM_CISCAT_LOGTAG, "Internal calling. Exiting...");
+                    _exit(EXIT_FAILURE);
             }
 
             _exit(0);

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -350,12 +350,9 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
 
         setsid();
         if (nice(wm_task_nice)) {}
-        if (execvp(argv[0], argv) < 0)
-            exit(EXECVE_ERROR);
+        execvp(argv[0], argv);
+        _exit(EXECVE_ERROR);
 
-        // Dead code
-        // ToDo: remove execvpe()
-        free_strarray(argv);
         break;
 
     default:


### PR DESCRIPTION
This PR aims to fix this error:

```
wazuh-modulesd: ERROR: Couldn't delete PID file.
```

Daemons register a trigger to clean up their PID file before exiting (with `atexit()`). When a process is forked, it inherits its parent's functions. If a module fails to execute an external program after forking, the child process exits as a _wazuh-modulesd_ process, this makes the process delete its PID file, but, since it's a subprocess, there is no PID file for it.