### PR TITLE
Fix race condition in upload_group_configuration

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -3,7 +3,8 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from datetime import datetime
+import random
+import time
 from os import remove, path as os_path
 import re
 from shutil import move
@@ -644,8 +645,7 @@ def upload_group_configuration(group_id, xml_file):
         raise WazuhException(1710)
 
     # path of temporary files for parsing xml input
-    tmp_file_path = '{}/tmp/api_tmp_file_{}.xml'.format(common.ossec_path,
-                                                        datetime.strftime(datetime.utcnow(), '%Y-%m-%d-%m-%s'))
+    tmp_file_path = '{}/tmp/api_tmp_file_{}_{}.xml'.format(common.ossec_path, time.time(), random.randint(0, 1000))
 
     # create temporary file for parsing xml input
     try:


### PR DESCRIPTION
Hello team,

When the `upload_group_configuration` function was called at the same time by two different clients, a tmp file with the same name for both calls was created. The name of the tmp file created has been randomized to prevent this.

Best regards,
Marta