### PR TITLE
Fix the tag name for audit keys

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -775,7 +775,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_tag = "tags";
 #endif
     const char *xml_whodata_options = "whodata";
-    const char *xml_audit_extra_key = "audit_extra_key";
+    const char *xml_audit_key = "audit_key";
 
     /* Configuration example
     <directories check_all="yes">/etc,/usr/bin</directories>
@@ -1226,19 +1226,19 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
             for (j = 0; children[j]; j++) {
                 /* Listen another audit keys */
-                if (strcmp(children[j]->element, xml_audit_extra_key) == 0) {
+                if (strcmp(children[j]->element, xml_audit_key) == 0) {
                     int keyit = 0;
                     char delim = ',';
                     char *key;
-                    os_calloc(1, sizeof(char *), syscheck->audit_extra_key);
-                    syscheck->audit_extra_key[keyit] = NULL;
+                    os_calloc(1, sizeof(char *), syscheck->audit_key);
+                    syscheck->audit_key[keyit] = NULL;
                     key = strtok(children[j]->content, &delim);
 
                     while (key) {
                         if (*key) {
-                            syscheck->audit_extra_key[keyit] = check_ascci_hex(key);
-                            os_realloc(syscheck->audit_extra_key, (keyit + 2) * sizeof(char *), syscheck->audit_extra_key);
-                            syscheck->audit_extra_key[keyit + 1] = NULL;
+                            syscheck->audit_key[keyit] = check_ascci_hex(key);
+                            os_realloc(syscheck->audit_key, (keyit + 2) * sizeof(char *), syscheck->audit_key);
+                            syscheck->audit_key[keyit + 1] = NULL;
                             key = strtok(NULL, &delim);
                             keyit++;
                         }

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -208,7 +208,7 @@ typedef struct _config {
     int max_audit_entries;          /* Maximum entries for Audit (whodata) */
 #endif
 
-    char **audit_extra_key;                // Listen audit keys
+    char **audit_key;                // Listen audit keys
 
     OSHash *fp;
     OSHash *last_check;

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -1022,11 +1022,11 @@ int filterkey_audit_events(char *buffer) {
         return 1;
     }
 
-    while (syscheck.audit_extra_key[i]) {
-        snprintf(logkey1, OS_SIZE_256, "key=\"%s\"", syscheck.audit_extra_key[i]);
-        snprintf(logkey2, OS_SIZE_256, "key=%s", syscheck.audit_extra_key[i]);
+    while (syscheck.audit_key[i]) {
+        snprintf(logkey1, OS_SIZE_256, "key=\"%s\"", syscheck.audit_key[i]);
+        snprintf(logkey2, OS_SIZE_256, "key=%s", syscheck.audit_key[i]);
         if (strstr(buffer, logkey1) || strstr(buffer, logkey2)) {
-            mdebug2("Match audit_extra_key: '%s'", logkey1);
+            mdebug2("Match audit_key: '%s'", logkey1);
             return 2;
         }
         i++;


### PR DESCRIPTION
Change tag name for audit keys to `audit_key`