### PR TITLE
Fix syscollector store network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 - Fixed regular expression for audit.key in audit decoder. ([#2134](https://github.com/wazuh/wazuh/pull/2134))
 - Agent's ossec-control stop should wait a bit after killing a process. ([#2149](https://github.com/wazuh/wazuh/pull/2149))
 - Fixed error ocurred while monitoring symbolic links in Linux. ([#2152](https://github.com/wazuh/wazuh/pull/2152))
+- Fix bug in Wazuh DB when trying to store multiple network interfaces with the same IP from Syscollector. ([#1928](https://github.com/wazuh/wazuh/pull/1928))
 
 
 ## [v3.7.2] 2018-12-17

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -128,7 +128,7 @@ def get_netaddr_agent(agent_id, offset=0, limit=common.database_limit, select={}
     """
     Get info about an agent's network address
     """
-    valid_select_fields = {'scan_id', 'proto', 'address',
+    valid_select_fields = {'scan_id', 'iface', 'proto', 'address',
                            'netmask', 'broadcast'}
 
     return get_item_agent(agent_id=agent_id, offset=offset, limit=limit, select=select,

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -345,6 +345,12 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                             wm_strcat(&msg, "NULL", ' ');
                         }
 
+                        if (name) {
+                            wm_strcat(&msg, name->valuestring, '|');
+                        } else {
+                            wm_strcat(&msg, "NULL", '|');
+                        }
+
                         // Information about an IPv4 address
                         wm_strcat(&msg, "0", '|');
 

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -428,6 +428,12 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                             wm_strcat(&msg, "NULL", ' ');
                         }
 
+                        if (name) {
+                            wm_strcat(&msg, name->valuestring, '|');
+                        } else {
+                            wm_strcat(&msg, "NULL", '|');
+                        }
+
                         // Information about an IPv6 address
                         wm_strcat(&msg, "1", '|');
 

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -72,7 +72,7 @@ CREATE INDEX IF NOT EXISTS netproto_id ON sys_netproto (scan_id);
 
 CREATE TABLE IF NOT EXISTS sys_netaddr (
     scan_id INTEGER REFERENCES sys_netproto (scan_id),
-    iface TEXT REFERENCES sys_netproto (iface),
+    iface TEXT REFERENCES sys_netproto (name),
     proto TEXT REFERENCES sys_netproto (type),
     address TEXT,
     netmask TEXT,

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -72,7 +72,7 @@ CREATE INDEX IF NOT EXISTS netproto_id ON sys_netproto (scan_id);
 
 CREATE TABLE IF NOT EXISTS sys_netaddr (
     scan_id INTEGER REFERENCES sys_netproto (scan_id),
-    iface TEXT REFERENCES sys_netproto (name),
+    iface TEXT REFERENCES sys_netproto (iface),
     proto TEXT REFERENCES sys_netproto (type),
     address TEXT,
     netmask TEXT,

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -44,7 +44,7 @@ static const char *SQL_STMT[] = {
     "DELETE FROM sys_processes WHERE scan_id != ?;",
     "INSERT INTO sys_netiface (scan_id, scan_time, name, adapter, type, state, mtu, mac, tx_packets, rx_packets, tx_bytes, rx_bytes, tx_errors, rx_errors, tx_dropped, rx_dropped) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     "INSERT INTO sys_netproto (scan_id, iface, type, gateway, dhcp) VALUES (?, ?, ?, ?, ?);",
-    "INSERT INTO sys_netaddr (scan_id, proto, address, netmask, broadcast) VALUES (?, ?, ?, ?, ?);",
+    "INSERT INTO sys_netaddr (scan_id, iface proto, address, netmask, broadcast) VALUES (?, ?, ?, ?, ?, ?);",
     "DELETE FROM sys_netiface WHERE scan_id != ?;",
     "DELETE FROM sys_netproto WHERE scan_id != ?;",
     "DELETE FROM sys_netaddr WHERE scan_id != ?;",

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -44,7 +44,7 @@ static const char *SQL_STMT[] = {
     "DELETE FROM sys_processes WHERE scan_id != ?;",
     "INSERT INTO sys_netiface (scan_id, scan_time, name, adapter, type, state, mtu, mac, tx_packets, rx_packets, tx_bytes, rx_bytes, tx_errors, rx_errors, tx_dropped, rx_dropped) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     "INSERT INTO sys_netproto (scan_id, iface, type, gateway, dhcp) VALUES (?, ?, ?, ?, ?);",
-    "INSERT INTO sys_netaddr (scan_id, iface proto, address, netmask, broadcast) VALUES (?, ?, ?, ?, ?, ?);",
+    "INSERT INTO sys_netaddr (scan_id, iface, proto, address, netmask, broadcast) VALUES (?, ?, ?, ?, ?, ?);",
     "DELETE FROM sys_netiface WHERE scan_id != ?;",
     "DELETE FROM sys_netproto WHERE scan_id != ?;",
     "DELETE FROM sys_netaddr WHERE scan_id != ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -327,10 +327,10 @@ int wdb_netproto_insert(wdb_t * wdb, const char * scan_id, const char * iface,  
 int wdb_netproto_save(wdb_t * wdb, const char * scan_id, const char * iface,  int type, const char * gateway, const char * dhcp);
 
 // Insert IPv4/IPv6 address info tuple. Return 0 on success or -1 on error.
-int wdb_netaddr_insert(wdb_t * wdb, const char * scan_id, int proto, const char * address, const char * netmask, const char * broadcast);
+int wdb_netaddr_insert(wdb_t * wdb, const char * scan_id, const char * iface, int proto, const char * address, const char * netmask, const char * broadcast);
 
 // Save IPv4/IPv6 address info into DB.
-int wdb_netaddr_save(wdb_t * wdb, const char * scan_id, int proto, const char * address, const char * netmask, const char * broadcast);
+int wdb_netaddr_save(wdb_t * wdb, const char * scan_id, const char * iface, int proto, const char * address, const char * netmask, const char * broadcast);
 
 // Insert OS info tuple. Return 0 on success or -1 on error.
 int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -854,9 +854,9 @@ int wdb_parse_netaddr(wdb_t * wdb, char * input, char * output) {
 			iface = NULL;
 
 		if (next = strchr(curr, '|'), !next) {
-			mdebug1("Invalid netproto query syntax.");
-			mdebug2("netproto query: %s", iface);
-			snprintf(output, OS_MAXSTR + 1, "err Invalid netproto query syntax, near '%.32s'", iface);
+			mdebug1("Invalid netaddr query syntax.");
+			mdebug2("netaddr query: %s", iface);
+			snprintf(output, OS_MAXSTR + 1, "err Invalid netaddr query syntax, near '%.32s'", iface);
 			return -1;
 		}
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -809,6 +809,7 @@ int wdb_parse_netaddr(wdb_t * wdb, char * input, char * output) {
     char * address;
     char * netmask;
     char * broadcast;
+    char * iface;
     int result;
 
     if (next = strchr(input, ' '), !next) {
@@ -844,6 +845,20 @@ int wdb_parse_netaddr(wdb_t * wdb, char * input, char * output) {
             snprintf(output, OS_MAXSTR + 1, "err Invalid netaddr query syntax, near '%.32s'", curr);
             return -1;
         }
+
+        iface = curr;
+		*next++ = '\0';
+		curr = next;
+
+		if (!strcmp(iface, "NULL"))
+			iface = NULL;
+
+		if (next = strchr(curr, '|'), !next) {
+			mdebug1("Invalid netproto query syntax.");
+			mdebug2("netproto query: %s", iface);
+			snprintf(output, OS_MAXSTR + 1, "err Invalid netproto query syntax, near '%.32s'", iface);
+			return -1;
+		}
 
         proto = strtol(curr,NULL,10);
 
@@ -882,7 +897,7 @@ int wdb_parse_netaddr(wdb_t * wdb, char * input, char * output) {
         else
             broadcast = next;
 
-        if (result = wdb_netaddr_save(wdb, scan_id, proto, address, netmask, broadcast), result < 0) {
+        if (result = wdb_netaddr_save(wdb, scan_id, iface, proto, address, netmask, broadcast), result < 0) {
             mdebug1("Cannot save netaddr information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save netaddr information.");
         } else {

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -195,7 +195,7 @@ int wdb_netaddr_save(wdb_t * wdb, const char * scan_id, int proto, const char * 
 }
 
 // Insert IPv4/IPv6 address info tuple. Return 0 on success or -1 on error.
-int wdb_netaddr_insert(wdb_t * wdb, const char * scan_id, int proto, const char * address, const char * netmask, const char * broadcast) {
+int wdb_netaddr_insert(wdb_t * wdb, const char * scan_id, const char * iface, int proto, const char * address, const char * netmask, const char * broadcast) {
 
     sqlite3_stmt *stmt = NULL;
 
@@ -207,15 +207,16 @@ int wdb_netaddr_insert(wdb_t * wdb, const char * scan_id, int proto, const char 
     stmt = wdb->stmt[WDB_STMT_ADDR_INSERT];
 
     sqlite3_bind_text(stmt, 1, scan_id, -1, NULL);
+    sqlite3_bind_text(stmt, 2, key, -1, NULL);
 
     if (proto == WDB_NETADDR_IPV4)
-        sqlite3_bind_text(stmt, 2, "ipv4", -1, NULL);
+        sqlite3_bind_text(stmt, 3, "ipv4", -1, NULL);
     else
-        sqlite3_bind_text(stmt, 2, "ipv6", -1, NULL);
+        sqlite3_bind_text(stmt, 3, "ipv6", -1, NULL);
 
-    sqlite3_bind_text(stmt, 3, address, -1, NULL);
-    sqlite3_bind_text(stmt, 4, netmask, -1, NULL);
-    sqlite3_bind_text(stmt, 5, broadcast, -1, NULL);
+    sqlite3_bind_text(stmt, 4, address, -1, NULL);
+    sqlite3_bind_text(stmt, 5, netmask, -1, NULL);
+    sqlite3_bind_text(stmt, 6, broadcast, -1, NULL);
 
     if (sqlite3_step(stmt) == SQLITE_DONE){
         return 0;

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -174,7 +174,7 @@ int wdb_netproto_insert(wdb_t * wdb, const char * scan_id, const char * iface, i
 }
 
 // Save IPv4/IPv6 address info into DB.
-int wdb_netaddr_save(wdb_t * wdb, const char * scan_id, int proto, const char * address, const char * netmask, const char * broadcast) {
+int wdb_netaddr_save(wdb_t * wdb, const char * scan_id, const char * iface, int proto, const char * address, const char * netmask, const char * broadcast) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
         mdebug1("at wdb_netaddr_save(): cannot begin transaction");
@@ -183,6 +183,7 @@ int wdb_netaddr_save(wdb_t * wdb, const char * scan_id, int proto, const char * 
 
     if (wdb_netaddr_insert(wdb,
         scan_id,
+		iface
         proto,
         address,
         netmask,
@@ -207,7 +208,7 @@ int wdb_netaddr_insert(wdb_t * wdb, const char * scan_id, const char * iface, in
     stmt = wdb->stmt[WDB_STMT_ADDR_INSERT];
 
     sqlite3_bind_text(stmt, 1, scan_id, -1, NULL);
-    sqlite3_bind_text(stmt, 2, key, -1, NULL);
+    sqlite3_bind_text(stmt, 2, iface, -1, NULL);
 
     if (proto == WDB_NETADDR_IPV4)
         sqlite3_bind_text(stmt, 3, "ipv4", -1, NULL);

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -183,7 +183,7 @@ int wdb_netaddr_save(wdb_t * wdb, const char * scan_id, const char * iface, int 
 
     if (wdb_netaddr_insert(wdb,
         scan_id,
-		iface
+		iface,
         proto,
         address,
         netmask,


### PR DESCRIPTION
This PR fixes #1904 
Change in database in order to make network interface name a primary key in sys_netaddr table. Doing this  the error caused by trying to store two network interfaces with the same IP address is fixed.