### PR TITLE
Fix bug in POST/agents/group/:group_id/configuration

### DIFF
--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -153,7 +153,7 @@ functions = {
         'type': 'local_master'
     },
     'POST/agents/groups/:group_id/configuration': {
-        'function': configuration.upload_group_configuration,
+        'function': configuration.upload_group_file,
         'type': 'local_master'
     },
     'POST/agents/groups/:group_id/files/:file_name': {

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -695,7 +695,7 @@ def upload_group_configuration(group_id, xml_file):
         raise e
 
 
-def upload_group_file(group_id, xml_file, file_name):
+def upload_group_file(group_id, xml_file, file_name='agent.conf'):
     """
     Updates a group file
 


### PR DESCRIPTION
Hello team,

This PR fixes the API call `POST/agents/group/:group_id/configuration`: the final configuration was always empty.

Best regards,
Marta