### PR TITLE
Fix race condition in distributed API calls

### DIFF
--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -17,6 +17,7 @@ from operator import itemgetter
 from multiprocessing.dummy import Pool as ThreadPool
 import logging
 import time
+import copy
 try:
     from Queue import Queue
 except ImportError:
@@ -165,13 +166,13 @@ def forward_request(input_json, master_name, pretty, debug):
         """
         if node_name == 'unknown' or node_name == '':
             # if the agent is never connected or pending (i.e. its node name is unknown or empty), do the request locally
-            response = json.loads(distribute_function(input_json))
+            response = json.loads(distribute_function(copy.deepcopy(input_json)))
         else:
             # if not, check if the node the request is being forwarded to is the master or a worker.
             command = 'dapi_forward {}'.format(node_name) if node_name != master_name else 'dapi'
             if command == 'dapi':
                 # if it's the master, execute the request directly
-                response = json.loads(distribute_function(input_json, debug=debug))
+                response = json.loads(distribute_function(copy.deepcopy(input_json), debug=debug))
             else:
                 # if it's a worker, forward it
                 response = i_s.execute('{} {}'.format(command, json.dumps(input_json)),


### PR DESCRIPTION
Hello team,

This PR fixes https://github.com/wazuh/wazuh-api/issues/247. Without this PR, the following error will be raised when using distributed API calls with never connected agents:
```javascript
# curl -u foo:bar "localhost:55000/experimental/syscollector/hardware?pretty"
{
   "error": 1000,
   "message": "'wait_for_complete'"
}
```

After installing the fix, the API call returns successfully:
```javascript
# curl -u foo:bar "localhost:55000/experimental/syscollector/hardware?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "cpu": {
               "cores": 2,
               "mhz": 1992.001,
               "name": "Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz"
            },
            "ram": {
               "usage": 96,
               "total": 499256,
               "free": 22580
            },
            "scan": {
               "id": 801518184,
               "time": "2018/12/01 00:50:09"
            },
            "agent_id": "000",
            "board_serial": "0"
         }
      ]
   }
}
```

Best regards,
Marta