### PR TITLE
Fix ruleset bug when configuring more than one stanza

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -496,6 +496,7 @@ int main_analysisd(int argc, char **argv)
                 /* Legacy loading */
                 /* Read default decoders */
                 Read_Rules(NULL, &Config, NULL);
+                free_rules_structures();
             }
 
             /* New loaded based on file loaded (in ossec.conf or default) */
@@ -549,6 +550,7 @@ int main_analysisd(int argc, char **argv)
             /* If we haven't specified a rules directory, load default */
             if (!Config.includes) {
                 Read_Rules(NULL, &Config, NULL);
+                free_rules_structures();
             }
 
             /* Read the rules */

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -496,7 +496,7 @@ int main_analysisd(int argc, char **argv)
                 /* Legacy loading */
                 /* Read default decoders */
                 Read_Rules(NULL, &Config, NULL);
-                free_rules_structures();
+                free_ruleset_structures();
             }
 
             /* New loaded based on file loaded (in ossec.conf or default) */
@@ -550,7 +550,7 @@ int main_analysisd(int argc, char **argv)
             /* If we haven't specified a rules directory, load default */
             if (!Config.includes) {
                 Read_Rules(NULL, &Config, NULL);
-                free_rules_structures();
+                free_ruleset_structures();
             }
 
             /* Read the rules */

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -221,6 +221,7 @@ int main(int argc, char **argv)
                 /* Legacy loading */
                 /* Read decoders */
                 Read_Rules(NULL, &Config, NULL);
+                free_ruleset_structures();
 
                 /* New loaded based on file specified in ossec.conf */
                 char **decodersfiles;

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -167,6 +167,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
 
         fail:
         OS_ClearNode(chld_node);
+        free_ruleset_structures();
         return (OS_INVALID);
     }
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -54,6 +54,7 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2);
 int Read_Global(XML_NODE node, void *d1, void *d2);
 int Read_GlobalSK(XML_NODE node, void *configp, void *mailp);
 int Read_Rules(XML_NODE node, void *d1, void *d2);
+void free_rules_structures();
 int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 int Read_Rootcheck(XML_NODE node, void *d1, void *d2);
 int Read_Alerts(XML_NODE node, void *d1, void *d2);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -54,7 +54,7 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2);
 int Read_Global(XML_NODE node, void *d1, void *d2);
 int Read_GlobalSK(XML_NODE node, void *configp, void *mailp);
 int Read_Rules(XML_NODE node, void *d1, void *d2);
-void free_rules_structures();
+void free_ruleset_structures();
 int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 int Read_Rootcheck(XML_NODE node, void *d1, void *d2);
 int Read_Alerts(XML_NODE node, void *d1, void *d2);

--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -99,6 +99,8 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
 {
     int i = 0;
     int retval = 0;
+    unsigned int j = 0;
+    unsigned int k = 0;
 
     char path[PATH_MAX + 2];
     char f_name[PATH_MAX + 2];
@@ -190,7 +192,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
             // <rule_include>
             else if (strcmp(node[i]->element, xml_rules_rule) == 0) {
                 int found = 0;
-                for(unsigned int j=0; j<rules_size-1; j++){
+                for(j=0; j<rules_size-1; j++){
                     if(aux_include_rules[j] && node[i]->content && !strcmp(node[i]->content, aux_include_rules[j])){
                         found = 1;
                         break;
@@ -220,7 +222,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
             // <decoder_include>
             } else if (strcmp(node[i]->element, xml_rules_decoders) == 0) {
                 int found = 0;
-                for(unsigned int j=0; j<decoders_size-1; j++){
+                for(j=0; j<decoders_size-1; j++){
                     if(aux_include_decoders[j] && node[i]->content && !strcmp(node[i]->content, aux_include_decoders[j])){
                         found = 1;
                         break;
@@ -256,7 +258,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
             // <rule_exclude>
             } else if (strcmp(node[i]->element, xml_rules_exclude) == 0) {
                 int found = 0;
-                for(unsigned int j=0; j<total_rules_excluded; j++){
+                for(j=0; j<total_rules_excluded; j++){
                     if(aux_exclude_rules[j] && node[i]->content && !strcmp(node[i]->content, aux_exclude_rules[j])){
                         found = 1;
                         break;
@@ -272,7 +274,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
             // <decoder_exclude>
             } else if (strcmp(node[i]->element, xml_rules_exclude_decoder) == 0) {
                 int found = 0;
-                for(unsigned int j=0; j<total_decoders_excluded; j++){
+                for(j=0; j<total_decoders_excluded; j++){
                     if(aux_exclude_decoders[j] && node[i]->content && !strcmp(node[i]->content, aux_exclude_decoders[j])){
                         found = 1;
                         break;
@@ -403,8 +405,8 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
                 // Exclude
                 if (file_in_list(decoders_exclude_size, f_name, entry->d_name, exclude_decoders)) {
                     int found = 0;
-                    for(unsigned int i=0; i<total_decoders_excluded; i++){
-                        if(aux_exclude_decoders[i] && !strcmp(f_name, aux_exclude_decoders[i])){
+                    for(k=0; k<total_decoders_excluded; k++){
+                        if(aux_exclude_decoders[k] && !strcmp(f_name, aux_exclude_decoders[k])){
                             found = 1;
                             break;
                         }
@@ -425,8 +427,8 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
 
                 if (OSRegex_Execute(f_name, &regex)) {
                     int found = 0;
-                    for(unsigned int i=0; i<decoders_size-1; i++){
-                        if(aux_include_decoders[i] && !strcmp(f_name, aux_include_decoders[i])){
+                    for(k=0; k<decoders_size-1; k++){
+                        if(aux_include_decoders[k] && !strcmp(f_name, aux_include_decoders[k])){
                             found = 1;
                             break;
                         }
@@ -484,8 +486,8 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
                 // Exclude
                 if (file_in_list(rules_exclude_size, f_name, entry->d_name, exclude_rules)) {
                     int found = 0;
-                    for(unsigned int i=0; i<total_rules_excluded; i++){
-                        if(aux_exclude_rules[i] && !strcmp(f_name, aux_exclude_rules[i])){
+                    for(k=0; k<total_rules_excluded; k++){
+                        if(aux_exclude_rules[k] && !strcmp(f_name, aux_exclude_rules[k])){
                             found = 1;
                             break;
                         }
@@ -506,8 +508,8 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
 
                 if (OSRegex_Execute(f_name, &regex)) {
                     int found = 0;
-                    for(unsigned int i=0; i<rules_size-1; i++){
-                        if(aux_include_rules[i] && !strcmp(f_name, aux_include_rules[i])){
+                    for(k=0; k<rules_size-1; k++){
+                        if(aux_include_rules[k] && !strcmp(f_name, aux_include_rules[k])){
                             found = 1;
                             break;
                         }


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/2100. Configuring more than one `<ruleset>` block was overwriting the previous ones. Now it is possible to set various blocks.

Testing checks:
* Adding more than one ruleset blocks with the `<rule_exclude>` field.
* Adding more than one ruleset blocks with the `<rule_include>` field.
* Adding more than one ruleset blocks with the `<rule_dir>` field.
* Adding more than one ruleset blocks with the `<decoder_exclude>` field.
* Adding more than one ruleset blocks with the `<decoder_include>` field.
* Adding more than one ruleset blocks with the `<decoder_dir>` field.
* Excluding a rule file that has a rule definition which makes other rule files dependant.
* Valgrind does not return any leaks.
* Testing on Ubuntu
* Testing on CentOS