### PR TITLE
Fix memory leaks in the control module

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -135,16 +135,15 @@ void run_notify()
     int sock;
     char label_ip[50];
     int i;
-    int ip_length = 16;
     os_calloc(16,sizeof(char),agent_ip);
 
     for (i = SOCK_ATTEMPTS; i > 0; --i) {
         if (sock = control_check_connection(), sock >= 0) {
-            if (OS_SendUnix(sock, agent_ip, ip_length) < 0) {
+            if (OS_SendUnix(sock, agent_ip, IPSIZE) < 0) {
                 merror("Error sending msg to control socket (%d) %s", errno, strerror(errno));
             }
             else{
-                if(OS_RecvUnix(sock, ip_length - 1, agent_ip) == 0){
+                if(OS_RecvUnix(sock, IPSIZE - 1, agent_ip) == 0){
                     merror("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
                 }
                 else{

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -73,9 +73,6 @@ void run_notify()
     char *shared_files;
     os_md5 md5sum;
     time_t curr_time;
-    int sock;
-    char label_ip[50];
-    int i;
 
     keep_alive_random[0] = '\0';
     curr_time = time(0);
@@ -135,6 +132,9 @@ void run_notify()
 
 #ifdef __linux__
     char *agent_ip;
+    int sock;
+    char label_ip[50];
+    int i;
     int ip_length = 16;
     os_calloc(16,sizeof(char),agent_ip);
 

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -135,15 +135,16 @@ void run_notify()
 
 #ifdef __linux__
     char *agent_ip;
+    int ip_length = 16;
     os_calloc(16,sizeof(char),agent_ip);
 
     for (i = SOCK_ATTEMPTS; i > 0; --i) {
         if (sock = control_check_connection(), sock >= 0) {
-            if (OS_SendUnix(sock, agent_ip, 16) < 0) {
+            if (OS_SendUnix(sock, agent_ip, ip_length) < 0) {
                 merror("Error sending msg to control socket (%d) %s", errno, strerror(errno));
             }
             else{
-                if(OS_RecvUnix(sock, 16, agent_ip) == 0){
+                if(OS_RecvUnix(sock, ip_length - 1, agent_ip) == 0){
                     merror("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
                 }
                 else{

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -67,9 +67,11 @@ char* getPrimaryIP(){
             if (gateway) {
                 cJSON * metric = cJSON_GetObjectItem(ipv4, "metric");
                 if (metric && metric->valueint < min_metric) {
-
                     cJSON *addresses = cJSON_GetObjectItem(ipv4, "address");
                     cJSON *address = cJSON_GetArrayItem(addresses,0);
+                    if(agent_ip){
+                        free(agent_ip);
+                    }
                     os_strdup(address->valuestring, agent_ip);
                     min_metric = metric->valueint;
 
@@ -122,6 +124,7 @@ cJSON *wm_control_dump(void) {
 void *send_ip(){
     int sock;
     int peer;
+    int ip_length = 16;
     char *buffer = NULL;
     char *response = NULL;
     ssize_t length;
@@ -158,8 +161,8 @@ void *send_ip(){
             continue;
         }
 
-        os_calloc(OS_MAXSTR, sizeof(char), buffer);
-        switch (length = OS_RecvUnix(peer, OS_MAXSTR, buffer), length) {
+        os_calloc(ip_length, sizeof(char), buffer);
+        switch (length = OS_RecvUnix(peer, ip_length - 1, buffer), length) {
         case -1:
             mterror(WM_CONTROL_LOGTAG, "At send_ip(): OS_RecvUnix(): %s", strerror(errno));
             break;

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -69,7 +69,7 @@ char* getPrimaryIP(){
                 if (metric && metric->valueint < min_metric) {
                     cJSON *addresses = cJSON_GetObjectItem(ipv4, "address");
                     cJSON *address = cJSON_GetArrayItem(addresses,0);
-                    if(agent_ip){
+                    if(strcmp(agent_ip,"")){
                         free(agent_ip);
                     }
                     os_strdup(address->valuestring, agent_ip);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -123,7 +123,6 @@ cJSON *wm_control_dump(void) {
 void *send_ip(){
     int sock;
     int peer;
-    int ip_length = 16;
     char *buffer = NULL;
     char *response = NULL;
     ssize_t length;
@@ -160,8 +159,8 @@ void *send_ip(){
             continue;
         }
 
-        os_calloc(ip_length, sizeof(char), buffer);
-        switch (length = OS_RecvUnix(peer, ip_length - 1, buffer), length) {
+        os_calloc(IPSIZE, sizeof(char), buffer);
+        switch (length = OS_RecvUnix(peer, IPSIZE - 1, buffer), length) {
         case -1:
             mterror(WM_CONTROL_LOGTAG, "At send_ip(): OS_RecvUnix(): %s", strerror(errno));
             break;

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -31,7 +31,7 @@ const wm_context WM_CONTROL_CONTEXT = {
 
 char* getPrimaryIP(){
      /* Get Primary IP */
-    char * agent_ip = "";
+    char * agent_ip = NULL;
     char **ifaces_list;
     struct ifaddrs *ifaddr, *ifa;
     int size;
@@ -55,7 +55,7 @@ char* getPrimaryIP(){
             free(ifaces_list);
             return agent_ip;
         }
-    }    
+    }
 
     for (i=0; i<size; i++) {
         cJSON *object = cJSON_CreateObject();
@@ -69,12 +69,11 @@ char* getPrimaryIP(){
                 if (metric && metric->valueint < min_metric) {
                     cJSON *addresses = cJSON_GetObjectItem(ipv4, "address");
                     cJSON *address = cJSON_GetArrayItem(addresses,0);
-                    if(strcmp(agent_ip,"")){
+                    if(agent_ip != NULL){
                         free(agent_ip);
                     }
                     os_strdup(address->valuestring, agent_ip);
                     min_metric = metric->valueint;
-
                 }
             }
         }
@@ -178,7 +177,8 @@ void *send_ip(){
             break;
 
         default:
-            OS_SendUnix(peer, getPrimaryIP(), 0);
+            response = getPrimaryIP();
+            OS_SendUnix(peer, response, 0);
             free(response);
             close(peer);
         }


### PR DESCRIPTION
Valgrind detects a memory leak in the module agent:

![image](https://user-images.githubusercontent.com/9034923/52941578-74763f80-3369-11e9-9001-e53686719a1f.png)

The function `send_ip()` had a leak because after the `sendUnix()` call, the IP still was in memory.

Also it detects an invalid write

```
==19351== Thread 5:
==19351== Invalid write of size 1
==19351==    at 0x413D29: OS_RecvUnix (os_net.c:454)
==19351==    by 0x42B131: send_ip (wm_control.c:162)
==19351==    by 0x42ADF8: wm_control_main (wm_control.c:97)
==19351==    by 0x59D0DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==19351==    by 0x5CE2EAC: clone (in /usr/lib64/libc-2.17.so)
==19351==  Address 0x6258b10 is 0 bytes after a block of size 65,536 alloc'd
==19351==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==19351==    by 0x42B0D7: send_ip (wm_control.c:161)
==19351==    by 0x42ADF8: wm_control_main (wm_control.c:97)
==19351==    by 0x59D0DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==19351==    by 0x5CE2EAC: clone (in /usr/lib64/libc-2.17.so)
==19351== 
```

The issue was that OS_RecvUnix was called with `IPSIZE` instead of `IPSIZE - 1` to write in the last position the `\0`

This PR also fix two memory leaks in the new module:
 - Free the agent IP when an interface with less metric is found.
 - Free the agent IP when it is sent to the agentd module.

And reallocate variables that are only used in linux to avoid warnings about unused variables.