### PR TITLE
Fix decoding of the "nice" value for the process inventory

### DIFF
--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2108,7 +2108,7 @@ int wdb_parse_processes(wdb_t * wdb, char * input, char * output) {
         }
 
         if (!strncmp(curr, "NULL", 4))
-            nice = -1;
+            nice = 0;
         else
             nice = strtol(curr,NULL,10);
 

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -797,14 +797,12 @@ int wdb_process_insert(wdb_t * wdb, const char * scan_id, const char * scan_time
     sqlite3_bind_text(stmt, 15, rgroup, -1, NULL);
     sqlite3_bind_text(stmt, 16, sgroup, -1, NULL);
     sqlite3_bind_text(stmt, 17, fgroup, -1, NULL);
-    if (priority >= 0)
+    if (priority >= 0) {
         sqlite3_bind_int(stmt, 18, priority);
-    else
+    } else {
         sqlite3_bind_null(stmt, 18);
-    if (nice >= 0)
-        sqlite3_bind_int(stmt, 19, nice);
-    else
-        sqlite3_bind_null(stmt, 19);
+    }
+    sqlite3_bind_int(stmt, 19, nice);
     if (size >= 0)
         sqlite3_bind_int(stmt, 20, size);
     else


### PR DESCRIPTION
The `nice` value of Linux processes was being stored as NULL for negative values. This PR fixes that issue by taking into account negative cases and setting to 0 the nice in case of the value doesn't exist.