### PR TITLE
Delete deprecated flag `REUSE_ID` from the Makefile options

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,6 @@ EXTERNAL_PROCPS=external/procps/
 EXTERNAL_LIBDB=external/libdb/build_unix/
 endif
 MAXAGENTS?=14000
-REUSE_ID?=no
 # XXX Becareful NO EXTRA Spaces here
 PREFIX?=/var/ossec
 PG_CONFIG?=pg_config
@@ -61,10 +60,6 @@ DEFINES+=-DREMUSER=\"${OSSEC_USER_REM}\"
 DEFINES+=-DGROUPGLOBAL=\"${OSSEC_GROUP}\"
 DEFINES+=-DMAILUSER=\"${OSSEC_USER_MAIL}\"
 DEFINES+=-D${uname_S}
-
-ifneq (,$(filter ${REUSE_ID},yes y Y 1))
-	DEFINES+=-DREUSE_ID
-endif
 
 OSSEC_CFLAGS = ${CFLAGS}
 OSSEC_LDFLAGS = ${LDFLAGS}
@@ -426,7 +421,6 @@ help: failtarget
 	@echo "   make DEBUGAD                 Enables extra debugging logging in ossec-analysisd"
 	@echo "   make PREFIX=/path            Install OSSEC to '/path'. Defaults to /var/ossec"
 	@echo "   make MAXAGENTS=NUMBER        Set the number of maximum agents to NUMBER. Defaults to 2048"
-	@echo "   make REUSE_ID=yes            Enables agent ID re-use"
 	@echo "   make ONEWAY=no               Disables manager's ACK towards agent. It allows connecting agents without backward connection from manager"
 	@echo "   make CLEANFULL=no            Makes the alert mailing subject clear in the format: '<location> - <level> - <description>'"
 	@echo "   make RESOURCES_URL           Set the Wazuh resources URL"
@@ -467,7 +461,6 @@ settings:
 	@echo "    DEBUGAD             ${DEBUGAD}"
 	@echo "    PREFIX:             ${PREFIX}"
 	@echo "    MAXAGENTS:          ${MAXAGENTS}"
-	@echo "    REUSE_ID:           ${REUSE_ID}"
 	@echo "    DATABASE:           ${DATABASE}"
 	@echo "    ONEWAY:             ${ONEWAY}"
 	@echo "    CLEANFULL:          ${CLEANFULL}"

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -221,9 +221,6 @@ int add_agent(int json_output, int no_limit)
             double antiquity = OS_AgentAntiquity_ID(id_exist);
 
             if (env_remove_dup && (antiquity >= force_antiquity || antiquity < 0)) {
-#ifdef REUSE_ID
-                strncpy(id, id_exist, FILE_SIZE);
-#endif
                 OS_BackupAgentInfo_ID(id_exist);
                 OS_RemoveAgent(id_exist);
             } else {

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -112,7 +112,6 @@ int OS_RemoveAgent(const char *u_id) {
         return 0;
     }
 
-#ifndef REUSE_ID
     char *ptr_name = strchr(buf_curline, ' ');
 
     if (!ptr_name) {
@@ -128,8 +127,6 @@ int OS_RemoveAgent(const char *u_id) {
     size_t curline_len = strlen(buf_curline);
     memcpy(buffer + fp_read, buf_curline, curline_len);
     fp_read += curline_len;
-
-#endif
 
     if (!feof(fp))
         fp_read += fread(buffer + fp_read, sizeof(char), fp_stat.st_size, fp);


### PR DESCRIPTION
This PR removes the flag `REUSE_ID` from the Makefile options and the source code.