### PR TITLE
Wazuh manager must start regardless of the contents of local_decoder.xml

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -17,11 +17,6 @@
 #include "plugin_decoders.h"
 #include "config.h"
 
-#ifdef TESTRULE
-#undef XML_LDECODER
-#define XML_LDECODER "etc/local_decoder.xml"
-#endif
-
 /* Internal functions */
 static char *_loadmemory(char *at, char *str);
 static int addDecoder2list(const char *name);
@@ -205,8 +200,10 @@ int ReadDecodeXML(const char *file)
 
     /* Check if the file is empty */
     if(FileSize(file) == 0){
-        retval = 0;
-        goto cleanup;
+        if (strcmp(file, XML_LDECODER) != 0) {
+            retval = 0;
+            goto cleanup;
+        }
     }
 
     /* Get the root elements */

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -239,7 +239,7 @@ int main(int argc, char **argv)
 
                 /* Read local ones */
 
-                c = ReadDecodeXML("etc/local_decoder.xml");
+                c = ReadDecodeXML(XML_LDECODER);
                 if (!c) {
                     if ((c != -2)) {
                         merror_exit(CONFIG_ERROR,  XML_LDECODER);

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -176,7 +176,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define ARQUEUE         "/queue/alerts/ar"
 
 /* Decoder file */
-#define XML_LDECODER    "/etc/decoders/local_decoder.xml"
+#define XML_LDECODER    "etc/decoders/local_decoder.xml"
 
 /* Agent information location */
 #define AGENTINFO_DIR    "/queue/agent-info"


### PR DESCRIPTION
Hi, Team,

This PR fixes the issue https://github.com/wazuh/wazuh/issues/2179.

Problem description
--
When `/var/ossec/etc/decoders/local_decoders.xml` is empty, the manager fails to start. A critical error appears in `ossec.log`:
```
2019/01/24 07:04:14 ossec-analysisd: CRITICAL: (1202): Configuration error at 'etc/decoders/local_decoder.xml'.
```
Also, an error appears when the XML file contains only comments:
```
2019/01/24 15:11:40 ossec-analysisd: ERROR: (1231): Invalid NULL element in the configuration.
2019/01/24 15:11:40 ossec-analysisd: CRITICAL: (1202): Configuration error at 'etc/decoders/local_decoder.xml'.
```


Solution description
--
- The paths `etc/local_decoder.xml` have been removed and/or replaced by `etc/decoders/local_decoder.xml` (macro `XML_LDECODER`).
- if the file `etc/decoders/local_decoder.xml` is empty, this is not an error. Any other XML decoder file empty is an error.
- Extra leading `/` removed from a macro, because `strcmp("etc/decoder/local_decoder.xml", "/etc/decoder/local_decoder.xml")` could not return the expected `0`.


The shell script `src/init/update.sh` seems to move the file `etc/local_decoder.xml` to `etc/decoder/local_decoder.xml` (or removes `etc/local_decoder.xml` if it is empty).
The shell script `src/init/inst-functions.sh` seems to install `etc/local_decoder.xml` to `etc/decoder/local_decoder.xml`.
The python script `framework/tests/test_cluster_sync.py` uses `etc/decoders/local_decoder.xml`.
So `etc/decoders/local_decoder.xml` seems to be the correct file path. The results of the testing (see below) are OK.


Regards.
