### PR TITLE
Optimize network performance in Remoted

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -199,6 +199,14 @@ remoted.guess_agent_group=0
 # 0 means never clean up residual data
 remoted.group_data_flush=86400
 
+# Receiving chunk size for TCP. We suggest using powers of two. [1024..16384]
+remoted.receive_chunk=4096
+
+# Deallocate network buffers after usage.
+# 0. Do not deallocate memory.
+# 1. Shrink memory to the reception chunk.
+# 2. Full memory deallocation.
+remoted.buffer_relax=1
 
 # Timeout to execute remote requests [1..3600]
 execd.request_timeout=60

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -178,7 +178,19 @@ void start_agent(int is_startup)
         /* Read until our reply comes back */
         while (attempts <= 5) {
             if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
-                recv_b = OS_RecvSecureTCP(agt->sock, buffer, OS_MAXSTR);
+
+                switch (wnet_select(agt->sock, timeout)) {
+                case -1:
+                    merror(SELECT_ERROR, errno, strerror(errno));
+                    break;
+
+                case 0:
+                    // Timeout
+                    break;
+
+                default:
+                    recv_b = OS_RecvSecureTCP(agt->sock, buffer, OS_MAXSTR);
+                }
             } else {
                 recv_b = recv(agt->sock, buffer, OS_MAXSTR, MSG_DONTWAIT);
             }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -221,8 +221,12 @@ void start_agent(int is_startup)
                         if (!connect_server(agt->rip_id)) {
                             continue;
                         }
+                    } else {
+                        send_msg(msg, -1);
                     }
+                }
 
+                if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
                     send_msg(msg, -1);
                 }
 

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -849,3 +849,14 @@ ssize_t os_recv_waitall(int sock, void * buf, size_t size) {
 
     return offset;
 }
+
+// Wrapper for select()
+int wnet_select(int sock, int timeout) {
+    fd_set fdset;
+    struct timeval fdtimeout = { timeout, 0 };
+
+    FD_ZERO(&fdset);
+    FD_SET(sock, &fdset);
+
+    return select(sock + 1, &fdset, NULL, NULL, &fdtimeout);
+}

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -128,4 +128,7 @@ int OS_SetSocketSize(int sock, int mode, int max_msg_size);
  */
 ssize_t os_recv_waitall(int sock, void * buf, size_t size);
 
+// Wrapper for select()
+int wnet_select(int sock, int timeout);
+
 #endif /* __OS_NET_H */

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -29,6 +29,8 @@ int INTERVAL;
 rlim_t nofile;
 int guess_agent_group;
 int group_data_flush;
+unsigned receive_chunk;
+int buffer_relax;
 
 /* Read the config file (the remote access) */
 int RemotedConfig(const char *cfgfile, remoted *cfg)
@@ -43,6 +45,9 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
     cfg->denyips = NULL;
     cfg->nocmerged = 0;
     cfg->queue_size = 131072;
+
+    receive_chunk = (unsigned)getDefine_Int("remoted", "receive_chunk", 1024, 16384);
+    buffer_relax = getDefine_Int("remoted", "buffer_relax", 0, 2);
 
     if (ReadConfig(modules, cfgfile, cfg, NULL) < 0) {
         return (OS_INVALID);
@@ -144,6 +149,8 @@ cJSON *getRemoteInternalConfig(void) {
     cJSON_AddNumberToObject(remoted,"merge_shared",logr.nocmerged);
     cJSON_AddNumberToObject(remoted,"guess_agent_group",guess_agent_group);
     cJSON_AddNumberToObject(remoted,"group_data_flush",group_data_flush);
+    cJSON_AddNumberToObject(remoted,"receive_chunk",receive_chunk);
+    cJSON_AddNumberToObject(remoted,"buffer_relax",buffer_relax);
 
     cJSON_AddItemToObject(internals,"remoted",remoted);
     cJSON_AddItemToObject(root,"internal",internals);

--- a/src/remoted/netbuffer.c
+++ b/src/remoted/netbuffer.c
@@ -1,0 +1,101 @@
+/* Network buffer library for Remoted
+ * November 26, 2018
+ *
+ * Copyright (C) 2018 Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+*/
+
+#include <shared.h>
+#include <os_net/os_net.h>
+#include "remoted.h"
+
+#define BUF_SIZE 4096
+
+void nb_open(netbuffer_t * buffer, int sock, const struct sockaddr_in * peer_info) {
+    if (sock >= buffer->max_fd) {
+        os_realloc(buffer->buffers, sizeof(sockbuffer_t) * (sock + 1), buffer->buffers);
+        buffer->max_fd = sock;
+    }
+
+    memset(buffer->buffers + sock, 0, sizeof(sockbuffer_t));
+    memcpy(&buffer->buffers[sock].peer_info, peer_info, sizeof(struct sockaddr_in));
+}
+
+int nb_close(netbuffer_t * buffer, int sock) {
+    int retval = close(sock);
+
+    if (!retval) {
+        free(buffer->buffers[sock].data);
+        memset(buffer->buffers + sock, 0, sizeof(sockbuffer_t));
+    }
+
+    return retval;
+}
+
+/*
+ * Receive available data from the network and push as many message as possible
+ * Returns -2 on data corruption at application layer (header).
+ * Returns -1 on system call error: recv().
+ * Returns 0 if no data was available in the socket.
+ * Returns the number of bytes received on success.
+*/
+int nb_recv(netbuffer_t * buffer, int sock) {
+    sockbuffer_t * sockbuf = &buffer->buffers[sock];
+    unsigned long data_ext = sockbuf->data_len + BUF_SIZE;
+    long recv_len;
+    unsigned long i;
+    unsigned long cur_offset;
+    uint32_t cur_len;
+
+    // Extend data buffer
+
+    if (data_ext > sockbuf->data_size) {
+        os_realloc(sockbuf->data, data_ext, sockbuf->data);
+        sockbuf->data_size = data_ext;
+    }
+
+    // Receive and append
+
+    recv_len = recv(sock, sockbuf->data + sockbuf->data_len, BUF_SIZE, 0);
+
+    if (recv_len <= 0) {
+        return recv_len;
+    }
+
+    sockbuf->data_len += recv_len;
+
+    // Dispatch as most messages as possible
+
+    for (i = 0; i + sizeof(uint32_t) <= sockbuf->data_len; i = cur_offset + cur_len) {
+        cur_len = wnet_order(*(uint32_t *)(sockbuf->data + i));
+
+        if (cur_len > OS_MAXSTR) {
+            return -2;
+        }
+
+        cur_offset = i + sizeof(uint32_t);
+
+        if (cur_offset + cur_len > sockbuf->data_len) {
+            break;
+        }
+
+        rem_msgpush(sockbuf->data + cur_offset, cur_len, &sockbuf->peer_info, sock);
+    }
+
+    // Move remaining data to data start
+
+    if (i > 0) {
+        if (i < sockbuf->data_len) {
+            memcpy(sockbuf->data, sockbuf->data + i, sockbuf->data_len - i);
+        }
+
+        sockbuf->data_len -= i;
+    }
+
+    return recv_len;
+}

--- a/src/remoted/netbuffer.c
+++ b/src/remoted/netbuffer.c
@@ -14,8 +14,6 @@
 #include <os_net/os_net.h>
 #include "remoted.h"
 
-#define BUF_SIZE 4096
-
 void nb_open(netbuffer_t * buffer, int sock, const struct sockaddr_in * peer_info) {
     if (sock >= buffer->max_fd) {
         os_realloc(buffer->buffers, sizeof(sockbuffer_t) * (sock + 1), buffer->buffers);
@@ -46,7 +44,7 @@ int nb_close(netbuffer_t * buffer, int sock) {
 */
 int nb_recv(netbuffer_t * buffer, int sock) {
     sockbuffer_t * sockbuf = &buffer->buffers[sock];
-    unsigned long data_ext = sockbuf->data_len + BUF_SIZE;
+    unsigned long data_ext = sockbuf->data_len + receive_chunk;
     long recv_len;
     unsigned long i;
     unsigned long cur_offset;
@@ -61,7 +59,7 @@ int nb_recv(netbuffer_t * buffer, int sock) {
 
     // Receive and append
 
-    recv_len = recv(sock, sockbuf->data + sockbuf->data_len, BUF_SIZE, 0);
+    recv_len = recv(sock, sockbuf->data + sockbuf->data_len, receive_chunk, 0);
 
     if (recv_len <= 0) {
         return recv_len;
@@ -95,6 +93,28 @@ int nb_recv(netbuffer_t * buffer, int sock) {
         }
 
         sockbuf->data_len -= i;
+
+        switch (buffer_relax) {
+        case 0:
+            // Do not deallocate memory.
+            break;
+
+        case 1:
+            // Shrink memory to fit the current buffer or the receive chunk.
+            sockbuf->data_size = sockbuf->data_len > receive_chunk ? sockbuf->data_len : receive_chunk;
+            os_realloc(sockbuf->data, sockbuf->data_size, sockbuf->data);
+            break;
+
+        default:
+            // Full memory deallocation.
+            sockbuf->data_size = sockbuf->data_len;
+
+            if (sockbuf->data_size) {
+                os_realloc(sockbuf->data, sockbuf->data_size, sockbuf->data);
+            } else {
+                os_free(sockbuf->data);
+            }
+        }
     }
 
     return recv_len;

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -48,6 +48,7 @@ typedef struct remoted_state_t {
     unsigned int evt_count;
     unsigned int ctrl_msg_count;
     unsigned int msg_sent;
+    unsigned long recv_bytes;
 } remoted_state_t;
 
 /* Network buffer structure */
@@ -140,6 +141,7 @@ void rem_inc_evt();
 void rem_inc_ctrl_msg();
 void rem_inc_msg_sent();
 void rem_inc_discarded();
+void rem_add_recv(unsigned long bytes);
 
 // Read config
 size_t rem_getconfig(const char * section, char ** output);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -50,6 +50,20 @@ typedef struct remoted_state_t {
     unsigned int msg_sent;
 } remoted_state_t;
 
+/* Network buffer structure */
+
+typedef struct sockbuffer_t {
+    struct sockaddr_in peer_info;
+    char * data;
+    unsigned long data_size;
+    unsigned long data_len;
+} sockbuffer_t;
+
+typedef struct netbuffer_t {
+    int max_fd;
+    sockbuffer_t * buffers;
+} netbuffer_t;
+
 /** Function prototypes **/
 
 /* Read remoted config */
@@ -131,6 +145,12 @@ void rem_inc_discarded();
 size_t rem_getconfig(const char * section, char ** output);
 cJSON *getRemoteConfig(void);
 cJSON *getRemoteInternalConfig(void);
+
+/* Network buffer */
+
+void nb_open(netbuffer_t * buffer, int sock, const struct sockaddr_in * peer_info);
+int nb_close(netbuffer_t * buffer, int sock);
+int nb_recv(netbuffer_t * buffer, int sock);
 
 /** Global variables **/
 

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -172,5 +172,7 @@ extern int INTERVAL;
 extern rlim_t nofile;
 extern int guess_agent_group;
 extern int group_data_flush;
+extern unsigned receive_chunk;
+extern int buffer_relax;
 
 #endif /* __LOGREMOTE_H */

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -15,6 +15,8 @@
 /* Global variables */
 int sender_pool;
 
+static netbuffer_t netbuffer;
+
 // Message handler thread
 static void * rem_handler_main(__attribute__((unused)) void * args);
 
@@ -53,7 +55,6 @@ void HandleSecure()
     int n_events = 0;
     char buffer[OS_MAXSTR + 1];
     ssize_t recv_b;
-    uint32_t length;
     struct sockaddr_in peer_info;
     wnotify_t * notify = NULL;
 
@@ -158,6 +159,7 @@ void HandleSecure()
                         merror_exit(ACCEPT_ERROR);
                     }
 
+                    nb_open(&netbuffer, sock_client, &peer_info);
                     rem_inc_tcp();
                     mdebug1("New TCP connection at %s [%d]", inet_ntoa(peer_info.sin_addr), sock_client);
 
@@ -167,63 +169,34 @@ void HandleSecure()
                     }
                 } else {
                     sock_client = fd;
-                    recv_b = recv(sock_client, (char*)&length, sizeof(length), MSG_WAITALL);
-                    length = wnet_order(length);
 
-                    if (getpeername(sock_client, (struct sockaddr *)&peer_info, &logr.peer_size) < 0) {
+                    switch (nb_recv(&netbuffer, sock_client)) {
+                    case -2:
+                        mwarn("Too big message size from %s [%d].", inet_ntoa(peer_info.sin_addr), sock_client);
+                        _close_sock(&keys, sock_client);
+                        continue;
+
+                    case -1:
                         switch (errno) {
-                            case ENOTCONN:
-                                mdebug1("TCP peer was disconnected: cannot get peer name. [%d]", sock_client);
-                                break;
-                            default:
-                                merror("Couldn't get the remote peer information: %s [%d]", strerror(errno), errno);
-                        }
-
-                        _close_sock(&keys, sock_client);
-                        continue;
-                    }
-
-                    /* Nothing received */
-                    if (recv_b <= 0 || length > OS_MAXSTR) {
-                        switch (recv_b) {
-                        case -1:
-                            if (errno == ENOTCONN) {
-                                mdebug1("TCP peer at %s disconnected (ENOTCONN) [%d]", inet_ntoa(peer_info.sin_addr), sock_client);
-                            } else {
-                                merror("TCP peer at %s: %s (%d)", inet_ntoa(peer_info.sin_addr), strerror(errno), errno);
-                            }
-
+                        case ECONNRESET:
+                        case ENOTCONN:
+                            mdebug2("TCP peer [%d] at %s: %s (%d)", sock_client, inet_ntoa(peer_info.sin_addr), strerror(errno), errno);
                             break;
-
-                        case 0:
-                            mdebug1("TCP peer at %s disconnected [%d]", inet_ntoa(peer_info.sin_addr), sock_client);
-                            break;
-
                         default:
-                            // length > OS_MAXSTR
-                            mwarn("Too big message size from %s.", inet_ntoa(peer_info.sin_addr));
+                            merror("TCP peer [%d] at %s: %s (%d)", sock_client, inet_ntoa(peer_info.sin_addr), strerror(errno), errno);
                         }
 
+                        // Fallthrough
+
+                    case 0:
                         if (wnotify_delete(notify, sock_client) < 0) {
                             merror("wnotify_delete(%d): %s (%d)", sock_client, strerror(errno), errno);
                         }
 
                         _close_sock(&keys, sock_client);
                         continue;
-                    }
 
-                    recv_b = recv(sock_client, buffer, length, MSG_WAITALL);
-
-                    if (recv_b != (ssize_t)length) {
-                        mwarn("Incorrect message size from %s: expecting %u, got %zd. Agent may have disconnected [%d]", inet_ntoa(peer_info.sin_addr), length, recv_b, sock_client);
-
-                        if (wnotify_delete(notify, sock_client) < 0) {
-                            merror("wnotify_delete(%d): %s (%d)", sock_client, strerror(errno), errno);
-                        }
-
-                        _close_sock(&keys, sock_client);
-                    } else {
-                        rem_msgpush(buffer, recv_b, &peer_info, sock_client);
+                    default: ;
                     }
                 }
             }
@@ -444,7 +417,7 @@ int _close_sock(keystore * keys, int sock) {
     retval = OS_DeleteSocket(keys, sock);
     key_unlock();
 
-    if (close(sock) == 0) {
+    if (nb_close(&netbuffer, sock) == 0) {
         rem_dec_tcp();
     }
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -170,7 +170,7 @@ void HandleSecure()
                 } else {
                     sock_client = fd;
 
-                    switch (nb_recv(&netbuffer, sock_client)) {
+                    switch (recv_b = nb_recv(&netbuffer, sock_client), recv_b) {
                     case -2:
                         mwarn("Too big message size from %s [%d].", inet_ntoa(peer_info.sin_addr), sock_client);
                         _close_sock(&keys, sock_client);
@@ -196,7 +196,8 @@ void HandleSecure()
                         _close_sock(&keys, sock_client);
                         continue;
 
-                    default: ;
+                    default:
+                        rem_add_recv((unsigned long)recv_b);
                     }
                 }
             }
@@ -208,6 +209,7 @@ void HandleSecure()
                 continue;
             } else {
                 rem_msgpush(buffer, recv_b, &peer_info, -1);
+                rem_add_recv((unsigned long)recv_b);
             }
         }
     }

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -13,7 +13,7 @@
 #include "remoted.h"
 #include <pthread.h>
 
-remoted_state_t remoted_state = {0, 0, 0, 0, 0};
+remoted_state_t remoted_state;
 static pthread_mutex_t state_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int rem_write_state();
 static char *refresh_time;
@@ -93,9 +93,12 @@ int rem_write_state() {
         "discarded_count='%u'\n"
         "\n"
         "# Messages sent\n"
-        "msg_sent='%u'\n",
+        "msg_sent='%u'\n"
+        "\n"
+        "# Total number of bytes received\n"
+        "recv_bytes='%lu'\n",
         __local_name, refresh_time, rem_get_qsize(), rem_get_tsize(), state_cpy.tcp_sessions,
-        state_cpy.evt_count, state_cpy.ctrl_msg_count, state_cpy.discarded_count, state_cpy.msg_sent);
+        state_cpy.evt_count, state_cpy.ctrl_msg_count, state_cpy.discarded_count, state_cpy.msg_sent, state_cpy.recv_bytes);
 
     fclose(fp);
 
@@ -143,5 +146,11 @@ void rem_inc_msg_sent() {
 void rem_inc_discarded() {
     w_mutex_lock(&state_mutex);
     remoted_state.discarded_count++;
+    w_mutex_unlock(&state_mutex);
+}
+
+void rem_add_recv(unsigned long bytes) {
+    w_mutex_lock(&state_mutex);
+    remoted_state.recv_bytes += bytes;
     w_mutex_unlock(&state_mutex);
 }


### PR DESCRIPTION
|Implements|
|---|
|#1908|

Remoted uses a dedicated thread for networking. The goal of this issue is that the bottleneck of this thread should be the network itself.

The `epoll` system call notifies when a socket is available to receive data. When operating in TCP mode, Remoted gets a notification when at less one byte is available, then it tries to receive the entire message. This may produce a delay if the message is not completely in the kernel.

## Main changes

1. Implementation of network buffer in Remoted.
2. Improvement of the socket waiting operation in the Agent: replace `recv()`-relayed timeout with `select()`.
3. Prevent the agent from receiving a response three times in a row on the handshake, if the connection mode is TCP.

## Approach

Use one buffer per socket. When `epoll` notifies that some data is available, try to get at most data as possible. Then, find complete messages and dispatch them. Store the remaining data —part of the nest message— in the buffer. The next `receive` operation may append the data in the buffer.

## New options

### Internal options

|Option|Range|Default|Description|
|---|---|---|---|
|`remoted.receive_chunk`|`1024`..`16384`|`4096`|Receiving chunk size for TCP. We suggest using powers of two.|
|`remoted.buffer_relax`|`0`, `1` and `2`|`1`|Deallocate network buffers after usage, for memory saving.|

#### `remoted.buffer_relax`

This parameter selects the network buffer memory deallocation scheduling.

|Value|Description|
|---|---|
|`0`|Do not deallocate memory.|
|`1`|Shrink memory to the reception chunk. (default)|
|`2`|Full memory deallocation.|

## New statistic data

### recv_bytes

Number of raw bytes received from the network interface, related to any socket client (even if it's not an agent).