### PR TITLE
Prevent Analysisd from crashing when receiving an invalid Syscollector event

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -52,6 +52,7 @@ void SyscollectorInit(){
 int DecodeSyscollector(Eventinfo *lf,int *socket)
 {
     cJSON *logJSON;
+    cJSON *json_type;
     char *msg_type = NULL;
 
     lf->decoder_info = sysc_decoder;
@@ -81,8 +82,8 @@ int DecodeSyscollector(Eventinfo *lf,int *socket)
     }
 
     // Detect message type
-    msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
-    if (!msg_type) {
+    json_type = cJSON_GetObjectItem(logJSON, "type");
+    if (!(json_type && (msg_type = json_type->valuestring))) {
         mdebug1("Invalid message. Type not found.");
         cJSON_Delete (logJSON);
         return (0);


### PR DESCRIPTION
This line at the Syscollector decoder:
```c
msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
```

It assumes that the input JSON event from Syscollector contents an item with name `type`, and checks that its string is valid.

So, an input JSON event like this:
```json
{ "This" : "is not a Syscollector event." } 
```

It would make Analysisd crash.

Despite there is no known way for an agent to send a corrupt JSON event for Syscollector, the decoder should be protected against corrupt messages.