### PR TITLE
Fix wodle command error messages

### DIFF
--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -190,12 +190,13 @@ void * wm_command_main(wm_command_t * command) {
                     mtdebug2(WM_COMMAND_LOGTAG, "OUTPUT: %s", output);
                 }
             }
-
+        case 1:
+            mterror(WM_COMMAND_LOGTAG, "%s: Timeout overtaken. You can modify your command timeout at ossec.conf. Exiting...", command->tag);
             break;
 
         default:
-            mterror(WM_COMMAND_LOGTAG, "%s: Timeout overtaken. You can modify your command timeout at ossec.conf. Exiting...", command->tag);
-            pthread_exit(NULL);
+            mterror(WM_COMMAND_LOGTAG, "Command '%s' failed.", command->tag);
+            break;
         }
 
         if (!command->ignore_output) {

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -85,14 +85,16 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
         // Create stdout pipe and make it inheritable
 
         if (!CreatePipe(&tinfo.pipe, &sinfo.hStdOutput, NULL, 0)) {
-            merror("CreatePipe()");
+            int winerror = GetLastError();
+            merror("in wm_exec(): CreatePipe(%ld): %s", winerror, win_strerror(winerror));
             return -1;
         }
 
         sinfo.hStdError = sinfo.hStdOutput;
 
         if (!SetHandleInformation(sinfo.hStdOutput, HANDLE_FLAG_INHERIT, 1)) {
-            merror("SetHandleInformation()");
+            int winerror = GetLastError();
+            merror("in wm_exec(): SetHandleInformation(%ld): %s", winerror, win_strerror(winerror));
             return -1;
         }
     }
@@ -106,7 +108,8 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
                       IDLE_PRIORITY_CLASS;
 
     if (!CreateProcess(NULL, command, NULL, NULL, TRUE, dwCreationFlags, NULL, NULL, &sinfo, &pinfo)) {
-        merror("CreateProcess(): %ld", GetLastError());
+        int winerror = GetLastError();
+        merror("in wm_exec(): CreateProcess(%ld): %s", winerror, win_strerror(winerror));
         return -1;
     }
 
@@ -118,8 +121,9 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
         hThread = CreateThread(NULL, 0, Reader, &tinfo, 0, NULL);
 
         if (!hThread) {
-            merror("CreateThread(): %ld", GetLastError());
-            return -1;
+            int winerror = GetLastError();
+            merror("in wm_exec(): CreateThread(%ld): %s", winerror, win_strerror(winerror));
+            return -1
         }
     }
 
@@ -139,7 +143,8 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
         break;
 
     default:
-        merror("WaitForSingleObject()");
+        int winerror = GetLastError();
+        merror("in wm_exec(): WaitForSingleObject(%ld): %s", winerror, win_strerror(winerror));
         TerminateProcess(pinfo.hProcess, 1);
         retval = -1;
     }


### PR DESCRIPTION
## Related issue:
- Confusing error messages in _wodle command_ #1981 

## Description
When some error occurs in the function wm_exec always appeared the same error of _timeout overtaken_ which is confusing.