### PR TITLE
Split exception number 1602 into two new exceptions

### DIFF
--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -82,8 +82,9 @@ class WazuhException(Exception):
         # Syscheck/Rootcheck/AR: 1600 - 1699
         1600: 'There is no database for selected agent',  # Also, agent
         1601: 'Unable to restart syscheck/rootcheck',
-        1602: 'Impossible to run syscheck/run due to agent is not active',
         1603: 'Invalid status. Valid statuses are: all, solved and outstanding',
+        1604: 'Impossible to run FIM scan due to agent is not active',
+        1605: 'Impossible to run policy monitoring scan due to agent is not active',
         1650: 'Active response - Bad arguments',
         1651: 'Active response - Agent is not active',
         1652: 'Active response - Unable to run command',

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -99,7 +99,7 @@ def run(agent_id=None, all_agents=False):
             agent_status = "N/A"
 
         if agent_status.lower() != 'active':
-            raise WazuhException(1602, '{0} - {1}'.format(agent_id, agent_status))
+            raise WazuhException(1605, '{0} - {1}'.format(agent_id, agent_status))
 
         oq = OssecQueue(common.ARQUEUE)
         ret_msg = oq.send_msg_to_agent(OssecQueue.HC_SK_RESTART, agent_id)

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -47,7 +47,7 @@ def run(agent_id=None, all_agents=False):
             agent_status = "N/A"
 
         if agent_status.lower() != 'active':
-            raise WazuhException(1602, '{0} - {1}'.format(agent_id, agent_status))
+            raise WazuhException(1604, '{0} - {1}'.format(agent_id, agent_status))
 
         oq = OssecQueue(common.ARQUEUE)
         ret_msg = oq.send_msg_to_agent(OssecQueue.HC_SK_RESTART, agent_id)


### PR DESCRIPTION
Before:

```
   ...
1602: 'Impossible to run syscheck/run due to agent is not active',
   ...
```

After:

```
   ...
1604: 'Impossible to run FIM scan due to agent is not active',
1605: 'Impossible to run policy monitoring scan due to agent is not active',
   ...
```

Closes https://github.com/wazuh/wazuh-api/issues/291