### PR TITLE
Fix corrupted randombytes key for generating random numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file.
 - Fix to overwrite FIM configuration when directories come in the same tag separated by commas. ([#1886](https://github.com/wazuh/wazuh/pull/1886))
 - Fixed starting wodles after a delay specified in `interval` when `run_on_start` is set to `no`, on the first run of the agent. ([#1906](https://github.com/wazuh/wazuh/pull/1906))
 - Fixed id's and description of FIM alerts. ([#1891](https://github.com/wazuh/wazuh/pull/1891))
+- Let the Windows agent reset the random generator context if it's corrupt. ([#1898](https://github.com/wazuh/wazuh/pull/1898))
+
 
 ## [v3.7.0] - 2018-11-10
 

--- a/src/shared/randombytes.c
+++ b/src/shared/randombytes.c
@@ -36,6 +36,8 @@ void randombytes(void *ptr, size_t length)
                     failed = 1;
                 }
             }else if(GetLastError() == (DWORD)NTE_KEYSET_ENTRY_BAD){
+                mwarn("The agent's RSA key container for the random generator is corrupt. Resetting container...");
+
                 if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, CRYPT_DELETEKEYSET)){
                     merror("CryptAcquireContext Flag: DeleteKeySet: (%lx)", GetLastError());
                     failed = 1;

--- a/src/shared/randombytes.c
+++ b/src/shared/randombytes.c
@@ -32,11 +32,20 @@ void randombytes(void *ptr, size_t length)
                 mdebug1("No default container was found. Attempting to create default container.");
 
                 if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, CRYPT_NEWKEYSET)) {
-                    merror("CryptAcquireContext: (%lx)", GetLastError());
+                    merror("CryptAcquireContext Flag: NewKeySet (1): (%lx)", GetLastError());
+                    failed = 1;
+                }
+            }else if(GetLastError() == (DWORD)NTE_KEYSET_ENTRY_BAD){
+                if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, CRYPT_DELETEKEYSET)){
+                    merror("CryptAcquireContext Flag: DeleteKeySet: (%lx)", GetLastError());
+                    failed = 1;
+                }
+                if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, CRYPT_NEWKEYSET)) {
+                    merror("CryptAcquireContext Flag: NewKeySet (2): (%lx)", GetLastError());
                     failed = 1;
                 }
             } else {
-                merror("CryptAcquireContext: (%lx)", GetLastError());
+                merror("CryptAcquireContext no Flag: (%lx)", GetLastError());
                 failed = 1;
             }
         }


### PR DESCRIPTION
This PR solves the issue: https://github.com/wazuh/wazuh/issues/1825
In case the key is corrupted the agent will delete the corrupted key and regenerate again