### PR TITLE
Fix description and id for decoded events from FIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Fix issue in Logcollector when reaching the file end before getting a full line. ([#1744](https://github.com/wazuh/wazuh/pull/1744))
 - Avoid that the attribute `ignore` of rules silence alerts. ([#1874](https://github.com/wazuh/wazuh/pull/1874))
 - Fix to overwrite FIM configuration when directories come in the same tag separated by commas. ([#1886](https://github.com/wazuh/wazuh/pull/1886))
+- Fixed id's and description of FIM alerts. ([#1891](https://github.com/wazuh/wazuh/pull/1891))
 
 
 ## [v3.7.0] - 2018-11-10

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -60,8 +60,8 @@ int DecodeRootcheck(Eventinfo *lf);
 int DecodeHostinfo(Eventinfo *lf);
 int DecodeSyscollector(Eventinfo *lf,int *socket);
 int DecodeCiscat(Eventinfo *lf);
-// Init sdb struct
-void sdb_init(_sdb *localsdb);
+// Init sdb and decoder struct
+void sdb_init(_sdb *localsdb, OSDecoderInfo *fim_decoder);
 
 /* For stats */
 static void DumpLogstats(void);
@@ -81,7 +81,6 @@ char __shost[512];
 OSDecoderInfo *NULL_Decoder;
 rlim_t nofile;
 int sys_debug_level;
-OSDecoderInfo *fim_decoder;
 int num_rule_matching_threads;
 EventList *last_events_list;
 time_t current_time;
@@ -1778,9 +1777,12 @@ void * w_decode_syscheck_thread(__attribute__((unused)) void * args){
     Eventinfo *lf = NULL;
     char *msg = NULL;
     _sdb sdb;
+    OSDecoderInfo *fim_decoder = NULL;
+
+    os_calloc(1, sizeof(OSDecoderInfo), fim_decoder);
 
     /* Initialize the integrity database */
-    sdb_init(&sdb);
+    sdb_init(&sdb, fim_decoder);
 
     while(1){
 
@@ -1805,6 +1807,7 @@ void * w_decode_syscheck_thread(__attribute__((unused)) void * args){
             DEBUG_MSG("%s: DEBUG: Msg cleanup: %s ", ARGV0, lf->log);
 
             w_inc_syscheck_decoded_events();
+            lf->decoder_info = fim_decoder;
 
             if (DecodeSyscheck(lf, &sdb) != 1) {
                 /* We don't process syscheck events further */


### PR DESCRIPTION
Related issues:
 - Improve FIM alerts description #1852 
 - FIM rules not working as expected #1875 

For version 3.7 several threads were created to decode FIM events. Thats thread used the same structure for all events and only the `syscheck_integrity_changed` string was used for all events.

Now a decoder is used for each thread allowing to select the value of the string according to the generated event. Using:
- syscheck_deleted
- syscheck_new_entry
- syscheck_integrity_changed

Depending on the string a different rule will be macheted:
```
  <rule id="550" level="7">
    <category>ossec</category>
    <decoded_as>syscheck_integrity_changed</decoded_as>
    <description>Integrity checksum changed.</description>
    <group>syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,</group>
  </rule>

  <rule id="553" level="7">
    <category>ossec</category>
    <decoded_as>syscheck_deleted</decoded_as>
    <description>File deleted.</description>
    <group>syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,</group>
  </rule>

  <rule id="554" level="5">
    <category>ossec</category>
    <decoded_as>syscheck_new_entry</decoded_as>
    <description>File added to the system.</description>
    <group>syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,</group>
  </rule>
```
## Test:
- [x] Check that the 3 different types of rules are generated with their corresponding ids and descriptions
```
Rule: 553 (level 7) -> 'File deleted.'
File '/test/folder1/folder2/file2' was deleted.

Rule: 554 (level 5) -> 'File added to the system.'
File '/test/folder186/file186' was added.

Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/test/folder56/file56' checksum changed.
```
- [x] Check that Valgrind doesn't report any memory leaks.
```
==17057== LEAK SUMMARY:
==17057==    definitely lost: 100 bytes in 9 blocks -->(normal)
==17057==    indirectly lost: 0 bytes in 0 blocks
==17057==      possibly lost: 8,976 bytes in 33 blocks
==17057==    still reachable: 12,621,717 bytes in 64,027 blocks
==17057==         suppressed: 0 bytes in 0 blocks
==17057== Reachable blocks (those to which a pointer was found) are not shown.
```