### PR TITLE
Add syscollector fields to the Elasticsearch template

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -661,11 +661,17 @@
                 }
               }
             },
+            "type": {
+              "type": "text"
+            },
             "netinfo": {
               "properties": {
                 "iface": {
                   "properties": {
                     "name": {
+                      "type": "text"
+                    },
+                    "mac": {
                       "type": "text"
                     },
                     "adapter": {
@@ -702,6 +708,14 @@
                       "doc_values": "true"
                     },
                     "rx_dropped": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "tx_packets": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "rx_packets": {
                       "type": "double",
                       "doc_values": "true"
                     },
@@ -750,7 +764,8 @@
             "os":{
               "properties": {
                 "hostname": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "architecture": {
                   "type": "text"
@@ -801,7 +816,8 @@
                   "doc_values": "true"
                 },
                 "remote_ip": {
-                  "type": "text"
+                  "type": "ip",
+                  "doc_values": "true"
                 },
                 "remote_port": {
                   "type": "double",
@@ -952,6 +968,9 @@
                   "type": "text"
                 },
                 "fgroup": {
+                  "type": "text"
+                },
+                "rgroup": {
                   "type": "text"
                 },
                 "priority": {

--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -746,6 +746,10 @@
                         "broadcast": {
                           "type": "keyword",
                           "doc_values": "true"
+                        },
+                        "metric": {
+                          "type": "long",
+                          "doc_values": "true"
                         }
                       }
                     },
@@ -768,6 +772,10 @@
                         },
                         "broadcast": {
                           "type": "keyword",
+                          "doc_values": "true"
+                        },
+                        "metric": {
+                          "type": "long",
                           "doc_values": "true"
                         }
                       }

--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -660,6 +660,353 @@
                   }
                 }
               }
+            },
+            "netinfo": {
+              "properties": {
+                "iface": {
+                  "properties": {
+                    "name": {
+                      "type": "text"
+                    },
+                    "adapter": {
+                      "type": "text"
+                    },
+                    "type": {
+                      "type": "text"
+                    },
+                    "state": {
+                      "type": "text"
+                    },
+                    "mtu": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "tx_bytes": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "rx_bytes": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "tx_errors": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "rx_errors": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "tx_dropped": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "rx_dropped": {
+                      "type": "double",
+                      "doc_values": "true"
+                    },
+                    "ipv4": {
+                      "properties": {
+                        "gateway": {
+                          "type": "text"
+                        },
+                        "dhcp": {
+                          "type": "text"
+                        },
+                        "address": {
+                          "type": "text"
+                        },
+                        "netmask": {
+                          "type": "text"
+                        },
+                        "broadcast": {
+                          "type": "text"
+                        }
+                      }
+                    },
+                    "ipv6": {
+                      "properties": {
+                        "gateway": {
+                          "type": "text"
+                        },
+                        "dhcp": {
+                          "type": "text"
+                        },
+                        "address": {
+                          "type": "text"
+                        },
+                        "netmask": {
+                          "type": "text"
+                        },
+                        "broadcast": {
+                          "type": "text"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "os":{
+              "properties": {
+                "hostname": {
+                  "type": "text"
+                },
+                "architecture": {
+                  "type": "text"
+                },
+                "name": {
+                  "type": "text"
+                },
+                "version": {
+                  "type": "text"
+                },
+                "codename": {
+                  "type": "text"
+                },
+                "major": {
+                  "type": "text"
+                },
+                "minor": {
+                  "type": "text"
+                },
+                "build": {
+                  "type": "text"
+                },
+                "platform": {
+                  "type": "text"
+                },
+                "sysname": {
+                  "type": "text"
+                },
+                "release": {
+                  "type": "text"
+                },
+                "release_version": {
+                  "type": "text"
+                }
+              }
+            },
+            "port": {
+              "properties": {
+                "protocol": {
+                  "type": "text"
+                },
+                "local_ip": {
+                  "type": "ip",
+                  "doc_values": "true"
+                },
+                "local_port": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "remote_ip": {
+                  "type": "text"
+                },
+                "remote_port": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "tx_queue": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "rx_queue": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "inode": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "state": {
+                  "type": "text"
+                },
+                "pid": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "process": {
+                  "type": "text"
+                }
+              }
+            },
+            "hardware": {
+              "properties": {
+                "serial": {
+                  "type": "text"
+                },
+                "cpu_name": {
+                  "type": "text"
+                },
+                "cpu_cores": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "cpu_mhz": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "ram_total": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "ram_free": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "ram_usage": {
+                  "type": "double",
+                  "doc_values": "true"
+                }
+              }
+            },
+            "program": {
+              "properties": {
+                "format": {
+                  "type": "text"
+                },
+                "name": {
+                  "type": "text"
+                },
+                "priority": {
+                  "type": "text"
+                },
+                "section": {
+                  "type": "text"
+                },
+                "size": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "vendor": {
+                  "type": "text"
+                },
+                "install_time": {
+                  "type": "date",
+                  "doc_values": "true"
+                },
+                "version": {
+                  "type": "text"
+                },
+                "architecture": {
+                  "type": "text"
+                },
+                "multiarch": {
+                  "type": "text"
+                },
+                "source": {
+                  "type": "text"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "location": {
+                  "type": "text"
+                }
+              }
+            },
+            "process": {
+              "properties": {
+                "pid": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "name": {
+                  "type": "text"
+                },
+                "state": {
+                  "type": "text"
+                },
+                "ppid": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "utime": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "stime": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "cmd": {
+                  "type": "text"
+                },
+                "args": {
+                  "type": "text"
+                },
+                "euser": {
+                  "type": "text"
+                },
+                "ruser": {
+                  "type": "text"
+                },
+                "suser": {
+                  "type": "text"
+                },
+                "egroup": {
+                  "type": "text"
+                },
+                "sgroup": {
+                  "type": "text"
+                },
+                "fgroup": {
+                  "type": "text"
+                },
+                "priority": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "nice": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "size": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "vm_size": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "resident": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "share": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "start_time": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "pgrp": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "session": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "nlwp": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "tgid": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "tty": {
+                  "type": "double",
+                  "doc_values": "true"
+                },
+                "processor": {
+                  "type": "double",
+                  "doc_values": "true"
+                }
+              }
             }
           }
         },

--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -662,26 +662,32 @@
               }
             },
             "type": {
-              "type": "text"
+              "type": "keyword",
+              "doc_values": "true"
             },
             "netinfo": {
               "properties": {
                 "iface": {
                   "properties": {
                     "name": {
-                      "type": "text"
+                      "type": "keyword",
+                      "doc_values": "true"
                     },
                     "mac": {
-                      "type": "text"
+                      "type": "keyword",
+                      "doc_values": "true"
                     },
                     "adapter": {
-                      "type": "text"
+                      "type": "keyword",
+                      "doc_values": "true"
                     },
                     "type": {
-                      "type": "text"
+                      "type": "keyword",
+                      "doc_values": "true"
                     },
                     "state": {
-                      "type": "text"
+                      "type": "keyword",
+                      "doc_values": "true"
                     },
                     "mtu": {
                       "type": "double",
@@ -722,38 +728,47 @@
                     "ipv4": {
                       "properties": {
                         "gateway": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         },
                         "dhcp": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         },
                         "address": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         },
                         "netmask": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         },
                         "broadcast": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         }
                       }
                     },
                     "ipv6": {
                       "properties": {
                         "gateway": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         },
                         "dhcp": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         },
                         "address": {
-                          "type": "text"
+                          "type": "keyword"
                         },
                         "netmask": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         },
                         "broadcast": {
-                          "type": "text"
+                          "type": "keyword",
+                          "doc_values": "true"
                         }
                       }
                     }
@@ -768,44 +783,56 @@
                   "doc_values": "true"
                 },
                 "architecture": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "name": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "version": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "codename": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "major": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "minor": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "build": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "platform": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "sysname": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "release": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "release_version": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 }
               }
             },
             "port": {
               "properties": {
                 "protocol": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "local_ip": {
                   "type": "ip",
@@ -836,24 +863,28 @@
                   "doc_values": "true"
                 },
                 "state": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "pid": {
                   "type": "double",
                   "doc_values": "true"
                 },
                 "process": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 }
               }
             },
             "hardware": {
               "properties": {
                 "serial": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "cpu_name": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "cpu_cores": {
                   "type": "double",
@@ -880,45 +911,56 @@
             "program": {
               "properties": {
                 "format": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "name": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "priority": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "section": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "size": {
                   "type": "double",
                   "doc_values": "true"
                 },
                 "vendor": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "install_time": {
                   "type": "date",
                   "doc_values": "true"
                 },
                 "version": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "architecture": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "multiarch": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "source": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "description": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "location": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 }
               }
             },
@@ -929,10 +971,12 @@
                   "doc_values": "true"
                 },
                 "name": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "state": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "ppid": {
                   "type": "double",
@@ -947,31 +991,40 @@
                   "doc_values": "true"
                 },
                 "cmd": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "args": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "euser": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "ruser": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "suser": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "egroup": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "sgroup": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "fgroup": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "rgroup": {
-                  "type": "text"
+                  "type": "keyword",
+                  "doc_values": "true"
                 },
                 "priority": {
                   "type": "double",

--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -764,7 +764,8 @@
                           "doc_values": "true"
                         },
                         "address": {
-                          "type": "keyword"
+                          "type": "keyword",
+                          "doc_values": "true"
                         },
                         "netmask": {
                           "type": "keyword",
@@ -903,11 +904,11 @@
                   "doc_values": "true"
                 },
                 "ram_total": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "ram_free": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "ram_usage": {
@@ -943,7 +944,7 @@
                   "doc_values": "true"
                 },
                 "install_time": {
-                  "type": "date",
+                  "type": "keyword",
                   "doc_values": "true"
                 },
                 "version": {

--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -690,39 +690,39 @@
                       "doc_values": "true"
                     },
                     "mtu": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "tx_bytes": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "rx_bytes": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "tx_errors": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "rx_errors": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "tx_dropped": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "rx_dropped": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "tx_packets": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "rx_packets": {
-                      "type": "double",
+                      "type": "long",
                       "doc_values": "true"
                     },
                     "ipv4": {
@@ -839,7 +839,7 @@
                   "doc_values": "true"
                 },
                 "local_port": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "remote_ip": {
@@ -847,19 +847,19 @@
                   "doc_values": "true"
                 },
                 "remote_port": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "tx_queue": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "rx_queue": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "inode": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "state": {
@@ -867,7 +867,7 @@
                   "doc_values": "true"
                 },
                 "pid": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "process": {
@@ -887,7 +887,7 @@
                   "doc_values": "true"
                 },
                 "cpu_cores": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "cpu_mhz": {
@@ -903,7 +903,7 @@
                   "doc_values": "true"
                 },
                 "ram_usage": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 }
               }
@@ -927,7 +927,7 @@
                   "doc_values": "true"
                 },
                 "size": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "vendor": {
@@ -967,7 +967,7 @@
             "process": {
               "properties": {
                 "pid": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "name": {
@@ -979,15 +979,15 @@
                   "doc_values": "true"
                 },
                 "ppid": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "utime": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "stime": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "cmd": {
@@ -1027,55 +1027,55 @@
                   "doc_values": "true"
                 },
                 "priority": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "nice": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "size": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "vm_size": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "resident": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "share": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "start_time": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "pgrp": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "session": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "nlwp": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "tgid": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "tty": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "processor": {
-                  "type": "double",
+                  "type": "long",
                   "doc_values": "true"
                 }
               }

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -966,7 +966,7 @@ int decode_hardware( Eventinfo *lf, cJSON * logJSON,int *socket) {
         if (ram_total) {
             char total[OS_SIZE_512];
             snprintf(total, OS_SIZE_512 - 1, "%f", ram_total->valuedouble);
-            fillData(lf,"harware.ram_total",total);
+            fillData(lf,"hardware.ram_total",total);
             wm_strcat(&msg, total, '|');
         } else {
             wm_strcat(&msg, "NULL", '|');


### PR DESCRIPTION
This PR solves the issue: #2554 

As the syscollector information can be used now in the alerts to give more information, the fields of Syscollector scan has been add to the elastic template in order to use them as a filter, as a script argument,...
The list of fields is available in the index pattern:

![image](https://user-images.githubusercontent.com/9034923/52779872-521eb200-3049-11e9-8ecc-eb8203451404.png)

![image](https://user-images.githubusercontent.com/9034923/52779896-5fd43780-3049-11e9-8b0d-222a1456ec02.png)

![image](https://user-images.githubusercontent.com/9034923/52779921-6b276300-3049-11e9-92b4-3f00cba5d9a8.png)

![image](https://user-images.githubusercontent.com/9034923/52779970-8a25f500-3049-11e9-8043-24e8c6bb12ce.png)

![image](https://user-images.githubusercontent.com/9034923/52780005-9ca02e80-3049-11e9-9271-3ffb34c5bc5c.png)

![image](https://user-images.githubusercontent.com/9034923/52780072-bb062a00-3049-11e9-9743-c68c284ed583.png)
