### PR TITLE
Fix agent connection in TCP mode on Windows XP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ All notable changes to this project will be documented in this file.
   - The regex parser did not accept a group terminated with an escaped byte or a class. ([#2224](https://github.com/wazuh/wazuh/pull/2224))
 - Fixed buffer overflow hazard in FIM when performing change report on long paths on macOS platform. ([#2285](https://github.com/wazuh/wazuh/pull/2285))
 - Fix sending of the owner attribute when a file is created in Windows. ([#2292](https://github.com/wazuh/wazuh/pull/2292))
+- Fixed agent connection in TCP mode on Windows XP. ([#2329](https://github.com/wazuh/wazuh/pull/2329))
 
 
 ## [v3.7.2] 2018-12-17

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -22,7 +22,6 @@ w_queue_t * winexec_queue;
 void *receiver_thread(__attribute__((unused)) void *none)
 {
     ssize_t recv_b;
-    uint32_t length;
     size_t msg_length;
     int reads;
     int undefined_msg_logged = 0;
@@ -86,14 +85,15 @@ void *receiver_thread(__attribute__((unused)) void *none)
                     break;
                 }
 
-                recv_b = recv(agt->sock, (char*)&length, sizeof(length), MSG_WAITALL);
-                length = wnet_order(length);
-
-                // Manager disconnected or error
+                recv_b = OS_RecvSecureTCP(agt->sock, buffer, OS_MAXSTR);
 
                 if (recv_b <= 0) {
-                    if (recv_b < 0) {
-                        merror("Receiver: %s [%d]", strerror(errno), errno);
+                    switch (recv_b) {
+                    case OS_SOCKTERR:
+                        merror("Corrupt payload (exceeding size) received.");
+                        break;
+                    case -1:
+                        merror("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
                     }
 
                     update_status(GA_STATUS_NACTIVE);
@@ -103,19 +103,6 @@ void *receiver_thread(__attribute__((unused)) void *none)
                     minfo(SERVER_UP);
                     os_delwait();
                     update_status(GA_STATUS_ACTIVE);
-                    break;
-                }else if (length == 0) {
-                    merror("Empty message from manager");
-                    break;
-                }else if (length > OS_MAXSTR) {
-                    merror("Too big message size from manager.");
-                    break;
-                }
-
-                recv_b = recv(agt->sock, buffer, length, MSG_WAITALL);
-
-                if (recv_b != (ssize_t)length) {
-                    merror("Incorrect message size from manager: expecting %u, got %d", length, (int)recv_b);
                     break;
                 }
             } else {

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -150,7 +150,6 @@ int connect_server(int initial_id)
 void start_agent(int is_startup)
 {
     ssize_t recv_b = 0;
-    uint32_t length;
     size_t msg_length;
     int attempts = 0, g_attempts = 1;
 
@@ -178,17 +177,7 @@ void start_agent(int is_startup)
         /* Read until our reply comes back */
         while (attempts <= 5) {
             if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
-                recv_b = recv(agt->sock, (char*)&length, sizeof(length), MSG_WAITALL);
-                length = wnet_order(length);
-
-                if (recv_b > 0) {
-                    recv_b = recv(agt->sock, buffer, length, MSG_WAITALL);
-
-                    if (recv_b != (ssize_t)length) {
-                        merror(RECV_ERROR);
-                        recv_b = 0;
-                    }
-                }
+                recv_b = OS_RecvSecureTCP(agt->sock, buffer, OS_MAXSTR);
             } else {
                 recv_b = recv(agt->sock, buffer, OS_MAXSTR, MSG_DONTWAIT);
             }
@@ -198,10 +187,23 @@ void start_agent(int is_startup)
                  * the server again
                  */
                 attempts++;
+
+                switch (recv_b) {
+                case OS_SOCKTERR:
+                    merror("Corrupt payload (exceeding size) received.");
+                    break;
+                case -1:
+#ifdef WIN32
+                    merror("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
+#else
+                    merror("Connection socket: %s (%d)", strerror(errno), errno);
+#endif
+                }
+
                 sleep(attempts);
 
                 /* Send message again (after three attempts) */
-                if (attempts >= 3) {
+                if (attempts >= 3 || recv_b == OS_SOCKTERR) {
                     if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
                         if (!connect_server(agt->rip_id)) {
                             continue;

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -571,7 +571,8 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
     ssize_t recvval, recvb;
     uint32_t msgsize;
 
-    recvval = recv(sock, (char *) &msgsize, sizeof(msgsize), MSG_WAITALL);
+    /* Get header */
+    recvval = os_recv_waitall(sock, &msgsize, sizeof(msgsize));
 
     switch(recvval) {
         case -1:
@@ -586,10 +587,14 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
     msgsize = wnet_order(msgsize);
 
     if(msgsize > size){
+        /* Error: the payload length is too long */
         return OS_SOCKTERR;
     }
 
-    recvb = recv(sock, ret, msgsize, MSG_WAITALL);
+    /* Get payload */
+    recvb = os_recv_waitall(sock, ret, msgsize);
+
+    /* Terminate string if there is space left */
 
     if (recvb == (int32_t) msgsize && msgsize < size) {
         ret[msgsize] = '\0';
@@ -645,7 +650,7 @@ ssize_t OS_RecvSecureTCP_Dynamic(int sock, char **ret) {
         recvval = strlen(data);
 
         if ((uint32_t)recvval < msgsize) {
-            recvmsg = recv(sock, *ret + recvval, msgsize - recvval, MSG_WAITALL);
+            recvmsg = os_recv_waitall(sock, *ret + recvval, msgsize - recvval);
 
             switch(recvmsg){
                 case -1:
@@ -796,7 +801,7 @@ int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length) {
     uint32_t size = 0;
     char buffer[HEADER_SIZE];
 
-    recvval = recv(sock, buffer, HEADER_SIZE, MSG_WAITALL);
+    recvval = os_recv_waitall(sock, buffer, HEADER_SIZE);
 
     switch(recvval){
         case -1:
@@ -821,5 +826,25 @@ int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length) {
     }
 
     /* Read the payload */
-    return recv(sock, ret, size, MSG_WAITALL);
+    return os_recv_waitall(sock, ret, size);
+}
+
+/* Receive a message from a stream socket, full message (MSG_WAITALL)
+ * Returns size on success.
+ * Returns -1 on socket error.
+ * Returns 0 on socket disconnected or timeout.
+ */
+ssize_t os_recv_waitall(int sock, void * buf, size_t size) {
+    size_t offset;
+    ssize_t recvb;
+
+    for (offset = 0; offset < size; offset += recvb) {
+        recvb = recv(sock, buf + offset, size - offset, 0);
+
+        if (recvb <= 0) {
+            return recvb;
+        }
+    }
+
+    return offset;
 }

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -120,4 +120,11 @@ uint32_t wnet_order(uint32_t value);
 /* Set the maximum buffer size for the socket */
 int OS_SetSocketSize(int sock, int mode, int max_msg_size);
 
+/* Receive a message from a stream socket, full message (MSG_WAITALL)
+ * Returns size on success.
+ * Returns -1 on socket error.
+ * Returns 0 on socket disconnected or timeout.
+ */
+ssize_t os_recv_waitall(int sock, void * buf, size_t size);
+
 #endif /* __OS_NET_H */


### PR DESCRIPTION
|Fixes|
|---|
|#953|

As explained at the issue, the network API for Windows does not support the flag `MSG_WAITALL` in `recv()`. This prevents the agent from connecting to the manager in TCP mode on Windows XP.

## Solution

We implemented the `os_recv_waitall()` function to emulate the _WAITALL_ behavior. We changed `OS_RecvSecureTCP()` to use that function and replaced calls to `recv()` in:
- **_start_agent.c_**: Connection handshake.
- **_receiver.c_**: Incoming message handler for UNIX.
- **_receiver-win.c_**: Incoming message handler for Windows. 

## Tests

1. Agent connection in TCP mode.
2. Log reporting.
3. Shared configuration delivery.
4. Agent restart via Active response.

### Platforms

- Windows XP SP2 x32
- Windows XP SP3 x32
- Windows Server 2016 x64
- Debian 9
- CentOS 7
- FreeBSD 11.2