### PR TITLE
Fixed an error when wazuh-db non updating any database

### DIFF
--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -17,7 +17,7 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
     char db_version[OS_SIZE_256 + 2];
     int version = 0;
     int result = 0;
-    wdb_t *new_wdb = wdb;
+    wdb_t *new_wdb = NULL;
 
     if(result = wdb_metadata_get_entry(wdb, "db_version", db_version), result) {
         version = atoi(db_version);


### PR DESCRIPTION
If there are no databases to update or if it is updated correctly and a new database is not generated, `wdb_upgrade` returns NULL to continue with the existing one.