### PR TITLE
New message when cluster restarts

### DIFF
--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -5,7 +5,7 @@ import itertools
 from wazuh.utils import md5, mkdir_with_mode
 from wazuh.exception import WazuhException
 from wazuh.agent import Agent
-from wazuh.manager import status
+from wazuh.manager import status, restart
 from wazuh.configuration import get_ossec_conf
 from wazuh.InputValidator import InputValidator
 from wazuh.database import Connection
@@ -366,6 +366,16 @@ def clean_up(node_name=""):
         logger.debug("[Cluster] Removed '{}'.".format(rm_path))
     except Exception as e:
         logger.error("[Cluster] Error cleaning up: {0}.".format(str(e)))
+
+
+def restart_all_nodes():
+    """
+    Restart all cluster nodes.
+
+    :return: Confirmation message.
+    """
+    return restart()
+    return "Restarting cluster"
 
 
 #

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -374,7 +374,7 @@ def restart_all_nodes():
 
     :return: Confirmation message.
     """
-    return restart()
+    restart()
     return "Restarting cluster"
 
 

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -390,7 +390,7 @@ functions = {
         'is_async': False
     },
     'PUT/cluster/restart': {
-        'function': manager.restart,
+        'function': cluster.restart_all_nodes,
         'type': 'distributed_master',
         'is_async': False
     },


### PR DESCRIPTION
Hi team,

I changed the message for API call `cluster/restart`:
```bash
# curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/cluster/restart?pretty"
{
   "error": 0,
   "data": "Restarting cluster"
}

```
Best regards,

Demetrio.