### PR TITLE
Fix out-of-memory error in Remoted when upgrading an agent

### DIFF
--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     arg_parser.add_argument("-s", "--silent", action="store_true", help="Do not show output.")
     arg_parser.add_argument("-d", "--debug", action="store_true", help="Debug mode.")
     arg_parser.add_argument("-l", "--list_outdated", action="store_true", help="Generates a list with all outdated agents.")
-    arg_parser.add_argument("-c", "--chunk_size", type=int, help="Chunk size sending WPK file. [Default: {0}]".format(common.wpk_chunk_size))
+    arg_parser.add_argument("-c", "--chunk_size", type=int, help="Chunk size sending WPK file. Allowed values: [1 - 64000]. [Default: {0}]".format(common.wpk_chunk_size))
     arg_parser.add_argument("-t", "--timeout", type=int, help="Timeout until agent restart is unlocked.")
     arg_parser.add_argument("-f", "--file", type=str, help="Custom WPK filename.")
     arg_parser.add_argument("-x", "--execute", type=str, help="Executable filename in the WPK custom file. [Default: upgrade.sh]")

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -81,6 +81,9 @@ def main():
         if not pattern.match(args.version):
             raise WazuhException(1733, "Version received: {0}".format(args.version))
 
+    if args.chunk_size is not None and args.chunk_size < 1 or args.chunk_size > 64000:
+        raise WazuhException(1744, "Chunk defined: {0}".format(args.chunk_size))
+
     # Custom WPK file
     if args.file:
         upgrade_command_result = agent.upgrade_custom(file_path=args.file,

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -137,6 +137,7 @@ class WazuhException(Exception):
         1741: 'Could not remove multigroup',
         1742: 'Error running XML syntax validator',
         1743: 'Error running Wazuh syntax validator',
+        1744: 'Invalid chunk size',
 
         # CDB List: 1800 - 1899
         1800: 'Bad format in CDB list {path}',

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -120,6 +120,10 @@ void * req_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("OS_RecvSecureTCP(): Too big message size received from an internal component.");
+            free(buffer);
+            break;
         case -1:
             merror("OS_RecvSecureTCP(): %s", strerror(errno));
             free(buffer);


### PR DESCRIPTION
This error may occur if agent_upgrade delivers a large file chunk.

## Rationale

Remoted uses the shared network function `OS_RecvSecureTCP()` to get data from `agent_upgrade` or the API. The maximum buffer size is currently `65144` bytes (`OS_MAXSTR`). This function returns:
- `-1` in case of network error.
- `OS_SOCKTERR` (`-6`) if the message header has a size bigger than `OS_MAXSTR`.

Unfortunately, the Remoted missed the return status check for `OS_SOCKTERR`. That made Remoted try to allocate a "negative" number of bytes.

## Fix

1. Make Remoted check that the length of the data received is valid.
2. Make `agent_upgrade` validate the _chunk size_ parameter (`-c`): allow values in the range `[1..64000]`

@wazuh/framework Could you check the chunk size parameter in the API to behave like the point (2), please?