### PR TITLE
Fix bug configuring empty blocks in FIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+ - Fix bug configuring empty blocks in FIM. ([#1897](https://github.com/wazuh/wazuh/pull/1897))
+
+
+## [v3.7.0]
+
+### Added
+
 - Adding feature to **remotely query agent configuration on demand.** ([#548](https://github.com/wazuh/wazuh/pull/548))
 - **Boost Analysisd performance with multithreading.** ([#1039](https://github.com/wazuh/wazuh/pull/1039))
 - Adding feature to **let agents belong to multiple groups.** ([#1135](https://github.com/wazuh/wazuh/pull/1135))

--- a/src/config/rootcheck-config.c
+++ b/src/config/rootcheck-config.c
@@ -61,7 +61,9 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
     rootcheck = (rkconfig *)configp;
 
     /* If rootcheck is defined, enable it by default */
-    rootcheck->disabled = 0;
+    if (rootcheck->disabled == RK_CONF_UNPARSED) {
+        rootcheck->disabled = RK_CONF_UNDEFINED;
+    }
 
     if (!node)
         return 0;

--- a/src/config/rootcheck-config.h
+++ b/src/config/rootcheck-config.h
@@ -12,6 +12,9 @@
 
 #include <stdio.h>
 
+#define RK_CONF_UNPARSED -2
+#define RK_CONF_UNDEFINED -1
+
 typedef struct _rkconfig {
     const char *workdir;
     char *basedir;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -21,7 +21,7 @@ int dump_syscheck_entry(syscheck_config *syscheck, const char *entry, int vals, 
     } else {
         pl = overwrite;
     }
-    
+
     if (reg == 1) {
 #ifdef WIN32
         if (syscheck->registry == NULL) {
@@ -786,6 +786,10 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     syscheck_config *syscheck;
     syscheck = (syscheck_config *)configp;
     unsigned int nodiff_size = 0;
+
+    if (syscheck->disabled == SK_CONF_UNPARSED) {
+        syscheck->disabled = SK_CONF_UNDEFINED;
+    }
 
     while (node && node[i]) {
         if (!node[i]->element) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -787,15 +787,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     syscheck = (syscheck_config *)configp;
     unsigned int nodiff_size = 0;
 
-    /* If no options are defined, disable it */
-    if (!node) {
-        syscheck->disabled = 1;
-        return 0;
-    } else {
-        syscheck->disabled = 0;
-    }
-
-    while (node[i]) {
+    while (node && node[i]) {
         if (!node[i]->element) {
             merror(XML_ELEMNULL);
             return (OS_INVALID);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -50,6 +50,9 @@
 #define WD_IGNORE_REST      0x0000008
 #endif
 
+#define SK_CONF_UNPARSED -2
+#define SK_CONF_UNDEFINED -1
+
 //Max allowed value for recursion
 #define MAX_DEPTH_ALLOWED 320
 

--- a/src/rootcheck/config.c
+++ b/src/rootcheck/config.c
@@ -30,6 +30,14 @@ int Read_Rootcheck_Config(const char *cfgfile)
     ReadConfig(modules, AGENTCONFIG, &rootcheck, NULL);
 #endif
 
+    switch (rootcheck.disabled) {
+    case RK_CONF_UNPARSED:
+        rootcheck.disabled = 1;
+        break;
+    case RK_CONF_UNDEFINED:
+        rootcheck.disabled = 0;
+    }
+
     return (0);
 }
 

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -78,7 +78,7 @@ int rootcheck_init(int test_config)
     rootcheck.notify = QUEUE;
     rootcheck.scanall = 0;
     rootcheck.readall = 0;
-    rootcheck.disabled = 1;
+    rootcheck.disabled = RK_CONF_UNPARSED;
     rootcheck.skip_nfs = 0;
     rootcheck.alert_msg = NULL;
     rootcheck.time = ROOTCHECK_WAIT;

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -24,7 +24,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     modules |= CSYSCHECK;
 
     syscheck.rootcheck      = 0;
-    syscheck.disabled       = 1;
+    syscheck.disabled       = SK_CONF_UNPARSED;
     syscheck.skip_nfs       = 1;
     syscheck.scan_on_start  = 1;
     syscheck.time           = 43200;
@@ -65,6 +65,14 @@ int Read_Syscheck_Config(const char *cfgfile)
     modules |= CAGENT_CONFIG;
     ReadConfig(modules, AGENTCONFIG, &syscheck, NULL);
 #endif
+
+    switch (syscheck.disabled) {
+    case SK_CONF_UNPARSED:
+        syscheck.disabled = 1;
+        break;
+    case SK_CONF_UNDEFINED:
+        syscheck.disabled = 0;
+    }
 
 #ifndef WIN32
     /* We must have at least one directory to check */


### PR DESCRIPTION
Related issue:
- #1896 

When defining a second FIM configuration block, if it is empty, the module is disabled. If the agent in question had different configurations because it belonged to several groups, the last block would make the rest of the applied configurations unusable. This _PR_ solve this behavior.

## Tests
- [x] In the ossec.conf, after the default configuration defines an empty Syscheck block.
- [x] Define a block with a single directory and place an empty block above or below it.
- [x] Apply these settings via remote configuration.