### PR TITLE
Fix error when updating group configurations in a custom installation path

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -667,7 +667,8 @@ def upload_group_configuration(group_id, xml_file):
 
         # check Wazuh xml format
         try:
-            subprocess.check_output(['/var/ossec/bin/verify-agent-conf', '-f', tmp_file_path], stderr=subprocess.STDOUT)
+            subprocess.check_output(['{}/bin/verify-agent-conf'.format(common.ossec_path), '-f', tmp_file_path],
+                                    stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             # extract error message from output.
             # Example of raw output


### PR DESCRIPTION
Hello team,

This PR fixes a bug when executing `POST/agents/group/:group_id/configuration` API in a custom install directory, such as `/opt/ossec`.

Best regards,
Marta