### PR TITLE
Fix bug updating group configuration when there's a wazuh syntax error using python 3

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -676,7 +676,7 @@ def upload_group_configuration(group_id, xml_file):
             # Example of desired output:
             # Invalid element in the configuration: 'agent_conf'. Syscheck remote configuration in '/var/ossec/tmp/api_tmp_file_2019-01-08-01-1546959069.xml' is corrupted.
             output_regex = re.findall(pattern=r"\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} verify-agent-conf: ERROR: "
-                                              r"\(\d+\): ([\w \/ \_ \- \. ' :]+)", string=e.output)
+                                              r"\(\d+\): ([\w \/ \_ \- \. ' :]+)", string=e.output.decode())
             raise WazuhException(1114, ' '.join(output_regex))
         except Exception as e:
             raise WazuhException(1743, str(e))


### PR DESCRIPTION
Hello team,

When using the API call in python 3 to update agents with a configuration having Wazuh syntax errors (i.e. verify-agent-conf binary would return an error code) the following error was being returned by the API:
```javascript
# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "http://localhost:55000/agents/groups/webserver/files/agent.conf?pretty"
{
   "error": 1000,
   "message": "cannot use a string pattern on a bytes-like object"
}
```

This PR fixes that error:
```javascript
# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "http://localhost:55000/agents/groups/webserver/files/agent.conf?pretty"
{
   "error": 1114,
   "message": "Wazuh syntax error: Invalid element in the configuration: 'directoriess'. Configuration error at '/var/ossec/tmp/api_tmp_file_2019-01-10-01-1547129789.xml'. Syscheck remote configuration in '/var/ossec/tmp/api_tmp_file_2019-01-10-01-1547129789.xml' is corrupted."
}
```

Best regards,
Marta