### PR TITLE
Fix attempt to set the file limit to 0 in Logcollector

### DIFF
--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -26,7 +26,6 @@
 static void help_logcollector(void) __attribute__((noreturn));
 
 int lc_debug_level;
-rlim_t nofile;
 
 /* Print help statement */
 static void help_logcollector()

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -11,6 +11,7 @@
  * Monitor some files and forward the output to our analysis system
  */
 
+#include "shared.h"
 #include <sys/types.h>
 #include <sys/time.h>
 #include <stdio.h>


### PR DESCRIPTION
This global variable:

```c
rlim_t nofile
```

Was defined twice in the Logcollector's code. This issue leads to undefined behavior.

We detected an issue in HP-UX:
```
2018/12/03 11:29:31 ossec-logcollector: ERROR: Could not set resource limit for file descriptors to 0: Invalid argument (22)
```

That value is set in the internal option `logcollector.rlimit_nofile`. This parameter must be a number between 1024 and 1048576, it cannot be `0`. Then, the compiler may spill two different variables in the program, that's why Logcollector tries to set the file limit to 0.

On the other hand, `nofile` is being interpreted in a different way in `config.c` and `main.c`. The latter should include `shared.h` in order to apply some compiling definitions.