### PR TITLE
Fix overwrite FIM settings when entering directories separated by commas

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -625,6 +625,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 
         /* Add directory - look for the last available */
         j = 0;
+        int overwrite = 0;
         while (syscheck->dir && syscheck->dir[j]) {
             char expandedpath[OS_MAXSTR];
             char *ptfile;
@@ -655,7 +656,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 mdebug2("Overwriting the file entry %s", expandedpath);
                 dump_syscheck_entry(syscheck, expandedpath, opts, 0, restrictfile, recursion_limit, clean_tag, j);
                 ret = 1;
-                goto out_free;
+                overwrite = 1;
             }
 
             j++;
@@ -685,17 +686,23 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             }
 
             while (g.gl_pathv[gindex]) {
-                dump_syscheck_entry(syscheck, g.gl_pathv[gindex], opts, 0, restrictfile, recursion_limit, clean_tag, -1);
+                if(overwrite == 0) {
+                    dump_syscheck_entry(syscheck, g.gl_pathv[gindex], opts, 0, restrictfile, recursion_limit, clean_tag, -1);
+                }
                 gindex++;
             }
 
             globfree(&g);
         }
         else {
-            dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile, recursion_limit, clean_tag, -1);
+            if(overwrite == 0) {
+                dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile, recursion_limit, clean_tag, -1);
+            }
         }
 #else
-	    dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile, recursion_limit, clean_tag, -1);
+        if(overwrite == 0) {
+            dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile, recursion_limit, clean_tag, -1);
+        }
 #endif
 
         if (restrictfile) {


### PR DESCRIPTION
This PR solve #1865 

The error occurred when adding path separated by commas in the same tag.

## Test:
ossec.conf configuration:
```
<syscheck
 ...
   <directories check_all="yes">/test1,/test2</directories>
   <directories check_all="yes">/test3,/test4</directories>
 ...
</syscheck>
```
Add this configuration to agent.conf
```
<agent_config>
  <!-- Shared agent configuration here -->
  <syscheck>
    <directories check_all="no" check_sha1sum="yes" check_size="yes" check_mtime="yes"  whodata="yes">/test1,/test2</directories>
    <directories check_all="no" check_md5sum="yes" check_perm="yes" check_group="yes" realtime="yes">/test3,/test4</directories>
 </syscheck>
</agent_config>
```

- [ ] You should see the following messages in the log, where the added directories get the agent.conf configuration.
```
2018/11/15 09:03:26 ossec-syscheckd: INFO: Monitoring directory: '/test1', with options size | sha1sum | mtime | whodata.
2018/11/15 09:03:26 ossec-syscheckd: INFO: Monitoring directory: '/test2', with options size | sha1sum | mtime | whodata.
2018/11/15 09:03:26 ossec-syscheckd: INFO: Monitoring directory: '/test3', with options perm | group | md5sum | realtime.
2018/11/15 09:03:26 ossec-syscheckd: INFO: Monitoring directory: '/test4', with options perm | group | md5sum | realtime.
```