### PR TITLE
Fix eventchannel additional path slashes

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -51,15 +51,18 @@ char *replace_win_format(char *str){
     char *ret1 = NULL;
     char *ret2 = NULL;
     char *ret3 = NULL;
+    char *ret4 = NULL;
 
     ret1 = wstr_replace(str, "\\r", "");
     ret2 = wstr_replace(ret1, "\\t", "");
     ret3 = wstr_replace(ret2, "\\n", "");
+    ret4 = wstr_replace(ret3, "\\\\", "\\");
 
     os_free(ret1);
     os_free(ret2);
+    os_free(ret3);
 
-    return ret3;
+    return ret4;
 }
 
 /* Special decoder for Windows eventchannel */


### PR DESCRIPTION
This PR fixes the issue https://github.com/wazuh/wazuh/issues/2482.
Retrieving the generated event from Windows eventchannel generates alerts with additional back slashes since it is the way of scaping this characters ('\\') from Windows paths.