### PR TITLE
The run_daemon option for module osquery must accept only values 'yes' or 'no'

### DIFF
--- a/src/config/wmodules-osquery-monitor.c
+++ b/src/config/wmodules-osquery-monitor.c
@@ -97,13 +97,13 @@ int wm_osquery_monitor_read(xml_node **nodes, wmodule *module)
             osquery_monitor->packs[pack_i] = pack;
             osquery_monitor->packs[++pack_i] = NULL;
         } else if (!strcmp(nodes[i]->element, XML_ADD_LABELS)) {
-            if (osquery_monitor->add_labels = eval_bool(nodes[i]->content), osquery_monitor->disable == OS_INVALID) {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_DISABLED, WM_OSQUERYMONITOR_CONTEXT.name);
+            if (osquery_monitor->add_labels = eval_bool(nodes[i]->content), osquery_monitor->add_labels == OS_INVALID) {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_ADD_LABELS, WM_OSQUERYMONITOR_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_RUN_DAEMON)) {
-            if (osquery_monitor->run_daemon = eval_bool(nodes[i]->content), osquery_monitor->disable == OS_INVALID) {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_DISABLED, WM_OSQUERYMONITOR_CONTEXT.name);
+            if (osquery_monitor->run_daemon = eval_bool(nodes[i]->content), osquery_monitor->run_daemon == OS_INVALID) {
+                merror("Invalid content for tag '%s' at module '%s'.", XML_RUN_DAEMON, WM_OSQUERYMONITOR_CONTEXT.name);
                 return OS_INVALID;
             }
         } else {

--- a/src/wazuh_modules/wm_osquery_monitor.h
+++ b/src/wazuh_modules/wm_osquery_monitor.h
@@ -29,8 +29,8 @@ typedef struct wm_osquery_monitor_t {
    int msg_delay;
    int queue_fd;
    wm_osquery_pack_t ** packs;
-   unsigned int add_labels:1;
-   unsigned int run_daemon:1;
+   signed int add_labels:2;
+   signed int run_daemon:2;
 } wm_osquery_monitor_t;
 
 int wm_osquery_monitor_read(xml_node **nodes, wmodule *module);


### PR DESCRIPTION
Hi, Team,

This PR fixes the issue https://github.com/wazuh/wazuh/issues/2318.


Problem description
--
The `osqueryd` daemon starts when the option `run_daemon` contains any string, whether it is `yes`, `no` or anything else.

In the source code:
1. The option is not correctly handled: the decision whether the error message must or must not be thrown is based on the value of the option `disabled` (a fuzzy copy-paste?).
2. The variable receiving the value of the encoded option is declared in a struct as a bit field of length 1 unsigned. The values can be `1=yes`, `0=no`, and also `-1` indicating an error (i.e. incorrect option, neither `yes` nor `no`). The value `-1` cannot be stored in 1 bit, and an incorrect option is thus encoded as just `1`, interpreted as a `yes`.

The same applies to the `add_labels` option.

Solution description
--
1. Use the correct variables in the corresponding pieces of code.
2. Declare the variables as bit fields of length 2 signed, so they can contain the values `0`, `1`, and also `-1`.

Same correction also for the `add_labels` option.


Regards.
