### PR TITLE
Default configuration of key request module

### DIFF
--- a/src/config/wmodules-key-request.c
+++ b/src/config/wmodules-key-request.c
@@ -24,6 +24,7 @@ int wm_key_request_read(xml_node **nodes, wmodule *module)
     os_calloc(1, sizeof(wm_krequest_t), key_request);
     key_request->enabled = 1;
     key_request->force_insert = 1;
+    key_request->timeout = 60;
     key_request->threads = 1;
     key_request->queue_size = 1024;
     module->context = &WM_KEY_REQUEST_CONTEXT;
@@ -75,7 +76,7 @@ int wm_key_request_read(xml_node **nodes, wmodule *module)
         {
             key_request->timeout = strtoul(nodes[i]->content, NULL, 0);
 
-            if (key_request->timeout == 0 || key_request->timeout == UINT_MAX) {
+            if (key_request->timeout < 1 || key_request->timeout >= UINT_MAX) {
                 merror("Invalid interval at module '%s'", WM_KEY_REQUEST_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -86,7 +87,7 @@ int wm_key_request_read(xml_node **nodes, wmodule *module)
         {
             key_request->threads = strtoul(nodes[i]->content, NULL, 0);
 
-            if (key_request->threads == 0 || key_request->threads >= 32) {
+            if (key_request->threads < 1 || key_request->threads > 32) {
                 merror("Invalid number of threads at module '%s'", WM_KEY_REQUEST_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -95,7 +96,7 @@ int wm_key_request_read(xml_node **nodes, wmodule *module)
         {
             key_request->queue_size = strtoul(nodes[i]->content, NULL, 0);
 
-            if (key_request->queue_size == 0 || key_request->queue_size >= 220000) {
+            if (key_request->queue_size < 1 || key_request->queue_size > 220000) {
                 merror("Invalid queue size at module '%s'", WM_KEY_REQUEST_CONTEXT.name);
                 return OS_INVALID;
             }

--- a/src/wazuh_modules/wm_keyrequest.h
+++ b/src/wazuh_modules/wm_keyrequest.h
@@ -15,8 +15,8 @@
 #define WM_KEY_REQUEST_LOGTAG ARGV0 ":" KEY_WM_NAME
 
 typedef struct wm_krequest_t {
-    int enabled:1;
-    int force_insert:1;
+    int enabled;
+    int force_insert;
     unsigned int timeout;
     unsigned int threads;
     unsigned int queue_size;


### PR DESCRIPTION
The initial value of the variables `enable` and `force_insert` has been changed due to an error that assigned the value -1 to these variables. Some default values of the configuration have also been modified.
Related PR #2127 