### PR TITLE
Discard invalid entries in syscheck database

### DIFF
--- a/tools/migration/fim_migrate.py
+++ b/tools/migration/fim_migrate.py
@@ -5,7 +5,7 @@
 # September 28, 2018.
 # This program is a free software, you can redistribute it
 # and/or modify it under the terms of GPLv2.
-# Revision 11/12/2018
+# Revision 11/13/2018
 
 import sys
 from getopt import getopt, GetoptError
@@ -70,9 +70,11 @@ def _fim_decode(fline):
     timestamp = None
     path = None
     readed = fline
-    fline = fline[3:-1].split(b'!')
+    fline = fline[3:-1].split(b' !')
     if len(fline) == 2:
-        fim = fline[0][:-1]
+        fim = fline[0]
+        # Delete invalid content "!:::::::"
+        fim = fim.split(b'!')[0]
         parsed = fline[1].split(b' ', 1)
         if len(parsed) == 2:
             timestamp = parsed[0]

--- a/tools/migration/fim_migrate.py
+++ b/tools/migration/fim_migrate.py
@@ -5,6 +5,7 @@
 # September 28, 2018.
 # This program is a free software, you can redistribute it
 # and/or modify it under the terms of GPLv2.
+# Revision 11/12/2018
 
 import sys
 from getopt import getopt, GetoptError
@@ -77,10 +78,13 @@ def _fim_decode(fline):
             timestamp = parsed[0]
             path = parsed[1]
         else:
-            logging.debug("Error parsing line: {0}".format(readed))
             logging.error("Couldn't decode line at syscheck database.")
+            logging.debug("Error parsing line: {0}".format(readed))
+            return None
     else:
         logging.error("Couldn't decode line at syscheck database.")
+        logging.debug("Error parsing line: {0}".format(readed))
+        return None
 
     return fim, timestamp, path
 
@@ -231,6 +235,8 @@ if __name__ == '__main__':
             for line in syscheck:
                 if not line[0] == b'#':
                     decoded = _fim_decode(line)
+                    if not decoded:
+                        continue
                     if not _force:
                         if not check_file_entry(0, decoded[2], s):
                             res = insert_fim(0, decoded, 'file', s)
@@ -283,6 +289,8 @@ if __name__ == '__main__':
                 for line in syscheck:
                     if not line[0] == b'#':
                         decoded = _fim_decode(line)
+                        if not decoded:
+                            continue
                         if not _force:
                             if not check_file_entry(agt[0], decoded[2], s):
                                 res = insert_fim(agt[0], decoded, 'file', s)
@@ -316,6 +324,8 @@ if __name__ == '__main__':
                 for line in syscheck:
                     if not line[0] == b'#':
                         decoded = _fim_decode(line)
+                        if not decoded:
+                            continue
                         if not _force:
                             if not check_file_entry(agt[0], decoded[2], s):
                                 res = insert_fim(agt[0], decoded, 'registry', s)


### PR DESCRIPTION
The migration tool for FIM is crashing with some invalid entries such as the entry reported in the issue https://github.com/wazuh/wazuh/issues/1849

```
!++4285:33256:0:0:829c192f512518213afeb2ab88dfffac:f571d66a3211fff4200891b5ff7320bebe6768f6:root:root:1532064424:134005:a44478ea6a17c7dd7deeb4ff0692b34d5f1039ff94d39b65e92aa02fbcf7312e!:::::::::: !1532681200 /etc/init.d/elasticsearch.dpkg-new
```

This part should not be in the database: `!::::::::::`

Now the script does not crash when the entry is not decoded and it will show an error:
```
2018-11-12 18:10:14 [INFO] Upgrading FIM database for manager...
2018-11-12 18:10:14 [ERROR] Couldn't decode line at syscheck database.
2018-11-12 18:10:14 [INFO] Added 3679 file entries in manager database.
```

It's possible to get the line using the debug option `-d`:

```
# ./fim_migrate -d 2>&1 | grep -A 1 ERROR
2018-11-12 18:19:40 [ERROR] Couldn't decode line at syscheck database.
2018-11-12 18:19:40 [DEBUG] Error parsing line: !++4285:33256:0:0:829c192f512518213afeb2ab88dfffac:f571d66a3211fff4200891b5ff7320bebe6768f6:root:root:1532064424:134005:a44478ea6a17c7dd7deeb4ff0692b34d5f1039ff94d39b65e92aa02fbcf7312e!:::::::::: !1532681200 /etc/init.d/elasticsearch.dpkg-new
```