### PR TITLE
Cast pid_t to int at log printing to avoid compile warnings in Solaris 10

### DIFF
--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -439,12 +439,12 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
                         case -1:
                             switch(errno){
                                 case ESRCH:
-                                    merror("At wm_exec(): No such process. Couldn't wait PID %d: (%d) %s.", pid, errno, strerror(errno));
+                                    merror("At wm_exec(): No such process. Couldn't wait PID %d: (%d) %s.", (int)pid, errno, strerror(errno));
                                     retval = -2;
                                     break;
 
                                 default:
-                                    merror("At wm_exec(): Couldn't wait PID %d: (%d) %s.", pid, errno, strerror(errno));
+                                    merror("At wm_exec(): Couldn't wait PID %d: (%d) %s.", (int)pid, errno, strerror(errno));
                                     retval = -3;
                             }
                             break;
@@ -623,7 +623,7 @@ void wm_kill_children() {
                                 exit(EXIT_SUCCESS);
 
                             default:
-                                merror("wm_kill_children(): Couldn't wait PID %d: (%d) %s.", sid, errno, strerror(errno));
+                                merror("wm_kill_children(): Couldn't wait PID %d: (%d) %s.", (int)sid, errno, strerror(errno));
                                 exit(EXIT_FAILURE);
                             }
 
@@ -634,7 +634,7 @@ void wm_kill_children() {
 
                     // If time is gone, kill process
 
-                    mdebug1("Killing process group %d", sid);
+                    mdebug1("Killing process group %d", (int)sid);
 
                     kill(-sid, SIGKILL);
                     exit(EXIT_SUCCESS);


### PR DESCRIPTION
This PR closes issue #2120.

The compiler complains that `pid_t` is not `int` in Solaris 10. 
According to the [GNU C Library](https://www.gnu.org/software/libc/manual/html_node/Process-Identification.html), the type `pid_t` is a signed integer. Then, the closes standard C type is `int`.

We propose to cast `pid_t` to `int` when printing logs.