### PR TITLE
Fix wodle command conditional jump

### DIFF
--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -200,7 +200,7 @@ void * wm_command_main(wm_command_t * command) {
             break;
         }
 
-        if (!command->ignore_output) {
+        if (!command->ignore_output && output != NULL) {
             char * line;
 
             for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){


### PR DESCRIPTION
Fixed the next conditional jump at wodle command:

```
==7845== Thread 5:
==7845== Conditional jump or move depends on uninitialised value(s)
==7845==    at 0x5B12B75: strtok_r (strtok_r.c:49)
==7845==    by 0x16EA49: wm_command_main (wm_command.c:206)
==7845==    by 0x585C6DA: start_thread (pthread_create.c:463)
==7845==    by 0x5B9588E: clone (clone.S:95)
==7845== 
```