### PR TITLE
Let Remoted wait for download module availability.

### DIFF
--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -24,4 +24,7 @@ int w_download_status(int status,const char *url,const char *dest);
 int wurl_request(const char * url, const char * dest);
 int wurl_http_get(const char * url, char * data);
 
+/* Check download module availability */
+int wurl_check_connection();
+
 #endif /* CUSTOM_OUTPUT_SEARCH_H_ */

--- a/src/remoted/shared_download.h
+++ b/src/remoted/shared_download.h
@@ -29,6 +29,9 @@
 #define W_PARSER_FILE_CHANGED "File '%s' changed. Reloading data"
 #define W_PARSER_GROUP_TOO_LARGE "The group name is too large. The maximum length is %d"
 
+/* Maximum connection attempts for download module avilability check */
+#define W_DOWNLOAD_MAX_ATTEMPTS 10
+
 typedef struct _file{
     char *name;
     char *url;

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -154,21 +154,33 @@ end:
     return retval;
 }
 
+/* Check download module availability */
+int wurl_check_connection() {
+    int sock = OS_ConnectUnixDomain(isChroot() ? WM_DOWNLOAD_SOCK : WM_DOWNLOAD_SOCK_PATH, SOCK_STREAM, OS_MAXSTR);
+
+    if (sock < 0) {
+        return -1;
+    } else {
+        close(sock);
+        return 0;
+    }
+}
+
 static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
   struct MemoryStruct *mem = (struct MemoryStruct *)userp;
- 
+
   char *ptr = realloc(mem->memory, mem->size + realsize + 1);
   if(ptr == NULL) {
     return 0;
   }
- 
+
   mem->memory = ptr;
   memcpy(&(mem->memory[mem->size]), contents, realsize);
   mem->size += realsize;
   mem->memory[mem->size] = 0;
- 
+
   return realsize;
 }
 
@@ -179,9 +191,9 @@ int wurl_http_get(const char * url, char * data){
     char errbuf[CURL_ERROR_SIZE];
 
     struct MemoryStruct chunk;
- 
-    chunk.memory = malloc(1);  /* will be grown as needed by the realloc above */ 
-    chunk.size = 0;    /* no data at this point */ 
+
+    chunk.memory = malloc(1);  /* will be grown as needed by the realloc above */
+    chunk.size = 0;    /* no data at this point */
 
     if (curl){
         curl_easy_setopt(curl, CURLOPT_URL, url);

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -91,7 +91,7 @@ void * wm_download_main(wm_download_t * data) {
             break;
 
         case 0:
-            mdebug1("Client disconnected.");
+            mdebug1("Client disconnected. This may be a healthcheck.");
             break;
 
         default:


### PR DESCRIPTION
|Fixes|
|---|
|#2516|

This PR will prevent timing issues with external shared files download.

Remoted checks _files.yml_ on startup. It that file exists and it's parsed successfully, Remoted will try to connect to the file download module (at Modulesd), performing up to 10 attempts with a 1-second delay.

If the module is not available, Remoted will show this log:
```
2019/02/01 20:50:11 ossec-remoted: ERROR: Cannot connect to the download module socket. External shared file download is not available.
```

Nevertheless, Remoted will still try to download files, and will show this log on each failed download attempt:

```
2019/02/01 20:50:11 ossec-remoted: WARNING: Couldn't connect to download module socket '/var/ossec/queue/ossec/download'
```