### PR TITLE
Fix for getting all AWS VPC logs

### DIFF
--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -100,17 +100,39 @@ ID: 80200 - 80499
     <rule id="80301" level="3">
         <if_sid>80300</if_sid>
         <field name="aws.severity">0|1|2|3</field>
-        <description>Guard Duty Finding with a low level: $(aws.description)</description>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title)</description>
     </rule>
     <rule id="80302" level="6">
         <if_sid>80300</if_sid>
         <field name="aws.severity">4|5|6</field>
-        <description>Guard Duty Finding with a medium level: $(aws.description)</description>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title)</description>
     </rule>
     <rule id="80303" level="10">
         <if_sid>80300</if_sid>
         <field name="aws.severity">7|8|9</field>
-        <description>Guard Duty Finding with a high level: $(aws.description)</description>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title)</description>
+    </rule>
+
+    <!-- PORT_PROBE rules -->
+    <rule id="80305" level="3">
+        <if_sid>80301</if_sid>
+        <field name="aws.service.action.actionType">PORT_PROBE</field>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)]
+         [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
+    </rule>
+
+    <rule id="80306" level="6">
+        <if_sid>80302</if_sid>
+        <field name="aws.service.action.actionType">PORT_PROBE</field>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)]
+         [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
+    </rule>
+
+    <rule id="80307" level="10">
+        <if_sid>80303</if_sid>
+        <field name="aws.service.action.actionType">PORT_PROBE</field>
+        <description>Guard Duty Finding - $(aws.service.action.actionType): $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)]
+         [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
     </rule>
 
     <!-- Macie Alerts -->

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -437,7 +437,7 @@ class AWSBucket(WazuhIntegration):
     def get_full_prefix(self, account_id, account_region):
         raise NotImplementedError
 
-    def build_s3_filter_args(self, aws_account_id, aws_region):
+    def build_s3_filter_args(self, aws_account_id, aws_region, next_token=None):
         filter_marker = ''
         if self.reparse:
             if self.only_logs_after:
@@ -458,9 +458,11 @@ class AWSBucket(WazuhIntegration):
                     filter_marker = self.marker_only_logs_after(aws_region, aws_account_id)
         filter_args = {
             'Bucket': self.bucket,
-            'MaxKeys': 1000,
+            'MaxKeys': 50,
             'Prefix': self.get_full_prefix(aws_account_id, aws_region)
         }
+        if next_token:
+            filter_args['ContinuationToken'] = next_token
         if filter_marker:
             filter_args['StartAfter'] = filter_marker
             debug('+++ Marker: {0}'.format(filter_marker), 2)
@@ -561,6 +563,36 @@ class AWSBucket(WazuhIntegration):
                 # Send the message
                 self.send_msg(event_msg)
 
+    def process_files_in_bucket(self, aws_account_id, aws_region, next_token=None):
+        bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region, next_token))
+        if 'Contents' not in bucket_files:
+            debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
+            return
+
+        for bucket_file in bucket_files['Contents']:
+            if not bucket_file['Key']:
+                continue
+
+            if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
+                if self.reparse:
+                    debug("++ File previously processed, but reparse flag set: {file}".format(
+                        file=bucket_file['Key']), 1)
+                else:
+                    debug("++ Skipping previously processed file: {file}".format(file=bucket_file['Key']), 1)
+                    continue
+            debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
+            # Get the log file from S3 and decompress it
+            log_json = self.get_log_file(aws_account_id, bucket_file['Key'])
+            self.iter_events(log_json, bucket_file['Key'], aws_account_id)
+            # Remove file from S3 Bucket
+            if self.delete_file:
+                debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
+                self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
+            self.mark_complete(aws_account_id, aws_region, bucket_file)
+        # return next continuation token if is truncated
+        if bucket_files['IsTruncated']:
+            return bucket_files['NextContinuationToken']
+
     def iter_files_in_bucket(self, aws_account_id, aws_region):
         try:
             bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region))
@@ -590,9 +622,11 @@ class AWSBucket(WazuhIntegration):
                 self.mark_complete(aws_account_id, aws_region, bucket_file)
             # iterate if there are more logs
             while bucket_files['IsTruncated']:
-                new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region)
-                new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
-                bucket_files = self.client.list_objects_v2(**new_s3_args)
+                #new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region)
+                #new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
+                #bucket_files = self.client.list_objects_v2(**new_s3_args)
+                bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, \
+                    aws_region, bucket_files['NextContinuationToken']))
                 if 'Contents' not in bucket_files:
                     debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
                     return
@@ -602,6 +636,7 @@ class AWSBucket(WazuhIntegration):
                         continue
 
                     if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
+                        print("ya procesado")
                         if self.reparse:
                             debug("++ File previously processed, but reparse flag set: {file}".format(
                                 file=bucket_file['Key']), 1)

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -588,6 +588,35 @@ class AWSBucket(WazuhIntegration):
                     debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                     self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                 self.mark_complete(aws_account_id, aws_region, bucket_file)
+            # iterate if there are more logs
+            while bucket_files['IsTruncated']:
+                new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region)
+                new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
+                bucket_files = self.client.list_objects_v2(**new_s3_args)
+                if 'Contents' not in bucket_files:
+                    debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
+                    return
+
+                for bucket_file in bucket_files['Contents']:
+                    if not bucket_file['Key']:
+                        continue
+
+                    if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
+                        if self.reparse:
+                            debug("++ File previously processed, but reparse flag set: {file}".format(
+                                file=bucket_file['Key']), 1)
+                        else:
+                            debug("++ Skipping previously processed file: {file}".format(file=bucket_file['Key']), 1)
+                            continue
+                    debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
+                    # Get the log file from S3 and decompress it
+                    log_json = self.get_log_file(aws_account_id, bucket_file['Key'])
+                    self.iter_events(log_json, bucket_file['Key'], aws_account_id)
+                    # Remove file from S3 Bucket
+                    if self.delete_file:
+                        debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
+                        self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
+                    self.mark_complete(aws_account_id, aws_region, bucket_file)
         except SystemExit:
             raise
         except Exception as err:

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -587,7 +587,7 @@ class AWSBucket(WazuhIntegration):
             for bucket_file in bucket_files['Contents']:
                 if not bucket_file['Key']:
                     continue
-                
+
                 if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
                     if self.reparse:
                         debug("++ File previously processed, but reparse flag set: {file}".format(

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -283,7 +283,7 @@ class AWSBucket(WazuhIntegration):
                                         aws_account_id='{aws_account_id}' AND
                                         aws_region = '{aws_region}'
                                     ORDER BY
-                                        created_date ASC
+                                        log_key ASC
                                     LIMIT 1;"""
 
     sql_db_maintenance = """DELETE
@@ -578,8 +578,7 @@ class AWSBucket(WazuhIntegration):
     def iter_files_in_bucket(self, aws_account_id, aws_region):
         try:
             bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region))
-            if 'NextContinuationToken' in bucket_files:
-                print("PRIMERA ITERACION continuation token -> " + bucket_files['NextContinuationToken'])
+
             if 'Contents' not in bucket_files:
                 debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
                 return

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -739,9 +739,9 @@ class AWSCloudTrailBucket(AWSLogsBucket):
     Represents a bucket with AWS CloudTrail logs
     """
 
-    def __init__(self, *args):
+    def __init__(self, **kwargs):
         self.db_table_name = 'trail_progress'
-        AWSLogsBucket.__init__(self, *args)
+        AWSLogsBucket.__init__(self, **kwargs)
         self.service = 'CloudTrail'
         self.field_to_load = 'Records'
 
@@ -762,9 +762,9 @@ class AWSVPCFlowBucket(AWSLogsBucket):
     Represents a bucket with AWS CloudTrail logs
     """
 
-    def __init__(self, *args):
+    def __init__(self, **kwargs):
         self.db_table_name = 'vpc'
-        AWSLogsBucket.__init__(self, *args)
+        AWSLogsBucket.__init__(self, **kwargs)
         self.service = 'vpcflowlogs'
 
     def load_information_from_file(self, log_key):
@@ -781,17 +781,17 @@ class AWSConfigBucket(AWSLogsBucket):
     Represents a bucket with AWS Config logs
     """
 
-    def __init__(self, *args):
+    def __init__(self, **kwargs):
         self.db_table_name = 'config'
-        AWSLogsBucket.__init__(self, *args)
+        AWSLogsBucket.__init__(self, **kwargs)
         self.service = 'Config'
         self.field_to_load = 'configurationItems'
 
 
 class AWSCustomBucket(AWSBucket):
 
-    def __init__(self, *args):
-        AWSBucket.__init__(self, *args)
+    def __init__(self, **kwargs):
+        AWSBucket.__init__(self, **kwargs)
         self.retain_db_records = 1000  # in firehouse logs there are no regions/users, this number must be increased.
 
     def load_information_from_file(self, log_key):
@@ -846,8 +846,8 @@ class AWSCustomBucket(AWSBucket):
 
 class AWSGuardDutyBucket(AWSCustomBucket):
 
-    def __init__(self, *args):
-        AWSBucket.__init__(self, *args)
+    def __init__(self, **kwargs):
+        AWSBucket.__init__(self, **kwargs)
 
     def iter_events(self, event_list, log_key, aws_account_id):
         if event_list is not None:
@@ -1106,11 +1106,12 @@ def main(argv):
                 bucket_type = AWSGuardDutyBucket
             else:
                 raise Exception("Invalid type of bucket")
-            bucket = bucket_type(options.reparse, options.access_key, options.secret_key,
-                            options.aws_profile, options.iam_role_arn, options.logBucket,
-                            options.only_logs_after, options.skip_on_error,
-                            options.aws_account_alias, max_queue_buffer,
-                            options.trail_prefix, options.deleteFile)
+            bucket = bucket_type(reparse=options.reparse, access_key=options.access_key,
+                           secret_key=options.secret_key, profile=options.aws_profile,
+                           iam_role_arn=options.iam_role_arn, bucket=options.logBucket,
+                           only_logs_after=options.only_logs_after, skip_on_error=options.skip_on_error,
+                           account_alias=options.aws_account_alias, max_queue_buffer=max_queue_buffer,
+                           prefix=options.trail_prefix, delete_file=options.deleteFile)
             bucket.iter_bucket(options.aws_account_id, options.regions)
         elif options.service:
             if options.service.lower() == 'inspector':

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -922,7 +922,7 @@ class AWSVPCFlowBucket(AWSLogsBucket):
             last_date_processed = query_date_last_log.fetchone()[0]
         # if DB is empty
         except TypeError as e:
-            last_date_processed = '20181211' #### fix this value!
+            last_date_processed = datetime.strftime(datetime.utcnow(), "%Y%m%d") # get today date if DB is empty
         return str(last_date_processed)
 
     def iter_regions_and_accounts(self, account_id, regions):

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -68,6 +68,7 @@ from datetime import datetime
 from os import path
 import operator
 from datetime import datetime
+from datetime import timedelta
 
 
 ################################################################################
@@ -765,7 +766,13 @@ class AWSVPCFlowBucket(AWSLogsBucket):
     """
 
     def __init__(self, **kwargs):
-        # SQL queries for VPC
+        self.db_table_name = 'vpcflow'
+        AWSLogsBucket.__init__(self, **kwargs)
+        self.service = 'vpcflowlogs'
+        self.flow_logs_ids = self.get_flow_logs_ids(kwargs['access_key'],
+            kwargs['secret_key'])
+        self.today = self.get_today()
+        # SQL queries for VPC must be after constructor call
         self.sql_already_processed = """
                           SELECT
                             count(*)
@@ -774,7 +781,8 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                           WHERE
                             aws_account_id='{aws_account_id}' AND
                             aws_region='{aws_region}' AND
-                            log_key='{log_name}'"""
+                            flow_log_id='{flow_log_id}' AND
+                            log_key='{log_key}'"""
 
         self.sql_mark_complete = """
                             INSERT INTO {table_name} (
@@ -800,20 +808,34 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                                 log_key 'text' NOT NULL,
                                 processed_date 'text' NOT NULL,
                                 created_date 'integer' NOT NULL,
-                                PRIMARY KEY (aws_account_id, aws_region, log_key));"""
+                                PRIMARY KEY (aws_account_id, aws_region, flow_log_id, log_key));"""
 
-        self.sql_find_last_key_processed = """
-                                        SELECT
-                                            log_key
-                                        FROM
-                                            {table_name}
-                                        WHERE
-                                            aws_account_id='{aws_account_id}' AND
-                                            aws_region = '{aws_region}' AND
-                                            flow_log_id = '{flow_log_id}
-                                        ORDER BY
-                                            log_key ASC
-                                        LIMIT 1;"""
+        self.sql_find_last_key_processed_of_day = """
+                                                SELECT
+                                                    log_key
+                                                FROM
+                                                    {table_name}
+                                                WHERE
+                                                    aws_account_id='{aws_account_id}' AND
+                                                    aws_region = '{aws_region}' AND
+                                                    flow_log_id = '{flow_log_id}' AND
+                                                    created_date = {created_date}
+                                                ORDER BY
+                                                    log_key ASC
+                                                LIMIT 1;"""
+
+        self.sql_get_date_last_log_processed = """
+                                            SELECT
+                                                created_date
+                                            FROM
+                                                {table_name}
+                                            WHERE
+                                                aws_account_id='{aws_account_id}' AND
+                                                aws_region = '{aws_region}' AND
+                                                flow_log_id = '{flow_log_id}'
+                                            ORDER BY
+                                                log_key DESC
+                                            LIMIT 1;"""
 
         self.sql_db_maintenance = """DELETE
                             FROM
@@ -821,7 +843,7 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                             WHERE
                                 aws_account_id='{aws_account_id}' AND
                                 aws_region='{aws_region}' AND
-                                flow_log_id = '{flow_log_id} AND
+                                flow_log_id='{flow_log_id}' AND
                                 rowid NOT IN
                                 (SELECT ROWID
                                     FROM
@@ -829,16 +851,10 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                                     WHERE
                                     aws_account_id='{aws_account_id}' AND
                                     aws_region='{aws_region}' AND
-                                    flow_log_id = '{flow_log_id}
+                                    flow_log_id='{flow_log_id}'
                                     ORDER BY
                                     ROWID DESC
                                     LIMIT {retain_db_records})"""
-        self.db_table_name = 'vpcflow'
-        AWSLogsBucket.__init__(self, **kwargs)
-        self.service = 'vpcflowlogs'
-        self.flow_logs_ids = self.get_flow_logs_ids(kwargs['access_key'],
-            kwargs['secret_key'])
-        print("flow log ids -> " + str(self.flow_logs_ids))
 
     def load_information_from_file(self, log_key):
         with self.decompress_file(log_key=log_key) as f:
@@ -871,6 +887,211 @@ class AWSVPCFlowBucket(AWSLogsBucket):
         for log_id in flow_logs:
             flow_logs_ids.append(log_id['FlowLogId'])
         return flow_logs_ids
+
+    def already_processed(self, downloaded_file, aws_account_id, aws_region, flow_log_id):
+        cursor = self.db_connector.execute(self.sql_already_processed.format(
+            table_name=self.db_table_name,
+            aws_account_id=aws_account_id,
+            aws_region=aws_region,
+            flow_log_id=flow_log_id,
+            log_key=downloaded_file
+        ))
+        return cursor.fetchone()[0] > 0
+
+    def get_today(self):
+        return datetime.strftime(datetime.utcnow(), "%Y%m%d")
+
+    def get_days_since_today(self, date):
+        date = datetime.strptime(date, "%Y%m%d")
+        # it is necessary to add one day
+        delta = datetime.utcnow() - date + timedelta(days=1)
+        return delta.days
+
+    def get_date_list(self, aws_account_id, aws_region, flow_log_id):
+        num_days = self.get_days_since_today(self.get_date_last_log(aws_account_id, aws_region, flow_log_id))
+        date_list_time = [datetime.utcnow() - timedelta(days=x) for x in range(0, num_days)]
+        return [datetime.strftime(date, "%Y/%m/%d") for date in reversed(date_list_time)]
+
+    def get_date_last_log(self, aws_account_id, aws_region, flow_log_id):
+        try:
+            query_date_last_log = self.db_connector.execute(self.sql_get_date_last_log_processed.format(
+                                                                                        table_name=self.db_table_name,
+                                                                                        aws_account_id=aws_account_id,
+                                                                                        aws_region=aws_region,
+                                                                                        flow_log_id=flow_log_id))
+            last_date_processed = query_date_last_log.fetchone()[0]
+        # if DB is empty
+        except TypeError as e:
+            last_date_processed = '20181211' #### fix this value!
+        return str(last_date_processed)
+
+    def iter_regions_and_accounts(self, account_id, regions):
+        if not account_id:
+            # No accounts provided, so find which exist in s3 bucket
+            account_id = self.find_account_ids()
+        for aws_account_id in account_id:
+            # No regions provided, so find which exist for this AWS account
+            if not regions:
+                regions = self.find_regions(aws_account_id)
+                if regions == []:
+                    continue
+            for aws_region in regions:
+                debug("+++ Working on {} - {}".format(aws_account_id, aws_region), 1)
+                # for each flow log id
+                for flow_log_id in self.flow_logs_ids:
+                    date_list = self.get_date_list(aws_account_id, aws_region, flow_log_id)
+                    for date in date_list:
+                        self.iter_files_in_bucket(aws_account_id, aws_region, date, flow_log_id)
+                self.db_maintenance(aws_account_id, aws_region, flow_log_id)
+
+    def db_maintenance(self, aws_account_id, aws_region, flow_log_id):
+        debug("+++ DB Maintenance", 1)
+        try:
+            self.db_connector.execute(self.sql_db_maintenance.format(
+                table_name=self.db_table_name,
+                aws_account_id=aws_account_id,
+                aws_region=aws_region,
+                flow_log_id=flow_log_id,
+                retain_db_records=self.retain_db_records
+            ))
+        except Exception as e:
+            print("ERROR: Failed to execute DB cleanup - AWS Account ID: {aws_account_id}  Region: {aws_region}: {error_msg}".format(
+                aws_account_id=aws_account_id,
+                aws_region=aws_region,
+                error_msg=e))
+            sys.exit(10)
+
+    def get_vpc_prefix(self, aws_account_id, aws_region, date, flow_log_id):
+        return self.get_full_prefix(aws_account_id, aws_region) + date \
+            + '/' + aws_account_id + '_vpcflowlogs_' + aws_region + '_' + flow_log_id
+
+    def build_s3_filter_args(self, aws_account_id, aws_region, date, flow_log_id, iterating=False):
+        filter_marker = ''
+        if self.reparse:
+            if self.only_logs_after:
+                filter_marker = self.marker_only_logs_after(aws_region, aws_account_id, self.only_logs_after)
+        else:
+
+            query_last_key_of_day = self.db_connector.execute(self.sql_find_last_key_processed_of_day.format(table_name=self.db_table_name,
+                                                                                        aws_account_id=aws_account_id,
+                                                                                        aws_region=aws_region,
+                                                                                        flow_log_id=flow_log_id,
+                                                                                        created_date=int(date.replace('/', ''))))
+            try:
+                last_key = query_last_key_of_day.fetchone()[0]
+            except TypeError as e:
+                # if DB is empty for a region
+                last_key = self.get_full_prefix(aws_account_id, aws_region) + date
+
+        vpc_prefix = self.get_vpc_prefix(aws_account_id, aws_region, date, flow_log_id)
+        filter_args = {
+            'Bucket': self.bucket,
+            'MaxKeys': 1000,
+            'Prefix': vpc_prefix
+            }
+
+        # if nextContinuationToken is not used for processing logs in a bucket
+        if not iterating:
+            if filter_marker:
+                filter_args['StartAfter'] = filter_marker
+                debug('+++ Marker: {0}'.format(filter_marker), 2)
+            else:
+                filter_args['StartAfter'] = last_key
+                debug('+++ Marker: {0}'.format(last_key), 2)
+
+        return filter_args
+
+    def iter_files_in_bucket(self, aws_account_id, aws_region, date, flow_log_id):
+        try:
+            bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region, date, flow_log_id))
+
+            if 'Contents' not in bucket_files:
+                debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
+                return
+
+            for bucket_file in bucket_files['Contents']:
+                if not bucket_file['Key']:
+                    continue
+
+                if self.already_processed(bucket_file['Key'], aws_account_id, aws_region, flow_log_id):
+                    if self.reparse:
+                        debug("++ File previously processed, but reparse flag set: {file}".format(
+                            file=bucket_file['Key']), 1)
+                    else:
+                        debug("++ Skipping previously processed file: {file}".format(file=bucket_file['Key']), 1)
+                        continue
+
+                debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
+                # Get the log file from S3 and decompress it
+                log_json = self.get_log_file(aws_account_id, bucket_file['Key'])
+                self.iter_events(log_json, bucket_file['Key'], aws_account_id)
+                # Remove file from S3 Bucket
+                if self.delete_file:
+                    debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
+                    self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
+                self.mark_complete(aws_account_id, aws_region, bucket_file, flow_log_id)
+            # optimize DB
+            self.db_maintenance(aws_account_id, aws_region, flow_log_id)
+            self.db_connector.commit()
+            # iterate if there are more logs
+            while bucket_files['IsTruncated']:
+                new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, date, flow_log_id, True)
+                new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
+                bucket_files = self.client.list_objects_v2(**new_s3_args)
+
+                if 'Contents' not in bucket_files:
+                    debug("+++ No logs to process in bucket: {}/{}".format(aws_account_id, aws_region), 1)
+                    return
+
+                for bucket_file in bucket_files['Contents']:
+                    if not bucket_file['Key']:
+                        continue
+                    if self.already_processed(bucket_file['Key'], aws_account_id, aws_region, flow_log_id):
+                        if self.reparse:
+                            debug("++ File previously processed, but reparse flag set: {file}".format(
+                                file=bucket_file['Key']), 1)
+                        else:
+                            debug("++ Skipping previously processed file: {file}".format(file=bucket_file['Key']), 1)
+                            continue 
+                    debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
+                    # Get the log file from S3 and decompress it
+                    log_json = self.get_log_file(aws_account_id, bucket_file['Key'])
+                    self.iter_events(log_json, bucket_file['Key'], aws_account_id)
+                    # Remove file from S3 Bucket
+                    if self.delete_file:
+                        debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
+                        self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
+                    self.mark_complete(aws_account_id, aws_region, bucket_file, flow_log_id)
+                # optimize DB
+                self.db_maintenance(aws_account_id, aws_region, flow_log_id)
+                self.db_connector.commit()
+        except SystemExit:
+            raise
+        except Exception as err:
+            if hasattr(err, 'message'):
+                debug("+++ Unexpected error: {}".format(err.message), 2)
+            else:
+                debug("+++ Unexpected error: {}".format(err), 2)
+            print("ERROR: Unexpected error querying/working with objects in S3: {}".format(err))
+            sys.exit(7)
+
+    def mark_complete(self, aws_account_id, aws_region, log_file, flow_log_id):
+        if self.reparse:
+            if self.already_processed(log_file['Key'], aws_account_id, aws_region):
+                debug('+++ File already marked complete, but reparse flag set: {log_key}'.format(log_key=log_file['Key']), 2)
+        else:
+            try:
+                self.db_connector.execute(self.sql_mark_complete.format(
+                    table_name=self.db_table_name,
+                    aws_account_id=aws_account_id,
+                    aws_region=aws_region,
+                    flow_log_id=flow_log_id,
+                    log_key=log_file['Key'],
+                    created_date=self.get_creation_date(log_file)
+                ))
+            except Exception as e:
+                debug("+++ Error marking log {} as completed: {}".format(log_file['Key'], e), 2)
+                raise e
 
 
 class AWSConfigBucket(AWSLogsBucket):

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -406,7 +406,7 @@ class AWSBucket(WazuhIntegration):
     def marker_only_logs_after(self, aws_region, aws_account_id, only_logs_after):
         return '{init}{only_logs_after}'.format(
             init=self.get_full_prefix(aws_account_id, aws_region),
-            only_logs_after=only_logs_after
+            only_logs_after=only_logs_after.strftime('%Y/%m/%d')
         )
 
     def get_alert_msg(self, aws_account_id, log_key, event, error_msg=""):

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -462,7 +462,8 @@ class AWSBucket(WazuhIntegration):
             'Prefix': self.get_full_prefix(aws_account_id, aws_region)
         }
         if next_token:
-            filter_args['ContinuationToken'] = next_token
+            filter_args['StartAfter'] = next_token
+            return filter_args
         if filter_marker:
             filter_args['StartAfter'] = filter_marker
             debug('+++ Marker: {0}'.format(filter_marker), 2)


### PR DESCRIPTION
Hi team,

This PR is for #2065. `VPC` service stores logs with a `flow_log_id` in the key name, and this is a problem for processing the logs of the current day (it would be possible to skip logs), and this PR avoid that.

Best regards,

Demetrio.