### PR TITLE
Fix warning when building Unix version

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -78,9 +78,6 @@ void LogCollectorStart()
     IT_control f_control = 0;
     char keepalive[1024];
     logreader *current;
-    const char *m_uname;
-
-    m_uname = getuname();
 
     set_sockets();
     pthread_rwlock_init(&files_update_rwlock, NULL);
@@ -96,6 +93,9 @@ void LogCollectorStart()
 #else
     BY_HANDLE_FILE_INFORMATION lpFileInformation;
     int r;
+    const char *m_uname;
+
+    m_uname = getuname();
 
     /* Check if we are on Windows Vista */
     if (!checkVista()) {


### PR DESCRIPTION
This PR solves a warning compilation in branch 3.8:

```
logcollector/logcollector.c: In function ‘LogCollectorStart’:
logcollector/logcollector.c:81:17: warning: variable ‘m_uname’ set but not used [-Wunused-but-set-variable]
     const char *m_uname;
                 ^~~~~~~
```