### PR TITLE
Avoid errors when executing make clean if Python is not compiled

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1586,7 +1586,7 @@ endif
 
 clean-wpython:
 ifneq ($(wildcard external/cpython/*),)
-	cd ${EXTERNAL_CPYTHON} && make clean && make distclean
+	- cd ${EXTERNAL_CPYTHON} && make clean && make distclean
 endif
 
 clean-deps:


### PR DESCRIPTION
Hi team,

this PR fix an error when executing `make clean` if Python is not compiled yet. 

Regards,
Braulio.