### PR TITLE
Let Auth client change to the installation directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Fix log flooding by Logcollector when monitored files disappear. ([#1893](https://github.com/wazuh/wazuh/pull/1893))
 - Let the Windows agent reset the random generator context if it's corrupt. ([#1898](https://github.com/wazuh/wazuh/pull/1898))
 - Fix race condition hazard in Remoted when handling control messages. ([#1902](https://github.com/wazuh/wazuh/pull/1902))
+- Prevent `agent-auth` tool from creating the file _client.keys_ outside the agent's installation folder. ([#1924](https://github.com/wazuh/wazuh/pull/1924))
 
 
 ## [v3.7.0] - 2018-11-10

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -83,9 +83,6 @@ int main(int argc, char **argv)
     gid_t gid;
 #else
     FILE *fp;
-    TCHAR path[2048];
-    DWORD last_error;
-    int ret;
 #endif
 
     /* Set the name */
@@ -238,33 +235,8 @@ int main(int argc, char **argv)
     /* Start signal handler */
     StartSIG2(ARGV0, manage_shutdown);
 #else
-    /* Get full path to the directory this executable lives in */
-    ret = GetModuleFileName(NULL, path, sizeof(path));
 
-    /* Check for errors */
-    if (!ret) {
-        merror_exit(GMF_ERROR);
-    }
-
-    /* Get last error */
-    last_error = GetLastError();
-
-    /* Look for errors */
-    if (last_error != ERROR_SUCCESS) {
-        if (last_error == ERROR_INSUFFICIENT_BUFFER) {
-            merror_exit(GMF_BUFF_ERROR, ret, sizeof(path));
-        } else {
-            merror_exit(GMF_UNKN_ERROR, last_error);
-        }
-    }
-
-    /* Remove file name from path */
-    PathRemoveFileSpec(path);
-
-    /* Move to correct directory */
-    if (chdir(path)) {
-        merror_exit(CHDIR_ERROR, path, errno, strerror(errno));
-    }
+    w_ch_exec_dir();
 
     /* Check permissions */
     fp = fopen(OSSECCONF, "r");

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -167,9 +167,3 @@ extern char shost[];
 #define BANNER_CLIENT   "   (I)mport key from the server (I).\n" \
                         "   (Q)uit.\n" \
                         "Choose your action: I or Q: "
-
-/* WIN32 errors */
-#define CONF_ERROR      "Could not read (%s) (Make sure config exists and executable is running with Administrative privileges)."
-#define GMF_ERROR       "Could not run GetModuleFileName."
-#define GMF_BUFF_ERROR  "Could not get path because it is too long and was shrunk by (%d) characters with a max of (%d)."
-#define GMF_UNKN_ERROR  "Could not run GetModuleFileName which returned (%ld)."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -361,4 +361,10 @@
 #define OS_FULL_BUFFER  "wazuh: Agent buffer: 'full'."
 #define OS_FLOOD_BUFFER "wazuh: Agent buffer: 'flooded'."
 
+/* WIN32 errors */
+#define CONF_ERROR      "Could not read (%s) (Make sure config exists and executable is running with Administrative privileges)."
+#define GMF_ERROR       "Could not run GetModuleFileName."
+#define GMF_BUFF_ERROR  "Could not get path because it is too long and was shrunk by (%d) characters with a max of (%d)."
+#define GMF_UNKN_ERROR  "Could not run GetModuleFileName which returned (%ld)."
+
 #endif /* _ERROR_MESSAGES__H */

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -96,6 +96,9 @@ int w_copy_file(const char *src, const char *dst,char mode,char * message);
 int checkVista();
 int isVista;
 int get_creation_date(char *dir, SYSTEMTIME *utc);
+
+// Move to the directory where this executable lives in
+void w_ch_exec_dir();
 #endif
 
 /* Delete directory recursively */

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -97,6 +97,9 @@ int main(int argc, char **argv)
 
 #ifdef WIN32
     WSADATA wsaData;
+
+    // Move to the directory where this executable lives in
+    w_ch_exec_dir();
 #endif
 
     /* Set the name */
@@ -256,6 +259,7 @@ int main(int argc, char **argv)
     if (WSAStartup(MAKEWORD(2, 0), &wsaData) != 0) {
         merror_exit("WSAStartup() failed");
     }
+
 #endif /* WIN32 */
 
     /* Start up message */

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1861,6 +1861,41 @@ const char *getuname()
     return (ret);
 }
 
+// Move to the directory where this executable lives in
+
+void w_ch_exec_dir() {
+    TCHAR path[2048];
+    DWORD last_error;
+    int ret;
+
+    /* Get full path to the directory this executable lives in */
+    ret = GetModuleFileName(NULL, path, sizeof(path));
+
+    /* Check for errors */
+    if (!ret) {
+        merror_exit(GMF_ERROR);
+    }
+
+    /* Get last error */
+    last_error = GetLastError();
+
+    /* Look for errors */
+    if (last_error != ERROR_SUCCESS) {
+        if (last_error == ERROR_INSUFFICIENT_BUFFER) {
+            merror_exit(GMF_BUFF_ERROR, ret, sizeof(path));
+        } else {
+            merror_exit(GMF_UNKN_ERROR, last_error);
+        }
+    }
+
+    /* Remove file name from path */
+    PathRemoveFileSpec(path);
+
+    /* Move to correct directory */
+    if (chdir(path)) {
+        merror_exit(CHDIR_ERROR, path, errno, strerror(errno));
+    }
+}
 
 #endif /* WIN32 */
 
@@ -2077,7 +2112,7 @@ int w_copy_file(const char *src, const char *dst,char mode,char * message) {
     else {
         fp_dst = fopen(dst, "w");
     }
-    
+
 
     if (!fp_dst) {
         merror("At w_copy_file(): Couldn't open file '%s'", dst);
@@ -2362,7 +2397,7 @@ char ** wreaddir(const char * name) {
 
         files = realloc(files, (i + 2) * sizeof(char *));
         if(!files){
-           merror_exit(MEM_ERROR, errno, strerror(errno)); 
+           merror_exit(MEM_ERROR, errno, strerror(errno));
         }
         files[i++] = strdup(dirent->d_name);
     }
@@ -2474,7 +2509,7 @@ int w_remove_line_from_file(char *file,int line){
 
         if(i != line){
             count_w = fwrite(buffer, 1, strlen(buffer) , fp_dst);
-           
+
             if (count_w != strlen(buffer) || ferror(fp_dst)) {
                 merror("At remove_line_from_file(): Couldn't write file '%s'", destination);
                 break;


### PR DESCRIPTION
This PR fixes #1639.

The agent on Windows always uses relative paths. This made `agent-auth` create the agent key file, _client.keys_ and also the result log, _ossec.log_ in the current user folder instead of the agent's installation folder.

This PR aims to fix this issue by making the application change its current working directory to the installation folder, just as `manage_agents` already does.