### PR TITLE
Fix for AWS confing

### DIFF
--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -932,7 +932,7 @@ class AWSConfigBucket(AWSLogsBucket):
                 last_key = self.get_full_prefix(aws_account_id, aws_region) + date
 
         # for getting only logs of the current date
-        config_prefix = self.get_full_prefix(aws_account_id, aws_region) + date
+        config_prefix = self.get_full_prefix(aws_account_id, aws_region) + date + '/'
 
         filter_args = {
             'Bucket': self.bucket,


### PR DESCRIPTION
Hi team,

`AWS Config` was not getting logs properly (it jumps from day 1 to 10 day). I made a fix by using `Prefix` argument in filter arguments.

Best regards,

Demetrio.