### PR TITLE
Fix bug in regex when the group terminator is escaped

### DIFF
--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -288,7 +288,7 @@ static const char *_OS_Regex(const char *pattern, const char *str, const char **
                             prts_int = 0;
                             while (prts_closure[prts_int]) {
                                 if (prts_closure[prts_int] == (next_pt - 1)) {
-                                    if (_regex_matched) {
+                                    if (_regex_matched && ok_here == 1) {
                                         prts_str[prts_int] = st + 1;
                                     } else {
                                         prts_str[prts_int] = st;


### PR DESCRIPTION
|Related issue|
|---|
|#2091|

PR #2216 fixed a bug that included the termination character of a regex in the group. However, the problem persists when the group terminator is a class (`\p`) or an escaped character (`\)`). This is because 

## Regex tests

```shellsession
$ echo "failed: ttyq4 changing from ldap to root" | ./ossec-regex '^failed: \S+ changing from (\S+) to (\S+)'
+OSRegex_Execute: failed: ttyq4 changing from ldap to root
 -Substring: ldap
 -Substring: root

$ echo 'key="hello' | ./ossec-regex 'key="(\S+)'
+OSRegex_Execute: key="hello
 -Substring: hello

$ echo 'key="hello"' | ./ossec-regex 'key="(\S+)"'
+OSRegex_Execute: key="hello"
 -Substring: hello

$ echo 'key="hello".' | ./ossec-regex 'key="(\S+)"'
+OSRegex_Execute: key="hello".
 -Substring: hello

$ echo 'type=CONFIG_CHANGE msg=audit(1546479838.821:1048736): auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 op=add_rule key=(null) list=1 res=1' | ./ossec-regex 'key=\((\S+)\)|key="(\S+)"|key=(\S+) '
+OSRegex_Execute: type=CONFIG_CHANGE msg=audit(1546479838.821:1048736): auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 op=add_rule key=(null) list=1 res=1
 -Substring: null

$ echo 'key=(null) list=1 res=1' | ./ossec-regex 'key=\p(\S+)\p'
+OSRegex_Execute: key=(null) list=1 res=1
 -Substring: null

$ echo 'key=(null) list=1 res=1' | ./ossec-regex 'key=\p(\S+)\p+'
+OSRegex_Execute: key=(null) list=1 res=1
 -Substring: null

$ echo 'key="hello" list=1 res=1' | ./ossec-regex 'key=\p(\S+)\p'
+OSRegex_Execute: key="hello" list=1 res=1
 -Substring: hello

$ echo 'key="hello" list=1 res=1' | ./ossec-regex 'key=\p(\S+)\p+'
+OSRegex_Execute: key="hello" list=1 res=1
 -Substring: hello

```