### PR TITLE
Fix: Sleep before starting wodle during agent's first run (#1394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New internal option `remoted.guess_agent_group` allowing agent group guessing by Remoted to be optional. ([#1890](https://github.com/wazuh/wazuh/pull/1890))
-- Added option to configure anothers audit keys to monitor. ([#1882](https://github.com/wazuh/wazuh/pull/1882))
+- Added option to configure another audit keys to monitor. ([#1882](https://github.com/wazuh/wazuh/pull/1882))
 - Added option to create the SSL certificate and key with the install.sh script. ([#1856](https://github.com/wazuh/wazuh/pull/1856))
 
 ### Changed
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix to overwrite FIM configuration when directories come in the same tag separated by commas. ([#1886](https://github.com/wazuh/wazuh/pull/1886))
+- Fixed starting wodles after a delay specified in `interval` when `run_on_start` is set to `no`, on the first run of the agent. ([#1906](https://github.com/wazuh/wazuh/pull/1906))
 
 ## [v3.7.0] - 2018-11-10
 

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -143,7 +143,7 @@ typedef int sock2len_t;
 typedef int uid_t;
 typedef int gid_t;
 typedef int socklen_t;
-#define sleep(x) Sleep(x * 1000)
+#define sleep(x) Sleep((x) * 1000)
 #define srandom(x) srand(x)
 #define lstat(x,y) stat(x,y)
 #define CloseSocket(x) closesocket(x)

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -55,6 +55,11 @@ void* wm_sys_main(wm_sys_t *sys) {
     if (!sys->flags.scan_on_start) {
         time_start = time(NULL);
 
+        // On first run, take into account the interval of time specified
+        if (sys->state.next_time == 0) {
+            sys->state.next_time = time_start + sys->interval;
+        }
+
         if (sys->state.next_time > time_start) {
             mtinfo(WM_SYS_LOGTAG, "Waiting for turn to evaluate.");
             wm_delay(1000 * (sys->state.next_time - time_start));

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -48,9 +48,15 @@ void* wm_aws_main(wm_aws *aws_config) {
     if (!aws_config->run_on_start) {
         time_start = time(NULL);
 
+        // On first run, take into account the interval of time specified
+        if (aws_config->state.next_time == 0) {
+            aws_config->state.next_time = time_start + aws_config->interval;
+        }
+
         if (aws_config->state.next_time > time_start) {
             mtinfo(WM_AWS_LOGTAG, "Waiting interval to start fetching.");
-            sleep(aws_config->state.next_time - time_start);
+            time_sleep = aws_config->state.next_time - time_start;
+            wm_delay(1000 * time_sleep);
         }
     }
 
@@ -92,7 +98,7 @@ void* wm_aws_main(wm_aws *aws_config) {
         }
 
         // If time_sleep=0, yield CPU
-        sleep(time_sleep);
+        wm_delay(1000 * time_sleep);
     }
 
     return NULL;
@@ -159,7 +165,7 @@ void wm_aws_setup(wm_aws *_aws_config) {
     // Connect to socket
 
     for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        sleep(WM_MAX_WAIT);
+        wm_delay(1000 * WM_MAX_WAIT);
 
     if (i == WM_MAX_ATTEMPTS) {
         mterror(WM_AWS_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -136,6 +136,7 @@ void* wm_azure_main(wm_azure_t *azure_config) {
 
         mtinfo(WM_AZURE_LOGTAG, "Fetching logs finished.");
 
+        wm_delay(1000); // Avoid infinite loop when execution fails
         time_sleep = time(NULL) - time_start;
 
         if (azure_config->scan_day) {

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -87,11 +87,16 @@ void* wm_azure_main(wm_azure_t *azure_config) {
             mtdebug2(WM_AZURE_LOGTAG, "Sleeping for %d seconds", (int)time_sleep);
             wm_delay(1000 * time_sleep);
 
-        } else if (azure_config->state.next_time > time_start) {
+        } else if (azure_config->state.next_time == 0 || azure_config->state.next_time > time_start) {
+
+            // On first run, take into account the interval of time specified
+            time_sleep = azure_config->state.next_time == 0 ?
+                         azure_config->interval :
+                         azure_config->state.next_time - time_start;
 
             mtinfo(WM_AZURE_LOGTAG, "Waiting for turn to evaluate.");
-            mtdebug2(WM_AZURE_LOGTAG, "Sleeping for %ld seconds", (long)(azure_config->state.next_time - time_start));
-            wm_delay(1000 * azure_config->state.next_time - time_start);
+            mtdebug2(WM_AZURE_LOGTAG, "Sleeping for %ld seconds", (long)time_sleep);
+            wm_delay(1000 * time_sleep);
 
         }
     }
@@ -425,7 +430,7 @@ void wm_azure_setup(wm_azure_t *_azure_config) {
     // Connect to socket
 
     for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        sleep(WM_MAX_WAIT);
+        wm_delay(1000 * WM_MAX_WAIT);
 
     if (i == WM_MAX_ATTEMPTS) {
         mterror(WM_AZURE_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -182,11 +182,16 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
             mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %d seconds", (int)time_sleep);
             wm_delay(1000 * time_sleep);
 
-        } else if (ciscat->state.next_time > time_start) {
+        } else if (ciscat->state.next_time == 0 || ciscat->state.next_time > time_start) {
+
+            // On first run, take into account the interval of time specified
+            time_sleep = ciscat->state.next_time == 0 ?
+                         ciscat->interval :
+                         ciscat->state.next_time - time_start;
 
             mtinfo(WM_CISCAT_LOGTAG, "Waiting for turn to evaluate.");
-            mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %ld seconds", (long)(ciscat->state.next_time - time_start));
-            wm_delay(1000 * ciscat->state.next_time - time_start);
+            mtdebug2(WM_CISCAT_LOGTAG, "Sleeping for %ld seconds", (long)time_sleep);
+            wm_delay(1000 * time_sleep);
 
         }
     }
@@ -327,7 +332,7 @@ void wm_ciscat_setup(wm_ciscat *_ciscat) {
     // Connect to socket
 
     for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        sleep(WM_MAX_WAIT);
+        wm_delay(1000 * WM_MAX_WAIT);
 
     if (i == WM_MAX_ATTEMPTS) {
         mterror(WM_CISCAT_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -252,6 +252,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
             }
         }
 
+        wm_delay(1000); // Avoid infinite loop when execution fails
         time_sleep = time(NULL) - time_start;
 
         mtinfo(WM_CISCAT_LOGTAG, "Evaluation finished.");

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -145,7 +145,7 @@ void * wm_command_main(wm_command_t * command) {
         int i;
 
         for (i = 0; command->queue_fd = StartMQ(DEFAULTQPATH, WRITE), command->queue_fd < 0 && i < WM_MAX_ATTEMPTS; i++) {
-            sleep(WM_MAX_WAIT);
+            wm_delay(1000 * WM_MAX_WAIT);
         }
 
         if (i == WM_MAX_ATTEMPTS) {
@@ -160,9 +160,15 @@ void * wm_command_main(wm_command_t * command) {
     if (!command->run_on_start) {
         time_start = time(NULL);
 
+        // On first run, take into account the interval of time specified
+        if (command->interval && command->state.next_time == 0) {
+            command->state.next_time = time_start + command->interval;
+        }
+
         if (command->state.next_time > time_start) {
             mtinfo(WM_COMMAND_LOGTAG, "%s: Waiting for turn to evaluate.", command->tag);
-            sleep(command->state.next_time - time_start);
+            time_sleep = command->state.next_time - time_start;
+            wm_delay(1000 * time_sleep);
         }
     }
 
@@ -225,7 +231,7 @@ void * wm_command_main(wm_command_t * command) {
         }
 
         // If time_sleep=0, yield CPU
-        sleep(time_sleep);
+        wm_delay(1000 * time_sleep);
     }
 
     return NULL;

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -54,9 +54,15 @@ void* wm_oscap_main(wm_oscap *oscap) {
     if (!oscap->flags.scan_on_start) {
         time_start = time(NULL);
 
+        // On first run, take into account the interval of time specified
+        if (oscap->state.next_time == 0) {
+            oscap->state.next_time = time_start + oscap->interval;
+        }
+
         if (oscap->state.next_time > time_start) {
             mtinfo(WM_OSCAP_LOGTAG, "Waiting for turn to evaluate.");
-            sleep(oscap->state.next_time - time_start);
+            time_sleep = oscap->state.next_time - time_start;
+            wm_delay(1000 * time_sleep);
         }
     }
 
@@ -89,7 +95,7 @@ void* wm_oscap_main(wm_oscap *oscap) {
             mterror(WM_OSCAP_LOGTAG, "Couldn't save running state.");
 
         // If time_sleep=0, yield CPU
-        sleep(time_sleep);
+        wm_delay(1000 * time_sleep);
     }
 
     return NULL;
@@ -114,7 +120,7 @@ void wm_oscap_setup(wm_oscap *_oscap) {
     // Connect to socket
 
     for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        sleep(WM_MAX_WAIT);
+        wm_delay(1000 * WM_MAX_WAIT);
 
     if (i == WM_MAX_ATTEMPTS) {
         mterror(WM_OSCAP_LOGTAG, "Can't connect to queue.");


### PR DESCRIPTION
   Hi, Team,

  This PR fixes the bug described in the issue https://github.com/wazuh/wazuh/issues/1394.
  - On the first start of the agent, when a wodle has `run_on_start` set to `no`, the said wodle is not started until the time delay specified in `interval` has elapsed.
  - By the way, a bug has been fixed in a macro defined for Windows.

  Best regards.

