### PR TITLE
Add a file reloading feature to Logcollector

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -86,7 +86,7 @@ logcollector.open_attempts=8
 # Logcollector - If it should accept remote commands from the manager
 logcollector.remote_commands=0
 
-# Logcollector - Number of readings before checking files
+# Logcollector - File checking interval (seconds) [0..1024]
 logcollector.vcheck_files=64
 
 # Logcollector - Maximum number of lines to read from the same file [1..1000000]
@@ -111,6 +111,16 @@ logcollector.sample_log_length=64
 # Maximum number of file descriptor that Logcollector can open [1024..1048576]
 # This value must be higher than logcollector.max_files
 logcollector.rlimit_nofile=1100
+
+# Force file handler reloading: close and reopen monitored files
+# 0: Disabled
+# 1: Enabled
+logcollector.force_reload=0
+
+# File reloading interval, in seconds, if force_reload=1 [1..86400]
+# This interval must be greater or equal than vcheck_files.
+logcollector.reload_interval=64
+
 
 # Remoted counter io flush.
 remoted.recv_counter_flush=128

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -121,6 +121,9 @@ logcollector.force_reload=0
 # This interval must be greater or equal than vcheck_files.
 logcollector.reload_interval=64
 
+# File reloading delay (between close and open), in milliseconds [0..30000]
+logcollector.reload_delay=1000
+
 
 # Remoted counter io flush.
 remoted.recv_counter_flush=128

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -75,6 +75,7 @@ typedef struct _logreader {
     void *(*read)(struct _logreader *lf, int *rc, int drop_it);
 
     FILE *fp;
+    fpos_t position; // Pointer offset when closed
 } logreader;
 
 typedef struct _logreader_glob {

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -44,6 +44,13 @@ int LogCollectorConfig(const char *cfgfile)
     maximum_files = getDefine_Int("logcollector", "max_files", 1, 100000);
     sock_fail_time = getDefine_Int("logcollector", "sock_fail_time", 1, 3600);
     sample_log_length = getDefine_Int("logcollector", "sample_log_length", 1, 4096);
+    force_reload = getDefine_Int("logcollector", "force_reload", 0, 1);
+    reload_interval = getDefine_Int("logcollector", "reload_interval", 1, 86400);
+
+    if (force_reload && reload_interval < vcheck_files) {
+        mwarn("Reload interval (%d) must be greater or equal than the checking interval (%d).", reload_interval, vcheck_files);
+    }
+
 #ifndef WIN32
     nofile = getDefine_Int("logcollector", "rlimit_nofile", 1024, 1048576);
 #endif
@@ -202,6 +209,8 @@ cJSON *getLogcollectorInternalOptions(void) {
     cJSON_AddNumberToObject(logcollector,"sample_log_length",sample_log_length);
     cJSON_AddNumberToObject(logcollector,"queue_size",OUTPUT_QUEUE_SIZE);
     cJSON_AddNumberToObject(logcollector,"input_threads",N_INPUT_THREADS);
+    cJSON_AddNumberToObject(logcollector,"force_reload",force_reload);
+    cJSON_AddNumberToObject(logcollector,"reload_interval",reload_interval);
 #ifndef WIN32
     cJSON_AddNumberToObject(logcollector,"rlimit_nofile",nofile);
 #endif

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -46,6 +46,7 @@ int LogCollectorConfig(const char *cfgfile)
     sample_log_length = getDefine_Int("logcollector", "sample_log_length", 1, 4096);
     force_reload = getDefine_Int("logcollector", "force_reload", 0, 1);
     reload_interval = getDefine_Int("logcollector", "reload_interval", 1, 86400);
+    reload_delay = getDefine_Int("logcollector", "reload_delay", 0, 30000);
 
     if (force_reload && reload_interval < vcheck_files) {
         mwarn("Reload interval (%d) must be greater or equal than the checking interval (%d).", reload_interval, vcheck_files);
@@ -211,6 +212,7 @@ cJSON *getLogcollectorInternalOptions(void) {
     cJSON_AddNumberToObject(logcollector,"input_threads",N_INPUT_THREADS);
     cJSON_AddNumberToObject(logcollector,"force_reload",force_reload);
     cJSON_AddNumberToObject(logcollector,"reload_interval",reload_interval);
+    cJSON_AddNumberToObject(logcollector,"reload_delay",reload_delay);
 #ifndef WIN32
     cJSON_AddNumberToObject(logcollector,"rlimit_nofile",nofile);
 #endif

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -35,6 +35,9 @@ int maximum_files;
 int sample_log_length;
 int current_files = 0;
 int total_files = 0;
+int force_reload;
+int reload_interval;
+
 static int _cday = 0;
 int N_INPUT_THREADS = N_MIN_INPUT_THREADS;
 int OUTPUT_QUEUE_SIZE = OUTPUT_MIN_QUEUE_SIZE;
@@ -75,6 +78,7 @@ void LogCollectorStart()
 {
     int i = 0, j = -1, tg;
     int f_check = 0;
+    int f_reload = 0;
     IT_control f_control = 0;
     char keepalive[1024];
     logreader *current;
@@ -237,14 +241,12 @@ void LogCollectorStart()
 
     /* Daemon loop */
     while (1) {
-
-        f_check++;
-
-        if(f_check > vcheck_files) {
+        if (f_check >= vcheck_files) {
             w_rwlock_wrlock(&files_update_rwlock);
-            f_check = 0;
             int i;
             int j = -1;
+            f_reload += f_check;
+
             /* Check if any file has been renamed/removed */
             for (i = 0, j = -1;; i++) {
                 if (f_control = update_current(&current, &i, &j), f_control) {
@@ -289,6 +291,32 @@ void LogCollectorStart()
 
                 /* Check for file change -- if the file is open already */
                 if (current->fp) {
+
+                    // Force reload, if enabled
+
+                    if (force_reload && f_reload >= reload_interval) {
+                        if (reload_file(current) == -1) {
+                            if (current->exists){
+                                minfo(FORGET_FILE, current->file);
+                                current->exists = 0;
+                            }
+
+                            current->ign++;
+                            mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
+
+                            // Only expanded files that have been deleted will be forgotten
+
+                            if (j >= 0) {
+                                if (Remove_Localfile(&(globs[j].gfiles), i, 1, 0)) {
+                                    merror(REM_ERROR, current->file);
+                                } else {
+                                    mdebug2(CURRENT_FILES, current_files, maximum_files);
+                                    i--;
+                                    continue;
+                                }
+                            }
+                        }
+                    }
 #ifndef WIN32
 
                     /* To help detect a file rollover, temporarily open the file a second time.
@@ -413,7 +441,7 @@ void LogCollectorStart()
                         CloseHandle(h1);
 #endif
                         current->fp = NULL;
-                        if (handle_file(i, j, 1, 1) ) {
+                        if (handle_file(i, j, 0, 1) ) {
                             current->ign++;
                             mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
                         }
@@ -490,10 +518,19 @@ void LogCollectorStart()
             }
 #endif
             w_rwlock_unlock(&files_update_rwlock);
+
+            if (f_reload >= reload_interval) {
+                f_reload = 0;
+            }
+
+            f_check = 0;
         }
+
         rand_keepalive_str(keepalive, KEEPALIVE_SIZE);
         SendMSG(logr_queue, keepalive, "ossec-keepalive", LOCALFILE_MQ);
         sleep(1);
+
+        f_check++;
     }
 }
 
@@ -638,6 +675,57 @@ int handle_file(int i, int j, int do_fseek, int do_log)
     /* Set ignore to zero */
     lf->ign = 0;
     return (0);
+}
+
+/* Reload file: close and reopen */
+int reload_file(logreader * lf) {
+    fpos_t position;
+
+    if (!(lf && lf->fp)) {
+        return 0;
+    }
+
+    fgetpos(lf->fp, &position);
+    fclose(lf->fp);
+    lf->fp = NULL;
+
+#ifndef WIN32
+    lf->fp = fopen(lf->file, "r");
+
+    if (!lf->fp) {
+        return -1;
+    }
+#else
+    int fd;
+
+    CloseHandle(lf->h);
+
+    lf->h = CreateFile(lf->file, GENERIC_READ,
+                            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                            NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (lf->h == INVALID_HANDLE_VALUE) {
+        DWORD error = GetLastError();
+        return (-1);
+    }
+
+    fd = _open_osfhandle((long)lf->h, 0);
+
+    if (fd == -1) {
+        CloseHandle(lf->h);
+        return (-1);
+    }
+
+    lf->fp = _fdopen(fd, "r");
+
+    if (!lf->fp) {
+        CloseHandle(lf->h);
+        return (-1);
+    }
+#endif
+
+    fsetpos(lf->fp, &position);
+    return 0;
 }
 
 #ifdef WIN32

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -38,6 +38,9 @@ void LogCollectorStart(void) __attribute__((noreturn));
 /* Handle files */
 int handle_file(int i, int j, int do_fseek, int do_log);
 
+/* Reload file: close and reopen */
+int reload_file(logreader * lf);
+
 /* Read syslog file */
 void *read_syslog(logreader *lf, int *rc, int drop_it);
 
@@ -105,6 +108,8 @@ extern logsocket default_agent;
 extern int maximum_files;
 extern int current_files;
 extern int total_files;
+extern int force_reload;
+extern int reload_interval;
 
 typedef enum {
     CONTINUE_IT,

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -38,8 +38,11 @@ void LogCollectorStart(void) __attribute__((noreturn));
 /* Handle files */
 int handle_file(int i, int j, int do_fseek, int do_log);
 
-/* Reload file: close and reopen */
+/* Reload file: open after close, and restore position */
 int reload_file(logreader * lf);
+
+/* Close file and save position */
+void close_file(logreader * lf);
 
 /* Read syslog file */
 void *read_syslog(logreader *lf, int *rc, int drop_it);
@@ -110,6 +113,7 @@ extern int current_files;
 extern int total_files;
 extern int force_reload;
 extern int reload_interval;
+extern int reload_delay;
 
 typedef enum {
     CONTINUE_IT,


### PR DESCRIPTION
This closes #2018.

This PR aims to introduce a file reloading feature during the file checking stage in Logcollector.

This option fixes two problems in agents monitoring files in shared folders on VMware:

1. In Linux agents, the vmhgfs file system cannot update the file inode while it is open. Logcollector would stop following a file if it is rotated.
2. In Windows agents, the shared folder system cannot even update the file contents while it's open by Logcollector. This would prevent the file from being monitored.