### PR TITLE
Let DB synchronize module clean the table belongs when removing agents

### DIFF
--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -216,6 +216,7 @@ int wdb_remove_agent(int id) {
     sqlite3_bind_int(stmt, 1, id);
     result = wdb_step(stmt) == SQLITE_DONE;
     sqlite3_finalize(stmt);
+    wdb_delete_agent_belongs(id);
 
     result = result && name ? wdb_remove_agent_db(id, name) : -1;
 


### PR DESCRIPTION
This fixes the count of agents belonging to a group, preventing the Framework from counting removed agents.