### PR TITLE
Fix merge cluster results

### DIFF
--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -236,11 +236,15 @@ class DistributedAPI:
             del self.input_json['arguments']['node_id']
             return {node_id: []}
 
-        else:  # agents, syscheck, rootcheck and syscollector
-            # API calls that affect all agents. For example, PUT/agents/restart, DELETE/rootcheck, etc...
-            agents = agent.Agent.get_agents_overview(select=select_node, limit=None,
-                                                     sort={'fields': ['node_name'], 'order': 'desc'})['items']
-            node_name = {k: [] for k, _ in itertools.groupby(agents, key=operator.itemgetter('node_name'))}
+        else:
+            if 'cluster' in self.input_json['function']:
+                node_name = {'fw_all_nodes': []}
+            else:
+                # agents, syscheck, rootcheck and syscollector
+                # API calls that affect all agents. For example, PUT/agents/restart, DELETE/rootcheck, etc...
+                agents = agent.Agent.get_agents_overview(select=select_node, limit=None,
+                                                        sort={'fields': ['node_name'], 'order': 'desc'})['items']
+                node_name = {k: [] for k, _ in itertools.groupby(agents, key=operator.itemgetter('node_name'))}
             return node_name
 
     def merge_results(self, responses, final_json):
@@ -258,7 +262,8 @@ class DistributedAPI:
         :return: single JSON with the final result
         """
         priorities = {
-            ("Some agents were not restarted", "All selected agents were restarted")
+            ("Some agents were not restarted", "All selected agents were restarted"),
+            ("KO", "OK")
         }
 
         for local_json in responses:

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -243,7 +243,7 @@ class DistributedAPI:
                 # agents, syscheck, rootcheck and syscollector
                 # API calls that affect all agents. For example, PUT/agents/restart, DELETE/rootcheck, etc...
                 agents = agent.Agent.get_agents_overview(select=select_node, limit=None,
-                                                        sort={'fields': ['node_name'], 'order': 'desc'})['items']
+                                                         sort={'fields': ['node_name'], 'order': 'desc'})['items']
                 node_name = {k: [] for k, _ in itertools.groupby(agents, key=operator.itemgetter('node_name'))}
             return node_name
 

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -238,7 +238,7 @@ class DistributedAPI:
 
         else:
             if 'cluster' in self.input_json['function']:
-                node_name = {'fw_all_nodes': []}
+                node_name = {'fw_all_nodes': [], self.node_info['node']: []}
             else:
                 # agents, syscheck, rootcheck and syscollector
                 # API calls that affect all agents. For example, PUT/agents/restart, DELETE/rootcheck, etc...

--- a/framework/wazuh/cluster/local_server.py
+++ b/framework/wazuh/cluster/local_server.py
@@ -101,7 +101,11 @@ class LocalServerHandlerMaster(LocalServerHandler):
         elif command == b'dapi_forward':
             node_name, request = data.split(b' ', 1)
             node_name = node_name.decode()
-            if node_name in self.server.node.clients:
+            if node_name == 'fw_all_nodes':
+                for node_name, node in self.server.node.clients.items():
+                    asyncio.create_task(node.send_request(b'dapi', self.name.encode() + b' ' + request))
+                return b'ok', b'Request forwarded to all worker nodes'
+            elif node_name in self.server.node.clients:
                 asyncio.create_task(
                     self.server.node.clients[node_name].send_request(b'dapi', self.name.encode() + b' ' + request))
                 return b'ok', b'Request forwarded to worker node'


### PR DESCRIPTION
Hi team,

This PR closes #2601. Errors which happens when we make a distributed request in API were fixed.

Call with `ossec.conf` corrupted in worker:

```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/configuration/validation?pretty"
{
   "error": 0,
   "data": {
      "status": "KO",
      "details": [
         "(1235): Invalid value for element 'alerts_log': yyes.",
         "(1202): Configuration error at '/var/ossec/etc/ossec.conf'.",
         "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
      ]
   }
}
```
Call with `ossec.conf` OK in all nodes:
```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/configuration/validation?pretty"
{
   "error": 0,
   "data": {
      "status": "OK"
   }
}
```

Call for restarting all cluster nodes restarts all nodes:
```curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/cluster/restart?pretty"
{
   "error": 0,
   "data": "Restarting manager"
}
-----------------------------------------
master -> restarted
worker -> restarted
```


Best regards,

Demetrio.