### PR TITLE
Improve logging in 3.9 cluster workers

### DIFF
--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -243,7 +243,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
     def end_receiving_integrity_checksums(self, task_and_file_names: str) -> Tuple[bytes, bytes]:
         return super().end_receiving_file(task_and_file_names)
 
-    async def sync_worker_files(self, task_name: str, received_file: asyncio.Task, logger):
+    async def sync_worker_files(self, task_name: str, received_file: asyncio.Event, logger):
         logger.info("Waiting to receive zip file from worker")
         await received_file.wait()
         received_filename = self.sync_tasks[task_name].filename
@@ -258,21 +258,21 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.process_files_from_worker(files_checksums, decompressed_files_path, logger)
         shutil.rmtree(decompressed_files_path)
 
-    async def sync_extra_valid(self, task_name: str, received_file: asyncio.Task):
+    async def sync_extra_valid(self, task_name: str, received_file: asyncio.Event):
         extra_valid_logger = self.task_loggers['Extra valid']
         self.sync_extra_valid_status['date_start_master'] = str(datetime.now())
         await self.sync_worker_files(task_name, received_file, extra_valid_logger)
         self.sync_extra_valid_free = True
         self.sync_extra_valid_status['date_end_master'] = str(datetime.now())
 
-    async def sync_agent_info(self, task_name: str, received_file: asyncio.Task):
+    async def sync_agent_info(self, task_name: str, received_file: asyncio.Event):
         agent_info_logger = self.task_loggers['Agent info']
         self.sync_agent_info_status['date_start_master'] = str(datetime.now())
         await self.sync_worker_files(task_name, received_file, agent_info_logger)
         self.sync_agent_info_free = True
         self.sync_agent_info_status['date_end_master'] = str(datetime.now())
 
-    async def sync_integrity(self, task_name: str, received_file: asyncio.Task):
+    async def sync_integrity(self, task_name: str, received_file: asyncio.Event):
         logger = self.task_loggers['Integrity']
 
         self.sync_integrity_status['date_start_master'] = str(datetime.now())

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -3,7 +3,10 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import errno
+import glob
+import itertools
 import os
+import re
 import shutil
 import time
 from typing import Tuple, Dict, Callable
@@ -11,6 +14,8 @@ from wazuh.cluster import client, cluster, common as c_common
 from wazuh import cluster as metadata
 from wazuh import common, utils
 from wazuh.exception import WazuhException
+from wazuh.agent import Agent
+from wazuh.database import Connection
 from wazuh.cluster.dapi import dapi
 
 
@@ -67,6 +72,9 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
     def __init__(self, version, node_type, cluster_name, **kwargs):
         super().__init__(**kwargs, tag="Worker")
         self.client_data = "{} {} {} {}".format(self.name, cluster_name, node_type, version).encode()
+        self.task_loggers = {'Integrity': self.setup_task_logger('Integrity'),
+                             'Extra valid': self.setup_task_logger('Extra valid'),
+                             'Agent info': self.setup_task_logger('Agent info')}
 
     def connection_result(self, future_result):
         super().connection_result(future_result)
@@ -79,7 +87,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
     def process_request(self, command: bytes, data: bytes) -> Tuple[bytes, bytes]:
         self.logger.debug("Command received: '{}'".format(command))
         if command == b'sync_m_c_ok':
-            return b'ok', b'Thanks'
+            return self.sync_integrity_ok_from_master()
         elif command == b'sync_m_c':
             return self.setup_receive_files_from_master()
         elif command == b'sync_m_c_e':
@@ -107,8 +115,13 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
     def end_receiving_integrity(self, task_and_file_names: str) -> Tuple[bytes, bytes]:
         return super().end_receiving_file(task_and_file_names)
 
+    def sync_integrity_ok_from_master(self) -> Tuple[bytes, bytes]:
+        integrity_logger = self.task_loggers['Integrity']
+        integrity_logger.info("The master has verified that the integrity is right.")
+        return b'ok', b'Thanks'
+
     async def sync_integrity(self):
-        integrity_logger = self.setup_task_logger("Integrity")
+        integrity_logger = self.task_loggers["Integrity"]
         while True:
             try:
                 if self.connected:
@@ -125,7 +138,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             await asyncio.sleep(self.cluster_items['intervals']['worker']['sync_integrity'])
 
     async def sync_agent_info(self):
-        agent_info_logger = self.setup_task_logger("Agent info")
+        agent_info_logger = self.task_loggers["Agent info"]
         while True:
             try:
                 if self.connected:
@@ -143,7 +156,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             await asyncio.sleep(self.cluster_items['intervals']['worker']['sync_files'])
 
     async def sync_extra_valid(self, extra_valid: Dict):
-        extra_valid_logger = self.setup_task_logger("Extra valid")
+        extra_valid_logger = self.task_loggers["Extra valid"]
         try:
             before = time.time()
             self.logger.debug("Starting to send extra valid files")
@@ -164,35 +177,128 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
 
     async def process_files_from_master(self, name: str, file_received: asyncio.Event):
         await file_received.wait()
-        self.logger.info("Analyzing received files: Start.")
+        logger = self.task_loggers['Integrity']
+        logger.info("Analyzing received files: Start.")
 
         ko_files, zip_path = cluster.decompress_files(self.sync_tasks[name].filename)
-        self.logger.info("Analyzing received files: Missing: {}. Shared: {}. Extra: {}. ExtraValid: {}".format(
+        logger.info("Analyzing received files: Missing: {}. Shared: {}. Extra: {}. ExtraValid: {}".format(
             len(ko_files['missing']), len(ko_files['shared']), len(ko_files['extra']), len(ko_files['extra_valid'])))
 
         # Update files
         if ko_files['extra_valid']:
-            self.logger.info("Master requires some worker files.")
+            logger.info("Master requires some worker files.")
             asyncio.create_task(self.sync_extra_valid(ko_files['extra_valid']))
 
         if not ko_files['shared'] and not ko_files['missing'] and not ko_files['extra']:
-            self.logger.info("Worker meets integrity checks. No actions.")
+            logger.info("Worker meets integrity checks. No actions.")
         else:
-            self.logger.info("Worker does not meet integrity checks. Actions required.")
-            self.logger.info("Updating files: Start.")
+            logger.info("Worker does not meet integrity checks. Actions required.")
+            logger.info("Updating files: Start.")
             self.update_master_files_in_worker(ko_files, zip_path)
             shutil.rmtree(zip_path)
-            self.logger.info("Updating files: End.")
+            logger.info("Updating files: End.")
+
+    @staticmethod
+    def remove_bulk_agents(agent_ids_list, logger):
+        """
+        Removes files created by agents in worker nodes. This function doesn't remove agents from client.keys since the
+        client.keys file is overwritten by the master node.
+        :param agent_ids_list: List of agents ids to remove.
+        :return: None.
+        """
+
+        def remove_agent_file_type(glob_args, agent_args, agent_files):
+            for filetype in agent_files:
+                for agent_file in set(glob.iglob(filetype.format(common.ossec_path, *glob_args))) & \
+                                  {filetype.format(common.ossec_path, *(a[arg] for arg in agent_args)) for a in
+                                   agent_info}:
+                    os.remove(agent_file)
+
+        if not agent_ids_list:
+            return  # the function doesn't make sense if there is no agents to remove
+
+        logger.info("Removing files from {} agents".format(len(agent_ids_list)))
+        logger.debug("Agents to remove: {}".format(', '.join(agent_ids_list)))
+        # the agents must be removed in groups of 997: 999 is the limit of SQL variables per query. Limit and offset are
+        # always included in the SQL query, so that leaves 997 variables as limit.
+        for agents_ids_sublist in itertools.zip_longest(*itertools.repeat(iter(agent_ids_list), 997), fillvalue='0'):
+            # Get info from DB
+            agent_info = Agent.get_agents_overview(q=",".join(["id={}".format(i) for i in agents_ids_sublist]),
+                                                   select={'fields': ['ip', 'id', 'name']}, limit=None)['items']
+
+            # Remove agent files that need agent name and ip
+            agent_files = ['{}/queue/agent-info/{}-{}', '{}/queue/rootcheck/({}) {}->rootcheck']
+            remove_agent_file_type(('*', '*'), ('name', 'ip'), agent_files)
+
+            # Remove agent files that only need agent id
+            agent_files = ['{}/queue/agent-groups/{}', '{}/queue/rids/{}']
+            remove_agent_file_type(('*',), ('id',), agent_files)
+
+            # remove agent from groups
+            db_global = glob.glob(common.database_path_global)
+            if not db_global:
+                raise WazuhException(1600)
+
+            conn = Connection(db_global[0])
+            agent_ids_db = {'id_agent{}'.format(i): int(i) for i in agents_ids_sublist}
+            conn.execute('delete from belongs where {}'.format(
+                ' or '.join(['id_agent = :{}'.format(i) for i in agent_ids_db.keys()])), agent_ids_db)
+            conn.commit()
+        logger.info("Agent files removed")
+
+    @staticmethod
+    def _check_removed_agents(new_client_keys_path, logger):
+        """
+        Function to delete agents that have been deleted in a synchronized
+        client.keys.
+
+        It makes a diff of the old client keys and the new one and search for
+        deleted or changed lines (in the diff those lines start with -).
+
+        If a line starting with - matches the regex structure of a client.keys line
+        that agent is deleted.
+        """
+
+        def parse_client_keys(client_keys_contents):
+            """
+            Parses client.keys file into a dictionary
+            :param client_keys_contents: \n splitted contents of client.keys file
+            :return: generator of dictionaries.
+            """
+            ck_line = re.compile(r'\d+ \S+ \S+ \S+')
+            return {a_id: {'name': a_name, 'ip': a_ip, 'key': a_key} for a_id, a_name, a_ip, a_key in
+                    map(lambda x: x.split(' '), filter(lambda x: ck_line.match(x) is not None, client_keys_contents))
+                    if not a_name.startswith('!')}
+
+        ck_path = "{0}/etc/client.keys".format(common.ossec_path)
+        try:
+            with open(ck_path) as ck:
+                # can't use readlines function since it leaves a \n at the end of each item of the list
+                client_keys_dict = parse_client_keys(ck)
+        except Exception as e:
+            # if client.keys can't be read, it can't be parsed
+            logger.warning("Could not parse client.keys file: {}".format(e))
+            return
+
+        with open(new_client_keys_path) as n_ck:
+            new_client_keys_dict = parse_client_keys(n_ck)
+
+        # get removed agents: the ones missing in the new client keys and present in the old
+        try:
+            WorkerHandler.remove_bulk_agents(client_keys_dict.keys() - new_client_keys_dict.keys(), logger)
+        except Exception as e:
+            logger.error("Error removing agent files: {}".format(e))
+            raise e
 
     def update_master_files_in_worker(self, ko_files: Dict, zip_path: str):
         def overwrite_or_create_files(filename, data):
             full_filename_path = common.ossec_path + filename
             if os.path.basename(filename) == 'client.keys':
-                cluster._check_removed_agents("{}{}".format(zip_path, filename))
+                self._check_removed_agents("{}{}".format(zip_path, filename), logger)
 
             if data['merged']:  # worker nodes can only receive agent-groups files
                 if data['merge-type'] == 'agent-info':
-                    self.logger.warning("Agent status received in a worker node")
+                    logger.warning("Agent status received in a worker node")
                     raise WazuhException(3011)
 
                 for name, content, _ in cluster.unmerge_agent_info('agent-groups', zip_path, filename):
@@ -207,35 +313,36 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 os.chown(full_filename_path, common.ossec_uid, common.ossec_gid)
                 os.chmod(full_filename_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
 
+        logger = self.task_loggers['Integrity']
         errors = {'shared': 0, 'missing': 0, 'extra': 0}
         for filetype, files in ko_files.items():
             if filetype == 'shared' or filetype == 'missing':
-                self.logger.debug("Received {} {} files to update from master.".format(len(ko_files[filetype]),
+                logger.debug("Received {} {} files to update from master.".format(len(ko_files[filetype]),
                                                                                        filetype))
                 for filename, data in files.items():
                     try:
-                        self.logger.debug2("Processing file {}".format(filename))
+                        logger.debug2("Processing file {}".format(filename))
                         overwrite_or_create_files(filename, data)
                     except Exception as e:
                         errors[filetype] += 1
-                        self.logger.error("Error processing {} file '{}': {}".format(filetype, filename, e))
+                        logger.error("Error processing {} file '{}': {}".format(filetype, filename, e))
                         continue
             elif filetype == 'extra':
                 for file_to_remove in files:
                     try:
-                        self.logger.debug2("Remove file: '{}'".format(file_to_remove))
+                        logger.debug2("Remove file: '{}'".format(file_to_remove))
                         file_path = common.ossec_path + file_to_remove
                         try:
                             os.remove(file_path)
                         except OSError as e:
                             if e.errno == errno.ENOENT and '/queue/agent-groups/' in file_path:
-                                self.logger.debug2("File {} doesn't exist.".format(file_to_remove))
+                                logger.debug2("File {} doesn't exist.".format(file_to_remove))
                                 continue
                             else:
                                 raise e
                     except Exception as e:
                         errors['extra'] += 1
-                        self.logger.debug2("Error removing file '{}': {}".format(file_to_remove, e))
+                        logger.debug2("Error removing file '{}': {}".format(file_to_remove, e))
                         continue
 
         directories_to_check = (os.path.dirname(f) for f, data in ko_files['extra'].items()
@@ -248,13 +355,13 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     shutil.rmtree(full_path)
             except Exception as e:
                 errors['extra'] += 1
-                self.logger.debug2("Error removing directory '{}': {}".format(directory, e))
+                logger.debug2("Error removing directory '{}': {}".format(directory, e))
                 continue
 
         if sum(errors.values()) > 0:
-            self.logger.error("Found errors: {} overwriting, {} creating and {} removing".format(errors['shared'],
-                                                                                                 errors['missing'],
-                                                                                                 errors['extra']))
+            logger.error("Found errors: {} overwriting, {} creating and {} removing".format(errors['shared'],
+                                                                                            errors['missing'],
+                                                                                            errors['extra']))
 
     def get_logger(self, logger_tag: str = ''):
         return self.logger


### PR DESCRIPTION
Hello team,

The current cluster available in p 3.9-new-framework` branch shows the following log when processing integrity files from the master node:
```
2019-02-07 16:59:56,242 INFO    : [Worker worker-1] [Main           ] Analyzing received files: Start.
2019-02-07 16:59:56,244 INFO    : [Worker worker-1] [Main           ] Analyzing received files: Missing: 1. Shared: 0. Extra: 0. ExtraValid: 0
2019-02-07 16:59:56,244 INFO    : [Worker worker-1] [Main           ] Worker does not meet integrity checks. Actions required.
2019-02-07 16:59:56,244 INFO    : [Worker worker-1] [Main           ] Updating files: Start.
2019-02-07 16:59:56,244 WARNING : [Cluster        ] [Main           ] Could not parse client.keys file: [Errno 2] No such file or directory: '/var/ossec/etc/client.keys'
2019-02-07 16:59:56,244 INFO    : [Worker worker-1] [Main           ] Updating files: End.
```

The `Main` tag is quite confusing about what files are being processed. This PR fixes that. The new log looks like this:
```
2019-02-08 09:50:57,604 INFO    : [Worker worker-1] [Integrity      ] Analyzing received files: Start.
2019-02-08 09:50:57,605 INFO    : [Worker worker-1] [Integrity      ] Analyzing received files: Missing: 0. Shared: 1. Extra: 0. ExtraValid: 0
2019-02-08 09:50:57,605 INFO    : [Worker worker-1] [Integrity      ] Worker does not meet integrity checks. Actions required.
2019-02-08 09:50:57,605 INFO    : [Worker worker-1] [Integrity      ] Updating files: Start.
2019-02-08 09:50:57,606 INFO    : [Worker worker-1] [Integrity      ] Removing files from 1 agents
2019-02-08 09:50:57,842 INFO    : [Worker worker-1] [Integrity      ] Agent files removed
2019-02-08 09:50:57,844 INFO    : [Worker worker-1] [Integrity      ] Updating files: End.
```

Also, I have added a new log line when the integrity is correct:
```
2019-02-08 11:45:54,351 INFO    : [Worker worker-1] [Integrity      ] The master has verified that the integrity is right.
```

Finally, this PR also fixes a typo in one of the parameters types. This didn't affect the code's behaviour but a warning was shown in Pycharm (https://github.com/wazuh/wazuh/commit/a50ee8c37c5007e581554f28911a08c398f6308c).

Best regards,
Marta