### PR TITLE
Update Selinux policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ All notable changes to this project will be documented in this file.
   - The regex parser did not accept a group terminated with an escaped byte or a class. ([#2224](https://github.com/wazuh/wazuh/pull/2224))
 - Fixed buffer overflow hazard in FIM when performing change report on long paths on macOS platform. ([#2285](https://github.com/wazuh/wazuh/pull/2285))
 - Fix sending of the owner attribute when a file is created in Windows. ([#2292](https://github.com/wazuh/wazuh/pull/2292))
+- Fix audit reconnection to the Whodata socket ([#2305](https://github.com/wazu2305h/wazuh/pull/2305))
 
 
 ## [v3.7.2] 2018-12-17

--- a/src/selinux/wazuh.te
+++ b/src/selinux/wazuh.te
@@ -6,14 +6,14 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-module wazuh 1.1;
+module wazuh 1.2;
 
 require {
 	type audisp_t;
 	type var_t;
 	type auditd_t;
 	type usr_t;
-	class sock_file { create setattr };
+	class sock_file { create setattr unlink };
 	class process { noatsecure siginh };
 	class dir { remove_name add_name read write };
 	class file { getattr open read };
@@ -32,7 +32,7 @@ allow audisp_t usr_t:file { open read };
 allow audisp_t var_t:dir { remove_name add_name read write };
 allow audisp_t var_t:file getattr;
 
-allow audisp_t var_t:sock_file { create setattr };
+allow audisp_t var_t:sock_file { create setattr unlink };
 allow audisp_t var_t:file { open read };
 
 #============= auditd_t ==============


### PR DESCRIPTION
Updated Selinux policy to allow the deletion of the socket used by whodata. 
Audisp needs to remove the socket when Audit is restarted in order to recreate it.