### PR TITLE
Fix bug when creating multigroups using Python 3

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1548,7 +1548,7 @@ class Agent:
         # Create group in /var/multigroups
         try:
             Agent().append_multigroups_metadata(group_id)
-            folder = hashlib.sha256(group_id).hexdigest()[:8]
+            folder = hashlib.sha256(group_id.encode()).hexdigest()[:8]
             multi_group_path = "{0}/{1}".format(common.multi_groups_path, folder)
             mkdir_with_mode(multi_group_path)
             chown(multi_group_path, common.ossec_uid, common.ossec_gid)


### PR DESCRIPTION
Hello team,

This PR fixes https://github.com/wazuh/wazuh-api/issues/246. Without this fix, creating multigroups using python 3 ends up in the following error:
```javascript
# curl -u foo:bar "localhost:55000/agents/001/group/mygroup?pretty" -XPUT
{
   "error": 1005,
   "message": "Error reading file: Unicode-objects must be encoded before hashing"
}
```
With this fix the error is fixed and works in both python 2 and 3:
```shellsession
# vim /var/ossec/api/configuration/config.js
# systemctl restart wazuh-api
# tail /var/ossec/logs/api.log
WazuhAPI 2018-12-01 00:30:57 : Selected Python binary at 'python'.
WazuhAPI 2018-12-01 00:30:57 : Listening on: http://:::55000
# curl -u foo:bar "localhost:55000/agents/001/group/mygroup?pretty" -XDELETE
{
   "error": 0,
   "data": "Group 'mygroup' unset for agent '001'."
}
# curl -u foo:bar "localhost:55000/agents/001/group/mygroup?pretty" -XPUT
{
   "error": 0,
   "data": "Group 'mygroup' added to agent '001'."
}
# vim /var/ossec/api/configuration/config.js
# systemctl restart wazuh-api
# tail -n2 /var/ossec/logs/api.log
WazuhAPI 2018-12-01 00:31:24 : Selected Python binary at 'python3'.
WazuhAPI 2018-12-01 00:31:24 : Listening on: http://:::55000
# curl -u foo:bar "localhost:55000/agents/001/group/mygroup?pretty" -XDELETE
{
   "error": 0,
   "data": "Group 'mygroup' unset for agent '001'."
}
# curl -u foo:bar "localhost:55000/agents/001/group/mygroup?pretty" -XPUT
{
   "error": 0,
   "data": "Group 'mygroup' added to agent '001'."
}
```

Best regards,
Marta