### PR TITLE
Fix for restart.sh script

### DIFF
--- a/active-response/restart.sh
+++ b/active-response/restart.sh
@@ -45,7 +45,7 @@ fi
 if command -v systemctl > /dev/null 2>&1; then        
     systemctl restart wazuh-$TYPE
 elif command -v service > /dev/null 2>&1; then        
-    service restart wazuh-$TYPE
+    service wazuh-$TYPE restart
 elif command -v update-rc.d > /dev/null 2>&1; then        
     update-rc.d wazuh-$TYPE restart
 else

--- a/active-response/restart.sh
+++ b/active-response/restart.sh
@@ -47,7 +47,7 @@ if command -v systemctl > /dev/null 2>&1; then
 elif command -v service > /dev/null 2>&1; then        
     service restart wazuh-$TYPE
 elif command -v update-rc.d > /dev/null 2>&1; then        
-    update-rc.d restart wazuh-$TYPE
+    update-rc.d wazuh-$TYPE restart
 else
     ${PWD}/bin/ossec-control restart
 fi

--- a/active-response/restart.sh
+++ b/active-response/restart.sh
@@ -44,10 +44,8 @@ fi
 # Restart Wazuh
 if command -v systemctl > /dev/null 2>&1; then        
     systemctl restart wazuh-$TYPE
-elif command -v service > /dev/null 2>&1; then        
+elif command -v service > /dev/null 2>&1; then
     service wazuh-$TYPE restart
-elif command -v update-rc.d > /dev/null 2>&1; then        
-    update-rc.d wazuh-$TYPE restart
 else
     ${PWD}/bin/ossec-control restart
 fi


### PR DESCRIPTION
Hi team,

This PR fixes our script `restart.sh` for old Linux distributions. Below there is an example with `CentOS 6`:

```bash
# /var/ossec/active-response/bin/restart.sh manager
Stopping OSSEC:                                            [  OK  ]
Starting OSSEC:                                            [  OK  ]
```

Best regards,

Demetrio.