### PR TITLE
Fix validation of field white_list

### DIFF
--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -416,8 +416,8 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
 #ifndef WIN32
 
             const char *ip_address_regex =
-                "^!?\\d{1,3}(\\.\\d{1,3}){3}"
-                "(/\\d{1,2}(\\d(\\.\\d{1,3}){3})?)?$";
+                "^!?[[:digit:]]{1,3}(\\.[[:digit:]]{1,3}){3}"
+                "(/[[:digit:]]{1,2}([[:digit:]](\\.[[:digit:]]{1,3}){3})?)?$";
 
             if (Config && OS_PRegex(node[i]->content, ip_address_regex)) {
                 white_size++;
@@ -548,7 +548,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                     merror(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 }
-             
+
                 if(strncmp(node[i]->content,"alerts.log",10) == 0){
                     Mail->source = MAIL_SOURCE_LOGS;
                 }


### PR DESCRIPTION
|Related PR|
|---|
|#1497|

The option `white_list` was not working properly:

```xml
<global>
  <white_list>127.0.0.1</white_list>
  <white_list>^localhost.localdomain$</white_list>
  <white_list>10.0.2.3</white_list>
</global>
```

The configuration parser must classify entries between CIDR and hostnames (not CIDR). This is the implied POSIX regex:

```regex
^!?\d{1,3}(\.\d{1,3}){3}(/\d{1,2}(\d(\.\d{1,3}){3})?)?$
```

POSIX regexes don't accept `\d`. Instead, we must use `[[:digit:]]`:

```regex
^!?[[:digit:]]{1,3}(\.[[:digit:]]{1,3}){3}(/[[:digit:]]{1,2}([[:digit:]](\.[[:digit:]]{1,3}){3})?)?$
```
