### PR TITLE
Fixed memory leak

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1203,6 +1203,8 @@ int read_links(const char *dir_name, int dir_position, int max_depth, unsigned i
         return 1;
     }
 
+    free(real_path);
+    free(dir_name_full);
     return 0;
 }
 #endif


### PR DESCRIPTION
This PR solves a memory leak caused by calling the function https://github.com/wazuh/wazuh/blob/3.8/src/syscheckd/create_db.c#L1145 by passing a 0 to the function argument `is_link`.

It reserves memory for the pointers `real_path` and `dir_name_full` , and returns 0 without freeing the memory.