### PR TITLE
Fix bug when synchronizing merged files with ossecr owner

### DIFF
--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -350,6 +350,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                                                                       data['merge_name']):
                         try:
                             full_unmerged_name = common.ossec_path + file_path
+                            tmp_unmerged_path = full_unmerged_name + '.tmp'
                             if is_agent_info:
                                 agent_name_re = re.match(r'(^.+)-(.+)$', os.path.basename(file_path))
                                 agent_name = agent_name_re.group(1) if agent_name_re else os.path.basename(file_path)
@@ -383,13 +384,14 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                     logger.debug2("Receiving an old file ({})".format(file_path))
                                     return
 
-                            with open(full_unmerged_name, 'wb') as f:
+                            with open(tmp_unmerged_path, 'wb') as f:
                                 f.write(file_data)
 
                             mtime_epoch = timegm(mtime.timetuple())
-                            os.utime(full_unmerged_name, (mtime_epoch, mtime_epoch))  # (atime, mtime)
-                            os.chown(full_unmerged_name, common.ossec_uid, common.ossec_gid)
-                            os.chmod(full_unmerged_name, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
+                            os.utime(tmp_unmerged_path, (mtime_epoch, mtime_epoch))  # (atime, mtime)
+                            os.chown(tmp_unmerged_path, common.ossec_uid, common.ossec_gid)
+                            os.chmod(tmp_unmerged_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
+                            os.rename(tmp_unmerged_path, full_unmerged_name)
                         except Exception as e:
                             self.logger.debug2("Error updating agent group/status: {}".format(e))
                             if is_agent_info:

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -303,9 +303,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
 
                 for name, content, _ in cluster.unmerge_agent_info('agent-groups', zip_path, filename):
                     full_unmerged_name = common.ossec_path + name
-                    with open(full_unmerged_name, 'wb') as f:
+                    tmp_unmerged_path = full_unmerged_name + '.tmp'
+                    with open(tmp_unmerged_path, 'wb') as f:
                         f.write(content)
-                    os.chown(full_unmerged_name, common.ossec_uid, common.ossec_gid)
+                    os.chown(tmp_unmerged_path, common.ossec_uid, common.ossec_gid)
+                    os.rename(tmp_unmerged_path, full_unmerged_name)
             else:
                 if not os.path.exists(os.path.dirname(full_filename_path)):
                     utils.mkdir_with_mode(os.path.dirname(full_filename_path))


### PR DESCRIPTION
Hello team,

There is a bug when synchronizing merged files (such as `agent-info`). 
https://github.com/wazuh/wazuh/blob/85a52ab00a0a912dc5f0ec4625734aa4d9a91478/framework/wazuh/cluster/master.py#L391
A `chown` operation is performed, to make sure correct user and group are set to the file when it is updated. When an `agent-info` file having `ossecr` user (instead of `ossec`) is updated, the following error is show in the log:
```
[Errno 1] Operation not permitted
```
This PR is related to https://github.com/wazuh/wazuh/issues/2522

Best regards,
Marta