### PR TITLE
Fix 3.8 rename config fields

### DIFF
--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -69,6 +69,7 @@ from os import path
 import operator
 from datetime import datetime
 from datetime import timedelta
+from time import mktime
 # Python 2/3 compatibility
 if sys.version_info[0] == 3:
     unicode = str
@@ -1039,7 +1040,7 @@ class AWSConfigBucket(AWSLogsBucket):
                 elif isinstance(configuration['securityGroups'], dict):
                     configuration['securityGroups'] = {key: [value] for key, value in security_groups.items()}
                 else:
-                    print("WARNING: Could not reformat event {event}").format(event)
+                    print("WARNING: Could not reformat event {0}".format(event))
 
             if 'availabilityZones' in configuration:
                 availability_zones = configuration['availabilityZones']
@@ -1056,7 +1057,7 @@ class AWSConfigBucket(AWSLogsBucket):
                 elif isinstance(configuration['availabilityZones'], dict):
                     configuration['availabilityZones'] = {key: [value] for key, value in availability_zones.items()}
                 else:
-                    print("WARNING: Could not reformat event {event}").format(event)
+                    print("WARNING: Could not reformat event {0}".format(event))
 
             if 'state' in configuration:
                 state = configuration['state']
@@ -1065,7 +1066,28 @@ class AWSConfigBucket(AWSLogsBucket):
                 elif isinstance(state, dict):
                     pass
                 else:
-                    print("WARNING: Could not reformat event {event}").format(event)
+                    print("WARNING: Could not reformat event {0}".format(event))
+
+            if 'createdTime' in configuration:
+                created_time = configuration['createdTime']
+                if isinstance(created_time, float) or isinstance(created_time, int):
+                    configuration['createdTime'] = float(created_time)
+                else:
+                    try:
+                        date_string = str(created_time)
+                        configuration['createdTime'] = mktime(datetime.strptime(date_string,
+                                                                                "%Y-%m-%dT%H:%M:%S.%fZ").timetuple())
+                    except Exception:
+                        print("WARNING: Could not reformat event {0}".format(event))
+
+            if 'iamInstanceProfile' in configuration:
+                iam_profile = configuration['iamInstanceProfile']
+                if isinstance(iam_profile, unicode):
+                    configuration['iamInstanceProfile'] = {'name': iam_profile}
+                elif isinstance(iam_profile, dict):
+                    pass
+                else:
+                    print("WARNING: Could not reformat event {0}".format(event))
 
         return event
 

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -1039,12 +1039,13 @@ class AWSConfigBucket(AWSLogsBucket):
                 """
                 pass
 
-
+        """
         if 'configuration' in event['aws'] and 'availabilityZones' in event['aws']['configuration']:
             if not isinstance(event['aws']['configuration']['availabilityZones'], list):
                 availability_zones = event['aws']['configuration']['availabilityZones']
                 del event['aws']['configuration']['availabilityZones']
                 event['aws']['configuration']['availabilityZones'] = {'zoneName': availability_zones}
+        """
 
         if 'configuration' in event['aws'] and 'state' in event['aws']['configuration']:
             if isinstance(event['aws']['configuration']['state'], unicode):


### PR DESCRIPTION
This closes #2385.

## Description:
This fix reformat some events from aws wodle that contains tricky fields with dynamic types. Now, all this fields are standardized in some way to let them hit elasticsearch.

However, list fields are not decoded properly in wazuh JSON decoder, appearing in elasticsearch as a string separated by commas instead of an array.

## Tests performed:
* Sample of event generated:
```json
{
  "_index": "wazuh-alerts-3.x-2019.01.18",
  "_type": "wazuh",
  "_id": "NqadYGgB1tpD6-hML4eW",
  "_version": 1,
  "_score": null,
  "_source": {
    "decoder": {
      "name": "json"
    },
    "prospector": {
      "type": "log"
    },
    "full_log": "{\"aws\": {\"configurationItemCaptureTime\": \"2019-01-14T15:11:04.767Z\", \"relationships\": [{\"resourceType\": \"AWS::EC2::NetworkInterface\", \"resourceId\": \"eni-0796c1f8a4a056d93\", \"name\": \"Contains NetworkInterface\"}, {\"resourceType\": \"AWS::EC2::SecurityGroup\", \"resourceId\": \"sg-860709f4\", \"name\": \"Is associated with SecurityGroup\"}, {\"resourceType\": \"AWS::EC2::SecurityGroup\", \"resourceId\": \"sg-938fdce7\", \"name\": \"Is associated with SecurityGroup\"}, {\"resourceType\": \"AWS::EC2::Subnet\", \"resourceId\": \"subnet-5ab96a55\", \"name\": \"Is contained in Subnet\"}, {\"resourceType\": \"AWS::EC2::Volume\", \"resourceId\": \"vol-06860db3306f34a65\", \"name\": \"Is attached to Volume\"}, {\"resourceType\": \"AWS::EC2::VPC\", \"resourceId\": \"vpc-b8b30ec0\", \"name\": \"Is contained in Vpc\"}], \"availabilityZone\": \"us-east-1f\", \"configurationStateMd5Hash\": \"\", \"tags\": {\"opsworks:stack\": \"wazuh-stack-devel\", \"opsworks:layer:wazuh-cluster-master\": \"wazuh-cluster-master\", \"opsworks:instance\": \"wazuh-cluster-master-qa\", \"Name\": \"wazuh-stack-devel - wazuh-cluster-master-qa\"}, \"configurationItemVersion\": \"1.3\", \"supplementaryConfiguration\": {}, \"configuration\": {\"productCodes\": {\"productCodeId\": \"aw0evgkw8e5c1q413zgy5pjce\", \"productCodeType\": \"marketplace\"}, \"vpcId\": \"vpc-b8b30ec0\", \"cpuOptions\": {\"threadsPerCore\": 1, \"coreCount\": 1}, \"instanceId\": \"i-0f80ba0ee4c171ae8\", \"enaSupport\": true, \"imageId\": \"ami-d5bf2caa\", \"keyName\": \"wazuh-devel\", \"securityGroups\": {\"groupName\": [\"AWS-OpsWorks-Default-Server\", \"AWS-OpsWorks-WazuhStack-WazuhCluster\"], \"groupId\": [\"sg-860709f4\", \"sg-938fdce7\"]}, \"clientToken\": \"39773d26-eb9d-43c2-b5e3-93457e667e4e\", \"subnetId\": \"subnet-5ab96a55\", \"amiLaunchIndex\": 0, \"instanceType\": \"t2.micro\", \"networkInterfaces\": {\"status\": \"in-use\", \"macAddress\": \"16:ae:b4:44:6f:04\", \"sourceDestCheck\": true, \"vpcId\": \"vpc-b8b30ec0\", \"description\": \"\", \"networkInterfaceId\": \"eni-0796c1f8a4a056d93\", \"privateIpAddresses\": [{\"privateDnsName\": \"ip-172-0-2-40.ec2.internal\", \"primary\": true, \"privateIpAddress\": \"172.0.2.40\"}], \"privateDnsName\": \"ip-172-0-2-40.ec2.internal\", \"attachment\": {\"status\": \"attached\", \"deviceIndex\": 0, \"deleteOnTermination\": true, \"attachmentId\": \"eni-attach-08753b5ed192b881f\", \"attachTime\": \"2019-01-14T14:36:17.000Z\"}, \"groups\": [{\"groupName\": \"AWS-OpsWorks-Default-Server\", \"groupId\": \"sg-860709f4\"}, {\"groupName\": \"AWS-OpsWorks-WazuhStack-WazuhCluster\", \"groupId\": \"sg-938fdce7\"}], \"ipv6Addresses\": [], \"ownerId\": \"166157441623\", \"subnetId\": \"subnet-5ab96a55\", \"privateIpAddress\": \"172.0.2.40\"}, \"monitoring\": {\"state\": \"disabled\"}, \"tags\": [{\"value\": \"wazuh-stack-devel\", \"key\": \"opsworks:stack\"}, {\"value\": \"wazuh-cluster-master\", \"key\": \"opsworks:layer:wazuh-cluster-master\"}, {\"value\": \"wazuh-stack-devel - wazuh-cluster-master-qa\", \"key\": \"Name\"}, {\"value\": \"wazuh-cluster-master-qa\", \"key\": \"opsworks:instance\"}], \"publicDnsName\": \"\", \"state\": {\"code\": 80, \"name\": \"stopped\"}, \"ebsOptimized\": false, \"stateReason\": {\"message\": \"Client.UserInitiatedShutdown: User initiated shutdown\", \"code\": \"Client.UserInitiatedShutdown\"}, \"privateIpAddress\": \"172.0.2.40\", \"virtualizationType\": \"hvm\", \"elasticGpuAssociations\": [], \"stateTransitionReason\": \"User initiated (2019-01-14 15:08:23 GMT)\", \"privateDnsName\": \"ip-172-0-2-40.ec2.internal\", \"sourceDestCheck\": true, \"placement\": {\"groupName\": \"\", \"tenancy\": \"default\", \"availabilityZone\": \"us-east-1f\"}, \"hypervisor\": \"xen\", \"blockDeviceMappings\": {\"deviceName\": \"/dev/sda1\", \"ebs\": {\"status\": \"attached\", \"deleteOnTermination\": false, \"volumeId\": \"vol-06860db3306f34a65\", \"attachTime\": \"2019-01-14T14:36:18.000Z\"}}, \"launchTime\": \"2019-01-14T14:36:17.000Z\", \"architecture\": \"x86_64\", \"rootDeviceType\": \"ebs\", \"iamInstanceProfile\": {\"id\": \"AIPAJ2JD2NI2TL6MUOIKY\", \"arn\": \"arn:aws:iam::166157441623:instance-profile/aws-opsworks-ec2-role\"}, \"rootDeviceName\": \"/dev/sda1\"}, \"resourceCreationTime\": \"2019-01-14T14:36:17.000Z\", \"aws_account_id\": \"166157441623\", \"resourceType\": \"AWS::EC2::Instance\", \"configurationStateId\": 1547478664767, \"relatedEvents\": [], \"awsRegion\": \"us-east-1\", \"source\": \"config\", \"ARN\": \"arn:aws:ec2:us-east-1:166157441623:instance/i-0f80ba0ee4c171ae8\", \"resourceId\": \"i-0f80ba0ee4c171ae8\", \"log_info\": {\"s3bucket\": \"wazuh-aws-wodle\", \"aws_account_alias\": \"\", \"log_file\": \"config/AWSLogs/166157441623/Config/us-east-1/2019/1/18/ConfigSnapshot/166157441623_Config_us-east-1_ConfigSnapshot_20190118T105551Z_66bf25c7-f9ad-4d60-93b9-52b6abf6c4f1.json.gz\"}, \"configurationItemStatus\": \"OK\", \"awsAccountId\": \"166157441623\"}, \"integration\": \"aws\"}",
    "location": "Wazuh-AWS",
    "@timestamp": "2019-01-18T10:58:57.637Z",
    "data": {
      "integration": "aws",
      "aws": {
        "resourceType": "AWS::EC2::Instance",
        "awsAccountId": "166157441623",
        "tags": {
          "opsworks:stack": "wazuh-stack-devel",
          "opsworks:instance": "wazuh-cluster-master-qa",
          "Name": "wazuh-stack-devel - wazuh-cluster-master-qa",
          "opsworks:layer:wazuh-cluster-master": "wazuh-cluster-master"
        },
        "aws_account_id": "166157441623",
        "configurationItemCaptureTime": "2019-01-14T15:11:04.767Z",
        "ARN": "arn:aws:ec2:us-east-1:166157441623:instance/i-0f80ba0ee4c171ae8",
        "configurationItemVersion": "1.3",
        "availabilityZone": "us-east-1f",
        "configuration": {
          "blockDeviceMappings": {
            "deviceName": "/dev/sda1",
            "ebs": {
              "volumeId": "vol-06860db3306f34a65",
              "deleteOnTermination": "false",
              "attachTime": "2019-01-14T14:36:18.000Z",
              "status": "attached"
            }
          },
          "launchTime": "2019-01-14T14:36:17.000Z",
          "monitoring": {
            "state": "disabled"
          },
          "productCodes": {
            "productCodeId": "aw0evgkw8e5c1q413zgy5pjce",
            "productCodeType": "marketplace"
          },
          "subnetId": "subnet-5ab96a55",
          "keyName": "wazuh-devel",
          "imageId": "ami-d5bf2caa",
          "cpuOptions": {
            "coreCount": "1",
            "threadsPerCore": "1"
          },
          "ebsOptimized": "false",
          "instanceType": "t2.micro",
          "sourceDestCheck": "true",
          "privateIpAddress": "172.0.2.40",
          "instanceId": "i-0f80ba0ee4c171ae8",
          "iamInstanceProfile": {
            "arn": "arn:aws:iam::166157441623:instance-profile/aws-opsworks-ec2-role",
            "id": "AIPAJ2JD2NI2TL6MUOIKY"
          },
          "amiLaunchIndex": "0",
          "enaSupport": "true",
          "rootDeviceType": "ebs",
          "securityGroups": {
            "groupId": "sg-860709f4,sg-938fdce7,",
            "groupName": "AWS-OpsWorks-Default-Server,AWS-OpsWorks-WazuhStack-WazuhCluster,"
          },
          "placement": {
            "availabilityZone": "us-east-1f",
            "tenancy": "default"
          },
          "rootDeviceName": "/dev/sda1",
          "architecture": "x86_64",
          "stateTransitionReason": "User initiated (2019-01-14 15:08:23 GMT)",
          "privateDnsName": "ip-172-0-2-40.ec2.internal",
          "networkInterfaces": {
            "privateIpAddress": "172.0.2.40",
            "ownerId": "166157441623",
            "attachment": {
              "attachmentId": "eni-attach-08753b5ed192b881f",
              "deviceIndex": "0",
              "deleteOnTermination": "true",
              "attachTime": "2019-01-14T14:36:17.000Z",
              "status": "attached"
            },
            "status": "in-use",
            "macAddress": "16:ae:b4:44:6f:04",
            "vpcId": "vpc-b8b30ec0",
            "networkInterfaceId": "eni-0796c1f8a4a056d93",
            "subnetId": "subnet-5ab96a55",
            "privateDnsName": "ip-172-0-2-40.ec2.internal",
            "sourceDestCheck": "true"
          },
          "hypervisor": "xen",
          "vpcId": "vpc-b8b30ec0",
          "virtualizationType": "hvm",
          "state": {
            "name": "stopped",
            "code": "80"
          },
          "clientToken": "39773d26-eb9d-43c2-b5e3-93457e667e4e",
          "stateReason": {
            "message": "Client.UserInitiatedShutdown: User initiated shutdown",
            "code": "Client.UserInitiatedShutdown"
          }
        },
        "source": "config",
        "resourceId": "i-0f80ba0ee4c171ae8",
        "awsRegion": "us-east-1",
        "resourceCreationTime": "2019-01-14T14:36:17.000Z",
        "configurationItemStatus": "OK",
        "log_info": {
          "log_file": "config/AWSLogs/166157441623/Config/us-east-1/2019/1/18/ConfigSnapshot/166157441623_Config_us-east-1_ConfigSnapshot_20190118T105551Z_66bf25c7-f9ad-4d60-93b9-52b6abf6c4f1.json.gz",
          "s3bucket": "wazuh-aws-wodle"
        },
        "configurationStateId": "1547478664767.000000"
      }
    },
    "id": "1547809137.313080713",
    "manager": {
      "name": "manager"
    },
    "rule": {
      "id": "80475",
      "firedtimes": 45452,
      "level": 3,
      "description": "AWS Config - Snapshot [166157441623 us-east-1] [AWS::EC2::Instance]: i-0f80ba0ee4c171ae8 (OK)",
      "mail": false,
      "groups": [
        "amazon",
        "aws",
        "aws_config",
        "aws_config_snapshot"
      ]
    },
    "source": "/var/ossec/logs/alerts/alerts.json",
    "input": {
      "type": "log"
    },
    "agent": {
      "id": "000",
      "name": "manager"
    }
  },
  "fields": {
    "@timestamp": [
      "2019-01-18T10:58:57.637Z"
    ]
  },
  "highlight": {
    "data.integration": [
      "@kibana-highlighted-field@aws@/kibana-highlighted-field@"
    ]
  },
  "sort": [
    1547809137637
  ]
}
```
