### PR TITLE
Fix internal error in agent_groups tool

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -70,7 +70,7 @@ def show_agents_with_group(group_id):
     else:
         print("{0} agent(s) in group '{1}':".format(agents_data['totalItems'], group_id))
         for agent in agents_data['items']:
-            print("  ID: {0}  Name: {1}. {2}".format(agent['id'], agent['name'], agent['multi_group']))
+            print("  ID: {0}  Name: {1}. {2}".format(agent['id'], agent['name'], '*' if len(agent['group']) > 1 else ''))
 
 
 def show_group_files(group_id):


### PR DESCRIPTION
This PR aims to fix the following error when querying the list of agents belonging to a group on `agent_groups`:

```shellsession
# agent_groups -g default -ld
1 agent(s) in group 'default':
Internal error: 'multi_group'
Traceback (most recent call last):
  File "/var/ossec/bin/agent_groups", line 308, in <module>
    main()
  File "/var/ossec/bin/agent_groups", line 264, in main
    show_agents_with_group(arguments['group'])
  File "/var/ossec/bin/agent_groups", line 73, in show_agents_with_group
    print("  ID: {0}  Name: {1}. {2}".format(agent['id'], agent['name'], agent['multi_group']))
KeyError: 'multi_group'
```

## Expected behavior

If the agent belongs to multiple groups (including the selected group), the agent will appear with a trailing asterisk (`*`):

```shellsession
# agent_groups -g default -ld
1 agent(s) in group 'default':
  ID: 001  Name: centos. *
```

If the agent belongs only to the selected group, the agent will appear without such asterisk:

```shellsession
# agent_groups -g default -ld
1 agent(s) in group 'default':
  ID: 001  Name: centos.
```
