### PR TITLE
Fix duplicated field names at some events for Windows eventchannel

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -402,14 +402,14 @@ int DecodeWinevt(Eventinfo *lf){
         cJSON_AddStringToObject(json_system_in, "Message", "No message");
     }
 
-    if(strcmp(join_data,"")){
-        cJSON_AddStringToObject(json_eventdata_in, "Data", join_data);
-    }
-
     if(json_system_in){
         cJSON_AddItemToObject(json_event, "System", json_system_in);
     }
+
     if (json_eventdata_in){
+        if(strcmp(join_data,"")){
+            cJSON_AddStringToObject(json_eventdata_in, "Data", join_data);
+        }
         cJSON_AddItemToObject(json_event, "EventData", json_eventdata_in);
     }
     if (extra){

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -52,6 +52,7 @@ char *replace_win_format(char *str){
     char *ret2 = NULL;
     char *ret3 = NULL;
     char *ret4 = NULL;
+    char *ret5 = NULL;
     char *end = NULL;
     int spaces = 0;
 
@@ -59,11 +60,12 @@ char *replace_win_format(char *str){
     ret1 = wstr_replace(str, "\\r", "");
     ret2 = wstr_replace(ret1, "\\t", "");
     ret3 = wstr_replace(ret2, "\\n", "");
-    ret4 = wstr_replace(ret3, "\\\\", "\\");
+    ret4 = wstr_replace(ret3, "\\\"", "\"");
+    ret5 = wstr_replace(ret4, "\\\\", "\\");
 
     // Remove trailing spaces at the end of the string
-    end = ret4 + strlen(ret4) - 1;
-    while(end > ret4 && isspace((unsigned char)*end)) {
+    end = ret5 + strlen(ret5) - 1;
+    while(end > ret5 && isspace((unsigned char)*end)) {
         end--;
         spaces = 1;
     }
@@ -74,8 +76,9 @@ char *replace_win_format(char *str){
     os_free(ret1);
     os_free(ret2);
     os_free(ret3);
+    os_free(ret4);
 
-    return ret4;
+    return ret5;
 }
 
 /* Special decoder for Windows eventchannel */
@@ -106,11 +109,14 @@ int DecodeWinevt(Eventinfo *lf){
     char *end_msg = NULL;
     char *next = NULL;
     char *category = NULL;
+    char *join_data = NULL;
+    char *join_data2 = NULL;
     char aux = 0;
     lf->decoder_info = winevt_decoder;
 
     os_calloc(OS_MAXSTR, sizeof(char), event);
     os_calloc(OS_MAXSTR, sizeof(char), msg_from_prov);
+    os_calloc(OS_MAXSTR, sizeof(char), join_data);
 
     find_event = strstr(lf->log, "Event");
 
@@ -253,7 +259,21 @@ int DecodeWinevt(Eventinfo *lf){
                                 }
                             } else if (child_attr[p]->content && strcmp(child_attr[p]->content, "(NULL)") != 0){
                                 filtered_string = replace_win_format(child_attr[p]->content);
-                                cJSON_AddStringToObject(json_eventdata_in, child_attr[p]->element, filtered_string);
+
+                                if (strcmp(filtered_string, "") && !strcmp(child_attr[p]->element, "Data")){
+                                    if(strcmp(join_data, "")){
+                                        snprintf(join_data, strlen(join_data) + strlen(filtered_string) + 3, "%s, %s", join_data2, filtered_string);
+                                    } else {
+                                        snprintf(join_data, strlen(filtered_string) + 1, "%s", filtered_string);
+                                    }
+                                    if (join_data2){
+                                        os_free(join_data2);
+                                    }
+                                    os_strdup(join_data,join_data2);
+                                } else if (strcmp(child_attr[p]->element, "Data")){
+                                    cJSON_AddStringToObject(json_eventdata_in, child_attr[p]->element, filtered_string);
+                                }
+
                                 os_free(filtered_string);
                             }
                         } else {
@@ -367,7 +387,9 @@ int DecodeWinevt(Eventinfo *lf){
             }
             memcpy(msg_from_prov, find_msg, num);
             msg_from_prov[num] = '\0';
-            cJSON_AddStringToObject(json_system_in, "Message", msg_from_prov);
+            filtered_string = replace_win_format(msg_from_prov);
+            cJSON_AddStringToObject(json_system_in, "Message", filtered_string);
+            os_free(filtered_string);
 
             find_msg = NULL;
             end_msg = NULL;
@@ -378,6 +400,10 @@ int DecodeWinevt(Eventinfo *lf){
     } else {
         mdebug1("Malformed JSON output received. No 'Message' field found");
         cJSON_AddStringToObject(json_system_in, "Message", "No message");
+    }
+
+    if(strcmp(join_data,"")){
+        cJSON_AddStringToObject(json_eventdata_in, "Data", join_data);
     }
 
     if(json_system_in){
@@ -412,6 +438,8 @@ cleanup:
     os_free(level);
     os_free(event);
     os_free(extra);
+    os_free(join_data);
+    os_free(join_data2);
     os_free(filtered_string);
     os_free(keywords);
     os_free(msg_from_prov);


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/2424.
Now events containing more than one field called Data are modified to join those fields into one if they have relevant information.

It also fixes some spurious backslashes for ", as it returned \\\" instead of \" at the JSON log.

Testing process:
* Valgrind does not report any bugs.
* Insert by `analysisd` socket some events containing various `Data` fields. Those fields have to be joined into one separated by commas.