### PR TITLE
Set close-on-exec flag to socket descriptor

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -163,6 +163,11 @@ int OS_BindUnixDomain(const char *path, int type, int max_msg_size)
         return (OS_SOCKTERR);
     }
 
+    // Set close-on-exec
+    if (fcntl(ossock, F_SETFD, FD_CLOEXEC) == -1) {
+        mwarn("Cannot set close-on-exec flag to socket: %s (%d)", strerror(errno), errno);
+    }
+
     return (ossock);
 }
 
@@ -196,6 +201,11 @@ int OS_ConnectUnixDomain(const char *path, int type, int max_msg_size)
     if (OS_SetSocketSize(ossock, SEND_SOCK, max_msg_size) < 0) {
         OS_CloseSocket(ossock);
         return (OS_SOCKTERR);
+    }
+
+    // Set close-on-exec
+    if (fcntl(ossock, F_SETFD, FD_CLOEXEC) == -1) {
+        mwarn("Cannot set close-on-exec flag to socket: %s (%d)", strerror(errno), errno);
     }
 
     return (ossock);


### PR DESCRIPTION
This PR aims to fix a file descriptor leak that may impact agents running on UNIX platforms.

When an agent is restarted via Active response, _ossec-execd_ calls the script `restart-ssec.sh`, that calls `ossec-control`. This tool kills the Wazuh daemons running and starts them again. So the new daemon processes are transitively children of the previous _ossec-execd_, then all they will inherit the file descriptors open by the daemon.

In this case, _ossec-execd_ has two sockets open:
- _queue/alerts/execd_, for Active response.
- _queue/ossec/com_, for modern commands (configuration request and WPK management).

## Screenshot

This is the output from `lsof` showing all descriptors open by _ossec-execd_ after restarting via Active response:

```
COMMAND     PID USER   FD   TYPE             DEVICE SIZE/OFF   NODE NAME
ossec-exe 11008 root  cwd    DIR                8,1     4096      2 /
ossec-exe 11008 root  rtd    DIR                8,1     4096      2 /
ossec-exe 11008 root  txt    REG                8,1  1100424 788422 /var/ossec/bin/ossec-execd
ossec-exe 11008 root  mem    REG                8,1    62184 920082 /usr/lib64/libnss_files-2.17.so
ossec-exe 11008 root  mem    REG                8,1  2173512 920064 /usr/lib64/libc-2.17.so
ossec-exe 11008 root  mem    REG                8,1   144792 920090 /usr/lib64/libpthread-2.17.so
ossec-exe 11008 root  mem    REG                8,1  5178720 788419 /var/ossec/lib/libwazuhext.so
ossec-exe 11008 root  mem    REG                8,1    19776 920070 /usr/lib64/libdl-2.17.so
ossec-exe 11008 root  mem    REG                8,1    44448 920094 /usr/lib64/librt-2.17.so
ossec-exe 11008 root  mem    REG                8,1   164240 920057 /usr/lib64/ld-2.17.so
ossec-exe 11008 root    0u   CHR                1,3      0t0   1028 /dev/null
ossec-exe 11008 root    1u   CHR                1,3      0t0   1028 /dev/null
ossec-exe 11008 root    2u   CHR                1,3      0t0   1028 /dev/null
ossec-exe 11008 root    3u  unix 0xffff9af306e91000      0t0 315019 /var/ossec/queue/alerts/execq
ossec-exe 11008 root    4u  unix 0xffff9af306e92800      0t0 315020 /var/ossec/queue/ossec/com
ossec-exe 11008 root    5u  unix 0xffff9af312f8ec00      0t0 316421 /var/ossec/queue/alerts/execq
ossec-exe 11008 root    6u  unix 0xffff9af312f8f400      0t0 316422 /var/ossec/queue/ossec/com
```

File descriptors `3` and `4` are inherited and leaked. Descriptors `5` and `6` are the currently valid socket descriptors.

## Impact

Two hazards appear if the agent is continuously restarted from the manager:

1. The file descriptor may reach the system limit, typically 1024. This would make daemons crash.
2. Even if more than 1024 descriptors are allowed, if any socket descriptor in Agentd (either remote communication socket (port 1514) or the local queue) reaches 1024, the `select` call may fail.

## Proposed solution

We suggest setting the _close-on-exec_ flag to the local sockets that Execd opens. This flag will prevent subprocesses from inheriting open socket descriptors.