### PR TITLE
Prepare whodata to alert about hot-added symlinks

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -193,6 +193,8 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
 #else
     char str_owner[50], str_group[50], str_perm[50];
     char *hash_file_name;
+    char *file_inode;
+    char *inode;
 #endif
 
 
@@ -208,6 +210,11 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
     /* Win32 does not have lstat */
     if (stat(file_name, &statbuf) < 0)
 #else
+    if (evt && evt->inode) {
+        if (file_inode = OSHash_Get_ex(syscheck.inode_hash, evt->inode), file_inode) {
+            file_name = file_inode;
+        }
+    }
     if (lstat(file_name, &statbuf) < 0)
 #endif
     {
@@ -227,6 +234,12 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             if (s_node = OSHash_Delete_ex(syscheck.fp, file_name), s_node) {
                 os_free(s_node->checksum);
                 os_free(s_node);
+            }
+            // Delete from inode hash table
+            if (evt && evt->inode) {
+                if (inode = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), inode) {
+                    os_free(inode);
+                }
             }
             os_free(alert_msg);
             os_free(wd_sum);

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -131,15 +131,15 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             struct stat statbuf;
             if (lstat(file_name, &statbuf) < 0) {
                 mdebug2("Stat() function failed on: %s. File may have been deleted", file_name);
-                return -1;
             }
-            if S_ISLNK(statbuf.st_mode) {
+            if (S_ISLNK(statbuf.st_mode) && (syscheck.opts[pos] & CHECK_FOLLOW)) {
                 read_dir(file_name, pos, evt, depth, 1);
-            } else
-#endif
-            {
-                read_dir(file_name, pos, evt, depth, 0);
+                return 0;
+            } else if (S_ISLNK(statbuf.st_mode) && !(syscheck.opts[pos] & CHECK_FOLLOW)) {
+                return 0;
             }
+#endif
+            read_dir(file_name, pos, evt, depth, 0);
         }
 
     }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -129,14 +129,16 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             }
 #ifndef WIN32
             struct stat statbuf;
+
             if (lstat(file_name, &statbuf) < 0) {
                 mdebug2("Stat() function failed on: %s. File may have been deleted", file_name);
-            }
-            if (S_ISLNK(statbuf.st_mode) && (syscheck.opts[pos] & CHECK_FOLLOW)) {
-                read_dir(file_name, pos, evt, depth, 1);
-                return 0;
-            } else if (S_ISLNK(statbuf.st_mode) && !(syscheck.opts[pos] & CHECK_FOLLOW)) {
-                return 0;
+            } else {
+                if (S_ISLNK(statbuf.st_mode) && (syscheck.opts[pos] & CHECK_FOLLOW)) {
+                    read_dir(file_name, pos, evt, depth, 1);
+                    return 0;
+                } else if (S_ISLNK(statbuf.st_mode) && !(syscheck.opts[pos] & CHECK_FOLLOW)) {
+                    return 0;
+                }
             }
 #endif
             read_dir(file_name, pos, evt, depth, 0);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -662,12 +662,6 @@ void audit_parse(char *buffer) {
                 os_malloc(match_size + 1, path1);
                 snprintf (path1, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
             }
-            // path2
-            if(regexec(&regexCompiled_path2, buffer, 2, match, 0) == 0) {
-                match_size = match[1].rm_eo - match[1].rm_so;
-                os_malloc(match_size + 1, path2);
-                snprintf (path2, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-            }
             // inode
             if(regexec(&regexCompiled_inode, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
@@ -727,6 +721,7 @@ void audit_parse(char *buffer) {
                                 break;
                             }
 
+                            free(file_path);
                             w_evt->path = real_path;
 
                             if (filterpath_audit_events(w_evt->path)) {
@@ -742,6 +737,12 @@ void audit_parse(char *buffer) {
                     }
                     break;
                 case 3:
+                    // path2
+                    if(regexec(&regexCompiled_path2, buffer, 2, match, 0) == 0) {
+                        match_size = match[1].rm_eo - match[1].rm_so;
+                        os_malloc(match_size + 1, path2);
+                        snprintf (path2, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+                    }
                     if (cwd && path1 && path2) {
                         if (file_path = gen_audit_path(cwd, path1, path2), file_path) {
                             w_evt->path = file_path;

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -504,6 +504,7 @@ void audit_parse(char *buffer) {
     char *file_path = NULL;
     char *syscall = NULL;
     char *inode = NULL;
+    char *real_path = NULL;
     whodata_evt *w_evt;
     unsigned int items = 0;
     char *inode_temp;
@@ -661,6 +662,12 @@ void audit_parse(char *buffer) {
                 os_malloc(match_size + 1, path1);
                 snprintf (path1, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
             }
+            // path2
+            if(regexec(&regexCompiled_path2, buffer, 2, match, 0) == 0) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                os_malloc(match_size + 1, path2);
+                snprintf (path2, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+            }
             // inode
             if(regexec(&regexCompiled_inode, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
@@ -714,6 +721,14 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
+                            os_calloc(PATH_MAX + 2, sizeof(char), real_path);
+                            if (realpath(w_evt->path, real_path), !real_path) {
+                                mdebug1("Error checking realpath() of link '%s'", w_evt->path);
+                                break;
+                            }
+
+                            w_evt->path = real_path;
+
                             if (filterpath_audit_events(w_evt->path)) {
                                 realtime_checksumfile(w_evt->path, w_evt);
                             } else if (w_evt->inode) {
@@ -725,6 +740,34 @@ void audit_parse(char *buffer) {
                             }
                         }
                     }
+                    break;
+                case 3:
+                    if (cwd && path1 && path2) {
+                        if (file_path = gen_audit_path(cwd, path1, path2), file_path) {
+                            w_evt->path = file_path;
+                            mdebug2("audit_event: uid=%s, auid=%s, euid=%s, gid=%s, pid=%i, ppid=%i, inode=%s, path=%s, pname=%s",
+                                (w_evt->user_name)?w_evt->user_name:"",
+                                (w_evt->audit_name)?w_evt->audit_name:"",
+                                (w_evt->effective_name)?w_evt->effective_name:"",
+                                (w_evt->group_name)?w_evt->group_name:"",
+                                w_evt->process_id,
+                                w_evt->ppid,
+                                (w_evt->inode)?w_evt->inode:"",
+                                (w_evt->path)?w_evt->path:"",
+                                (w_evt->process_name)?w_evt->process_name:"");
+
+                            if (filterpath_audit_events(w_evt->path)) {
+                                realtime_checksumfile(w_evt->path, w_evt);
+                            } else if (w_evt->inode) {
+                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
+                                    realtime_checksumfile(inode_temp, w_evt);
+                                } else {
+                                    realtime_checksumfile(w_evt->path, w_evt);
+                                }
+                            }
+                        }
+                    }
+                    free(path2);
                     break;
                 case 4:
                     // path2
@@ -1231,12 +1274,17 @@ exit_err:
 
 int filterpath_audit_events(char *path) {
     int i = 0;
+    char *dir_path;
 
     for(i = 0; i < W_Vector_length(audit_added_dirs); i++) {
-        if (strstr(path, W_Vector_get(audit_added_dirs, i))) {
-            mdebug2("Found '%s' in '%s'", W_Vector_get(audit_added_dirs, i), path);
+        os_strdup(W_Vector_get(audit_added_dirs, i), dir_path);
+        wm_strcat(&dir_path, "/", '\0');
+        if (strstr(path, dir_path)) {
+            mdebug2("Found '%s' in '%s'", dir_path, path);
+            free(dir_path);
             return 1;
         }
+        free(dir_path);
     }
     return 0;
 }


### PR DESCRIPTION
Hi team,

This PR solves #2359 and #2434.

### Bug summary

- **`whodata`** wasn't prepared to handle the event that creates a symbolic link as said in #2359.
- **`realtime`** was producing alerts from directories pointed by links although the option `follow_symbolic_link` was disabled as said in #2434

### Solution

- An extra check has been added to take this option into account.
- Improved audit decoder for syscheck to handle symlinks creation correctly.
___

### Testing

- File creation in a monitored folder. Using different commands like `touch`, `/bin/echo` or redirecting the output of another commands.
- Regular file deletion in a monitored folder.
- Changing permissions with `chmod`. 
- Changing owner to files and folders with `-R` option. 
- Changing group to files and folders with `-R` option.
- Deleting folders recursively with `rm -rf folder`.
- Creating and deleting links (should not log any alert).
- Create a link to an unmonitored folder with `follow_symbolic_link` set to **no** and create files in that folder (should not log any alert).
- Create a link to an unmonitored folder with `follow_symbolic_link` set to **yes** and create files in that folder (should log alerts and add a rule in audit).
- Test `realtime` and `whodata` at the same time. Only `whodata` alerts should appear.
- Create a symlink pointing to a monitored folder or subfolder. It shouldn't add it to audit rules.
- Everything works fine with SELinux in _permissive_ mode. 
- Everything works fine with SELinux in _enforcing_ mode. 

Best regards,
Cerv1.