### PR TITLE
Fix for Inspector configuration

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -282,6 +282,11 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         } else if (!strcmp(nodes[i]->element, XML_SERVICE)) {
 
             mtdebug2(WM_AWS_LOGTAG, "Found a service tag");
+
+            if (!nodes[i]->attributes) {
+                mterror(WM_AWS_LOGTAG, "Undefined type for service.");
+                return OS_INVALID;
+            }
             // Create service node
             if (cur_service) {
                 os_calloc(1, sizeof(wm_aws_service), cur_service->next);
@@ -295,17 +300,18 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             }
 
             // type is an attribute of the service tag
-            if (nodes[i]->attributes && !strcmp(*nodes[i]->attributes, XML_SERVICE_TYPE)) {
-                if (nodes[i]->values && !strcmp(*nodes[i]->values, INSPECTOR_SERVICE_TYPE)) {
+            if (!strcmp(*nodes[i]->attributes, XML_SERVICE_TYPE)) {
+                if (!nodes[i]->values) {
+                    mterror(WM_AWS_LOGTAG, "Empty service type. Valid one is '%s'", INSPECTOR_SERVICE_TYPE);
+                    return OS_INVALID;
+                } else if (!strcmp(*nodes[i]->values, INSPECTOR_SERVICE_TYPE)) {
                     os_strdup(*nodes[i]->values, cur_service->type);
                 } else {
                     mterror(WM_AWS_LOGTAG, "Invalid service type '%s'. Valid one is '%s'", *nodes[i]->values, INSPECTOR_SERVICE_TYPE);
-                    OS_ClearNode(children);
                     return OS_INVALID;
                 }
             } else {
                 mterror(WM_AWS_LOGTAG, "Attribute name '%s' is not valid. The valid one is '%s'.", *nodes[i]->attributes, XML_SERVICE_TYPE);
-                OS_ClearNode(children);
                 return OS_INVALID;
             }
 

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -295,8 +295,8 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             }
 
             // type is an attribute of the service tag
-            if (!strcmp(*nodes[i]->attributes, XML_SERVICE_TYPE)) {
-                if (!strcmp(*nodes[i]->values, INSPECTOR_SERVICE_TYPE)) {
+            if (nodes[i]->attributes && !strcmp(*nodes[i]->attributes, XML_SERVICE_TYPE)) {
+                if (nodes[i]->values && !strcmp(*nodes[i]->values, INSPECTOR_SERVICE_TYPE)) {
                     os_strdup(*nodes[i]->values, cur_service->type);
                 } else {
                     mterror(WM_AWS_LOGTAG, "Invalid service type '%s'. Valid one is '%s'", *nodes[i]->values, INSPECTOR_SERVICE_TYPE);

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -294,12 +294,6 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 mtdebug2(WM_AWS_LOGTAG, "Creating first service structure");
             }
 
-            // Expand service Child Nodes
-
-            if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
-                continue;
-            }
-
             // type is an attribute of the service tag
             if (!strcmp(*nodes[i]->attributes, XML_SERVICE_TYPE)) {
                 if (!strcmp(*nodes[i]->values, INSPECTOR_SERVICE_TYPE)) {
@@ -313,6 +307,12 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 mterror(WM_AWS_LOGTAG, "Attribute name '%s' is not valid. The valid one is '%s'.", *nodes[i]->attributes, XML_SERVICE_TYPE);
                 OS_ClearNode(children);
                 return OS_INVALID;
+            }
+
+            // Expand service Child Nodes
+
+            if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
+                continue;
             }
 
             mtdebug2(WM_AWS_LOGTAG, "Loop thru child nodes");

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -450,7 +450,8 @@ void wm_aws_run_service(wm_aws_service *exec_service) {
 
     // Execute
     char *service_title = NULL;
-    wm_strcat(&service_title, "Bucket:", ' ');
+    wm_strcat(&service_title, "Service:", ' ');
+    wm_strcat(&service_title, exec_service->type, ' ');
     wm_strcat(&service_title, exec_service->aws_account_id, ' ');
     if(exec_service->aws_account_alias){
         wm_strcat(&service_title, "(", '\0');


### PR DESCRIPTION
Hi team,

This PR is for issue #2124. It is possible to configure `AWS Inspector` with these lines if we have our credentials in `.aws/credentials` file:
```bash
  <service type="inspector">
  </service>
```

I made some changes to allow this configuration (we needed to have child nodes for getting the configuration properly).

Best regards,

Demetrio.