### PR TITLE
Support for upgrading group configuration

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1723,26 +1723,26 @@ class Agent:
             delete_empty_lines(tmp_file_path)
             replace_line(tmp_file_path, 0, '')
         except Exception as e:
-            raise WazuhException(1005)
+            raise WazuhException(1005, str(e))
 
         # check xml format
         try:
             load_wazuh_xml(tmp_file_path)
         except Exception as e:
-            raise WazuhException(1742)
+            raise WazuhException(1742, str(e))
 
         # check Wazuh xml format
         try:
             check_output(['/var/ossec/bin/verify-agent-conf', '-f', tmp_file_path])
         except Exception as e:
-            raise WazuhException(1743)
+            raise WazuhException(1743, str(e))
 
         # move temporary file to group folder
         try:
             new_conf_path = common.shared_path + '/' + group_id + '/' + destination_file
             move(tmp_file_path, new_conf_path)
         except Exception as e:
-            raise WazuhException(1017)
+            raise WazuhException(1017, str(e))
 
         return {'msg': 'agent configuration was updated successfully'}
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1693,30 +1693,30 @@ class Agent:
 
         # create temporary file for parsing xml input
         try:
-            tmp_file = open(tmp_file_path, 'w')
-            # beauty xml file
-            xml = parseString(xml_file)
-            pretty_xml = xml.toprettyxml(indent='  ')  # two spaces for identation
-            tmp_file.write(pretty_xml)
-            tmp_file.close()
+            with open(tmp_file_path, 'w') as tmp_file:
+                # beauty xml file
+                xml = parseString(xml_file)
+                pretty_xml = xml.toprettyxml(indent='  ')  # two spaces for identation
+                tmp_file.write(pretty_xml)
         except Exception as e:
-            raise WazuhException(1005)
+            raise WazuhException(1005, str(e))
 
         # function to replace a line in a text file
         def replace_line(file_name, line_num, text):
-            lines = open(file_name, 'r').readlines()
+            with open(file_name) as f:
+                lines = f.readlines()
             lines[line_num] = text
-            out = open(file_name, 'w')
-            out.writelines(lines)
-            out.close()
+            with open(file_name, 'w') as out:
+                out.writelines(lines)
 
         def delete_empty_lines(file_name):
-            lines = open(file_name, 'r').readlines()
-            out = open(file_name, 'w')
-            for line in lines:
-                if not line.strip(): continue  # skip the empty line
-                out.write(line)
-            out.close()
+            with open(file_name) as f:
+                lines = f.readlines()
+
+            with open(file_name, 'w') as out:
+                for line in lines:
+                    if not line.strip(): continue  # skip the empty line
+                    out.write(line)
 
         # it is necessary to delete the first line and empty lines
         try:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1744,7 +1744,7 @@ class Agent:
         except Exception as e:
             raise WazuhException(1017, str(e))
 
-        return {'msg': 'agent configuration was updated successfully'}
+        return 'Agent configuration was updated successfully'
 
 
     @staticmethod

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -152,6 +152,10 @@ functions = {
         'function': configuration.upload_group_configuration,
         'type': 'local_master'
     },
+    'POST/agents/groups/:group_id/files/:file_name': {
+        'function': configuration.upload_group_file,
+        'type': 'local_master'
+    },
     'DELETE/agents/groups/:group_id': {
         'function': Agent.remove_group,
         'type': 'local_master'

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -149,7 +149,7 @@ functions = {
         'type': 'local_master'
     },
     'POST/agents/groups/:group_id/configuration': {
-        'function': Agent.upload_group_configuration,
+        'function': configuration.upload_group_configuration,
         'type': 'local_master'
     },
     'DELETE/agents/groups/:group_id': {

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -148,6 +148,10 @@ functions = {
         'function': Agent.create_group,
         'type': 'local_master'
     },
+    'POST/agents/groups/:group_id/configuration': {
+        'function': Agent.upload_group_configuration,
+        'type': 'local_master'
+    },
     'DELETE/agents/groups/:group_id': {
         'function': Agent.remove_group,
         'type': 'local_master'

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -650,13 +650,13 @@ def upload_group_configuration(group_id, xml_file):
             pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent='  ').split('\n')[1:])) + '\n'
             tmp_file.write(pretty_xml)
     except Exception as e:
-        raise WazuhException(1005, str(e))
+        raise WazuhException(1113, str(e))
 
     # check xml format
     try:
         load_wazuh_xml(tmp_file_path)
     except Exception as e:
-        raise WazuhException(1742, str(e))
+        raise WazuhException(1113, str(e))
 
     # check Wazuh xml format
     try:
@@ -669,7 +669,7 @@ def upload_group_configuration(group_id, xml_file):
         # Invalid element in the configuration: 'agent_conf'. Syscheck remote configuration in '/var/ossec/tmp/api_tmp_file_2019-01-08-01-1546959069.xml' is corrupted.
         output_regex = re.findall(pattern=r"\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} verify-agent-conf: ERROR: \(\d+\): "
                                           r"([\w \/ \_ \- \. ' :]+)", string=e.output)
-        raise WazuhException(1743, ' '.join(output_regex))
+        raise WazuhException(1114, ' '.join(output_regex))
     except Exception as e:
         raise WazuhException(1743, str(e))
 

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -407,6 +407,7 @@ def _rootkit_trojans2json(filepath):
 
     return data
 
+
 def _ar_conf2json(file_path):
     """
     Returns the lines of the ar.conf file
@@ -453,7 +454,7 @@ def get_ossec_conf(section=None, field=None):
     return data
 
 
-def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filename=None, format=None):
+def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filename=None, return_format=None):
     """
     Returns agent.conf as dictionary.
 
@@ -478,7 +479,7 @@ def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filenam
     try:       
 
         # Read RAW file
-        if agent_conf_name == 'agent.conf' and format and 'xml' in format:
+        if agent_conf_name == 'agent.conf' and return_format and 'xml' == return_format.lower():
             with open(agent_conf, 'r') as xml_data:
                 data = xml_data.read().replace('\n', '')
                 return data
@@ -491,8 +492,8 @@ def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filenam
     except Exception as e:
         raise WazuhException(1101, str(e))
 
-
     return {'totalItems': len(data), 'items': cut_array(data, offset, limit)}
+
 
 def get_agent_conf_multigroup(group_id=None, offset=0, limit=common.database_limit, filename=None):
     """
@@ -529,7 +530,7 @@ def get_agent_conf_multigroup(group_id=None, offset=0, limit=common.database_lim
     return {'totalItems': len(data), 'items': cut_array(data, offset, limit)}
 
 
-def get_file_conf(filename, group_id=None, type_conf=None, format=None):
+def get_file_conf(filename, group_id=None, type_conf=None, return_format=None):
     """
     Returns the configuration file as dictionary.
 
@@ -567,7 +568,7 @@ def get_file_conf(filename, group_id=None, type_conf=None, format=None):
             raise WazuhException(1104, "{0}. Valid types: {1}".format(type_conf, types.keys()))
     else:
         if filename == "agent.conf":
-            data = get_agent_conf(group_id, limit=None, filename=filename, format=format)
+            data = get_agent_conf(group_id, limit=None, filename=filename, return_format=return_format)
         elif filename == "rootkit_files.txt":
             data = _rootkit_files2json(file_path)
         elif filename == "rootkit_trojans.txt":
@@ -589,7 +590,6 @@ def parse_internal_options(high_name, low_name):
         config.readfp(str_config)
 
         return config
-
 
     if not os_path.exists(common.internal_options):
         raise WazuhException(1107)

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -682,6 +682,9 @@ def upload_group_file(group_id, xml_file, file_name):
     :param file_name: File name to update
     :return: Confirmation message in string
     """
+    if len(xml_file) == 0:
+        raise WazuhException(1112)
+
     if file_name == 'agent.conf':
         return upload_group_configuration(group_id, xml_file)
     else:

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -645,9 +645,9 @@ def upload_group_configuration(group_id, xml_file):
     try:
         with open(tmp_file_path, 'w') as tmp_file:
             # beauty xml file
-            xml = parseString(xml_file)
-            # remove first line (XML specification: <? xmlversion="1.0" ?>) and empty lines
-            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent='  ').split('\n')[1:])) + '\n'
+            xml = parseString('<root>' + xml_file + '</root>')
+            # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
+            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent='  ').split('\n')[2:-2])) + '\n'
             tmp_file.write(pretty_xml)
     except Exception as e:
         raise WazuhException(1113, str(e))

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -453,7 +453,7 @@ def get_ossec_conf(section=None, field=None):
     return data
 
 
-def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filename=None):
+def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filename=None, format=None):
     """
     Returns agent.conf as dictionary.
 
@@ -475,12 +475,19 @@ def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filenam
     if not os_path.exists(agent_conf):
         raise WazuhException(1006, agent_conf)
 
-    try:
-        # Read XML
-        xml_data = load_wazuh_xml(agent_conf)
+    try:       
 
+        # Read RAW file
+        if agent_conf_name == 'agent.conf' and format and 'xml' in format:
+            with open(agent_conf, 'r') as xml_data:
+                data = xml_data.read().replace('\n', '')
+                return data
         # Parse XML to JSON
-        data = _agentconf2json(xml_data)
+        else: 
+            # Read XML
+            xml_data = load_wazuh_xml(agent_conf)
+
+            data = _agentconf2json(xml_data)
     except Exception as e:
         raise WazuhException(1101, str(e))
 
@@ -522,7 +529,7 @@ def get_agent_conf_multigroup(group_id=None, offset=0, limit=common.database_lim
     return {'totalItems': len(data), 'items': cut_array(data, offset, limit)}
 
 
-def get_file_conf(filename, group_id=None, type_conf=None):
+def get_file_conf(filename, group_id=None, type_conf=None, format=None):
     """
     Returns the configuration file as dictionary.
 
@@ -560,7 +567,7 @@ def get_file_conf(filename, group_id=None, type_conf=None):
             raise WazuhException(1104, "{0}. Valid types: {1}".format(type_conf, types.keys()))
     else:
         if filename == "agent.conf":
-            data = get_agent_conf(group_id, limit=None, filename=filename)
+            data = get_agent_conf(group_id, limit=None, filename=filename, format=format)
         elif filename == "rootkit_files.txt":
             data = _rootkit_files2json(file_path)
         elif filename == "rootkit_trojans.txt":

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -625,8 +625,13 @@ def get_internal_options_value(high_name, low_name, max, min):
     return option
 
 
-def upload_group_configuration(group_id, xml_file, destination_file='agent.conf'):
-
+def upload_group_configuration(group_id, xml_file):
+    """
+    Updates group configuration
+    :param group_id: Group to update
+    :param xml_file: File contents of the new configuration in string.
+    :return: Confirmation message.
+    """
     # check if the group exists
     if not Agent.group_exists(group_id):
         raise WazuhException(1710)
@@ -660,9 +665,24 @@ def upload_group_configuration(group_id, xml_file, destination_file='agent.conf'
 
     # move temporary file to group folder
     try:
-        new_conf_path = "{}/{}/{}".format(common.shared_path, group_id, destination_file)
+        new_conf_path = "{}/{}/agent.conf".format(common.shared_path, group_id)
         move(tmp_file_path, new_conf_path)
     except Exception as e:
         raise WazuhException(1017, str(e))
 
     return 'Agent configuration was updated successfully'
+
+
+def upload_group_file(group_id, xml_file, file_name):
+    """
+    Updates a group file
+
+    :param group_id: Group to update
+    :param xml_file: File contents in string
+    :param file_name: File name to update
+    :return: Confirmation message in string
+    """
+    if file_name == 'agent.conf':
+        return upload_group_configuration(group_id, xml_file)
+    else:
+        raise WazuhException(1111)

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -697,10 +697,14 @@ def upload_group_file(group_id, xml_file, file_name):
     :param file_name: File name to update
     :return: Confirmation message in string
     """
-    if len(xml_file) == 0:
-        raise WazuhException(1112)
-
     if file_name == 'agent.conf':
-        return upload_group_configuration(group_id, xml_file)
+        with open(xml_file) as f:
+            xml_file_data = f.read()
+
+        remove(xml_file)
+        if len(xml_file_data) == 0:
+            raise WazuhException(1112)
+
+        return upload_group_configuration(group_id, xml_file_data)
     else:
         raise WazuhException(1111)

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -41,6 +41,7 @@ class WazuhException(Exception):
         1108: 'Value not found in internal_options.conf',
         1109: 'Option must be a digit',
         1110: 'Option value is out of the limits',
+        1111: "Remote group file updates are only available in 'agent.conf' file",
 
         # Rule: 1200 - 1299
         1200: 'Error reading rules from ossec.conf',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -129,7 +129,6 @@ class WazuhException(Exception):
         1740: 'Action only available for active agents',
         1741: 'Could not remove multigroup',
         1742: 'Error running Wazuh syntax validator',
-        1743: 'File for updating agent.conf is wrong',
 
         # Manager:
 

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -42,6 +42,7 @@ class WazuhException(Exception):
         1109: 'Option must be a digit',
         1110: 'Option value is out of the limits',
         1111: "Remote group file updates are only available in 'agent.conf' file",
+        1112: "Empty files aren't supported",
 
         # Rule: 1200 - 1299
         1200: 'Error reading rules from ossec.conf',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -128,7 +128,8 @@ class WazuhException(Exception):
         1739: "Error getting agent's group sync",
         1740: 'Action only available for active agents',
         1741: 'Could not remove multigroup',
-        1742: 'Error running Wazuh syntax validator',
+        1742: 'Error running XML syntax validator',
+        1743: 'Error running Wazuh syntax validator',
 
         # Manager:
 

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -43,6 +43,8 @@ class WazuhException(Exception):
         1110: 'Option value is out of the limits',
         1111: "Remote group file updates are only available in 'agent.conf' file",
         1112: "Empty files aren't supported",
+        1113: "XML syntax error",
+        1114: "Wazuh syntax error",
 
         # Rule: 1200 - 1299
         1200: 'Error reading rules from ossec.conf',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -27,6 +27,7 @@ class WazuhException(Exception):
         1013: 'Unable to connect with socket',
         1014: 'Error communicating with socket',
         1015: 'Error agent version is null. Was the agent ever connected?',
+        1016: 'Error moving file',
 
         # Configuration: 1100 - 1199
         1100: 'Error checking configuration',
@@ -127,6 +128,7 @@ class WazuhException(Exception):
         1739: "Error getting agent's group sync",
         1740: 'Action only available for active agents',
         1741: 'Could not remove multigroup',
+        1742: 'Error running Wazuh syntax validator',
 
         # Manager:
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -672,7 +672,7 @@ InstallCommon(){
         ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/bin
     fi
 
-  ${INSTALL} -d -m 0750 -o root -g 0 ${PREFIX}/lib
+  ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/lib
 
     if [ ${NUNAME} = 'Darwin' ]
     then
@@ -682,7 +682,7 @@ InstallCommon(){
         fi
     elif [ -f libwazuhext.so ]
     then
-        ${INSTALL} -m 0750 -o root -g 0 libwazuhext.so ${PREFIX}/lib
+        ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} libwazuhext.so ${PREFIX}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ ${DIST_VER} -le 5 ]; then
             chcon -t textrel_shlib_t ${PREFIX}/lib/libwazuhext.so
@@ -726,7 +726,7 @@ InstallCommon(){
          ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} /etc/localtime ${PREFIX}/etc
     fi
 
-  ${INSTALL} -d -m 1750 -o root -g ${OSSEC_GROUP} ${PREFIX}/tmp
+  ${INSTALL} -d -m 1770 -o root -g ${OSSEC_GROUP} ${PREFIX}/tmp
 
     if [ -f /etc/TIMEZONE ]; then
          ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} /etc/TIMEZONE ${PREFIX}/etc/
@@ -820,7 +820,7 @@ InstallLocal(){
     ${INSTALL} -m 0750 -o root -g 0 ossec-csyslogd ${PREFIX}/bin
     ${INSTALL} -m 0750 -o root -g 0 ossec-dbd ${PREFIX}/bin
     ${INSTALL} -m 0750 -o root -g 0 ossec-makelists ${PREFIX}/bin
-    ${INSTALL} -m 0750 -o root -g 0 verify-agent-conf ${PREFIX}/bin/
+    ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} verify-agent-conf ${PREFIX}/bin/
     ${INSTALL} -m 0750 -o root -g 0 clear_stats ${PREFIX}/bin/
     ${INSTALL} -m 0750 -o root -g 0 ossec-regex ${PREFIX}/bin/
     ${INSTALL} -m 0750 -o root -g 0 syscheck_update ${PREFIX}/bin/


### PR DESCRIPTION
Hi team,

This PR is for the new API call in PR [#257](https://github.com/wazuh/wazuh-api/pull/257).

With this PR it is possible to upgrade groups configurations with an API call as the next:

```bash
curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "http://localhost:55000/agents/groups/dmz/configuration?pretty"
```

We check if the new configuration is valid before update the group configuration by executing our binary `verify-agent-conf` over the new configuration file.

Best regards,

Demetrio.
