### PR TITLE
Fix bug when preparsing Debian OVAL

### DIFF
--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -1101,8 +1101,8 @@ char * wm_vuldet_xml_preparser(char *path, distribution dist) {
     char *tmp_file;
     static const char *exclude_tags[] = {
         // Debian
-        "oval:org.debian.oval:tst:1",
-        "oval:org.debian.oval:tst:2"
+        "oval:org.debian.oval:tst:1\"",
+        "oval:org.debian.oval:tst:2\""
     };
 
     os_strdup(CVE_FIT_TEMP_FILE, tmp_file);
@@ -1164,8 +1164,8 @@ char * wm_vuldet_xml_preparser(char *path, distribution dist) {
                     continue;
                 break;
                 case V_DEFINITIONS:
-                    if (wstr_end(buffer, exclude_tags[0]) ||
-                        wstr_end(buffer, exclude_tags[1])) {
+                    if (strstr(buffer, exclude_tags[0]) ||
+                        strstr(buffer, exclude_tags[1])) {
                         continue;
                     } else if (found = strstr(buffer, "</definitions>"), found) {
                         state = V_STATES;


### PR DESCRIPTION
This bug has been introduced in https://github.com/wazuh/wazuh/pull/2301. Its only consequence is a flooding error output:
```

2019/01/14 11:37:18 wazuh-modulesd:vulnerability-detector[7397] wm_vuln_detector.c:1570 at wm_vuldet_xml_parser(): ERROR: (5404): The package name could not be obtained.
2019/01/14 11:37:18 wazuh-modulesd:vulnerability-detector[7397] wm_vuln_detector.c:1570 at wm_vuldet_xml_parser(): ERROR: (5404): The package name could not be obtained.
2019/01/14 11:37:18 wazuh-modulesd:vulnerability-detector[7397] wm_vuln_detector.c:1570 at wm_vuldet_xml_parser(): ERROR: (5404): The package name could not be obtained.
2019/01/14 11:37:18 wazuh-modulesd:vulnerability-detector[7397] wm_vuln_detector.c:1570 at wm_vuldet_xml_parser(): ERROR: (5404): The package name could not be obtained.
```

This is because content which had to be removed at the preparsing step was being processed.
