### PR TITLE
Default values for auto-ignore parameters

### DIFF
--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -58,6 +58,8 @@ int GlobalConf(const char *cfgfile)
     Config.keeplogdate = 0;
     Config.syscheck_alert_new = 0;
     Config.syscheck_auto_ignore = 1;
+    Config.syscheck_ignore_frequency = 10;
+    Config.syscheck_ignore_time = 3600;
     Config.ar = 0;
 
     Config.syscheck_ignore = NULL;

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -57,7 +57,7 @@ int GlobalConf(const char *cfgfile)
     Config.mailnotify = -1;
     Config.keeplogdate = 0;
     Config.syscheck_alert_new = 0;
-    Config.syscheck_auto_ignore = 1;
+    Config.syscheck_auto_ignore = 0;
     Config.syscheck_ignore_frequency = 10;
     Config.syscheck_ignore_time = 3600;
     Config.ar = 0;

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -54,8 +54,6 @@ int Read_GlobalSK(XML_NODE node, void *configp, __attribute__((unused)) void *ma
             merror(XML_VALUENULL, node[i]->element);
             return (OS_INVALID);
         } else if (strcmp(node[i]->element, xml_auto_ignore) == 0) {
-            Config->syscheck_ignore_frequency = 10;
-            Config->syscheck_ignore_time = 3600;
             if (strcmp(node[i]->content, "yes") == 0) {
                 Config->syscheck_auto_ignore = 1;
             } else if (strcmp(node[i]->content, "no") == 0) {


### PR DESCRIPTION
Setting default values for auto-ignore parameters when doesn't any block of FIM had configured