### PR TITLE
Retrieve whodata configuration section for syscheck

### DIFF
--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -205,8 +205,10 @@ cJSON *getSyscheckConfig(void) {
         for (i=0;syscheck.audit_key[i];i++) {
             cJSON_AddItemToArray(audkey, cJSON_CreateString(syscheck.audit_key[i]));
         }
-        cJSON_AddItemToObject(whodata,"audit_key",audkey);
-        cJSON_AddItemToObject(syscfg,"whodata",whodata);
+        if (cJSON_GetArraySize(audkey) > 0) {
+            cJSON_AddItemToObject(whodata,"audit_key",audkey);
+            cJSON_AddItemToObject(syscfg,"whodata",whodata);
+        }
     }
 #ifdef WIN32
     cJSON_AddNumberToObject(syscfg,"windows_audit_interval",syscheck.wdata.interval_scan);

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -199,6 +199,15 @@ cJSON *getSyscheckConfig(void) {
         }
         cJSON_AddItemToObject(syscfg,"ignore",igns);
     }
+    cJSON *whodata = cJSON_CreateObject();
+    if (syscheck.audit_key) {
+        cJSON *audkey = cJSON_CreateArray();
+        for (i=0;syscheck.audit_key[i];i++) {
+            cJSON_AddItemToArray(audkey, cJSON_CreateString(syscheck.audit_key[i]));
+        }
+        cJSON_AddItemToObject(whodata,"audit_key",audkey);
+        cJSON_AddItemToObject(syscfg,"whodata",whodata);
+    }
 #ifdef WIN32
     cJSON_AddNumberToObject(syscfg,"windows_audit_interval",syscheck.wdata.interval_scan);
     if (syscheck.registry) {


### PR DESCRIPTION
Hi, Team,

This PR solves the issue https://github.com/wazuh/wazuh/issues/2172, on the core side. Some changes may be needed on the APP side too.

The command `curl -u foo:bar -k http://127.0.0.1:55000/agents/000/config/syscheck/syscheck?pretty` shows the `whodata` part in the JSON data as:
```
         (...)
         "whodata": {
            "audit_key": [
               "auditkey1",
               "auditkey2"
            ]
         },
         (...)
```
Unless any of these XML elements is empty, for example:
-  `<whodata></whodata>`
- `<audit_key></audit_key>`

In these cases, `whodata` is not present in the JSON output.

Regards.
