### PR TITLE
Fixes bytes literals issue

### DIFF
--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_localhost_ips():
-    return set(str(check_output(['hostname', '--all-ip-addresses'])).split(" ")[:-1])
+    return set(str(check_output(['hostname', '--all-ip-addresses']).decode()).split(" ")[:-1]) 
 
 
 def check_cluster_config(config):

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_localhost_ips():
-    return set(str(check_output(['hostname', '--all-ip-addresses']).decode()).split(" ")[:-1]) 
+    return set(str(check_output(['hostname', '--all-ip-addresses']).decode()).split(" ")[:-1])
 
 
 def check_cluster_config(config):


### PR DESCRIPTION
The subprocess returns bytes, which need to be decoded. This fixes an issue I was encountering where the following error message was being returned:


```
ERROR: Error 3004 - Error in cluster configuration: Master IP not valid. Valid ones are: b'<REDACTED IP>
```