### PR TITLE
Fix incorrect rule frecuency printed by Analysisd

### DIFF
--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -184,7 +184,7 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         cJSON_AddNumberToObject(rule,"sigid",node->ruleinfo->sigid);
         cJSON_AddNumberToObject(rule,"level",node->ruleinfo->level);
         cJSON_AddNumberToObject(rule,"maxsize",node->ruleinfo->maxsize);
-        cJSON_AddNumberToObject(rule,"frequency",node->ruleinfo->frequency);
+        cJSON_AddNumberToObject(rule,"frequency",node->ruleinfo->event_search ? node->ruleinfo->frequency + 2 : node->ruleinfo->frequency);
         cJSON_AddNumberToObject(rule,"timeframe",node->ruleinfo->timeframe);
         cJSON_AddNumberToObject(rule,"ignore_time",node->ruleinfo->ignore_time);
         cJSON_AddNumberToObject(rule,"decoded_as",node->ruleinfo->decoded_as);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -94,8 +94,8 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         if(lf->generated_rule->info) {
             cJSON_AddStringToObject(rule, "info", lf->generated_rule->info);
         }
-        if(lf->generated_rule->frequency){
-            cJSON_AddNumberToObject(rule, "frequency", lf->generated_rule->frequency);
+        if(lf->generated_rule->event_search){
+            cJSON_AddNumberToObject(rule, "frequency", lf->generated_rule->frequency + 2);
         }
         if(lf->r_firedtimes != -1 && !(lf->generated_rule->alert_opts & NO_COUNTER)) {
             cJSON_AddNumberToObject(rule, "firedtimes", lf->r_firedtimes);


### PR DESCRIPTION
This rule:
```xml
<rule id="5712" level="10" frequency="8" timeframe="120" ignore="60" />
```

It means that it will produce an alert when the child rule appears 8 times in the last 2 minutes.

On the other hand, this is an alert of the rule 5712:
```json
{
  "timestamp": "2019-02-21T18:31:26.151-0800",
  "rule": {
    "level": 10,
    "description": "sshd: brute force trying to get access to the system.",
    "id": "5712",
    "frequency": 6,
    "firedtimes": 1,
    "mail": false,
    "groups": [
      "syslog",
      "sshd",
      "authentication_failures"
    ],
    "pci_dss": [
      "11.4",
      "10.2.4",
      "10.2.5"
    ],
    "gdpr": [
      "IV_35.7.d",
      "IV_32.2"
    ]
  }
}
```

The alert shows _frequency=6_.

This is because Analysisd stores the actual frequency _- 2_ in the internal data structure.
The XML parser decreases _2_ to the desired frequency.


## Fix
The JSON formatter and the remote configuration should increase back that value.

Since the "default" value for _frequency_ is `0`, we cannot distinguish between `frequency="2"` and no frequency. But defining a frequency has only sense when made together with `<if_matched_sid>` or `<if_matched_group>`. That's why the best condition is checking `rule->eventsearch`.