### PR TITLE
Support for new API call to add multiple agents to a group

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1647,6 +1647,42 @@ class Agent:
         else:
             return Agent.add_group_to_agent(agent_id=agent_id, group_id=group_id, force=force)
 
+    @staticmethod
+    def set_group_list(group_id, agent_id_list):
+        """
+        Set a group to a list of agents.
+
+        :param agent_id: List of Agent IDs.
+        :param group_id: Group ID.
+        :return: Confirmation message.
+        """
+        failed_ids = list()
+        affected_agents = list()
+
+        # raise an exception if agent_list_id is empty
+        if len(agent_id_list) < 1:
+            raise WazuhException(1732)
+
+        for agent_id in agent_id_list:
+            try:
+                Agent.add_group_to_agent(agent_id=agent_id, group_id=group_id)
+                affected_agents.append(agent_id)
+            except Exception as e:
+                failed_ids.append(agent_id)
+
+            if not failed_ids:
+                message = 'All selected agents assigned to group ' + group_id
+            else:
+                message = 'Some agents were not assigned to group ' + group_id
+
+            final_dict = {}
+            if failed_ids:
+                final_dict = {'msg': message, 'affected_agents': affected_agents, 'failed_ids': failed_ids}
+            else:
+                final_dict = {'msg': message, 'affected_agents': affected_agents}
+
+        return final_dict
+
 
     @staticmethod
     def get_agents_group_file(agent_id):

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -144,6 +144,10 @@ functions = {
         'function': Agent.set_group,
         'type': 'local_master'
     },
+    'POST/agents/group/:group_id': {
+        'function': Agent.set_group_list,
+        'type': 'local_master'
+    },
     'PUT/agents/groups/:group_id': {
         'function': Agent.create_group,
         'type': 'local_master'


### PR DESCRIPTION
Hi team,

This PR is for API issue [#254](https://github.com/wazuh/wazuh-api/issues/254). A new API call for adding multiple agents to a group was added into PR [256](https://github.com/wazuh/wazuh-api/pull/256) and I gave support to it:

```bash
$ curl -u foo:bar -X POST -H "Content-Type:application/json" -d '{"ids":["001","002"]}' "http://localhost:55000/agents/group/dmz?pretty"
{
   "error": 0,
   "data": {
      "msg": "All selected agents assigned to group dmz",
      "affected_agents": [
         "001",
         "002"
      ]
   }
}
```

```bash
$ curl -u foo:bar -X POST -H "Content-Type:application/json" -d '{"ids":["003","007"]}' "http://localhost:55000/agents/group/dmz?pretty"
{
   "error": 0,
   "data": {
      "msg": "Some agents were not assigned to group dmz",
      "failed_ids": [
         "007"
      ],
      "affected_agents": [
         "003"
      ]
   }
}
```

Best regards,

Demetrio.