### PR TITLE
Remove multi_group field

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -183,13 +183,6 @@ class WazuhDBQueryMultigroups(WazuhDBQueryAgents):
         return 'COUNT(DISTINCT a.id)'
 
 
-    def _get_data(self):
-        if self.group_id != "null":
-            self.fields['multi_group'] = "CASE WHEN COUNT(*) > 1 THEN '' ELSE '' END as num_groups"
-            self.select['fields'].update(['multi_group'])
-        WazuhDBQueryAgents._get_data(self)
-
-
     def _get_total_items(self):
         WazuhDBQueryAgents._get_total_items(self)
         self.query += ' GROUP BY a.id '


### PR DESCRIPTION
Hi team,

This PR is for API issue [#249](https://github.com/wazuh/wazuh-api/issues/249). `multi_group``field was deprecated and I deleted it.

Best regards,

Demetrio.