### PR TITLE
Improve API errors when the cluster is not enabled

### DIFF
--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -56,7 +56,10 @@ class DistributedAPI:
                 self.input_json['arguments']['wait_for_complete'] = False
 
             # if it is a cluster API request and the cluster is not enabled, raise an exception
-            if is_cluster_disabled and 'cluster' in self.input_json['function']:
+            if is_cluster_disabled and 'cluster' in self.input_json['function'] and \
+                    self.input_json['function'] != '/cluster/status' and \
+                    self.input_json['function'] != '/cluster/config' and \
+                    self.input_json['function'] != '/cluster/node':
                 raise exception.WazuhException(3013)
 
             # First case: execute the request local.

--- a/framework/wazuh/cluster/local_client.py
+++ b/framework/wazuh/cluster/local_client.py
@@ -86,6 +86,8 @@ class LocalClient(client.AbstractClientManager):
                                                                                          fernet_key='', manager=self,
                                                                                          cluster_items=self.cluster_items),
                                              path='{}/queue/cluster/c-internal.sock'.format(common.ossec_path))
+        except ConnectionRefusedError:
+            raise exception.WazuhException(3012)
         except Exception as e:
             raise exception.WazuhException(3009, str(e))
 

--- a/framework/wazuh/cluster/local_server.py
+++ b/framework/wazuh/cluster/local_server.py
@@ -141,6 +141,8 @@ class LocalServerHandlerWorker(LocalServerHandler):
         if command == b'dapi':
             api_call_name = json.loads(data.decode())['function']
             if api_call_name not in {'/cluster/nodes', '/cluster/nodes/:node_name', '/cluster/healthcheck'}:
+                if self.server.node.client is None:
+                    return b'err', b'Worker is not connected to the master node'
                 asyncio.create_task(self.server.node.client.send_request(b'dapi', self.name.encode() + b' ' + data))
                 return b'ok', b'Added request to API requests queue'
             else:


### PR DESCRIPTION
Hello team,

As explained in https://github.com/wazuh/wazuh-api/issues/190, when a cluster API call was requested and the cluster wasn't running, an unhandled exception was returned. This PR improves the returned error:
```javascript
# curl -u foo:bar "localhost:55000/cluster/worker-1/logs?pretty"
{
   "error": 3013,
   "message": "Cluster is disabled"
}
```

Best regards,
Marta