### PR TITLE
Add Python and PyPi dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If you want to contribute to our project please don't hesitate to send a pull re
 * Software developed by the cJSON project (Dave Gamble).
 * Node.js (Ryan Dahl).
 * NPM packages Body Parser, Express, HTTP-Auth and Moment.
+* CPython interpreter by Guido van Rossum and the Python Software Foundation (https://www.python.org).
+* PyPi packages: [azure-storage-blob](https://github.com/Azure/azure-storage-python), [boto3](https://github.com/boto/boto3), [cryptography](https://github.com/pyca/cryptography), [docker](https://github.com/docker/docker-py), [pytz](https://pythonhosted.org/pytz/), [requests](http://python-requests.org/) and [uvloop](http://github.com/MagicStack/uvloop).
 
 ## Credits and Thank you
 


### PR DESCRIPTION
Hi team,

in this PR I've added CPython and all the external dependencies of Python to the _Software and libraries used_ section in the README.md file.

Best regards,
Braulio.