### PR TITLE
Allow the manager to run with an empty configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
   - Building option `USE_BIG_ENDIAN` is not already needed on Solaris (SPARC) or HP-UX.
 - Expanded the regex pattern maximum size from 2048 to 20480 bytes. ([#2036](https://github.com/wazuh/wazuh/pull/2036))
 - Fix invalid error "Unable to verity server certificate" in _ossec-authd_ (server). ([#2045](https://github.com/wazuh/wazuh/pull/2045))
+- Now Wazuh manager can be started with an empty configuration in ossec.conf. ([#2086](https://github.com/wazuh/wazuh/pull/2086))
 
 ### Fixed
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -484,26 +484,15 @@ int main_analysisd(int argc, char **argv)
             /* Initialize the decoders list */
             OS_CreateOSDecoderList();
 
+            /* If we haven't specified a decoders directory, load default */
             if (!Config.decoders) {
                 /* Legacy loading */
-                /* Read decoders */
-                if (!ReadDecodeXML(XML_DECODER)) {
-                    merror_exit(CONFIG_ERROR,  XML_DECODER);
-                }
+                /* Read default decoders */
+                Read_Rules(NULL, &Config, NULL);
+            }
 
-                /* Read local ones */
-                c = ReadDecodeXML(XML_LDECODER);
-                if (!c) {
-                    if ((c != -2)) {
-                        merror_exit(CONFIG_ERROR,  XML_LDECODER);
-                    }
-                } else {
-                    if (!test_config) {
-                        minfo("Reading local decoder file.");
-                    }
-                }
-            } else {
-                /* New loaded based on file speified in ossec.conf */
+            /* New loaded based on file loaded (in ossec.conf or default) */
+            {
                 char **decodersfiles;
                 decodersfiles = Config.decoders;
                 while ( decodersfiles && *decodersfiles) {
@@ -549,6 +538,11 @@ int main_analysisd(int argc, char **argv)
             /* Load Rules */
             /* Create the rules list */
             Rules_OP_CreateRules();
+
+            /* If we haven't specified a rules directory, load default */
+            if (!Config.includes) {
+                Read_Rules(NULL, &Config, NULL);
+            }
 
             /* Read the rules */
             {

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -219,11 +219,25 @@ int main(int argc, char **argv)
             if (!Config.decoders) {
                 /* Legacy loading */
                 /* Read decoders */
-                if (!ReadDecodeXML("etc/decoder.xml")) {
-                    merror_exit(CONFIG_ERROR,  XML_DECODER);
+                Read_Rules(NULL, &Config, NULL);
+
+                /* New loaded based on file specified in ossec.conf */
+                char **decodersfiles;
+                decodersfiles = Config.decoders;
+                while ( decodersfiles && *decodersfiles) {
+                    if (!test_config) {
+                        minfo("Reading decoder file %s.", *decodersfiles);
+                    }
+                    if (!ReadDecodeXML(*decodersfiles)) {
+                        merror_exit(CONFIG_ERROR, *decodersfiles);
+                    }
+
+                    free(*decodersfiles);
+                    decodersfiles++;
                 }
 
                 /* Read local ones */
+
                 c = ReadDecodeXML("etc/local_decoder.xml");
                 if (!c) {
                     if ((c != -2)) {
@@ -232,6 +246,7 @@ int main(int argc, char **argv)
                 } else {
                     minfo("Reading local decoder file.");
                 }
+
             } else {
                 /* New loaded based on file specified in ossec.conf */
                 char **decodersfiles;

--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -242,7 +242,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
     }
 
     /* If we haven't specified the decoders directory, use default */
-    if (!decoder_dirs[i]) {
+    if (!decoder_dirs[0]) {
         dec_dirs_size++;
         os_realloc(decoder_dirs, sizeof(char *)*dec_dirs_size, decoder_dirs);
         os_realloc(decoder_dirs_pattern, sizeof(char *)*dec_dirs_size, decoder_dirs_pattern);
@@ -255,7 +255,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
     }
 
     /* If we haven't specified the rules directory, use default*/
-    if (!rules_dirs[i]) {
+    if (!rules_dirs[0]) {
         rul_dirs_size++;
         os_realloc(rules_dirs, sizeof(char *)*rul_dirs_size, rules_dirs);
         os_realloc(rules_dirs_pattern, sizeof(char *)*rul_dirs_size, rules_dirs_pattern);

--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -112,138 +112,170 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
     regex.d_sub_strings = NULL;
     regex.mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
 
-    while (node[i]) {
-        if (!node[i]->element) {
-            merror(XML_ELEMNULL);
-            retval = OS_INVALID;
-            goto cleanup;
-        } else if (!node[i]->content) {
-            merror(XML_VALUENULL, node[i]->element);
-            retval = OS_INVALID;
-            goto cleanup;
-        }
-        // <rule_include>
-        else if (strcmp(node[i]->element, xml_rules_rule) == 0) {
-            rules_size++;
-            f_name[PATH_MAX + 1] = '\0';
-            os_realloc(Config->includes, sizeof(char *)*rules_size, Config->includes);
-
-            /* If no directory in the rulefile, add the default */
-            if ((strchr(node[i]->content, '/')) == NULL) {
-                /* Build the rule file name + path */
-                snprintf(f_name, PATH_MAX + 1, "%s/%s", DEFAULT_RULE_DIR, node[i]->content);
-            } else {
-                snprintf(f_name, PATH_MAX + 1, "%s", node[i]->content);
+    if (node) {
+        while (node[i]) {
+            if (!node[i]->element) {
+                merror(XML_ELEMNULL);
+                retval = OS_INVALID;
+                goto cleanup;
+            } else if (!node[i]->content) {
+                merror(XML_VALUENULL, node[i]->element);
+                retval = OS_INVALID;
+                goto cleanup;
             }
+            // <rule_include>
+            else if (strcmp(node[i]->element, xml_rules_rule) == 0) {
+                rules_size++;
+                f_name[PATH_MAX + 1] = '\0';
+                os_realloc(Config->includes, sizeof(char *)*rules_size, Config->includes);
 
-            os_strdup(f_name, Config->includes[rules_size - 2]);
-            Config->includes[rules_size - 1] = NULL;
-            mdebug1("Adding rule: %s", f_name);
-        // <decoder_include>
-        } else if (strcmp(node[i]->element, xml_rules_decoders) == 0) {
-            decoders_size++;
-            f_name[PATH_MAX + 1] = '\0';
-            os_realloc(Config->decoders, sizeof(char *)*decoders_size, Config->decoders);
+                /* If no directory in the rulefile, add the default */
+                if ((strchr(node[i]->content, '/')) == NULL) {
+                    /* Build the rule file name + path */
+                    snprintf(f_name, PATH_MAX + 1, "%s/%s", DEFAULT_RULE_DIR, node[i]->content);
+                } else {
+                    snprintf(f_name, PATH_MAX + 1, "%s", node[i]->content);
+                }
 
-            /* If no directory in the decoder file, add the default */
-            if ((strchr(node[i]->content, '/')) == NULL) {
-                /* Build the decoder file name + path */
-                snprintf(f_name, PATH_MAX + 1, "%s/%s", DEFAULT_DECODER_DIR, node[i]->content);
-            } else {
-                snprintf(f_name, PATH_MAX + 1, "%s", node[i]->content);
-            }
+                os_strdup(f_name, Config->includes[rules_size - 2]);
+                Config->includes[rules_size - 1] = NULL;
+                mdebug1("Adding rule: %s", f_name);
+            // <decoder_include>
+            } else if (strcmp(node[i]->element, xml_rules_decoders) == 0) {
+                decoders_size++;
+                f_name[PATH_MAX + 1] = '\0';
+                os_realloc(Config->decoders, sizeof(char *)*decoders_size, Config->decoders);
 
-            os_strdup(f_name, Config->decoders[decoders_size - 2]);
-            Config->decoders[decoders_size - 1] = NULL;
-            mdebug1("Adding decoder: %s", f_name);
-        // <list>
-        } else if (strcmp(node[i]->element, xml_rules_lists) == 0) {
-            lists_size++;
-            os_realloc(Config->lists, sizeof(char *)*lists_size, Config->lists);
-            os_strdup(node[i]->content, Config->lists[lists_size - 2]);
-            Config->lists[lists_size - 1] = NULL;
-        // <rule_exclude>
-        } else if (strcmp(node[i]->element, xml_rules_exclude) == 0) {
-            rules_exclude_size++;
-            os_realloc(exclude_rules, sizeof(char *)*rules_exclude_size, exclude_rules);
-            os_strdup(node[i]->content, exclude_rules[rules_exclude_size - 2]);
-            exclude_rules[rules_exclude_size - 1] = NULL;
-            mdebug1("Excluding rule: %s", node[i]->content);
-        // <decoder_exclude>
-        } else if (strcmp(node[i]->element, xml_rules_exclude_decoder) == 0) {
-            decoders_exclude_size++;
-            os_realloc(exclude_decoders, sizeof(char *)*decoders_exclude_size, exclude_decoders);
-            os_strdup(node[i]->content, exclude_decoders[decoders_exclude_size - 2]);
-            exclude_decoders[decoders_exclude_size - 1] = NULL;
-            mdebug1("Excluding decoder: %s", node[i]->content);
-        // <decoder_dir>
-        } else if (strcmp(node[i]->element, xml_rules_decoders_dir) == 0) {
-            dec_dirs_size++;
-            os_realloc(decoder_dirs, sizeof(char *)*dec_dirs_size, decoder_dirs);
-            os_realloc(decoder_dirs_pattern, sizeof(char *)*dec_dirs_size, decoder_dirs_pattern);
-            os_strdup(node[i]->content, decoder_dirs[dec_dirs_size - 2]);
-            decoder_dirs[dec_dirs_size - 1] = NULL;
-            decoder_dirs_pattern[dec_dirs_size - 1] = NULL;
-            mdebug1("Adding decoder dir: %s", node[i]->content);
+                /* If no directory in the decoder file, add the default */
+                if ((strchr(node[i]->content, '/')) == NULL) {
+                    /* Build the decoder file name + path */
+                    snprintf(f_name, PATH_MAX + 1, "%s/%s", DEFAULT_DECODER_DIR, node[i]->content);
+                } else {
+                    snprintf(f_name, PATH_MAX + 1, "%s", node[i]->content);
+                }
 
-            if (node[i]->attributes && node[i]->values) {
-                att_count = 0;
-                while (node[i]->attributes[att_count]) {
-                    if ((strcasecmp(node[i]->attributes[att_count], "pattern") == 0)) {
-                        if (node[i]->values[att_count]) {
-                            os_strdup(node[i]->values[att_count], decoder_dirs_pattern[dec_dirs_size - 2]);
+                os_strdup(f_name, Config->decoders[decoders_size - 2]);
+                Config->decoders[decoders_size - 1] = NULL;
+                mdebug1("Adding decoder: %s", f_name);
+            // <list>
+            } else if (strcmp(node[i]->element, xml_rules_lists) == 0) {
+                lists_size++;
+                os_realloc(Config->lists, sizeof(char *)*lists_size, Config->lists);
+                os_strdup(node[i]->content, Config->lists[lists_size - 2]);
+                Config->lists[lists_size - 1] = NULL;
+            // <rule_exclude>
+            } else if (strcmp(node[i]->element, xml_rules_exclude) == 0) {
+                rules_exclude_size++;
+                os_realloc(exclude_rules, sizeof(char *)*rules_exclude_size, exclude_rules);
+                os_strdup(node[i]->content, exclude_rules[rules_exclude_size - 2]);
+                exclude_rules[rules_exclude_size - 1] = NULL;
+                mdebug1("Excluding rule: %s", node[i]->content);
+            // <decoder_exclude>
+            } else if (strcmp(node[i]->element, xml_rules_exclude_decoder) == 0) {
+                decoders_exclude_size++;
+                os_realloc(exclude_decoders, sizeof(char *)*decoders_exclude_size, exclude_decoders);
+                os_strdup(node[i]->content, exclude_decoders[decoders_exclude_size - 2]);
+                exclude_decoders[decoders_exclude_size - 1] = NULL;
+                mdebug1("Excluding decoder: %s", node[i]->content);
+            // <decoder_dir>
+            } else if (strcmp(node[i]->element, xml_rules_decoders_dir) == 0) {
+                dec_dirs_size++;
+                os_realloc(decoder_dirs, sizeof(char *)*dec_dirs_size, decoder_dirs);
+                os_realloc(decoder_dirs_pattern, sizeof(char *)*dec_dirs_size, decoder_dirs_pattern);
+                os_strdup(node[i]->content, decoder_dirs[dec_dirs_size - 2]);
+                decoder_dirs[dec_dirs_size - 1] = NULL;
+                decoder_dirs_pattern[dec_dirs_size - 1] = NULL;
+                mdebug1("Adding decoder dir: %s", node[i]->content);
+
+                if (node[i]->attributes && node[i]->values) {
+                    att_count = 0;
+                    while (node[i]->attributes[att_count]) {
+                        if ((strcasecmp(node[i]->attributes[att_count], "pattern") == 0)) {
+                            if (node[i]->values[att_count]) {
+                                os_strdup(node[i]->values[att_count], decoder_dirs_pattern[dec_dirs_size - 2]);
+                            }
                         }
+                        att_count++;
                     }
-                    att_count++;
+                } else {
+                    os_strdup(".xml$", decoder_dirs_pattern[dec_dirs_size - 2]);
+                }
+            // <rule_dir>
+            } else if (strcmp(node[i]->element, xml_rules_rules_dir) == 0) {
+                rul_dirs_size++;
+                os_realloc(rules_dirs, sizeof(char *)*rul_dirs_size, rules_dirs);
+                os_realloc(rules_dirs_pattern, sizeof(char *)*rul_dirs_size, rules_dirs_pattern);
+
+                if (!rules_dirs) {
+                    merror(MEM_ERROR, errno, strerror(errno));
+                    retval = OS_INVALID;
+                    goto cleanup;
+                }
+
+                os_strdup(node[i]->content, rules_dirs[rul_dirs_size - 2]);
+                rules_dirs[rul_dirs_size - 1] = NULL;
+                rules_dirs_pattern[rul_dirs_size - 1] = NULL;
+                mdebug1("Adding rules dir: %s", node[i]->content);
+
+                if (node[i]->attributes && node[i]->values) {
+                    att_count = 0;
+                    while (node[i]->attributes[att_count]) {
+                        if ((strcasecmp(node[i]->attributes[att_count], "pattern") == 0)) {
+                            if (node[i]->values[att_count]) {
+                                os_strdup(node[i]->values[att_count], rules_dirs_pattern[rul_dirs_size - 2]);
+                            }
+                        }
+                        att_count++;
+                    }
+                } else {
+                    os_strdup(".xml$", rules_dirs_pattern[rul_dirs_size - 2]);
                 }
             } else {
-                os_strdup(".xml$", decoder_dirs_pattern[dec_dirs_size - 2]);
-            }
-        // <rule_dir>
-        } else if (strcmp(node[i]->element, xml_rules_rules_dir) == 0) {
-            rul_dirs_size++;
-            os_realloc(rules_dirs, sizeof(char *)*rul_dirs_size, rules_dirs);
-            os_realloc(rules_dirs_pattern, sizeof(char *)*rul_dirs_size, rules_dirs_pattern);
-
-            if (!rules_dirs) {
-                merror(MEM_ERROR, errno, strerror(errno));
+                merror(XML_INVELEM, node[i]->element);
+                OSRegex_FreePattern(&regex);
                 retval = OS_INVALID;
                 goto cleanup;
             }
 
-            os_strdup(node[i]->content, rules_dirs[rul_dirs_size - 2]);
-            rules_dirs[rul_dirs_size - 1] = NULL;
-            rules_dirs_pattern[rul_dirs_size - 1] = NULL;
-            mdebug1("Adding rules dir: %s", node[i]->content);
-
-            if (node[i]->attributes && node[i]->values) {
-                att_count = 0;
-                while (node[i]->attributes[att_count]) {
-                    if ((strcasecmp(node[i]->attributes[att_count], "pattern") == 0)) {
-                        if (node[i]->values[att_count]) {
-                            os_strdup(node[i]->values[att_count], rules_dirs_pattern[rul_dirs_size - 2]);
-                        }
-                    }
-                    att_count++;
-                }
-            } else {
-                os_strdup(".xml$", rules_dirs_pattern[rul_dirs_size - 2]);
-            }
-        } else {
-            merror(XML_INVELEM, node[i]->element);
-            OSRegex_FreePattern(&regex);
-            retval = OS_INVALID;
-            goto cleanup;
+            i++;
         }
+    }
 
-        i++;
+    /* If we haven't specified the decoders directory, use default */
+    if (!decoder_dirs[i]) {
+        dec_dirs_size++;
+        os_realloc(decoder_dirs, sizeof(char *)*dec_dirs_size, decoder_dirs);
+        os_realloc(decoder_dirs_pattern, sizeof(char *)*dec_dirs_size, decoder_dirs_pattern);
+        os_strdup(DEFAULT_DECODER_DIR, decoder_dirs[dec_dirs_size - 2]);
+        decoder_dirs[dec_dirs_size - 1] = NULL;
+        decoder_dirs_pattern[dec_dirs_size - 1] = NULL;
+        mdebug1("Adding decoder dir: %s", DEFAULT_DECODER_DIR);
+
+        os_strdup(".xml$", decoder_dirs_pattern[dec_dirs_size - 2]);
+    }
+
+    /* If we haven't specified the rules directory, use default*/
+    if (!rules_dirs[i]) {
+        rul_dirs_size++;
+        os_realloc(rules_dirs, sizeof(char *)*rul_dirs_size, rules_dirs);
+        os_realloc(rules_dirs_pattern, sizeof(char *)*rul_dirs_size, rules_dirs_pattern);
+        os_strdup(DEFAULT_RULE_DIR, rules_dirs[rul_dirs_size - 2]);
+        rules_dirs[rul_dirs_size - 1] = NULL;
+        rules_dirs_pattern[rul_dirs_size - 1] = NULL;
+        mdebug1("Adding rules dir: %s", DEFAULT_RULE_DIR);
+
+        os_strdup(".xml$", rules_dirs_pattern[rul_dirs_size - 2]);
     }
 
     // Read decoder list
 
     for (i = 0; decoder_dirs[i]; i++) {
         mdebug1("Reading decoders folder: %s", decoder_dirs[i]);
-        snprintf(path, PATH_MAX + 1, "%s/%s", DEFAULTDIR, decoder_dirs[i]);
+        if(isChroot()) {
+            snprintf(path, PATH_MAX + 1, "%s", decoder_dirs[i]);
+        } else {
+            snprintf(path, PATH_MAX + 1, "%s/%s", DEFAULTDIR, decoder_dirs[i]);
+        }
 
         OSRegex_FreePattern(&regex);
         if (!OSRegex_Compile(decoder_dirs_pattern[i], &regex, 0)) {
@@ -296,7 +328,11 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
 
     for (i = 0; rules_dirs[i]; i++) {
         mdebug1("Reading rules folder: %s", rules_dirs[i]);
-        snprintf(path, PATH_MAX + 1, "%s/%s", DEFAULTDIR, rules_dirs[i]);
+        if(isChroot()) {
+            snprintf(path, PATH_MAX + 1, "%s", rules_dirs[i]);
+        } else {
+            snprintf(path, PATH_MAX + 1, "%s/%s", DEFAULTDIR, rules_dirs[i]);
+        }
 
         OSRegex_FreePattern(&regex);
         if (!OSRegex_Compile(rules_dirs_pattern[i], &regex, 0)) {

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -171,8 +171,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define ARQUEUE         "/queue/alerts/ar"
 
 /* Decoder file */
-#define XML_DECODER     "/etc/decoder.xml"
-#define XML_LDECODER    "/etc/local_decoder.xml"
+#define XML_LDECODER    "/etc/decoders/local_decoder.xml"
 
 /* Agent information location */
 #define AGENTINFO_DIR    "/queue/agent-info"

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -49,20 +49,7 @@ getPreinstalled()
 {
     . ${OSSEC_INIT}
 
-    # agent
-    cat $DIRECTORY/etc/ossec.conf | grep "<client>" > /dev/null 2>&1
-    if [ $? = 0 ]; then
-        echo "agent"
-        return 0;
-    fi
-
-    cat $DIRECTORY/etc/ossec.conf | grep "<remote>" > /dev/null 2>&1
-    if [ $? = 0 ]; then
-        echo "server"
-        return 0;
-    fi
-
-    echo "local"
+	echo $TYPE
     return 0;
 }
 


### PR DESCRIPTION
#1909 
Change in default configuration to make Wazuh manager work with an empty configuration in `ossec.conf`.
In order to do this, both rules and decoders directories are added by default (if the user haven't specified them).
Also, a bug (that was making a manager installation turn into a local installation after an update) have been discovered and fixed