### PR TITLE
Show rule variables

### DIFF
--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -423,8 +423,7 @@ class Rule:
                                     for variable in root.findall('var'):
                                         if variable.get('name') == value[1:]:
                                             values = variable.text.replace('|', ',')
-                                            variables = {'variables': {value[1:]: values}}
-                                            rule.add_detail(tag, variables)
+                                            rule.add_detail(tag, values)
                                             break
                                 else:
                                     rule.add_detail(tag, value)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -419,11 +419,11 @@ class Rule:
                                 elif tag == "field":
                                     rule.add_detail(xml_rule_tags.attrib['name'], value)
                                 # show rule variables
-                                elif tag == "match" and value[0] == "$":
+                                elif (tag == "match" and value[0] == "$") or \
+                                    (tag == "regex" and value[0] == "$"):
                                     for variable in root.findall('var'):
                                         if variable.get('name') == value[1:]:
-                                            values = variable.text.replace('|', ',')
-                                            rule.add_detail(tag, values)
+                                            rule.add_detail(tag, variable.text)
                                             break
                                 else:
                                     rule.add_detail(tag, value)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -418,6 +418,14 @@ class Rule:
                                     rule.description += value
                                 elif tag == "field":
                                     rule.add_detail(xml_rule_tags.attrib['name'], value)
+                                # show rule variables
+                                elif tag == "match" and value[0] == "$":
+                                    for variable in root.findall('var'):
+                                        if variable.get('name') == value[1:]:
+                                            values = variable.text.replace('|', ',')
+                                            variables = {'variables': {value[1:]: values}}
+                                            rule.add_detail(tag, variables)
+                                            break
                                 else:
                                     rule.add_detail(tag, value)
 

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -419,12 +419,9 @@ class Rule:
                                 elif tag == "field":
                                     rule.add_detail(xml_rule_tags.attrib['name'], value)
                                 # show rule variables
-                                elif (tag == "match" and value[0] == "$") or \
-                                    (tag == "regex" and value[0] == "$"):
-                                    for variable in root.findall('var'):
-                                        if variable.get('name') == value[1:]:
-                                            rule.add_detail(tag, variable.text)
-                                            break
+                                elif tag in {'regex', 'match', 'user', 'id'} and value != '' and value[0] == "$":
+                                    for variable in filter(lambda x: x.get('name') == value[1:], root.findall('var')):
+                                        rule.add_detail(tag, variable.text)
                                 else:
                                     rule.add_detail(tag, value)
 


### PR DESCRIPTION
Hi team,

This PR is for API issue [#253](https://github.com/wazuh/wazuh-api/issues/253). Rule variables weren't shown (`$BAD_WORDS`):
```bash
$ curl -u foo:bar -X GET "http://localhost:55000/rules/1002?pretty"
{
  "error": 0,
  "data": {
     "items": [
        {
           "file": "0020-syslog_rules.xml",
           "path": "/var/ossec/ruleset/rules",
           "id": 1002,
           "level": 2,
           "description": "Unknown problem somewhere in the system.",
           "status": "enabled",
           "groups": [
              "gpg13_4.3",
              "syslog",
              "errors"
           ],
           "pci": [],
           "gdpr": [],
           "details": {
              "match": "$BAD_WORDS"
           }
        }
     ],
     "totalItems": 1
  }
}
```

With this fix, the content of the variable `BAD_WORDS` is shown:

```bash
curl -u foo:bar -X GET "http://localhost:55000/rules/1002?pretty"
{
   "error": 0,
   "data": {
      "items": [
         {
            "file": "0020-syslog_rules.xml",
            "path": "/var/ossec/ruleset/rules",
            "id": 1002,
            "level": 2,
            "description": "Unknown problem somewhere in the system.",
            "status": "enabled",
            "groups": [
               "gpg13_4.3",
               "syslog",
               "errors"
            ],
            "pci": [],
            "gdpr": [],
            "details": {
               "match": "core_dumped|failure|error|attack| bad |illegal |denied|refused|unauthorized|fatal|failed|Segmentation Fault|Corrupted"
            }
         }
      ],
      "totalItems": 1
   }
}
```

Best regards,

Demetrio.