### PR TITLE
Fix memory leak in Logcollector (Windows Event channel)

### DIFF
--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -447,7 +447,6 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
 
     os_malloc(OS_MAXSTR, filtered_msg);
     os_malloc(OS_MAXSTR, provider_name);
-    os_malloc(OS_MAXSTR, xml_event);
 
     result = EvtRender(NULL,
                        evt,


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/2450

A memory leak was introduced in version 3.8.0 with the new implementation of the Windows Event channel reader in logcollector.

The program was allocating unnecessary memory in each execution but this memory was dereferenced and not freed.

`450:    os_malloc(OS_MAXSTR, xml_event);` (Memory allocation)
https://github.com/wazuh/wazuh/blob/3.8/src/logcollector/read_win_event_channel.c#L450

`489:    xml_event = convert_windows_string((LPCWSTR) properties_values);` (Memory dereference)
https://github.com/wazuh/wazuh/blob/3.8/src/logcollector/read_win_event_channel.c#L489

