### PR TITLE
Prevent Logcollector from forcing reloading after the configured attempts

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -290,13 +290,10 @@ void LogCollectorStart()
                         }
                     }
 
-                    if (current->file) {
+                    if (current->file && current->exists) {
                         if (reload_file(current) == -1) {
-                            if (current->exists){
-                                minfo(FORGET_FILE, current->file);
-                                current->exists = 0;
-                            }
-
+                            minfo(FORGET_FILE, current->file);
+                            current->exists = 0;
                             current->ign++;
                             mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
 


### PR DESCRIPTION
The option `force_reload` tried to open the files no matter that they had exceeded the limit of attempts.

This behavior causes Logcollector to log this message:
```
2018/12/03 11:05:50 ossec-logcollector[11234] logcollector.c:301 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/var/ossec/logs/active-responses.log'. Remaining attempts: -992
```

> _default_attempts - NO_RETRY = 7 - 999 = -992_

This change makes Logcollector try to re-open the monitored files if they were properly opened.