### PR TITLE
Fix dropping events because of aws.requestParameters.disabledApiTermination field

### DIFF
--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -804,6 +804,17 @@ class AWSCloudTrailBucket(AWSLogsBucket):
             if field_to_cast in event['aws'] and not isinstance(event['aws'][field_to_cast], dict):
                 event['aws'][field_to_cast] = {'string': str(event['aws'][field_to_cast])}
 
+        if 'requestParameters' in event['aws']:
+            request_parameters = event['aws']['requestParameters']
+            if 'disableApiTermination' in request_parameters:
+                disable_api_termination = request_parameters['disableApiTermination']
+                if isinstance(disable_api_termination, bool):
+                    request_parameters['disableApiTermination'] = {'value': disable_api_termination}
+                elif isinstance(disable_api_termination, dict):
+                    pass
+                else:
+                    print("WARNING: Could not reformat event {0}".format(event))
+
         return event
 
 
@@ -1064,17 +1075,6 @@ class AWSConfigBucket(AWSLogsBucket):
                 if isinstance(iam_profile, unicode):
                     configuration['iamInstanceProfile'] = {'name': iam_profile}
                 elif isinstance(iam_profile, dict):
-                    pass
-                else:
-                    print("WARNING: Could not reformat event {0}".format(event))
-
-        if 'requestParameters' in event['aws']:
-            request_parameters = event['aws']['requestParameters']
-            if 'disableApiTermination' in request_parameters:
-                disable_api_termination = request_parameters['disableApiTermination']
-                if isinstance(request_parameters['disableApiTermination'], bool):
-                    request_parameters['disableApiTermination'] = {'value': disable_api_termination}
-                elif isinstance(disable_api_termination, dict):
                     pass
                 else:
                     print("WARNING: Could not reformat event {0}".format(event))

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -1068,6 +1068,17 @@ class AWSConfigBucket(AWSLogsBucket):
                 else:
                     print("WARNING: Could not reformat event {0}".format(event))
 
+        if 'requestParameters' in event['aws']:
+            request_parameters = event['aws']['requestParameters']
+            if 'disableApiTermination' in request_parameters:
+                disable_api_termination = request_parameters['disableApiTermination']
+                if isinstance(request_parameters['disableApiTermination'], bool):
+                    request_parameters['disableApiTermination'] = {'value': disable_api_termination}
+                elif isinstance(disable_api_termination, dict):
+                    pass
+                else:
+                    print("WARNING: Could not reformat event {0}".format(event))
+
         return event
 
 


### PR DESCRIPTION
This PR fixes #2606 

Now events are shown properly in the Wazuh App:

![imagen](https://user-images.githubusercontent.com/17462947/52866004-11ed2b80-313e-11e9-92ba-45addfaadfa3.png)

And no errors are shown in logstash logs:
```
...
2019-02-15T15:00:18,269][WARN ][logstash.outputs.elasticsearch] Detected a 6.x and above cluster: the `type` event field won't be used to determine the document _type {:es_version=>6}
[2019-02-15T15:00:18,270][INFO ][logstash.outputs.elasticsearch] New Elasticsearch output {:class=>"LogStash::Outputs::ElasticSearch", :hosts=>["http://elasticsearch:9200"]}
[2019-02-15T15:00:18,307][INFO ][logstash.pipeline        ] Pipeline started successfully {:pipeline_id=>".monitoring-logstash", :thread=>"#<Thread:0x6e209d93 sleep>"}
[2019-02-15T15:00:18,310][INFO ][logstash.agent           ] Pipelines running {:count=>2, :running_pipelines=>[:main, :".monitoring-logstash"], :non_running_pipelines=>[]}
[2019-02-15T15:00:18,459][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
```