### PR TITLE
Fix sending of the owner attribute when a file is created in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ All notable changes to this project will be documented in this file.
 - The regex parser included the next character after a group:
   - If the input string just ends after that character. ([#2216](https://github.com/wazuh/wazuh/pull/2216))
   - The regex parser did not accept a group terminated with an escaped byte or a class. ([#2224](https://github.com/wazuh/wazuh/pull/2224))
+- Fix sending of the owner attribute when a file is created in Windows. ([#2292](https://github.com/wazuh/wazuh/pull/2292))
 
 
 ## [v3.7.2] 2018-12-17

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -381,7 +381,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                     opts & CHECK_SHA256SUM ? sf256_sum : "",
                     opts & CHECK_ATTRS ? w_get_file_attrs(file_name) : 0);
 
-            os_free(user);
 #else
             if (opts & CHECK_SIZE) {
                 if (opts & CHECK_FOLLOW) {


### PR DESCRIPTION
When a file is created in Windows over a directory with CHECK_OWNER its user is being released after adding it in the hash table. This must be done after the next step: send the checksum to the manager.