### PR TITLE
Fix for AWS > 1000 logs limit

### DIFF
--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -437,7 +437,7 @@ class AWSBucket(WazuhIntegration):
     def get_full_prefix(self, account_id, account_region):
         raise NotImplementedError
 
-    def build_s3_filter_args(self, aws_account_id, aws_region):
+    def build_s3_filter_args(self, aws_account_id, aws_region, next_token=None):
         filter_marker = ''
         if self.reparse:
             if self.only_logs_after:
@@ -458,9 +458,11 @@ class AWSBucket(WazuhIntegration):
                     filter_marker = self.marker_only_logs_after(aws_region, aws_account_id)
         filter_args = {
             'Bucket': self.bucket,
-            'MaxKeys': 1000,
+            'MaxKeys': 50,
             'Prefix': self.get_full_prefix(aws_account_id, aws_region)
         }
+        if next_token:
+            filter_args['ContinuationToken'] = next_token
         if filter_marker:
             filter_args['StartAfter'] = filter_marker
             debug('+++ Marker: {0}'.format(filter_marker), 2)
@@ -561,6 +563,36 @@ class AWSBucket(WazuhIntegration):
                 # Send the message
                 self.send_msg(event_msg)
 
+    def process_files_in_bucket(self, aws_account_id, aws_region, next_token=None):
+        bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region, next_token))
+        if 'Contents' not in bucket_files:
+            debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
+            return
+
+        for bucket_file in bucket_files['Contents']:
+            if not bucket_file['Key']:
+                continue
+
+            if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
+                if self.reparse:
+                    debug("++ File previously processed, but reparse flag set: {file}".format(
+                        file=bucket_file['Key']), 1)
+                else:
+                    debug("++ Skipping previously processed file: {file}".format(file=bucket_file['Key']), 1)
+                    continue
+            debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
+            # Get the log file from S3 and decompress it
+            log_json = self.get_log_file(aws_account_id, bucket_file['Key'])
+            self.iter_events(log_json, bucket_file['Key'], aws_account_id)
+            # Remove file from S3 Bucket
+            if self.delete_file:
+                debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
+                self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
+            self.mark_complete(aws_account_id, aws_region, bucket_file)
+        # return next continuation token if is truncated
+        if bucket_files['IsTruncated']:
+            return bucket_files['NextContinuationToken']
+
     def iter_files_in_bucket(self, aws_account_id, aws_region):
         try:
             bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region))
@@ -590,9 +622,11 @@ class AWSBucket(WazuhIntegration):
                 self.mark_complete(aws_account_id, aws_region, bucket_file)
             # iterate if there are more logs
             while bucket_files['IsTruncated']:
-                new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region)
-                new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
-                bucket_files = self.client.list_objects_v2(**new_s3_args)
+                #new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region)
+                #new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
+                #bucket_files = self.client.list_objects_v2(**new_s3_args)
+                bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, \
+                    aws_region, bucket_files['NextContinuationToken']))
                 if 'Contents' not in bucket_files:
                     debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
                     return
@@ -602,6 +636,7 @@ class AWSBucket(WazuhIntegration):
                         continue
 
                     if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
+                        print("ya procesado")
                         if self.reparse:
                             debug("++ File previously processed, but reparse flag set: {file}".format(
                                 file=bucket_file['Key']), 1)

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -414,10 +414,10 @@ class AWSBucket(WazuhIntegration):
                     error_msg=e))
             sys.exit(10)
 
-    def marker_only_logs_after(self, aws_region, aws_account_id, only_logs_after):
+    def marker_only_logs_after(self, aws_region, aws_account_id):
         return '{init}{only_logs_after}'.format(
             init=self.get_full_prefix(aws_account_id, aws_region),
-            only_logs_after=only_logs_after.strftime('%Y/%m/%d')
+            only_logs_after=self.only_logs_after.strftime('%Y/%m/%d')
         )
 
     def get_alert_msg(self, aws_account_id, log_key, event, error_msg=""):
@@ -453,7 +453,7 @@ class AWSBucket(WazuhIntegration):
         filter_marker = ''
         if self.reparse:
             if self.only_logs_after:
-                filter_marker = self.marker_only_logs_after(aws_region, aws_account_id, self.only_logs_after)
+                filter_marker = self.marker_only_logs_after(aws_region, aws_account_id)
         else:
             query_last_key = self.db_connector.execute(AWSBucket.sql_find_last_key_processed.format(aws_account_id=aws_account_id,
                                                                                          aws_region=aws_region))
@@ -461,7 +461,7 @@ class AWSBucket(WazuhIntegration):
                 last_key = query_last_key.fetchone()[0]
             except TypeError as e:
                 # if DB is empty for a region
-                last_key = self.marker_only_logs_after(aws_region, aws_account_id, self.only_logs_after)
+                last_key = self.marker_only_logs_after(aws_region, aws_account_id)
 
         filter_args = {
             'Bucket': self.bucket,

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -588,6 +588,35 @@ class AWSBucket(WazuhIntegration):
                     debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                     self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                 self.mark_complete(aws_account_id, aws_region, bucket_file)
+            # iterate if there are more logs
+            while bucket_files['IsTruncated']:
+                new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region)
+                new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
+                bucket_files = self.client.list_objects_v2(**new_s3_args)
+                if 'Contents' not in bucket_files:
+                    debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
+                    return
+
+                for bucket_file in bucket_files['Contents']:
+                    if not bucket_file['Key']:
+                        continue
+
+                    if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
+                        if self.reparse:
+                            debug("++ File previously processed, but reparse flag set: {file}".format(
+                                file=bucket_file['Key']), 1)
+                        else:
+                            debug("++ Skipping previously processed file: {file}".format(file=bucket_file['Key']), 1)
+                            continue
+                    debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
+                    # Get the log file from S3 and decompress it
+                    log_json = self.get_log_file(aws_account_id, bucket_file['Key'])
+                    self.iter_events(log_json, bucket_file['Key'], aws_account_id)
+                    # Remove file from S3 Bucket
+                    if self.delete_file:
+                        debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
+                        self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
+                    self.mark_complete(aws_account_id, aws_region, bucket_file)
         except SystemExit:
             raise
         except Exception as err:

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -587,7 +587,7 @@ class AWSBucket(WazuhIntegration):
             for bucket_file in bucket_files['Contents']:
                 if not bucket_file['Key']:
                     continue
-                
+
                 if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
                     if self.reparse:
                         debug("++ File previously processed, but reparse flag set: {file}".format(

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -283,7 +283,7 @@ class AWSBucket(WazuhIntegration):
                                         aws_account_id='{aws_account_id}' AND
                                         aws_region = '{aws_region}'
                                     ORDER BY
-                                        created_date ASC
+                                        log_key ASC
                                     LIMIT 1;"""
 
     sql_db_maintenance = """DELETE
@@ -578,8 +578,7 @@ class AWSBucket(WazuhIntegration):
     def iter_files_in_bucket(self, aws_account_id, aws_region):
         try:
             bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region))
-            if 'NextContinuationToken' in bucket_files:
-                print("PRIMERA ITERACION continuation token -> " + bucket_files['NextContinuationToken'])
+
             if 'Contents' not in bucket_files:
                 debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
                 return

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -406,7 +406,7 @@ class AWSBucket(WazuhIntegration):
     def marker_only_logs_after(self, aws_region, aws_account_id, only_logs_after):
         return '{init}{only_logs_after}'.format(
             init=self.get_full_prefix(aws_account_id, aws_region),
-            only_logs_after=only_logs_after
+            only_logs_after=only_logs_after.strftime('%Y/%m/%d')
         )
 
     def get_alert_msg(self, aws_account_id, log_key, event, error_msg=""):

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -462,7 +462,8 @@ class AWSBucket(WazuhIntegration):
             'Prefix': self.get_full_prefix(aws_account_id, aws_region)
         }
         if next_token:
-            filter_args['ContinuationToken'] = next_token
+            filter_args['StartAfter'] = next_token
+            return filter_args
         if filter_marker:
             filter_args['StartAfter'] = filter_marker
             debug('+++ Marker: {0}'.format(filter_marker), 2)


### PR DESCRIPTION
Hi team,

This PR is for issue #1367. We were losing logs  because we didn't use `nextContinuationToken` parameter when there were more than 1000 logs (this is the limit of the `list_objects_v2` for each call) and I fix it. I discovered that when we iterate in different buckets the time marker was used wrong and I fixed it too.

I was inspired by PR #1602 (thank you @UranusBytes) to do this changes.

With this PR, we store 1000 entries for each prefix in the database for avoid to skip logs (see #1367 for more information about this).

Best regards,

Demetrio.