### PR TITLE
Added missing initialized values for Configuration Assessment decoder

### DIFF
--- a/src/analysisd/decoders/configuration_assessment.c
+++ b/src/analysisd/decoders/configuration_assessment.c
@@ -729,12 +729,12 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
 
     int result_event = 0;
     char *hash_scan_info = NULL;
-    os_md5 hash_md5;
+    os_md5 hash_md5 = {0};
     os_calloc(OS_MAXSTR,sizeof(char),hash_scan_info);
     
     int result_db = FindScanInfo(lf,policy_id->valuestring,socket,hash_scan_info);
 
-    int scan_id_old;
+    int scan_id_old = 0;
     sscanf(hash_scan_info,"%s %d",hash_md5,&scan_id_old);
 
     switch (result_db)


### PR DESCRIPTION
### Decoder

The configuration assessment  `analysisd` decoder had some values uninitialized inside the `HandleScanInfo` function.

Valgrind report shows it:

```
2019/02/21 08:53:29 ossec-analysisd: INFO: Started (pid: 32743).
==32743== Thread 44:
==32743== Conditional jump or move depends on uninitialised value(s)
==32743==    at 0x4C33DAC: strcmp (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==32743==    by 0x142C3C: HandleScanInfo (configuration_assessment.c:768)
==32743==    by 0x1406D7: DecodeConfigurationAssessment (configuration_assessment.c:180)
==32743==    by 0x133651: w_decode_configuration_assessment_thread (analysisd.c:2030)
==32743==    by 0x583B6DA: start_thread (pthread_create.c:463)
==32743==    by 0x5B7488E: clone (clone.S:95)
==32743==  Uninitialised value was created by a stack allocation
==32743==    at 0x14241E: HandleScanInfo (configuration_assessment.c:622)
==32743== 
==32743== Conditional jump or move depends on uninitialised value(s)
==32743==    at 0x142C3F: HandleScanInfo (configuration_assessment.c:768)
==32743==    by 0x1406D7: DecodeConfigurationAssessment (configuration_assessment.c:180)
==32743==    by 0x133651: w_decode_configuration_assessment_thread (analysisd.c:2030)
==32743==    by 0x583B6DA: start_thread (pthread_create.c:463)
==32743==    by 0x5B7488E: clone (clone.S:95)
==32743==  Uninitialised value was created by a stack allocation
==32743==    at 0x14241E: HandleScanInfo (configuration_assessment.c:622)
==32743== 
==32743== Conditional jump or move depends on uninitialised value(s)
==32743==    at 0x5AAF8DA: vfprintf (vfprintf.c:1642)
==32743==    by 0x5ADB90F: vsnprintf (vsnprintf.c:114)
==32743==    by 0x5AB7FDE: snprintf (snprintf.c:33)
==32743==    by 0x1447D3: UpdateCheckScanId (configuration_assessment.c:1257)
==32743==    by 0x142E96: HandleScanInfo (configuration_assessment.c:816)
==32743==    by 0x1406D7: DecodeConfigurationAssessment (configuration_assessment.c:180)
==32743==    by 0x133651: w_decode_configuration_assessment_thread (analysisd.c:2030)
==32743==    by 0x583B6DA: start_thread (pthread_create.c:463)
==32743==    by 0x5B7488E: clone (clone.S:95)
==32743==  Uninitialised value was created by a stack allocation
==32743==    at 0x14241E: HandleScanInfo (configuration_assessment.c:622)
==32743== 
==32743== Use of uninitialised value of size 8
==32743==    at 0x5AAB86B: _itoa_word (_itoa.c:179)
==32743==    by 0x5AAEF0D: vfprintf (vfprintf.c:1642)
==32743==    by 0x5ADB90F: vsnprintf (vsnprintf.c:114)
==32743==    by 0x5AB7FDE: snprintf (snprintf.c:33)
==32743==    by 0x1447D3: UpdateCheckScanId (configuration_assessment.c:1257)
==32743==    by 0x142E96: HandleScanInfo (configuration_assessment.c:816)
==32743==    by 0x1406D7: DecodeConfigurationAssessment (configuration_assessment.c:180)
==32743==    by 0x133651: w_decode_configuration_assessment_thread (analysisd.c:2030)
==32743==    by 0x583B6DA: start_thread (pthread_create.c:463)
==32743==    by 0x5B7488E: clone (clone.S:95)
==32743==  Uninitialised value was created by a stack allocation
==32743==    at 0x14241E: HandleScanInfo (configuration_assessment.c:622)
==32743== 
==32743== Conditional jump or move depends on uninitialised value(s)
==32743==    at 0x5AAB875: _itoa_word (_itoa.c:179)
==32743==    by 0x5AAEF0D: vfprintf (vfprintf.c:1642)
==32743==    by 0x5ADB90F: vsnprintf (vsnprintf.c:114)
==32743==    by 0x5AB7FDE: snprintf (snprintf.c:33)
==32743==    by 0x1447D3: UpdateCheckScanId (configuration_assessment.c:1257)
==32743==    by 0x142E96: HandleScanInfo (configuration_assessment.c:816)
==32743==    by 0x1406D7: DecodeConfigurationAssessment (configuration_assessment.c:180)
==32743==    by 0x133651: w_decode_configuration_assessment_thread (analysisd.c:2030)
==32743==    by 0x583B6DA: start_thread (pthread_create.c:463)
==32743==    by 0x5B7488E: clone (clone.S:95)
==32743==  Uninitialised value was created by a stack allocation
==32743==    at 0x14241E: HandleScanInfo (configuration_assessment.c:622)
==32743== 
==32743== Conditional jump or move depends on uninitialised value(s)
==32743==    at 0x5AAF014: vfprintf (vfprintf.c:1642)
==32743==    by 0x5ADB90F: vsnprintf (vsnprintf.c:114)
==32743==    by 0x5AB7FDE: snprintf (snprintf.c:33)
==32743==    by 0x1447D3: UpdateCheckScanId (configuration_assessment.c:1257)
==32743==    by 0x142E96: HandleScanInfo (configuration_assessment.c:816)
==32743==    by 0x1406D7: DecodeConfigurationAssessment (configuration_assessment.c:180)
==32743==    by 0x133651: w_decode_configuration_assessment_thread (analysisd.c:2030)
==32743==    by 0x583B6DA: start_thread (pthread_create.c:463)
==32743==    by 0x5B7488E: clone (clone.S:95)
==32743==  Uninitialised value was created by a stack allocation
==32743==    at 0x14241E: HandleScanInfo (configuration_assessment.c:622)
==32743== 
==32743== Conditional jump or move depends on uninitialised value(s)
==32743==    at 0x5AAFB4C: vfprintf (vfprintf.c:1642)
==32743==    by 0x5ADB90F: vsnprintf (vsnprintf.c:114)
==32743==    by 0x5AB7FDE: snprintf (snprintf.c:33)
==32743==    by 0x1447D3: UpdateCheckScanId (configuration_assessment.c:1257)
==32743==    by 0x142E96: HandleScanInfo (configuration_assessment.c:816)
==32743==    by 0x1406D7: DecodeConfigurationAssessment (configuration_assessment.c:180)
==32743==    by 0x133651: w_decode_configuration_assessment_thread (analysisd.c:2030)
==32743==    by 0x583B6DA: start_thread (pthread_create.c:463)
==32743==    by 0x5B7488E: clone (clone.S:95)
==32743==  Uninitialised value was created by a stack allocation
==32743==    at 0x14241E: HandleScanInfo (configuration_assessment.c:622)
```

This is now fixed.