### PR TITLE
Fix Windows username

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -189,7 +189,7 @@ int DecodeSyscheck(Eventinfo *lf, _sdb *sdb)
     c_sum = lf->log;
 
     // Get w_sum
-    if (w_sum = strchr(c_sum, '!'), w_sum) {
+    if (w_sum = wstr_chr(c_sum, '!'), w_sum) {
         *(w_sum++) = '\0';
     }
 
@@ -234,7 +234,7 @@ int fim_db_search(char *f_name, char *c_sum, char *w_sum, Eventinfo *lf, _sdb *s
         os_free(lf->data);
         goto exit_fail;
     }
-    check_sum = strchr(response, ' ');
+    check_sum = wstr_chr(response, ' ');
     *(check_sum++) = '\0';
 
     //extract changes and date_alert fields only available from wazuh_db

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -382,6 +382,7 @@ int fim_db_search(char *f_name, char *c_sum, char *w_sum, Eventinfo *lf, _sdb *s
         goto exit_ok;
     }
     sk_sum_clean(&newsum);
+    sk_sum_clean(&oldsum);
     os_free(response);
     os_free(new_check_sum);
     os_free(old_check_sum);
@@ -390,6 +391,7 @@ int fim_db_search(char *f_name, char *c_sum, char *w_sum, Eventinfo *lf, _sdb *s
 
 exit_ok:
     sk_sum_clean(&newsum);
+    sk_sum_clean(&oldsum);
     os_free(response);
     os_free(new_check_sum);
     os_free(old_check_sum);
@@ -398,6 +400,7 @@ exit_ok:
 
 exit_fail:
     sk_sum_clean(&newsum);
+    sk_sum_clean(&oldsum);
     os_free(response);
     os_free(new_check_sum);
     os_free(old_check_sum);

--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -80,6 +80,7 @@ int intcheck_file(const char *file_name, const char *dir)
             dir,
             file_name);
 
+    os_free(user);
     if (sid) {
         LocalFree(sid);
     }

--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -22,7 +22,7 @@ int intcheck_file(const char *file_name, const char *dir)
     os_sha256 sf256_sum;
     char newsum[1172 + 1];
 #ifdef WIN32
-    const char *user;
+    char *user;
     char *sid;
 #endif
 

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -153,7 +153,7 @@ const char* get_group(int gid);
 
 #else
 
-const char *get_user(const char *path, __attribute__((unused)) int uid, char **sid);
+char *get_user(const char *path, __attribute__((unused)) int uid, char **sid);
 const char *get_group(__attribute__((unused)) int gid);
 
 #endif

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -149,7 +149,7 @@ void normalize_path(char *path);
 #ifndef WIN32
 
 const char *get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid);
-const char* get_group(int gid);
+const char *get_group(int gid);
 
 #else
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -507,18 +507,19 @@ const char* get_group(int gid) {
 
 #else
 
-const char *get_user(const char *path, __attribute__((unused)) int uid, char **sid)
+char *get_user(const char *path, __attribute__((unused)) int uid, char **sid)
 {
     DWORD dwRtnCode = 0;
     PSID pSidOwner = NULL;
     BOOL bRtnBool = TRUE;
-    static char AcctName[BUFFER_LEN];
+    char AcctName[BUFFER_LEN];
     char DomainName[BUFFER_LEN];
     DWORD dwAcctName = BUFFER_LEN;
     DWORD dwDomainName = BUFFER_LEN;
     SID_NAME_USE eUse = SidTypeUnknown;
     HANDLE hFile;
     PSECURITY_DESCRIPTOR pSD = NULL;
+    char *result;
 
     // Get the handle of the file object.
     hFile = CreateFile(
@@ -613,7 +614,10 @@ end:
     if (pSD) {
         LocalFree(pSD);
     }
-    return AcctName;
+
+    result = wstr_replace(&AcctName, " ", "\\ ");
+
+    return result;
 }
 
 const char *get_group(__attribute__((unused)) int gid) {

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -500,7 +500,7 @@ const char *get_user(__attribute__((unused)) const char *path, int uid, __attrib
     return user ? user->pw_name : "";
 }
 
-const char* get_group(int gid) {
+const char *get_group(int gid) {
     struct group *group = getgrgid(gid);
     return group ? group->gr_name : "";
 }
@@ -615,7 +615,7 @@ end:
         LocalFree(pSD);
     }
 
-    result = wstr_replace(&AcctName, " ", "\\ ");
+    result = wstr_replace((const char*)&AcctName, " ", "\\ ");
 
     return result;
 }

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -24,6 +24,7 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
     char *c_inode;
     char *tag;
     int retval = 0;
+    char *username_esc;
 
     if (c_sum[0] == '-' && c_sum[1] == '1') {
         retval = 1;
@@ -65,6 +66,10 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
                 return -1;
 
             *(sum->gname++) = '\0';
+
+            if (username_esc = os_strip_char(sum->uname, '\\'), username_esc) {
+                sum->uname = username_esc;
+            }
 
             if (!(c_mtime = strchr(sum->gname, ':')))
                 return -1;
@@ -427,6 +432,7 @@ int delete_target_file(const char *path) {
 void sk_sum_clean(sk_sum_t * sum) {
     os_free(sum->wdata.user_name);
     os_free(sum->wdata.process_name);
+    os_free(sum->uname);
 }
 
 int fim_find_child_depth(const char *parent, const char *child) {

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -337,6 +337,7 @@ int sk_build_sum(const sk_sum_t * sum, char * output, size_t size) {
     char s_perm[16];
     char s_mtime[16];
     char s_inode[16];
+    char *username;
 
     if(sum->perm) {
         snprintf(s_perm, sizeof(s_perm), "%d", sum->perm);
@@ -346,14 +347,18 @@ int sk_build_sum(const sk_sum_t * sum, char * output, size_t size) {
     snprintf(s_mtime, sizeof(s_mtime), "%ld", sum->mtime);
     snprintf(s_inode, sizeof(s_inode), "%ld", sum->inode);
 
-    r = snprintf(output, size, "%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s!%d:%ld", // format: c:h:e:c:k:s:u:m!extra:data
+    username = wstr_replace((const char*)sum->uname, " ", "\\ ");
+
+    // size:permision:uid:gid:md5:sha1:uname:gname:mtime:inode:sha256!changes:date_alert
+    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^checksum^^^^^^^^^^^^^^^^^^^^^^^^^^^!^^^^extradata^^^^^
+    r = snprintf(output, size, "%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s!%d:%ld",
             sum->size,
             s_perm,
             sum->uid,
             sum->gid,
             sum->md5,
             sum->sha1,
-            sum->uname? sum->uname : "",
+            sum->uname? username : "",
             sum->gname? sum->gname : "",
             sum->mtime? s_mtime : "",
             sum->inode? s_inode : "",

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -185,7 +185,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
 #ifndef WIN32
     char str_owner[50], str_group[50];
 #else
-    const char *user;
+    char *user;
     char *sid = NULL;
 #endif
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -356,6 +356,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                     str_inode,
                     opts & CHECK_SHA256SUM ? sf256_sum : "");
 
+                os_free(user);
                 if (sid) {
                      LocalFree(sid);
                  }
@@ -480,6 +481,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 file_name,
                 alertdump ? "\n" : "",
                 alertdump ? alertdump : "");
+
+            os_free(user);
             if (sid) {
                 LocalFree(sid);
             }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -318,7 +318,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
     char str_owner[50], str_group[50];
 #else
     char *sid = NULL;
-    const char *user;
+    char *user;
 #endif
 
     /* Clean sums */

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -533,6 +533,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
         str_inode,
         sha256sum  == 0 ? "" : sf256_sum);
 
+        os_free(user);
         if (sid) {
             LocalFree(sid);
         }

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -647,8 +647,8 @@ void audit_parse(char *buffer) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, uid);
                 snprintf (uid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                const char *user = get_user("",atoi(uid), NULL);
-                w_evt->user_name = strdup(user);
+                char *user = get_user("",atoi(uid), NULL);
+                w_evt->user_name = user;
                 w_evt->user_id = strdup(uid);
                 free(uid);
             }
@@ -665,8 +665,8 @@ void audit_parse(char *buffer) {
                     w_evt->audit_name = NULL;
                     w_evt->audit_uid = NULL;
                 } else {
-                    const char *user = get_user("",atoi(auid), NULL);
-                    w_evt->audit_name = strdup(user);
+                    char *user = get_user("",atoi(auid), NULL);
+                    w_evt->audit_name = user;
                     w_evt->audit_uid = strdup(auid);
                 }
                 free(auid);
@@ -676,8 +676,8 @@ void audit_parse(char *buffer) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, euid);
                 snprintf (euid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                const char *user = get_user("",atoi(euid), NULL);
-                w_evt->effective_name = strdup(user);
+                char *user = get_user("",atoi(euid), NULL);
+                w_evt->effective_name = user;
                 w_evt->effective_uid = strdup(euid);
                 free(euid);
             }

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -647,8 +647,8 @@ void audit_parse(char *buffer) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, uid);
                 snprintf (uid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                char *user = get_user("",atoi(uid), NULL);
-                w_evt->user_name = user;
+                const char *user = get_user("",atoi(uid), NULL);
+                w_evt->user_name = strdup(user);
                 w_evt->user_id = strdup(uid);
                 free(uid);
             }
@@ -665,8 +665,8 @@ void audit_parse(char *buffer) {
                     w_evt->audit_name = NULL;
                     w_evt->audit_uid = NULL;
                 } else {
-                    char *user = get_user("",atoi(auid), NULL);
-                    w_evt->audit_name = user;
+                    const char *user = get_user("",atoi(auid), NULL);
+                    w_evt->audit_name = strdup(user);
                     w_evt->audit_uid = strdup(auid);
                 }
                 free(auid);
@@ -676,8 +676,8 @@ void audit_parse(char *buffer) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, euid);
                 snprintf (euid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                char *user = get_user("",atoi(euid), NULL);
-                w_evt->effective_name = user;
+                const char *user = get_user("",atoi(euid), NULL);
+                w_evt->effective_name = strdup(user);
                 w_evt->effective_uid = strdup(euid);
                 free(euid);
             }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -35,7 +35,7 @@ int wdb_parse(char * input, char * output) {
         return -1;
     }
 
-    if (next = strchr(input, ' '), !next) {
+    if (next = wstr_chr(input, ' '), !next) {
         mdebug1("Invalid DB query syntax.");
         mdebug2("DB query: %s", input);
         snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", input);
@@ -48,7 +48,7 @@ int wdb_parse(char * input, char * output) {
     if (strcmp(actor, "agent") == 0) {
         id = next;
 
-        if (next = strchr(id, ' '), !next) {
+        if (next = wstr_chr(id, ' '), !next) {
             mdebug1("Invalid DB query syntax.");
             mdebug2("DB query error near: %s", id);
             snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", id);
@@ -74,7 +74,7 @@ int wdb_parse(char * input, char * output) {
 
         mdebug2("Executing query: %s", query);
 
-        if (next = strchr(query, ' '), next) {
+        if (next = wstr_chr(query, ' '), next) {
             *next++ = '\0';
         }
 
@@ -280,7 +280,7 @@ int wdb_parse_syscheck(wdb_t * wdb, char * input, char * output) {
     int result;
     long ts;
 
-    if (next = strchr(input, ' '), !next) {
+    if (next = wstr_chr(input, ' '), !next) {
         mdebug1("Invalid Syscheck query syntax.");
         mdebug2("Syscheck query: %s", input);
         snprintf(output, OS_MAXSTR + 1, "err Invalid Syscheck query syntax, near '%.32s'", input);
@@ -320,7 +320,7 @@ int wdb_parse_syscheck(wdb_t * wdb, char * input, char * output) {
     } else if (strcmp(curr, "scan_info_update") == 0) {
         curr = next;
 
-        if (next = strchr(curr, ' '), !next) {
+        if (next = wstr_chr(curr, ' '), !next) {
             mdebug1("Invalid scan_info fim query syntax.");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Syscheck query syntax, near '%.32s'", curr);
             return -1;
@@ -366,7 +366,7 @@ int wdb_parse_syscheck(wdb_t * wdb, char * input, char * output) {
     } else if (strcmp(curr, "save") == 0) {
         curr = next;
 
-        if (next = strchr(curr, ' '), !next) {
+        if (next = wstr_chr(curr, ' '), !next) {
             mdebug1("Invalid Syscheck query syntax.");
             mdebug2("Syscheck query: %s", curr);
             snprintf(output, OS_MAXSTR + 1, "err Invalid Syscheck query syntax, near '%.32s'", curr);
@@ -388,7 +388,7 @@ int wdb_parse_syscheck(wdb_t * wdb, char * input, char * output) {
 
         checksum = next;
 
-        if (next = strchr(checksum, ' '), !next) {
+        if (next = wstr_chr(checksum, ' '), !next) {
             mdebug1("Invalid Syscheck query syntax.");
             mdebug2("Syscheck query: %s", checksum);
             snprintf(output, OS_MAXSTR + 1, "err Invalid Syscheck query syntax, near '%.32s'", checksum);


### PR DESCRIPTION
## Related issue:
- Error decoding windows events with spaced usernames. #1922 

## Description:
Windows usernames can contain spaces. This causes a malfunction of the fim decoder when checksum with this content are decoded.

This PR solves this problem.

Now the checksum contain the user names with the escaped spaces. And the time to display the alerts appears correctly:
 ```
Rule: 554 (level 5) -> 'File added to the system.'
File 'c:\windows\logs\dosvc\dosvc.20181122_093514_628.etl' was added.

Attributes:
 - Size: 24576
 - Permissions: 100666
 - Date: Thu Nov 22 10:40:11 2018
 - User: Servicio de red (S-1-5-20)
 - MD5: f8e2d695f1d8890f1c23d596bc8790c3
 - SHA1: c2526e6892b0b6547d92ff34e13170283455977b
 - SHA256: d8f56c6965d49c1052254d1104147eb231bea584f928faa3d604e9c3d8c6b87f

Rule: 550 (level 7) -> 'Integrity checksum changed.'
File 'c:\windows\logs\dosvc\dosvc.20181122_093514_628.etl' checksum changed.
Size changed from '24576' to '24583'
Old md5sum was: 'f8e2d695f1d8890f1c23d596bc8790c3'
New md5sum is : '3585b1e64e0175293c3f278e4dfefeda'
Old sha1sum was: 'c2526e6892b0b6547d92ff34e13170283455977b'
New sha1sum is : '6cfffab835f32169673242a10ba3d51607508f2a'
Old sha256sum was: 'd8f56c6965d49c1052254d1104147eb231bea584f928faa3d604e9c3d8c6b87f'
New sha256sum is : 'decca2424f7342f64f888439a72b0e4263d23bc27475de841e3312003a5bb731'
Old modification time was: 'Thu Nov 22 10:40:11 2018', now it is 'Thu Nov 22 12:08:35 2018'
(Audit) User: 'borja (S-1-5-21-3372414813-2303984644-549331509-1001)'
```

## Test:
- [x] Check alerts generated with frequency, realtime and whodata.
- [x] Check all type of alerts: add, delete and modified.
- [x] Check Valgrind report.