### PR TITLE
Fix invalid read at CleanMSG

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -67,7 +67,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
      * repair to only one slot so we can detect the correct date format in the next step
      * ex: Mär 02 17:30:52
      */
-    if (loglen >= 5 && pieces[1] == (char) 195) {
+    if (loglen >= 3 && pieces[1] == (char) 195) {
         if (pieces[2] == (char) 164) {
             pieces[0] = '\0';
             pieces[1] = 'M';

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -67,7 +67,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
      * repair to only one slot so we can detect the correct date format in the next step
      * ex: Mär 02 17:30:52
      */
-    if (pieces[1] == (char) 195) {
+    if (loglen >= 5 && pieces[1] == (char) 195) {
         if (pieces[2] == (char) 164) {
             pieces[0] = '\0';
             pieces[1] = 'M';


### PR DESCRIPTION
This PR fixes the next invalid read:
```
==1724== Invalid read of size 1
==1724==    at 0x128411: OS_CleanMSG (cleanevent.c:70)
==1724==    by 0x1330C6: w_decode_event_thread (analysisd.c:2012)
==1724==    by 0x585C6DA: start_thread (pthread_create.c:463)
==1724==    by 0x5B9588E: clone (clone.S:95)
==1724==  Address 0x72da740 is 0 bytes after a block of size 16 alloc'd
==1724==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1724==    by 0x5B119B9: strdup (strdup.c:42)
==1724==    by 0x13220C: ad_input_main (analysisd.c:1687)
==1724==    by 0x585C6DA: start_thread (pthread_create.c:463)
==1724==    by 0x5B9588E: clone (clone.S:95)
```

The code was intended to fix the next specific log with an umlaut: `Mär 02 17:30:52`. 
This character is stored in two bytes, `195 164`, and the message received at CleanMSG has 4 bytes as minimum. Accessing `pieces[1]` could cause an invalid read as the message would have 5 bytes counting the id. To fix it, the length of the log has to be higher than 4, because `Mär` counts as 4 bytes.