### PR TITLE
Fix memory and descriptor leaks in Remoted

### DIFF
--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -16,8 +16,6 @@
 /* Prototypes */
 static void __memclear(char *id, char *name, char *ip, char *key, size_t size) __attribute((nonnull));
 
-void OS_FreeKey(keyentry *key);
-
 static int pass_empty_keyfile = 0;
 static OSHash *last_freed_keys = NULL;
 
@@ -61,8 +59,8 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
     os_md5 filesum1;
     os_md5 filesum2;
 
-    char *tmp_str = NULL;
-    char _finalstr[KEYSIZE] = {'\0'};
+    char *tmp_str;
+    char _finalstr[KEYSIZE];
 
     /* Allocate for the whole structure */
     keys->keyentries = (keyentry **)realloc(keys->keyentries,
@@ -179,8 +177,6 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
     char key[KEYSIZE + 1];
     char *end;
     int id_number;
-    
-    int success = 0;
 
     /* Check if the keys file is present and we can read it */
     if ((keys->file_change = File_DateofChange(keys_file)) < 0) {
@@ -201,14 +197,9 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
     keys->keyhash_ip = OSHash_Create();
     keys->keyhash_sock = OSHash_Create();
 
-    if (!keys->keyhash_id || !keys->keyhash_ip || !keys->keyhash_sock) {
-        merror(MEM_ERROR, errno, strerror(errno));
-        goto ret;
+    if (!(keys->keyhash_id && keys->keyhash_ip && keys->keyhash_sock)) {
+        merror_exit(MEM_ERROR, errno, strerror(errno));
     }
-    
-    OSHash_SetFreeDataPointer(keys->keyhash_id, (void (*)(void *))OS_FreeKey);
-    OSHash_SetFreeDataPointer(keys->keyhash_ip, (void (*)(void *))OS_FreeKey);
-    OSHash_SetFreeDataPointer(keys->keyhash_sock, (void (*)(void *))OS_FreeKey);
 
     /* Initialize structure */
     os_calloc(1, sizeof(keyentry*), keys->keyentries);
@@ -307,8 +298,7 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
         /* Check for maximum agent size */
         if ( !no_limit && keys->keysize >= (MAX_AGENTS - 2) ) {
             merror(AG_MAX_ERROR, MAX_AGENTS - 2);
-            merror(CONFIG_ERROR, keys_file);
-            goto ret;
+            merror_exit(CONFIG_ERROR, keys_file);
         }
 
         continue;
@@ -326,23 +316,15 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
         if (pass_empty_keyfile) {
             mdebug1(NO_CLIENT_KEYS);
         } else {
-            merror(NO_CLIENT_KEYS);
-            goto ret;
+            merror_exit(NO_CLIENT_KEYS);
         }
     }
 
     /* Add additional entry for sender == keysize */
     os_calloc(1, sizeof(keyentry), keys->keyentries[keys->keysize]);
     w_mutex_init(&keys->keyentries[keys->keysize]->mutex, NULL);
-    
-    success = 1;
-    
-ret:
-    if (!success) {
-        if (fp) fclose(fp);
-        OS_FreeKeys(keys);
-        exit(1);
-    }
+
+    return;
 }
 
 void OS_FreeKey(keyentry *key) {
@@ -350,7 +332,7 @@ void OS_FreeKey(keyentry *key) {
         last_freed_keys = OSHash_Create();
         if (!last_freed_keys) {
             merror_exit(LIST_ERROR);
-        }  
+        }
     }
     char key_c[64];
 #ifdef WIN32
@@ -393,7 +375,7 @@ void OS_FreeKey(keyentry *key) {
 /* Free the auth keys */
 void OS_FreeKeys(keystore *keys)
 {
-    size_t i;
+    unsigned int i;
 
     /* Free the hashes */
 

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -17,7 +17,6 @@
 static void __memclear(char *id, char *name, char *ip, char *key, size_t size) __attribute((nonnull));
 
 static int pass_empty_keyfile = 0;
-static OSHash *last_freed_keys = NULL;
 
 /* Clear keys entries */
 static void __memclear(char *id, char *name, char *ip, char *key, size_t size)
@@ -328,23 +327,6 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
 }
 
 void OS_FreeKey(keyentry *key) {
-    if(!last_freed_keys){
-        last_freed_keys = OSHash_Create();
-        if (!last_freed_keys) {
-            merror_exit(LIST_ERROR);
-        }
-    }
-    char key_c[64];
-#ifdef WIN32
-    sprintf(key_c,"%p",key);
-#else
-    sprintf(key_c,"%p",key);
-#endif
-
-    if(OSHash_Get(last_freed_keys,key_c)){
-        return;
-    }
-
     if (key->ip) {
         free(key->ip->ip);
         free(key->ip);
@@ -368,7 +350,6 @@ void OS_FreeKey(keyentry *key) {
     }
 
     pthread_mutex_destroy(&key->mutex);
-    OSHash_Add(last_freed_keys,key_c,(void *)1);
     free(key);
 }
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -563,6 +563,7 @@ static void c_files()
                 }
 
                 free(groups[i]->group);
+                free(groups[i]);
             }
 
             free(groups);
@@ -1263,8 +1264,8 @@ void manager_init()
     w_yaml_create_groups();
     memset(pending_queue, 0, MAX_AGENTS * 9);
     pending_data = OSHash_Create();
-    
+
     if (!m_hash || !pending_data) merror_exit("At manager_init(): OSHash_Create() failed");
-    
+
     OSHash_SetFreeDataPointer(pending_data, (void (*)(void *))free_pending_data);
 }


### PR DESCRIPTION
This PR fixes issue #2380.

## Solution

1. Rollover these PRs for the file _src/os_crypto/shared/keys.c_:

- ae29d7ecf3cd15fcd45a0ca5bea3ad67d06fcd79
- eaa3614a125e8f76883967ef3853a6cb8b77b1c6

2. Add a missing `free()` to the shared file list destructor.

## Test

Stop Authd and Remoted. Reduce the key reload interval to speed up this test:

```shell
pkill -f ossec-authd
pkill -f ossec-remoted
echo "remoted.keyupdate_interval=1" >> /var/ossec/etc/local_internal_options.conf
echo "remoted.shared_reload=1" >> /var/ossec/etc/local_internal_options.conf
valgrind --leak-check=full --num-callers=20 --track-origins=yes /var/ossec/bin/ossec-remoted
```

- Fill _client.keys_:
```shell
k=1
for i in {0..48}
do
    for j in {1..254}
    do
        echo `printf %03d $k` agent$k 192.168.$i.$j blablabla >> /var/ossec/etc/client.keys
        k=$((k+1))
    done
done

while true
do 
    touch /var/ossec/etc/client.keys
    sleep 1
done
```

Caution: Remoted running on Valgrind may take a long to load this huge _client.keys_.

- Connect an agent in TCP mode.

- Stop Valgrind, leave the `touch` loop. Launch Remoted normally:
```shell
pkill -f remoted
/var/ossec/bin/ossec-remoted
```
- Check that there are no memory leaks.
- Check that the number of file descriptors doesn't grow on reloads:
```
watch "ls /proc/`pidof ossec-remoted`/fd | wc -l"
```