### PR TITLE
Create an empty client.keys file on a fresh Windows agent installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Create an empty `client.keys` file on a fresh installation of a Windows agent. ([2040](https://github.com/wazuh/wazuh/pull/2040))
 - Fixed the reading of the OS name and version in HP-UX systems. ([#1990](https://github.com/wazuh/wazuh/pull/1990))
 
 ## [v3.7.1]

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -34,6 +34,12 @@ time_reconnect  = Replace(args(5), Chr(34), "")
 ' Only try to set the configuration if variables are setted
 
 Set objFSO = CreateObject("Scripting.FileSystemObject")
+
+' Create an empty client.keys file on first install
+If Not objFSO.fileExists(home_dir & "client.keys") Then
+    objFSO.CreateTextFile(home_dir & "client.keys")
+End If
+
 If objFSO.fileExists(home_dir & "ossec.conf") Then
     ' Reading ossec.conf file
     Const ForReading = 1


### PR DESCRIPTION
Hi Team,

This PR fixes the issue https://github.com/wazuh/wazuh/issues/1921.

To be consistent with the behaviour of the Linux installers, an empty `client.keys` file must be created on a fresh installation of a Windows agent.

It seems as though it is no possible to create a file directly with WiX (https://stackoverflow.com/questions/4392497/how-can-you-create-a-text-file-in-wix, the accepted answer is from 2010 though, and I didn't search further...). So the solution is to create this empty file through a script, such as the existing `InstallerScripts.vbs` script.

Some simple tests have been carried out on Win10 and Win2016 Server. It seems to work correctly:
- New install: the file is created, empty
- Upgrade to the same version: the existing file is not overwritten
- Upgrade from older version: the existing file is not overwritten

On a session opened by a non-admin user:
- `agent-auth` triggers the UAC asking for elevated privileges, both on Win10 and Win2016.
- `manage_agents` returns an error: `CRITICAL: (1226): Error reading XML file 'ossec.conf': (line 0).` ¿Probably because of the lack of authorization? Running `type ossec.conf` or `type client.keys` returns the message `access denied`.

On a session opened by an admin user, not user Administrator:
- `agent-auth` does not trigger the UAC on Win10, but does on Win2016, and the agent is registered.
- `manage_agents` works both on Win10 and Win2016 (although once it returned the same error: `CRITICAL: (1226): Error reading XML file 'ossec.conf': (line 0).`).


Regards.
