### PR TITLE
Split Guard Duty PORT_PROBE events

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -36,6 +36,7 @@ static const char *LEGACY_AWS_ACCOUNT_ALIAS = "LEGACY";
 static const char *CLOUDTRAIL_BUCKET_TYPE = "cloudtrail";
 static const char *CONFIG_BUCKET_TYPE = "config";
 static const char *CUSTOM_BUCKET_TYPE = "custom";
+static const char *GUARDDUTY_BUCKET_TYPE = "guardduty";
 static const char *INSPECTOR_SERVICE_TYPE = "inspector";
 
 // Parse XML
@@ -175,11 +176,11 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 // type is an attribute of the bucket tag
                 if (!strcmp(*nodes[i]->attributes, XML_BUCKET_TYPE)) {
                     if (!strcmp(*nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CONFIG_BUCKET_TYPE)
-                        || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE)) {
+                        || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE) || !strcmp(*nodes[i]->values, GUARDDUTY_BUCKET_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
-                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE,
-                            CONFIG_BUCKET_TYPE, CUSTOM_BUCKET_TYPE);
+                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s', '%s' or '%s'", *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE,
+                            CONFIG_BUCKET_TYPE, CUSTOM_BUCKET_TYPE, GUARDDUTY_BUCKET_TYPE);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }


### PR DESCRIPTION
Hi team,

This PR is for issue #1263. Many Guard Duty events have lists which contains objects, and this is a problem for visualize the events on Kibana or Splunk.

I made changes by split this events and show the information properly.

Best regards,

Demetrio.