### PR TITLE
#2473 - Support AWS Organizations in the AWS wodle

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -22,6 +22,7 @@ static const char *XML_REMOVE_FORM_BUCKET = "remove_from_bucket";
 static const char *XML_SKIP_ON_ERROR = "skip_on_error";
 static const char *XML_AWS_PROFILE = "aws_profile";
 static const char *XML_IAM_ROLE_ARN = "iam_role_arn";
+static const char *XML_AWS_ORGANISATION_ID = "aws_organisation_id";
 static const char *XML_AWS_ACCOUNT_ID = "aws_account_id";
 static const char *XML_AWS_ACCOUNT_ALIAS = "aws_account_alias";
 static const char *XML_TRAIL_PREFIX = "path";
@@ -212,6 +213,14 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         }
                         free(cur_bucket->bucket);
                         os_strdup(children[j]->content, cur_bucket->bucket);
+                    } else if (!strcmp(children[j]->element, XML_AWS_ORGANISATION_ID)) {
+                        if (strlen(children[j]->content) == 0) {
+                            merror("Empty content for tag '%s' at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);
+                            OS_ClearNode(children);
+                            return OS_INVALID;
+                        }
+                        free(cur_bucket->aws_organisation_id);
+                        os_strdup(children[j]->content, cur_bucket->aws_organisation_id);
                     } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ID)) {
                         if (strlen(children[j]->content) == 0) {
                             merror("Empty content for tag '%s' at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -277,6 +277,10 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
         wm_strcat(&command, "--iam_role_arn", ' ');
         wm_strcat(&command, exec_bucket->iam_role_arn, ' ');
     }
+    if (exec_bucket->aws_organisation_id) {
+        wm_strcat(&command, "--aws_organisation_id", ' ');
+        wm_strcat(&command, exec_bucket->aws_organisation_id, ' ');
+    }
     if (exec_bucket->aws_account_id) {
         wm_strcat(&command, "--aws_account_id", ' ');
         wm_strcat(&command, exec_bucket->aws_account_id, ' ');

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -29,6 +29,7 @@ typedef struct wm_aws_bucket {
     char *secret_key;                   // IAM secret key
     char *aws_profile;                  // AWS credentials profile
     char *iam_role_arn;                 // IAM role
+    char *aws_organisation_id;          // AWS organisation ID
     char *aws_account_id;               // AWS account ID(s)
     char *aws_account_alias;            // AWS account alias
     char *trail_prefix;                 // Trail prefix

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -64,7 +64,6 @@ import gzip
 import zipfile
 import re
 import io
-from datetime import datetime
 from os import path
 import operator
 from datetime import datetime
@@ -305,7 +304,7 @@ class AWSBucket(WazuhIntegration):
 
     def __init__(self, reparse, access_key, secret_key, profile, iam_role_arn,
                  bucket, only_logs_after, skip_on_error, account_alias,
-                 prefix, delete_file):
+                 prefix, delete_file, aws_organisation_id):
         """
         AWS Bucket constructor.
 
@@ -320,6 +319,7 @@ class AWSBucket(WazuhIntegration):
         :param account_alias: Alias of the AWS account where the bucket is.
         :param prefix: Prefix to filter files in bucket
         :param delete_file: Wether to delete an already processed file from a bucket or not
+        :param aws_organisation_id: The AWS Organisation ID
         """
 
         # common SQL queries
@@ -417,6 +417,7 @@ class AWSBucket(WazuhIntegration):
         self.prefix = prefix
         self.delete_file = delete_file
         self.bucket_path = self.bucket + '/' + self.prefix
+        self.aws_organisation_id = aws_organisation_id
 
     def already_processed(self, downloaded_file, aws_account_id, aws_region):
         cursor = self.db_connector.execute(self.sql_already_processed.format(
@@ -731,11 +732,24 @@ class AWSLogsBucket(AWSBucket):
     Abstract class for logs generated from services such as CloudTrail or Config
     """
 
-    def get_full_prefix(self, account_id, account_region):
-        return '{trail_prefix}AWSLogs/{aws_account_id}/{aws_service}/{aws_region}/'.format(
-            trail_prefix=self.prefix,
+    def get_base_prefix(self):
+        base_prefix = '{}AWSLogs/'.format(self.prefix)
+        if self.aws_organisation_id:
+            base_prefix = '{base_prefix}{aws_organisation_id}/'.format(
+                base_prefix=base_prefix,
+                aws_organisation_id=self.aws_organisation_id)
+
+        return base_prefix
+
+    def get_service_prefix(self, account_id):
+        return '{base_prefix}{aws_account_id}/{aws_service}/'.format(
+            base_prefix=self.get_base_prefix(),
             aws_account_id=account_id,
-            aws_service=self.service,
+            aws_service=self.service)
+
+    def get_full_prefix(self, account_id, account_region):
+        return '{service_prefix}{aws_region}/'.format(
+            service_prefix=self.get_service_prefix(account_id),
             aws_region=account_region)
 
     def get_creation_date(self, log_file):
@@ -765,17 +779,13 @@ class AWSLogsBucket(AWSBucket):
     def find_account_ids(self):
         return [common_prefix['Prefix'].split('/')[-2] for common_prefix in
                 self.client.list_objects_v2(Bucket=self.bucket,
-                                            Prefix='{}AWSLogs/'.format(self.prefix),
+                                            Prefix=self.get_base_prefix(),
                                             Delimiter='/')['CommonPrefixes']
                 ]
 
     def find_regions(self, account_id):
-        regions_prefix = '{trail_prefix}AWSLogs/{aws_account_id}/{aws_service}/'.format(
-            trail_prefix=self.prefix,
-            aws_account_id=account_id,
-            aws_service=self.service)
         regions = self.client.list_objects_v2(Bucket=self.bucket,
-                                              Prefix=regions_prefix,
+                                              Prefix=self.get_service_prefix(account_id=account_id),
                                               Delimiter='/')
 
         if 'CommonPrefixes' in regions:
@@ -1932,6 +1942,8 @@ def get_script_arguments():
                         action='store')
     group.add_argument('-sr', '--service', dest='service', help='Specify the name of the service',
                         action='store')
+    parser.add_argument('-O', '--aws_organisation_id', dest='aws_organisation_id',
+                        help='AWS Organisation ID for logs', required=False)
     parser.add_argument('-c', '--aws_account_id', dest='aws_account_id',
                         help='AWS Account ID for logs', required=False,
                         type=arg_valid_accountid)
@@ -1996,7 +2008,8 @@ def main(argv):
                            iam_role_arn=options.iam_role_arn, bucket=options.logBucket,
                            only_logs_after=options.only_logs_after, skip_on_error=options.skip_on_error,
                            account_alias=options.aws_account_alias,
-                           prefix=options.trail_prefix, delete_file=options.deleteFile)
+                           prefix=options.trail_prefix, delete_file=options.deleteFile,
+                           aws_organisation_id=options.aws_organisation_id)
             bucket.iter_bucket(options.aws_account_id, options.regions)
         elif options.service:
             if options.service.lower() == 'inspector':


### PR DESCRIPTION
This pull requests adds the XML parsing for `aws_organisation_id` in a bucket tag in a aws-s3 wodle. This variable is passed to `aws-s3.py` as argument `--aws_organisation_id` and used in the generation of the path prefix for the AWSLogsBucket when set.