### PR TITLE
Avoid that the ignore attribute silence alerts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix issue in Logcollector when reaching the file end before getting a full line. ([#1744](https://github.com/wazuh/wazuh/pull/1744))
+- Avoid that the attribute `ignore` of rules silence alerts. ([#1874](https://github.com/wazuh/wazuh/pull/1874))
 - Fix to overwrite FIM configuration when directories come in the same tag separated by commas. ([#1886](https://github.com/wazuh/wazuh/pull/1886))
 
 

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -125,7 +125,7 @@ void OS_LogOutput(Eventinfo *lf)
     printf(
         "** Alert %ld.%ld:%s - %s\n"
         "%d %s %02d %s %s%s%s\n%sRule: %d (level %d) -> '%s'"
-        "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
+        "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
         (long int)lf->time.tv_sec,
         __crt_ftell,
         lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
@@ -174,7 +174,10 @@ void OS_LogOutput(Eventinfo *lf)
         lf->dstport == NULL ? "" : "\nDst Port: ",
         lf->dstport == NULL ? "" : lf->dstport,
 
-        lf->dstuser == NULL ? "" : "\nUser: ",
+        lf->srcuser == NULL ? "" : "\nSrc User: ",
+        lf->srcuser == NULL ? "" : lf->srcuser,
+
+        lf->dstuser == NULL ? "" : "\nDst User: ",
         lf->dstuser == NULL ? "" : lf->dstuser,
 
         lf->generated_rule->alert_opts & NO_FULL_LOG ? "" : "\n",
@@ -291,7 +294,7 @@ void OS_Log(Eventinfo *lf)
     fprintf(_aflog,
             "** Alert %ld.%ld:%s - %s\n"
             "%d %s %02d %s %s%s%s\n%sRule: %d (level %d) -> '%s'"
-            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
+            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
             (long int)lf->time.tv_sec,
             __crt_ftell,
             lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
@@ -339,7 +342,10 @@ void OS_Log(Eventinfo *lf)
             lf->dstport == NULL ? "" : "\nDst Port: ",
             lf->dstport == NULL ? "" : lf->dstport,
 
-            lf->dstuser == NULL ? "" : "\nUser: ",
+            lf->srcuser == NULL ? "" : "\nSrc User: ",
+            lf->srcuser == NULL ? "" : lf->srcuser,
+
+            lf->dstuser == NULL ? "" : "\nDst User: ",
             lf->dstuser == NULL ? "" : lf->dstuser,
             "\n",
             lf->full_log);

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -125,7 +125,7 @@ void OS_LogOutput(Eventinfo *lf)
     printf(
         "** Alert %ld.%ld:%s - %s\n"
         "%d %s %02d %s %s%s%s\n%sRule: %d (level %d) -> '%s'"
-        "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
+        "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
         (long int)lf->time.tv_sec,
         __crt_ftell,
         lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
@@ -174,10 +174,7 @@ void OS_LogOutput(Eventinfo *lf)
         lf->dstport == NULL ? "" : "\nDst Port: ",
         lf->dstport == NULL ? "" : lf->dstport,
 
-        lf->srcuser == NULL ? "" : "\nSrc User: ",
-        lf->srcuser == NULL ? "" : lf->srcuser,
-
-        lf->dstuser == NULL ? "" : "\nDst User: ",
+        lf->dstuser == NULL ? "" : "\nUser: ",
         lf->dstuser == NULL ? "" : lf->dstuser,
 
         lf->generated_rule->alert_opts & NO_FULL_LOG ? "" : "\n",
@@ -294,7 +291,7 @@ void OS_Log(Eventinfo *lf)
     fprintf(_aflog,
             "** Alert %ld.%ld:%s - %s\n"
             "%d %s %02d %s %s%s%s\n%sRule: %d (level %d) -> '%s'"
-            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
+            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
             (long int)lf->time.tv_sec,
             __crt_ftell,
             lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
@@ -342,10 +339,7 @@ void OS_Log(Eventinfo *lf)
             lf->dstport == NULL ? "" : "\nDst Port: ",
             lf->dstport == NULL ? "" : lf->dstport,
 
-            lf->srcuser == NULL ? "" : "\nSrc User: ",
-            lf->srcuser == NULL ? "" : lf->srcuser,
-
-            lf->dstuser == NULL ? "" : "\nDst User: ",
+            lf->dstuser == NULL ? "" : "\nUser: ",
             lf->dstuser == NULL ? "" : lf->dstuser,
             "\n",
             lf->full_log);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2143,6 +2143,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
                             < t_currently_rule->ignore_time) {
                     if (t_currently_rule->prev_rule) {
                         t_currently_rule = (RuleInfo*)t_currently_rule->prev_rule;
+                        w_FreeArray(lf->last_events);
                     } else {
                         break;
                     }

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1591,6 +1591,8 @@ RuleInfo *zerorulemember(int id, int level,
     ruleinfo_pt->compiled_rule = NULL;
     ruleinfo_pt->lists = NULL;
 
+    ruleinfo_pt->prev_rule = NULL;
+
     return (ruleinfo_pt);
 }
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -172,6 +172,9 @@ typedef struct _RuleInfo {
     pthread_mutex_t mutex;
 
     char *file;
+
+    /* Pointer to the previous rule matched */
+    void *prev_rule;
 } RuleInfo;
 
 


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/1862.

Now, when a child rule is ignored due to its attribute, the parent one is triggered instead. Here is an example:

The rule 40601 looks like this one:
```
<group name="syslog,recon,">
  <rule id="40601" level="10" frequency="12" timeframe="90" ignore="90">
    <if_matched_group>connection_attempt</if_matched_group>
    <description>Network scan from same source ip.</description>
    <same_source_ip />
    <info type="link">http://project.honeynet.org/papers/enemy2/</info>
    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
  </rule>
</group>
```

If the alert is matched while the "ignore" period, the parent alert 2551 is triggered fixing the missing of any alert for the received event.

```
<rule id="2551" level="10">
    <if_sid>2550</if_sid>
    <regex>^Connection from \S+ on illegal port$</regex>
    <description>Connection to rshd from unprivileged port. Possible network scan.</description>
    <group>connection_attempt,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,</group>
  </rule>
</group>
```

It also has been added the missing field `srcuser` for the plain alerts. 