### PR TITLE
Fix regex in CentOS 5

### DIFF
--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -29,8 +29,8 @@ else
     # CentOS
     if [ -r "/etc/centos-release" ]; then
         DIST_NAME="centos"
-        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.([0-9]{1,2}).*/\1/p' /etc/centos-release`
+        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/centos-release`
+        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.*([0-9]{0,2}).*/\1/p' /etc/centos-release`
 
     # Fedora
     elif [ -r "/etc/fedora-release" ]; then
@@ -44,8 +44,8 @@ else
         else
             DIST_NAME="rhel"
         fi
-        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
-        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.([0-9]{1,2}).*/\1/p' /etc/redhat-release`
+        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/redhat-release`
+        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.*([0-9]{0,2}).*/\1/p' /etc/redhat-release`
 
     # Ubuntu
     elif [ -r "/etc/lsb-release" ]; then


### PR DESCRIPTION
This PR solves the problem with the regex in the file `/etc/redhat-release` en **CentOS 5.0**

```
$ cat /etc/redhat-release

CentOS release 5 (Final)
```