### PR TITLE
Fix race condition when decoding file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,25 +19,26 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix symbolic links attributes reported by `syscheck` in the alerts. ([#1926](https://github.com/wazuh/wazuh/pull/1926))
+- Prevent duplicates entries for denied IP addresses by `host-deny.sh`. (by @iasdeoupxe). ([#1583](https://github.com/wazuh/wazuh/pull/1583))
 - Fix issue in Logcollector when reaching the file end before getting a full line. ([#1744](https://github.com/wazuh/wazuh/pull/1744))
 - Throw an error when a nonexistent CDB file is added in the ossec.conf file. ([#1783](https://github.com/wazuh/wazuh/pull/1783))
 - Fix bug in Remoted that truncated control messages to 1024 bytes. ([#1847](https://github.com/wazuh/wazuh/pull/1847))
 - Avoid that the attribute `ignore` of rules silence alerts. ([#1874](https://github.com/wazuh/wazuh/pull/1874))
+- Fix race condition when decoding file permissions. ([#1879](https://github.com/wazuh/wazuh/pull/1879)
 - Fix to overwrite FIM configuration when directories come in the same tag separated by commas. ([#1886](https://github.com/wazuh/wazuh/pull/1886))
-- Fixed starting wodles after a delay specified in `interval` when `run_on_start` is set to `no`, on the first run of the agent. ([#1906](https://github.com/wazuh/wazuh/pull/1906))
+- Fixed issue with hash table handling in FTS and label management. ([#1889](https://github.com/wazuh/wazuh/pull/1889))
 - Fixed id's and description of FIM alerts. ([#1891](https://github.com/wazuh/wazuh/pull/1891))
 - Fix log flooding by Logcollector when monitored files disappear. ([#1893](https://github.com/wazuh/wazuh/pull/1893))
+- Fix bug configuring empty blocks in FIM. ([#1897](https://github.com/wazuh/wazuh/pull/1897))
 - Let the Windows agent reset the random generator context if it's corrupt. ([#1898](https://github.com/wazuh/wazuh/pull/1898))
 - Prevent Remoted from logging errors if the cluster configuration is missing or invalid. ([#1900](https://github.com/wazuh/wazuh/pull/1900))
 - Fix race condition hazard in Remoted when handling control messages. ([#1902](https://github.com/wazuh/wazuh/pull/1902))
+- Fixed starting wodles after a delay specified in `interval` when `run_on_start` is set to `no`, on the first run of the agent. ([#1906](https://github.com/wazuh/wazuh/pull/1906))
 - Prevent `agent-auth` tool from creating the file _client.keys_ outside the agent's installation folder. ([#1924](https://github.com/wazuh/wazuh/pull/1924))
+- Fix symbolic links attributes reported by `syscheck` in the alerts. ([#1926](https://github.com/wazuh/wazuh/pull/1926))
 - Added some improvements and fixes in Whodata. ([#1929](https://github.com/wazuh/wazuh/pull/1929))
-- Prevent duplicates entries for denied IP addresses by `host-deny.sh`. (by @iasdeoupxe). ([#1583](https://github.com/wazuh/wazuh/pull/1583))
-- Add missing field `restrict` when querying the FIM configuration remotely. ([#1931](https://github.com/wazuh/wazuh/pull/1931))
 - Fix FIM decoder to accept Windows user containing spaces. ([#1930](https://github.com/wazuh/wazuh/pull/1930))
-- Fix bug configuring empty blocks in FIM. ([#1897](https://github.com/wazuh/wazuh/pull/1897))
-- Fixed issue with hash table handling in FTS and label management. ([#1889](https://github.com/wazuh/wazuh/pull/1889))
+- Add missing field `restrict` when querying the FIM configuration remotely. ([#1931](https://github.com/wazuh/wazuh/pull/1931))
 
 
 ## [v3.7.0] - 2018-11-10

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -540,11 +540,15 @@ int fim_alert (char *f_name, sk_sum_t *oldsum, sk_sum_t *newsum, Eventinfo *lf, 
                     wm_strcat(&lf->fields[SK_CHFIELDS].value, "perm", ',');
                     char opstr[10];
                     char npstr[10];
+                    char *old_perm =  agent_file_perm(oldsum->perm);
+                    char *new_perm =  agent_file_perm(newsum->perm);
 
-                    strncpy(opstr, agent_file_perm(oldsum->perm), sizeof(opstr) - 1);
-                    strncpy(npstr, agent_file_perm(newsum->perm), sizeof(npstr) - 1);
+                    strncpy(opstr, old_perm, sizeof(opstr) - 1);
+                    strncpy(npstr, new_perm, sizeof(npstr) - 1);
+                    free(old_perm);
+                    free(new_perm);
+
                     opstr[9] = npstr[9] = '\0';
-
                     snprintf(localsdb->perm, OS_FLSIZE, "Permissions changed from "
                              "'%9.9s' to '%9.9s'\n", opstr, npstr);
 

--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -77,7 +77,7 @@ int connect_to_remoted(void);
 /* Return the unix permission string
  * Returns a pointer to a local static array
  */
-const char *agent_file_perm(mode_t mode);
+char *agent_file_perm(mode_t mode);
 #endif
 
 /* Sends a message to an agent

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -57,6 +57,7 @@ static int _do_print_attrs_syscheck(const char *prev_attrs, const char *attrs, _
                                     cJSON *json_output, int is_win, int number_of_changes)
 {
     const char *p_size, *size;
+    char *file_perm;
     char *p_perm, *p_uid, *p_gid, *p_md5, *p_sha1;
     char *perm, *uid, *gid, *md5, *sha1;
     mode_t mode;
@@ -139,7 +140,9 @@ static int _do_print_attrs_syscheck(const char *prev_attrs, const char *attrs, _
     perm_str[35] = '\0';
     /* octal or decimal */
     mode = (mode_t) strtoul(perm, 0, strlen(perm) == 3 ? 8 : 10);
-    snprintf(perm_str, 35, "%9.9s", agent_file_perm(mode));
+    file_perm = agent_file_perm(mode);
+    snprintf(perm_str, 35, "%9.9s", file_perm);
+    free(file_perm);
 
     if (json_output) {
         cJSON_AddStringToObject(json_output, "size", size);
@@ -948,23 +951,24 @@ int connect_to_remoted()
     return (arq);
 }
 
-const char *agent_file_perm(mode_t mode)
+char *agent_file_perm(mode_t mode)
 {
-	/* rwxrwxrwx0 -> 10 */
-	static char permissions[10];
+    /* rwxrwxrwx0 -> 10 */
+    char *permissions;
 
-	permissions[0] = (mode & S_IRUSR) ? 'r' : '-';
-	permissions[1] = (mode & S_IWUSR) ? 'w' : '-';
-	permissions[2] = (mode & S_ISUID) ? 's' : (mode & S_IXUSR) ? 'x' : '-';
-	permissions[3] = (mode & S_IRGRP) ? 'r' : '-';
-	permissions[4] = (mode & S_IWGRP) ? 'w' : '-';
-	permissions[5] = (mode & S_ISGID) ? 's' : (mode & S_IXGRP) ? 'x' : '-';
-	permissions[6] = (mode & S_IROTH) ? 'r' : '-';
-	permissions[7] = (mode & S_IWOTH) ? 'w' : '-';
-	permissions[8] = (mode & S_ISVTX) ? 't' : (mode & S_IXOTH) ? 'x' : '-';
+    os_calloc(10, sizeof(char), permissions);
+    permissions[0] = (mode & S_IRUSR) ? 'r' : '-';
+    permissions[1] = (mode & S_IWUSR) ? 'w' : '-';
+    permissions[2] = (mode & S_ISUID) ? 's' : (mode & S_IXUSR) ? 'x' : '-';
+    permissions[3] = (mode & S_IRGRP) ? 'r' : '-';
+    permissions[4] = (mode & S_IWGRP) ? 'w' : '-';
+    permissions[5] = (mode & S_ISGID) ? 's' : (mode & S_IXGRP) ? 'x' : '-';
+    permissions[6] = (mode & S_IROTH) ? 'r' : '-';
+    permissions[7] = (mode & S_IWOTH) ? 'w' : '-';
+    permissions[8] = (mode & S_ISVTX) ? 't' : (mode & S_IXOTH) ? 'x' : '-';
     permissions[9] = '\0';
 
-	return &permissions[0];
+    return permissions;
 }
 
 #endif /* !WIN32 */


### PR DESCRIPTION
This PR solves a race condition appeared in Wazuh 3.7, with multithread analysisd.