### PR TITLE
Clear JSON queue file error state before reading

### DIFF
--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -62,6 +62,8 @@ cJSON * jqueue_next(file_queue * queue) {
         return NULL;
     }
 
+    clearerr(queue->fp);
+
     if (fgets(buffer, OS_MAXSTR + 1, queue->fp)) {
         if (end = strchr(buffer, '\n'), end) {
             *end = '\0';


### PR DESCRIPTION
This will prevent CSyslogd, Maild and Integratord from locking file reads.

|Type|Components|Platform|
|---|---|---|
|Manager|Syslog client, Integrator, Mail|Ubuntu 18.10|

_Csyslogd_ was not forwarding alerts with this configuration:

```xml
<syslog_output>
  <server>192.168.33.11</server>
  <format>json</format>
</syslog_output>
```

This is due to C function `fgets()` in looping: when `fgets()` consumes the whole file, it returns `NULL` and marks the `EOF` flag. This prevented the function from reading data anymore from that file, on Ubuntu 18.10 (_libc_ version 2.28).

## Fix

The loop must clear the error state (`clearerror()`) prior to trying to read further data from the file.