### PR TITLE
Fix agent group updating in database module

### DIFF
--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -371,7 +371,9 @@ void wm_sync_agents() {
             continue;
         }
 
-        get_agent_group(entry->id, group, OS_SIZE_65536 + 1);
+        if (get_agent_group(entry->id, group, OS_SIZE_65536 + 1) < 0) {
+            *group = 0;
+        }
 
         if (!(wdb_insert_agent(id, entry->name, OS_CIDRtoStr(entry->ip, cidr, 20) ? entry->ip->ip : cidr, entry->key, *group ? group : NULL) || module->full_sync)) {
 


### PR DESCRIPTION
The database synchronizer module was producing an inconsistency in the agent group assignation.

The module parses the file _etc/client.keys_ and gets the group of each agent, but the agent group assignation file (at _queue/agent-group_) has not to always exist. In this case, the module incorrectly saved the group of the previous agent for the current agent.

This PR fixes this bug.