### PR TITLE
Fixing some issues in Logcollector

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -470,12 +470,9 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr) {
             if (i != size -1) {
                 memcpy(&(*logf)[i], &(*logf)[size - 1], sizeof(logreader));
             }
+
             (*logf)[size - 1].file = NULL;
-            (*logf)[size - 1].ffile = NULL;
-            (*logf)[size - 1].command = NULL;
-            (*logf)[size - 1].logformat = NULL;
             (*logf)[size - 1].fp = NULL;
-            (*logf)[size - 1].target = NULL;
 
             if (!size)
                 size = 1;

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -187,11 +187,11 @@
 #define REM_ERROR       "(1956): Error removing '%s' file."
 #define NEW_GLOB_FILE   "(1957): New file that matches the '%s' pattern: '%s'."
 #define DUP_FILE        "(1958): Log file '%s' is duplicated."
-#define FORGET_FILE     "(1959): File '%s' does not exist."
+#define FORGET_FILE     "(1959): File '%s' no longer exists."
 #define FILE_LIMIT      "(1960): File limit has been reached (%d). Please reduce the number of files or increase \"logcollector.max_files\"."
 #define CURRENT_FILES   "(1961): Files being monitored: %i/%i."
 #define OPEN_ATTEMPT    "(1962): Unable to open file '%s'. Remaining attempts: %d"
-
+#define OPEN_UNABLE     "(1963): Unable to open file '%s'."
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -341,6 +341,7 @@ void LogCollectorStart()
 #endif
                         }
                         current->fp = NULL;
+                        current->exists = 1;
 
                         handle_file(i, j, 0, 1);
                         continue;
@@ -707,6 +708,7 @@ int handle_file(int i, int j, int do_fseek, int do_log)
 
     /* Set ignore to zero */
     lf->ign = 0;
+    lf->exists = 1;
     return (0);
 
 error:
@@ -948,6 +950,7 @@ int check_pattern_expand(int do_seek) {
                     os_strdup(g.gl_pathv[glob_offset], globs[j].gfiles[i].file);
                     globs[j].gfiles[i].mutex = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
                     globs[j].gfiles[i].fp = NULL;
+                    globs[j].gfiles[i].exists = 1;
                     globs[j].gfiles[i + 1].file = NULL;
                     globs[j].gfiles[i + 1].target = NULL;
                     current_files++;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -295,7 +295,6 @@ void LogCollectorStart()
                             minfo(FORGET_FILE, current->file);
                             current->exists = 0;
                             current->ign++;
-                            mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
 
                             // Only expanded files that have been deleted will be forgotten
 
@@ -307,6 +306,8 @@ void LogCollectorStart()
                                     i--;
                                     continue;
                                 }
+                            } else {
+                                mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
                             }
                         }
                     }
@@ -372,7 +373,7 @@ void LogCollectorStart()
                                 current->exists = 0;
                             }
                             current->ign++;
-                            mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
+
                             // Only expanded files that have been deleted will be forgotten
                             if (j >= 0) {
                                 if (Remove_Localfile(&(globs[j].gfiles), i, 1, 0)) {
@@ -382,6 +383,8 @@ void LogCollectorStart()
                                     i--;
                                     continue;
                                 }
+                            } else {
+                                mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
                             }
                         } else {
                             merror(FOPEN_ERROR, current->file, errno, strerror(errno));

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1194,13 +1194,13 @@ int w_msg_queue_push(w_msg_queue_t * msg, const char * buffer, char *file, unsig
     if (result < 0) {
         free(message->buffer);
         free(message);
-        mdebug2("Discarding log line from logcollector");
+        mdebug2("Discarding log line for target '%s'", log_target->log_socket->name);
 
         if (!reported) {
 #ifndef WIN32
-            mwarn("Message message queue is full (%zu). Log lines may be lost.", msg->msg_queue->size);
+            mwarn("Target '%s' message queue is full (%zu). Log lines may be lost.", log_target->log_socket->name, msg->msg_queue->size);
 #else
-            mwarn("Message message queue is full (%u). Log lines may be lost.", msg->msg_queue->size);
+            mwarn("Target '%s' message queue is full (%u). Log lines may be lost.", log_target->log_socket->name, msg->msg_queue->size);
 #endif
             reported = 1;
         }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -736,7 +736,6 @@ int reload_file(logreader * lf) {
                             NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
     if (lf->h == INVALID_HANDLE_VALUE) {
-        DWORD error = GetLastError();
         return (-1);
     }
 

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -67,7 +67,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
             if (strlen(buffer) == OS_MAXSTR - 1) {
                 // Message too large, discard line
                 while (fgets(buffer, OS_MAXSTR, lf->fp) && !strchr(buffer, '\n'));
-            } else {
+            } else if (feof(lf->fp)) {
                 mdebug1("Message not complete. Trying again: '%s'", buffer);
 
                 if (fseek(lf->fp, offset, SEEK_SET) < 0) {

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -58,9 +58,15 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
         rbytes = ftell(lf->fp) - offset;
         lines++;
 
-        if (buffer[rbytes - 1] == '\n')
+        if (buffer[rbytes - 1] == '\n') {
             buffer[rbytes - 1] = '\0';
-        else {
+
+            if ((long)strlen(buffer) != rbytes - 1)
+            {
+                mdebug2("Line in '%s' contains some zero-bytes (valid=%ld / total=%ld). Dropping line.", lf->file, (long)strlen(buffer), rbytes - 1);
+                continue;
+            }
+        } else {
             if (rbytes == OS_MAXSTR - 1) {
                 // Message too large, discard line
                 for (offset += rbytes; fgets(buffer, OS_MAXSTR, lf->fp); offset += rbytes) {

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -44,7 +44,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
         else if (strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)) {
             /* Message size > maximum allowed */
             __ms = 1;
-        } else {
+        } else if (feof(lf->fp)) {
             /* Message not complete. Return. */
             mdebug1("Message not complete from '%s'. Trying again: '%.*s'%s", lf->file, sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
             fsetpos(lf->fp, &fp_pos);

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -98,10 +98,6 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
         if (__ms) {
             // strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)
             // truncate str before logging to ossec.log
-#define OUTSIZE 4096
-            char buf[OUTSIZE + 1];
-            buf[OUTSIZE] = '\0';
-            snprintf(buf, OUTSIZE, "%s", str);
 
             if (!__ms_reported) {
                 merror("Large message size from file '%s' (length = %ld): '%.*s'...", lf->file, rbytes, sample_log_length, str);

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -39,6 +39,12 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
             str[rbytes - 1] = '\0';
+
+            if ((long)strlen(str) != rbytes - 1)
+            {
+                mdebug2("Line in '%s' contains some zero-bytes (valid=%ld / total=%ld). Dropping line.", lf->file, (long)strlen(str), rbytes - 1);
+                continue;
+            }
         }
 
         /* If we didn't get the new line, because the

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -17,11 +17,12 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     int __ms_reported = 0;
     int linesgot = 0;
     size_t buffer_size = 0;
-    char *p;
     char str[OS_MAXSTR + 1];
     char buffer[OS_MAXSTR + 1];
     fpos_t fp_pos;
     int lines = 0;
+    long offset;
+    long rbytes;
 
     buffer[0] = '\0';
     buffer[OS_MAXSTR] = '\0';
@@ -31,30 +32,32 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     /* Get initial file location */
     fgetpos(lf->fp, &fp_pos);
 
-    while (fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
-
+    for (offset = ftell(lf->fp); fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
+        rbytes = ftell(lf->fp) - offset;
         lines++;
         linesgot++;
 
         /* Get the last occurrence of \n */
-        if ((p = strrchr(str, '\n')) != NULL) {
-            *p = '\0';
+        if (str[rbytes - 1] == '\n') {
+            str[rbytes - 1] = '\0';
         }
 
         /* If we didn't get the new line, because the
          * size is large, send what we got so far.
          */
-        else if (strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)) {
+        else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
             __ms = 1;
         } else if (feof(lf->fp)) {
             /* Message not complete. Return. */
-            mdebug1("Message not complete from '%s'. Trying again: '%.*s'%s", lf->file, sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
+            mdebug2("Message not complete from '%s'. Trying again: '%.*s'%s", lf->file, sample_log_length, str, rbytes > sample_log_length ? "..." : "");
             fsetpos(lf->fp, &fp_pos);
             break;
         }
 
 #ifdef WIN32
+        char * p;
+
         if ((p = strrchr(str, '\r')) != NULL) {
             *p = '\0';
         }
@@ -87,15 +90,17 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         /* Incorrect message size */
         if (__ms) {
             if (!__ms_reported) {
-                merror("Large message size from file '%s' (length = %zu): '%.*s'...", lf->file, strlen(str), sample_log_length, str);
+                merror("Large message size from file '%s' (length = %ld): '%.*s'...", lf->file, rbytes, sample_log_length, str);
                 __ms_reported = 1;
             } else {
-                mdebug2("Large message size from file '%s' (length = %zu): '%.*s'...", lf->file, strlen(str), sample_log_length, str);
+                mdebug2("Large message size from file '%s' (length = %ld): '%.*s'...", lf->file, rbytes, sample_log_length, str);
             }
 
-            while (fgets(str, OS_MAXSTR - 2, lf->fp) != NULL) {
+            for (offset += rbytes; fgets(str, OS_MAXSTR - 2, lf->fp) != NULL; offset += rbytes) {
+                rbytes = ftell(lf->fp) - offset;
+
                 /* Get the last occurrence of \n */
-                if ((p = strrchr(str, '\n')) != NULL) {
+                if (str[rbytes - 1] == '\n') {
                     break;
                 }
             }

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -47,7 +47,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         else if (strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)) {
             /* Message size > maximum allowed */
             __ms = 1;
-        } else {
+        } else if (feof(lf->fp)) {
             /* Message not complete. Return. */
             mdebug1("Message not complete from '%s'. Trying again: '%.*s'%s", lf->file, sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
             fsetpos(lf->fp, &fp_pos);

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -40,6 +40,12 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
             str[rbytes - 1] = '\0';
+
+            if ((long)strlen(str) != rbytes - 1)
+            {
+                mdebug2("Line in '%s' contains some zero-bytes (valid=%ld / total=%ld). Dropping line.", lf->file, (long)strlen(str), rbytes - 1);
+                continue;
+            }
         }
 
         /* If we didn't get the new line, because the

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -86,10 +86,6 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         if (__ms) {
             // strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)
             // truncate str before logging to ossec.log
-#define OUTSIZE 4096
-            char buf[OUTSIZE + 1];
-            buf[OUTSIZE] = '\0';
-            snprintf(buf, OUTSIZE, "%s", str);
 
             if (!__ms_reported) {
                 merror("Large message size from file '%s' (length = %ld): '%.*s'...", lf->file, rbytes, sample_log_length, str);

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -46,13 +46,11 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
             /* We may not have gotten a line feed
              * because we reached EOF.
              */
-	    off_t offset = (off_t)ftell(lf->fp);
-	    if (offset < lf->size)
-	    {
+             if (feof(lf->fp)) {
                 /* Message not complete. Return. */
                 mdebug1("Message not complete from '%s'. Trying again: '%.*s'%s", lf->file, sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
                 fsetpos(lf->fp, &fp_pos);
-		break;
+                break;
             }
         }
 

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -17,10 +17,11 @@
 void *read_syslog(logreader *lf, int *rc, int drop_it) {
     int __ms = 0;
     int __ms_reported = 0;
-    char *p;
     char str[OS_MAXSTR + 1];
     fpos_t fp_pos;
     int lines = 0;
+    long offset;
+    long rbytes;
 
     str[OS_MAXSTR] = '\0';
     *rc = 0;
@@ -28,18 +29,19 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     /* Get initial file location */
     fgetpos(lf->fp, &fp_pos);
 
-    while (fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
-
+    for (offset = ftell(lf->fp); fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
+        rbytes = ftell(lf->fp) - offset;
         lines++;
+
         /* Get the last occurrence of \n */
-        if ((p = strrchr(str, '\n')) != NULL) {
-            *p = '\0';
+        if (str[rbytes - 1] == '\n') {
+            str[rbytes - 1] = '\0';
         }
 
         /* If we didn't get the new line, because the
          * size is large, send what we got so far.
          */
-        else if (strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)) {
+        else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
             __ms = 1;
         } else {
@@ -48,19 +50,21 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
              */
              if (feof(lf->fp)) {
                 /* Message not complete. Return. */
-                mdebug1("Message not complete from '%s'. Trying again: '%.*s'%s", lf->file, sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
+                mdebug2("Message not complete from '%s'. Trying again: '%.*s'%s", lf->file, sample_log_length, str, rbytes > sample_log_length ? "..." : "");
                 fsetpos(lf->fp, &fp_pos);
                 break;
             }
         }
 
 #ifdef WIN32
+        char * p;
+
         if ((p = strrchr(str, '\r')) != NULL) {
             *p = '\0';
         }
 
         /* Look for empty string (only on Windows) */
-        if (strlen(str) <= 2) {
+        if (rbytes <= 2) {
             fgetpos(lf->fp, &fp_pos);
             continue;
         }
@@ -72,11 +76,11 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
-        mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, str, strlen(str) > (size_t)sample_log_length ? "..." : "");
+        mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, str, rbytes > sample_log_length ? "..." : "");
 
         /* Send message to queue */
         if (drop_it == 0) {
-            w_msg_hash_queues_push(str, lf->file, strlen(str) + 1, lf->log_target, LOCALFILE_MQ);
+            w_msg_hash_queues_push(str, lf->file, rbytes, lf->log_target, LOCALFILE_MQ);
         }
         /* Incorrect message size */
         if (__ms) {
@@ -88,15 +92,17 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
             snprintf(buf, OUTSIZE, "%s", str);
 
             if (!__ms_reported) {
-                merror("Large message size from file '%s' (length = %zu): '%.*s'...", lf->file, strlen(str), sample_log_length, str);
+                merror("Large message size from file '%s' (length = %ld): '%.*s'...", lf->file, rbytes, sample_log_length, str);
                 __ms_reported = 1;
             } else {
-                mdebug2("Large message size from file '%s' (length = %zu): '%.*s'...", lf->file, strlen(str), sample_log_length, str);
+                mdebug2("Large message size from file '%s' (length = %ld): '%.*s'...", lf->file, rbytes, sample_log_length, str);
             }
 
-            while (fgets(str, OS_MAXSTR - 2, lf->fp) != NULL) {
+            for (offset += rbytes; fgets(str, OS_MAXSTR - 2, lf->fp) != NULL; offset += rbytes) {
+                rbytes = ftell(lf->fp) - offset;
+
                 /* Get the last occurrence of \n */
-                if (strrchr(str, '\n') != NULL) {
+                if (str[rbytes - 1] == '\n') {
                     break;
                 }
             }

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -36,6 +36,12 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
             str[rbytes - 1] = '\0';
+
+            if ((long)strlen(str) != rbytes - 1)
+            {
+                mdebug2("Line in '%s' contains some zero-bytes (valid=%ld / total=%ld). Dropping line.", lf->file, (long)strlen(str), rbytes - 1);
+                continue;
+            }
         }
 
         /* If we didn't get the new line, because the


### PR DESCRIPTION
This PR aims to fix the following issues in Logcollector:

1. Let Logcollector handle binary data: 
  a) Logcollector could stop reading a local file with format `syslog`, `multiline`, `audit` or `json` if a binary `0` is inserted into the file. This is because that `0` prevented Logcollector from finding the log delimiter `\n`.
  b) We improved the socket output to be able to send a binary string. This string will be delimited by `\n` instead of `\0`.
2. Logcollector wouldn't report a file if it is opened after disappearing. This change prevents Logcollector from going forward to the file end after opening it, except if the daemon is booting.
3. If a file discovered with a wildcarded `<location>` stanza disappears, Logcollector forgets it immediately. If it comes back, Logcollector will re-open it. But, in the first case, the program incorrectly logged the remaining opening attempts. This change deletes that log.
4. We fixed a bug when querying if a file reached its end. This is important in order to let Logcollector go backward to the begin of a line that does not contain a line end (`\n`).