### PR TITLE
Fix string boundary in Logcollector when reading too long logs

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -474,6 +474,13 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr) {
             (*logf)[size - 1].file = NULL;
             (*logf)[size - 1].fp = NULL;
 
+            if(!gl) {
+                (*logf)[size - 1].target = NULL;
+                (*logf)[size - 1].ffile = NULL;
+                (*logf)[size - 1].logformat = NULL;
+                (*logf)[size - 1].command = NULL;
+            }
+
             if (!size)
                 size = 1;
             os_realloc(*logf, size*sizeof(logreader), *logf);

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -180,6 +180,8 @@ extern const char *__local_name;
 
 #define os_clearnl(x,p) if((p = strrchr(x, '\n')))*p = '\0';
 
+#define w_ftell(x)({ long z = ftell(x); if(z < 0) merror_exit("Ftell function failed due to [(%d)-(%s)]", errno, strerror(errno)); z; })
+
 #ifdef CLIENT
 #define isAgent 1
 #else

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -54,8 +54,8 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
 
     *rc = 0;
 
-    for (offset = ftell(lf->fp); fgets(buffer, OS_MAXSTR, lf->fp) && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
-        rbytes = ftell(lf->fp) - offset;
+    for (offset = w_ftell(lf->fp); fgets(buffer, OS_MAXSTR, lf->fp) && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
+        rbytes = w_ftell(lf->fp) - offset;
         lines++;
 
         if (buffer[rbytes - 1] == '\n') {
@@ -70,7 +70,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
             if (rbytes == OS_MAXSTR - 1) {
                 // Message too large, discard line
                 for (offset += rbytes; fgets(buffer, OS_MAXSTR, lf->fp); offset += rbytes) {
-                    rbytes = ftell(lf->fp) - offset;
+                    rbytes = w_ftell(lf->fp) - offset;
 
                     if (buffer[rbytes - 1] == '\n') {
                         break;

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -32,8 +32,8 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
     /* Get initial file location */
     fgetpos(lf->fp, &fp_pos);
 
-    for (offset = ftell(lf->fp); fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
-        rbytes = ftell(lf->fp) - offset;
+    for (offset = w_ftell(lf->fp); fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
+        rbytes = w_ftell(lf->fp) - offset;
         lines++;
 
         /* Get the last occurrence of \n */
@@ -113,7 +113,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
             }
 
             for (offset += rbytes; fgets(str, OS_MAXSTR - 2, lf->fp) != NULL; offset += rbytes) {
-                rbytes = ftell(lf->fp) - offset;
+                rbytes = w_ftell(lf->fp) - offset;
 
                 /* Get the last occurrence of \n */
                 if (str[rbytes - 1] == '\n') {

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -32,8 +32,8 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     /* Get initial file location */
     fgetpos(lf->fp, &fp_pos);
 
-    for (offset = ftell(lf->fp); fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
-        rbytes = ftell(lf->fp) - offset;
+    for (offset = w_ftell(lf->fp); fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
+        rbytes = w_ftell(lf->fp) - offset;
         lines++;
         linesgot++;
 
@@ -103,7 +103,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
             }
 
             for (offset += rbytes; fgets(str, OS_MAXSTR - 2, lf->fp) != NULL; offset += rbytes) {
-                rbytes = ftell(lf->fp) - offset;
+                rbytes = w_ftell(lf->fp) - offset;
 
                 /* Get the last occurrence of \n */
                 if (str[rbytes - 1] == '\n') {

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -50,6 +50,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
             __ms = 1;
+            str[rbytes - 1] = '\0';
         } else {
             /* We may not have gotten a line feed
              * because we reached EOF.

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -29,8 +29,8 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     /* Get initial file location */
     fgetpos(lf->fp, &fp_pos);
 
-    for (offset = ftell(lf->fp); fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
-        rbytes = ftell(lf->fp) - offset;
+    for (offset = w_ftell(lf->fp); fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines); offset += rbytes) {
+        rbytes = w_ftell(lf->fp) - offset;
         lines++;
 
         /* Get the last occurrence of \n */
@@ -102,7 +102,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
             }
 
             for (offset += rbytes; fgets(str, OS_MAXSTR - 2, lf->fp) != NULL; offset += rbytes) {
-                rbytes = ftell(lf->fp) - offset;
+                rbytes = w_ftell(lf->fp) - offset;
 
                 /* Get the last occurrence of \n */
                 if (str[rbytes - 1] == '\n') {


### PR DESCRIPTION
If Logcollector picks up a log exceeding 65279 (_65536 - 256 - 1_) bytes, it will truncate the log. This log won't contain an explicit string terminator (`\0`).

The queues support any kind of strings —including binary strings—, however, the event builder (for Agentd and Analysisd) does not. Since there is not an explicit `\0`, this component may read beyond the string limit and produce a spurious log tail, or an out-of-memory error.

This is a Valgrind report:
```
==15974== Thread 2:
==15974== Invalid read of size 1
==15974==    at 0x4C2C9E4: __GI_strlen (vg_replace_strmem.c:459)
==15974==    by 0x5B790BD: strdup (in /usr/lib64/libc-2.17.so)
==15974==    by 0x43F679: msgsubst (mq_op.c:232)
==15974==    by 0x43F0AB: SendMSGtoSCK (mq_op.c:115)
==15974==    by 0x40D8A3: w_output_thread (logcollector.c:1243)
==15974==    by 0x58D8DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==15974==    by 0x5BEAEAC: clone (in /usr/lib64/libc-2.17.so)
==15974==  Address 0x5f22c7f is 0 bytes after a block of size 65,279 alloc'd
==15974==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==15974==    by 0x40D53F: w_msg_queue_push (logcollector.c:1187)
==15974==    by 0x40D3F5: w_msg_hash_queues_push (logcollector.c:1156)
==15974==    by 0x408BA7: read_syslog (read_syslog.c:89)
==15974==    by 0x40DD2F: w_input_thread (logcollector.c:1374)
==15974==    by 0x58D8DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==15974==    by 0x5BEAEAC: clone (in /usr/lib64/libc-2.17.so)
==15974==
==15974== Conditional jump or move depends on uninitialised value(s)
==15974==    at 0x5B39EF9: vfprintf (in /usr/lib64/libc-2.17.so)
==15974==    by 0x5B64F38: vsnprintf (in /usr/lib64/libc-2.17.so)
==15974==    by 0x5B403C1: snprintf (in /usr/lib64/libc-2.17.so)
==15974==    by 0x43EF77: SendMSG (mq_op.c:79)
==15974==    by 0x43F0ED: SendMSGtoSCK (mq_op.c:118)
==15974==    by 0x40D8A3: w_output_thread (logcollector.c:1243)
==15974==    by 0x58D8DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==15974==    by 0x5BEAEAC: clone (in /usr/lib64/libc-2.17.so)
==15974==
```