### PR TITLE
Relative dates and db file per bucket

### DIFF
--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -261,7 +261,8 @@ class WazuhIntegration:
                 sys.exit(11)
             else:
                 print("ERROR: Error sending message to wazuh: {}".format(e))
-                sys.exit(13)
+                #sys.exit(13)
+                s.close()
         except Exception as e:
             print("ERROR: Error sending message to wazuh: {}".format(e))
             sys.exit(13)
@@ -411,7 +412,10 @@ class AWSBucket(WazuhIntegration):
         self.legacy_db_table_name = 'log_progress'
         self.retain_db_records = 1000
         self.reparse = reparse
-        self.only_logs_after = datetime.strptime(only_logs_after, "%Y%m%d")
+        if only_logs_after[0]=='-':
+            self.only_logs_after = datetime.strptime(datetime.today()) - timedelta(days=int(only_logs_after))
+        else:
+            self.only_logs_after = datetime.strptime(only_logs_after, "%Y%m%d")
         self.skip_on_error = skip_on_error
         self.account_alias = account_alias
         self.prefix = prefix
@@ -1886,7 +1890,10 @@ def debug(msg, msg_level):
 
 def arg_valid_date(arg_string):
     try:
-        parsed_date = datetime.strptime(arg_string, "%Y-%b-%d")
+        if arg_string[0]=="-":
+            parsed_date = datetime.today()
+        else:
+            parsed_date = datetime.strptime(arg_string, "%Y-%b-%d")
         # Return int created from date in YYYYMMDD format
         return parsed_date.strftime('%Y%m%d')
     except ValueError:


### PR DESCRIPTION
I made some changes to the script that worked fine for me, I have multiple buckets with different prefixes and different accounts and to be able to run multiple instances of the script in parallel I added one db file per bucket to avoid db lock errors.
To prevent modifying the configuration files daily modified the date format validation so it can take negative numbers like "-2" to parse only logs two days older and newer no matter the date.