### PR TITLE
Update Guard Duty rules

### DIFF
--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -100,17 +100,39 @@ ID: 80200 - 80499
     <rule id="80301" level="3">
         <if_sid>80300</if_sid>
         <field name="aws.severity">0|1|2|3</field>
-        <description>Guard Duty Finding with a low level: $(aws.description)</description>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title)</description>
     </rule>
     <rule id="80302" level="6">
         <if_sid>80300</if_sid>
         <field name="aws.severity">4|5|6</field>
-        <description>Guard Duty Finding with a medium level: $(aws.description)</description>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title)</description>
     </rule>
     <rule id="80303" level="10">
         <if_sid>80300</if_sid>
         <field name="aws.severity">7|8|9</field>
-        <description>Guard Duty Finding with a high level: $(aws.description)</description>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title)</description>
+    </rule>
+
+    <!-- PORT_PROBE rules -->
+    <rule id="80305" level="3">
+        <if_sid>80301</if_sid>
+        <field name="aws.service.action.actionType">PORT_PROBE</field>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)]
+         [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
+    </rule>
+
+    <rule id="80306" level="6">
+        <if_sid>80302</if_sid>
+        <field name="aws.service.action.actionType">PORT_PROBE</field>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)]
+         [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
+    </rule>
+
+    <rule id="80307" level="10">
+        <if_sid>80303</if_sid>
+        <field name="aws.service.action.actionType">PORT_PROBE</field>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)]
+         [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
     </rule>
 
     <!-- Macie Alerts -->


### PR DESCRIPTION
Hi team,

This PR updates rules for `AWS Guard Duty`. Descriptions were updated to show information more useful. Below there is an example of a `Guard Duty` event:
```bash
# /var/ossec/bin/ossec-logtest 
2018/11/24 10:10:34 ossec-testrule: INFO: Started (pid: 4944).
ossec-testrule: Type one log per line.

{"aws": {"description": "EC2 instance has an unprotected port which is being probed by a known malicious host.", "updatedAt": "2018-11-24T09:53:00.202Z", "schemaVersion": "2.0", "id": "22b3XXXXXX", "arn": "arn:aws:guardduty:us-east-1:1XXXXXXX:detector/caXXXXXXXXXebffb79d/finding/22b3XXXXXXXX", "accountId": "16XXXXXX", "resource": {"resourceType": "Instance", "instanceDetails": {"productCodes": [], "availabilityZone": "us-east-1e", "tags": {"value": "demo-ag-windows (r)", "key": "Name"}, "instanceId": "i-024bXXXXXX", "instanceState": "running", "imageId": "ami-7e901", "platform": "windows", "launchTime": "2018-07-21T18:01:56Z", "instanceType": "t2.medium", "networkInterfaces": {"vpcId": "vpc-921fa", "publicDnsName": "ec2-34.compute-1.amazonaws.com", "networkInterfaceId": "eni-9XX06c6", "privateIpAddresses": [{"privateDnsName": "ip-10-0-0-XX.ec2.internal", "privateIpAddress": "10.0.0.XXX"}], "publicIp": "XX.X02.2XX.24", "privateDnsName": "ip-10-0-0-XXX.ec2.internal", "securityGroups": [{"groupName": "Windows", "groupId": "sg-c46XXXXa1"}], "ipv6Addresses": [], "subnetId": "subnet-6bXXXX3", "privateIpAddress": "10.0.0.XXX"}}}, "severity": 2, "service": {"count": 1881, "additionalInfo": {"threatName": "Scanner", "threatListName": "ProofPoint"}, "archived": false, "resourceRole": "TARGET", "eventFirstSeen": "2018-11-12T09:12:58Z", "detectorId": "cab38390b72XXXXdfce", "action": {"portProbeAction": {"portProbeDetails": {"remoteIpDetails": {"organization": {"org": "HiNet", "isp": "HiNet", "asn": "3462", "asnOrg": "Data Communication Business Group"}, "ipAddressV4": "220.133.14.47", "city": {"cityName": "Taipei"}, "geoLocation": {"lat": 25.0478, "lon": 121.5318}, "country": {"countryName": "Taiwan"}}, "localPortDetails": {"portName": "RDP", "port": 3389}}, "blocked": false}, "actionType": "PORT_PROBE"}, "serviceName": "guardduty", "eventLastSeen": "2018-11-24T09:47:06Z"}, "title": "Unprotected port on EC2 instance i-024XXXXXX1a is being probed.", "region": "us-east-1", "partition": "aws", "source": "guardduty", "createdAt": "2018-11-12T09:16:57.631Z", "log_info": {"s3bucket": "wazuh-aws-wodle", "aws_account_alias": "", "log_file": "guardduty/2018/11/24/10/firehose_guardduty-1-2018-11-24-10-01-05-eed81f82-c7e2-47e1-b483-2c9030f91bae.zip"}, "type": "Recon:EC2/PortProbeUnprotectedPort"}, "integration": "aws"}


**Phase 1: Completed pre-decoding.
       full event: '{"aws": {"description": "EC2 instance has an unprotected port which is being probed by a known malicious host.", "updatedAt": "2018-11-24T09:53:00.202Z", "schemaVersion": "2.0", "id": "22b3XXXXXX", "arn": "arn:aws:guardduty:us-east-1:1XXXXXXX:detector/caXXXXXXXXXebffb79d/finding/22b3XXXXXXXX", "accountId": "16XXXXXX", "resource": {"resourceType": "Instance", "instanceDetails": {"productCodes": [], "availabilityZone": "us-east-1e", "tags": {"value": "demo-ag-windows (r)", "key": "Name"}, "instanceId": "i-024bXXXXXX", "instanceState": "running", "imageId": "ami-7e901", "platform": "windows", "launchTime": "2018-07-21T18:01:56Z", "instanceType": "t2.medium", "networkInterfaces": {"vpcId": "vpc-921fa", "publicDnsName": "ec2-34.compute-1.amazonaws.com", "networkInterfaceId": "eni-9XX06c6", "privateIpAddresses": [{"privateDnsName": "ip-10-0-0-XX.ec2.internal", "privateIpAddress": "10.0.0.XXX"}], "publicIp": "XX.X02.2XX.24", "privateDnsName": "ip-10-0-0-XXX.ec2.internal", "securityGroups": [{"groupName": "Windows", "groupId": "sg-c46XXXXa1"}], "ipv6Addresses": [], "subnetId": "subnet-6bXXXX3", "privateIpAddress": "10.0.0.XXX"}}}, "severity": 2, "service": {"count": 1881, "additionalInfo": {"threatName": "Scanner", "threatListName": "ProofPoint"}, "archived": false, "resourceRole": "TARGET", "eventFirstSeen": "2018-11-12T09:12:58Z", "detectorId": "cab38390b72XXXXdfce", "action": {"portProbeAction": {"portProbeDetails": {"remoteIpDetails": {"organization": {"org": "HiNet", "isp": "HiNet", "asn": "3462", "asnOrg": "Data Communication Business Group"}, "ipAddressV4": "220.133.14.47", "city": {"cityName": "Taipei"}, "geoLocation": {"lat": 25.0478, "lon": 121.5318}, "country": {"countryName": "Taiwan"}}, "localPortDetails": {"portName": "RDP", "port": 3389}}, "blocked": false}, "actionType": "PORT_PROBE"}, "serviceName": "guardduty", "eventLastSeen": "2018-11-24T09:47:06Z"}, "title": "Unprotected port on EC2 instance i-024XXXXXX1a is being probed.", "region": "us-east-1", "partition": "aws", "source": "guardduty", "createdAt": "2018-11-12T09:16:57.631Z", "log_info": {"s3bucket": "wazuh-aws-wodle", "aws_account_alias": "", "log_file": "guardduty/2018/11/24/10/firehose_guardduty-1-2018-11-24-10-01-05-eed81f82-c7e2-47e1-b483-2c9030f91bae.zip"}, "type": "Recon:EC2/PortProbeUnprotectedPort"}, "integration": "aws"}'
       timestamp: '(null)'
       hostname: 'splunk'
       program_name: '(null)'
       log: '{"aws": {"description": "EC2 instance has an unprotected port which is being probed by a known malicious host.", "updatedAt": "2018-11-24T09:53:00.202Z", "schemaVersion": "2.0", "id": "22b3XXXXXX", "arn": "arn:aws:guardduty:us-east-1:1XXXXXXX:detector/caXXXXXXXXXebffb79d/finding/22b3XXXXXXXX", "accountId": "16XXXXXX", "resource": {"resourceType": "Instance", "instanceDetails": {"productCodes": [], "availabilityZone": "us-east-1e", "tags": {"value": "demo-ag-windows (r)", "key": "Name"}, "instanceId": "i-024bXXXXXX", "instanceState": "running", "imageId": "ami-7e901", "platform": "windows", "launchTime": "2018-07-21T18:01:56Z", "instanceType": "t2.medium", "networkInterfaces": {"vpcId": "vpc-921fa", "publicDnsName": "ec2-34.compute-1.amazonaws.com", "networkInterfaceId": "eni-9XX06c6", "privateIpAddresses": [{"privateDnsName": "ip-10-0-0-XX.ec2.internal", "privateIpAddress": "10.0.0.XXX"}], "publicIp": "XX.X02.2XX.24", "privateDnsName": "ip-10-0-0-XXX.ec2.internal", "securityGroups": [{"groupName": "Windows", "groupId": "sg-c46XXXXa1"}], "ipv6Addresses": [], "subnetId": "subnet-6bXXXX3", "privateIpAddress": "10.0.0.XXX"}}}, "severity": 2, "service": {"count": 1881, "additionalInfo": {"threatName": "Scanner", "threatListName": "ProofPoint"}, "archived": false, "resourceRole": "TARGET", "eventFirstSeen": "2018-11-12T09:12:58Z", "detectorId": "cab38390b72XXXXdfce", "action": {"portProbeAction": {"portProbeDetails": {"remoteIpDetails": {"organization": {"org": "HiNet", "isp": "HiNet", "asn": "3462", "asnOrg": "Data Communication Business Group"}, "ipAddressV4": "220.133.14.47", "city": {"cityName": "Taipei"}, "geoLocation": {"lat": 25.0478, "lon": 121.5318}, "country": {"countryName": "Taiwan"}}, "localPortDetails": {"portName": "RDP", "port": 3389}}, "blocked": false}, "actionType": "PORT_PROBE"}, "serviceName": "guardduty", "eventLastSeen": "2018-11-24T09:47:06Z"}, "title": "Unprotected port on EC2 instance i-024XXXXXX1a is being probed.", "region": "us-east-1", "partition": "aws", "source": "guardduty", "createdAt": "2018-11-12T09:16:57.631Z", "log_info": {"s3bucket": "wazuh-aws-wodle", "aws_account_alias": "", "log_file": "guardduty/2018/11/24/10/firehose_guardduty-1-2018-11-24-10-01-05-eed81f82-c7e2-47e1-b483-2c9030f91bae.zip"}, "type": "Recon:EC2/PortProbeUnprotectedPort"}, "integration": "aws"}'

**Phase 2: Completed decoding.
       decoder: 'json'
       aws.description: 'EC2 instance has an unprotected port which is being probed by a known malicious host.'
       aws.updatedAt: '2018-11-24T09:53:00.202Z'
       aws.schemaVersion: '2.0'
       aws.id: '22b3XXXXXX'
       aws.arn: 'arn:aws:guardduty:us-east-1:1XXXXXXX:detector/caXXXXXXXXXebffb79d/finding/22b3XXXXXXXX'
       aws.accountId: '16XXXXXX'
       aws.resource.resourceType: 'Instance'
       aws.resource.instanceDetails.availabilityZone: 'us-east-1e'
       aws.resource.instanceDetails.tags.value: 'demo-ag-windows (r)'
       aws.resource.instanceDetails.tags.key: 'Name'
       aws.resource.instanceDetails.instanceId: 'i-024bXXXXXX'
       aws.resource.instanceDetails.instanceState: 'running'
       aws.resource.instanceDetails.imageId: 'ami-7e901'
       aws.resource.instanceDetails.platform: 'windows'
       aws.resource.instanceDetails.launchTime: '2018-07-21T18:01:56Z'
       aws.resource.instanceDetails.instanceType: 't2.medium'
       aws.resource.instanceDetails.networkInterfaces.vpcId: 'vpc-921fa'
       aws.resource.instanceDetails.networkInterfaces.publicDnsName: 'ec2-34.compute-1.amazonaws.com'
       aws.resource.instanceDetails.networkInterfaces.networkInterfaceId: 'eni-9XX06c6'
       aws.resource.instanceDetails.networkInterfaces.publicIp: 'XX.X02.2XX.24'
       aws.resource.instanceDetails.networkInterfaces.privateDnsName: 'ip-10-0-0-XXX.ec2.internal'
       aws.resource.instanceDetails.networkInterfaces.subnetId: 'subnet-6bXXXX3'
       aws.resource.instanceDetails.networkInterfaces.privateIpAddress: '10.0.0.XXX'
       aws.severity: '2'
       aws.service.count: '1881'
       aws.service.additionalInfo.threatName: 'Scanner'
       aws.service.additionalInfo.threatListName: 'ProofPoint'
       aws.service.archived: 'false'
       aws.service.resourceRole: 'TARGET'
       aws.service.eventFirstSeen: '2018-11-12T09:12:58Z'
       aws.service.detectorId: 'cab38390b72XXXXdfce'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.organization.org: 'HiNet'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.organization.isp: 'HiNet'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.organization.asn: '3462'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.organization.asnOrg: 'Data Communication Business Group'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4: '220.133.14.47'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.city.cityName: 'Taipei'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.geoLocation.lat: '25.047800'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.geoLocation.lon: '121.531800'
       aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.country.countryName: 'Taiwan'
       aws.service.action.portProbeAction.portProbeDetails.localPortDetails.portName: 'RDP'
       aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port: '3389'
       aws.service.action.portProbeAction.blocked: 'false'
       aws.service.action.actionType: 'PORT_PROBE'
       aws.service.serviceName: 'guardduty'
       aws.service.eventLastSeen: '2018-11-24T09:47:06Z'
       aws.title: 'Unprotected port on EC2 instance i-024XXXXXX1a is being probed.'
       aws.region: 'us-east-1'
       aws.partition: 'aws'
       aws.source: 'guardduty'
       aws.createdAt: '2018-11-12T09:16:57.631Z'
       aws.log_info.s3bucket: 'wazuh-aws-wodle'
       aws.log_info.aws_account_alias: ''
       aws.log_info.log_file: 'guardduty/2018/11/24/10/firehose_guardduty-1-2018-11-24-10-01-05-eed81f82-c7e2-47e1-b483-2c9030f91bae.zip'
       aws.type: 'Recon:EC2/PortProbeUnprotectedPort'
       integration: 'aws'

**Phase 3: Completed filtering (rules).
       Rule id: '80305'
       Level: '3'
       Description: 'Guard Duty Finding - PORT_PROBE: Unprotected port on EC2 instance i-024XXXXXX1a is being probed. [IP: 220.133.14.47]          [Port: 3389]'
**Alert to be generated.

```

Best regards,

Demetrio.