### PR TITLE
Fix agent-upgrade script

### DIFF
--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -81,8 +81,9 @@ def main():
         if not pattern.match(args.version):
             raise WazuhException(1733, "Version received: {0}".format(args.version))
 
-    if args.chunk_size is not None and args.chunk_size < 1 or args.chunk_size > 64000:
-        raise WazuhException(1744, "Chunk defined: {0}".format(args.chunk_size))
+    if args.chunk_size is not None:
+        if args.chunk_size < 1 or args.chunk_size > 64000:
+            raise WazuhException(1744, "Chunk defined: {0}".format(args.chunk_size))
 
     # Custom WPK file
     if args.file:


### PR DESCRIPTION
- Fixed `agent-upgrade` script. It was failing to upgrade an agent when `chunk_size` wasn't set.