### PR TITLE
Enable wazuh to send directly from filebeat to elasticsearch, without logstash

### DIFF
--- a/extensions/elasticsearch/wazuh_alert_pipeline.json
+++ b/extensions/elasticsearch/wazuh_alert_pipeline.json
@@ -1,0 +1,54 @@
+{
+  "description": "Pipeline for parsing Wazuh json alerts.",
+  "processors": [{
+    "date": {
+      "field": "timestamp",
+      "target_field": "@timestamp",
+      "formats": ["ISO8601"]
+    }
+  }, {
+    "set": {
+      "field": "_type",
+      "value": "wazuh",
+      "override": true
+    }
+  }, {
+    "set": {
+      "field": "@srcip",
+      "value": "{{data.srcip}}",
+      "if": "ctx?.data?.srcip != null",
+      "override": true
+    }
+  }, {
+    "set": {
+      "field": "@srcip",
+      "value": "{{data.aws.sourceIPAddress}}",
+      "if": "ctx?.data?.aws?.sourceIPAddress != null",
+      "override": true
+    }
+  }, {
+    "geoip": {
+      "field": "@srcip",
+      "target_field": "GeoLocation",
+      "properties": ["country_iso_code", "region_name", "city_name", "location"],
+      "ignore_missing": true
+    }
+  }, {
+    "rename": {
+      "field": "GeoLocation.country_iso_code",
+      "target_field": "GeoLocation.country_name",
+      "ignore_missing": true
+    }
+  }, {
+    "remove": {
+      "field": ["timestamp", "beat", "input_type", "tags", "count", "@version", "@srcip", "log", "offset", "type", "host"],
+      "ignore_missing": true
+    }
+  }],
+  "on_failure" : [{
+    "set" : {
+      "field" : "error.message",
+      "value" : "{{ _ingest.on_failure_message }}"
+    }
+  }]
+}

--- a/extensions/filebeat/filebeat-es.yml
+++ b/extensions/filebeat/filebeat-es.yml
@@ -1,0 +1,25 @@
+filebeat.inputs:
+- type: log
+  paths:
+    - /var/ossec/logs/alerts/alerts.json
+  json.keys_under_root: true
+  json.overwrite_keys: true
+  json.add_error_key: true
+
+setup.template.enabled: false
+
+output.elasticsearch:
+  hosts: ["YOUR_ELASTIC_SERVER_IP:9200"]
+  # ssl
+  # protocol: https
+  # ssl.certificate_authorities: ["/etc/filebeat/logstash.crt"]
+  index: "wazuh-alerts-3.x-%{+YYYY.MM.dd}"
+  pipeline: wazuh_alert_pipeline
+
+logging.level: warning
+logging.to_files: true
+logging.files:
+  path: /var/log/filebeat
+  name: filebeat
+  rotateeverybytes: 10485760
+  keepfiles: 30


### PR DESCRIPTION
Copy filebeat-es.yml to `/etc/filebeat/filebeat.yml` (edit elasticsearch hostname)

Upload elasticsearch ingest pipeline:

`curl -X PUT localhost:9200/_ingest/pipeline/wazuh_alert_pipeline -H 'Content-Type: application/json' --data @extensions/elasticsearch/wazuh_alert_pipeline.json`

Requires geoip plugin:
`/usr/share/elasticsearch/bin/elasticsearch-plugin install ingest-geoip`