### PR TITLE
Remove debug message when no tmp/cve has been created

### DIFF
--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -1736,7 +1736,7 @@ free_mem:
         OS_ClearNode(chld_node);
         OS_ClearXML(&xml);
     }
-    if (remove(CVE_TEMP_FILE) < 0) {
+    if (remove(CVE_TEMP_FILE) < 0 && errno != ENOENT) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, "remove(%s): %s", CVE_TEMP_FILE, strerror(errno));
     }
     if (remove(CVE_FIT_TEMP_FILE) < 0) {


### PR DESCRIPTION
In Wazuh 3.8.0, when tmp/cve has not been created the following debug message is given.

> 2019/01/22 09:04:52 wazuh-modulesd:vulnerability-detector[6124] wm_vuln_detector.c:1743 at wm_vuldet_update_feed(): DEBUG: remove(tmp/cve): No such file or directory

Before Wazuh 3.8.0, this debug message was error.

This PR prevents a message when remove has failed because the file does not exist, since it may not be created in the offline update.
