### PR TITLE
Fix socket timeout setup in agent running on Windows

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -97,7 +97,11 @@ int connect_server(int initial_id)
 
         if (agt->sock < 0) {
             agt->sock = -1;
+#ifdef WIN32
+            merror(CONNS_ERROR, tmp_str, win_strerror(WSAGetLastError()));
+#else
             merror(CONNS_ERROR, tmp_str, strerror(errno));
+#endif
             rc++;
 
             if (agt->server[rc].rip == NULL) {

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -274,7 +274,9 @@ static int OS_Connect(u_int16_t _port, unsigned int protocol, const char *_ip, i
         server.sin_addr.s_addr = inet_addr(_ip);
 
         if (connect(ossock, (struct sockaddr *)&server, sizeof(server)) < 0) {
+            int error = WSAGetLastError();
             OS_CloseSocket(ossock);
+            WSASetLastError(error);
             return (OS_SOCKTERR);
         }
     }

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -518,14 +518,24 @@ int OS_CloseSocket(int socket)
 
 int OS_SetRecvTimeout(int socket, long seconds, long useconds)
 {
+#ifdef WIN32
+    DWORD ms = seconds * 1000 + useconds / 1000;
+    return setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const void *)&ms, sizeof(ms));
+#else
     struct timeval tv = { seconds, useconds };
     return setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const void *)&tv, sizeof(tv));
+#endif
 }
 
 int OS_SetSendTimeout(int socket, int seconds)
 {
+#ifdef WIN32
+    DWORD ms = seconds * 1000;
+    return setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, (const void *)&ms, sizeof(ms));
+#else
     struct timeval tv = { seconds, 0 };
     return setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, (const void *)&tv, sizeof(tv));
+#endif
 }
 
 /* Send secure TCP message


### PR DESCRIPTION
Per these documentation pages:
- Windows: https://docs.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-setsockopt
- Linux: https://linux.die.net/man/7/socket

The socket timeout setup function, `setsockopt()` expects the parameter value with different type, depending on the platform:

- UNIX: `struct timeval`
- Windows: `DWORD`

This PR aims to fix the socket timeout in agents running on Windows. This probably fixes #2184.

It also makes the agent describe a connection problem. So it replaces:
```
ERROR: (1216): Unable to connect to '192.168.33.10': 'No error'.
```
with:
```
ERROR: (1216): Unable to connect to '192.168.33.10': 'No connection could be made because the target machine actively refused it.'.
```