### PR TITLE
Fixed AIX Libyaml compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -736,7 +736,7 @@ $(EXTERNAL_LIBYAML)Makefile:
 ifeq (${TARGET},winagent)
 	cd $(EXTERNAL_LIBYAML) && CC=${MING_BASE}${CC} && CFLAGS=-fPIC ./configure --host=${MINGW_HOST} --enable-static=yes
 else
-	cd $(EXTERNAL_LIBYAML) && CFLAGS=-fPIC ./configure --enable-static=yes
+	cd $(EXTERNAL_LIBYAML) && CFLAGS=-fPIC ./configure --enable-static=yes --enable-shared=no
 endif
 
 #### curl ##########


### PR DESCRIPTION
### Compilation 

The compilation flag `--enabled-shared=no` is needed for compiling the agent on **AIX**. This flag was missing causing the daemons to look for the shared library of **libyaml**.

```xml
CC libwazuhext.so
ld: 0706-012 The -- flag is not recognized.
ld: 0706-012 The -w flag is not recognized.
ld: 0706-012 The -h flag is not recognized.
ld: 0706-012 The -- flag is not recognized.
ld: 0706-027 The -n flag is ignored.
collect2: error: ld returned 255 exit status
gmake[1]: *** [Makefile:1040: libwazuhext.so] Error 1
gmake[1]: Leaving directory '/home/root/wazuh-agent-3.9.0/src'
gmake: *** [Makefile:568: agent] Error 2

 Error 0x5.
 Building error. Unable to finish the installation.
```


