### PR TITLE
New format for AWS Inspector alerts

### DIFF
--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -310,7 +310,7 @@ ID: 80200 - 80499
 
     <rule id="80495" level="0">
         <if_sid>80200</if_sid>
-        <field name="aws.service">Inspector</field>
+        <field name="aws.source">inspector</field>
         <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
     </rule>

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -1732,6 +1732,20 @@ class AWSInspector(AWSService):
         self.db_connector.commit()
         self.close_db()
 
+    def format_message(self, msg):
+        return {'integration': 'aws', 'aws': self.reformat_msg(msg)}
+
+    def reformat_msg(self, event):
+        # format createdAt field
+        if 'createdAt' in event:
+            event['createdAt'] = datetime.strftime(event['createdAt'],
+                '%Y-%m-%dT%H:%M:%SZ')
+        # format updatedAt field
+        if 'updatedAt' in event:
+            event['updatedAt'] = datetime.strftime(event['updatedAt'],
+            '%Y-%m-%dT%H:%M:%SZ')
+        return event
+
 
 ################################################################################
 # Functions

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -1653,9 +1653,6 @@ class AWSService(WazuhIntegration):
                                 scan_date DESC
                                 LIMIT {retain_db_records})"""
 
-    def format_message(self, msg):
-        return {'integration': 'aws', 'aws': msg}
-
     def get_last_log_date(self):
         return '{Y}-{m}-{d} 00:00:00.0'.format(Y=self.only_logs_after[0:4],
             m=self.only_logs_after[4:6], d=self.only_logs_after[6:8])
@@ -1733,18 +1730,20 @@ class AWSInspector(AWSService):
         self.close_db()
 
     def format_message(self, msg):
-        return {'integration': 'aws', 'aws': self.reformat_msg(msg)}
-
-    def reformat_msg(self, event):
-        # format createdAt field
-        if 'createdAt' in event:
-            event['createdAt'] = datetime.strftime(event['createdAt'],
+        # rename service field to source
+        if 'service' in msg:
+            msg['source'] = msg['service'].lower()
+            del msg['service']
+        # cast createdAt
+        if 'createdAt' in msg:
+            msg['createdAt'] = datetime.strftime(msg['createdAt'],
                 '%Y-%m-%dT%H:%M:%SZ')
-        # format updatedAt field
-        if 'updatedAt' in event:
-            event['updatedAt'] = datetime.strftime(event['updatedAt'],
+        # cast updatedAt
+        if 'updatedAt' in msg:
+            msg['updatedAt'] = datetime.strftime(msg['updatedAt'],
             '%Y-%m-%dT%H:%M:%SZ')
-        return event
+
+        return {'integration': 'aws', 'aws': msg}
 
 
 ################################################################################


### PR DESCRIPTION
Hi team,

There was some problems to visualize alerts from `AWS Inspector` in our `Kibana` app (#2067).

Fields `aws.updatedAt` and `aws.createdAt` were reformatted for avoid this problems (date format caused a problem in Elastic template). Furthermore, field `aws.service` was renamed to `aws.source` in order to be equal as other `AWS` services.

Rules for `AWS` were updated due of the change of `aws.service` to `aws.source`.

Best regards,

Demetrio.