### PR TITLE
Adding default ignore_time setting in vulnerability detector wodle

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -1,6 +1,7 @@
   <wodle name="vulnerability-detector">
     <disabled>yes</disabled>
     <interval>5m</interval>
+    <ignore_time>6h</ignore_time>
     <run_on_start>yes</run_on_start>
     <feed name="ubuntu-18">
       <disabled>yes</disabled>


### PR DESCRIPTION
Hello team,

this PR adds the default value for the `ignore_time` setting into the vulnerability-detector settings for a generic new installation.

Regards.