### PR TITLE
Extract more fields in Audit decoder

### DIFF
--- a/etc/decoders/0040-auditd_decoders.xml
+++ b/etc/decoders/0040-auditd_decoders.xml
@@ -25,8 +25,8 @@ type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 success=yes e
 <!-- SYSCALL -->
 <decoder name="auditd-syscall">
     <parent>auditd</parent>
-    <regex offset="after_regex">^arch=\S+ syscall=(\d+) success=(\S+) exit=(\S+) a0=\S+ a1=\S+ a2=\S+ a3=\S+ items=\S+ ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm=\p(\S+)\p exe=\p(\S+)\p </regex>
-    <order>audit.syscall,audit.success,audit.exit,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session,audit.command,audit.exe</order>
+    <regex offset="after_regex">^arch=(\S+) syscall=(\d+) success=(\S+) exit=(\S+) a0=(\S+) a1=(\S+) a2=(\S+) a3=(\S+) items=(\S+) ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm=\p(\S+)\p exe=\p(\S+)\p</regex>
+    <order>audit.arch,audit.syscall,audit.success,audit.exit,audit.a0,audit.a1,audit.a2,audit.a3,audit.items,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session,audit.command,audit.exe</order>
 </decoder>
 
 <!-- SYSCALL - key -->


### PR DESCRIPTION
Before:
```
**Phase 1: Completed pre-decoding.
       full event: 'type=SYSCALL msg=audit(1546956747.723:17): arch=c000003e syscall=1 success=yes exit=122732 a0=6 a1=7fd88a9c9010 a2=1df6c a3=0 items=0 ppid=763 pid=765 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="apparmor_parser" exe="/sbin/apparmor_parser" key=(null)'
       timestamp: '(null)'
       hostname: 'ubuntu1710'
       program_name: '(null)'
       log: 'type=SYSCALL msg=audit(1546956747.723:17): arch=c000003e syscall=1 success=yes exit=122732 a0=6 a1=7fd88a9c9010 a2=1df6c a3=0 items=0 ppid=763 pid=765 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="apparmor_parser" exe="/sbin/apparmor_parser" key=(null)'

**Phase 2: Completed decoding.
       decoder: 'auditd'
       audit.type: 'SYSCALL'
       audit.id: '17'
       audit.syscall: '1'
       audit.success: 'yes'
       audit.exit: '122732'
       audit.ppid: '763'
       audit.pid: '765'
       audit.auid: '4294967295'
       audit.uid: '0'
       audit.gid: '0'
       audit.euid: '0'
       audit.suid: '0'
       audit.fsuid: '0'
       audit.egid: '0'
       audit.sgid: '0'
       audit.fsgid: '0'
       audit.tty: '(none)'
       audit.session: '4294967295'
       audit.command: 'apparmor_parser'
       audit.exe: '/sbin/apparmor_parser'
       audit.key: 'null'

**Phase 3: Completed filtering (rules).
       Rule id: '80700'
       Level: '0'
       Description: 'Audit: messages grouped.'
```
After:
```
**Phase 1: Completed pre-decoding.
       full event: 'type=SYSCALL msg=audit(1546956747.723:17): arch=c000003e syscall=1 success=yes exit=122732 a0=6 a1=7fd88a9c9010 a2=1df6c a3=0 items=0 ppid=763 pid=765 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="apparmor_parser" exe="/sbin/apparmor_parser" key=(null)'
       timestamp: '(null)'
       hostname: 'ubuntu1710'
       program_name: '(null)'
       log: 'type=SYSCALL msg=audit(1546956747.723:17): arch=c000003e syscall=1 success=yes exit=122732 a0=6 a1=7fd88a9c9010 a2=1df6c a3=0 items=0 ppid=763 pid=765 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="apparmor_parser" exe="/sbin/apparmor_parser" key=(null)'

**Phase 2: Completed decoding.
       decoder: 'auditd'
       audit.type: 'SYSCALL'
       audit.id: '17'
       audit.arch: 'c000003e'
       audit.syscall: '1'
       audit.success: 'yes'
       audit.exit: '122732'
       audit.a0: '6'
       audit.a1: '7fd88a9c9010'
       audit.a2: '1df6c'
       audit.a3: '0'
       audit.items: '0'
       audit.ppid: '763'
       audit.pid: '765'
       audit.auid: '4294967295'
       audit.uid: '0'
       audit.gid: '0'
       audit.euid: '0'
       audit.suid: '0'
       audit.fsuid: '0'
       audit.egid: '0'
       audit.sgid: '0'
       audit.fsgid: '0'
       audit.tty: '(none)'
       audit.session: '4294967295'
       audit.command: 'apparmor_parser'
       audit.exe: '/sbin/apparmor_parser'
       audit.key: 'null'

**Phase 3: Completed filtering (rules).
       Rule id: '80700'
       Level: '0'
       Description: 'Audit: messages grouped.'
```