### PR TITLE
Improvement for checking manager configuration

### DIFF
--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -652,7 +652,7 @@ static int CheckManagerConfiguration(char ** output) {
     int timeout = 2000;
     char command_in[PATH_MAX] = {0};
     char *output_msg = NULL;
-    char *daemons[] = { "bin/ossec-authd", "bin/ossec-remoted", "bin/ossec-execd", "bin/ossec-analysisd", "bin/ossec-logcollector", "bin/ossec-integratord",  "bin/ossec-syscheckd", NULL };
+    char *daemons[] = { "bin/ossec-authd", "bin/ossec-remoted", "bin/ossec-execd", "bin/ossec-analysisd", "bin/ossec-logcollector", "bin/ossec-integratord",  "bin/ossec-syscheckd", "bin/ossec-maild", "bin/wazuh-modulesd", NULL };
     int i;
     ret_val = 0;
 

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -647,6 +647,7 @@ static int CheckManagerConfiguration(char ** output) {
         snprintf(command_in, PATH_MAX, "%s/%s %s", DEFAULTDIR, daemons[i],"-t");
       
         if (wm_exec(command_in, output, &result_code, timeout, NULL) < 0) {
+       
             if (result_code == 0x7F) {
                 mwarn("Path is invalid or file has insufficient permissions. %s", command_in);
             } else {
@@ -656,10 +657,14 @@ static int CheckManagerConfiguration(char ** output) {
             os_free(*output);
             goto error;
         }
-    
+
         wm_strcat(&output_msg,*output,' ');
         os_free(*output);
         *output = output_msg;
+
+        if(result_code) {
+            break;
+        }
     }
 
     gettimeofday(&end, NULL);

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -384,9 +384,9 @@ static void ExecdStart(int q)
                 cJSON_AddStringToObject(result_obj,"message",error_msg);
                 os_free(output);
                 output = cJSON_PrintUnformatted(result_obj);
-              
+
             } else {
-             
+
                 cJSON_AddNumberToObject(result_obj,"error",0);
                 cJSON_AddStringToObject(result_obj,"message","ok");
                 os_free(output);
@@ -652,7 +652,7 @@ static int CheckManagerConfiguration(char ** output) {
     int timeout = 2000;
     char command_in[PATH_MAX] = {0};
     char *output_msg = NULL;
-    char *daemons[7] = { "bin/ossec-authd", "bin/ossec-remoted", "bin/ossec-execd", "bin/ossec-analysisd", "bin/ossec-logcollector", "bin/ossec-integratord",  "bin/ossec-syscheckd" };
+    char *daemons[] = { "bin/ossec-authd", "bin/ossec-remoted", "bin/ossec-execd", "bin/ossec-analysisd", "bin/ossec-logcollector", "bin/ossec-integratord",  "bin/ossec-syscheckd", NULL };
     int i;
     ret_val = 0;
 
@@ -661,9 +661,9 @@ static int CheckManagerConfiguration(char ** output) {
 
     for (i = 0; daemons[i]; i++) {
         snprintf(command_in, PATH_MAX, "%s/%s %s", DEFAULTDIR, daemons[i],"-t");
-      
+
         if (wm_exec(command_in, output, &result_code, timeout, NULL) < 0) {
-       
+
             if (result_code == 0x7F) {
                 mwarn("Path is invalid or file has insufficient permissions. %s", command_in);
             } else {

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -372,29 +372,27 @@ static void ExecdStart(int q)
             tmp_msg++;
         }
 
-        if(!strcmp(name,"check-manager-configuration")) {
+        if(!strcmp(name, "check-manager-configuration")) {
             char *output = NULL;
             cJSON *result_obj = cJSON_CreateObject();
 
             if(CheckManagerConfiguration(&output)) {
                 char error_msg[OS_SIZE_4096 - 27] = {0};
-                snprintf(error_msg,OS_SIZE_4096 - 27,"%s",output);
+                snprintf(error_msg, OS_SIZE_4096 - 27, "%s", output);
 
-                cJSON_AddNumberToObject(result_obj,"error",1);
-                cJSON_AddStringToObject(result_obj,"message",error_msg);
+                cJSON_AddNumberToObject(result_obj, "error", 1);
+                cJSON_AddStringToObject(result_obj, "message", error_msg);
                 os_free(output);
                 output = cJSON_PrintUnformatted(result_obj);
-
             } else {
-
-                cJSON_AddNumberToObject(result_obj,"error",0);
-                cJSON_AddStringToObject(result_obj,"message","ok");
+                cJSON_AddNumberToObject(result_obj, "error", 0);
+                cJSON_AddStringToObject(result_obj, "message", "ok");
                 os_free(output);
                 output = cJSON_PrintUnformatted(result_obj);
             }
 
             cJSON_Delete(result_obj);
-            mdebug1("Sending configuration check: %s",output);
+            mdebug1("Sending configuration check: %s", output);
 
             int rc;
             /* Start api socket */
@@ -661,10 +659,9 @@ static int CheckManagerConfiguration(char ** output) {
 
     for (i = 0; daemons[i]; i++) {
         output_msg = NULL;
-        snprintf(command_in, PATH_MAX, "%s/%s %s", DEFAULTDIR, daemons[i],"-t");
+        snprintf(command_in, PATH_MAX, "%s/%s %s", DEFAULTDIR, daemons[i], "-t");
 
         if (wm_exec(command_in, &output_msg, &result_code, timeout, NULL) < 0) {
-
             if (result_code == 0x7F) {
                 mwarn("Path is invalid or file has insufficient permissions. %s", command_in);
             } else {
@@ -694,7 +691,7 @@ static int CheckManagerConfiguration(char ** output) {
     gettimeofday(&end, NULL);
 
     double elapsed = (end.tv_usec - start.tv_usec) / 1000;
-    mdebug1("Elapsed configuration check time: %0.3f milliseconds",elapsed);
+    mdebug1("Elapsed configuration check time: %0.3f milliseconds", elapsed);
 
     return ret_val;
 

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -113,15 +113,18 @@ int main(int argc, char **argv)
     /* Reading configuration */
     if(!OS_ReadIntegratorConf(cfg, &integrator_config) || !integrator_config[0])
     {
-        /* Not configured */
-        minfo("Remote integrations not configured. "
-                "Clean exit.");
         exit(0);
     }
 
     /* Exit here if test config is set */
     if(test_config)
         exit(0);
+
+    if (!integrator_config[0]) {
+        /* Not configured */
+        minfo("Remote integrations not configured. Clean exit.");
+        exit(0);
+    }
 
     /* Pid before going into daemon mode. */
     i = getpid();


### PR DESCRIPTION
|Related PR|
|---|
|#2637 (Framework)|

The API call `curl -u foo:bar -k -X GET "http://127.0.0.1:55000/manager/configuration/validation?pretty"` tells the user if the `ossec.conf` file has a valid configuration.

This was made using only the `ossec-logtest` daemon which only covered the `analysisd` configuration. If a user made a change to, for example `remoted` configuration that was wrong, it was parsed as a valid configuration.

Now all the daemons except `modulesd` are tested, and if any one fails it will output the error correctly.
