### PR TITLE
Get OS name and version in HP-UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed the reading of the OS name and version in HP-UX systems. ([#1990](https://github.com/wazuh/wazuh/pull/1990))
 
 ## [v3.7.1]
 

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -586,6 +586,19 @@ os_info *get_unix_version()
                     pclose(cmd_output);
                   goto free_os_info;
                 }
+            } else if (strcmp(strtok(buff, "\n"),"HP-UX") == 0){ // HP-UX
+                info->os_name = strdup("HP-UX");
+                info->os_platform = strdup("hp-ux");
+                if (cmd_output_ver = popen("uname -r", "r"), cmd_output_ver) {
+                    if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
+                        mdebug1("Cannot read from command output (uname -r).");
+                    } else if (w_regexec("B\\.([0-9][0-9]*\\.[0-9]*)", buff, 2, match)){
+                        match_size = match[1].rm_eo - match[1].rm_so;
+                        info->os_version = malloc(match_size +1);
+                        snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
+                    }
+                    pclose(cmd_output_ver);
+                }
             } else if (strcmp(strtok(buff, "\n"),"OpenBSD") == 0 ||
                        strcmp(strtok(buff, "\n"),"NetBSD")  == 0 ||
                        strcmp(strtok(buff, "\n"),"FreeBSD") == 0 ){ // BSD

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -89,7 +89,7 @@ static void send_sk_db(int first_start)
     /* Send end scan control message */
     if(first_start) {
         send_syscheck_msg(HC_FIM_DB_EFS);
-#ifndef WIN32
+#ifdef ENABLE_AUDIT
         audit_set_db_consistency();
 #endif
     } else {


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/1987

```
2018/11/28 04:31:40 ossec-agentd: INFO: Version detected -> HP-UX |sovmh366 |B.11.31 |U |ia64 [HP-UX|hp-ux: 11.31] - Wazuh v3.7.0
```