### PR TITLE
Fix ossec-remoted messages

### DIFF
--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
             mdebug1("Cluster worker node: Disabling the merged.mg creation");
             logr.nocmerged = 1;
             break;
-}
+    }
 
     /* Exit if test_config is set */
     if (test_config) {
@@ -152,6 +152,7 @@ int main(int argc, char **argv)
 
     if (logr.conn == NULL) {
         /* Not configured */
+        mwarn("Remoted connection is not configured... Exiting." );
         exit(0);
     }
 
@@ -197,9 +198,6 @@ int main(int argc, char **argv)
     signal(SIGPIPE, SIG_IGN);
 
     os_random();
-
-    /* Start up message */
-    minfo(STARTUP_MSG, (int)getpid());
 
     //Start shared download
     w_init_shared_download();

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
 
     if (logr.conn == NULL) {
         /* Not configured */
-        mwarn("Remoted connection is not configured... Exiting." );
+        minfo("Remoted connection is not configured... Exiting.");
         exit(0);
     }
 
@@ -198,6 +198,9 @@ int main(int argc, char **argv)
     signal(SIGPIPE, SIG_IGN);
 
     os_random();
+
+    /* Start up message */
+    mdebug2(STARTUP_MSG, (int)getpid());
 
     //Start shared download
     w_init_shared_download();

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -90,7 +90,11 @@ void HandleRemote(int uid)
     }
 
     /* Start up message */
-    minfo(STARTUP_MSG, (int)getpid());
+    minfo(STARTUP_MSG " Listening on port %d/%s (%s).",
+    (int)getpid(),
+    logr.port[position],
+    logr.proto[position] == TCP_PROTO ? "TCP" : "UDP",
+    logr.conn[position] == SECURE_CONN ? "secure" : "syslog");
 
     /* If secure connection, deal with it */
     if (logr.conn[position] == SECURE_CONN) {


### PR DESCRIPTION
Hi team,

This PR solves #2090.

### Problems solved

1. If `ossec-remoted` wasn't properly configured, it exited without logging any message: 
https://github.com/wazuh/wazuh/blob/5a75e3d91314bd89208cdc754fea1e1a9a9f9077/src/remoted/main.c#L153-L156

2. It logged two startup messages but we only need the last one (Inside the `HandleRemote` function) because this is message wich has the real PID of `ossec-remoted`.

Best regards,
Cerv1.