### PR TITLE
Silence warning error in Syscheck on repeated inodes

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -446,7 +446,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             hash_file_name = strdup(file_name);
             if (OSHash_Add_ex(syscheck.inode_hash, str_inode, hash_file_name) != 2) {
                 free(hash_file_name);
-                mwarn("Unable to add inode to db: %s (%s) ", file_name, str_inode);
+                mdebug1("Unable to add inode to db: %s (%s) ", file_name, str_inode);
             }
 #endif
             /* Send the new checksum to the analysis server */

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -446,7 +446,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             hash_file_name = strdup(file_name);
             if (OSHash_Add_ex(syscheck.inode_hash, str_inode, hash_file_name) != 2) {
                 free(hash_file_name);
-                mdebug1("Unable to add inode to db: %s (%s) ", file_name, str_inode);
+                mdebug2("Unable to add inode to db: %s (%s) ", file_name, str_inode);
             }
 #endif
             /* Send the new checksum to the analysis server */


### PR DESCRIPTION
Syscheck stores a hash table for file inodes in memory. Monitoring two hard links to the same file will produce a key colission:

```
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/echo (193)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/expr (195)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/fgrep (3240)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/grep (3240)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/kill (198)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/ln (199)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/rmdir (3252)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/sed (204)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/sort (205)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/ed (212)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/find (213)
2018/11/27 11:41:10 ossec-syscheckd: WARNING: Unable to add inode to db: /usr/bin/getopt (214)
```

This issue has no impact enough to be a warning. We suggest to switch this log and propose a table redesign in a future version.