### PR TITLE
Re-registered agent reassigned to correct multigroup if multigroup empty

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -570,11 +570,11 @@ static void c_files()
             groups = NULL;
         }
 
-        // Clean hash table
-        OSHash_Clean(m_hash, cleaner);
-        m_hash = OSHash_Create();
-
         if(should_clean == 1){
+            // Clean hash table
+            OSHash_Clean(m_hash, cleaner);
+            m_hash = OSHash_Create();
+
             reported_non_existing_group = 0;
 
             dp = opendir(MULTIGROUPS_DIR);
@@ -1212,7 +1212,7 @@ int purge_group(char *group){
         fp = fopen(path,"r+");
 
         if(!fp) {
-            mdebug1("At c_files(): Could not open file '%s'",entry->d_name);
+            mdebug1("At purge_group(): Could not open file '%s'",entry->d_name);
             closedir(dp);
             return -1;
         }
@@ -1222,7 +1222,7 @@ int purge_group(char *group){
                 fp = fopen(path,"w");
 
                 if(!fp){
-                    mdebug1("At c_files(): Could not open file '%s'",entry->d_name);
+                    mdebug1("At purge_group(): Could not open file '%s'",entry->d_name);
                     closedir(dp);
                     return -1;
                 }


### PR DESCRIPTION
Hi, Team,

This PR should fix the issue https://github.com/wazuh/wazuh/issues/2288.

When an agent was removed from a multigroup and said multigroup was thus empty, registering again the same agent did not assign it to its previous multigroup.

- Problem
A hash table contains the multigroups and the md5 sums of their corresponding `merged.mg` files (sent to the agents). The hash table is continuously emptied at each cycle, and filled again using the information contained in `queue/agent-groups/<ID>` files. But when an agent is removed and/or registered again, this `<ID>` file is removed, the hash table is emptied, and the multigroup information is lost. If the same agent is registered again, it is assigned to `defautlt` instead of its previous multigroup.

- Solution
The fix consists in emptying the hash table only when the directories under `multigroups` are removed.

Regards.
