### PR TITLE
Fix wodle command message

### DIFF
--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -476,7 +476,7 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
 
             if(retval != 0){
                 kill(pid,SIGTERM);
-                retval = ETIMEDOUT;
+                retval = WM_ERROR_TIMEOUT;
 
                 // Wait for child process
 


### PR DESCRIPTION
This PR solves the problem reported at the wodle command testing issue https://github.com/wazuh/wazuh/issues/2259 about the message shown when using a command that doesn't finish with any timeout different than 0 and the `ignore_output` option enabled.