### PR TITLE
Fix for remove_from_bucket parameter

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -219,9 +219,9 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         free(cur_bucket->aws_account_id);
                         os_strdup(children[j]->content, cur_bucket->aws_account_id);
                     } else if (!strcmp(children[j]->element, XML_REMOVE_FORM_BUCKET)) {
-                        if (strcmp(children[j]->content, "yes")) {
+                        if (!strcmp(children[j]->content, "yes")) {
                             cur_bucket->remove_from_bucket = 1;
-                        } else if (strcmp(children[j]->content, "no")) {
+                        } else if (!strcmp(children[j]->content, "no")) {
                             cur_bucket->remove_from_bucket = 0;
                         } else {
                             merror("Invalid content for tag '%s' at module '%s'.", XML_REMOVE_FORM_BUCKET, WM_AWS_CONTEXT.name);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -215,7 +215,7 @@ void wm_aws_check() {
 
     // Check if buckets defines
 
-    if (!aws_config->buckets || !aws_config->services) {
+    if (!aws_config->buckets && !aws_config->services) {
         mtwarn(WM_AWS_LOGTAG, "No AWS buckets or services defined. Exiting...");
         pthread_exit(NULL);
     }


### PR DESCRIPTION
Hi team,

This PR is for issue #1618. We were sending `remove_from_bucket` improperly: when we put this parameter with `yes` value in `ossec.conf`, this parameter was not being send and vice versa. I fix this bug with this PR.

Best regards,

Demetrio.