### PR TITLE
Fix bug when running distributed requests to all nodes from a worker

### DIFF
--- a/framework/wazuh/cluster/common.py
+++ b/framework/wazuh/cluster/common.py
@@ -562,8 +562,7 @@ class WazuhCommon:
         return b'ok', b'File correctly received'
 
     def get_node(self):
-        return {'type': self.get_manager().configuration['node_type'], 'cluster': self.get_manager().configuration['name'],
-                'node': self.get_manager().configuration['node_name']}
+        return self.get_manager().get_node()
 
 
 def asyncio_exception_handler(loop, context: Dict):

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -150,7 +150,7 @@ class DistributedAPI:
         # a temporary file in /var/ossec/tmp which needs to be sent to the master before forwarding the request
         res = await self.node.send_file(os.path.join(common.ossec_path, self.input_json['arguments']['tmp_file']), node_name)
         os.remove(os.path.join(common.ossec_path, self.input_json['arguments']['tmp_file']))
-        if res.startswith('Error'):
+        if res.startswith(b'Error'):
             return self.print_json(data=res.decode(), error=1000)
 
     async def execute_remote_request(self) -> str:

--- a/framework/wazuh/cluster/local_client.py
+++ b/framework/wazuh/cluster/local_client.py
@@ -122,4 +122,5 @@ async def execute(command: bytes, data: bytes, wait_for_complete: bool) -> str:
 async def send_file(path: str, node_name: str = None) -> str:
     lc = LocalClient(b'send_file', "{} {}".format(path, node_name).encode(), False)
     await lc.start()
-    return await lc.send_api_request()
+    return (await lc.send_api_request()).encode()
+

--- a/framework/wazuh/cluster/local_server.py
+++ b/framework/wazuh/cluster/local_server.py
@@ -44,6 +44,9 @@ class LocalServerHandler(server.AbstractServerHandler):
     def get_config(self) -> Tuple[bytes, bytes]:
         return b'ok', json.dumps(self.server.configuration).encode()
 
+    def get_node(self):
+        return self.server.node.get_node()
+
     def get_nodes(self, filter_nodes) -> Tuple[bytes, bytes]:
         raise NotImplementedError
 

--- a/framework/wazuh/cluster/local_server.py
+++ b/framework/wazuh/cluster/local_server.py
@@ -146,7 +146,7 @@ class LocalServerHandlerWorker(LocalServerHandler):
             api_call_name = json.loads(data.decode())['function']
             if api_call_name not in {'/cluster/nodes', '/cluster/nodes/:node_name', '/cluster/healthcheck'}:
                 if self.server.node.client is None:
-                    return b'err', b'Worker is not connected to the master node'
+                    raise WazuhException(3023)
                 asyncio.create_task(self.server.node.client.send_request(b'dapi', self.name.encode() + b' ' + data))
                 return b'ok', b'Added request to API requests queue'
             else:
@@ -162,7 +162,7 @@ class LocalServerHandlerWorker(LocalServerHandler):
 
     def send_request_to_master(self, command: bytes, arguments: bytes):
         if self.server.node.client is None:
-            return b'err', b'Worker is not connected to the master node'
+            raise WazuhException(3023)
         else:
             request = asyncio.create_task(self.server.node.client.send_request(command, arguments))
             request.add_done_callback(functools.partial(self.get_api_response, command))
@@ -180,7 +180,7 @@ class LocalServerHandlerWorker(LocalServerHandler):
 
     def send_file_request(self, path, node_name):
         if self.server.node.client is None:
-            raise WazuhException(3022)
+            raise WazuhException(3023)
         else:
             req = asyncio.create_task(self.server.node.client.send_file(path))
             req.add_done_callback(self.get_send_file_response)

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -540,3 +540,7 @@ class Master(server.AbstractServer):
                     datetime.fromtimestamp(workers_info[node_name]['status']['last_keep_alive']))
 
         return {"n_connected_nodes": n_connected_nodes, "nodes": workers_info}
+
+    def get_node(self) -> Dict:
+        return {'type': self.configuration['node_type'], 'cluster': self.configuration['name'],
+                'node': self.configuration['node_name']}

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -405,3 +405,7 @@ class Worker(client.AbstractClientManager):
     def add_tasks(self):
         return super().add_tasks() + [(self.client.sync_integrity, tuple()), (self.client.sync_agent_info, tuple()),
                                       (self.dapi.run, tuple())]
+
+    def get_node(self) -> Dict:
+        return {'type': self.configuration['node_type'], 'cluster': self.configuration['name'],
+                'node': self.configuration['node_name']}

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -181,7 +181,8 @@ class WazuhException(Exception):
         3019: 'Wazuh is running in cluster mode: {EXECUTABLE_NAME} is not available in worker nodes. Please, try again in the master node: {MASTER_IP}',
         3020: 'Timeout sending request',
         3021: 'Timeout executing API request',
-        3022: 'Unknown node ID'
+        3022: 'Unknown node ID',
+        3023: 'Worker node is not connected to master'
 
         # > 9000: Authd
     }


### PR DESCRIPTION
Hello team,

This PR fixes #2625.

The API call works correctly from a worker node now:
```shellsession
root@worker-1:/home/vagrant# curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/configuration/validation?pretty"
{
   "error": 0,
   "data": {
      "status": "OK"
   }
}
```

Best regards,
Marta