### PR TITLE
Fix defects reported by Coverity

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1247,6 +1247,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                     return OS_INVALID;
                 }
             }
+            OS_ClearNode(children);
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1425,7 +1425,7 @@ char* check_ascci_hex (char *input) {
     char outhex[OS_SIZE_256];
 
     for (j = 0; j < strlen(input); j++) {
-        snprintf(outhex + j*2, OS_SIZE_256, "%hhX", input[j]);
+        snprintf(outhex + j*2, OS_SIZE_256 - j * 2, "%hhX", input[j]);
         if ((unsigned int)input[j] > 126 ||
                 (unsigned int)input[j] == 32 ||
                 (unsigned int)input[j] == 34) {
@@ -1435,10 +1435,8 @@ char* check_ascci_hex (char *input) {
 
     char *output;
     if (hex) {
-        os_calloc(strlen(outhex) + 1, sizeof(char *), output);
         os_strdup(outhex, output);
     } else {
-        os_calloc(strlen(input) + 1, sizeof(char *), output);
         os_strdup(input, output);
     }
     return output;

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1008,7 +1008,7 @@ void *wait_for_msgs(__attribute__((unused)) void *none)
 
     /* Should never leave this loop */
     while (1) {
-        char * msg;
+        char * msg = NULL;
 
         /* Lock mutex */
         w_mutex_lock(&lastmsg_mutex);
@@ -1025,7 +1025,6 @@ void *wait_for_msgs(__attribute__((unused)) void *none)
         } else {
             merror("Couldn't get pending data from hash table for agent ID '%s'.", pending_queue[queue_j]);
             *agent_id = '\0';
-            *msg = '\0';
         }
 
         forward(queue_j);
@@ -1033,7 +1032,7 @@ void *wait_for_msgs(__attribute__((unused)) void *none)
         /* Unlock mutex */
         w_mutex_unlock(&lastmsg_mutex);
 
-        if (*agent_id) {
+        if (msg && *agent_id) {
             read_controlmsg(agent_id, msg);
         }
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1003,12 +1003,13 @@ static void read_controlmsg(const char *agent_id, char *msg)
  */
 void *wait_for_msgs(__attribute__((unused)) void *none)
 {
-    char * msg;
     char agent_id[9];
     pending_data_t *data;
 
     /* Should never leave this loop */
     while (1) {
+        char * msg;
+
         /* Lock mutex */
         w_mutex_lock(&lastmsg_mutex);
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -36,7 +36,7 @@ void HandleSecure()
     ssize_t recv_b;
     uint32_t length;
     struct sockaddr_in peer_info;
-    wnotify_t * notify;
+    wnotify_t * notify = NULL;
 
     /* Initialize manager */
     manager_init();

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -1387,6 +1387,7 @@ int query_wazuhdb(const char *wazuhdb_query, const char *source, char **output) 
 
             if (OS_SendSecureTCP(wdb_socket, size + 1, wazuhdb_query)) {
                 merror("%s: in send reattempt (%d) '%s'.", source, errno, strerror(errno));
+                close(wdb_socket);
                 return (-2);
             }
         } else {
@@ -1400,6 +1401,7 @@ int query_wazuhdb(const char *wazuhdb_query, const char *source, char **output) 
 
     if (select(wdb_socket + 1, &fdset, NULL, NULL, &timeout) < 0) {
         merror("%s: in select (%d) '%s'.", source, errno, strerror(errno));
+        close(wdb_socket);
         return (-2);
     }
 
@@ -1411,13 +1413,12 @@ int query_wazuhdb(const char *wazuhdb_query, const char *source, char **output) 
             retval = 0;
         } else {
             merror("%s: Bad response '%s'.", source, response);
-            return retval;
         }
     } else {
         merror("%s: no response from wazuh-db.", source);
-        return retval;
     }
 
+    close(wdb_socket);
     return retval;
 }
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -372,6 +372,7 @@ int sk_build_sum(const sk_sum_t * sum, char * output, size_t size) {
             sum->date_alert
     );
 
+    free(username);
     return r < (int)size ? 0 : -1;
 }
 

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -83,6 +83,8 @@ static void wm_sync_agents();
 // Clean dangling database files
 static void wm_clean_dangling_db();
 
+static void wm_sync_multi_groups(const char *dirname);
+
 #endif // LOCAL
 
 static int wm_sync_agentinfo(int id_agent, const char *path);
@@ -90,7 +92,6 @@ static int wm_sync_agent_group(int id_agent, const char *fname);
 static int wm_sync_shared_group(const char *fname);
 static void wm_scan_directory(const char *dirname);
 static int wm_sync_file(const char *dirname, const char *path);
-static void wm_sync_multi_groups(const char *dirname);
 // Fill syscheck database from an offset. Returns offset at last successful read event, or -1 on error.
 static long wm_fill_syscheck(sqlite3 *db, const char *path, long offset, int is_registry);
 // Fill complete rootcheck database.
@@ -466,6 +467,11 @@ void wm_clean_dangling_db() {
     closedir(dir);
 }
 
+void wm_sync_multi_groups(const char *dirname) {
+
+    wdb_update_groups(dirname);
+}
+
 #endif // LOCAL
 
 char * wm_get_os_arch(char * os_header) {
@@ -745,11 +751,6 @@ void wm_scan_directory(const char *dirname) {
             wm_sync_file(dirname, dirent->d_name);
 
     closedir(dir);
-}
-
-void wm_sync_multi_groups(const char *dirname) {
-
-    wdb_update_groups(dirname);
 }
 
 int wm_sync_file(const char *dirname, const char *fname) {


### PR DESCRIPTION
This PR aims to fix some defects that Coverity reported:

- Write to pointer after `free` (_manager.c_)
- Resource leak (_syscheck-config.c_)
- Resource leak (_syscheck-config.c_)
- Out-of-bounds access (_syscheck-config.c_)
- Resource leaks (_syscheck_op.c_)
- Resource leak (_read-agents.c_)
- Wrong `sizeof` argument (_syscheck-config.c_)