### PR TITLE
Reduced shards. Auto expand replicas.

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -2,7 +2,10 @@
   "order": 0,
   "index_patterns": ["wazuh-alerts-3.x-*"],
   "settings": {
-    "index.refresh_interval": "5s"
+    "index.refresh_interval": "5s",
+    "index.number_of_shards": "3",
+    "index.number_of_replicas": "0",
+    "index.auto_expand_replicas": "0-1"
   },
   "mappings": {
     "wazuh": {

--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -5,7 +5,8 @@
     "index.refresh_interval": "5s",
     "index.number_of_shards": "3",
     "index.number_of_replicas": "0",
-    "index.auto_expand_replicas": "0-1"
+    "index.auto_expand_replicas": "0-1",
+    "index.mapping.total_fields.limit": 2000
   },
   "mappings": {
     "wazuh": {


### PR DESCRIPTION
> "index.number_of_shards": "3",

Reduced number of shards from 5 to 3.

> "index.number_of_replicas": "0",

Default number of replicas is now 0.

> "index.auto_expand_replicas": "0-1"

Total fields increased from 1000 (default) to 2000 due to https://github.com/wazuh/wazuh-kibana-app/issues/1214

> "index.mapping.total_fields.limit": 2000

If you have two or more nodes, alert indices will use 1 replica. If you come back to just one node, alert indices will use 0 replicas.

Note: this template also prevents from "yellow" states on fresh installations, which is frustrating for the user.