### PR TITLE
Add warning when trying to enable authd

### DIFF
--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -128,6 +128,8 @@ help()
     exit 1;
 }
 
+AUTHD_MSG="This option is deprecated because Authd is now enabled by default. If you want to change it, modify the ossec.conf file."
+
 # Enables additional daemons
 enable()
 {
@@ -146,6 +148,8 @@ enable()
         echo "AGENTLESS_DAEMON=ossec-agentlessd" >> ${PLIST};
     elif [ "X$2" = "Xintegrator" ]; then
         echo "INTEGRATOR_DAEMON=ossec-integratord" >> ${PLIST};
+    elif [ "X$2" = "Xauth" ]; then
+        echo "$AUTHD_MSG"
     elif [ "X$2" = "Xdebug" ]; then
         echo "DEBUG_CLI=\"-d\"" >> ${PLIST};
     else
@@ -180,6 +184,8 @@ disable()
     elif [ "X$2" = "Xintegrator" ]; then
         echo "INTEGRATOR_DAEMON=\"\"" >> ${PLIST};
         daemon='ossec-integratord'
+    elif [ "X$2" = "Xauth" ]; then
+        echo "$AUTHD_MSG"
     elif [ "X$2" = "Xdebug" ]; then
         echo "DEBUG_CLI=\"\"" >> ${PLIST};
     else


### PR DESCRIPTION
Since this PR Authd is enabled by default, but is considered an invalid option when trying to add to **ossec-control enable**. This PR prevents it from being considered an error to try to add this option.