### PR TITLE
Fix XML validation for API

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -489,7 +489,7 @@ def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filenam
     if not os_path.exists(agent_conf):
         raise WazuhException(1006, agent_conf)
 
-    try:       
+    try:
 
         # Read RAW file
         if agent_conf_name == 'agent.conf' and return_format and 'xml' == return_format.lower():
@@ -497,7 +497,7 @@ def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filenam
                 data = xml_data.read().replace('\n', '')
                 return data
         # Parse XML to JSON
-        else: 
+        else:
             # Read XML
             xml_data = load_wazuh_xml(agent_conf)
 
@@ -648,7 +648,7 @@ def upload_group_configuration(group_id, xml_file):
     # path of temporary files for parsing xml input
     tmp_file_path = '{}/tmp/api_tmp_file_{}_{}.xml'.format(common.ossec_path, time.time(), random.randint(0, 1000))
 
-    # create temporary file for parsing xml input
+    # create temporary file for parsing xml input and validate XML format
     try:
         with open(tmp_file_path, 'w') as tmp_file:
             # beauty xml file
@@ -664,11 +664,6 @@ def upload_group_configuration(group_id, xml_file):
         raise WazuhException(1113, str(e))
 
     try:
-        # check xml format
-        try:
-            load_wazuh_xml(tmp_file_path)
-        except Exception as e:
-            raise WazuhException(1113, str(e))
 
         # check Wazuh xml format
         try:

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -365,13 +365,13 @@ def mkdir_with_mode(name, mode=0o770):
                 raise
         if tail == curdir:           # xxx/newdir/. exists if xxx/newdir exists
             return
-    try:         
+    try:
         mkdir(name, mode)
     except OSError as e:
         # be happy if someone already created the path
         if e.errno != errno.EEXIST:
             raise
-            
+
     chmod(name, mode)
 
 
@@ -493,7 +493,7 @@ def load_wazuh_xml(xml_path):
     data = re.sub(r"<(?!/?\w+.+>|!--)", "&lt;", data)
 
     # & characters should be scaped if they don't represent an &entity;
-    data = re.sub(r"&(?!\w+;)", "&amp;", data)
+    data = re.sub(r"&(?!(amp|lt|gt|apos|quot);)", "&amp;", data)
 
     return fromstring('<root_tag>' + data + '</root_tag>')
 


### PR DESCRIPTION
The `load_wazuh_xml` function to parse a XML file was escaping incorrectly the `&` character. The following string was not scaped due to a wrong  regex: `<command>2>&1;</command>`.


On the other hand, I removed a duplicated XML validation that was performed when an agent.conf is uploaded.

It fixed this issue (https://github.com/wazuh/wazuh/issues/2060) too.

## Tests

```
# cat agent.conf.xml.1
  <agent_config>

    <!-- The big & -->
    <localfile>
      <log_format>full_command</log_format>
      <alias>ciscat-ossec-log</alias>
      <command>2>&amp;1;</command>
      <frequency>86400</frequency>
    </localfile>

</agent_config>
```

```
# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml.1 "http://127.0.0.1:55000/agents/groups/default/files/agent.conf?pretty" -k
{
   "error": 0,
   "data": "Agent configuration was updated successfully"
}
```

```
# cat /var/ossec/etc/shared/default/agent.conf
  <agent_config>
    <!-- The big & -->
    <localfile>
      <log_format>full_command</log_format>
      <alias>ciscat-ossec-log</alias>
      <command>2>&1;</command>
      <frequency>86400</frequency>
    </localfile>
  </agent_config>
```

```
# curl -u foo:bar -X GET  "http://127.0.0.1:55000/agents/groups/default/files/agent.conf?pretty" -k
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "config": {
               "localfile": [
                  {
                     "alias": "ciscat-ossec-log",
                     "log_format": "full_command",
                     "frequency": "86400",
                     "command": "2>&1;"
                  }
               ]
            },
            "filters": {}
         }
      ]
   }
}
```
