### PR TITLE
Error updating database in Wazuh-db

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -200,12 +200,13 @@ wdb_t * wdb_open_agent2(int agent_id) {
     }
     else {
         wdb = wdb_init(db, sagent_id);
+        wdb_pool_append(wdb);
 
         if (new_wdb = wdb_upgrade(wdb), new_wdb != NULL) {
             // If I had to generate backup and change DB
             wdb = new_wdb;
+            wdb_pool_append(wdb);
         }
-        wdb_pool_append(wdb);
     }
 
 success:

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -26,14 +26,13 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
     //All cases must contain /* Fallthrough */ except the last one that needs to break;
     switch(version) {
     case 0:
-        mdebug2("Updating database for agent %s", wdb->agent_id);
+        mdebug2("Updating database for agent %s to version 1", wdb->agent_id);
         if(result = wdb_sql_exec(wdb, schema_upgrade_v1_sql), result == -1) {
             new_wdb = wdb_backup(wdb, version);
         }
         /* Fallthrough */
     case 1:
         //Updated to last version
-        mdebug2("Database updated for agent %s", wdb->agent_id);
         break;
     default:
         merror("Incorrect database version %d", version);
@@ -54,7 +53,7 @@ wdb_t * wdb_backup(wdb_t *wdb, int version) {
 
     if (wdb_close(wdb) != -1) {
         if (wdb_create_backup(sagent_id, version) != -1) {
-            mwarn("Creating DB backup and create clear DB for agent: '%s'", wdb->agent_id);
+            mwarn("Creating DB backup and create clear DB for agent: '%s'", sagent_id);
             unlink(path);
 
             //Recreate DB
@@ -79,8 +78,6 @@ wdb_t * wdb_backup(wdb_t *wdb, int version) {
             if (wdb_scan_info_init(new_wdb) < 0) {
                 mwarn("Couldn't initialize scan_info table in '%s'", path);
             }
-            
-            wdb_pool_append(new_wdb);
         }
     } else {
         merror("Couldn't create SQLite database backup for agent '%s'", sagent_id);


### PR DESCRIPTION
An error was discovered when Wazuh-db tried to update an already updated database.

To reproduce the error in a clean installation version 3.8 rev 3800 and after Wazuh-db has created the administrator database:
- Stop the manager.
- Modify the value of the db_version field to 0 manually.
- Start the manager.

This will take you to the next point:
`wdb.c:562 at wdb_pool_append(): CRITICAL: OSHash_Add(000) returned 1.`