### PR TITLE
Fix for missing keys in default group

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -390,7 +390,7 @@ def _rootkit_trojans2json(filepath):
     # file_name !string_to_search!Description
     regex_comment = re.compile("^\s*#")
     regex_check = re.compile("^\s*(.+)\s+!\s*(.+)\s*!\s*(.+)")
-    regex_binary_check = re.compile("^\s*(.+)\s+!\s*(.+)")
+    regex_binary_check = re.compile("^\s*(.+)\s+!\s*(.+)\s*!")
 
     try:
         with open(filepath) as f:
@@ -403,9 +403,8 @@ def _rootkit_trojans2json(filepath):
                 if match_check:
                     new_check = {'filename': match_check.group(1).strip(), 'name': match_check.group(2).strip(), 'description': match_check.group(3).strip()}
                     data.append(new_check)
-                    continue
-                if match_binary_check:
-                    new_check = {'binary': match_binary_check.group(1).strip(), 'check': match_binary_check.group(2).strip()}
+                elif match_binary_check:
+                    new_check = {'filename': match_binary_check.group(1).strip(), 'name': match_binary_check.group(2).strip()}
                     data.append(new_check)
 
 

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -403,8 +403,9 @@ def _rootkit_trojans2json(filepath):
                 if match_check:
                     new_check = {'filename': match_check.group(1).strip(), 'name': match_check.group(2).strip(), 'description': match_check.group(3).strip()}
                     data.append(new_check)
-                if match_binary_check and not match_check:
-                    new_check = {'binary': match_binary_check.group(1).strip(), 'entries': match_binary_check.group(2).strip()}
+                    continue
+                if match_binary_check:
+                    new_check = {'binary': match_binary_check.group(1).strip(), 'check': match_binary_check.group(2).strip()}
                     data.append(new_check)
 
 

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -390,6 +390,7 @@ def _rootkit_trojans2json(filepath):
     # file_name !string_to_search!Description
     regex_comment = re.compile("^\s*#")
     regex_check = re.compile("^\s*(.+)\s+!\s*(.+)\s*!\s*(.+)")
+    regex_binary_check = re.compile("^\s*(.+)\s+!\s*(.+)")
 
     try:
         with open(filepath) as f:
@@ -397,10 +398,15 @@ def _rootkit_trojans2json(filepath):
                 if re.search(regex_comment, line):
                     continue
 
-                match_check= re.search(regex_check, line)
+                match_check = re.search(regex_check, line)
+                match_binary_check = re.search(regex_binary_check, line)
                 if match_check:
                     new_check = {'filename': match_check.group(1).strip(), 'name': match_check.group(2).strip(), 'description': match_check.group(3).strip()}
                     data.append(new_check)
+                if match_binary_check and not match_check:
+                    new_check = {'binary': match_binary_check.group(1).strip(), 'entries': match_binary_check.group(2).strip()}
+                    data.append(new_check)
+
 
     except Exception as e:
         raise WazuhException(1101, str(e))


### PR DESCRIPTION
Hi team,

This PR is for API issue [#261](https://github.com/wazuh/wazuh-api/issues/261). Entries as the next weren't been shown with API call `curl -u foo:bar -X GET "localhost:55000/agents/groups/default/files/rootkit_trojans.txt?pretty"`:

```bash
# Trojan entries for common daemons
sendmail    !bash|fuck!
named       !bash|blah|/dev/[0-9]|^/bin/sh!
inetd       !bash|^/bin/sh|file\.h|proc\.h|/dev/[^un%]|^/bin/.*sh!
apachectl   !bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh!
sshd        !check_global_passwd|panasonic|satori|vejeta|\.ark|/hash\.zk|bash|/dev[a-s]|/dev[A-Z]/!
syslogd     !bash|/usr/lib/pt07|/dev/[^cln]]|syslogs\.h|proc\.h!
xinetd      !bash|file\.h|proc\.h!
in.telnetd  !cterm100|vt350|VT100|ansi-term|bash|^/bin/sh|/dev[A-R]|/dev/[a-z]/!
in.fingerd  !bash|^/bin/sh|cterm100|/dev/!
identd      !bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh!
init        !bash|/dev/h
tcpd        !bash|proc\.h|p1r0c4|hack|/dev/[^n]!
rlogin      !p1r0c4|r00t|bash|/dev/[^nt]!

# Kill trojan
killall     !/dev/[^t%]|proc\.h|bash|tmp!
kill        !/dev/[ab,d-k,m-z]|/dev/[F-Z]|/dev/[A-D]|/dev/[0-9]|proc\.h|bash|tmp!
```

With this PR, we got these entries:
```bash
curl -u foo:bar -X GET "localhost:55000/agents/groups/default/files/rootkit_trojans.txt?pretty" 
{
   "error": 0,
   "data": [
      {
         "binary": "ls",
         "check": "bash|^/bin/sh|dev/[^clu]|\\.tmp/lsfile|duarawkz|/prof|/security|file\\.h!"
      },
      {
         "binary": "env",
         "check": "bash|^/bin/sh|file\\.h|proc\\.h|/dev/|^/bin/.*sh!"
      },
      {
         "binary": "echo",
         "check": "bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^cl]|^/bin/.*sh!"
      },
      {
         "binary": "chown",
         "check": "bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^cl]|^/bin/.*sh!"
      },
```

Best regards,

Demetrio.