### PR TITLE
ossec-dbd: fix invalid strdup() in os_LoadString() + fix invalid memory access in osdb_escapestr().

### DIFF
--- a/src/os_dbd/db_op.c
+++ b/src/os_dbd/db_op.c
@@ -75,7 +75,7 @@ static DBConfig *db_config_pt = NULL;
  */
 void osdb_escapestr(char *str)
 {
-    if (!str) {
+    if (!str || !*str) {
         return;
     }
 

--- a/src/shared/mem_op.c
+++ b/src/shared/mem_op.c
@@ -91,12 +91,20 @@ void os_FreeArray(char *ch1, char **ch2)
 char *os_LoadString(char *at, const char *str)
 {
     if (at == NULL) {
+        if (!str || !*str) {
+            return (NULL);
+        }
+
         at = strdup(str);
         if (!at) {
             merror(MEM_ERROR, errno, strerror(errno));
         }
         return (at);
     } else { /* at is not null. Need to reallocate its memory and copy str to it */
+        if (!str || !*str) {
+            return (at);
+        }
+
         char *newat;
         size_t strsize = strlen(str);
         size_t finalsize = strsize + strlen(at) + 1;


### PR DESCRIPTION
This PR fixes #2098 by introducing the following changes:

* Added checks in `os_LoadString()` to verify if the data to duplicate/concatenate is actually valid.
* Expanded the check in `osdb_escapestr()` to verify not only if the pointer address is valid, but also if its dereference points to a non-null character.