### PR TITLE
Add option to disable audit healthcheck

### DIFF
--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -34,7 +34,4 @@
     <nodiff>/etc/ssl/private.key</nodiff>
 
     <skip_nfs>yes</skip_nfs>
-
-    <!-- Allow the system to restart Auditd after installing the plugin -->
-    <restart_audit>yes</restart_audit>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -40,7 +40,4 @@
     <nodiff>/etc/ssl/private.key</nodiff>
 
     <skip_nfs>yes</skip_nfs>
-
-    <!-- Allow the system to restart Auditd after installing the plugin -->
-    <restart_audit>yes</restart_audit>
   </syscheck>

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -813,7 +813,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 #endif
     const char *xml_whodata_options = "whodata";
     const char *xml_audit_key = "audit_key";
-    const char *xml_audit_hc = "audit_healthcheck_enabled";
+    const char *xml_audit_hc = "startup_healthcheck";
 
     /* Configuration example
     <directories check_all="yes">/etc,/usr/bin</directories>
@@ -1236,6 +1236,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         } else if (strcmp(node[i]->element, xml_remove_old_diff) == 0) {
             // Deprecated since 3.8.0, aplied by default...
         } else if (strcmp(node[i]->element, xml_restart_audit) == 0) {
+            // To be deprecated. This field is now readed inside the <whodata> block.
             if(strcmp(node[i]->content, "yes") == 0)
                 syscheck->restart_audit = 1;
             else if(strcmp(node[i]->content, "no") == 0)
@@ -1277,6 +1278,16 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         syscheck->audit_healthcheck = 1;
                     else if(strcmp(children[j]->content, "no") == 0)
                         syscheck->audit_healthcheck = 0;
+                    else
+                    {
+                        merror(XML_VALUEERR,children[j]->element,children[j]->content);
+                        return(OS_INVALID);
+                    }
+                } else if (strcmp(children[j]->element, xml_restart_audit) == 0) {
+                    if(strcmp(children[j]->content, "yes") == 0)
+                        syscheck->restart_audit = 1;
+                    else if(strcmp(children[j]->content, "no") == 0)
+                        syscheck->restart_audit = 0;
                     else
                     {
                         merror(XML_VALUEERR,children[j]->element,children[j]->content);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -813,6 +813,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 #endif
     const char *xml_whodata_options = "whodata";
     const char *xml_audit_key = "audit_key";
+    const char *xml_audit_hc = "audit_healthcheck_enabled";
 
     /* Configuration example
     <directories check_all="yes">/etc,/usr/bin</directories>
@@ -1270,6 +1271,16 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                             key = strtok(NULL, &delim);
                             keyit++;
                         }
+                    }
+                } else if (strcmp(children[j]->element, xml_audit_hc) == 0) {
+                    if(strcmp(children[j]->content, "yes") == 0)
+                        syscheck->audit_healthcheck = 1;
+                    else if(strcmp(children[j]->content, "no") == 0)
+                        syscheck->audit_healthcheck = 0;
+                    else
+                    {
+                        merror(XML_VALUEERR,children[j]->element,children[j]->content);
+                        return(OS_INVALID);
                     }
                 } else {
                     merror(XML_ELEMNULL);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -208,12 +208,10 @@ typedef struct _config {
     int max_fd_win_rt;
     whodata wdata;
     whodata_event_list wlist;
-#else
-    int max_audit_entries;          /* Maximum entries for Audit (whodata) */
-    int audit_healthcheck;
 #endif
-
-    char **audit_key;                // Listen audit keys
+    int max_audit_entries;          /* Maximum entries for Audit (whodata) */
+    char **audit_key;               // Listen audit keys
+    int audit_healthcheck;          // Startup health-check for whodata
 
     OSHash *fp;
     OSHash *last_check;

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -210,6 +210,7 @@ typedef struct _config {
     whodata_event_list wlist;
 #else
     int max_audit_entries;          /* Maximum entries for Audit (whodata) */
+    int audit_healthcheck;
 #endif
 
     char **audit_key;                // Listen audit keys

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -39,6 +39,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.restart_audit  = 1;
     syscheck.enable_whodata = 0;
     syscheck.realtime       = NULL;
+    syscheck.audit_healthcheck = 1;
 #ifdef WIN_WHODATA
     syscheck.wdata.interval_scan = 0;
     syscheck.wdata.fd      = NULL;
@@ -211,9 +212,14 @@ cJSON *getSyscheckConfig(void) {
         }
         if (cJSON_GetArraySize(audkey) > 0) {
             cJSON_AddItemToObject(whodata,"audit_key",audkey);
-            cJSON_AddItemToObject(syscfg,"whodata",whodata);
         }
     }
+    if (syscheck.audit_healthcheck) {
+        cJSON_AddStringToObject(whodata,"audit_healthcheck_enabled","yes");
+    } else {
+        cJSON_AddStringToObject(whodata,"audit_healthcheck_enabled","no");
+    }
+    cJSON_AddItemToObject(syscfg,"whodata",whodata);
 #ifdef WIN32
     cJSON_AddNumberToObject(syscfg,"windows_audit_interval",syscheck.wdata.interval_scan);
     if (syscheck.registry) {

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -152,7 +152,6 @@ cJSON *getSyscheckConfig(void) {
     if (syscheck.disabled) cJSON_AddStringToObject(syscfg,"disabled","yes"); else cJSON_AddStringToObject(syscfg,"disabled","no");
     cJSON_AddNumberToObject(syscfg,"frequency",syscheck.time);
     if (syscheck.skip_nfs) cJSON_AddStringToObject(syscfg,"skip_nfs","yes"); else cJSON_AddStringToObject(syscfg,"skip_nfs","no");
-    if (syscheck.restart_audit) cJSON_AddStringToObject(syscfg,"restart_audit","yes"); else cJSON_AddStringToObject(syscfg,"restart_audit","no");
     if (syscheck.scan_on_start) cJSON_AddStringToObject(syscfg,"scan_on_start","yes"); else cJSON_AddStringToObject(syscfg,"scan_on_start","no");
     if (syscheck.scan_day) cJSON_AddStringToObject(syscfg,"scan_day",syscheck.scan_day);
     if (syscheck.scan_time) cJSON_AddStringToObject(syscfg,"scan_time",syscheck.scan_time);
@@ -204,7 +203,13 @@ cJSON *getSyscheckConfig(void) {
         }
         cJSON_AddItemToObject(syscfg,"ignore",igns);
     }
+#ifndef WIN32
     cJSON *whodata = cJSON_CreateObject();
+    if (syscheck.restart_audit) {
+        cJSON_AddStringToObject(whodata,"restart_audit","yes");
+    } else {
+        cJSON_AddStringToObject(whodata,"restart_audit","no");
+    }
     if (syscheck.audit_key) {
         cJSON *audkey = cJSON_CreateArray();
         for (i=0;syscheck.audit_key[i];i++) {
@@ -215,11 +220,12 @@ cJSON *getSyscheckConfig(void) {
         }
     }
     if (syscheck.audit_healthcheck) {
-        cJSON_AddStringToObject(whodata,"audit_healthcheck_enabled","yes");
+        cJSON_AddStringToObject(whodata,"startup_healthcheck","yes");
     } else {
-        cJSON_AddStringToObject(whodata,"audit_healthcheck_enabled","no");
+        cJSON_AddStringToObject(whodata,"startup_healthcheck","no");
     }
     cJSON_AddItemToObject(syscfg,"whodata",whodata);
+#endif
 #ifdef WIN32
     cJSON_AddNumberToObject(syscfg,"windows_audit_interval",syscheck.wdata.interval_scan);
     if (syscheck.registry) {

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -375,7 +375,7 @@ int audit_init(void) {
             return -1;
         }
     } else {
-        mwarn("Audit health check is disabled. Whodata could not work correctly.");
+        minfo("Audit health check is disabled. Whodata could not work correctly.");
     }
 
     // Add Audit rules
@@ -1098,6 +1098,7 @@ void audit_read_events(int *audit_sock, int mode) {
 
     }
 
+    free(cache_id);
     free(cache);
     free(buffer);
 }


### PR DESCRIPTION
This PR solves the issue: https://github.com/wazuh/wazuh/issues/2322

A new option was added to disable the audit healthcheck.
```
  <syscheck>
    <whodata>
        <audit_healthcheck_enabled>no</audit_healthcheck_enabled>
    </whodata>
```
```
2019/01/11 15:40:18 ossec-syscheckd[9726] syscheck_audit.c:378 at audit_init(): WARNING: Audit health check is disabled. Whodata could not work correctly.
2019/01/11 15:40:18 ossec-syscheckd[9726] audit_op.c:82 at audit_print_reply(): DEBUG: Audit rule loaded: -w /root/test -p wa -k wazuh_fim
2019/01/11 15:40:18 ossec-syscheckd[9726] syscheck_audit.c:224 at add_audit_rules_syscheck(): DEBUG: Audit rule for monitoring directory '/root/test' already added.
2019/01/11 15:40:18 ossec-syscheckd[9726] syscheck_audit.c:394 at audit_init(): INFO: Starting FIM Whodata engine...
```