### PR TITLE
ossec-logtest: allocate (and populate) group_node_to_delete member from Eventinfo structs.

### DIFF
--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -597,11 +597,14 @@ void OS_ReadMSG(char *ut_str)
                 else if (currently_rule->group_prev_matched) {
                     unsigned int i = 0;
 
+                    OSListNode *node;
+                    os_calloc(currently_rule->group_prev_matched_sz, sizeof(OSListNode *), lf->group_node_to_delete);
+
                     while (i < currently_rule->group_prev_matched_sz) {
-                        if (!OSList_AddData(
-                                    currently_rule->group_prev_matched[i],
-                                    lf)) {
+                        if (node = OSList_AddData(currently_rule->group_prev_matched[i], lf), !node) {
                             merror("Unable to add data to grp list.");
+                        } else {
+                            lf->group_node_to_delete[i] = node;
                         }
                         i++;
                     }


### PR DESCRIPTION
This PR aims to fix issue #2557 by allocating (and populating) `group_node_to_delete` member from Eventinfo structs, resulting in the following changes to the `ossec-logtest` codebase:

* Fixes a segmentation fault when group lists are being used, too many events have been created and the last events from the list need to be removed.
* Allows for a proper deallocation of event nodes from group lists when the previous conditions are met.