### PR TITLE
Add tracing information to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Added option to configure another audit keys to monitor. ([#1882](https://github.com/wazuh/wazuh/pull/1882))
 - Added option to create the SSL certificate and key with the install.sh script. ([#1856](https://github.com/wazuh/wazuh/pull/1856))
 - Add IPv6 support to `host-deny.sh` script. (by @iasdeoupxe). ([#1583](https://github.com/wazuh/wazuh/pull/1583))
+- Added tracing information (PID, function, file and line number) to logs when debugging is enabled. ([#1866](https://github.com/wazuh/wazuh/pull/1866))
 
 ### Changed
 

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -36,21 +36,36 @@
 #endif
 #endif
 
-void mdebug1(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
-void mtdebug1(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
-void mdebug2(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
-void mtdebug2(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
-void merror(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
-void mterror(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
-void mwarn(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
-void mtwarn(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
-void minfo(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
-void mtinfo(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
+#define mdebug1(msg, ...) _mdebug1(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mtdebug1(tag, msg, ...) _mtdebug1(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mdebug2(msg, ...) _mdebug2(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mtdebug2(tag, msg, ...) _mtdebug2(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define merror(msg, ...) _merror(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mwarn(msg, ...) _mwarn(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mtwarn(tag, msg, ...) _mtwarn(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define minfo(msg, ...) _minfo(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mtinfo(tag, msg, ...) _mtinfo(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mferror(msg, ...) _mferror(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mtferror(tag, msg, ...) _mtferror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define merror_exit(msg, ...) _merror_exit(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mterror_exit(tag, msg, ...) _mterror_exit(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+
+void _mdebug1(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull));
+void _mtdebug1(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
+void _mdebug2(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull));
+void _mtdebug2(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
+void _merror(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull));
+void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
+void _mwarn(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull));
+void _mtwarn(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
+void _minfo(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull));
+void _mtinfo(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
 void print_out(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
-void mferror(const char *msg, ... ) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull));
-void mtferror(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull));
-void merror_exit(const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 1, 2))) __attribute__((nonnull)) __attribute__ ((noreturn));
-void mterror_exit(const char *tag, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 2, 3))) __attribute__((nonnull)) __attribute__ ((noreturn));
+void _mferror(const char * file, int line, const char * func, const char *msg, ... ) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull));
+void _mtferror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
+void _merror_exit(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull)) __attribute__ ((noreturn));
+void _mterror_exit(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull)) __attribute__ ((noreturn));
 
 /* Function to read the logging format configuration */
 void os_logging_config(void);

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -17,6 +17,7 @@
 static int dbg_flag = 0;
 static int chroot_flag = 0;
 static int daemon_flag = 0;
+static int pid;
 
 struct{
   unsigned int log_plain:1;
@@ -24,13 +25,13 @@ struct{
   unsigned int read:1;
 } flags;
 
-static void _log(int level, const char *tag, const char *msg, va_list args) __attribute__((format(printf, 2, 0))) __attribute__((nonnull));
+static void _log(int level, const char *tag, const char * file, int line, const char * func, const char *msg, va_list args) __attribute__((format(printf, 5, 0))) __attribute__((nonnull));
 
 #ifdef WIN32
 void WinSetError();
 #endif
 
-static void _log(int level, const char *tag, const char *msg, va_list args)
+static void _log(int level, const char *tag, const char * file, int line, const char * func, const char *msg, va_list args)
 {
     time_t now;
     struct tm localtm;
@@ -41,6 +42,7 @@ static void _log(int level, const char *tag, const char *msg, va_list args)
     char jsonstr[OS_MAXSTR];
     char *output;
     char logfile[PATH_MAX + 1];
+    char * filename;
 
     const char *strlevel[5]={
       "DEBUG",
@@ -65,6 +67,10 @@ static void _log(int level, const char *tag, const char *msg, va_list args)
 
     if (!flags.read) {
       os_logging_config();
+    }
+
+    if (filename = strrchr(file, '/'), filename) {
+        file = filename + 1;
     }
 
     if (flags.log_json) {
@@ -111,6 +117,14 @@ static void _log(int level, const char *tag, const char *msg, va_list args)
 
             cJSON_AddStringToObject(json_log, "timestamp", timestamp);
             cJSON_AddStringToObject(json_log, "tag", tag);
+
+            if (dbg_flag > 0) {
+                cJSON_AddNumberToObject(json_log, "pid", pid);
+                cJSON_AddStringToObject(json_log, "file", file);
+                cJSON_AddNumberToObject(json_log, "line", line);
+                cJSON_AddStringToObject(json_log, "routine", func);
+            }
+
             cJSON_AddStringToObject(json_log, "level", strleveljson[level]);
             cJSON_AddStringToObject(json_log, "description", jsonstr);
 
@@ -165,7 +179,13 @@ static void _log(int level, const char *tag, const char *msg, va_list args)
             (void)fprintf(fp, "%d/%02d/%02d %02d:%02d:%02d ",
                         localtm.tm_year + 1900, localtm.tm_mon + 1,
                         localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
-            (void)fprintf(fp, "%s: ", tag);
+
+            if (dbg_flag > 0) {
+                (void)fprintf(fp, "%s[%d] %s:%d at %s(): ", tag, pid, file, line, func);
+            } else {
+                (void)fprintf(fp, "%s: ", tag);
+            }
+
             (void)fprintf(fp, "%s: ", strlevel[level]);
             (void)vfprintf(fp, msg, args);
             (void)fprintf(fp, "\n");
@@ -181,7 +201,13 @@ static void _log(int level, const char *tag, const char *msg, va_list args)
         (void)fprintf(stderr, "%d/%02d/%02d %02d:%02d:%02d ",
                       localtm.tm_year + 1900, localtm.tm_mon + 1 , localtm.tm_mday,
                       localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
-        (void)fprintf(stderr, "%s: ", tag);
+
+        if (dbg_flag > 0) {
+            (void)fprintf(stderr, "%s[%d] %s:%d at %s(): ", tag, pid, file, line, func);
+        } else {
+            (void)fprintf(stderr, "%s: ", tag);
+        }
+
         (void)fprintf(stderr, "%s: ", strlevel[level]);
         (void)vfprintf(stderr, msg, args2);
 #ifdef WIN32
@@ -203,6 +229,7 @@ void os_logging_config(){
   char ** parts = NULL;
   int i;
 
+  pid = (int)getpid();
   flags.read = 1;
 
   if (OS_ReadXML(chroot_flag ? OSSECCONF : DEFAULTCPATH, &xml) < 0){
@@ -264,117 +291,117 @@ cJSON *getLoggingConfig(void) {
     return root;
 }
 
-void mdebug1(const char *msg, ...)
+void _mdebug1(const char * file, int line, const char * func, const char *msg, ...)
 {
     if (dbg_flag >= 1) {
         va_list args;
         int level = LOGLEVEL_DEBUG;
         const char *tag = __local_name;
         va_start(args, msg);
-        _log(level, tag, msg, args);
+        _log(level, tag, file, line, func, msg, args);
         va_end(args);
     }
 }
 
-void mtdebug1(const char *tag, const char *msg, ...)
+void _mtdebug1(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {
     if (dbg_flag >= 1) {
         va_list args;
         int level = LOGLEVEL_DEBUG;
         va_start(args, msg);
-        _log(level, tag, msg, args);
+        _log(level, tag, file, line, func, msg, args);
         va_end(args);
     }
 }
 
-void mdebug2(const char *msg, ...)
+void _mdebug2(const char * file, int line, const char * func, const char *msg, ...)
 {
     if (dbg_flag >= 2) {
         va_list args;
         int level = LOGLEVEL_DEBUG;
         const char *tag = __local_name;
         va_start(args, msg);
-        _log(level, tag, msg, args);
+        _log(level, tag, file, line, func, msg, args);
         va_end(args);
     }
 }
 
-void mtdebug2(const char *tag, const char *msg, ...)
+void _mtdebug2(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {
     if (dbg_flag >= 2) {
         va_list args;
         int level = LOGLEVEL_DEBUG;
         va_start(args, msg);
-        _log(level, tag, msg, args);
+        _log(level, tag, file, line, func, msg, args);
         va_end(args);
     }
 }
 
-void merror(const char *msg, ... )
+void _merror(const char * file, int line, const char * func, const char *msg, ...)
 {
     va_list args;
     int level = LOGLEVEL_ERROR;
     const char *tag = __local_name;
 
     va_start(args, msg);
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
     va_end(args);
 }
 
-void mterror(const char *tag, const char *msg, ... )
+void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {
     va_list args;
     int level = LOGLEVEL_ERROR;
 
     va_start(args, msg);
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
     va_end(args);
 }
 
-void mwarn(const char *msg, ... )
+void _mwarn(const char * file, int line, const char * func, const char *msg, ...)
 {
     va_list args;
     int level = LOGLEVEL_WARNING;
     const char *tag = __local_name;
 
     va_start(args, msg);
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
     va_end(args);
 }
 
-void mtwarn(const char *tag, const char *msg, ... )
+void _mtwarn(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {
     va_list args;
     int level = LOGLEVEL_WARNING;
 
     va_start(args, msg);
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
     va_end(args);
 }
 
-void minfo(const char *msg, ... )
+void _minfo(const char * file, int line, const char * func, const char *msg, ...)
 {
     va_list args;
     int level = LOGLEVEL_INFO;
     const char *tag = __local_name;
 
     va_start(args, msg);
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
     va_end(args);
 }
 
-void mtinfo(const char *tag, const char *msg, ... )
+void _mtinfo(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {
     va_list args;
     int level = LOGLEVEL_INFO;
 
     va_start(args, msg);
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
     va_end(args);
 }
 
 /* Only logs to a file */
-void mferror(const char *msg, ... )
+void _mferror(const char * file, int line, const char * func, const char *msg, ...)
 {
     int level = LOGLEVEL_ERROR;
     const char *tag = __local_name;
@@ -385,7 +412,7 @@ void mferror(const char *msg, ... )
     /* We set daemon flag to 1, so nothing is printed to the terminal */
     dbg_tmp = daemon_flag;
     daemon_flag = 1;
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
 
     daemon_flag = dbg_tmp;
 
@@ -393,7 +420,7 @@ void mferror(const char *msg, ... )
 }
 
 /* Only logs to a file */
-void mtferror(const char *tag, const char *msg, ... )
+void _mtferror(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {
     int level = LOGLEVEL_ERROR;
     int dbg_tmp;
@@ -403,14 +430,14 @@ void mtferror(const char *tag, const char *msg, ... )
     /* We set daemon flag to 1, so nothing is printed to the terminal */
     dbg_tmp = daemon_flag;
     daemon_flag = 1;
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
 
     daemon_flag = dbg_tmp;
 
     va_end(args);
 }
 
-void merror_exit(const char *msg, ...)
+void _merror_exit(const char * file, int line, const char * func, const char *msg, ...)
 {
     va_list args;
     int level = LOGLEVEL_CRITICAL;
@@ -424,13 +451,13 @@ void merror_exit(const char *msg, ...)
 #endif
 
     va_start(args, msg);
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
     va_end(args);
 
     exit(1);
 }
 
-void mterror_exit(const char *tag, const char *msg, ...)
+void _mterror_exit(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {
     va_list args;
     int level = LOGLEVEL_CRITICAL;
@@ -443,7 +470,7 @@ void mterror_exit(const char *tag, const char *msg, ...)
 #endif
 
     va_start(args, msg);
-    _log(level, tag, msg, args);
+    _log(level, tag, file, line, func, msg, args);
     va_end(args);
 
     exit(1);

--- a/src/shared/exec_op.c
+++ b/src/shared/exec_op.c
@@ -74,7 +74,7 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
         }
     }
 
-    mdebug2("%s(): path = '%s', command = '%s'", __func__, path, lpCommandLine);
+    mdebug2("path = '%s', command = '%s'", path, lpCommandLine);
 
     if (!CreateProcess(path, lpCommandLine, NULL, NULL, TRUE, 0, NULL, NULL, &sinfo, &pinfo)) {
         mdebug1("CreateProcess(): %ld", GetLastError());

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -12,11 +12,17 @@
 #include "wmodules.h"
 #include <os_net/os_net.h>
 
-#define minfo(format, ...) mtinfo(WM_DOWNLOAD_LOGTAG, format, ##__VA_ARGS__)
-#define mwarn(format, ...) mtwarn(WM_DOWNLOAD_LOGTAG, format, ##__VA_ARGS__)
-#define merror(format, ...) mterror(WM_DOWNLOAD_LOGTAG, format, ##__VA_ARGS__)
-#define mdebug1(format, ...) mtdebug1(WM_DOWNLOAD_LOGTAG, format, ##__VA_ARGS__)
-#define mdebug2(format, ...) mtdebug2(WM_DOWNLOAD_LOGTAG, format, ##__VA_ARGS__)
+#undef minfo
+#undef mwarn
+#undef merror
+#undef mdebug1
+#undef mdebug2
+
+#define minfo(msg, ...) _mtinfo(WM_DOWNLOAD_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mwarn(msg, ...) _mtwarn(WM_DOWNLOAD_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define merror(msg, ...) _mterror(WM_DOWNLOAD_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mdebug1(msg, ...) _mtdebug1(WM_DOWNLOAD_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mdebug2(msg, ...) _mtdebug2(WM_DOWNLOAD_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 
 static void * wm_download_main(wm_download_t * data);   // Module main function. It won't return
 static void wm_download_destroy(wm_download_t * data);  // Destroy data

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -25,11 +25,17 @@
 #define OSQUERYD_BIN "osqueryd"
 #endif
 
-#define minfo(format, ...) mtinfo(WM_OSQUERYMONITOR_LOGTAG, format, ##__VA_ARGS__)
-#define mwarn(format, ...) mtwarn(WM_OSQUERYMONITOR_LOGTAG, format, ##__VA_ARGS__)
-#define merror(format, ...) mterror(WM_OSQUERYMONITOR_LOGTAG, format, ##__VA_ARGS__)
-#define mdebug1(format, ...) mtdebug1(WM_OSQUERYMONITOR_LOGTAG, format, ##__VA_ARGS__)
-#define mdebug2(format, ...) mtdebug2(WM_OSQUERYMONITOR_LOGTAG, format, ##__VA_ARGS__)
+#undef minfo
+#undef mwarn
+#undef merror
+#undef mdebug1
+#undef mdebug2
+
+#define minfo(msg, ...) _mtinfo(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mwarn(msg, ...) _mtwarn(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define merror(msg, ...) _mterror(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mdebug1(msg, ...) _mtdebug1(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mdebug2(msg, ...) _mtdebug2(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 
 static void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery_monitor);
 static void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor);
@@ -475,7 +481,7 @@ int wm_osquery_decorators(wm_osquery_monitor_t * osquery)
     // Write new configuration
 
     if (json_fwrite(osquery->config_path, root) < 0) {
-        merror("At %s(): couldn't write JSON content into configuration '%s': %s (%d)", __func__, osquery->config_path, strerror(errno), errno);
+        merror("Couldn't write JSON content into configuration '%s': %s (%d)", osquery->config_path, strerror(errno), errno);
         goto end;
     }
 
@@ -549,7 +555,7 @@ int wm_osquery_packs(wm_osquery_monitor_t *osquery)
     // Write new configuration
 
     if (json_fwrite(osquery->config_path, root) < 0) {
-        merror("At %s(): couldn't write JSON content into configuration '%s': %s (%d)", __func__, osquery->config_path, strerror(errno), errno);
+        merror("Couldn't write JSON content into configuration '%s': %s (%d)", osquery->config_path, strerror(errno), errno);
         retval = -1;
     }
 


### PR DESCRIPTION
This PR aims to add tracing information to every daemon log:

- Process ID.
- Name of the file.
- Line number.
- Name of the function.

Only applications running in _debug_ mode (running with `-d` or enabling the `.debug` internal option) will append this data. Otherwise, the log will remain as previously.

## Log example

### Plain text (ossec.log)

```
2018/11/12 17:53:22 ossec-logcollector[11274] main.c:178 at main(): DEBUG: Starting ...
2018/11/12 17:53:22 ossec-logcollector[11274] mq_op.c:46 at StartMQ(): DEBUG: (unix_domain) Maximum send buffer set to: '212992'.
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:106 at LogCollectorStart(): DEBUG: Entering LogCollectorStart().
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:697 at set_read(): INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:722 at set_read(): DEBUG: Socket target for '/var/ossec/logs/active-responses.log' -> agent
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:697 at set_read(): INFO: (1950): Analyzing file: '/var/log/messages'.
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:722 at set_read(): DEBUG: Socket target for '/var/log/messages' -> agent
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:697 at set_read(): INFO: (1950): Analyzing file: '/var/log/auth.log'.
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:722 at set_read(): DEBUG: Socket target for '/var/log/auth.log' -> agent
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:697 at set_read(): INFO: (1950): Analyzing file: '/var/log/syslog'.
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:722 at set_read(): DEBUG: Socket target for '/var/log/syslog' -> agent
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:697 at set_read(): INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:722 at set_read(): DEBUG: Socket target for '/var/log/dpkg.log' -> agent
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:697 at set_read(): INFO: (1950): Analyzing file: '/var/log/kern.log'.
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:722 at set_read(): DEBUG: Socket target for '/var/log/kern.log' -> agent
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:160 at LogCollectorStart(): INFO: Monitoring output of command(360): df -P
2018/11/12 17:53:22 ossec-logcollector[11274] logcollector.c:164 at LogCollectorStart(): DEBUG: Socket target for 'df -P' -> agent
```

### JSON format (ossec.json)
```json
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"main.c","line":178,"routine":"main","level":"debug","description":"Starting ..."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"mq_op.c","line":46,"routine":"StartMQ","level":"debug","description":"(unix_domain) Maximum send buffer set to: '212992'."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":106,"routine":"LogCollectorStart","level":"debug","description":"Entering LogCollectorStart()."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":697,"routine":"set_read","level":"info","description":"(1950): Analyzing file: '/var/ossec/logs/active-responses.log'."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":722,"routine":"set_read","level":"debug","description":"Socket target for '/var/ossec/logs/active-responses.log' -> agent"}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":697,"routine":"set_read","level":"info","description":"(1950): Analyzing file: '/var/log/messages'."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":722,"routine":"set_read","level":"debug","description":"Socket target for '/var/log/messages' -> agent"}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":697,"routine":"set_read","level":"info","description":"(1950): Analyzing file: '/var/log/auth.log'."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":722,"routine":"set_read","level":"debug","description":"Socket target for '/var/log/auth.log' -> agent"}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":697,"routine":"set_read","level":"info","description":"(1950): Analyzing file: '/var/log/syslog'."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":722,"routine":"set_read","level":"debug","description":"Socket target for '/var/log/syslog' -> agent"}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":697,"routine":"set_read","level":"info","description":"(1950): Analyzing file: '/var/log/dpkg.log'."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":722,"routine":"set_read","level":"debug","description":"Socket target for '/var/log/dpkg.log' -> agent"}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":697,"routine":"set_read","level":"info","description":"(1950): Analyzing file: '/var/log/kern.log'."}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":722,"routine":"set_read","level":"debug","description":"Socket target for '/var/log/kern.log' -> agent"}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":160,"routine":"LogCollectorStart","level":"info","description":"Monitoring output of command(360): df -P"}
{"timestamp":"2018/11/12 17:53:22","tag":"ossec-logcollector","pid":11274,"file":"logcollector.c","line":164,"routine":"LogCollectorStart","level":"debug","description":"Socket target for 'df -P' -> agent"}
```