### PR TITLE
Support for AWS organizations in CloudTrail

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -52,6 +52,7 @@ void SyscollectorInit(){
 int DecodeSyscollector(Eventinfo *lf,int *socket)
 {
     cJSON *logJSON;
+    cJSON *json_type;
     char *msg_type = NULL;
 
     lf->decoder_info = sysc_decoder;
@@ -81,8 +82,8 @@ int DecodeSyscollector(Eventinfo *lf,int *socket)
     }
 
     // Detect message type
-    msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
-    if (!msg_type) {
+    json_type = cJSON_GetObjectItem(logJSON, "type");
+    if (!(json_type && (msg_type = json_type->valuestring))) {
         mdebug1("Invalid message. Type not found.");
         cJSON_Delete (logJSON);
         return (0);

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -22,7 +22,7 @@ static const char *XML_REMOVE_FORM_BUCKET = "remove_from_bucket";
 static const char *XML_SKIP_ON_ERROR = "skip_on_error";
 static const char *XML_AWS_PROFILE = "aws_profile";
 static const char *XML_IAM_ROLE_ARN = "iam_role_arn";
-static const char *XML_AWS_ORGANISATION_ID = "aws_organisation_id";
+static const char *XML_AWS_ORGANIZATION_ID = "aws_organization_id";
 static const char *XML_AWS_ACCOUNT_ID = "aws_account_id";
 static const char *XML_AWS_ACCOUNT_ALIAS = "aws_account_alias";
 static const char *XML_TRAIL_PREFIX = "path";
@@ -213,14 +213,14 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         }
                         free(cur_bucket->bucket);
                         os_strdup(children[j]->content, cur_bucket->bucket);
-                    } else if (!strcmp(children[j]->element, XML_AWS_ORGANISATION_ID)) {
+                    } else if (!strcmp(children[j]->element, XML_AWS_ORGANIZATION_ID)) {
                         if (strlen(children[j]->content) == 0) {
                             merror("Empty content for tag '%s' at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);
                             OS_ClearNode(children);
                             return OS_INVALID;
                         }
-                        free(cur_bucket->aws_organisation_id);
-                        os_strdup(children[j]->content, cur_bucket->aws_organisation_id);
+                        free(cur_bucket->aws_organization_id);
+                        os_strdup(children[j]->content, cur_bucket->aws_organization_id);
                     } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ID)) {
                         if (strlen(children[j]->content) == 0) {
                             merror("Empty content for tag '%s' at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -277,9 +277,9 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
         wm_strcat(&command, "--iam_role_arn", ' ');
         wm_strcat(&command, exec_bucket->iam_role_arn, ' ');
     }
-    if (exec_bucket->aws_organisation_id) {
-        wm_strcat(&command, "--aws_organisation_id", ' ');
-        wm_strcat(&command, exec_bucket->aws_organisation_id, ' ');
+    if (exec_bucket->aws_organization_id) {
+        wm_strcat(&command, "--aws_organization_id", ' ');
+        wm_strcat(&command, exec_bucket->aws_organization_id, ' ');
     }
     if (exec_bucket->aws_account_id) {
         wm_strcat(&command, "--aws_account_id", ' ');

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -29,7 +29,7 @@ typedef struct wm_aws_bucket {
     char *secret_key;                   // IAM secret key
     char *aws_profile;                  // AWS credentials profile
     char *iam_role_arn;                 // IAM role
-    char *aws_organisation_id;          // AWS organisation ID
+    char *aws_organization_id;          // AWS organization ID
     char *aws_account_id;               // AWS account ID(s)
     char *aws_account_alias;            // AWS account alias
     char *trail_prefix;                 // Trail prefix

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -283,7 +283,7 @@ class AWSBucket(WazuhIntegration):
 
     def __init__(self, reparse, access_key, secret_key, profile, iam_role_arn,
                  bucket, only_logs_after, skip_on_error, account_alias,
-                 prefix, delete_file, aws_organisation_id):
+                 prefix, delete_file, aws_organization_id):
         """
         AWS Bucket constructor.
 
@@ -298,7 +298,7 @@ class AWSBucket(WazuhIntegration):
         :param account_alias: Alias of the AWS account where the bucket is.
         :param prefix: Prefix to filter files in bucket
         :param delete_file: Wether to delete an already processed file from a bucket or not
-        :param aws_organisation_id: The AWS Organisation ID
+        :param aws_organization_id: The AWS organization ID
         """
 
         # common SQL queries
@@ -396,7 +396,7 @@ class AWSBucket(WazuhIntegration):
         self.prefix = prefix
         self.delete_file = delete_file
         self.bucket_path = self.bucket + '/' + self.prefix
-        self.aws_organisation_id = aws_organisation_id
+        self.aws_organization_id = aws_organization_id
 
     def already_processed(self, downloaded_file, aws_account_id, aws_region):
         cursor = self.db_connector.execute(self.sql_already_processed.format(
@@ -713,10 +713,10 @@ class AWSLogsBucket(AWSBucket):
 
     def get_base_prefix(self):
         base_prefix = '{}AWSLogs/'.format(self.prefix)
-        if self.aws_organisation_id:
-            base_prefix = '{base_prefix}{aws_organisation_id}/'.format(
+        if self.aws_organization_id:
+            base_prefix = '{base_prefix}{aws_organization_id}/'.format(
                 base_prefix=base_prefix,
-                aws_organisation_id=self.aws_organisation_id)
+                aws_organization_id=self.aws_organization_id)
 
         return base_prefix
 
@@ -1932,8 +1932,8 @@ def get_script_arguments():
                         action='store')
     group.add_argument('-sr', '--service', dest='service', help='Specify the name of the service',
                         action='store')
-    parser.add_argument('-O', '--aws_organisation_id', dest='aws_organisation_id',
-                        help='AWS Organisation ID for logs', required=False)
+    parser.add_argument('-O', '--aws_organization_id', dest='aws_organization_id',
+                        help='AWS organization ID for logs', required=False)
     parser.add_argument('-c', '--aws_account_id', dest='aws_account_id',
                         help='AWS Account ID for logs', required=False,
                         type=arg_valid_accountid)
@@ -1999,7 +1999,7 @@ def main(argv):
                            only_logs_after=options.only_logs_after, skip_on_error=options.skip_on_error,
                            account_alias=options.aws_account_alias,
                            prefix=options.trail_prefix, delete_file=options.deleteFile,
-                           aws_organisation_id=options.aws_organisation_id)
+                           aws_organization_id=options.aws_organization_id)
             bucket.iter_bucket(options.aws_account_id, options.regions)
         elif options.service:
             if options.service.lower() == 'inspector':


### PR DESCRIPTION
Hi team,

This PR is for giving support to AWS organizations in `CloudTrail` service and it closes #2473.

With this enhancement, It is possible getting logs for organizations by adding `<aws_organization_id>ORGANIZATION</aws_organization_id>` in the wodle configuration:
```bash
<wodle name="aws-s3">
      <disabled>no</disabled>
      <bucket type="cloudtrail">
           <name>cloudtrail</name>
           <aws_organization_id>wazuh</aws_organization_id>
           <aws_profile>default</aws_profile>
       </bucket>
       <remove_from_bucket>no</remove_from_bucket>
       <interval>20m</interval>
       <run_on_start>yes</run_on_start>
       <skip_on_error>no</skip_on_error>
   </wodle>

```

This work has been made by @arnogeurts.

Best regards,

Demetrio.