### PR TITLE
Fixing inode hash table consitency when deleting in realtime

### DIFF
--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -150,11 +150,13 @@ void normalize_path(char *path);
 
 const char *get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid);
 const char *get_group(int gid);
+char *get_attr_from_checksum(char *checksum, int attr);
 
 #else
 
 char *get_user(const char *path, __attribute__((unused)) int uid, char **sid);
 const char *get_group(__attribute__((unused)) int gid);
+
 
 #endif
 

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -30,6 +30,11 @@
 
 #endif
 
+// Number of attributes in checksum
+#define FIM_NATTR 11
+// Number of options in checksum hash table
+#define FIM_NOPTS 10
+
 /* Fields for rules */
 typedef enum sk_syscheck {
     SK_FILE,
@@ -146,11 +151,13 @@ int fim_find_child_depth(const char *parent, const char *child);
 //Change in Windows paths all slashes for backslashes for compatibility agent<3.4 with manager>=3.4
 void normalize_path(char *path);
 
+//Return an attr from checksum
+char *get_attr_from_checksum(char *checksum, int attr);
+
 #ifndef WIN32
 
 const char *get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid);
 const char *get_group(int gid);
-char *get_attr_from_checksum(char *checksum, int attr);
 
 #else
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -517,6 +517,22 @@ const char *get_group(int gid) {
     return group ? group->gr_name : "";
 }
 
+
+char *get_attr_from_checksum(char *checksum, int attr){
+    char *inode;
+    char *aux;
+    int i;
+    inode = strchr(checksum, ':');
+    for(i = 0; i<attr; i++){
+        inode = strchr(inode, ':');
+        inode++;
+    }
+
+    aux = strchr(inode, ':');
+    *(aux++) = '\0';
+    return inode;
+}
+
 #else
 
 char *get_user(const char *path, __attribute__((unused)) int uid, char **sid)

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -505,6 +505,35 @@ void normalize_path(char * path) {
     }
 }
 
+char *get_attr_from_checksum(char *checksum, int attr) {
+    char *str_attr = NULL;
+    char *str_end = NULL;
+    int i;
+
+    if (attr < 1 || attr > FIM_NATTR) {
+        return NULL;
+    }
+
+    str_attr = checksum;
+
+    for(i = 2; i <= attr && str_attr; i++){
+        str_attr = strchr(str_attr, ':');
+        if(str_attr) {
+            str_attr++;
+        }
+    }
+
+    if (str_attr) {
+        if(str_end = strchr(str_attr, ':'), str_end) {
+            *(str_end++) = '\0';
+        }
+        return str_attr;
+    }
+
+    return NULL;
+}
+
+
 #ifndef WIN32
 
 const char *get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid) {
@@ -515,22 +544,6 @@ const char *get_user(__attribute__((unused)) const char *path, int uid, __attrib
 const char *get_group(int gid) {
     struct group *group = getgrgid(gid);
     return group ? group->gr_name : "";
-}
-
-
-char *get_attr_from_checksum(char *checksum, int attr){
-    char *inode;
-    char *aux;
-    int i;
-    inode = strchr(checksum, ':');
-    for(i = 0; i<attr; i++){
-        inode = strchr(inode, ':');
-        inode++;
-    }
-
-    aux = strchr(inode, ':');
-    *(aux++) = '\0';
-    return inode;
 }
 
 #else

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -364,11 +364,13 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             }
         }
         else {
-             if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, file_name), s_node) {
+            if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, file_name), s_node) {
                 char *inode_str;
                 char *checksum_inode;
+
                 os_strdup(s_node->checksum, checksum_inode);
                 inode_str = get_attr_from_checksum(checksum_inode, SK_INODE);
+                
                 if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str), w_inode) {
                     free(w_inode);
                 }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -356,16 +356,32 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
         snprintf(alert_msg, sizeof(alert_msg), "-1!%s:%s %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
         send_syscheck_msg(alert_msg);
 
+
+#ifndef WIN32
+        if(evt && evt->inode) {
+            if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), w_inode) {
+                free(w_inode);
+            }
+        }
+        else {
+             if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, file_name), s_node) {
+                char *inode_str;
+                char *checksum_inode;
+                os_strdup(s_node->checksum, checksum_inode);
+                inode_str = get_attr_from_checksum(checksum_inode, SK_INODE);
+                if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str), w_inode) {
+                    free(w_inode);
+                }
+                os_free(checksum_inode);
+            }
+        }
+#endif
         // Delete from hash table
         if (s_node = OSHash_Delete_ex(syscheck.fp, file_name), s_node) {
             free(s_node->checksum);
             free(s_node);
         }
-#ifndef WIN32
-        if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), w_inode) {
-            free(w_inode);
-        }
-#endif
+
         struct timeval timeout = {0, syscheck.rt_delay * 1000};
         select(0, NULL, NULL, NULL, &timeout);
 


### PR DESCRIPTION
This PR closes #1993 

In this PR we create a new function named `get_attr_from_checksum` that it's used to get an attribute from the checksum of a file.

We use this function to delete a file from the inode hash table when it has been deleted in realtime. We must do it this way because we don't have the `inode` attribute from the audit event.

Best regards,
Cerv1.