### PR TITLE
Fix cluster error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Fixed id's and description of FIM alerts. ([#1891](https://github.com/wazuh/wazuh/pull/1891))
 - Fix log flooding by Logcollector when monitored files disappear. ([#1893](https://github.com/wazuh/wazuh/pull/1893))
 - Let the Windows agent reset the random generator context if it's corrupt. ([#1898](https://github.com/wazuh/wazuh/pull/1898))
+- Prevent Remoted from logging errors if the cluster configuration is missing or invalid. ([#1900](https://github.com/wazuh/wazuh/pull/1900))
 - Fix race condition hazard in Remoted when handling control messages. ([#1902](https://github.com/wazuh/wazuh/pull/1902))
 - Prevent `agent-auth` tool from creating the file _client.keys_ outside the agent's installation folder. ([#1924](https://github.com/wazuh/wazuh/pull/1924))
 

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
 
     switch (is_worker){
         case -1:
-            merror("Cluster node type is not valid [client/worker/master]. Cluster not configured %s (%d)", strerror(errno), errno);
+            merror("Cluster node type is not valid [client/worker/master]. Cluster not configured. %s (%d)", strerror(errno), errno);
             break;
         case 1:
             mdebug1("Cluster client node: Disabling the merged.mg creation");

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -135,11 +135,11 @@ int main(int argc, char **argv)
     int is_worker = w_is_worker();
 
     switch (is_worker){
-        case -1:
-            merror("Cluster node type is not valid [worker/master]. Cluster not configured. %s (%d)", strerror(errno), errno);
+        case 0:
+            mdebug1("This is not a worker");
             break;
         case 1:
-            mdebug1("Cluster client node: Disabling the merged.mg creation");
+            mdebug1("Cluster worker node: Disabling the merged.mg creation");
             logr.nocmerged = 1;
             break;
 }

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
 
     switch (is_worker){
         case -1:
-            merror("Cluster node type is not valid [client/worker/master]. Cluster not configured. %s (%d)", strerror(errno), errno);
+            merror("Cluster node type is not valid [worker/master]. Cluster not configured. %s (%d)", strerror(errno), errno);
             break;
         case 1:
             mdebug1("Cluster client node: Disabling the merged.mg creation");

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
 
     switch (is_worker){
         case -1:
-            merror("Cannot read cluster config %s", strerror(errno));
+            merror("Cluster node type is not valid [client/worker/master]. Cluster not configured %s (%d)", strerror(errno), errno);
             break;
         case 1:
             mdebug1("Cluster client node: Disabling the merged.mg creation");

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -49,11 +49,11 @@ int w_is_worker(void) {
                     free(cl_type);
                 }
             } else if (strcmp(cl_status, "yes")){
-                is_worker = -1;
+                is_worker = 2;
             }
             free(cl_status);
         } else {
-            is_worker = -1;
+            is_worker = 2;
         }
     }
     OS_ClearXML(&xml);

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -17,8 +17,9 @@
 int w_is_worker(void) {
 
     OS_XML xml;
-    const char * xmlf[] = {"ossec_config", "cluster", "disabled", NULL};
+    const char * xmlf[] = {"ossec_config", "cluster", NULL};
     const char * xmlf2[] = {"ossec_config", "cluster", "node_type", NULL};
+    const char * xmlf3[] = {"ossec_config", "cluster", "disabled", NULL};
     const char *cfgfile = DEFAULTCPATH;
     int modules = 0;
     int is_worker = 0;
@@ -34,26 +35,34 @@ int w_is_worker(void) {
     if (OS_ReadXML(cfgfile, &xml) < 0) {
         mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
     } else {
-        char * cl_status = OS_GetOneContentforElement(&xml, xmlf);
-        if (cl_status && cl_status[0] != '\0') {
-            if (!strcmp(cl_status, "no")) {
-                char * cl_type = OS_GetOneContentforElement(&xml, xmlf2);
+        char * cl_config = OS_GetOneContentforElement(&xml, xmlf);
+        if (cl_config && cl_config[0] != '\0') {
+            char * cl_type = OS_GetOneContentforElement(&xml, xmlf2);
                 if (cl_type && cl_type[0] != '\0') {
-                    if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
-                        is_worker = 1;
-                    } else if (!strcmp(cl_type, "master")){
-                        is_worker = 0;
-                    } else {
-                        is_worker = -1;
-                    }
+                    char * cl_status = OS_GetOneContentforElement(&xml, xmlf3);
+                    if(cl_status && cl_status[0] != '\0'){
+                	    if (!strcmp(cl_status, "no")) {
+                            if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
+                                is_worker = 1;
+                            } else {
+                                is_worker = 0;
+                            }
+                		} else {
+                			is_worker = 0;
+                		}
+                	} else {
+                        if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
+                            is_worker = 1;
+                        } else {
+                        	is_worker = 0;
+                        }
+                	}
+                    free(cl_status);
                     free(cl_type);
                 }
-            } else if (strcmp(cl_status, "yes")){
-                is_worker = 2;
-            }
-            free(cl_status);
+            free(cl_config);
         } else {
-            is_worker = 2;
+            is_worker = 0;
         }
     }
     OS_ClearXML(&xml);

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -47,9 +47,9 @@ int w_is_worker(void) {
                             } else {
                                 is_worker = 0;
                             }
-                		} else {
-                			is_worker = 0;
-                		}
+                        } else {
+                            is_worker = 0;
+                        }
                 	} else {
                         if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
                             is_worker = 1;


### PR DESCRIPTION
This pull request fixes #1854 
The error message that was displaying when cluster configuration is disabled or non-existent is no longer displayed.
The cluster error message will only appear when a bad node type is configured in the cluster configuration (different from client/worker/master).