### PR TITLE
Fix multiple bugs in cluster configuration

### DIFF
--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -145,19 +145,7 @@ def check_cluster_status():
     """
     Function to check if cluster is enabled
     """
-    # for python 2/3 compatibility
-    # the osec directory is the first line of ossec-init.conf
-    try:
-        with open("/etc/ossec-init.conf") as f:
-            directory = f.readline().split("=")[1][:-1].replace('"', "")
-    except UnicodeDecodeError:
-        with open("/etc/ossec-init.conf", encoding='utf-8') as f:
-            directory = f.readline().split("=")[1][:-1].replace('"', "")
-
-    try:
-        return read_config()['disabled'] == 'no'
-    except:
-        return False
+    return read_config()['disabled'] != 'yes'
 
 
 def get_status_json():

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -57,21 +57,14 @@ def check_cluster_config(config):
     iv = InputValidator()
     reservated_ips = {'localhost', 'NODE_IP', '0.0.0.0', '127.0.1.1'}
 
-    if not 'key' in config:
+    if len(config['key']) == 0:
         raise WazuhException(3004, 'Unspecified key')
     elif not iv.check_name(config['key']) or not iv.check_length(config['key'], 32, eq):
         raise WazuhException(3004, 'Key must be 32 characters long and only have alphanumeric characters')
 
-    if 'node_type' not in config:
-        raise WazuhException(3004, "Node type not present in cluster configuration")
     elif config['node_type'] != 'master' and config['node_type'] != 'worker':
-        raise WazuhException(3004, 'Invalid node type {0}. Correct values are master and worker'.format(config['node_type']))
-
-    if 'nodes' not in config or len(config['nodes']) == 0:
-        raise WazuhException(3004, 'No nodes defined in cluster configuration.')
-
-    if 'disabled' not in config:
-        config['disabled'] = 'yes'
+        raise WazuhException(3004, 'Invalid node type {0}. Correct values are master and worker'.format(
+            config['node_type']))
 
     if config['disabled'] != 'yes' and config['disabled'] != 'no':
         raise WazuhException(3004, 'Invalid value for disabled option {}. Allowed values are yes and no'.
@@ -79,8 +72,8 @@ def check_cluster_config(config):
 
     if len(config['nodes']) > 1:
         logger.warning(
-            "Found more than one node in configuration. Only master node should be specified. Using {} as master.".format(
-                config['nodes'][0]))
+            "Found more than one node in configuration. Only master node should be specified. Using {} as master.".
+            format(config['nodes'][0]))
 
     invalid_elements = list(reservated_ips & set(config['nodes']))
 
@@ -111,23 +104,25 @@ def get_cluster_items_worker_intervals():
 
 
 def read_config():
+    cluster_default_configuration = {'disabled': 'no', 'node_type': 'master', 'name': 'wazuh', 'node_name': 'node01',
+                                     'key': '', 'port': 1516, 'bind_addr': '0.0.0.0', 'nodes': ['NODE_IP'],
+                                     'hidden': 'no'}
+
     try:
         config_cluster = get_ossec_conf('cluster')
-
     except WazuhException as e:
         if e.code == 1102:
-            raise WazuhException(3006, "Cluster configuration not present in ossec.conf")
+            # if no cluster configuration is present in ossec.conf, return default configuration but disabling it.
+            cluster_default_configuration['disabled'] = 'yes'
+            return cluster_default_configuration
         else:
             raise WazuhException(3006, e.message)
     except Exception as e:
         raise WazuhException(3006, str(e))
 
-    if 'port' in config_cluster:
-        config_cluster['port'] = int(config_cluster['port'])
-
-    if 'node_type' in config_cluster and config_cluster['node_type'] == 'client':
-        logger.warning("Deprecated node type 'client'. Using 'worker' instead.")
-        config_cluster['node_type'] = 'worker'
+    # if any value is missing from user's cluster configuration, add the default one:
+    for value_name in set(cluster_default_configuration.keys()) - set(config_cluster.keys()):
+        config_cluster[value_name] = cluster_default_configuration[value_name]
 
     return config_cluster
 

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -111,7 +111,7 @@ def read_config():
     try:
         config_cluster = get_ossec_conf('cluster')
     except WazuhException as e:
-        if e.code == 1102:
+        if e.code == 1106:
             # if no cluster configuration is present in ossec.conf, return default configuration but disabling it.
             cluster_default_configuration['disabled'] = 'yes'
             return cluster_default_configuration

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -80,6 +80,9 @@ def check_cluster_config(config):
     if len(invalid_elements) != 0:
         raise WazuhException(3004, "Invalid elements in node fields: {0}.".format(', '.join(invalid_elements)))
 
+    if not isinstance(config['port'], int) and not config['port'].isdigit():
+        raise WazuhException(3004, "Cluster port must be an integer.")
+
 
 def get_cluster_items():
     try:

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -28,6 +28,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     static const char *hidden = "hidden";
     static const char *port = "port";
     static const char *bind_addr = "bind_addr";
+    static const char *C_VALID = "!\"#$%&'-.0123456789:<=>?ABCDEFGHIJKLMNOPQRESTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~";
 
     _Config *Config;
     Config = (_Config *)d1;
@@ -44,9 +45,13 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             merror(XML_VALUENULL, node[i]->element);
             return OS_INVALID;
         } else if (!strcmp(node[i]->element, cluster_name)) {
+            if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content))
+            {
+                merror("Detected a not allowed character in cluster name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
+                return OS_INVALID;
+            }
             os_strdup(node[i]->content, Config->cluster_name);
         } else if (!strcmp(node[i]->element, node_name)) {
-            static const char *C_VALID = " !\"#$%&'-.0123456789:<=>?ABCDEFGHIJKLMNOPQRESTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~";
             if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content))
             {
                 merror("Detected a not allowed character in node name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
@@ -54,11 +59,19 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             }
             os_strdup(node[i]->content, Config->node_name);
         } else if (!strcmp(node[i]->element, node_type)) {
+            if (strcmp(node[i]->content, "worker") && strcmp(node[i]->content, "client") && strcmp(node[i]->content, "master")) {
+                merror("Detected a not allowed node type '%s'. Valid types are 'master' and 'worker'.", node[i]->content);
+                return OS_INVALID;
+            }
             os_strdup(node[i]->content, Config->node_type);
         } else if (!strcmp(node[i]->element, key)) {
         } else if (!strcmp(node[i]->element, socket_timeout)) {
         } else if (!strcmp(node[i]->element, connection_timeout)) {
         } else if (!strcmp(node[i]->element, disabled)) {
+            if (strcmp(node[i]->content, "yes") && strcmp(node[i]->content, "no")) {
+                merror("Detected a not allowed value for disabled tag '%s'. Valid values are 'yes' and 'no'.", node[i]->content);
+                return OS_INVALID;
+            }
             if (strcmp(node[i]->content, "yes") == 0) {
                 disable_cluster_info = 1;
             }

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -45,21 +45,28 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             merror(XML_VALUENULL, node[i]->element);
             return OS_INVALID;
         } else if (!strcmp(node[i]->element, cluster_name)) {
-            if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content))
-            {
+            if (!strlen(node[i]->content)) {
+                merror("Cluster name is empty in configuration");
+                return OS_INVALID;
+            } else if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content)) {
                 merror("Detected a not allowed character in cluster name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
                 return OS_INVALID;
             }
             os_strdup(node[i]->content, Config->cluster_name);
         } else if (!strcmp(node[i]->element, node_name)) {
-            if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content))
-            {
+            if (!strlen(node[i]->content)) {
+                merror("Node name is empty in configuration");
+                return OS_INVALID;
+            } else if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content)) {
                 merror("Detected a not allowed character in node name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
                 return OS_INVALID;
             }
             os_strdup(node[i]->content, Config->node_name);
         } else if (!strcmp(node[i]->element, node_type)) {
-            if (strcmp(node[i]->content, "worker") && strcmp(node[i]->content, "client") && strcmp(node[i]->content, "master")) {
+            if (!strlen(node[i]->content)) {
+                merror("Node type is empty in configuration");
+                return OS_INVALID;
+            } else if (strcmp(node[i]->content, "worker") && strcmp(node[i]->content, "client") && strcmp(node[i]->content, "master")) {
                 merror("Detected a not allowed node type '%s'. Valid types are 'master' and 'worker'.", node[i]->content);
                 return OS_INVALID;
             }


### PR DESCRIPTION
Hello team,

This PR fixes some bugs reported in cluster configuration (#1223).

### Missing cluster configuration
If no cluster configuration is present at ossec.conf, then the default configuration is returned. In this case, the cluster is disabled:
```python
Python 2.7.15rc1 (default, Nov 12 2018, 14:31:15)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh.cluster import cluster
>>> cluster.read_config()
{'disabled': 'yes', 'bind_addr': '0.0.0.0', 'node_type': 'master', 'hidden': 'no', 'name': 'wazuh', 'key': '', 'nodes': ['NODE_IP'], 'port': 1516, 'node_name': 'node01'}
>>> from wazuh import configuration
>>> configuration.get_ossec_conf('cluster')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "wazuh/configuration.py", line 445, in get_ossec_conf
    raise WazuhException(1106, e.args[0])
wazuh.exception.WazuhException: Error 1106 - Requested section not present in configuration: cluster
```

### Missing items in cluster configuration
If cluster configuration is present but empty, then the default configuration is returned but with `disabled` option set to `no`:
```python
Python 2.7.15rc1 (default, Nov 12 2018, 14:31:15)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh.cluster import cluster
>>> cluster.read_config()
{'bind_addr': '0.0.0.0', 'name': 'wazuh', 'port': 1516, 'node_name': 'node01', 'disabled': 'no', 'node_type': 'master', 'key': '', 'nodes': ['NODE_IP'], 'hidden': 'no'}
>>> from wazuh import configuration
>>> configuration.get_ossec_conf('cluster')
{}
```
Missing items are filled using its default value:
https://github.com/wazuh/wazuh/blob/7555c2eed47ff1b71c4b208b33aa8137bfaf7b2a/framework/wazuh/cluster/cluster.py#L133-L135

This fixes #1178, #1711, #1157 and https://github.com/wazuh/wazuh-api/issues/239



### Don't allow spaces in node_name, name and node_type options
The validation done at C level has been improved to not allow spaces in `node_name`, `name` and `node_type` options. If an space is used in any of those options the following error will be shown when restarting wazuh:
```shellsession
# /var/ossec/bin/ossec-control restart
2018/11/22 14:07:27 ossec-analysisd: ERROR: Detected a not allowed character in cluster name: "wa zuh". Characters allowed: "!"#$%&'-.0123456789:<=>?ABCDEFGHIJKLMNOPQRESTUVWXYZ[\]^_abcdefghijklmnopqrstuvwxyz{|}~".
2018/11/22 14:07:27 ossec-analysisd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
2018/11/22 14:07:27 ossec-analysisd: CRITICAL: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
ossec-analysisd: Configuration error. Exiting
```
This fixes #1176.

### Don't allow empty values in node_name, name and node_type options
If `node_name`, `name` or `node_type` are empty in the configuration, the following error is shown when attempting to restart Wazuh:
```shellsession
# /var/ossec/bin/ossec-control restart
2018/11/22 14:27:36 ossec-analysisd: ERROR: Node type is empty in configuration
2018/11/22 14:27:36 ossec-analysisd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
2018/11/22 14:27:36 ossec-analysisd: CRITICAL: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
ossec-analysisd: Configuration error. Exiting
```

This fixes #1092

### Port field must be an integer
Validation at Python level has been added for `port` option. If it's not an integer, the following error will be shown when attempting to start the cluster:
```shellsession
# /var/ossec/bin/wazuh-clusterd -f
2018-11-22 14:32:02,982 ERROR   : [wazuh-clusterd] Exiting. Reason: 'Invalid configuration: 'Error 3004 - Error in cluster configuration: Cluster port must be an integer.''.
```

### Validate master's IP
When a fake IP is used as master IP, the following error is shown (only in master nodes):
```shellsession
# /var/ossec/bin/wazuh-clusterd -fdd
2018-11-22 14:31:43,162 ERROR   : [wazuh-clusterd] Exiting. Reason: 'Invalid configuration: 'Error 3004 - Error in cluster configuration: Master IP not valid. Valid ones are: 10.0.2.15''.
```

This fixes #1181 and #1177.

Best regards,
Marta