### PR TITLE
Added Syscollector scan information to the syscollector events

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1896,7 +1896,7 @@ void * w_decode_syscollector_thread(__attribute__((unused)) void * args){
             /** Check the date/hour changes **/
 
             if (!DecodeSyscollector(lf,&socket)) {
-                /* We don't process syscheck events further */
+                /* We don't process syscollector events further */
                 w_free_event_info(lf);
             }
             else{

--- a/src/analysisd/decoders/plugin_decoders.h
+++ b/src/analysisd/decoders/plugin_decoders.h
@@ -35,6 +35,7 @@ void *OSSECAlert_Decoder_Exec(Eventinfo *lf, regex_matching *decoder_match);
 /* Plugin for JSON */
 void *JSON_Decoder_Init(void);
 void *JSON_Decoder_Exec(Eventinfo *lf, regex_matching *decoder_match);
+void fillData(Eventinfo *lf, const char *key, const char *value);
 
 /* List of plugins. All three lists must be in the same order */
 extern const char *(plugin_decoders[]);

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -15,7 +15,7 @@
 #include "../../config.h"
 #include "../../external/cJSON/cJSON.h"
 
-static void fillData(Eventinfo *lf, const char *key, const char *value)
+void fillData(Eventinfo *lf, const char *key, const char *value)
 {
 
     if (!key)

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -543,15 +543,15 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
                     }
 
                     if (ip6_address) {
-                        fillData(lf,"netinfo.iface.ipv4.address", ip6_address);
+                        fillData(lf,"netinfo.iface.ipv6.address", ip6_address);
                         free(ip6_address);
                     }
                     if(ip6_netmask) {
-                        fillData(lf,"netinfo.iface.ipv4.netmask", ip6_netmask);
+                        fillData(lf,"netinfo.iface.ipv6.netmask", ip6_netmask);
                         free(ip6_netmask);
                     }
                     if(ip6_broadcast) {
-                        fillData(lf,"netinfo.iface.ipv4.broadcast",ip6_broadcast);
+                        fillData(lf,"netinfo.iface.ipv6.broadcast",ip6_broadcast);
                         free(ip6_broadcast);
                     }
 

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -214,7 +214,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (mtu) {
             char _mtu[OS_MAXSTR];
             snprintf(_mtu, OS_MAXSTR - 1, "%d", mtu->valueint);
-            fillData(lf,"netinfo.iface._mtu",_mtu);
+            fillData(lf,"netinfo.iface.mtu",_mtu);
             wm_strcat(&msg, _mtu, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -230,7 +230,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (tx_packets) {
             char txpack[OS_MAXSTR];
             snprintf(txpack, OS_MAXSTR - 1, "%d", tx_packets->valueint);
-            fillData(lf,"netinfo.iface.txpack",txpack);
+            fillData(lf,"netinfo.iface.tx_packets",txpack);
             wm_strcat(&msg, txpack, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -239,7 +239,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (rx_packets) {
             char rxpack[OS_MAXSTR];
             snprintf(rxpack, OS_MAXSTR - 1, "%d", rx_packets->valueint);
-            fillData(lf,"netinfo.iface.rxpack",rxpack);
+            fillData(lf,"netinfo.iface.rx_packets",rxpack);
             wm_strcat(&msg, rxpack, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -248,7 +248,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (tx_bytes) {
             char txbytes[OS_MAXSTR];
             snprintf(txbytes, OS_MAXSTR - 1, "%d", tx_bytes->valueint);
-            fillData(lf,"netinfo.iface.txbytes",txbytes);
+            fillData(lf,"netinfo.iface.tx_bytes",txbytes);
             wm_strcat(&msg, txbytes, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -257,7 +257,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (rx_bytes) {
             char rxbytes[OS_MAXSTR];
             snprintf(rxbytes, OS_MAXSTR - 1, "%d", rx_bytes->valueint);
-            fillData(lf,"netinfo.iface.rxbytes",rxbytes);
+            fillData(lf,"netinfo.iface.rx_bytes",rxbytes);
             wm_strcat(&msg, rxbytes, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -266,7 +266,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (tx_errors) {
             char txerrors[OS_MAXSTR];
             snprintf(txerrors, OS_MAXSTR - 1, "%d", tx_errors->valueint);
-            fillData(lf,"netinfo.iface.txerrors",txerrors);
+            fillData(lf,"netinfo.iface.tx_errors",txerrors);
             wm_strcat(&msg, txerrors, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -275,7 +275,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (rx_errors) {
             char rxerrors[OS_MAXSTR];
             snprintf(rxerrors, OS_MAXSTR - 1, "%d", rx_errors->valueint);
-            fillData(lf,"netinfo.iface.rxerrors",rxerrors);
+            fillData(lf,"netinfo.iface.rx_errors",rxerrors);
             wm_strcat(&msg, rxerrors, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -284,7 +284,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (tx_dropped) {
             char txdropped[OS_MAXSTR];
             snprintf(txdropped, OS_MAXSTR - 1, "%d", tx_dropped->valueint);
-            fillData(lf,"netinfo.iface.txdropped",txdropped);
+            fillData(lf,"netinfo.iface.tx_dropped",txdropped);
             wm_strcat(&msg, txdropped, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -293,7 +293,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (rx_dropped) {
             char rxdropped[OS_MAXSTR];
             snprintf(rxdropped, OS_MAXSTR - 1, "%d", rx_dropped->valueint);
-            fillData(lf,"netinfo.iface.rxdropped",rxdropped);
+            fillData(lf,"netinfo.iface.rx_dropped",rxdropped);
             wm_strcat(&msg, rxdropped, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -404,19 +404,31 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
                         }
 
                         if (sc_send_db(msg,socket) < 0) {
+                            if (ip4_address) {
+                                free(ip4_address);
+                            }
+                            if(ip4_netmask) {
+                                free(ip4_netmask);
+                            }
+                            if(ip4_broadcast) {
+                                free(ip4_broadcast);
+                            }
                             return -1;
                         }
                     }
 
-                    fillData(lf,"netinfo.iface.ipv4.address", ip4_address);
-                    if(ip4_netmask)
+                    if (ip4_address) {
+                        fillData(lf,"netinfo.iface.ipv4.address", ip4_address);
+                        free(ip4_address);
+                    }
+                    if(ip4_netmask) {
                         fillData(lf,"netinfo.iface.ipv4.netmask", ip4_netmask);
-                    if(ip4_broadcast)
+                        free(ip4_netmask);
+                    }
+                    if(ip4_broadcast) {
                         fillData(lf,"netinfo.iface.ipv4.broadcast",ip4_broadcast);
-
-                    free(ip4_address);
-                    free(ip4_netmask);
-                    free(ip4_broadcast);
+                        free(ip4_broadcast);
+                    }
                 }
             }
 
@@ -447,12 +459,14 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
 
                 if (gateway) {
                     wm_strcat(&msg, gateway->valuestring, '|');
+                    fillData(lf, "netinfo.iface.ipv6.gateway",gateway->valuestring);
                 } else {
                     wm_strcat(&msg, "NULL", '|');
                 }
 
                 if (dhcp) {
                     wm_strcat(&msg, dhcp->valuestring, '|');
+                    fillData(lf, "netinfo.iface.ipv6.dhcp",dhcp->valuestring);
                 } else {
                     wm_strcat(&msg, "NULL", '|');
                 }
@@ -515,19 +529,31 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
                         }
 
                         if (sc_send_db(msg,socket) < 0) {
+                            if (ip6_address) {
+                                free(ip6_address);
+                            }
+                            if(ip6_netmask) {
+                                free(ip6_netmask);
+                            }
+                            if(ip6_broadcast) {
+                                free(ip6_broadcast);
+                            }
                             return -1;
                         }
                     }
 
-                    fillData(lf,"netinfo.iface.ipv6.address", ip6_address);
-                    if(ip6_netmask)
-                        fillData(lf,"netinfo.iface.ipv6.netmask", ip6_netmask);
-                    if(ip6_broadcast)
-                        fillData(lf,"netinfo.iface.ipv6.broadcast", ip6_broadcast);
-
-                    free(ip6_address);
-                    free(ip6_netmask);
-                    free(ip6_broadcast);
+                    if (ip6_address) {
+                        fillData(lf,"netinfo.iface.ipv4.address", ip6_address);
+                        free(ip6_address);
+                    }
+                    if(ip6_netmask) {
+                        fillData(lf,"netinfo.iface.ipv4.netmask", ip6_netmask);
+                        free(ip6_netmask);
+                    }
+                    if(ip6_broadcast) {
+                        fillData(lf,"netinfo.iface.ipv4.broadcast",ip6_broadcast);
+                        free(ip6_broadcast);
+                    }
 
                 }
             }
@@ -1066,7 +1092,7 @@ int decode_package( Eventinfo *lf,cJSON * logJSON,int *socket) {
 
         if (installtime) {
             wm_strcat(&msg, installtime->valuestring, '|');
-            fillData(lf,"program.installtime",installtime->valuestring);
+            fillData(lf,"program.install_time",installtime->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -1341,7 +1367,7 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (priority) {
             char prior[OS_MAXSTR];
             snprintf(prior, OS_MAXSTR - 1, "%d", priority->valueint);
-            fillData(lf,"process.prior",prior);
+            fillData(lf,"process.priority",prior);
             wm_strcat(&msg, prior, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1368,7 +1394,7 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (vm_size) {
             char vms[OS_MAXSTR];
             snprintf(vms, OS_MAXSTR - 1, "%d", vm_size->valueint);
-            fillData(lf,"process.vms",vms);
+            fillData(lf,"process.vm_size",vms);
             wm_strcat(&msg, vms, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -145,10 +145,10 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
 
     char *msg = NULL;
     cJSON * iface;
-    char id[OS_MAXSTR];
+    char id[OS_SIZE_1024];
     int i;
 
-    os_calloc(OS_MAXSTR, sizeof(char), msg);
+    os_calloc(OS_SIZE_6144, sizeof(char), msg);
 
     if (iface = cJSON_GetObjectItem(logJSON, "iface"), iface) {
         cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
@@ -168,10 +168,10 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         cJSON * rx_dropped = cJSON_GetObjectItem(iface, "rx_dropped");
         cJSON * mtu = cJSON_GetObjectItem(iface, "MTU");
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s netinfo save", lf->agent_id);
+        snprintf(msg, OS_SIZE_6144 - 1, "agent %s netinfo save", lf->agent_id);
 
         if (scan_id) {
-            snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
+            snprintf(id, OS_SIZE_1024 - 1, "%d", scan_id->valueint);
             wm_strcat(&msg, id, ' ');
         } else {
             wm_strcat(&msg, "NULL", ' ');
@@ -212,8 +212,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (mtu) {
-            char _mtu[OS_MAXSTR];
-            snprintf(_mtu, OS_MAXSTR - 1, "%d", mtu->valueint);
+            char _mtu[OS_SIZE_128];
+            snprintf(_mtu, OS_SIZE_128 - 1, "%d", mtu->valueint);
             fillData(lf,"netinfo.iface.mtu",_mtu);
             wm_strcat(&msg, _mtu, '|');
         } else {
@@ -228,8 +228,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (tx_packets) {
-            char txpack[OS_MAXSTR];
-            snprintf(txpack, OS_MAXSTR - 1, "%d", tx_packets->valueint);
+            char txpack[OS_SIZE_512];
+            snprintf(txpack, OS_SIZE_512 - 1, "%d", tx_packets->valueint);
             fillData(lf,"netinfo.iface.tx_packets",txpack);
             wm_strcat(&msg, txpack, '|');
         } else {
@@ -237,8 +237,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (rx_packets) {
-            char rxpack[OS_MAXSTR];
-            snprintf(rxpack, OS_MAXSTR - 1, "%d", rx_packets->valueint);
+            char rxpack[OS_SIZE_512];
+            snprintf(rxpack, OS_SIZE_512 - 1, "%d", rx_packets->valueint);
             fillData(lf,"netinfo.iface.rx_packets",rxpack);
             wm_strcat(&msg, rxpack, '|');
         } else {
@@ -246,8 +246,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (tx_bytes) {
-            char txbytes[OS_MAXSTR];
-            snprintf(txbytes, OS_MAXSTR - 1, "%d", tx_bytes->valueint);
+            char txbytes[OS_SIZE_512];
+            snprintf(txbytes, OS_SIZE_512 - 1, "%d", tx_bytes->valueint);
             fillData(lf,"netinfo.iface.tx_bytes",txbytes);
             wm_strcat(&msg, txbytes, '|');
         } else {
@@ -255,8 +255,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (rx_bytes) {
-            char rxbytes[OS_MAXSTR];
-            snprintf(rxbytes, OS_MAXSTR - 1, "%d", rx_bytes->valueint);
+            char rxbytes[OS_SIZE_512];
+            snprintf(rxbytes, OS_SIZE_512 - 1, "%d", rx_bytes->valueint);
             fillData(lf,"netinfo.iface.rx_bytes",rxbytes);
             wm_strcat(&msg, rxbytes, '|');
         } else {
@@ -264,8 +264,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (tx_errors) {
-            char txerrors[OS_MAXSTR];
-            snprintf(txerrors, OS_MAXSTR - 1, "%d", tx_errors->valueint);
+            char txerrors[OS_SIZE_512];
+            snprintf(txerrors, OS_SIZE_512 - 1, "%d", tx_errors->valueint);
             fillData(lf,"netinfo.iface.tx_errors",txerrors);
             wm_strcat(&msg, txerrors, '|');
         } else {
@@ -273,8 +273,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (rx_errors) {
-            char rxerrors[OS_MAXSTR];
-            snprintf(rxerrors, OS_MAXSTR - 1, "%d", rx_errors->valueint);
+            char rxerrors[OS_SIZE_512];
+            snprintf(rxerrors, OS_SIZE_512 - 1, "%d", rx_errors->valueint);
             fillData(lf,"netinfo.iface.rx_errors",rxerrors);
             wm_strcat(&msg, rxerrors, '|');
         } else {
@@ -282,8 +282,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (tx_dropped) {
-            char txdropped[OS_MAXSTR];
-            snprintf(txdropped, OS_MAXSTR - 1, "%d", tx_dropped->valueint);
+            char txdropped[OS_SIZE_512];
+            snprintf(txdropped, OS_SIZE_512 - 1, "%d", tx_dropped->valueint);
             fillData(lf,"netinfo.iface.tx_dropped",txdropped);
             wm_strcat(&msg, txdropped, '|');
         } else {
@@ -291,8 +291,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (rx_dropped) {
-            char rxdropped[OS_MAXSTR];
-            snprintf(rxdropped, OS_MAXSTR - 1, "%d", rx_dropped->valueint);
+            char rxdropped[OS_SIZE_512];
+            snprintf(rxdropped, OS_SIZE_512 - 1, "%d", rx_dropped->valueint);
             fillData(lf,"netinfo.iface.rx_dropped",rxdropped);
             wm_strcat(&msg, rxdropped, '|');
         } else {
@@ -312,8 +312,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
                 cJSON * gateway = cJSON_GetObjectItem(ip, "gateway");
                 cJSON * dhcp = cJSON_GetObjectItem(ip, "dhcp");
 
-                os_calloc(OS_MAXSTR, sizeof(char), msg);
-                snprintf(msg, OS_MAXSTR - 1, "agent %s netproto save", lf->agent_id);
+                os_calloc(OS_SIZE_6144, sizeof(char), msg);
+                snprintf(msg, OS_SIZE_6144 - 1, "agent %s netproto save", lf->agent_id);
 
                 if (scan_id) {
                     wm_strcat(&msg, id, ' ');
@@ -356,8 +356,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
                     char *ip4_broadcast = NULL;
                     for (i = 0; i < cJSON_GetArraySize(address); i++) {
 
-                        os_calloc(OS_MAXSTR, sizeof(char), msg);
-                        snprintf(msg, OS_MAXSTR - 1, "agent %s netaddr save", lf->agent_id);
+                        os_calloc(OS_SIZE_6144, sizeof(char), msg);
+                        snprintf(msg, OS_SIZE_6144 - 1, "agent %s netaddr save", lf->agent_id);
 
                         if (scan_id) {
                             wm_strcat(&msg, id, ' ');
@@ -439,8 +439,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
                 cJSON * gateway = cJSON_GetObjectItem(ip, "gateway");
                 cJSON * dhcp = cJSON_GetObjectItem(ip, "dhcp");
 
-                os_calloc(OS_MAXSTR, sizeof(char), msg);
-                snprintf(msg, OS_MAXSTR - 1, "agent %s netproto save", lf->agent_id);
+                os_calloc(OS_SIZE_6144, sizeof(char), msg);
+                snprintf(msg, OS_SIZE_6144 - 1, "agent %s netproto save", lf->agent_id);
 
                 if (scan_id) {
                     wm_strcat(&msg, id, ' ');
@@ -481,8 +481,8 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
                     char *ip6_broadcast = NULL;
                     for (i = 0; i < cJSON_GetArraySize(address); i++) {
 
-                        os_calloc(OS_MAXSTR, sizeof(char), msg);
-                        snprintf(msg, OS_MAXSTR - 1, "agent %s netaddr save", lf->agent_id);
+                        os_calloc(OS_SIZE_6144, sizeof(char), msg);
+                        snprintf(msg, OS_SIZE_6144 - 1, "agent %s netaddr save", lf->agent_id);
 
                         if (scan_id) {
                             wm_strcat(&msg, id, ' ');
@@ -571,7 +571,7 @@ int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         } else if (strcmp(msg_type, "network_end") == 0) {
 
             cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
-            snprintf(msg, OS_MAXSTR - 1, "agent %s netinfo del %d", lf->agent_id, scan_id->valueint);
+            snprintf(msg, OS_SIZE_6144 - 1, "agent %s netinfo del %d", lf->agent_id, scan_id->valueint);
 
             if (sc_send_db(msg,socket) < 0) {
                 return -1;
@@ -607,14 +607,14 @@ int decode_osinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
         cJSON * version = cJSON_GetObjectItem(inventory, "version");
 
         char * msg = NULL;
-        os_calloc(OS_MAXSTR, sizeof(char), msg);
+        os_calloc(OS_SIZE_6144, sizeof(char), msg);
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s osinfo save", lf->agent_id);
+        snprintf(msg, OS_SIZE_6144 - 1, "agent %s osinfo save", lf->agent_id);
 
 
         if (scan_id) {
-            char id[OS_MAXSTR];
-            snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
+            char id[OS_SIZE_1024];
+            snprintf(id, OS_SIZE_1024 - 1, "%d", scan_id->valueint);
             wm_strcat(&msg, id, ' ');
         } else {
             wm_strcat(&msg, "NULL", ' ');
@@ -728,7 +728,7 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         return -1;
     }
 
-    os_calloc(OS_MAXSTR, sizeof(char), msg);
+    os_calloc(OS_SIZE_6144, sizeof(char), msg);
 
     cJSON * inventory;
 
@@ -754,10 +754,10 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         cJSON * pid = cJSON_GetObjectItem(inventory, "PID");
         cJSON * process = cJSON_GetObjectItem(inventory, "process");
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s port save", lf->agent_id);
+        snprintf(msg, OS_SIZE_6144 - 1, "agent %s port save", lf->agent_id);
 
-        char id[OS_MAXSTR];
-        snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
+        char id[OS_SIZE_1024];
+        snprintf(id, OS_SIZE_1024 - 1, "%d", scan_id->valueint);
         wm_strcat(&msg, id, ' ');
 
         if (scan_time) {
@@ -781,8 +781,8 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (local_port) {
-            char lport[OS_MAXSTR];
-            snprintf(lport, OS_MAXSTR - 1, "%d", local_port->valueint);
+            char lport[OS_SIZE_128];
+            snprintf(lport, OS_SIZE_128 - 1, "%d", local_port->valueint);
             fillData(lf,"port.local_port",lport);
             wm_strcat(&msg, lport, '|');
         } else {
@@ -797,8 +797,8 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (remote_port) {
-            char rport[OS_MAXSTR];
-            snprintf(rport, OS_MAXSTR - 1, "%d", remote_port->valueint);
+            char rport[OS_SIZE_128];
+            snprintf(rport, OS_SIZE_128 - 1, "%d", remote_port->valueint);
             fillData(lf,"port.remote_port",rport);
             wm_strcat(&msg, rport, '|');
         } else {
@@ -806,8 +806,8 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (tx_queue) {
-            char txq[OS_MAXSTR];
-            snprintf(txq, OS_MAXSTR - 1, "%d", tx_queue->valueint);
+            char txq[OS_SIZE_512];
+            snprintf(txq, OS_SIZE_512 - 1, "%d", tx_queue->valueint);
             fillData(lf,"port.tx_queue",txq);
             wm_strcat(&msg, txq, '|');
         } else {
@@ -815,8 +815,8 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (rx_queue) {
-            char rxq[OS_MAXSTR];
-            snprintf(rxq, OS_MAXSTR - 1, "%d", rx_queue->valueint);
+            char rxq[OS_SIZE_512];
+            snprintf(rxq, OS_SIZE_512 - 1, "%d", rx_queue->valueint);
             fillData(lf,"port.rx_queue",rxq);
             wm_strcat(&msg, rxq, '|');
         } else {
@@ -824,8 +824,8 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (inode) {
-            char _inode[OS_MAXSTR];
-            snprintf(_inode, OS_MAXSTR - 1, "%d", inode->valueint);
+            char _inode[OS_SIZE_512];
+            snprintf(_inode, OS_SIZE_512 - 1, "%d", inode->valueint);
             fillData(lf,"port.inode",_inode);
             wm_strcat(&msg, _inode, '|');
         } else {
@@ -840,8 +840,8 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (pid) {
-            char _pid[OS_MAXSTR];
-            snprintf(_pid, OS_MAXSTR - 1, "%d", pid->valueint);
+            char _pid[OS_SIZE_512];
+            snprintf(_pid, OS_SIZE_512 - 1, "%d", pid->valueint);
             fillData(lf,"port.pid",_pid);
             wm_strcat(&msg, _pid, '|');
         } else {
@@ -881,7 +881,7 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
                 }
             }
 
-            snprintf(msg, OS_MAXSTR - 1, "agent %s port del %d", lf->agent_id, scan_id->valueint);
+            snprintf(msg, OS_SIZE_6144 - 1, "agent %s port del %d", lf->agent_id, scan_id->valueint);
 
             if (sc_send_db(msg,socket) < 0) {
                 error_port = 1;
@@ -912,13 +912,13 @@ int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket) {
         cJSON * ram_usage = cJSON_GetObjectItem(inventory, "ram_usage");
 
         char * msg = NULL;
-        os_calloc(OS_MAXSTR, sizeof(char), msg);
+        os_calloc(OS_SIZE_6144, sizeof(char), msg);
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s hardware save", lf->agent_id);
+        snprintf(msg, OS_SIZE_6144 - 1, "agent %s hardware save", lf->agent_id);
 
         if (scan_id) {
-            char id[OS_MAXSTR];
-            snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
+            char id[OS_SIZE_1024];
+            snprintf(id, OS_SIZE_1024 - 1, "%d", scan_id->valueint);
             wm_strcat(&msg, id, ' ');
         } else {
             wm_strcat(&msg, "NULL", ' ');
@@ -946,8 +946,8 @@ int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (cpu_cores) {
-            char cores[OS_MAXSTR];
-            snprintf(cores, OS_MAXSTR - 1, "%d", cpu_cores->valueint);
+            char cores[OS_SIZE_128];
+            snprintf(cores, OS_SIZE_128 - 1, "%d", cpu_cores->valueint);
             fillData(lf,"hardware.cpu_cores",cores);
             wm_strcat(&msg, cores, '|');
         } else {
@@ -955,8 +955,8 @@ int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (cpu_mhz) {
-            char freq[OS_MAXSTR];
-            snprintf(freq, OS_MAXSTR - 1, "%f", cpu_mhz->valuedouble);
+            char freq[OS_SIZE_512];
+            snprintf(freq, OS_SIZE_512 - 1, "%f", cpu_mhz->valuedouble);
             fillData(lf,"hardware.cpu_mhz",freq);
             wm_strcat(&msg, freq, '|');
         } else {
@@ -964,8 +964,8 @@ int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (ram_total) {
-            char total[OS_MAXSTR];
-            snprintf(total, OS_MAXSTR - 1, "%f", ram_total->valuedouble);
+            char total[OS_SIZE_512];
+            snprintf(total, OS_SIZE_512 - 1, "%f", ram_total->valuedouble);
             fillData(lf,"harware.ram_total",total);
             wm_strcat(&msg, total, '|');
         } else {
@@ -973,8 +973,8 @@ int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (ram_free) {
-            char rfree[OS_MAXSTR];
-            snprintf(rfree, OS_MAXSTR - 1, "%f", ram_free->valuedouble);
+            char rfree[OS_SIZE_512];
+            snprintf(rfree, OS_SIZE_512 - 1, "%f", ram_free->valuedouble);
             fillData(lf,"hardware.ram_free",rfree);
             wm_strcat(&msg, rfree, '|');
         } else {
@@ -982,8 +982,8 @@ int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (ram_usage) {
-            char usage[OS_MAXSTR];
-            snprintf(usage, OS_MAXSTR - 1, "%d", ram_usage->valueint);
+            char usage[OS_SIZE_128];
+            snprintf(usage, OS_SIZE_128 - 1, "%d", ram_usage->valueint);
             fillData(lf,"hardware.ram_usage",usage);
             wm_strcat(&msg, usage, '|');
         } else {
@@ -1008,7 +1008,7 @@ int decode_package( Eventinfo *lf,cJSON * logJSON,int *socket) {
         return -1;
     }
 
-    os_calloc(OS_MAXSTR, sizeof(char), msg);
+    os_calloc(OS_SIZE_6144, sizeof(char), msg);
 
     if (package = cJSON_GetObjectItem(logJSON, "program"), package) {
         if (error_package) {
@@ -1034,10 +1034,10 @@ int decode_package( Eventinfo *lf,cJSON * logJSON,int *socket) {
         cJSON * installtime = cJSON_GetObjectItem(package, "install_time");
         cJSON * location = cJSON_GetObjectItem(package, "location");
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s package save", lf->agent_id);
+        snprintf(msg, OS_SIZE_6144 - 1, "agent %s package save", lf->agent_id);
 
-        char id[OS_MAXSTR];
-        snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
+        char id[OS_SIZE_1024];
+        snprintf(id, OS_SIZE_1024 - 1, "%d", scan_id->valueint);
         wm_strcat(&msg, id, ' ');
 
         if (scan_time) {
@@ -1075,8 +1075,8 @@ int decode_package( Eventinfo *lf,cJSON * logJSON,int *socket) {
         }
 
         if (size) {
-            char _size[OS_MAXSTR];
-            snprintf(_size, OS_MAXSTR - 1, "%d", size->valueint);
+            char _size[OS_SIZE_512];
+            snprintf(_size, OS_SIZE_512 - 1, "%d", size->valueint);
             fillData(lf,"program.size",_size);
             wm_strcat(&msg, _size, '|');
         } else {
@@ -1166,7 +1166,7 @@ int decode_package( Eventinfo *lf,cJSON * logJSON,int *socket) {
                 }
             }
 
-            snprintf(msg, OS_MAXSTR - 1, "agent %s package del %d", lf->agent_id, scan_id->valueint);
+            snprintf(msg, OS_SIZE_6144 - 1, "agent %s package del %d", lf->agent_id, scan_id->valueint);
 
             if (sc_send_db(msg,socket) < 0) {
                 error_package = 1;
@@ -1191,7 +1191,7 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         return -1;
     }
 
-    os_calloc(OS_MAXSTR, sizeof(char), msg);
+    os_calloc(OS_SIZE_6144, sizeof(char), msg);
 
     cJSON * inventory;
 
@@ -1234,10 +1234,10 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         cJSON * tty = cJSON_GetObjectItem(inventory, "tty");
         cJSON * processor = cJSON_GetObjectItem(inventory, "processor");
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s process save", lf->agent_id);
+        snprintf(msg, OS_SIZE_6144 - 1, "agent %s process save", lf->agent_id);
 
-        char id[OS_MAXSTR];
-        snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
+        char id[OS_SIZE_1024];
+        snprintf(id, OS_SIZE_1024 - 1, "%d", scan_id->valueint);
         wm_strcat(&msg, id, ' ');
 
         if (scan_time) {
@@ -1247,8 +1247,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (pid) {
-            char _pid[OS_MAXSTR];
-            snprintf(_pid, OS_MAXSTR - 1, "%d", pid->valueint);
+            char _pid[OS_SIZE_128];
+            snprintf(_pid, OS_SIZE_128 - 1, "%d", pid->valueint);
             fillData(lf,"process.pid",_pid);
             wm_strcat(&msg, _pid, '|');
         } else {
@@ -1270,8 +1270,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (ppid) {
-            char _ppid[OS_MAXSTR];
-            snprintf(_ppid, OS_MAXSTR - 1, "%d", ppid->valueint);
+            char _ppid[OS_SIZE_128];
+            snprintf(_ppid, OS_SIZE_128 - 1, "%d", ppid->valueint);
             fillData(lf,"process.ppid",_ppid);
             wm_strcat(&msg, _ppid, '|');
         } else {
@@ -1279,8 +1279,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (utime) {
-            char _utime[OS_MAXSTR];
-            snprintf(_utime, OS_MAXSTR - 1, "%d", utime->valueint);
+            char _utime[OS_SIZE_128];
+            snprintf(_utime, OS_SIZE_128 - 1, "%d", utime->valueint);
             fillData(lf,"process.utime",_utime);
             wm_strcat(&msg, _utime, '|');
         } else {
@@ -1288,8 +1288,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (stime) {
-            char _stime[OS_MAXSTR];
-            snprintf(_stime, OS_MAXSTR - 1, "%d", stime->valueint);
+            char _stime[OS_SIZE_128];
+            snprintf(_stime, OS_SIZE_128 - 1, "%d", stime->valueint);
             fillData(lf,"process.stime",_stime);
             wm_strcat(&msg, _stime, '|');
         } else {
@@ -1365,8 +1365,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (priority) {
-            char prior[OS_MAXSTR];
-            snprintf(prior, OS_MAXSTR - 1, "%d", priority->valueint);
+            char prior[OS_SIZE_128];
+            snprintf(prior, OS_SIZE_128 - 1, "%d", priority->valueint);
             fillData(lf,"process.priority",prior);
             wm_strcat(&msg, prior, '|');
         } else {
@@ -1374,8 +1374,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (nice) {
-            char _nice[OS_MAXSTR];
-            snprintf(_nice, OS_MAXSTR - 1, "%d", nice->valueint);
+            char _nice[OS_SIZE_128];
+            snprintf(_nice, OS_SIZE_128 - 1, "%d", nice->valueint);
             fillData(lf,"process.nice",_nice);
             wm_strcat(&msg, _nice, '|');
         } else {
@@ -1383,8 +1383,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (size) {
-            char _size[OS_MAXSTR];
-            snprintf(_size, OS_MAXSTR - 1, "%d", size->valueint);
+            char _size[OS_SIZE_512];
+            snprintf(_size, OS_SIZE_512 - 1, "%d", size->valueint);
             fillData(lf,"process.size",_size);
             wm_strcat(&msg, _size, '|');
         } else {
@@ -1392,8 +1392,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (vm_size) {
-            char vms[OS_MAXSTR];
-            snprintf(vms, OS_MAXSTR - 1, "%d", vm_size->valueint);
+            char vms[OS_SIZE_512];
+            snprintf(vms, OS_SIZE_512 - 1, "%d", vm_size->valueint);
             fillData(lf,"process.vm_size",vms);
             wm_strcat(&msg, vms, '|');
         } else {
@@ -1401,8 +1401,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (resident) {
-            char _resident[OS_MAXSTR];
-            snprintf(_resident, OS_MAXSTR - 1, "%d", resident->valueint);
+            char _resident[OS_SIZE_512];
+            snprintf(_resident, OS_SIZE_512 - 1, "%d", resident->valueint);
             fillData(lf,"process.resident",_resident);
             wm_strcat(&msg, _resident, '|');
         } else {
@@ -1410,8 +1410,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (share) {
-            char _share[OS_MAXSTR];
-            snprintf(_share, OS_MAXSTR - 1, "%d", share->valueint);
+            char _share[OS_SIZE_512];
+            snprintf(_share, OS_SIZE_512 - 1, "%d", share->valueint);
             fillData(lf,"process.share",_share);
             wm_strcat(&msg, _share, '|');
         } else {
@@ -1419,8 +1419,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (start_time) {
-            char start[OS_MAXSTR];
-            snprintf(start, OS_MAXSTR - 1, "%d", start_time->valueint);
+            char start[OS_SIZE_512];
+            snprintf(start, OS_SIZE_512 - 1, "%d", start_time->valueint);
             fillData(lf,"process.start_time",start);
             wm_strcat(&msg, start, '|');
         } else {
@@ -1428,8 +1428,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (pgrp) {
-            char _pgrp[OS_MAXSTR];
-            snprintf(_pgrp, OS_MAXSTR - 1, "%d", pgrp->valueint);
+            char _pgrp[OS_SIZE_512];
+            snprintf(_pgrp, OS_SIZE_512 - 1, "%d", pgrp->valueint);
             fillData(lf,"process.pgrp",_pgrp);
             wm_strcat(&msg, _pgrp, '|');
         } else {
@@ -1437,8 +1437,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (session) {
-            char _session[OS_MAXSTR];
-            snprintf(_session, OS_MAXSTR - 1, "%d", session->valueint);
+            char _session[OS_SIZE_512];
+            snprintf(_session, OS_SIZE_512 - 1, "%d", session->valueint);
             fillData(lf,"process.session",_session);
             wm_strcat(&msg, _session, '|');
         } else {
@@ -1446,8 +1446,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (nlwp) {
-            char _nlwp[OS_MAXSTR];
-            snprintf(_nlwp, OS_MAXSTR - 1, "%d", nlwp->valueint);
+            char _nlwp[OS_SIZE_512];
+            snprintf(_nlwp, OS_SIZE_512 - 1, "%d", nlwp->valueint);
             fillData(lf,"process.nlwp",_nlwp);
             wm_strcat(&msg, _nlwp, '|');
         } else {
@@ -1455,8 +1455,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (tgid) {
-            char _tgid[OS_MAXSTR];
-            snprintf(_tgid, OS_MAXSTR - 1, "%d", tgid->valueint);
+            char _tgid[OS_SIZE_512];
+            snprintf(_tgid, OS_SIZE_512 - 1, "%d", tgid->valueint);
             fillData(lf,"process.tgid",_tgid);
             wm_strcat(&msg, _tgid, '|');
         } else {
@@ -1464,8 +1464,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (tty) {
-            char _tty[OS_MAXSTR];
-            snprintf(_tty, OS_MAXSTR - 1, "%d", tty->valueint);
+            char _tty[OS_SIZE_512];
+            snprintf(_tty, OS_SIZE_512 - 1, "%d", tty->valueint);
             fillData(lf,"process.tty",_tty);
             wm_strcat(&msg, _tty, '|');
         } else {
@@ -1473,8 +1473,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         }
 
         if (processor) {
-            char proc[OS_MAXSTR];
-            snprintf(proc, OS_MAXSTR - 1, "%d", processor->valueint);
+            char proc[OS_SIZE_512];
+            snprintf(proc, OS_SIZE_512 - 1, "%d", processor->valueint);
             fillData(lf,"process.processor",proc);
             wm_strcat(&msg, proc, '|');
         } else {
@@ -1508,7 +1508,7 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
                 }
             }
 
-            snprintf(msg, OS_MAXSTR - 1, "agent %s process del %d", lf->agent_id, scan_id->valueint);
+            snprintf(msg, OS_SIZE_6144 - 1, "agent %s process del %d", lf->agent_id, scan_id->valueint);
 
             if (sc_send_db(msg,socket) < 0) {
                 error_process = 1;

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -28,12 +28,12 @@ static int prev_port_id = 0;
 static int error_process = 0;
 static int prev_process_id = 0;
 
-static int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket);
-static int decode_osinfo(char *agent_id, cJSON * logJSON,int *socket);
-static int decode_hardware(char *agent_id, cJSON * logJSON,int *socket);
-static int decode_package(char *agent_id, cJSON * logJSON,int *socket);
-static int decode_port(char *agent_id, cJSON * logJSON,int *socket);
-static int decode_process(char *agent_id, cJSON * logJSON,int *socket);
+static int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket);
+static int decode_osinfo( Eventinfo *lf, cJSON * logJSON,int *socket);
+static int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket);
+static int decode_package( Eventinfo *lf, cJSON * logJSON,int *socket);
+static int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket);
+static int decode_process( Eventinfo *lf, cJSON * logJSON,int *socket);
 
 static OSDecoderInfo *sysc_decoder = NULL;
 
@@ -88,43 +88,44 @@ int DecodeSyscollector(Eventinfo *lf,int *socket)
         return (0);
     }
 
+    fillData(lf,"type",msg_type);
     if (strcmp(msg_type, "port") == 0 || strcmp(msg_type, "port_end") == 0) {
-        if (decode_port(lf->agent_id, logJSON,socket) < 0) {
+        if (decode_port(lf, logJSON,socket) < 0) {
             mdebug1("Unable to send ports information to Wazuh DB.");
             cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "program") == 0 || strcmp(msg_type, "program_end") == 0) {
-        if (decode_package(lf->agent_id, logJSON,socket) < 0) {
+        if (decode_package(lf, logJSON,socket) < 0) {
             mdebug1("Unable to send packages information to Wazuh DB.");
             cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "hardware") == 0) {
-        if (decode_hardware(lf->agent_id, logJSON,socket) < 0) {
+        if (decode_hardware(lf, logJSON,socket) < 0) {
             mdebug1("Unable to send hardware information to Wazuh DB.");
             cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "OS") == 0) {
-        if (decode_osinfo(lf->agent_id, logJSON,socket) < 0) {
+        if (decode_osinfo(lf, logJSON,socket) < 0) {
             mdebug1("Unable to send osinfo message to Wazuh DB.");
             cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "network") == 0 || strcmp(msg_type, "network_end") == 0) {
-        if (decode_netinfo(lf->agent_id, logJSON, socket) < 0) {
+        if (decode_netinfo(lf, logJSON, socket) < 0) {
             merror("Unable to send netinfo message to Wazuh DB.");
             cJSON_Delete (logJSON);
             return (0);
         }
     }
     else if (strcmp(msg_type, "process") == 0 || strcmp(msg_type, "process_end") == 0) {
-        if (decode_process(lf->agent_id, logJSON,socket) < 0) {
+        if (decode_process(lf, logJSON,socket) < 0) {
             mdebug1("Unable to send processes information to Wazuh DB.");
             cJSON_Delete (logJSON);
             return (0);
@@ -140,7 +141,7 @@ int DecodeSyscollector(Eventinfo *lf,int *socket)
     return (1);
 }
 
-int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
+int decode_netinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
 
     char *msg = NULL;
     cJSON * iface;
@@ -167,7 +168,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         cJSON * rx_dropped = cJSON_GetObjectItem(iface, "rx_dropped");
         cJSON * mtu = cJSON_GetObjectItem(iface, "MTU");
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s netinfo save", agent_id);
+        snprintf(msg, OS_MAXSTR - 1, "agent %s netinfo save", lf->agent_id);
 
         if (scan_id) {
             snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
@@ -184,24 +185,28 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (name) {
             wm_strcat(&msg, name->valuestring, '|');
+            fillData(lf,"netinfo.iface.name",name->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (adapter) {
             wm_strcat(&msg, adapter->valuestring, '|');
+            fillData(lf,"netinfo.iface.adapter",adapter->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (type) {
             wm_strcat(&msg, type->valuestring, '|');
+            fillData(lf,"netinfo.iface.type",type->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (state) {
             wm_strcat(&msg, state->valuestring, '|');
+            fillData(lf,"netinfo.iface.state",state->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -209,6 +214,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (mtu) {
             char _mtu[OS_MAXSTR];
             snprintf(_mtu, OS_MAXSTR - 1, "%d", mtu->valueint);
+            fillData(lf,"netinfo.iface._mtu",_mtu);
             wm_strcat(&msg, _mtu, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -216,6 +222,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (mac) {
             wm_strcat(&msg, mac->valuestring, '|');
+            fillData(lf,"netinfo.iface.mac",mac->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -223,6 +230,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (tx_packets) {
             char txpack[OS_MAXSTR];
             snprintf(txpack, OS_MAXSTR - 1, "%d", tx_packets->valueint);
+            fillData(lf,"netinfo.iface.txpack",txpack);
             wm_strcat(&msg, txpack, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -231,6 +239,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (rx_packets) {
             char rxpack[OS_MAXSTR];
             snprintf(rxpack, OS_MAXSTR - 1, "%d", rx_packets->valueint);
+            fillData(lf,"netinfo.iface.rxpack",rxpack);
             wm_strcat(&msg, rxpack, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -239,6 +248,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (tx_bytes) {
             char txbytes[OS_MAXSTR];
             snprintf(txbytes, OS_MAXSTR - 1, "%d", tx_bytes->valueint);
+            fillData(lf,"netinfo.iface.txbytes",txbytes);
             wm_strcat(&msg, txbytes, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -247,6 +257,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (rx_bytes) {
             char rxbytes[OS_MAXSTR];
             snprintf(rxbytes, OS_MAXSTR - 1, "%d", rx_bytes->valueint);
+            fillData(lf,"netinfo.iface.rxbytes",rxbytes);
             wm_strcat(&msg, rxbytes, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -255,6 +266,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (tx_errors) {
             char txerrors[OS_MAXSTR];
             snprintf(txerrors, OS_MAXSTR - 1, "%d", tx_errors->valueint);
+            fillData(lf,"netinfo.iface.txerrors",txerrors);
             wm_strcat(&msg, txerrors, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -263,6 +275,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (rx_errors) {
             char rxerrors[OS_MAXSTR];
             snprintf(rxerrors, OS_MAXSTR - 1, "%d", rx_errors->valueint);
+            fillData(lf,"netinfo.iface.rxerrors",rxerrors);
             wm_strcat(&msg, rxerrors, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -271,6 +284,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (tx_dropped) {
             char txdropped[OS_MAXSTR];
             snprintf(txdropped, OS_MAXSTR - 1, "%d", tx_dropped->valueint);
+            fillData(lf,"netinfo.iface.txdropped",txdropped);
             wm_strcat(&msg, txdropped, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -279,6 +293,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         if (rx_dropped) {
             char rxdropped[OS_MAXSTR];
             snprintf(rxdropped, OS_MAXSTR - 1, "%d", rx_dropped->valueint);
+            fillData(lf,"netinfo.iface.rxdropped",rxdropped);
             wm_strcat(&msg, rxdropped, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -298,7 +313,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                 cJSON * dhcp = cJSON_GetObjectItem(ip, "dhcp");
 
                 os_calloc(OS_MAXSTR, sizeof(char), msg);
-                snprintf(msg, OS_MAXSTR - 1, "agent %s netproto save", agent_id);
+                snprintf(msg, OS_MAXSTR - 1, "agent %s netproto save", lf->agent_id);
 
                 if (scan_id) {
                     wm_strcat(&msg, id, ' ');
@@ -317,12 +332,14 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
 
                 if (gateway) {
                     wm_strcat(&msg, gateway->valuestring, '|');
+                    fillData(lf,"netinfo.iface.ipv4.gateway",gateway->valuestring);
                 } else {
                     wm_strcat(&msg, "NULL", '|');
                 }
 
                 if (dhcp) {
                     wm_strcat(&msg, dhcp->valuestring, '|');
+                    fillData(lf,"netinfo.iface.ipv4.dhcp",dhcp->valuestring);
                 } else {
                     wm_strcat(&msg, "NULL", '|');
                 }
@@ -334,10 +351,13 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                 // Save addresses information into 'sys_netaddr' table
 
                 if (address) {
+                    char *ip4_address = NULL;
+                    char *ip4_netmask = NULL;
+                    char *ip4_broadcast = NULL;
                     for (i = 0; i < cJSON_GetArraySize(address); i++) {
 
                         os_calloc(OS_MAXSTR, sizeof(char), msg);
-                        snprintf(msg, OS_MAXSTR - 1, "agent %s netaddr save", agent_id);
+                        snprintf(msg, OS_MAXSTR - 1, "agent %s netaddr save", lf->agent_id);
 
                         if (scan_id) {
                             wm_strcat(&msg, id, ' ');
@@ -355,15 +375,30 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                         wm_strcat(&msg, "0", '|');
 
                         wm_strcat(&msg, cJSON_GetArrayItem(address,i)->valuestring, '|');
+                        if(i == 0){
+                            os_strdup(cJSON_GetArrayItem(address,i)->valuestring, ip4_address);
+                        } else {
+                            wm_strcat(&ip4_address, cJSON_GetArrayItem(address,i)->valuestring, ',');
+                        }
 
                         if (cJSON_GetArrayItem(netmask,i) != NULL) {
                             wm_strcat(&msg, cJSON_GetArrayItem(netmask,i)->valuestring, '|');
+                            if(i == 0){
+                                os_strdup(cJSON_GetArrayItem(netmask,i)->valuestring, ip4_netmask);
+                            } else {
+                                wm_strcat(&ip4_netmask, cJSON_GetArrayItem(netmask,i)->valuestring, ',');
+                            }
                         } else {
                             wm_strcat(&msg, "NULL", '|');
                         }
 
                         if (cJSON_GetArrayItem(broadcast,i) != NULL) {
                             wm_strcat(&msg, cJSON_GetArrayItem(broadcast,i)->valuestring, '|');
+                            if(i == 0){
+                                os_strdup(cJSON_GetArrayItem(broadcast,i)->valuestring, ip4_broadcast);
+                            } else {
+                                wm_strcat(&ip4_broadcast, cJSON_GetArrayItem(broadcast,i)->valuestring, ',');
+                            }
                         } else {
                             wm_strcat(&msg, "NULL", '|');
                         }
@@ -372,6 +407,16 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                             return -1;
                         }
                     }
+
+                    fillData(lf,"netinfo.iface.ipv4.address", ip4_address);
+                    if(ip4_netmask)
+                        fillData(lf,"netinfo.iface.ipv4.netmask", ip4_netmask);
+                    if(ip4_broadcast)
+                        fillData(lf,"netinfo.iface.ipv4.broadcast",ip4_broadcast);
+
+                    free(ip4_address);
+                    free(ip4_netmask);
+                    free(ip4_broadcast);
                 }
             }
 
@@ -383,7 +428,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                 cJSON * dhcp = cJSON_GetObjectItem(ip, "dhcp");
 
                 os_calloc(OS_MAXSTR, sizeof(char), msg);
-                snprintf(msg, OS_MAXSTR - 1, "agent %s netproto save", agent_id);
+                snprintf(msg, OS_MAXSTR - 1, "agent %s netproto save", lf->agent_id);
 
                 if (scan_id) {
                     wm_strcat(&msg, id, ' ');
@@ -417,10 +462,13 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                 }
 
                 if (address) {
+                    char *ip6_address = NULL;
+                    char *ip6_netmask = NULL;
+                    char *ip6_broadcast = NULL;
                     for (i = 0; i < cJSON_GetArraySize(address); i++) {
 
                         os_calloc(OS_MAXSTR, sizeof(char), msg);
-                        snprintf(msg, OS_MAXSTR - 1, "agent %s netaddr save", agent_id);
+                        snprintf(msg, OS_MAXSTR - 1, "agent %s netaddr save", lf->agent_id);
 
                         if (scan_id) {
                             wm_strcat(&msg, id, ' ');
@@ -438,15 +486,30 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                         wm_strcat(&msg, "1", '|');
 
                         wm_strcat(&msg, cJSON_GetArrayItem(address,i)->valuestring, '|');
+                        if(i == 0){
+                            os_strdup(cJSON_GetArrayItem(address,i)->valuestring,ip6_address);
+                        } else {
+                            wm_strcat(&ip6_address, cJSON_GetArrayItem(address,i)->valuestring, ',');
+                        }
 
                         if (cJSON_GetArrayItem(netmask,i) != NULL) {
                             wm_strcat(&msg, cJSON_GetArrayItem(netmask,i)->valuestring, '|');
+                            if(i == 0){
+                                os_strdup(cJSON_GetArrayItem(netmask,i)->valuestring,ip6_netmask);
+                            } else {
+                                wm_strcat(&ip6_netmask, cJSON_GetArrayItem(netmask,i)->valuestring, ',');
+                            }
                         } else {
                             wm_strcat(&msg, "NULL", '|');
                         }
 
                         if (cJSON_GetArrayItem(broadcast,i) != NULL) {
                             wm_strcat(&msg, cJSON_GetArrayItem(broadcast,i)->valuestring, '|');
+                            if(i == 0){
+                                os_strdup(cJSON_GetArrayItem(broadcast,i)->valuestring, ip6_broadcast);
+                            } else {
+                                wm_strcat(&ip6_broadcast, cJSON_GetArrayItem(broadcast,i)->valuestring, ',');
+                            }
                         } else {
                             wm_strcat(&msg, "NULL", '|');
                         }
@@ -455,6 +518,17 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
                             return -1;
                         }
                     }
+
+                    fillData(lf,"netinfo.iface.ipv6.address", ip6_address);
+                    if(ip6_netmask)
+                        fillData(lf,"netinfo.iface.ipv6.netmask", ip6_netmask);
+                    if(ip6_broadcast)
+                        fillData(lf,"netinfo.iface.ipv6.broadcast", ip6_broadcast);
+
+                    free(ip6_address);
+                    free(ip6_netmask);
+                    free(ip6_broadcast);
+
                 }
             }
         }
@@ -471,7 +545,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
         } else if (strcmp(msg_type, "network_end") == 0) {
 
             cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
-            snprintf(msg, OS_MAXSTR - 1, "agent %s netinfo del %d", agent_id, scan_id->valueint);
+            snprintf(msg, OS_MAXSTR - 1, "agent %s netinfo del %d", lf->agent_id, scan_id->valueint);
 
             if (sc_send_db(msg,socket) < 0) {
                 return -1;
@@ -486,7 +560,7 @@ int decode_netinfo(char *agent_id, cJSON * logJSON,int *socket) {
     return 0;
 }
 
-int decode_osinfo(char *agent_id, cJSON * logJSON,int *socket) {
+int decode_osinfo( Eventinfo *lf, cJSON * logJSON,int *socket) {
 
     cJSON * inventory;
 
@@ -509,7 +583,7 @@ int decode_osinfo(char *agent_id, cJSON * logJSON,int *socket) {
         char * msg = NULL;
         os_calloc(OS_MAXSTR, sizeof(char), msg);
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s osinfo save", agent_id);
+        snprintf(msg, OS_MAXSTR - 1, "agent %s osinfo save", lf->agent_id);
 
 
         if (scan_id) {
@@ -528,72 +602,84 @@ int decode_osinfo(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (hostname) {
             wm_strcat(&msg, hostname->valuestring, '|');
+            fillData(lf,"os.hostname",hostname->valuestring);
         } else {
                 wm_strcat(&msg, "NULL", '|');
         }
 
         if (architecture) {
             wm_strcat(&msg, architecture->valuestring, '|');
+            fillData(lf,"os.architecture",architecture->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (os_name) {
             wm_strcat(&msg, os_name->valuestring, '|');
+            fillData(lf,"os.name",os_name->valuestring);
         } else {
                 wm_strcat(&msg, "NULL", '|');
         }
 
         if (os_version) {
             wm_strcat(&msg, os_version->valuestring, '|');
+            fillData(lf,"os.version",os_version->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (os_codename) {
             wm_strcat(&msg, os_codename->valuestring, '|');
+            fillData(lf,"os.codename",os_codename->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (os_major) {
             wm_strcat(&msg, os_major->valuestring, '|');
+            fillData(lf,"os.major",os_major->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (os_minor) {
             wm_strcat(&msg, os_minor->valuestring, '|');
+            fillData(lf,"os.minor",os_minor->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (os_build) {
             wm_strcat(&msg, os_build->valuestring, '|');
+            fillData(lf,"os.build",os_build->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (os_platform) {
             wm_strcat(&msg, os_platform->valuestring, '|');
+            fillData(lf,"os.platform",os_platform->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (sysname) {
             wm_strcat(&msg, sysname->valuestring, '|');
+            fillData(lf,"os.sysname",sysname->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (release) {
             wm_strcat(&msg, release->valuestring, '|');
+            fillData(lf,"os.release",release->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (version) {
             wm_strcat(&msg, version->valuestring, '|');
+            fillData(lf,"os.release_version",version->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -607,7 +693,7 @@ int decode_osinfo(char *agent_id, cJSON * logJSON,int *socket) {
     return 0;
 }
 
-int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
+int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
 
     char * msg = NULL;
     cJSON * scan_id;
@@ -642,7 +728,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
         cJSON * pid = cJSON_GetObjectItem(inventory, "PID");
         cJSON * process = cJSON_GetObjectItem(inventory, "process");
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s port save", agent_id);
+        snprintf(msg, OS_MAXSTR - 1, "agent %s port save", lf->agent_id);
 
         char id[OS_MAXSTR];
         snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
@@ -656,12 +742,14 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (protocol) {
             wm_strcat(&msg, protocol->valuestring, '|');
+            fillData(lf,"port.protocol",protocol->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (local_ip) {
             wm_strcat(&msg, local_ip->valuestring, '|');
+            fillData(lf,"port.local_ip",local_ip->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -669,6 +757,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
         if (local_port) {
             char lport[OS_MAXSTR];
             snprintf(lport, OS_MAXSTR - 1, "%d", local_port->valueint);
+            fillData(lf,"port.local_port",lport);
             wm_strcat(&msg, lport, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -676,6 +765,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (remote_ip) {
             wm_strcat(&msg, remote_ip->valuestring, '|');
+            fillData(lf,"port.remote_ip",remote_ip->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -683,6 +773,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
         if (remote_port) {
             char rport[OS_MAXSTR];
             snprintf(rport, OS_MAXSTR - 1, "%d", remote_port->valueint);
+            fillData(lf,"port.remote_port",rport);
             wm_strcat(&msg, rport, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -691,6 +782,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
         if (tx_queue) {
             char txq[OS_MAXSTR];
             snprintf(txq, OS_MAXSTR - 1, "%d", tx_queue->valueint);
+            fillData(lf,"port.tx_queue",txq);
             wm_strcat(&msg, txq, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -699,6 +791,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
         if (rx_queue) {
             char rxq[OS_MAXSTR];
             snprintf(rxq, OS_MAXSTR - 1, "%d", rx_queue->valueint);
+            fillData(lf,"port.rx_queue",rxq);
             wm_strcat(&msg, rxq, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -707,6 +800,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
         if (inode) {
             char _inode[OS_MAXSTR];
             snprintf(_inode, OS_MAXSTR - 1, "%d", inode->valueint);
+            fillData(lf,"port.inode",_inode);
             wm_strcat(&msg, _inode, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -714,6 +808,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (state) {
             wm_strcat(&msg, state->valuestring, '|');
+            fillData(lf,"port.state",state->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -721,6 +816,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
         if (pid) {
             char _pid[OS_MAXSTR];
             snprintf(_pid, OS_MAXSTR - 1, "%d", pid->valueint);
+            fillData(lf,"port.pid",_pid);
             wm_strcat(&msg, _pid, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -728,6 +824,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (process) {
             wm_strcat(&msg, process->valuestring, '|');
+            fillData(lf,"port.process",process->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -758,7 +855,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
                 }
             }
 
-            snprintf(msg, OS_MAXSTR - 1, "agent %s port del %d", agent_id, scan_id->valueint);
+            snprintf(msg, OS_MAXSTR - 1, "agent %s port del %d", lf->agent_id, scan_id->valueint);
 
             if (sc_send_db(msg,socket) < 0) {
                 error_port = 1;
@@ -773,7 +870,7 @@ int decode_port(char *agent_id, cJSON * logJSON,int *socket) {
     return 0;
 }
 
-int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
+int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket) {
 
     cJSON * inventory;
 
@@ -791,7 +888,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
         char * msg = NULL;
         os_calloc(OS_MAXSTR, sizeof(char), msg);
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s hardware save", agent_id);
+        snprintf(msg, OS_MAXSTR - 1, "agent %s hardware save", lf->agent_id);
 
         if (scan_id) {
             char id[OS_MAXSTR];
@@ -809,12 +906,14 @@ int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (serial) {
             wm_strcat(&msg, serial->valuestring, '|');
+            fillData(lf,"hardware.serial",serial->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (cpu_name) {
             wm_strcat(&msg, cpu_name->valuestring, '|');
+            fillData(lf,"hardware.cpu_name",cpu_name->valuestring);
 
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -823,6 +922,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
         if (cpu_cores) {
             char cores[OS_MAXSTR];
             snprintf(cores, OS_MAXSTR - 1, "%d", cpu_cores->valueint);
+            fillData(lf,"hardware.cpu_cores",cores);
             wm_strcat(&msg, cores, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -831,6 +931,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
         if (cpu_mhz) {
             char freq[OS_MAXSTR];
             snprintf(freq, OS_MAXSTR - 1, "%f", cpu_mhz->valuedouble);
+            fillData(lf,"hardware.cpu_mhz",freq);
             wm_strcat(&msg, freq, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -839,6 +940,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
         if (ram_total) {
             char total[OS_MAXSTR];
             snprintf(total, OS_MAXSTR - 1, "%f", ram_total->valuedouble);
+            fillData(lf,"harware.ram_total",total);
             wm_strcat(&msg, total, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -847,6 +949,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
         if (ram_free) {
             char rfree[OS_MAXSTR];
             snprintf(rfree, OS_MAXSTR - 1, "%f", ram_free->valuedouble);
+            fillData(lf,"hardware.ram_free",rfree);
             wm_strcat(&msg, rfree, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -855,6 +958,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
         if (ram_usage) {
             char usage[OS_MAXSTR];
             snprintf(usage, OS_MAXSTR - 1, "%d", ram_usage->valueint);
+            fillData(lf,"hardware.ram_usage",usage);
             wm_strcat(&msg, usage, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -868,7 +972,7 @@ int decode_hardware(char *agent_id, cJSON * logJSON,int *socket) {
     return 0;
 }
 
-int decode_package(char *agent_id, cJSON * logJSON,int *socket) {
+int decode_package( Eventinfo *lf,cJSON * logJSON,int *socket) {
 
     char * msg = NULL;
     cJSON * package;
@@ -904,7 +1008,7 @@ int decode_package(char *agent_id, cJSON * logJSON,int *socket) {
         cJSON * installtime = cJSON_GetObjectItem(package, "install_time");
         cJSON * location = cJSON_GetObjectItem(package, "location");
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s package save", agent_id);
+        snprintf(msg, OS_MAXSTR - 1, "agent %s package save", lf->agent_id);
 
         char id[OS_MAXSTR];
         snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
@@ -918,24 +1022,28 @@ int decode_package(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (format) {
             wm_strcat(&msg, format->valuestring, '|');
+            fillData(lf,"program.format",format->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (name) {
             wm_strcat(&msg, name->valuestring, '|');
+            fillData(lf,"program.name",name->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (priority) {
             wm_strcat(&msg, priority->valuestring, '|');
+            fillData(lf,"program.priority",priority->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (section) {
             wm_strcat(&msg, section->valuestring, '|');
+            fillData(lf,"program.section",section->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -943,6 +1051,7 @@ int decode_package(char *agent_id, cJSON * logJSON,int *socket) {
         if (size) {
             char _size[OS_MAXSTR];
             snprintf(_size, OS_MAXSTR - 1, "%d", size->valueint);
+            fillData(lf,"program.size",_size);
             wm_strcat(&msg, _size, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -950,48 +1059,56 @@ int decode_package(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (vendor) {
             wm_strcat(&msg, vendor->valuestring, '|');
+            fillData(lf,"program.vendor",vendor->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (installtime) {
             wm_strcat(&msg, installtime->valuestring, '|');
+            fillData(lf,"program.installtime",installtime->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (version) {
             wm_strcat(&msg, version->valuestring, '|');
+            fillData(lf,"program.version",version->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (architecture) {
             wm_strcat(&msg, architecture->valuestring, '|');
+            fillData(lf,"program.architecture",architecture->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (multiarch) {
             wm_strcat(&msg, multiarch->valuestring, '|');
+            fillData(lf,"program.multiarch",multiarch->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (source) {
             wm_strcat(&msg, source->valuestring, '|');
+            fillData(lf,"program.source",source->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (description) {
             wm_strcat(&msg, description->valuestring, '|');
+            fillData(lf,"program.description",description->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (location) {
             wm_strcat(&msg, location->valuestring, '|');
+            fillData(lf,"program.location",location->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -1023,7 +1140,7 @@ int decode_package(char *agent_id, cJSON * logJSON,int *socket) {
                 }
             }
 
-            snprintf(msg, OS_MAXSTR - 1, "agent %s package del %d", agent_id, scan_id->valueint);
+            snprintf(msg, OS_MAXSTR - 1, "agent %s package del %d", lf->agent_id, scan_id->valueint);
 
             if (sc_send_db(msg,socket) < 0) {
                 error_package = 1;
@@ -1038,7 +1155,7 @@ int decode_package(char *agent_id, cJSON * logJSON,int *socket) {
     return 0;
 }
 
-int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
+int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
 
     int i;
     char * msg = NULL;
@@ -1091,7 +1208,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         cJSON * tty = cJSON_GetObjectItem(inventory, "tty");
         cJSON * processor = cJSON_GetObjectItem(inventory, "processor");
 
-        snprintf(msg, OS_MAXSTR - 1, "agent %s process save", agent_id);
+        snprintf(msg, OS_MAXSTR - 1, "agent %s process save", lf->agent_id);
 
         char id[OS_MAXSTR];
         snprintf(id, OS_MAXSTR - 1, "%d", scan_id->valueint);
@@ -1106,6 +1223,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (pid) {
             char _pid[OS_MAXSTR];
             snprintf(_pid, OS_MAXSTR - 1, "%d", pid->valueint);
+            fillData(lf,"process.pid",_pid);
             wm_strcat(&msg, _pid, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1113,12 +1231,14 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (name) {
             wm_strcat(&msg, name->valuestring, '|');
+            fillData(lf,"process.name",name->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (state) {
             wm_strcat(&msg, state->valuestring, '|');
+            fillData(lf,"process.state",state->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -1126,6 +1246,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (ppid) {
             char _ppid[OS_MAXSTR];
             snprintf(_ppid, OS_MAXSTR - 1, "%d", ppid->valueint);
+            fillData(lf,"process.ppid",_ppid);
             wm_strcat(&msg, _ppid, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1134,6 +1255,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (utime) {
             char _utime[OS_MAXSTR];
             snprintf(_utime, OS_MAXSTR - 1, "%d", utime->valueint);
+            fillData(lf,"process.utime",_utime);
             wm_strcat(&msg, _utime, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1142,6 +1264,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (stime) {
             char _stime[OS_MAXSTR];
             snprintf(_stime, OS_MAXSTR - 1, "%d", stime->valueint);
+            fillData(lf,"process.stime",_stime);
             wm_strcat(&msg, _stime, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1149,6 +1272,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (cmd) {
             wm_strcat(&msg, cmd->valuestring, '|');
+            fillData(lf,"process.cmd",cmd->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -1158,6 +1282,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
             for (i = 0; i < cJSON_GetArraySize(argvs); i++){
                 wm_strcat(&args, cJSON_GetArrayItem(argvs,i)->valuestring, ',');
             }
+            fillData(lf,"process.args",args);
             wm_strcat(&msg, args, '|');
             free(args);
         } else {
@@ -1166,42 +1291,49 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
 
         if (euser) {
             wm_strcat(&msg, euser->valuestring, '|');
+            fillData(lf,"process.euser",euser->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (ruser) {
             wm_strcat(&msg, ruser->valuestring, '|');
+            fillData(lf,"process.ruser",ruser->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (suser) {
             wm_strcat(&msg, suser->valuestring, '|');
+            fillData(lf,"process.suser",suser->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (egroup) {
             wm_strcat(&msg, egroup->valuestring, '|');
+            fillData(lf,"process.egroup",egroup->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (rgroup) {
             wm_strcat(&msg, rgroup->valuestring, '|');
+            fillData(lf,"process.rgroup",rgroup->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (sgroup) {
             wm_strcat(&msg, sgroup->valuestring, '|');
+            fillData(lf,"process.sgroup",sgroup->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
 
         if (fgroup) {
             wm_strcat(&msg, fgroup->valuestring, '|');
+            fillData(lf,"process.fgroup",fgroup->valuestring);
         } else {
             wm_strcat(&msg, "NULL", '|');
         }
@@ -1209,6 +1341,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (priority) {
             char prior[OS_MAXSTR];
             snprintf(prior, OS_MAXSTR - 1, "%d", priority->valueint);
+            fillData(lf,"process.prior",prior);
             wm_strcat(&msg, prior, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1217,6 +1350,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (nice) {
             char _nice[OS_MAXSTR];
             snprintf(_nice, OS_MAXSTR - 1, "%d", nice->valueint);
+            fillData(lf,"process.nice",_nice);
             wm_strcat(&msg, _nice, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1225,6 +1359,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (size) {
             char _size[OS_MAXSTR];
             snprintf(_size, OS_MAXSTR - 1, "%d", size->valueint);
+            fillData(lf,"process.size",_size);
             wm_strcat(&msg, _size, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1233,6 +1368,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (vm_size) {
             char vms[OS_MAXSTR];
             snprintf(vms, OS_MAXSTR - 1, "%d", vm_size->valueint);
+            fillData(lf,"process.vms",vms);
             wm_strcat(&msg, vms, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1241,6 +1377,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (resident) {
             char _resident[OS_MAXSTR];
             snprintf(_resident, OS_MAXSTR - 1, "%d", resident->valueint);
+            fillData(lf,"process.resident",_resident);
             wm_strcat(&msg, _resident, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1249,6 +1386,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (share) {
             char _share[OS_MAXSTR];
             snprintf(_share, OS_MAXSTR - 1, "%d", share->valueint);
+            fillData(lf,"process.share",_share);
             wm_strcat(&msg, _share, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1257,6 +1395,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (start_time) {
             char start[OS_MAXSTR];
             snprintf(start, OS_MAXSTR - 1, "%d", start_time->valueint);
+            fillData(lf,"process.start_time",start);
             wm_strcat(&msg, start, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1265,6 +1404,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (pgrp) {
             char _pgrp[OS_MAXSTR];
             snprintf(_pgrp, OS_MAXSTR - 1, "%d", pgrp->valueint);
+            fillData(lf,"process.pgrp",_pgrp);
             wm_strcat(&msg, _pgrp, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1273,6 +1413,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (session) {
             char _session[OS_MAXSTR];
             snprintf(_session, OS_MAXSTR - 1, "%d", session->valueint);
+            fillData(lf,"process.session",_session);
             wm_strcat(&msg, _session, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1281,6 +1422,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (nlwp) {
             char _nlwp[OS_MAXSTR];
             snprintf(_nlwp, OS_MAXSTR - 1, "%d", nlwp->valueint);
+            fillData(lf,"process.nlwp",_nlwp);
             wm_strcat(&msg, _nlwp, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1289,6 +1431,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (tgid) {
             char _tgid[OS_MAXSTR];
             snprintf(_tgid, OS_MAXSTR - 1, "%d", tgid->valueint);
+            fillData(lf,"process.tgid",_tgid);
             wm_strcat(&msg, _tgid, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1297,6 +1440,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (tty) {
             char _tty[OS_MAXSTR];
             snprintf(_tty, OS_MAXSTR - 1, "%d", tty->valueint);
+            fillData(lf,"process.tty",_tty);
             wm_strcat(&msg, _tty, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1305,6 +1449,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
         if (processor) {
             char proc[OS_MAXSTR];
             snprintf(proc, OS_MAXSTR - 1, "%d", processor->valueint);
+            fillData(lf,"process.processor",proc);
             wm_strcat(&msg, proc, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');
@@ -1337,7 +1482,7 @@ int decode_process(char *agent_id, cJSON * logJSON,int *socket) {
                 }
             }
 
-            snprintf(msg, OS_MAXSTR - 1, "agent %s process del %d", agent_id, scan_id->valueint);
+            snprintf(msg, OS_MAXSTR - 1, "agent %s process del %d", lf->agent_id, scan_id->valueint);
 
             if (sc_send_db(msg,socket) < 0) {
                 error_process = 1;

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -31,6 +31,7 @@
 #define OS_SIZE_4096    4096
 #define OS_SIZE_2048    2048
 #define OS_SIZE_1024    1024
+#define OS_SIZE_512     512
 #define OS_SIZE_256     256
 #define OS_SIZE_128     128
 


### PR DESCRIPTION
This PR add the ability to use the Syscollector information to trigger alerts and to show that information in the description of the alerts.
The PR resolves the issue: #2349 

As example, this rule will be triggered when the interface `eth0` of an agent is enabled and will show what IPv4 has that interface.
```
<rule id="100001" level="5">
    <if_sid>221</if_sid>
    <decoded_as>syscollector</decoded_as>
    <field name="netinfo.iface.name">eth0</field>
    <description>eth0 interface enabled. IP: $(netinfo.iface.ipv4.address)</description>
  </rule>
```
When the alerts is triggered it will be displayed in Kibana this way:
![network_rule](https://user-images.githubusercontent.com/9034923/51616887-5dd7f680-1f2b-11e9-9ca9-60b40f5748d5.png)

The tag `<if_sid>221</if_sid>` is necessary because the events from Syscollector are muted by default with that rule.

Testing
-----------------------------------------------
The rule 221 can be unmute to see all the Syscollector events and check the fields values in the alerts.
Also a general rule like this:
```
<rule id="100010" level="5">
    <if_sid>221</if_sid>
    <decoded_as>syscollector</decoded_as>
    <field name="type">^network$</field>
    <description>Syscollector network information</description>
  </rule>
```
Can be used to check the fields of one event type. Then, the values can be compared with the database information to check that it is the same.