### PR TITLE
Fixes from Cppcheck report

### DIFF
--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -766,7 +766,7 @@ void config_free(_Config *config) {
         free(config->geoip_db_path);
     }
     if (config->geoip6_db_path) {
-        free(config->geoip_db_path);
+        free(config->geoip6_db_path);
     }
 #endif
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -1269,7 +1269,7 @@ void add_remove(const keyentry *entry) {
 #ifdef __hpux
 char* strsignal(int sig)
 {
-    char str[12];
+    static char str[12];
     sprintf(str, "%d", sig);
     return str;
 }

--- a/src/shared/sig_op.c
+++ b/src/shared/sig_op.c
@@ -30,7 +30,7 @@ static const char *pidfile = NULL;
 #ifdef __hpux
 char* strsignal(int sig)
 {
-    char str[12];
+    static char str[12];
     sprintf(str, "%d", sig);
     return str;
 }

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -663,13 +663,14 @@ os_info *get_unix_version()
         // Get OSX codename
         if (strcmp(info->os_platform,"darwin") == 0) {
             if (info->os_codename) {
+                char * tmp_os_version;
                 size_t len = 4;
                 len += strlen(info->os_version);
                 len += strlen(info->os_codename);
-                os_realloc(info->os_version, len, info->os_version);
-                char tmp_os_version[len];
-                strncpy(tmp_os_version, info->os_version, len);
-                snprintf(info->os_version, len, "%s (%s)", tmp_os_version, info->os_codename);
+                os_malloc(len, tmp_os_version);
+                snprintf(tmp_os_version, len, "%s (%s)", info->os_version, info->os_codename);
+                free(info->os_version);
+                info->os_version = tmp_os_version;
             }
         }
     } else {
@@ -733,7 +734,7 @@ int get_nproc() {
         }
         fclose(fp);
     }
-    
+
     if(!cpu_cores)
         cpu_cores = 1;
 

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -667,7 +667,9 @@ os_info *get_unix_version()
                 len += strlen(info->os_version);
                 len += strlen(info->os_codename);
                 os_realloc(info->os_version, len, info->os_version);
-                snprintf(info->os_version, len, "%s (%s)", info->os_version, info->os_codename);
+                char tmp_os_version[len];
+                strncpy(tmp_os_version, info->os_version, len);
+                snprintf(info->os_version, len, "%s (%s)", tmp_os_version, info->os_codename);
             }
         }
     } else {

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1027,7 +1027,7 @@ void read_win_program(const char * sec_key, int arch, int root_key, int usec, co
             // Increase buffer length
 
             buffer_size += BYTEINCREMENT;
-            program_name = (char *)realloc(program_name, buffer_size);
+            os_realloc(program_name, buffer_size, program_name);
             cbData = buffer_size;
             ret = RegQueryValueEx(program_key, "DisplayName", NULL, NULL, (LPBYTE)program_name, &cbData);
         }
@@ -1062,7 +1062,7 @@ void read_win_program(const char * sec_key, int arch, int root_key, int usec, co
                 // Increase buffer length
 
                 buffer_size += BYTEINCREMENT;
-                version = (char *)realloc(version, buffer_size);
+                os_realloc(version, buffer_size, version);
                 cbData = buffer_size;
                 ret = RegQueryValueEx(program_key, "DisplayVersion", NULL, NULL, (LPBYTE)version, &cbData);
             }
@@ -1084,7 +1084,7 @@ void read_win_program(const char * sec_key, int arch, int root_key, int usec, co
                 // Increase buffer length
 
                 buffer_size += BYTEINCREMENT;
-                vendor = (char *)realloc(vendor, buffer_size);
+                os_realloc(vendor, buffer_size, vendor);
                 cbData = buffer_size;
                 ret = RegQueryValueEx(program_key, "Publisher", NULL, NULL, (LPBYTE)vendor, &cbData);
             }
@@ -1106,7 +1106,7 @@ void read_win_program(const char * sec_key, int arch, int root_key, int usec, co
                 // Increase buffer length
 
                 buffer_size += BYTEINCREMENT;
-                date = (char *)realloc(date, buffer_size);
+                os_realloc(date, buffer_size, date);
                 cbData = buffer_size;
                 ret = RegQueryValueEx(program_key, "InstallDate", NULL, NULL, (LPBYTE)date, &cbData);
             }
@@ -1128,7 +1128,7 @@ void read_win_program(const char * sec_key, int arch, int root_key, int usec, co
                 // Increase buffer length
 
                 buffer_size += BYTEINCREMENT;
-                location = (char *)realloc(location, buffer_size);
+                os_realloc(location, buffer_size, location);
                 cbData = buffer_size;
                 ret = RegQueryValueEx(program_key, "InstallLocation", NULL, NULL, (LPBYTE)location, &cbData);
             }


### PR DESCRIPTION
Hi team, using [cppcheck](http://cppcheck.sourceforge.net) I've attempted to fix some bugs found.

Summary:

- [diff-fba8b0f15b9799fad32e30b000884543](https://github.com/wazuh/wazuh/compare/3.9...cppcheck-fix?expand=1#diff-fba8b0f15b9799fad32e30b000884543) typo that causes a double free issue.
- [diff-c1d16a58d2ed41485e829b7ff16b2ecf](https://github.com/wazuh/wazuh/compare/3.9...cppcheck-fix?expand=1#diff-c1d16a58d2ed41485e829b7ff16b2ecf), [diff-351634c018e8b0aeec3c8716566badd3](https://github.com/wazuh/wazuh/compare/3.9...cppcheck-fix?expand=1#diff-351634c018e8b0aeec3c8716566badd3) declare `str` as static makes the variable live at `BSS` instead of being local. This way, we are not returning a pointer to a local variable.
- [diff-a5c1f2f20bef3ce136664f261161fb3e](https://github.com/wazuh/wazuh/compare/3.9...cppcheck-fix?expand=1#diff-a5c1f2f20bef3ce136664f261161fb3e) prevents from using the same variable (`info->os_version`) as target and as parameter for `snprintf`
- [diff-74a40b33660b026386f57bc9a3889073](https://github.com/wazuh/wazuh/compare/3.9...cppcheck-fix?expand=1#diff-74a40b33660b026386f57bc9a3889073) since `realloc` might fail due to not having enough memory, using `os_realloc` prevents unexpected behaviors.

I hope it helps.

Regards!