### PR TITLE
Fix ossec-control script in Solaris

### DIFF
--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -188,18 +188,18 @@ pstatus()
 }
 
 wait_pid() {
-    local i=1
+    wp_counter=1
 
     while kill -0 $1 2> /dev/null
     do
-        if [ "$i" = "$MAX_KILL_TRIES" ]
+        if [ "$wp_counter" = "$MAX_KILL_TRIES" ]
         then
             return 1
         else
             # sleep doesn't work in AIX
             # read doesn't work in FreeBSD
             sleep 0.1 > /dev/null 2>&1 || read -t 0.1 > /dev/null 2>&1
-            i=`expr $i + 1`
+            wp_counter=`expr $wp_counter + 1`
         fi
     done
 

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -281,18 +281,18 @@ pstatus()
 }
 
 wait_pid() {
-    local i=1
+    wp_counter=1
 
     while kill -0 $1 2> /dev/null
     do
-        if [ "$i" = "$MAX_KILL_TRIES" ]
+        if [ "$wp_counter" = "$MAX_KILL_TRIES" ]
         then
             return 1
         else
             # sleep doesn't work in AIX
             # read doesn't work in FreeBSD
             sleep 0.1 > /dev/null 2>&1 || read -t 0.1 > /dev/null 2>&1
-            i=`expr $i + 1`
+            wp_counter=`expr $wp_counter + 1`
         fi
     done
 

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -406,18 +406,18 @@ pstatus()
 }
 
 wait_pid() {
-    local i=1
+    wp_counter=1
 
     while kill -0 $1 2> /dev/null
     do
-        if [ "$i" = "$MAX_KILL_TRIES" ]
+        if [ "$wp_counter" = "$MAX_KILL_TRIES" ]
         then
             return 1
         else
             # sleep doesn't work in AIX
             # read doesn't work in FreeBSD
             sleep 0.1 > /dev/null 2>&1 || read -t 0.1 > /dev/null 2>&1
-            i=`expr $i + 1`
+            wp_counter=`expr $wp_counter + 1`
         fi
     done
 


### PR DESCRIPTION
The `local` definition is not working in Solaris 11.
It was removed in the `wait_pid()` function.