### PR TITLE
Add list/info attributes

### DIFF
--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -418,7 +418,7 @@ class Rule:
                                     rule.description += value
                                 elif tag == "field":
                                     rule.add_detail(xml_rule_tags.attrib['name'], value)
-                                elif tag == "list":
+                                elif tag in ("list", "info"):
                                     list_detail = {'name': value}
                                     for attrib, attrib_value in xml_rule_tags.attrib.items():
                                         list_detail[attrib] = attrib_value

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -386,7 +386,7 @@ class Rule:
     def __load_rules_from_file(rule_file, rule_path, rule_status):
         try:
             rules = []
-            
+
             root = load_wazuh_xml("{}/{}".format(rule_path, rule_file))
 
             for xml_group in root.getchildren():
@@ -418,6 +418,11 @@ class Rule:
                                     rule.description += value
                                 elif tag == "field":
                                     rule.add_detail(xml_rule_tags.attrib['name'], value)
+                                elif tag == "list":
+                                    list_detail = {'name': value}
+                                    for attrib, attrib_value in xml_rule_tags.attrib.items():
+                                        list_detail[attrib] = attrib_value
+                                    rule.add_detail(tag, list_detail)
                                 # show rule variables
                                 elif tag in {'regex', 'match', 'user', 'id'} and value != '' and value[0] == "$":
                                     for variable in filter(lambda x: x.get('name') == value[1:], root.findall('var')):


### PR DESCRIPTION
## Description
This fix closes #2354 . The same problem was detected with the "info" tags and also corrected with this fix.

## Tests
```bash
root@master:/var/ossec/ruleset/rules# curl -u foo:bar -k "https://localhost:55000/rules/80202?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "status": "enabled",
            "pci": [
               "10.6.1"
            ],
            "description": "AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName).",
            "file": "0350-amazon_rules.xml",
            "level": 3,
            "path": "/var/ossec/ruleset/rules",
            "details": {
               "if_sid": "80200",
               "list": {
                  "field": "aws.eventName",
                  "lookup": "match_key",
                  "name": "etc/lists/amazon/aws-eventnames"
               },
               "aws.source": "cloudtrail"
            },
            "groups": [
               "aws_cloudtrail",
               "amazon",
               "aws"
            ],
            "id": 80202,
            "gdpr": [
               "IV_35.7.d"
            ]
         }
      ]
   }
}

root@master:/var/ossec/ruleset/rules# curl -u foo:bar -k "https://localhost:55000/rules/40107?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "status": "enabled",
            "pci": [
               "6.2",
               "6.5.2",
               "11.4"
            ],
            "description": "Heap overflow in the Solaris cachefsd service.",
            "file": "0280-attack_rules.xml",
            "level": 14,
            "path": "/var/ossec/ruleset/rules",
            "details": {
               "regex": "cachefsd: Segmentation Fault - core dumped",
               "info": {
                  "type": "cve",
                  "name": "2002-0033"
               }
            },
            "groups": [
               "exploit_attempt",
               "syslog",
               "attacks"
            ],
            "id": 40107,
            "gdpr": [
               "IV_35.7.d"
            ]
         }
      ]
   }
}

```
Mocha tests OK.