### PR TITLE
Avoid network timeout error in the agent on unsupported platforms

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -114,7 +114,14 @@ int connect_server(int initial_id)
         } else {
             if (agt->server[rc].protocol == TCP_PROTO) {
                 if (OS_SetRecvTimeout(agt->sock, timeout, 0) < 0){
-                    merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
+                    switch (errno) {
+                    case ENOPROTOOPT:
+                        mdebug1("Cannot set network timeout: operation not supported by this OS.");
+                        break;
+                    default:
+                        merror("Cannot set network timeout: %s (%d)", strerror(errno), errno);
+                        return EXIT_FAILURE;
+                    }
                 }
             }
 


### PR DESCRIPTION
The agent sets a receiving timeout when operating in TCP mode. This prevents the agent from getting locked if the manager does not respond.

Some old operating systems like Solaris 10 don't support socket timeout. This produces the next error while trying to set up the receiving timeout on startup:

```
2018/11/28 04:57:45 ossec-agentd: ERROR: OS_SetRecvTimeout failed with error 'Option not supported by protocol'
```

This issue does not prevent the correct functioning of the agent. This PR will switch this error into a level-1 debug log.