### PR TITLE
Linux syscollector: retrieve MAC addresses from "/sys/class/net/<ifname>/address".

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -645,7 +645,7 @@ char * sys_deb_packages(int queue_fd, const char* LOCATION, int random_id){
                 if(object){
                     cJSON_Delete(object);
                 }
-                
+
                 object = cJSON_CreateObject();
                 package = cJSON_CreateObject();
                 cJSON_AddStringToObject(object, "type", "program");
@@ -1072,15 +1072,20 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
             if (fs_if_addr != NULL) {
                 char mac[MAC_LENGTH] = {'\0'};
 
-                if (fread(mac, 1, MAC_LENGTH - 1, fs_if_addr) == (MAC_LENGTH - 1)) {
+                if (fgets(mac, sizeof(mac), fs_if_addr)) {
+                    char * newline = strchr(mac, '\n');
+                    if (newline) {
+                        *newline = '\0';
+                    }
+
                     cJSON_AddStringToObject(interface, "MAC", mac);
                 } else {
-                    mterror(WM_SYS_LOGTAG, "Invalid MAC address length for interface \"%s\" at \"%s\".", ifaces_list[i], addr_path);
+                    mtdebug1(WM_SYS_LOGTAG, "Invalid MAC address length for interface \"%s\" at \"%s\": file is empty.", ifaces_list[i], addr_path);
                 }
 
                 fclose(fs_if_addr);
             } else {
-                mterror(WM_SYS_LOGTAG, "Unable to read MAC address for interface \"%s\" from \"%s\".", ifaces_list[i], addr_path);
+                mtwarn(WM_SYS_LOGTAG, "Unable to read MAC address for interface \"%s\" from \"%s\": %s (%d)", ifaces_list[i], addr_path, strerror(errno), errno);
             }
 
             if (ifa->ifa_addr) {

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -1059,8 +1059,28 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
             if (strcmp(ifaces_list[i], ifa->ifa_name)){
                 continue;
             }
+
             if (ifa->ifa_flags & IFF_LOOPBACK) {
                 continue;
+            }
+
+            /* Get MAC address */
+            char addr_path[PATH_LENGTH] = {'\0'};
+            snprintf(addr_path, PATH_LENGTH, "%s%s/address", WM_SYS_IFDATA_DIR, ifaces_list[i]);
+
+            FILE *fs_if_addr = fopen(addr_path, "r");
+            if (fs_if_addr != NULL) {
+                char MAC[MAC_LENGTH] = {'\0'};
+
+                if (fread(MAC, MAC_LENGTH - 1, 1, fs_if_addr) == (MAC_LENGTH - 1)) {
+                    cJSON_AddStringToObject(interface, "MAC", MAC);
+                } else {
+                    mterror(WM_SYS_LOGTAG, "Invalid MAC address length for interface \"%s\" at \"%s\".", ifaces_list[i], addr_path);
+                }
+
+                fclose(fs_if_addr);
+            } else {
+                mterror(WM_SYS_LOGTAG, "Unable to read MAC address for interface \"%s\" from \"%s\".", ifaces_list[i], addr_path);
             }
 
             if (ifa->ifa_addr) {
@@ -1172,13 +1192,8 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
                     }
 
                 } else if (family == AF_PACKET && ifa->ifa_data != NULL){
-
-                    /* Get MAC address and stats */
-                    char MAC[MAC_LENGTH];
+                    /* Get stats */
                     struct link_stats *stats = ifa->ifa_data;
-                    struct sockaddr_ll *addr = (struct sockaddr_ll*)ifa->ifa_addr;
-                    snprintf(MAC, MAC_LENGTH, "%02X:%02X:%02X:%02X:%02X:%02X", addr->sll_addr[0], addr->sll_addr[1], addr->sll_addr[2], addr->sll_addr[3], addr->sll_addr[4], addr->sll_addr[5]);
-                    cJSON_AddStringToObject(interface, "MAC", MAC);
                     cJSON_AddNumberToObject(interface, "tx_packets", stats->tx_packets);
                     cJSON_AddNumberToObject(interface, "rx_packets", stats->rx_packets);
                     cJSON_AddNumberToObject(interface, "tx_bytes", stats->tx_bytes);

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -1070,10 +1070,10 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
 
             FILE *fs_if_addr = fopen(addr_path, "r");
             if (fs_if_addr != NULL) {
-                char MAC[MAC_LENGTH] = {'\0'};
+                char mac[MAC_LENGTH] = {'\0'};
 
-                if (fread(MAC, MAC_LENGTH - 1, 1, fs_if_addr) == (MAC_LENGTH - 1)) {
-                    cJSON_AddStringToObject(interface, "MAC", MAC);
+                if (fread(mac, 1, MAC_LENGTH - 1, fs_if_addr) == (MAC_LENGTH - 1)) {
+                    cJSON_AddStringToObject(interface, "MAC", mac);
                 } else {
                     mterror(WM_SYS_LOGTAG, "Invalid MAC address length for interface \"%s\" at \"%s\".", ifaces_list[i], addr_path);
                 }


### PR DESCRIPTION
This PR fixes issue #2532 by reading the real MAC address for each interface using data at "/sys/class/net/<ifname>/address" instead of only getting it from interfaces with AF_PACKET sockets, avoiding problems with bonded interfaces sharing the same MAC address at software level.