### PR TITLE
Add error message to agent-auth -i

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -206,6 +206,9 @@ int main(int argc, char **argv)
                 sender_ip = optarg;
                 break;
             case 'i':
+		if(optarg){
+		    merror_exit("-%c takes no argument",c);
+		}
                 use_src_ip = 1;
                 break;
             default:

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -206,15 +206,16 @@ int main(int argc, char **argv)
                 sender_ip = optarg;
                 break;
             case 'i':
-		if(optarg){
-		    merror_exit("-%c takes no argument",c);
-		}
                 use_src_ip = 1;
                 break;
             default:
                 help_agent_auth();
                 break;
         }
+    }
+	
+    if (optind < argc) {
+        mwarn("Extra arguments detected. They will be ignored.");
     }
 
     if (debug_level == 0) {


### PR DESCRIPTION
Using agent-auth -i with arguments make no sense and allowing its use may cause confusion to those trying to use the -I modifier.