### PR TITLE
Fix use-after-free corruption in Analysisd at the accumulator library

### DIFF
--- a/src/analysisd/accumulator.c
+++ b/src/analysisd/accumulator.c
@@ -58,13 +58,11 @@ int Accumulate_Init()
     if (!acm_store) {
         merror(LIST_ERROR);
         return (0);
-    }    
+    }
     if (!OSHash_setSize(acm_store, 2048)) {
         merror(LIST_ERROR);
         return (0);
     }
-    
-    OSHash_SetFreeDataPointer(acm_store, (void (*)(void *))FreeACMStore);
 
     /* Default Expiry */
     gettimeofday(&tp, NULL);
@@ -201,7 +199,6 @@ Eventinfo *Accumulate(Eventinfo *lf)
     if ( do_update == 1 ) {
         /* Update the hash entry */
         if ( (result = OSHash_Update_ex(acm_store, _key, stored_data)) != 1) {
-            FreeACMStore(stored_data);
             merror("accumulator: ERROR: Update of stored data for %s failed (%d).", _key, result);
         } else {
             mdebug1("accumulator: DEBUG: Updated stored data for %s", _key);


### PR DESCRIPTION
|Fixes|
|---|
|#2453|

This PR aims to fix a double free memory corruption produced in the Accumulator library of Analysisd.

The bug reported by #2453 affects every decoder with the option `<accumulate />`, currently they are only the decoders for OpenLDAP.

When a log matches an entry in the accumulated data (https://github.com/wazuh/wazuh/blob/v3.8.1/src/analysisd/accumulator.c#L124) and it's not the time to expire (https://github.com/wazuh/wazuh/blob/v3.8.1/src/analysisd/accumulator.c#L135), the system reuses the same data block.

PR #1885 introduces a dynamic memory deallocator for hash tables. However, in this case, if a data block is reused, the library updates the hash table (https://github.com/wazuh/wazuh/blob/v3.8.1/src/analysisd/accumulator.c#L203). This is not strictly necessary, but that makes the hash table free the data block and it will produce an use-after-free corruption on the next log that matches the ID.

On the other hand, the PR #1885 tried to free the memory on hash insertion error —that would be a bug itself but this tries to prevent a memory leak—. We also changed this code to make sure that memory is only freed if it was not inserted in the hash table.