### PR TITLE
Fix bug in Analysisd when decoding a malformed FIM message

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -364,7 +364,7 @@ int fim_db_search(char *f_name, char *c_sum, char *w_sum, Eventinfo *lf, _sdb *s
             break;
 
         default: // Error in fim check sum
-            merror("at fim_db_search: Agent '%s' Couldn't decode fim sum '%s' from file '%s'.",
+            mwarn("at fim_db_search: Agent '%s' Couldn't decode fim sum '%s' from file '%s'.",
                     lf->agent_id, new_check_sum, f_name);
             goto exit_fail;
     }

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -24,7 +24,7 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
     char *c_inode;
     char *tag;
     int retval = 0;
-    char *username_esc;
+    char * uname;
 
     if (c_sum[0] == '-' && c_sum[1] == '1') {
         retval = 1;
@@ -59,17 +59,15 @@ int sk_decode_sum(sk_sum_t *sum, char *c_sum, char *w_sum) {
 
         // New fields: user name, group name, modification time and inode
 
-        if ((sum->uname = strchr(sum->sha1, ':'))) {
-            *(sum->uname++) = '\0';
+        if ((uname = strchr(sum->sha1, ':'))) {
+            *(uname++) = '\0';
 
-            if (!(sum->gname = strchr(sum->uname, ':')))
+            if (!(sum->gname = strchr(uname, ':')))
                 return -1;
 
             *(sum->gname++) = '\0';
 
-            if (username_esc = os_strip_char(sum->uname, '\\'), username_esc) {
-                sum->uname = username_esc;
-            }
+            sum->uname = os_strip_char(uname, '\\');
 
             if (!(c_mtime = strchr(sum->gname, ':')))
                 return -1;


### PR DESCRIPTION
|Version|Component|
|---|---|
|v3.7.1|Analysisd|

The latest release introduced file's owner string escaping. This will allow owner names including whitespaces. Unfortunately, if a Windows agent with version 3.7.0 gets connected to a manager with version 3.7.1, this error will appear in the manager:

```
2018/12/13 01:45:18 ossec-analysisd: ERROR: at fim_db_search: Agent '001' Couldn't decode fim sum '0:33206:S-1-5-20::d41d8cd98f00b204e9800998ecf8427e:da39a3ee5e6b4b0d3255bfef95601890afd80709:NETWORK' from file 'SERVICE::1544660436:0:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855!::::::::::: c:\users\administrator\desktop\myfile.txt'.
```

Just then, Analysisd crashes. GDB reports that the crash is produced in a `free()`:
```
*** Error in `/var/ossec/bin/ossec-analysisd': munmap_chunk(): invalid pointer: 0x00007fffdc002569 ***

Program received signal SIGABRT, Aborted.
[Switching to Thread 0x7fffee7fc700 (LWP 14721)]
0x00007ffff6c2c277 in raise () from /lib64/libc.so.6
```

This PR aims to fix this bug. It also switches that error message into a warning.