### PR TITLE
Fix .ssh folder permissions

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -838,7 +838,7 @@ InstallCommon()
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/agentless
   ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} agentlessd/scripts/* ${PREFIX}/agentless/
 
-  ${INSTALL} -d -m 0700 -o root -g ${OSSEC_GROUP} ${PREFIX}/.ssh
+  ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/.ssh
 
   ./init/fw-check.sh execute
   ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../active-response/*.sh ${PREFIX}/active-response/bin/


### PR DESCRIPTION
With the current group permissions for the `/var/ossec/.ssh` folder it is not possible to add a new ssh key for [agentless monitoring](https://documentation.wazuh.com/current/user-manual/capabilities/agentless-monitoring/how-it-works.html) and the debug of this capability will complain that it cannot add signatures to the `known_hosts`