### PR TITLE
Change connection error message to debug when agent starts

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -195,9 +195,9 @@ void start_agent(int is_startup)
                     break;
                 case -1:
 #ifdef WIN32
-                    merror("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
+                    mdebug1("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
 #else
-                    merror("Connection socket: %s (%d)", strerror(errno), errno);
+                    mdebug1("Connection socket: %s (%d)", strerror(errno), errno);
 #endif
                 }
 


### PR DESCRIPTION
When connecting agents to the manager by UDP, the receiver socket on the agent side can be empty when trying to read it.

This fact causes an error that has no sense to show it unless we are using TCP for the connection:

```
2019/01/16 03:35:02 ossec-agentd: ERROR: Connection socket: Resource temporarily unavailable (11)
```

This PR changes that error message to debug.