### PR TITLE
Detect more big-endian platforms natively

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -666,7 +666,7 @@ ssize_t OS_RecvSecureTCP_Dynamic(int sock, char **ret) {
 // Byte ordering
 
 uint32_t wnet_order(uint32_t value) {
-#if (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || defined(OS_BIG_ENDIAN)
+#if defined(__sparc__) || defined(__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || defined(OS_BIG_ENDIAN)
     return (value >> 24) | (value << 24) | ((value & 0xFF0000) >> 8) | ((value & 0xFF00) << 8);
 #else
     return value;
@@ -675,7 +675,11 @@ uint32_t wnet_order(uint32_t value) {
 
 
 uint32_t wnet_order_big(uint32_t value) {
+#if defined(__sparc__) || defined(__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || defined(OS_BIG_ENDIAN)
+    return value;
+#else
     return (value >> 24) | (value << 24) | ((value & 0xFF0000) >> 8) | ((value & 0xFF00) << 8);
+#endif
 }
 
 /* Set the maximum buffer size for the socket */


### PR DESCRIPTION
This PR allows compiling Wazuh on the platforms below with needing to explicitly declare `OS_BIG_ENDIAN` in the `make` call.

- Solaris 10 on SPARC: `__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__`
- Solaris 11 on SPARC: `defined(__sparc__)`
- HP-UX: `defined(__BIG_ENDIAN__)`

On the other hand, this change also limits the byte swapping to little-endian platforms when communicating with the cluster.