### PR TITLE
Make DB module read the environment to synchronize the cluster node name

### DIFF
--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -60,7 +60,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             } else if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content)) {
                 merror("Detected a not allowed character in node name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
                 return OS_INVALID;
-            } else if (strcasecmp(node[i]->content, "$NODE_NAME") == 0) {
+            } else if ((strcasecmp(node[i]->content, "$NODE_NAME") == 0)||(strcasecmp(node[i]->content, "$HOSTNAME") == 0)) {
                 // Get environment variables
                 char * node_name = wm_node_name();
 
@@ -70,6 +70,9 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 } else {
                     mwarn("Cannot find environment variable 'NODE_NAME'");
                 }
+            }else {
+                free(Config->node_name);
+                os_strdup(node[i]->content, Config->node_name);
             }
         } else if (!strcmp(node[i]->element, node_type)) {
             if (!strlen(node[i]->content)) {

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -62,7 +62,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 return OS_INVALID;
             } else if (strcasecmp(node[i]->content, "$NODE_NAME") == 0) {
                 // Get environment variables
-                char * node_name = getenv("NODE_NAME");
+                char * node_name = wm_node_name();
 
                 if (node_name) {
                     free(Config->node_name);
@@ -70,19 +70,6 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 } else {
                     mwarn("Cannot find environment variable 'NODE_NAME'");
                 }
-            } else if (strcasecmp(node[i]->content, "$HOSTNAME") == 0) {
-                char hostname[512];
-
-                if (gethostname(hostname, sizeof(hostname)) != 0) {
-                    strncpy(hostname, "localhost", sizeof(hostname));
-                }
-
-                hostname[sizeof(hostname) - 1] = '\0';
-                free(Config->node_name);
-                os_strdup(hostname, Config->node_name);
-            } else {
-                free(Config->node_name);
-                os_strdup(node[i]->content, Config->node_name);
             }
         } else if (!strcmp(node[i]->element, node_type)) {
             if (!strlen(node[i]->content)) {

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -69,6 +69,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                     os_strdup(node_name, Config->node_name);
                 } else {
                     mwarn("Cannot find environment variable 'NODE_NAME'");
+                    return OS_INVALID;
                 }
             }else {
                 free(Config->node_name);
@@ -78,7 +79,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             if (!strlen(node[i]->content)) {
                 merror("Node type is empty in configuration");
                 return OS_INVALID;
-            } else if (strcasecmp(node[i]->content, "$NODE_TYPE") == 0) {
+            } else if (strcasecmp(node[i]->content, "$NODE_TYPE")) {
                 // Get environment variables
                 char * node_type = getenv("NODE_TYPE");
 

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -75,7 +75,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             if (!strlen(node[i]->content)) {
                 merror("Node type is empty in configuration");
                 return OS_INVALID;
-            } else if (strcasecmp(node[i]->content, "$NODE_TYPE")) {
+            } else if (strcasecmp(node[i]->content, "$NODE_TYPE") == 0) {
                 // Get environment variables
                 char * node_type = getenv("NODE_TYPE");
 

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -49,7 +49,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 merror("Cluster name is empty in configuration");
                 return OS_INVALID;
             } else if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content)) {
-                merror("Detected a not allowed character in cluster name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
+                mwarn("Detected a not allowed character in cluster name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
                 return OS_INVALID;
             }
             os_strdup(node[i]->content, Config->cluster_name);
@@ -62,13 +62,14 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 return OS_INVALID;
             } else if ((strcasecmp(node[i]->content, "$NODE_NAME") == 0)||(strcasecmp(node[i]->content, "$HOSTNAME") == 0)) {
                 // Get environment variables
-                char * node_name = wm_node_name();
+                char * node_name_var = wm_node_name();
 
                 if (node_name) {
                     free(Config->node_name);
-                    os_strdup(node_name, Config->node_name);
+                    os_strdup(node_name_var, Config->node_name);
+                    free(node_name_var);
                 } else {
-                    mwarn("Cannot find environment variable 'NODE_NAME'");
+                    merror("Cannot find environment variable 'NODE_NAME'");
                     return OS_INVALID;
                 }
             }else {
@@ -78,17 +79,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
         } else if (!strcmp(node[i]->element, node_type)) {
             if (!strlen(node[i]->content)) {
                 merror("Node type is empty in configuration");
-                return OS_INVALID;
-            } else if (strcasecmp(node[i]->content, "$NODE_TYPE")) {
-                // Get environment variables
-                char * node_type = getenv("NODE_TYPE");
-
-                if (node_type) {
-                    free(Config->node_type);
-                    os_strdup(node_type, Config->node_type);
-                } else {
-                    mwarn("Cannot find environment variable 'NODE_TYPE'");
-                }
+                return OS_INVALID; 
             } else if (strcmp(node[i]->content, "worker") && strcmp(node[i]->content, "client") && strcmp(node[i]->content, "master")) {
                 merror("Detected a not allowed node type '%s'. Valid types are 'master', 'worker' and '$node_type'.", node[i]->content);
                 return OS_INVALID;

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -49,7 +49,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 merror("Cluster name is empty in configuration");
                 return OS_INVALID;
             } else if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content)) {
-                mwarn("Detected a not allowed character in cluster name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
+                merror("Detected a not allowed character in cluster name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
                 return OS_INVALID;
             }
             os_strdup(node[i]->content, Config->cluster_name);
@@ -60,7 +60,7 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             } else if (strspn(node[i]->content, C_VALID) < strlen(node[i]->content)) {
                 merror("Detected a not allowed character in node name: \"%s\". Characters allowed: \"%s\".", node[i]->content, C_VALID);
                 return OS_INVALID;
-            } else if ((strcasecmp(node[i]->content, "$NODE_NAME") == 0)||(strcasecmp(node[i]->content, "$HOSTNAME") == 0)) {
+            } else if ((strcasecmp(node[i]->content, "$NODE_NAME") == 0) || (strcasecmp(node[i]->content, "$HOSTNAME") == 0)) {
                 // Get environment variables
                 char *node_name_var = wm_node_name();
 
@@ -78,10 +78,10 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             }
         } else if (!strcmp(node[i]->element, node_type)) {
             if (!strlen(node[i]->content)) {
-                merror("Node type is empty in configuration");
+                merror("Node type is empty in configuration.");
                 return OS_INVALID; 
             } else if (strcmp(node[i]->content, "worker") && strcmp(node[i]->content, "client") && strcmp(node[i]->content, "master")) {
-                merror("Detected a not allowed node type '%s'. Valid types are 'master', 'worker' and '$node_type'.", node[i]->content);
+                merror("Detected a not allowed node type '%s'. Valid types are 'master', 'worker' and '$node_type'", node[i]->content);
                 return OS_INVALID;
             } else {
                 free(Config->node_type);

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -62,9 +62,9 @@ int Read_Cluster(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 return OS_INVALID;
             } else if ((strcasecmp(node[i]->content, "$NODE_NAME") == 0)||(strcasecmp(node[i]->content, "$HOSTNAME") == 0)) {
                 // Get environment variables
-                char * node_name_var = wm_node_name();
+                char *node_name_var = wm_node_name();
 
-                if (node_name) {
+                if (node_name_var) {
                     free(Config->node_name);
                     os_strdup(node_name_var, Config->node_name);
                     free(node_name_var);

--- a/src/headers/cluster_utils.h
+++ b/src/headers/cluster_utils.h
@@ -18,4 +18,7 @@ int w_is_worker(void);
 // Returns the master node or "undefined" if any node is specified.
 char *get_master_node(void);
 
+// Get cluster node name from configuration or environment variables
+char *wm_node_name();
+
 #endif

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -65,17 +65,7 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
         mwarn("Queue size is very high. The application may run out of memory.");
     }
 
-    const char *(xmlf[]) = {"ossec_config", "cluster", "node_name", NULL};
-
-    OS_XML xml;
-
-    if (OS_ReadXML(cfgfile, &xml) < 0){
-        merror_exit(XML_ERROR, cfgfile, xml.err, xml.err_line);
-    }
-
-    node_name = OS_GetOneContentforElement(&xml, xmlf);
-
-    OS_ClearXML(&xml);
+    node_name = wm_node_name();
 
     return (1);
 }

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -128,7 +128,7 @@ char * wm_node_name() {
     if (strcmp(node_name, "$NODE_NAME") == 0) {
         free(node_name);
         node_name = getenv("NODE_NAME");
-
+        
         if (node_name) {
             return strdup(node_name);
         } else {
@@ -136,9 +136,8 @@ char * wm_node_name() {
             return NULL;
         }
     } else if (strcmp(node_name, "$HOSTNAME") == 0) {
-        char hostname[512];
-
         free(node_name);
+        char hostname[512];
 
         if (gethostname(hostname, sizeof(hostname)) != 0) {
             strncpy(hostname, "localhost", sizeof(hostname));

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -29,16 +29,19 @@ int w_is_worker(void) {
 
     modules |= CCLUSTER;
 
-    node = OS_GetElementsbyNode(&xml, NULL);
+    if (OS_ReadXML(cfgfile, &xml) < 0){
+        merror_exit(XML_ERROR, cfgfile, xml.err, xml.err_line);
+    }
+    
+    node = OS_GetElementsbyNode(&xml, NULL); 
 
     if (ReadConfig(modules, cfgfile, &cfg, NULL) < 0) {
         return (OS_INVALID);
     }
-
+ 
     if (Read_Cluster(node, &cfg, NULL) < 0){
         return(OS_INVALID);
-    }
-
+    } 
     if (OS_ReadXML(cfgfile, &xml) < 0) {
         mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
     } else {

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -16,7 +16,6 @@
 // Returns 1 if the node is a worker, 0 if it is not and -1 if error.
 int w_is_worker(void) {
 
-    XML_NODE node = NULL;
     OS_XML xml;
     const char * xmlf[] = {"ossec_config", "cluster", NULL};
     const char * xmlf2[] = {"ossec_config", "cluster", "node_type", NULL};

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -29,21 +29,11 @@ int w_is_worker(void) {
 
     modules |= CCLUSTER;
 
-    if (OS_ReadXML(cfgfile, &xml) < 0){
-        merror_exit(XML_ERROR, cfgfile, xml.err, xml.err_line);
-    }
-    
-    node = OS_GetElementsbyNode(&xml, NULL); 
-
     if (ReadConfig(modules, cfgfile, &cfg, NULL) < 0) {
         return (OS_INVALID);
     }
- 
-    if (Read_Cluster(node, &cfg, NULL) < 0){
-        return(OS_INVALID);
-    } 
-    if (OS_ReadXML(cfgfile, &xml) < 0) {
-        mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
+    if (OS_ReadXML(DEFAULTCPATH, &xml) < 0){
+        merror_exit(XML_ERROR, DEFAULTCPATH, xml.err, xml.err_line);
     } else {
         char * cl_config = OS_GetOneContentforElement(&xml, xmlf);
         if (cl_config && cl_config[0] != '\0') {

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -32,7 +32,7 @@ int w_is_worker(void) {
         return (OS_INVALID);
     }
     if (OS_ReadXML(DEFAULTCPATH, &xml) < 0){
-        merror_exit(XML_ERROR, DEFAULTCPATH, xml.err, xml.err_line);
+        mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
     } else {
         char * cl_config = OS_GetOneContentforElement(&xml, xmlf);
         if (cl_config && cl_config[0] != '\0') {

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -106,9 +106,9 @@ char *get_master_node(void) {
 }
 
 // Get cluster node name from configuration or environment variables
-char * wm_node_name() {
+char *wm_node_name() {
     const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
-    char * node_name;
+    char *node_name;
 
     OS_XML xml;
 
@@ -130,7 +130,7 @@ char * wm_node_name() {
         node_name = getenv("NODE_NAME");
         
         if (node_name) {
-            return strdup(node_name);
+            return node_name;
         } else {
             mwarn("Cannot find environment variable 'NODE_NAME'");
             return NULL;

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -68,6 +68,8 @@ static void* wm_database_main(wm_database *data);
 static void* wm_database_destroy(wm_database *data);
 // Read config
 cJSON *wm_database_dump(const wm_database *data);
+// Get cluster node name from configuration or environment variables
+static char * wm_node_name();
 // Update manager information
 static void wm_sync_manager();
 // Get agent's architecture
@@ -207,6 +209,52 @@ void* wm_database_main(wm_database *data) {
     return NULL;
 }
 
+// Get cluster node name from configuration or environment variables
+char * wm_node_name() {
+    const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
+    char * node_name;
+
+    OS_XML xml;
+
+    if (OS_ReadXML(DEFAULTCPATH, &xml) < 0){
+        merror_exit(XML_ERROR, DEFAULTCPATH, xml.err, xml.err_line);
+    }
+
+    node_name = OS_GetOneContentforElement(&xml, xml_node);
+    OS_ClearXML(&xml);
+
+    if (!node_name) {
+        return NULL;
+    }
+
+    // Get environment variables
+
+    if (strcmp(node_name, "$NODE_NAME") == 0) {
+        free(node_name);
+        node_name = getenv("NODE_NAME");
+
+        if (node_name) {
+            return strdup(node_name);
+        } else {
+            mwarn("Cannot find environment variable 'NODE_NAME'");
+            return NULL;
+        }
+    } else if (strcmp(node_name, "$HOSTNAME") == 0) {
+        char hostname[512];
+
+        free(node_name);
+
+        if (gethostname(hostname, sizeof(hostname)) != 0) {
+            strncpy(hostname, "localhost", sizeof(hostname));
+        }
+
+        hostname[sizeof(hostname) - 1] = '\0';
+        return strdup(hostname);
+    } else {
+        return node_name;
+    }
+}
+
 // Update manager information
 void wm_sync_manager() {
     char hostname[1024];
@@ -230,19 +278,7 @@ void wm_sync_manager() {
         mterror(WM_DATABASE_LOGTAG, "Couldn't get manager's hostname: %s.", strerror(errno));
 
     /* Get node name of the manager in cluster */
-    char* node_name;
-
-    const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
-
-    OS_XML xml;
-
-    if (OS_ReadXML(DEFAULTCPATH, &xml) < 0){
-        merror_exit(XML_ERROR, DEFAULTCPATH, xml.err, xml.err_line);
-    }
-
-    node_name = OS_GetOneContentforElement(&xml, xml_node);
-
-    OS_ClearXML(&xml);
+    char* node_name = wm_node_name();
 
     if ((os_uname = strdup(getuname()))) {
         os_arch = wm_get_os_arch(os_uname);


### PR DESCRIPTION
This PR implements issue #2243.

The DB synchronization module will read the environment variable depending on particular values.

By default, the DB uses the configuration to get the cluster node name:

```xml
<cluster>
  <node_name>node01</node_name>
</cluster>
```

- If _node_name_ is `$NODE_NAME`, then the DB module will read the environment variable `NODE_NAME`. If such value is unset, the module will log:

```
wazuh-modulesd: WARNING: Cannot find environment variable 'NODE_NAME'
```

- If _node_name_ is `$HOSTNAME`, then the DB module will use the system hostname as node name.

## Tests

- No `<node_name>`: _node_name_ remains `NULL`.
- `<node_name>` = `$NODE_NAME` but the environment variable `NODE_NAME` is unset, _node_name_ is `NULL`.
- `<node_name>` = `$NODE_NAME` and the environment variable `NODE_NAME` is set, _node_name_ will be that value.
- `<node_name>` = `$HOSTNAME`, _node_name_ must be the system hostname.