### PR TITLE
Make FIM alert new files by default

### DIFF
--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -56,7 +56,7 @@ int GlobalConf(const char *cfgfile)
     Config.memorysize = 8192;
     Config.mailnotify = -1;
     Config.keeplogdate = 0;
-    Config.syscheck_alert_new = 0;
+    Config.syscheck_alert_new = 1;
     Config.syscheck_auto_ignore = 1;
     Config.ar = 0;
 


### PR DESCRIPTION
This PR makes this option apply by default:

```xml
<syscheck>
  <alert_new_files>yes</alert_new_files>
</syscheck>
```