### PR TITLE
Fix bug in regex when input string has no extra bytes

### DIFF
--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -288,7 +288,7 @@ static const char *_OS_Regex(const char *pattern, const char *str, const char **
                             prts_int = 0;
                             while (prts_closure[prts_int]) {
                                 if (prts_closure[prts_int] == (next_pt - 1)) {
-                                    if (*(st + 1) == '\0') {
+                                    if (_regex_matched) {
                                         prts_str[prts_int] = st + 1;
                                     } else {
                                         prts_str[prts_int] = st;


### PR DESCRIPTION
|Fixes|
|---|
|#2091|

If the last group of a regex had a termination character and the input ended with that group, then such byte was extracted as part of the group.

For instance:

```shellsession
$ echo 'key="hello"' | ./ossec-regex 'key="(\S+)"'
+OSRegex_Execute: key="hello"
 -Substring: hello"
```

Note the extra `"` in the result, that should not belong to the group.

The regex executor checked that the input string ended with the group, but it failed if the group had a terminator. IMHO the correct condition to match a (candidate) group end is that the regex has matched.

## Tests

```shellsession
$ echo "failed: ttyq4 changing from ldap to root" | ./ossec-regex '^failed: \S+ changing from (\S+) to (\S+)'
+OSRegex_Execute: failed: ttyq4 changing from ldap to root
 -Substring: ldap
 -Substring: root
 
$ echo 'key="hello' | ./ossec-regex 'key="(\S+)'
+OSRegex_Execute: key="hello
 -Substring: hello
 
$ echo 'key="hello"' | ./ossec-regex 'key="(\S+)"'
+OSRegex_Execute: key="hello"
 -Substring: hello
 
$ echo 'key="hello".' | ./ossec-regex 'key="(\S+)"'
+OSRegex_Execute: key="hello".
 -Substring: hello
```

I've also checked the ruleset tests, but they depend on https://github.com/wazuh/wazuh-ruleset/pull/252.