### PR TITLE
Error in FIM JSON alert in Windows systems

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -572,8 +572,7 @@ int fim_alert (char *f_name, sk_sum_t *oldsum, sk_sum_t *newsum, Eventinfo *lf, 
                         localsdb->perm[0] = '\0';
                     }
 
-                    lf->win_perm_before = oldsum->win_perm;
-                    oldsum->win_perm = NULL;
+                    os_strdup(oldsum->win_perm, lf->win_perm_before);
                 }
             }
 

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -573,6 +573,7 @@ int fim_alert (char *f_name, sk_sum_t *oldsum, sk_sum_t *newsum, Eventinfo *lf, 
                     }
 
                     lf->win_perm_before = oldsum->win_perm;
+                    oldsum->win_perm = NULL;
                 }
             }
 


### PR DESCRIPTION
When a Windows permission alert is generated, the JSON alert arrives without the `win_perm_before` field, showing the following error:

>  ossec-analysisd: ERROR: Old permissions could not be added to the JSON alert.