### PR TITLE
Fix invalid keys structure size on ARM architecture

### DIFF
--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -7,9 +7,8 @@
  * Foundation
  */
 
-#include <pthread.h>
-
 #include "shared.h"
+#include <pthread.h>
 #include "remoted.h"
 #include "os_net/os_net.h"
 

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -16,8 +16,8 @@
 #define ARGV0 "wazuh-modulesd"
 #endif // ARGV0
 
-#include <pthread.h>
 #include "shared.h"
+#include <pthread.h>
 #include "config/config.h"
 
 #define WM_DEFAULT_DIR  DEFAULTDIR "/wodles"        // Default modules directory.


### PR DESCRIPTION
Data corruption at database synchronization modulea and Remoted
The structure `keys` was 44-byte long while it should be 48-byte long.
The member `inode` was 4-byte long when it should be 8-byte long.

This produces a segmentation fault in Modulesd and a sending error in Remoted.

Related topic: https://groups.google.com/forum/#!topic/wazuh/fYDpX_r_3KU