### PR TITLE
Read restrict option

### DIFF
--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -175,6 +175,9 @@ cJSON *getSyscheckConfig(void) {
             cJSON_AddItemToObject(pair,"opts",opts);
             cJSON_AddStringToObject(pair,"dir",syscheck.dir[i]);
             cJSON_AddNumberToObject(pair,"recursion_level",syscheck.recursion_level[i]);
+            if (syscheck.filerestrict && syscheck.filerestrict[i]) {
+                cJSON_AddStringToObject(pair,"restrict",syscheck.filerestrict[i]->raw);
+            }
             if (syscheck.tag && syscheck.tag[i]) {
                 cJSON_AddStringToObject(pair,"tags",syscheck.tag[i]);
             }


### PR DESCRIPTION
This PR fixes the issue https://github.com/wazuh/wazuh/issues/1860

```
...
        "directories": [
            {
               "recursion_level": 256,
               "restrict": "txt$",
               "dir": "/etc",
               "opts": [
                  "check_md5sum",
                  "check_sha1sum",
                  "check_perm",
                  "check_size",
                  "check_owner",
                  "check_group",
                  "check_mtime",
                  "check_inode",
                  "check_sha256sum",
                  "check_whodata"
               ]
            },
...
```