### PR TITLE
Remove file .template.db on upgrade / restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Allow strings up to 64KB long for log difference analysis. ([#2032](https://github.com/wazuh/wazuh/pull/2032))
 - Now agents keep their registration date when upgrading the manager. ([#2033](https://github.com/wazuh/wazuh/pull/2033))
 - Create an empty `client.keys` file on a fresh installation of a Windows agent. ([2040](https://github.com/wazuh/wazuh/pull/2040))
+- Remove file `queue/db/.template.db` on upgrade / restart. ([2073](https://github.com/wazuh/wazuh/pull/2073))
 
 
 ## [v3.7.1]

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -104,6 +104,13 @@ int main(int argc, char ** argv) {
         nowDaemon();
     }
 
+    // Reset template. Basically, remove queue/db/.template.db
+    // The prefix is needed here, because we are not yet chrooted
+    char path_template[OS_FLSIZE + 1];
+    snprintf(path_template, sizeof(path_template), "%s/%s/%s", DEFAULTDIR, WDB2_DIR, WDB_PROF_NAME);
+    unlink(path_template);
+    mdebug1("Template file removed: %s", path_template);
+
     // Set max open files limit
     struct rlimit rlimit = { nofile, nofile };
 
@@ -196,6 +203,12 @@ int main(int argc, char ** argv) {
     free(worker_pool);
     pthread_join(thread_gc, NULL);
     wdb_close_all();
+
+    // Reset template here too, remove queue/db/.template.db again
+    // Without the prefix, because chrooted at that point
+    snprintf(path_template, sizeof(path_template), "%s/%s", WDB2_DIR, WDB_PROF_NAME);
+    unlink(path_template);
+    mdebug1("Template file removed again: %s", path_template);
 
     return EXIT_SUCCESS;
 }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -117,6 +117,12 @@ void* wm_database_main(wm_database *data) {
 
     mtinfo(WM_DATABASE_LOGTAG, "Module started.");
 
+    // Reset template. Basically, remove queue/db/.template.db
+    char path_template[PATH_MAX + 1];
+    snprintf(path_template, sizeof(path_template), "%s/%s/%s", DEFAULTDIR, WDB_DIR, WDB_PROF_NAME);
+    unlink(path_template);
+    mdebug1("Template db file removed: %s", path_template);
+
     // Manager name synchronization
     if (data->sync_agents) {
         wm_sync_manager();


### PR DESCRIPTION
Hi, Team,

This PR fixes the issue https://github.com/wazuh/wazuh/issues/2050.

The file `queue/db/.template.db` must be removed when upgrading and also when restarting the manager. The remove action is performed when the `wazuh-db` process starts or stops, either using the normal procedure with `systemctl`, `service`, `ossec-control`, or using `pkill`, `kill` and the like.

Tested on Debian 9 and CentOS 7:
- install wazuh-manager 3.7 (from packages)
- 3.7: register and restart an agent -> file `queue/db/.template.db` created
- upgrade to 3.8 (from sources) -> file removed
- 3.8: register and restart the agent again -> file created
- 3.8: stop process `wazuh-db` (pkill) -> file removed
- 3.8: `touch .../.../queue/db/.template.db` (`wazuh-db` has been stopped earlier)
- 3.8: start `wazuh-db` launching `/var/ossec/bin/wazuh-db` directly -> file removed
- 3.8: register-restart agent -> file created
- 3.8: restart the manager with `systemctl restart wazuh-manager` -> file removed

Regards.
