### PR TITLE
Fix: symbolic links must be alerted with the attributes of the linked file (#1316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix symbolic links attributes reported by `syscheck` in the alerts. ([#1926](https://github.com/wazuh/wazuh/pull/1926))
 - Fix issue in Logcollector when reaching the file end before getting a full line. ([#1744](https://github.com/wazuh/wazuh/pull/1744))
 - Throw an error when a nonexistent CDB file is added in the ossec.conf file. ([#1783](https://github.com/wazuh/wazuh/pull/1783))
 - Fix bug in Remoted that truncated control messages to 1024 bytes. ([#1847](https://github.com/wazuh/wazuh/pull/1847))

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -179,6 +179,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     char *buf;
     syscheck_node *s_node;
     struct stat statbuf;
+    struct stat statbuf_lnk;
     char str_size[50], str_perm[50], str_mtime[50], str_inode[50];
     char *wd_sum = NULL;
     os_calloc(OS_SIZE_6144 + 1, sizeof(char), wd_sum);
@@ -274,14 +275,12 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
         strncpy(sf256_sum, "", 1);
 
         /* Generate checksums */
-        struct stat *statbuf_lnk = NULL;
         if ((opts & CHECK_MD5SUM) || (opts & CHECK_SHA1SUM) || (opts & CHECK_SHA256SUM)) {
             /* If it is a link, check if dest is valid */
 #ifndef WIN32
             if (S_ISLNK(statbuf.st_mode)) {
-                os_calloc(1, sizeof(struct stat), statbuf_lnk);
-                if (stat(file_name, statbuf_lnk) == 0) {
-                    if (S_ISREG(statbuf_lnk->st_mode)) {
+                if (stat(file_name, &statbuf_lnk) == 0) {
+                    if (S_ISREG(statbuf_lnk.st_mode)) {
                         if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum,sf_sum, sf256_sum, OS_BINARY) < 0) {
                             strncpy(mf_sum, "n/a", 4);
                             strncpy(sf_sum, "n/a", 4);
@@ -368,8 +367,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
 
             if (opts & CHECK_PERM) {
-                if (S_ISLNK(statbuf.st_mode) && statbuf_lnk) {
-                    sprintf(str_perm,"%d",(int)statbuf_lnk->st_mode);
+                if (S_ISLNK(statbuf.st_mode)) {
+                    sprintf(str_perm,"%d",(int)statbuf_lnk.st_mode);
                 } else {
                     sprintf(str_perm,"%d",(int)statbuf.st_mode);
                 }
@@ -378,8 +377,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
 
             if (opts & CHECK_OWNER) {
-                if (S_ISLNK(statbuf.st_mode) && statbuf_lnk) {
-                    sprintf(str_owner,"%d",(int)statbuf_lnk->st_uid);
+                if (S_ISLNK(statbuf.st_mode)) {
+                    sprintf(str_owner,"%d",(int)statbuf_lnk.st_uid);
                 } else {
                     sprintf(str_owner,"%d",(int)statbuf.st_uid);
                 }
@@ -388,8 +387,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
 
             if (opts & CHECK_GROUP) {
-                if (S_ISLNK(statbuf.st_mode) && statbuf_lnk) {
-                    sprintf(str_group,"%d",(int)statbuf_lnk->st_gid);
+                if (S_ISLNK(statbuf.st_mode)) {
+                    sprintf(str_group,"%d",(int)statbuf_lnk.st_gid);
                 } else {
                     sprintf(str_group,"%d",(int)statbuf.st_gid);
                 }
@@ -426,8 +425,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                     str_group,
                     opts & CHECK_MD5SUM ? mf_sum : "",
                     opts & CHECK_SHA1SUM ? sf_sum : "",
-                    opts & CHECK_OWNER ? get_user(file_name, statbuf_lnk ? statbuf_lnk->st_uid : statbuf.st_uid, NULL) : "",
-                    opts & CHECK_GROUP ? get_group(statbuf_lnk ? statbuf_lnk->st_gid : statbuf.st_gid) : "",
+                    opts & CHECK_OWNER ? get_user(file_name, S_ISLNK(statbuf.st_mode) ? statbuf_lnk.st_uid : statbuf.st_uid, NULL) : "",
+                    opts & CHECK_GROUP ? get_group(S_ISLNK(statbuf.st_mode) ? statbuf_lnk.st_gid : statbuf.st_gid) : "",
                     str_mtime,
                     str_inode,
                     opts & CHECK_SHA256SUM ? sf256_sum : "");
@@ -504,8 +503,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
 
             if (opts & CHECK_PERM) {
-                if (S_ISLNK(statbuf.st_mode) && statbuf_lnk) {
-                    sprintf(str_perm,"%d",(int)statbuf_lnk->st_mode);
+                if (S_ISLNK(statbuf.st_mode)) {
+                    sprintf(str_perm,"%d",(int)statbuf_lnk.st_mode);
                 } else {
                     sprintf(str_perm,"%d",(int)statbuf.st_mode);
                 }
@@ -514,8 +513,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
 
             if (opts & CHECK_OWNER) {
-                if (S_ISLNK(statbuf.st_mode) && statbuf_lnk) {
-                    sprintf(str_owner,"%d",(int)statbuf_lnk->st_uid);
+                if (S_ISLNK(statbuf.st_mode)) {
+                    sprintf(str_owner,"%d",(int)statbuf_lnk.st_uid);
                 } else {
                     sprintf(str_owner,"%d",(int)statbuf.st_uid);
                 }
@@ -524,8 +523,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
 
             if (opts & CHECK_GROUP) {
-                if (S_ISLNK(statbuf.st_mode) && statbuf_lnk) {
-                    sprintf(str_group,"%d",(int)statbuf_lnk->st_gid);
+                if (S_ISLNK(statbuf.st_mode)) {
+                    sprintf(str_group,"%d",(int)statbuf_lnk.st_gid);
                 } else {
                     sprintf(str_group,"%d",(int)statbuf.st_gid);
                 }
@@ -552,8 +551,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 str_group,
                 opts & CHECK_MD5SUM ? mf_sum : "",
                 opts & CHECK_SHA1SUM ? sf_sum : "",
-                opts & CHECK_OWNER ? get_user(file_name, statbuf_lnk ? statbuf_lnk->st_uid : statbuf.st_uid, NULL) : "",
-                opts & CHECK_GROUP ? get_group(statbuf_lnk ? statbuf_lnk->st_gid : statbuf.st_gid) : "",
+                opts & CHECK_OWNER ? get_user(file_name, S_ISLNK(statbuf.st_mode) ? statbuf_lnk.st_uid : statbuf.st_uid, NULL) : "",
+                opts & CHECK_GROUP ? get_group(S_ISLNK(statbuf.st_mode) ? statbuf_lnk.st_gid : statbuf.st_gid) : "",
                 str_mtime,
                 str_inode,
                 opts & CHECK_SHA256SUM ? sf256_sum : "",
@@ -569,7 +568,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
 
             free(alert_msg);
             free(alertdump);
-
         } else {
             char *alert_msg = NULL;
             os_calloc(OS_MAXSTR + 1, sizeof(char), alert_msg);
@@ -623,10 +621,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
             free(alert_msg);
             free(c_sum);
-        }
-        if (statbuf_lnk) {
-            free(statbuf_lnk);
-            statbuf_lnk = NULL;
         }
 
         /* Sleep here too */

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -426,8 +426,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                     str_group,
                     opts & CHECK_MD5SUM ? mf_sum : "",
                     opts & CHECK_SHA1SUM ? sf_sum : "",
-                    opts & CHECK_OWNER ? get_user(file_name, statbuf.st_uid, NULL) : "",
-                    opts & CHECK_GROUP ? get_group(statbuf.st_gid) : "",
+                    opts & CHECK_OWNER ? get_user(file_name, statbuf_lnk ? statbuf_lnk->st_uid : statbuf.st_uid, NULL) : "",
+                    opts & CHECK_GROUP ? get_group(statbuf_lnk ? statbuf_lnk->st_gid : statbuf.st_gid) : "",
                     str_mtime,
                     str_inode,
                     opts & CHECK_SHA256SUM ? sf256_sum : "");
@@ -552,8 +552,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 str_group,
                 opts & CHECK_MD5SUM ? mf_sum : "",
                 opts & CHECK_SHA1SUM ? sf_sum : "",
-                opts & CHECK_OWNER ? get_user(file_name, statbuf.st_uid, NULL) : "",
-                opts & CHECK_GROUP ? get_group(statbuf.st_gid) : "",
+                opts & CHECK_OWNER ? get_user(file_name, statbuf_lnk ? statbuf_lnk->st_uid : statbuf.st_uid, NULL) : "",
+                opts & CHECK_GROUP ? get_group(statbuf_lnk ? statbuf_lnk->st_gid : statbuf.st_gid) : "",
                 str_mtime,
                 str_inode,
                 opts & CHECK_SHA256SUM ? sf256_sum : "",
@@ -569,10 +569,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
 
             free(alert_msg);
             free(alertdump);
-            if (statbuf_lnk) {
-                free(statbuf_lnk);
-                statbuf_lnk = NULL;
-            }
 
         } else {
             char *alert_msg = NULL;
@@ -627,6 +623,10 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             }
             free(alert_msg);
             free(c_sum);
+        }
+        if (statbuf_lnk) {
+            free(statbuf_lnk);
+            statbuf_lnk = NULL;
         }
 
         /* Sleep here too */

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -179,7 +179,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     char *buf;
     syscheck_node *s_node;
     struct stat statbuf;
-    struct stat statbuf_lnk;
     char str_size[50], str_perm[50], str_mtime[50], str_inode[50];
     char *wd_sum = NULL;
     os_calloc(OS_SIZE_6144 + 1, sizeof(char), wd_sum);
@@ -261,6 +260,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
 #ifdef WIN32
     if (S_ISREG(statbuf.st_mode))
 #else
+    struct stat statbuf_lnk;
+
     if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))
 #endif
     {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -309,7 +309,6 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
 {
     int size = 0, perm = 0, owner = 0, group = 0, md5sum = 0, sha1sum = 0, sha256sum = 0, mtime = 0, inode = 0;
     struct stat statbuf;
-    struct stat statbuf_lnk;
     os_md5 mf_sum;
     os_sha1 sf_sum;
     os_sha256 sf256_sum;
@@ -331,6 +330,8 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
 #ifdef WIN32
     if (stat(file_name, &statbuf) < 0)
 #else
+    struct stat statbuf_lnk;
+
     if (lstat(file_name, &statbuf) < 0)
 #endif
     {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -502,8 +502,8 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
         str_group,
         md5sum   == 0 ? "" : mf_sum,
         sha1sum  == 0 ? "" : sf_sum,
-        owner == 0 ? "" : get_user(file_name, statbuf.st_uid, NULL),
-        group == 0 ? "" : get_group(statbuf.st_gid),
+        owner == 0 ? "" : get_user(file_name, statbuf_lnk ? statbuf_lnk->st_uid : statbuf.st_uid, NULL),
+        group == 0 ? "" : get_group(statbuf_lnk ? statbuf_lnk->st_gid : statbuf.st_gid),
         str_mtime,
         str_inode,
         sha256sum  == 0 ? "" : sf256_sum);


### PR DESCRIPTION
Hi, Team,

This PR solves the issue https://github.com/wazuh/wazuh/issues/1316.
- For a symbolic link, the attributes reported by `syscheck` are those of the real file pointed to by the link. Namely: file permissions, user id, and group id.

Best regards.
