### PR TITLE
Set default value to node_name

### DIFF
--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -531,6 +531,8 @@ int wm_sync_agentinfo(int id_agent, const char *path) {
     regmatch_t match[2];
     int match_size;
 
+    strncpy(node_name, "unknown", sizeof(node_name) - 1);
+
     if (!(fp = fopen(path, "r"))) {
         mterror(WM_DATABASE_LOGTAG, FOPEN_ERROR, path, errno, strerror(errno));
         return -1;


### PR DESCRIPTION
This PR fixes the issue https://github.com/wazuh/wazuh/issues/2365

Now the default value for the variable `node_name` is `unknown`. When the the agent-info file is empty, this default value will be inserted in the DB.

```
sqlite> select * from agent;
0|redhat7|127.0.0.1||Red Hat Enterprise Linux Server|7.4|7|4|Maipo||rhel|Linux |redhat7 |3.10.0-693.17.1.el7.x86_64 |#1 SMP Sun Jan 14 10:36:03 EST 2018 |x86_64|x86_64|Wazuh v3.8.0|||redhat7|node01|2019-01-16 15:22:23|9999-12-31 23:59:59|updated|0|0|
1|Centos7|any|2a...4d|CentOS Linux|7|7||Core||centos|Linux |centos7 |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64|x86_64|Wazuh v3.8.0|ab73af41699f13fdd81903b5f23d8d00|f8d49771911ed9d5c45b03a40babd065|ubuntu1710|node02|2019-01-16 12:48:23|2019-01-16 15:22:39|empty|0|0|default
```

```
sqlite> select * from agent;
0|redhat7|127.0.0.1||Red Hat Enterprise Linux Server|7.4|7|4|Maipo||rhel|Linux |redhat7 |3.10.0-693.17.1.el7.x86_64 |#1 SMP Sun Jan 14 10:36:03 EST 2018 |x86_64|x86_64|Wazuh v3.8.0|||redhat7|node01|2019-01-16 15:22:23|9999-12-31 23:59:59|updated|0|0|
1|Centos7|any|2a...4d||||||||||||||unknown|2019-01-16 12:48:23|2019-01-16 15:23:04|empty|0|0|default
```

