### PR TITLE
Fixed double data free when deleting file

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -956,7 +956,7 @@ int run_dbcheck()
                 while(curr_node && curr_node->key);
             }
         }
-
+        last_backup->free_data_function = NULL;
         OSHash_Free(last_backup);
 
         // Check and delete backup local/diff


### PR DESCRIPTION
A bug encountered when deleting a file that was being monitored with a `Frequency` scan caused a double free segfault.

The data inside the hash table used to deleted the file was freed https://github.com/wazuh/wazuh/blob/3.8/src/syscheckd/create_db.c#L951 and the freed again https://github.com/wazuh/wazuh/blob/3.8/src/syscheckd/create_db.c#L960 because `OSHash_Free` calls `free_syscheck_node_data`