### PR TITLE
Added logs and temporary files to ignore in FIM

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -87,6 +87,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
 
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>
 

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -88,7 +88,7 @@
     <ignore>/sys/kernel/debug</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -101,6 +101,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
 
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>
 

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -102,7 +102,7 @@
     <ignore>/sys/kernel/debug</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -101,6 +101,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
 
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -102,7 +102,7 @@
     <ignore>/sys/kernel/debug</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -123,7 +123,7 @@
     <ignore>/sys/kernel/debug</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -122,6 +122,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
 
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>
 

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -26,7 +26,7 @@
     <ignore>/etc/svc/volatile</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -25,6 +25,9 @@
     <ignore>/etc/dumpdates</ignore>
     <ignore>/etc/svc/volatile</ignore>
 
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>
 

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -34,7 +34,7 @@
     <ignore>/sys/kernel/debug</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -33,6 +33,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
 
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>
 

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -28,7 +28,7 @@
     <ignore>/sys/kernel/debug</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -27,6 +27,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
 
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>
 

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -34,7 +34,7 @@
     <ignore>/sys/kernel/debug</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -33,6 +33,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
 
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swx$|.swp$</ignore>
+
     <!-- Check the file, but never compute the diff -->
     <nodiff>/etc/ssl/private.key</nodiff>
 


### PR DESCRIPTION
## Related issues:
- Warning messages when using Whodata & realtime v3.7.2 #2188

## Description:
Added ignore tag for logs and temporary files in FIM to prevent warning messages.