### PR TITLE
Update selinux policy for Audit 3.0

### DIFF
--- a/src/selinux/wazuh.te
+++ b/src/selinux/wazuh.te
@@ -6,18 +6,20 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-module wazuh 1.2;
+module wazuh 1.3;
 
 require {
 	type audisp_t;
 	type var_t;
 	type auditd_t;
 	type usr_t;
+	type auditd_etc_t;
 	class sock_file { create setattr unlink };
 	class process { noatsecure siginh };
 	class dir { remove_name add_name read write };
-	class file { getattr open read };
-	class capability dac_override;
+	class file { getattr open read map };
+	class capability { dac_override dac_read_search };
+	class lnk_file { read };
 }
 
 #============= audisp_t ==============
@@ -38,3 +40,9 @@ allow audisp_t var_t:file { open read };
 #============= auditd_t ==============
 
 allow auditd_t audisp_t:process { noatsecure siginh };
+
+allow auditd_t auditd_etc_t:lnk_file { read };
+allow auditd_t self:capability { dac_override dac_read_search };
+allow auditd_t var_t:file { getattr map open read };
+allow auditd_t var_t:dir { remove_name add_name read write };
+allow auditd_t var_t:sock_file { create setattr unlink };

--- a/src/selinux/wazuh.te
+++ b/src/selinux/wazuh.te
@@ -15,7 +15,7 @@ require {
 	type usr_t;
 	type auditd_etc_t;
 	class sock_file { create setattr unlink };
-	class process { noatsecure siginh };
+	class process { noatsecure siginh rlimitinh };
 	class dir { remove_name add_name read write };
 	class file { getattr open read map };
 	class capability { dac_override dac_read_search };
@@ -46,3 +46,5 @@ allow auditd_t self:capability { dac_override dac_read_search };
 allow auditd_t var_t:file { getattr map open read };
 allow auditd_t var_t:dir { remove_name add_name read write };
 allow auditd_t var_t:sock_file { create setattr unlink };
+
+allow auditd_t audisp_t:process rlimitinh;


### PR DESCRIPTION
This PR solves the problem caused by Selinux starting Whodata using the new Audit version. 
Since Audit changed the folder for plugins, the Selinux policies need to be updated.

Tested in: 
- Fedora 29: Audit 3.0
- RedHat7: Audit 3.0
- Centos7: Audit 2.8.1