### PR TITLE
Remove & Change doc_type for elasticsearch

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -5,7 +5,7 @@
     "index.refresh_interval": "5s"
   },
   "mappings": {
-    "wazuh": {
+    "doc": {
       "dynamic_templates": [
         {
           "string_as_keyword": {

--- a/extensions/logstash/01-wazuh-local.conf
+++ b/extensions/logstash/01-wazuh-local.conf
@@ -37,6 +37,5 @@ output {
     elasticsearch {
         hosts => ["localhost:9200"]
         index => "wazuh-alerts-3.x-%{+YYYY.MM.dd}"
-        document_type => "wazuh"
     }
 }

--- a/extensions/logstash/01-wazuh-remote.conf
+++ b/extensions/logstash/01-wazuh-remote.conf
@@ -39,6 +39,5 @@ output {
     elasticsearch {
         hosts => ["localhost:9200"]
         index => "wazuh-alerts-3.x-%{+YYYY.MM.dd}"
-        document_type => "wazuh"
     }
 }


### PR DESCRIPTION
We need to remove "document_type" in logstash-elasticsearch-output because doc_type will be deprecated in elasticsearch 7.x, and in logstash-output-elasticsearch(v 9.0.0), the default doc_type send to es was set to 'doc'. 

referrer:
https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html
https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v9.2.4/CHANGELOG.md#900