### PR TITLE
Remove option <remove_old-diff>

### DIFF
--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -29,7 +29,4 @@
     <nodiff>/etc/ssl/private.key</nodiff>
 
     <skip_nfs>yes</skip_nfs>
-
-    <!-- Remove not monitored files -->
-    <remove_old_diff>yes</remove_old_diff>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -37,7 +37,4 @@
     <nodiff>/etc/ssl/private.key</nodiff>
 
     <skip_nfs>yes</skip_nfs>
-
-    <!-- Remove not monitored files -->
-    <remove_old_diff>yes</remove_old_diff>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -32,9 +32,6 @@
 
     <skip_nfs>yes</skip_nfs>
 
-    <!-- Remove not monitored files -->
-    <remove_old_diff>yes</remove_old_diff>
-
     <!-- Allow the system to restart Auditd after installing the plugin -->
     <restart_audit>yes</restart_audit>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -38,9 +38,6 @@
 
     <skip_nfs>yes</skip_nfs>
 
-    <!-- Remove not monitored files -->
-    <remove_old_diff>yes</remove_old_diff>
-
     <!-- Allow the system to restart Auditd after installing the plugin -->
     <restart_audit>yes</restart_audit>
   </syscheck>

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -759,7 +759,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_registry_ignore = "registry_ignore";
     const char *xml_auto_ignore = "auto_ignore";
     const char *xml_alert_new_files = "alert_new_files";
-    const char *xml_remove_old_diff = "remove_old_diff"; // Deprecated since 3.7.1
+    const char *xml_remove_old_diff = "remove_old_diff"; // Deprecated since 3.8.0
     const char *xml_disabled = "disabled";
     const char *xml_scan_on_start = "scan_on_start";
     const char *xml_prefilter_cmd = "prefilter_cmd";
@@ -1194,7 +1194,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 }
             }
         } else if (strcmp(node[i]->element, xml_remove_old_diff) == 0) {
-            //Deprecated since 3.7.1, aplied by default...
+            // Deprecated since 3.8.0, aplied by default...
         } else if (strcmp(node[i]->element, xml_restart_audit) == 0) {
             if(strcmp(node[i]->content, "yes") == 0)
                 syscheck->restart_audit = 1;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -759,7 +759,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_registry_ignore = "registry_ignore";
     const char *xml_auto_ignore = "auto_ignore";
     const char *xml_alert_new_files = "alert_new_files";
-    const char *xml_remove_old_diff = "remove_old_diff";
+    const char *xml_remove_old_diff = "remove_old_diff"; // Deprecated since 3.7.1
     const char *xml_disabled = "disabled";
     const char *xml_scan_on_start = "scan_on_start";
     const char *xml_prefilter_cmd = "prefilter_cmd";
@@ -1194,14 +1194,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 }
             }
         } else if (strcmp(node[i]->element, xml_remove_old_diff) == 0) {
-            if (strcmp(node[i]->content, "yes") == 0) {
-                syscheck->remove_old_diff = 1;
-            } else if (strcmp(node[i]->content, "no") == 0) {
-                syscheck->remove_old_diff = 0;
-            } else {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
-                return (OS_INVALID);
-            }
+            //Deprecated since 3.7.1, aplied by default...
         } else if (strcmp(node[i]->element, xml_restart_audit) == 0) {
             if(strcmp(node[i]->content, "yes") == 0)
                 syscheck->restart_audit = 1;

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -168,8 +168,6 @@ typedef struct _config {
     int realtime_count;
     int max_depth;                  /* max level of recursivity allowed */
 
-    int remove_old_diff;            /* delete not monitored files history */
-
     short skip_nfs;
     int rt_delay;                   /* Delay before real-time dispatching (ms) */
 

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -39,7 +39,6 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.restart_audit  = 1;
     syscheck.enable_whodata = 0;
     syscheck.realtime       = NULL;
-    syscheck.remove_old_diff= 1;
 #ifdef WIN_WHODATA
     syscheck.wdata.interval_scan = 0;
     syscheck.wdata.fd      = NULL;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -820,9 +820,7 @@ int run_dbcheck()
         OSHash_Free(last_backup);
 
         // Check and delete backup local/diff
-        if (syscheck.remove_old_diff) {
-            remove_local_diff();
-        }
+        remove_local_diff();
     }
 
     free(alert_msg);
@@ -887,9 +885,7 @@ int create_db()
         i++;
     } while (syscheck.dir[i] != NULL);
 
-    if(syscheck.remove_old_diff) {
-        remove_local_diff();
-    }
+    remove_local_diff();
 
     w_mutex_lock(&lastcheck_mutex);
     OSHash_Free(syscheck.last_check);

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -154,9 +154,6 @@
     <registry_ignore>HKEY_LOCAL_MACHINE\Security\SAM\Domains\Account\Users</registry_ignore>
     <registry_ignore type="sregex">\Enum$</registry_ignore>
 
-    <!-- Remove not monitored files -->
-    <remove_old_diff>yes</remove_old_diff>
-
     <!-- Frequency for ACL checking (seconds) -->
     <windows_audit_interval>300</windows_audit_interval>
   </syscheck>


### PR DESCRIPTION
Related issues:
 - Deprecate syscheck option remove_old_diff #1277 

The option <remove_old_diff> is disabled. It becomes a mandatory behavior. In case that for old configurations it appears no warn message is shown, simply continues the execution.

## Test:
- [x] Check configuration with and without tag.
- [x] Check that the operation of deleting files configured with `report_changes` is correct. The files are deleted when:
- The option is removed, 
- The directory stops being monitored and 
- The source files are physically deleted.