### PR TITLE
Remove agent files from /queue/db, /queue/diff and /var/db directories when removing agents in framework

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -19,7 +19,7 @@ from wazuh import common
 from glob import glob
 from datetime import date, datetime, timedelta
 from base64 import b64encode
-from shutil import copyfile, move
+from shutil import copyfile, move, rmtree
 from platform import platform
 from os import chown, chmod, path, makedirs, rename, urandom, listdir, stat, remove
 from time import time, sleep
@@ -489,11 +489,19 @@ class Agent:
             agent_files = [
                 '{0}/queue/agent-info/{1}-{2}'.format(common.ossec_path, self.name, self.ip),
                 '{0}/queue/rootcheck/({1}) {2}->rootcheck'.format(common.ossec_path, self.name, self.ip),
-                '{0}/queue/agent-groups/{1}'.format(common.ossec_path, self.id)
+                '{0}/queue/agent-groups/{1}'.format(common.ossec_path, self.id),
+                '{}/queue/db/{}.db'.format(common.ossec_path, self.id),
+                '{}/queue/db/{}.db-wal'.format(common.ossec_path, self.id),
+                '{}/queue/db/{}.db-shm'.format(common.ossec_path, self.id),
+                '{}/var/db/agents/{}-{}.db'.format(common.ossec_path, self.name, self.id),
+                '{}/queue/diff/{}'.format(common.ossec_path, self.name)
             ]
 
             for agent_file in filter(path.exists, agent_files):
-                remove(agent_file)
+                if path.isdir(agent_file):
+                    rmtree(agent_file)
+                else:
+                    remove(agent_file)
 
         else:
             # Create backup directory
@@ -517,7 +525,12 @@ class Agent:
             agent_files = [
                 ('{0}/queue/agent-info/{1}-{2}'.format(common.ossec_path, self.name, self.ip), '{0}/agent-info'.format(agent_backup_dir)),
                 ('{0}/queue/rootcheck/({1}) {2}->rootcheck'.format(common.ossec_path, self.name, self.ip), '{0}/rootcheck'.format(agent_backup_dir)),
-                ('{0}/queue/agent-groups/{1}'.format(common.ossec_path, self.id), '{0}/agent-group'.format(agent_backup_dir))
+                ('{0}/queue/agent-groups/{1}'.format(common.ossec_path, self.id), '{0}/agent-group'.format(agent_backup_dir)),
+                ('{}/queue/db/{}.db'.format(common.ossec_path, self.id), '{}/queue_db'.format(agent_backup_dir)),
+                ('{}/queue/db/{}.db-wal'.format(common.ossec_path, self.id), '{}/queue_db_wal'.format(agent_backup_dir)),
+                ('{}/queue/db/{}.db-shm'.format(common.ossec_path, self.id), '{}/queue_db_shm'.format(agent_backup_dir)),
+                ('{}/var/db/agents/{}-{}.db'.format(common.ossec_path, self.name, self.id), '{}/var_db'.format(agent_backup_dir)),
+                ('{}/queue/diff/{}'.format(common.ossec_path, self.name), '{}/diff'.format(agent_backup_dir))
             ]
 
             for agent_file, backup_file in agent_files:

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -212,7 +212,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 for agent_file in set(glob.iglob(filetype.format(common.ossec_path, *glob_args))) & \
                                   {filetype.format(common.ossec_path, *(a[arg] for arg in agent_args)) for a in
                                    agent_info}:
-                    os.remove(agent_file)
+                    logger.debug2("Removing {}".format(agent_file))
+                    if os.path.isdir(agent_file):
+                        shutil.rmtree(agent_file)
+                    else:
+                        os.remove(agent_file)
 
         if not agent_ids_list:
             return  # the function doesn't make sense if there is no agents to remove
@@ -222,17 +226,28 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         # the agents must be removed in groups of 997: 999 is the limit of SQL variables per query. Limit and offset are
         # always included in the SQL query, so that leaves 997 variables as limit.
         for agents_ids_sublist in itertools.zip_longest(*itertools.repeat(iter(agent_ids_list), 997), fillvalue='0'):
+            agents_ids_sublist = list(filter(lambda x: x != '0', agents_ids_sublist))
             # Get info from DB
             agent_info = Agent.get_agents_overview(q=",".join(["id={}".format(i) for i in agents_ids_sublist]),
                                                    select={'fields': ['ip', 'id', 'name']}, limit=None)['items']
+            logger.debug2("Removing files from agents {}".format(', '.join(agents_ids_sublist)))
 
             # Remove agent files that need agent name and ip
             agent_files = ['{}/queue/agent-info/{}-{}', '{}/queue/rootcheck/({}) {}->rootcheck']
             remove_agent_file_type(('*', '*'), ('name', 'ip'), agent_files)
 
+            # remove agent files that need agent name
+            agent_files = ['{}/queue/diff/{}']
+            remove_agent_file_type(('*',), ('name',), agent_files)
+
             # Remove agent files that only need agent id
-            agent_files = ['{}/queue/agent-groups/{}', '{}/queue/rids/{}']
+            agent_files = ['{}/queue/agent-groups/{}', '{}/queue/rids/{}', '{}/queue/db/{}.db', '{}/queue/db/{}.db-wal',
+                           '{}/queue/db/{}.db-shm']
             remove_agent_file_type(('*',), ('id',), agent_files)
+
+            # remove agent files that need agent name and id
+            agent_files = ['{}/var/db/agents/{}-{}.db']
+            remove_agent_file_type(('*', '*'), ('id', 'name'), agent_files)
 
             # remove agent from groups
             db_global = glob.glob(common.database_path_global)


### PR DESCRIPTION
Hello team,

The functions to remove agent files in both the cluster and the Agent module were missing some agent files that need to be removed:
* /queue/db/<agent_id>.db*
* /queue/diff/<agent_name>/*
* /var/db/agents/<agent_id>-<agent_name>.db

This PR is related to #2522.

Best regards,
Marta