### PR TITLE
Solaris rootcheck fix 

### DIFF
--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -321,7 +321,7 @@ static int read_sys_dir(const char *dir_name, int do_read)
 
             /* Solaris /boot is terrible :) */
 #ifdef SOLARIS
-            if (strncmp(dir_name, "/boot", strlen("/boot")) != 0) {
+            if ((strncmp(dir_name, "/boot", strlen("/boot")) != 0) && (strncmp(dir_name, "/dev", strlen("/dev")) != 0)) {
                 notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
                 _sys_errors++;
             }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -319,7 +319,7 @@ static int read_sys_dir(const char *dir_name, int do_read)
                      "(%d,%d).",
                      dir_name, entry_count, (int)statbuf.st_nlink);
 
-            /* Solaris /boot is terrible :) */
+            /* Solaris /boot is terrible :), as is /dev! */
 #ifdef SOLARIS
             if ((strncmp(dir_name, "/boot", strlen("/boot")) != 0) && (strncmp(dir_name, "/dev", strlen("/dev")) != 0)) {
                 notify_rk(ALERT_ROOTKIT_FOUND, op_msg);


### PR DESCRIPTION
Linked file count is always off on solaris for /boot and /dev