### PR TITLE
Fix crash in Modulesd when parsing command with missing tag

### DIFF
--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -112,7 +112,7 @@ int wm_check() {
         for (j = prev = wmodules; j != i; j = next) {
             next = j->next;
 
-            if (!strcmp(i->tag, j->tag)) {
+            if (i->tag && j->tag && !strcmp(i->tag, j->tag)) {
 
                 mdebug1("Deleting repeated module '%s'.", j->tag);
 


### PR DESCRIPTION
|Fixes|
|---|
|#2469|

As described by Valgrind, Modulesd compares the tag of every module to find duplicates and remove one of them.

There is a special case: commands with no tag. They are unique, no internal tag is defined so they must never be removed.

## Fix
Tags must be compared when filled only: test that both strings are set before comparing them.