### PR TITLE
Support for AWS Inspector

### DIFF
--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -216,38 +216,38 @@ ID: 80200 - 80499
     <!-- AWS Inspector -->
     <!-- Documentation: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_introduction.html -->
 
-    <rule id="80495" level="3">
+    <rule id="80495" level="0">
         <field name="aws.service">Inspector</field>
-        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
+        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
     </rule>
 
-    <rule id="80496" level="6">
+    <rule id="80496" level="10">
         <if_sid>80495</if_sid>
         <field name="aws.severity">High</field>
-        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
-        <group>aws_inspector, aws_inspector_high,</group>
+        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <group>aws_inspector,</group>
     </rule>
 
-    <rule id="80497" level="5">
+    <rule id="80497" level="7">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Medium</field>
-        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
-        <group>aws_inspector, aws_inspector_medium,</group>
+        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <group>aws_inspector,</group>
     </rule>
 
     <rule id="80498" level="4">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Low</field>
-        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
-        <group>aws_inspector, aws_inspector_low,</group>
+        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <group>aws_inspector,</group>
     </rule>
 
     <rule id="80499" level="3">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Informational</field>
-        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
-        <group>aws_inspector, aws_inspector_informational,</group>
+        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <group>aws_inspector,</group>
     </rule>
   
 </group>

--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -218,7 +218,7 @@ ID: 80200 - 80499
 
     <rule id="80495" level="3">
         <field name="aws.service">Inspector</field>
-        <<description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
+        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector,</group>
     </rule>
 

--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -218,35 +218,35 @@ ID: 80200 - 80499
 
     <rule id="80495" level="0">
         <field name="aws.service">Inspector</field>
-        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <description>AWS Inspector - Network assesment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
     </rule>
 
     <rule id="80496" level="10">
         <if_sid>80495</if_sid>
         <field name="aws.severity">High</field>
-        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <description>AWS Inspector - Network assesment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
     </rule>
 
     <rule id="80497" level="7">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Medium</field>
-        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <description>AWS Inspector - Network assesment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
     </rule>
 
     <rule id="80498" level="4">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Low</field>
-        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <description>AWS Inspector - Network assesment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
     </rule>
 
     <rule id="80499" level="3">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Informational</field>
-        <description>AWS Inspector - Network assesment [$aws.createdAt]: $(aws.title) [$(aws.severity)]</description>
+        <description>AWS Inspector - Network assesment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
     </rule>
   

--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -218,35 +218,35 @@ ID: 80200 - 80499
 
     <rule id="80495" level="3">
         <field name="aws.service">Inspector</field>
-        <description>AWS Inspector</description>
+        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector,</group>
     </rule>
 
     <rule id="80496" level="6">
         <if_sid>80495</if_sid>
         <field name="aws.severity">High</field>
-        <description>AWS Inspector - Severity $(aws.severity)</description>
+        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector, aws_inspector_high,</group>
     </rule>
 
     <rule id="80497" level="5">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Medium</field>
-        <description>AWS Inspector - Severity $(aws.severity)</description>
+        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector, aws_inspector_medium,</group>
     </rule>
 
     <rule id="80498" level="4">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Low</field>
-        <description>AWS Inspector - Severity $(aws.severity)</description>
+        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector, aws_inspector_low,</group>
     </rule>
 
     <rule id="80499" level="3">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Informational</field>
-        <description>AWS Inspector - Severity $(aws.severity)</description>
+        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector, aws_inspector_informational,</group>
     </rule>
   

--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -218,35 +218,35 @@ ID: 80200 - 80499
 
     <rule id="80495" level="3">
         <field name="aws.service">Inspector</field>
-        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
+        <<description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector,</group>
     </rule>
 
     <rule id="80496" level="6">
         <if_sid>80495</if_sid>
         <field name="aws.severity">High</field>
-        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
+        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector, aws_inspector_high,</group>
     </rule>
 
     <rule id="80497" level="5">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Medium</field>
-        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
+        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector, aws_inspector_medium,</group>
     </rule>
 
     <rule id="80498" level="4">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Low</field>
-        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
+        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector, aws_inspector_low,</group>
     </rule>
 
     <rule id="80499" level="3">
         <if_sid>80495</if_sid>
         <field name="aws.severity">Informational</field>
-        <description>AWS Inspector [$(aws.title)]: $(aws.severity)</description>
+        <description>AWS Inspector - Network assesment [$(aws.title)]: $(aws.severity)</description>
         <group>aws_inspector, aws_inspector_informational,</group>
     </rule>
   

--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -212,5 +212,42 @@ ID: 80200 - 80499
         <description>AWS Config - Snapshot Compliance [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)] [$(aws.configuration.configRuleList.configRuleName)]: $(aws.resourceId) ($(aws.configurationItemStatus)) $(aws.configuration.complianceType)</description>
         <group>aws_config_snapshot,aws_config_snapshot_compliance,</group>
     </rule>
+
+    <!-- AWS Inspector -->
+    <!-- Documentation: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_introduction.html -->
+
+    <rule id="80495" level="3">
+        <field name="aws.service">Inspector</field>
+        <description>AWS Inspector</description>
+        <group>aws_inspector,</group>
+    </rule>
+
+    <rule id="80496" level="6">
+        <if_sid>80495</if_sid>
+        <field name="aws.severity">High</field>
+        <description>AWS Inspector - Severity $(aws.severity)</description>
+        <group>aws_inspector, aws_inspector_high,</group>
+    </rule>
+
+    <rule id="80497" level="5">
+        <if_sid>80495</if_sid>
+        <field name="aws.severity">Medium</field>
+        <description>AWS Inspector - Severity $(aws.severity)</description>
+        <group>aws_inspector, aws_inspector_medium,</group>
+    </rule>
+
+    <rule id="80498" level="4">
+        <if_sid>80495</if_sid>
+        <field name="aws.severity">Low</field>
+        <description>AWS Inspector - Severity $(aws.severity)</description>
+        <group>aws_inspector, aws_inspector_low,</group>
+    </rule>
+
+    <rule id="80499" level="3">
+        <if_sid>80495</if_sid>
+        <field name="aws.severity">Informational</field>
+        <description>AWS Inspector - Severity $(aws.severity)</description>
+        <group>aws_inspector, aws_inspector_informational,</group>
+    </rule>
   
 </group>

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -172,7 +172,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 // type is an attribute of the bucket tag
                 if (!strcmp(*nodes[i]->attributes, XML_BUCKET_TYPE)) {
                     if (!strcmp(*nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CONFIG_BUCKET_TYPE)
-                        || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE || !strcmp(*nodes[i]->values, INSPECTOR_TYPE)) {
+                        || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE) || !strcmp(*nodes[i]->values, INSPECTOR_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
                         mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE,

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -13,7 +13,7 @@
 
 static const char *XML_DISABLED = "disabled";
 static const char *XML_BUCKET = "bucket";
-static const char *XML_SERVICE = "service"; // for inspector
+static const char *XML_SERVICE = "service";
 static const char *XML_INTERVAL = "interval";
 static const char *XML_ACCESS_KEY = "access_key";
 static const char *XML_SECRET_KEY = "secret_key";
@@ -28,7 +28,7 @@ static const char *XML_TRAIL_PREFIX = "path";
 static const char *XML_ONLY_LOGS_AFTER = "only_logs_after";
 static const char *XML_REGION = "regions";
 static const char *XML_BUCKET_TYPE = "type";
-static const char *XML_SERVICE_TYPE = "type"; // for inspector
+static const char *XML_SERVICE_TYPE = "type";
 static const char *XML_BUCKET_NAME = "name";
 
 static const char *LEGACY_AWS_ACCOUNT_ALIAS = "LEGACY";
@@ -36,7 +36,7 @@ static const char *LEGACY_AWS_ACCOUNT_ALIAS = "LEGACY";
 static const char *CLOUDTRAIL_BUCKET_TYPE = "cloudtrail";
 static const char *CONFIG_BUCKET_TYPE = "config";
 static const char *CUSTOM_BUCKET_TYPE = "custom";
-static const char *INSPECTOR_SERVICE_TYPE = "inspector"; // for inspector
+static const char *INSPECTOR_SERVICE_TYPE = "inspector";
 
 // Parse XML
 
@@ -178,7 +178,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
-                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE,
+                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE,
                             CONFIG_BUCKET_TYPE, CUSTOM_BUCKET_TYPE);
                         OS_ClearNode(children);
                         return OS_INVALID;
@@ -273,126 +273,109 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         return OS_INVALID;
                     }
                 }
-
                 OS_ClearNode(children);
             }
-        // for inspector
+        // for services
         } else if (!strcmp(nodes[i]->element, XML_SERVICE)) {
-            if (!nodes[i]->attributes) { // Legacy ??
-                if (strlen(nodes[i]->content) == 0) {
-                    merror("Empty content for tag '%s' at module '%s'.", XML_SERVICE, WM_AWS_CONTEXT.name);
+
+            mtdebug2(WM_AWS_LOGTAG, "Found a service tag");
+            // Create service node
+            if (cur_service) {
+                os_calloc(1, sizeof(wm_aws_service), cur_service->next);
+                cur_service = cur_service->next;
+                mtdebug2(WM_AWS_LOGTAG, "Creating another service structure");
+            } else {
+                // First service
+                os_calloc(1, sizeof(wm_aws_service), cur_service);
+                aws_config->services = cur_service;
+                mtdebug2(WM_AWS_LOGTAG, "Creating first service structure");
+            }
+
+            // Expand service Child Nodes
+
+            if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
+                continue;
+            }
+
+            // type is an attribute of the service tag
+            if (!strcmp(*nodes[i]->attributes, XML_SERVICE_TYPE)) {
+                if (!strcmp(*nodes[i]->values, INSPECTOR_SERVICE_TYPE)) {
+                    os_strdup(*nodes[i]->values, cur_service->type);
+                } else {
+                    mterror(WM_AWS_LOGTAG, "Invalid service type '%s'. Valid one is '%s'", *nodes[i]->values, INSPECTOR_SERVICE_TYPE);
+                    OS_ClearNode(children);
                     return OS_INVALID;
                 }
-
-                free(aws_config->service);
-                os_strdup(nodes[i]->content, aws_config->service);
             } else {
-                mtdebug2(WM_AWS_LOGTAG, "Found a bucket tag");
-                // Create bucket node
-                if (cur_service) {
-                    os_calloc(1, sizeof(wm_aws_bucket), cur_service->next);
-                    cur_service = cur_service->next;
-                    mtdebug2(WM_AWS_LOGTAG, "Creating another bucket structure");
-                } else {
-                    // First bucket
-                    os_calloc(1, sizeof(wm_aws_service), cur_service);
-                    aws_config->buckets = cur_service;
-                    mtdebug2(WM_AWS_LOGTAG, "Creating first bucket structure");
-                }
+                mterror(WM_AWS_LOGTAG, "Attribute name '%s' is not valid. The valid one is '%s'.", *nodes[i]->attributes, XML_SERVICE_TYPE);
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
 
-                // Expand bucket Child Nodes
+            mtdebug2(WM_AWS_LOGTAG, "Loop thru child nodes");
+            for (j = 0; children[j]; j++) {
 
-                if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
-                    continue;
-                }
+                mtdebug2(WM_AWS_LOGTAG, "Parse child node: %s", children[j]->element);
 
-                // type is an attribute of the bucket tag
-                if (!strcmp(*nodes[i]->attributes, XML_SERVICE_TYPE)) {
-                    if (!strcmp(*nodes[i]->values, INSPECTOR_SERVICE_TYPE) {
-                        os_strdup(*nodes[i]->values, cur_service->type);
-                    } else {
-                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid one is '%s'", *nodes[i]->values, INSPECTOR_SERVICE_TYPE);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    }
-                } else {
-                    mterror(WM_AWS_LOGTAG, "Attribute name '%s' is not valid. The valid one is '%s'.", *nodes[i]->attributes, XML_SERVICE_TYPE);
+                if (!children[j]->element) {
+                    merror(XML_ELEMNULL);
                     OS_ClearNode(children);
                     return OS_INVALID;
                 }
 
-                mtdebug2(WM_AWS_LOGTAG, "Loop thru child nodes");
-                for (j = 0; children[j]; j++) {
-
-                    mtdebug2(WM_AWS_LOGTAG, "Parse child node: %s", children[j]->element);
-
-                    if (!children[j]->element) {
-                        merror(XML_ELEMNULL);
+                // Start
+                if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ID)) {
+                    if (strlen(children[j]->content) == 0) {
+                        merror("Empty content for tag '%s' at module '%s'.", XML_SERVICE, WM_AWS_CONTEXT.name);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }
-
-                    // Start
-                    if (!strcmp(children[j]->element, XML_SERVUCE_NAME)) {
-                        if (strlen(children[j]->content) == 0) {
-                            merror("Empty content for tag '%s' at module '%s'.", XML_SERVICE_NAME, WM_AWS_CONTEXT.name);
-                            OS_ClearNode(children);
-                            return OS_INVALID;
-                        }
-                        free(cur_service->service);
-                        os_strdup(children[j]->content, cur_service->service);
-                    } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ID)) {
-                        if (strlen(children[j]->content) == 0) {
-                            merror("Empty content for tag '%s' at module '%s'.", XML_SERVICE, WM_AWS_CONTEXT.name);
-                            OS_ClearNode(children);
-                            return OS_INVALID;
-                        }
-                        free(cur_service->aws_account_id);
-                        os_strdup(children[j]->content, cur_service->aws_account_id);
-                    } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
-                        if (strlen(children[j]->content) != 0) {
-                            free(cur_service->access_key);
-                            os_strdup(children[j]->content, cur_service->access_key);
-                        }
-                    } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ALIAS)) {
-                        if (strlen(children[j]->content) != 0) {
-                            free(cur_service->aws_account_alias);
-                            os_strdup(children[j]->content, cur_service->aws_account_alias);
-                        }
-                    } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
-                        if (strlen(children[j]->content) != 0) {
-                            free(cur_service->secret_key);
-                            os_strdup(children[j]->content, cur_service->secret_key);
-                        }
-                    } else if (!strcmp(children[j]->element, XML_AWS_PROFILE)) {
-                        if (strlen(children[j]->content) != 0) {
-                            free(cur_service->aws_profile);
-                            os_strdup(children[j]->content, cur_service->aws_profile);
-                        }
-                    } else if (!strcmp(children[j]->element, XML_IAM_ROLE_ARN)) {
-                        if (strlen(children[j]->content) != 0) {
-                            free(cur_service->iam_role_arn);
-                            os_strdup(children[j]->content, cur_service->iam_role_arn);
-                        }
-                    } else if (!strcmp(children[j]->element, XML_ONLY_LOGS_AFTER)) {
-                        if (strlen(children[j]->content) != 0) {
-                            free(cur_service->only_logs_after);
-                            os_strdup(children[j]->content, cur_service->only_logs_after);
-                        }
-                    } else if (!strcmp(children[j]->element, XML_REGION)) {
-                        if (strlen(children[j]->content) != 0) {
-                            free(cur_service->regions);
-                            os_strdup(children[j]->content, cur_service->regions);
-                        }
-                    } else {
-                        merror("No such child tag '%s' of bucket at module '%s'.", children[j]->element, WM_AWS_CONTEXT.name);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
+                    free(cur_service->aws_account_id);
+                    os_strdup(children[j]->content, cur_service->aws_account_id);
+                } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->access_key);
+                        os_strdup(children[j]->content, cur_service->access_key);
                     }
+                } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ALIAS)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->aws_account_alias);
+                        os_strdup(children[j]->content, cur_service->aws_account_alias);
+                    }
+                } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->secret_key);
+                        os_strdup(children[j]->content, cur_service->secret_key);
+                    }
+                } else if (!strcmp(children[j]->element, XML_AWS_PROFILE)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->aws_profile);
+                        os_strdup(children[j]->content, cur_service->aws_profile);
+                    }
+                } else if (!strcmp(children[j]->element, XML_IAM_ROLE_ARN)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->iam_role_arn);
+                        os_strdup(children[j]->content, cur_service->iam_role_arn);
+                    }
+                } else if (!strcmp(children[j]->element, XML_ONLY_LOGS_AFTER)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->only_logs_after);
+                        os_strdup(children[j]->content, cur_service->only_logs_after);
+                    }
+                } else if (!strcmp(children[j]->element, XML_REGION)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->regions);
+                        os_strdup(children[j]->content, cur_service->regions);
+                    }
+                } else {
+                    merror("No such child tag '%s' of service at module '%s'.", children[j]->element, WM_AWS_CONTEXT.name);
+                    OS_ClearNode(children);
+                    return OS_INVALID;
                 }
-
-                OS_ClearNode(children);
             }
+
+            OS_ClearNode(children);
+
         } else {
             merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_AWS_CONTEXT.name);
             return OS_INVALID;

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -175,7 +175,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE) || !strcmp(*nodes[i]->values, INSPECTOR_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
-                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE,
+                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE,
                             CONFIG_BUCKET_TYPE, CUSTOM_BUCKET_TYPE, INSPECTOR_TYPE);
                         OS_ClearNode(children);
                         return OS_INVALID;

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -34,6 +34,7 @@ static const char *LEGACY_AWS_ACCOUNT_ALIAS = "LEGACY";
 static const char *CLOUDTRAIL_BUCKET_TYPE = "cloudtrail";
 static const char *CONFIG_BUCKET_TYPE = "config";
 static const char *CUSTOM_BUCKET_TYPE = "custom";
+static const char *INSPECTOR_TYPE = "inspector";
 
 // Parse XML
 
@@ -170,10 +171,12 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
 
                 // type is an attribute of the bucket tag
                 if (!strcmp(*nodes[i]->attributes, XML_BUCKET_TYPE)) {
-                    if (!strcmp(*nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CONFIG_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE)) {
+                    if (!strcmp(*nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CONFIG_BUCKET_TYPE)
+                        || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE || !strcmp(*nodes[i]->values, INSPECTOR_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
-                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE, CONFIG_BUCKET_TYPE, CUSTOM_BUCKET_TYPE);
+                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE,
+                            CONFIG_BUCKET_TYPE, CUSTOM_BUCKET_TYPE, INSPECTOR_TYPE);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -131,6 +131,25 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
         }
         if (cJSON_GetArraySize(arr_buckets) > 0) cJSON_AddItemToObject(wm_aws,"buckets",arr_buckets);
     }
+    if (aws_config->services) {
+        wm_aws_service *iter;
+        cJSON *arr_services = cJSON_CreateArray();
+        for (iter = aws_config->services; iter; iter = iter->next) {
+            cJSON *service = cJSON_CreateObject();
+            if (iter->bucket) cJSON_AddStringToObject(service,"name",iter->bucket);
+            if (iter->access_key) cJSON_AddStringToObject(service,"access_key",iter->access_key);
+            if (iter->secret_key) cJSON_AddStringToObject(service,"secret_key",iter->secret_key);
+            if (iter->aws_profile) cJSON_AddStringToObject(service,"aws_profile",iter->aws_profile);
+            if (iter->iam_role_arn) cJSON_AddStringToObject(service,"iam_role_arn",iter->iam_role_arn);
+            if (iter->aws_account_id) cJSON_AddStringToObject(service,"aws_account_id",iter->aws_account_id);
+            if (iter->aws_account_alias) cJSON_AddStringToObject(service,"aws_account_alias",iter->aws_account_alias);
+            if (iter->only_logs_after) cJSON_AddStringToObject(service,"only_logs_after",iter->only_logs_after);
+            if (iter->regions) cJSON_AddStringToObject(service,"regions",iter->regions);
+            if (iter->type) cJSON_AddStringToObject(service,"type",iter->type);            
+            cJSON_AddItemToArray(arr_services,service);
+        }
+        if (cJSON_GetArraySize(arr_services) > 0) cJSON_AddItemToObject(wm_aws,"services",arr_services);
+    }
     cJSON_AddItemToObject(root,"aws-s3",wm_aws);
 
     return root;
@@ -220,6 +239,7 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     wm_strcat(&command, "--bucket", ' ');
     wm_strcat(&command, exec_bucket->bucket, ' ');
 
+    // bucket arguments
     if (exec_bucket->remove_from_bucket) {
         wm_strcat(&command, "--remove", ' ');
     }
@@ -262,6 +282,43 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     if (exec_bucket->type) {
         wm_strcat(&command, "--type", ' ');
         wm_strcat(&command, exec_bucket->type, ' ');
+    }
+    // service arguments
+    if (exec_service->access_key) {
+        wm_strcat(&command, "--access_key", ' ');
+        wm_strcat(&command, exec_service->access_key, ' ');
+    }
+    if (exec_service->secret_key) {
+        wm_strcat(&command, "--secret_key", ' ');
+        wm_strcat(&command, exec_service->secret_key, ' ');
+    }
+    if (exec_service->aws_profile) {
+        wm_strcat(&command, "--aws_profile", ' ');
+        wm_strcat(&command, exec_service->aws_profile, ' ');
+    }
+    if (exec_service->iam_role_arn) {
+        wm_strcat(&command, "--iam_role_arn", ' ');
+        wm_strcat(&command, exec_service->iam_role_arn, ' ');
+    }
+    if (exec_service->aws_account_id) {
+        wm_strcat(&command, "--aws_account_id", ' ');
+        wm_strcat(&command, exec_service->aws_account_id, ' ');
+    }
+    if (exec_service->aws_account_alias) {
+        wm_strcat(&command, "--aws_account_alias", ' ');
+        wm_strcat(&command, exec_service->aws_account_alias, ' ');
+    }
+    if (exec_service->only_logs_after) {
+        wm_strcat(&command, "--only_logs_after", ' ');
+        wm_strcat(&command, exec_service->only_logs_after, ' ');
+    }
+    if (exec_service->regions) {
+        wm_strcat(&command, "--regions", ' ');
+        wm_strcat(&command, exec_service->regions, ' ');
+    }
+    if (exec_service->type) {
+        wm_strcat(&command, "--type", ' ');
+        wm_strcat(&command, exec_service->type, ' ');
     }
     if (isDebug()) {
         wm_strcat(&command, "--debug", ' ');

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -20,7 +20,8 @@ static void* wm_aws_main(wm_aws *aws_config);           // Module main function.
 static void wm_aws_setup(wm_aws *_aws_config);          // Setup module
 static void wm_aws_cleanup();                           // Cleanup function, doesn't overwrite wm_cleanup
 static void wm_aws_check();                             // Check configuration, disable flag
-static void wm_aws_run_s3(wm_aws_bucket *bucket);       // Run a s3
+static void wm_aws_run_s3(wm_aws_bucket *bucket);       // Run a s3 bucket
+static void wm_aws_run_service(wm_aws_service *service);// Run a AWS service such as Inspector
 static void wm_aws_destroy(wm_aws *aws_config);         // Destroy data
 cJSON *wm_aws_dump(const wm_aws *aws_config);
 
@@ -72,6 +73,17 @@ void* wm_aws_main(wm_aws *aws_config) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analisys: %s", cur_bucket->bucket);
             }
             wm_aws_run_s3(cur_bucket);
+        }
+
+        for (cur_service = aws_config->services; cur_service; cur_service = cur_service->next) {
+            if (cur_service->aws_account_id && cur_service->aws_account_alias) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analisys: %s (%s)", cur_service->aws_account_alias, cur_service->aws_account_id);
+            } else if (cur_service->aws_account_id) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analisys: %s", cur_service->aws_account_id);
+            } else {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analisys: %s", cur_service->service);
+            }
+            wm_aws_run_s3(cur_service);
         }
 
         mtinfo(WM_AWS_LOGTAG, "Fetching logs finished.");
@@ -283,43 +295,6 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
         wm_strcat(&command, "--type", ' ');
         wm_strcat(&command, exec_bucket->type, ' ');
     }
-    // service arguments
-    if (exec_service->access_key) {
-        wm_strcat(&command, "--access_key", ' ');
-        wm_strcat(&command, exec_service->access_key, ' ');
-    }
-    if (exec_service->secret_key) {
-        wm_strcat(&command, "--secret_key", ' ');
-        wm_strcat(&command, exec_service->secret_key, ' ');
-    }
-    if (exec_service->aws_profile) {
-        wm_strcat(&command, "--aws_profile", ' ');
-        wm_strcat(&command, exec_service->aws_profile, ' ');
-    }
-    if (exec_service->iam_role_arn) {
-        wm_strcat(&command, "--iam_role_arn", ' ');
-        wm_strcat(&command, exec_service->iam_role_arn, ' ');
-    }
-    if (exec_service->aws_account_id) {
-        wm_strcat(&command, "--aws_account_id", ' ');
-        wm_strcat(&command, exec_service->aws_account_id, ' ');
-    }
-    if (exec_service->aws_account_alias) {
-        wm_strcat(&command, "--aws_account_alias", ' ');
-        wm_strcat(&command, exec_service->aws_account_alias, ' ');
-    }
-    if (exec_service->only_logs_after) {
-        wm_strcat(&command, "--only_logs_after", ' ');
-        wm_strcat(&command, exec_service->only_logs_after, ' ');
-    }
-    if (exec_service->regions) {
-        wm_strcat(&command, "--regions", ' ');
-        wm_strcat(&command, exec_service->regions, ' ');
-    }
-    if (exec_service->type) {
-        wm_strcat(&command, "--type", ' ');
-        wm_strcat(&command, exec_service->type, ' ');
-    }
     if (isDebug()) {
         wm_strcat(&command, "--debug", ' ');
         if (isDebug() > 2) {
@@ -338,7 +313,6 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     }
 
     // Execute
-
     char *trail_title = NULL;
     wm_strcat(&trail_title, "Bucket:", ' ');
     wm_strcat(&trail_title, exec_bucket->aws_account_id, ' ');
@@ -398,6 +372,140 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     }
     free(line);
     free(trail_title);
+    free(output);
+    free(command);
+}
+
+// Run a service parsing
+
+void wm_aws_run_service(wm_aws_service *exec_service) {
+    int status;
+    char *output = NULL;
+    char *command = NULL;
+
+    // Define time to sleep between messages sent
+    int usec = 1000000 / wm_max_eps;
+
+    // Create arguments
+    mtdebug2(WM_AWS_LOGTAG, "Create argument list");
+
+    wm_strcat(&command, WM_AWS_SCRIPT_PATH, '\0');
+    wm_strcat(&command, "--service", ' ');
+    wm_strcat(&command, exec_service->service, ' ');
+
+    if (exec_service->access_key) {
+        wm_strcat(&command, "--access_key", ' ');
+        wm_strcat(&command, exec_service->access_key, ' ');
+    }
+    if (exec_service->secret_key) {
+        wm_strcat(&command, "--secret_key", ' ');
+        wm_strcat(&command, exec_service->secret_key, ' ');
+    }
+    if (exec_service->aws_profile) {
+        wm_strcat(&command, "--aws_profile", ' ');
+        wm_strcat(&command, exec_service->aws_profile, ' ');
+    }
+    if (exec_service->iam_role_arn) {
+        wm_strcat(&command, "--iam_role_arn", ' ');
+        wm_strcat(&command, exec_service->iam_role_arn, ' ');
+    }
+    if (exec_service->aws_account_id) {
+        wm_strcat(&command, "--aws_account_id", ' ');
+        wm_strcat(&command, exec_service->aws_account_id, ' ');
+    }
+    if (exec_service->aws_account_alias) {
+        wm_strcat(&command, "--aws_account_alias", ' ');
+        wm_strcat(&command, exec_service->aws_account_alias, ' ');
+    }
+    if (exec_service->only_logs_after) {
+        wm_strcat(&command, "--only_logs_after", ' ');
+        wm_strcat(&command, exec_service->only_logs_after, ' ');
+    }
+    if (exec_service->regions) {
+        wm_strcat(&command, "--regions", ' ');
+        wm_strcat(&command, exec_service->regions, ' ');
+    }
+    if (exec_service->type) {
+        wm_strcat(&command, "--type", ' ');
+        wm_strcat(&command, exec_service->type, ' ');
+    }
+    if (isDebug()) {
+        wm_strcat(&command, "--debug", ' ');
+        if (isDebug() > 2) {
+            wm_strcat(&command, "3", ' ');
+        } else if (isDebug() > 1) {
+            wm_strcat(&command, "2", ' ');
+        } else {
+            wm_strcat(&command, "1", ' ');
+        }
+    }
+    if (aws_config->skip_on_error) {
+        wm_strcat(&command, "--skip_on_error", ' ');
+    }
+    if (wm_state_io(WM_AWS_CONTEXT.name, WM_IO_READ, &aws_config->state, sizeof(aws_config->state)) < 0) {
+        memset(&aws_config->state, 0, sizeof(aws_config->state));
+    }
+
+    // Execute
+    char *service_title = NULL;
+    wm_strcat(&service_title, "Bucket:", ' ');
+    wm_strcat(&service_title, exec_service->aws_account_id, ' ');
+    if(exec_service->aws_account_alias){
+        wm_strcat(&service_title, "(", '\0');
+        wm_strcat(&service_title, exec_bucket->aws_account_alias, '\0');
+        wm_strcat(&service_title, ")", '\0');
+    }
+    wm_strcat(&service_title, " - ", ' ');
+
+    mtdebug1(WM_AWS_LOGTAG, "Launching S3 Command: %s", command);
+    switch (wm_exec(command, &output, &status, 0, NULL)) {
+    case 0:
+        if (status > 0) {
+            mtwarn(WM_AWS_LOGTAG, "%s Returned exit code %d", service_title, status);
+            if(status == 1) {
+                char * unknown_error_msg = strstr(output,"Unknown error");
+                if (unknown_error_msg == NULL)
+                    mtwarn(WM_AWS_LOGTAG, "%s Unknown error.", service_title);
+                else
+                    mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, unknown_error_msg);
+            }
+            else if(status == 2) {
+                char * ptr;
+                if (ptr = strstr(output, "aws.py: error:"), ptr) {
+                    ptr += 14;
+                    mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments: %s", service_title, ptr);
+                } else {
+                    mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments.", service_title);
+                }
+            }
+            else {
+                char * ptr;
+                if (ptr = strstr(output, "ERROR: "), ptr) {
+                    ptr += 7;
+                    mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, ptr);
+                } else {
+                    mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, output);
+                }
+            }
+
+
+            mtdebug1(WM_AWS_LOGTAG, "%s OUTPUT: %s", service_title, output);
+        } else {
+            mtdebug2(WM_AWS_LOGTAG, "%s OUTPUT: %s", service_title, output);
+        }
+        break;
+
+    default:
+        mterror(WM_AWS_LOGTAG, "Internal calling. Exiting...");
+        pthread_exit(NULL);
+    }
+    char * line;
+
+    for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
+        wm_sendmsg(usec, queue_fd, line, WM_AWS_CONTEXT.name, LOCALFILE_MQ);
+    }
+    free(line);
+    free(service_title);
     free(output);
     free(command);
 }

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -39,6 +39,21 @@ typedef struct wm_aws_bucket {
     struct wm_aws_bucket *next;     // Pointer to next
 } wm_aws_bucket;
 
+
+typedef struct wm_aws_service {
+    char *service;                      // S3 service
+    char *access_key;                   // IAM access key
+    char *secret_key;                   // IAM secret key
+    char *aws_profile;                  // AWS credentials profile
+    char *iam_role_arn;                 // IAM role
+    char *aws_account_id;               // AWS account ID(s)
+    char *aws_account_alias;            // AWS account alias
+    char *only_logs_after;              // Date (YYYY-MMM-DD) to only parse logs after
+    char *regions;                      // CSV of regions to parse
+    char *type;                         // String defining servuce type.
+    struct wm_aws_service *next;     // Pointer to next
+} wm_aws_service;
+
 typedef struct wm_aws {
     char *bucket;                       // DEPRECATE
     char *access_key;                   // DEPRECATE
@@ -51,6 +66,7 @@ typedef struct wm_aws {
     unsigned int skip_on_error:1;
     wm_aws_state_t state;
     wm_aws_bucket *buckets;      // buckets (linked list)
+    wm_aws_service *services;      // services (linked list)
 } wm_aws;
 
 extern const wm_context WM_AWS_CONTEXT;   // Context

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -41,7 +41,7 @@ typedef struct wm_aws_bucket {
 
 
 typedef struct wm_aws_service {
-    char *service;                      // S3 service
+    char *type;                         // String defining service type.
     char *access_key;                   // IAM access key
     char *secret_key;                   // IAM secret key
     char *aws_profile;                  // AWS credentials profile
@@ -50,7 +50,6 @@ typedef struct wm_aws_service {
     char *aws_account_alias;            // AWS account alias
     char *only_logs_after;              // Date (YYYY-MMM-DD) to only parse logs after
     char *regions;                      // CSV of regions to parse
-    char *type;                         // String defining servuce type.
     struct wm_aws_service *next;     // Pointer to next
 } wm_aws_service;
 

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -856,16 +856,16 @@ class AWSInspector:
                 self.wazuh_integration.send_msg(self.format_message(elem))
 
     def get_alerts(self):
+        initial_date = '{Y}-{m}-{d} 00:00:00.0'.format(Y=self.only_logs_after[0:4],
+            m=self.only_logs_after[4:6], d=self.only_logs_after[6:8])
         try:
-            # if DB is empty write first date
-            initial_date = '1970-01-01 00:00:00.0'
+            # if DB is empty write initial date
             self.wazuh_integration.db_cursor.execute(AWSInspector.sql_inspector_insert_value.format(initial_date))
             self.wazuh_integration.db_cursor.execute(AWSInspector.sql_find_last_scan)
             last_scan = self.wazuh_integration.db_cursor.fetchone()[0]
         except sqlite3.IntegrityError:
             self.wazuh_integration.db_cursor.execute(AWSInspector.sql_find_last_scan)
             last_scan = self.wazuh_integration.db_cursor.fetchone()[0]
-
         datetime_last_scan = datetime.strptime(last_scan, '%Y-%m-%d %H:%M:%S.%f')
         # get current time (UTC)
         datetime_current = datetime.utcnow()

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -859,7 +859,7 @@ class AWSInspector:
             last_scan = self.wazuh_integration.db_cursor.fetchone()[0]
 
         datetime_last_scan = datetime.strptime(last_scan, '%Y-%m-%d %H:%M:%S.%f')
-        # get current time
+        # get current time (UTC)
         datetime_current = datetime.utcnow()
         # describe_findings only retrieves 100 results per call
         response = self.client.list_findings(maxResults=100, filter={'creationTimeRange':

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -830,8 +830,7 @@ class AWSInspector:
             debug('+++ Processing new events...', 1)
             response = self.client.describe_findings(findingArns=arn_list)['findings']
             for elem in response:
-                #self.wazuh_integration.send_msg(self.format_message(elem))
-                pass
+                self.wazuh_integration.send_msg(self.format_message(elem))
 
     def get_alerts(self):
         try:

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -792,7 +792,7 @@ class AWSInspector:
                                     CREATE TABLE
                                         inspector (
                                             scan_date 'text' NOT NULL,
-                                            PRIMARY KEY (last_scan_date));"""
+                                            PRIMARY KEY (scan_date));"""
 
     sql_inspector_mark_complete = """
                                     INSERT INTO inspector (

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -190,6 +190,10 @@ class AWSBucket:
         :param prefix: Prefix to filter files in bucket
         :param delete_file: Wether to delete an already processed file from a bucket or not
         """
+        ## temporal
+        self.access_key = access_key
+        self.secret_key = secret_key
+        ##
         self.wazuh_path = open('/etc/ossec-init.conf').readline().split('"')[1]
         self.wazuh_queue = '{0}/queue/ossec/queue'.format(self.wazuh_path)
         self.wazuh_wodle = '{0}/wodles/aws'.format(self.wazuh_path)
@@ -726,7 +730,7 @@ class AWSInspector(AWSBucket):
         ### conectar a la BD 
         ### procesar todas las alertas
 
-    def reformat_msg(self, event):
+    def reformat_msg(self, event):  ### quitar!
         debug('++ Reformat message', 3)
         AWSBucket.reformat_msg(self, event)
 

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -755,8 +755,9 @@ class AWSInspector:
     def __init__(self, **kwargs):
         ## it is necessary to pass region_name as argument
         self.client = boto3.client('inspector', region_name='us-east-1', aws_access_key_id=kwargs['access_key'], aws_secret_access_key=kwargs['secret_key'])
-        self.db_path = "{0}/s3_inspector.db".format(self.wazuh_wodle)
-        self.db_connector = sqlite3.connect(self.db_path)
+        #self.wazuh_wodle = '{0}/wodles/aws'.format(self.wazuh_path)
+        #self.db_path = "{0}/s3_inspector.db".format(self.wazuh_wodle)
+        #self.db_connector = sqlite3.connect(self.db_path)
         self.get_alerts()
 
     def format_message(self, msg):

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -825,14 +825,22 @@ class AWSInspector:
                                 scan_date DESC
                             LIMIT 1;"""
 
-    def __init__(self, **kwargs):
+    def __init__(self, access_key, secret_key, aws_profile=None, iam_role_arn=None,
+        only_logs_after=None, skip_on_error=None, aws_account_alias=None):
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.aws_profile = aws_profile
+        self.iam_role_arn = iam_role_arn
+        self.only_logs_after = only_logs_after
+        self.skip_on_error = skip_on_error
+        self.aws_account_alias = aws_account_alias
         self.db_name = 's3_inspector'
         self.table_name = 'inspector'
         self.wazuh_integration = WazuhIntegration(db_name=self.db_name,
             table_name=self.table_name, sql_create_table=AWSInspector.sql_inspector_create_table)
         ## it is necessary to pass region_name as argument
-        self.client = boto3.client('inspector', region_name='us-east-1', aws_access_key_id=kwargs['access_key'],
-            aws_secret_access_key=kwargs['secret_key'])
+        self.client = boto3.client('inspector', region_name='us-east-1', aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key)
         self.get_alerts()
 
     def format_message(self, msg):

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -918,7 +918,7 @@ def main(argv):
                             options.trail_prefix, options.deleteFile)
         bucket.iter_bucket(options.aws_account_id, options.regions)
     else:
-        bucket = bucket_type('access_key': options.access_key, 'secret_key': options.secret_key))
+        bucket = bucket_type(access_key=options.access_key, secret_key=options.secret_key)
 
 if __name__ == '__main__':
     try:

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -718,8 +718,8 @@ class AWSCustomBucket(AWSBucket):
 class AWSInspector:
 
     def __init__(self, **kwargs):
-        self.session = boto3.session.Session(aws_access_key_id=kwargs['access_key'], aws_secret_access_key=kwargs['secret_key'])
-        self.client = boto3.client('inspector')
+        ## it is necessary to pass region_name as argument
+        self.client = boto3.client('inspector', region_name='us-east-1', aws_access_key_id=kwargs['access_key'], aws_secret_access_key=kwargs['secret_key'])
         self.wazuh_path = open('/etc/ossec-init.conf').readline().split('"')[1]
         self.wazuh_queue = '{0}/queue/ossec/queue'.format(self.wazuh_path)
         self.wazuh_wodle = '{0}/wodles/aws'.format(self.wazuh_path)
@@ -737,7 +737,8 @@ class AWSInspector:
         :param msg: JSON message to be sent.
         """
         try:
-            json_msg = json.dumps(msg, default=str)
+            formatted_msg = {'integration': 'aws', 'aws': msg}
+            json_msg = json.dumps(formatted_msg, default=str)
             debug(json_msg, 3)
             s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
             s.connect(self.wazuh_queue)

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -869,6 +869,8 @@ def main(argv):
             bucket_type = AWSConfigBucket
         elif options.type.lower() == 'custom':
             bucket_type = AWSCustomBucket
+        elif options.type.lower() == 'inspector':
+            bucket_type = AWSInspector
         else:
             raise Exception("Invalid type of bucket")
     except Exception as err:


### PR DESCRIPTION
Hi team,

This PR is for getting events from `AWS Inspector`. This service is distinct than other from `AWS` because `Inspector` doesn't store logs on buckets.

I had to do many changes in `C` code for giving support to this service and others in the future that use API calls for catching events.

An example of configuration from `Inspector` in `ossec.conf` is the next:
```
<wodle name="aws-s3">
    <disabled>no</disabled>
    <interval>5m</interval>
    <run_on_start>yes</run_on_start>
    <skip_on_error>no</skip_on_error>
    <service type="inspector">
        <access_key>XXXX</access_key>
        <secret_key>XXXX</secret_key>
        <regions>us-east-1</regions>
    </service>
</wodle>
```

Best regards,

Demetrio.