### PR TITLE
Add date information to the name of backups generated by Wazuh-db

### DIFF
--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -108,7 +108,7 @@ int wdb_create_backup(const char * agent_id, int version) {
         return -1;
     }
 
-    snprintf(path, OS_FLSIZE, "%s/%s.db-oldv%d", WDB2_DIR, agent_id, version);
+    snprintf(path, OS_FLSIZE, "%s/%s.db-oldv%d-%lu", WDB2_DIR, agent_id, version, (unsigned long)time(NULL));
 
     if (!(dest = fopen(path, "w"))) {
         merror("Couldn't open dest '%s': %s (%d)", path, strerror(errno), errno);


### PR DESCRIPTION
In order to prevent the deletion of the contents of a database when generating a backup, the timestamp is added to the name generated by Wazuh-db.

This case may occur when an error occurs several times when generating the new database schema. In case of generating a second backup, overwrite the first one. 
