### PR TITLE
Added template for sles 11/12

### DIFF
--- a/etc/sca/sles/11/cis_sles11_linux_rcl.yml
+++ b/etc/sca/sles/11/cis_sles11_linux_rcl.yml
@@ -1,0 +1,780 @@
+# Security Configuration assessment
+# CIS Checks for SUSE SLES 11
+# Copyright (C) 2015-2019, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# CIS Benchmark for SUSE Linux Enterprise Server 11 v2.1.0 - 12-28-2017
+
+policy:
+  id: "cis_sles11_linux"
+  file: "cis_sles11_linux_rcl.yml"
+  name: "CIS SUSE Linux Enterprise 11 Benchmark"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for SUSE Linux Enterprise 11 systems running on x86 and x64 platforms. This document was tested against SUSE Linux Enterprise Server 11 SP4."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check Suse 11 version"
+  description: "Requirements for running the SCA scan against SUSE Linux Enterprise Server 11"
+  condition: "any required"
+  rules:
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 11";'
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 11 SP1";'
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 11 SP2";'
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 11 SP3";'
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 11 SP4";'
+
+variables:
+  $rc_dirs: /etc/rc.d/rc2.d,/etc/rc.d/rc3.d,/etc/rc.d/rc4.d,/etc/rc.d/rc5.d;
+
+
+checks:
+# Section 1.1 - Filesystem Configuration
+ - id: 7000
+   title: "Ensure separate partition exists for /tmp"
+   description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+   rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /tmp.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.2"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:/tmp;'
+ - id: 7001
+   title: "Ensure nodev option set on /tmp partition"
+   description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+   rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
+   remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information.  Run the following command to remount /tmp : # mount -o remount,nodev /tmp"
+   compliance:
+    - cis: "1.1.3"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/tmp && !r:nodev;'
+ - id: 7002
+   title: "Ensure nosuid option set on /tmp partition"
+   description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+   rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+   remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information.  Run the following command to remount /tmp : # mount -o remount,nosuid /tmp"
+   compliance:
+    - cis: "1.1.4"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/tmp && !r:nosuid;'
+ - id: 7003
+   title: "Ensure noexec option set on /tmp partition"
+   description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+   rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
+   remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information.  Run the following command to remount /tmp : # mount -o remount,noexec /tmp"
+   compliance:
+    - cis: "1.1.5"
+    - cis_csc: "2"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/tmp && !r:noexec;'
+ - id: 7004
+   title: "Ensure separate partition exists for /var"
+   description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+   rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.6"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r^# && !r:/var;'
+ - id: 7005
+   title: "Ensure separate partition exists for /var/log"
+   description: "The /var/log directory is used by system services to store log data."
+   rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.11"
+    - cis_csc: "6.3"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> ^# && !r:/var/log;'
+ - id: 7006
+   title: "Ensure separate partition exists for /var/log/audit"
+   description: "The auditing daemon, auditd , stores log data in the /var/log/audit directory."
+   rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog ) consume space in the same partition as auditd, it may not perform as desired."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log/audit.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.12"
+    - cis_csc: "6.3"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> ^# && !r:/var/log/audit;'
+ - id: 7007
+   title: "Ensure separate partition exists for /home"
+   description: "The /home directory is used to support disk storage needs of local users."
+   rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.13"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> ^# && !r:/home;'
+ - id: 7008
+   title: "Ensure nodev option set on /home partition"
+   description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+   rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
+   remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. See the fstab(5) manual page for more information.  # mount -o remount,nodev /home. Notes: The actions in this recommendation refer to the /home partition, which is the default user partition that is defined. If you have created other user partitions, it is recommended that the Remediation and Audit steps be applied to these partitions as well."
+   compliance:
+    - cis: "1.1.14"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/home && !r:nodev;'
+ - id: 7009
+   title: "Ensure nodev option set on /dev/shm partition"
+   description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+   rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
+   remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information.  Run the following command to remount /dev/shm : # mount -o remount,nodev /dev/shm"
+   compliance:
+    - cis: "1.1.15"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/dev/shm && !r:nodev;'
+ - id: 7010
+   title: "Ensure nosuid option set on /dev/shm partition"
+   description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+   rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
+   remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information.  Run the following command to remount /dev/shm : # mount -o remount,nosuid /dev/shm"
+   compliance:
+    - cis: "1.1.16"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/dev/shm && !r:nosuid;'
+ - id: 7011
+   title: "Ensure noexec option set on /dev/shm partition"
+   description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+   rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
+   remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information.  Run the following command to remount /dev/shm : # mount -o remount,noexec /dev/shm"
+   compliance:
+    - cis: "1.1.17"
+    - cis_csc: "2"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/dev/shm && !r:noexec;'
+ - id: 7012
+   title: "Ensure nodev option set on removable media partitions"
+   description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+   rationale: "Removable media containing character and block special devices could be used to circumvent security controls by allowing non-root users to access sensitive device files such as /dev/kmem or the raw disk partitions."
+   remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the fstab(5) manual page for more information."
+   compliance:
+    - cis: "1.1.18"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/media && !r:nodev;'
+ - id: 7013
+   title: "Ensure nosuid option set on removable media partitions"
+   description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+   rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
+   remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the fstab(5) manual page for more information."
+   compliance:
+    - cis: "1.1.19"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/media && !r:nosuid;'
+ - id: 7014
+   title: "Ensure noexec option set on removable media partitions"
+   description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+   rationale: "Setting this option on a file system prevents users from executing programs from the removable media. This deters users from being able to introduce potentially malicious software on the system."
+   remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the fstab(5) manual page for more information."
+   compliance:
+    - cis: "1.1.20"
+    - cis_csc: "8"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/media && !r:noexec;'
+# Section 1.4 - Secure Boot Settings
+ - id: 7015
+   title: "Ensure bootloader password is set"
+   description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
+   rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
+   remediation: "Create an encrypted password with grub-md5-crypt : # grub-md5-crypt. The result is an <encrypted-password>. Copy and paste the <encrypted-password> into the global section of /boot/grub/menu.lst: password --md5 <encrypted-password>    Notes: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
+   compliance:
+    - cis: "1.4.2"
+    - cis_csc: "5.1"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/boot/grub2/grub.cfg -> !r:^# && !r:password;'
+# Section 1.5 - Additional Process Hardening
+ - id: 7016
+   title: "Ensure core dumps are restricted"
+   description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
+   rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
+   remediation: "Add the following line to the /etc/security/limits.conf file: * hard core 0. Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: fs.suid_dumpable = 0. Run the following command to set the active kernel parameter: # sysctl -w fs.suid_dumpable=0."
+   compliance:
+    - cis: "1.5.1"
+    - cis_csc: "13"
+   condition: any
+   rules:
+     - 'f:/etc/security/limits.conf -> !r:^# && !r:hard\.+core\.+0;'
+ - id: 7017
+   title: "Ensure address space layout randomization (ASLR) is enabled"
+   description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
+   rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: kernel.randomize_va_space = 2. Run the following command to set the active kernel parameter: # sysctl -w kernel.randomize_va_space=2"
+   compliance:
+    - cis: "1.5.3"
+    - cis_csc: "8.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/kernel/randomize_va_space -> 2;'
+# Section 2.1 - inetd Services
+ - id: 7018
+   title: "Ensure chargen services are not enabled"
+   description: "chargen is a network service that responds with 0 to 512 ASCII characters for each connection it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable chargen and chargen-udp : # chkconfig chargen off # chkconfig chargen-udp off"
+   compliance:
+    - cis: "2.1.1"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/chargen -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/chargen-udp -> !r:^# && r:disable && r:no;'
+ - id: 7019
+   title: "Ensure daytime services are not enabled"
+   description: "daytime is a network service that responds with the server's current date and time. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable daytime - and daytime-udp: # chkconfig daytime-off # chkconfig daytime-udp off"
+   compliance:
+    - cis: "2.1.2"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/daytime -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/daytime-udp -> !r:^# && r:disable && r:no;'
+ - id: 7020
+   title: "Ensure discard services are not enabled"
+   description: "discardis a network service that simply discards all data it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable discard and discard-udp: # chkconfig discard off # chkconfig discard-udp off"
+   compliance:
+    - cis: "2.1.3"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/discard -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/discard-udp -> !r:^# && r:disable && r:no;'
+ - id: 7021
+   title: "Ensure echo services are not enabled"
+   description: "echo is a network service that responds to clients with the data sent to it by the client. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable echo and echo-udp: # chkconfig echo off # chkconfig echo-udp off"
+   compliance:
+    - cis: "2.1.4"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/echo -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/echo-udp -> !r:^# && r:disable && r:no;'
+ - id: 7022
+   title: "Ensure time services are not enabled"
+   description: "timeis a network service that responds with the server's current date and time as a 32 bit integer. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable time and time-udp: # chkconfig time off # chkconfig time-udp off"
+   compliance:
+    - cis: "2.1.5"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/time -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/time-udp -> !r:^# && r:disable && r:no;'
+ - id: 7023
+   title: "Ensure rsh server is not enabled"
+   description: "The Berkeley rsh-server ( rsh , rlogin , rexec ) package contains legacy services that exchange credentials in clear-text."
+   rationale: "These legacy services contain numerous security exposures and have been replaced with the more secure SSH package."
+   remediation: "Run the following commands to disable rsh , rlogin , and rexec : # chkconfig rexec off # chkconfig rlogin off # chkconfig rsh off"
+   compliance:
+    - cis: "2.1.6"
+    - cis_csc: "3.4, 9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/rlogin -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/rsh -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/shell -> !r:^# && r:disable && r:no;'
+ - id: 7024
+   title: "Ensure talk server is not enabled"
+   description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default."
+   rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+   remediation: "Run the following command to disable talk: # chkconfig talk off"
+   compliance:
+    - cis: "2.1.7"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/talk -> !r:^# && r:disable && r:no;'
+ - id: 7025
+   title: "Ensure telnet server is not enabled"
+   description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
+   rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
+   remediation: "Run the following command to disable telnet: # chkconfig telnet off"
+   compliance:
+    - cis: "2.1.8"
+    - cis_csc: "3.4, 9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/telnet -> !r:^# && r:disable && r:no;'
+ - id: 7026
+   title: "Ensure tftp server is not enabled"
+   description: "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package atftp is used to define and support a TFTP server."
+   rationale: "TFTP does not support authentication nor does it ensure the confidentiality or integrity of data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In that case, extreme caution must be used when configuring the services."
+   remediation: "Run the following command to disable tftp: # chkconfig tftp off"
+   compliance:
+    - cis: "2.1.9"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/tftpd -> !r:^# && r:disable && r:no;'
+ - id: 7027
+   title: "Ensure rsync service is not enabled"
+   description: "The rsyncd service can be used to synchronize files between systems over network links."
+   rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
+   remediation: "Run the following command to disable rsyncd : # chkconfig rsyncd off"
+   compliance:
+    - cis: "2.1.10, 2.2.17"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\drsyncd$;'
+# Section 2.2 - Special Purpose Services
+ - id: 7028
+   title: "Ensure ntp is configured"
+   description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://tools.ietf.org/html/rfc958. ntp can be configured to be a client and/or a server.  This recommendation only applies if ntp is in use on the system."
+   rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
+   remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod limited nomodify notrap nopeer noquery restrict -6 default kod limited nomodify notrap nopeer noquery    Add or edit server or pool lines to /etc/ntp.conf as appropriate: server <remote-server>    Add or edit the NTPD_OPTIONS in /etc/sysconfig/ntp to include '-u ntp:ntp': NTPD_OPTIONS='-u ntp:ntp'"
+   compliance:
+    - cis: "2.2.1.2"
+    - cis_csc: "6.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'f:/etc/ntp.conf -> r:restrict default kod nomodify notrap nopeer noquery && r:^server;'
+     - 'f:/etc/sysconfig/ntpd -> r:OPTIONS="-u ntp:ntp -p /var/run/ntpd.pid";'
+ - id: 7029
+   title: "Ensure X Window System is not installed"
+   description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+   rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+   remediation: "Run the following command to remove the X Windows System packages: # zypper remove xorg-x11*"
+   compliance:
+    - cis: "2.2.2"
+    - cis_csc: "2"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'f:/etc/inittab -> !r:^# && r:id:5;'
+ - id: 7030
+   title: "Ensure Avahi Server is not enabled"
+   description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+   rationale: "Automatic discovery of network services is not normally required for system functionality.  It is recommended to disable the service to reduce the potential attack surface."
+   remediation: "Run the following command to disable avahi-daemon : # chkconfig avahi-daemon off"
+   compliance:
+    - cis: "2.2.3"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'p:avahi-daemon;'
+ - id: 7031
+   title: "Ensure DHCP Server is not enabled"
+   description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+   rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable dhcpd : # chkconfig dhcpd off"
+   compliance:
+    - cis: "2.2.5"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dhcpd$;'
+     - 'd:$rc_dirs -> ^S\d\dhcpd6$;'
+ - id: 7032
+   title: "Ensure NFS and RPC are not enabled"
+   description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+   rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
+   remediation: "Run the following commands to disable nfs and rpcbind : # chkconfig nfs off # chkconfig rpcbind off"
+   compliance:
+    - cis: "2.2.7"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dnfs$;'
+     - 'd:$rc_dirs -> ^S\d\dnfslock$;'
+ - id: 7033
+   title: "Ensure DNS Server is not enabled"
+   description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+   rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable named : # chkconfig named off"
+   compliance:
+    - cis: "2.2.8"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dnamed$;'
+ - id: 7034
+   title: "Ensure FTP Server is not enabled"
+   description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
+   rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable vsftpd : # chkconfig vsftpd off  Notes: Additional FTP servers also exist and should be audited."
+   compliance:
+    - cis: "2.2.9"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/vsftpd -> !r:^# && r:disable && r:no;'
+ - id: 7035
+   title: "Ensure HTTP server is not enabled"
+   description: "HTTP or web servers provide the ability to host web site content."
+   rationale: "Unless there is a need to run the system as a web server, it is recommended that the service be disabled to reduce the potential attack surface.  Notes: Several httpd servers exist and can use other service names. apache, apache2, lighttpd, and nginx are example services that provide an HTTP server. These and other services should also be audited."
+   remediation: "Run the following command to disable apache2 : # chkconfig apache2 off"
+   compliance:
+    - cis: "2.2.10"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dapache2$;'
+ - id: 7036
+   title: "Ensure IMAP and POP3 server is not enabled"
+   description: "cyrus is an open source IMAP and POP3 server for Linux based systems."
+   rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable cyrus : # chkconfig cyrus off   Notes: Several IMAP/POP3 servers exist and can use other service names. dovecot is an example service that provides an IMAP/POP3 server. These and other services should also be audited."
+   compliance:
+    - cis: "2.2.11"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/cyrus-imapd -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/dovecot -> !r:^# && r:disable && r:no;'
+ - id: 7037
+   title: "Ensure Samba is not enabled"
+   description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+   rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable smb : # chkconfig smb off"
+   compliance:
+    - cis: "2.2.12"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dsamba$;'
+     - 'd:$rc_dirs -> ^S\d\dsmb$;'
+ - id: 7038
+   title: "Ensure HTTP Proxy Server is not enabled"
+   description: "Squid is a standard proxy server used in many environments."
+   rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable squid : # chkconfig squid off"
+   compliance:
+    - cis: "2.2.13"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dsquid$;'
+ - id: 7039
+   title: "Ensure SNMP Server is not enabled"
+   description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
+   rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
+   remediation: "Run the following command to disable snmpd: # chkconfig snmpd off    Notes: Additional methods of disabling a service exist. Consult your distribution documentation for appropriate methods."
+   compliance:
+    - cis: "2.2.14"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dsnmpd$;'
+ - id: 7040
+   title: "Ensure NIS Server is not enabled"
+   description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+   rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used."
+   remediation: "Run the following command to disable ypserv : # chkconfig ypserv off"
+   compliance:
+    - cis: "2.2.16"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dypserv$;'
+# Section 2.3 - Service Clients
+ - id: 7041
+   title: "Ensure NIS Client is not installed"
+   description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
+   rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+   remediation: "Run the following command to uninstall ypbind : # zypper remove ypbind"
+   compliance:
+    - cis: "2.3.1"
+    - cis_csc: "2"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dypbind$;'
+# Section 3.1 - Network Parameters (Host Only)
+ - id: 7042
+   title: "Ensure IP forwarding is disabled"
+   description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
+   rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.ip_forward = 0.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.ip_forward=0 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.1.1"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/ip_forward -> 1;'
+     - 'f:/proc/sys/net/ipv6/ip_forward -> 1;'
+ - id: 7043
+   title: "Ensure packet redirect sending is disabled"
+   description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
+   rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.send_redirects = 0    net.ipv4.conf.default.send_redirects = 0. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.send_redirects=0 # sysctl -w net.ipv4.conf.default.send_redirects=0 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.1.2"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/send_redirects -> 0;'
+     - 'f:/proc/sys/net/ipv4/conf/default/send_redirects -> 0;'
+# Section 3.2 - Network Parameters (Host and Router)
+ - id: 7044
+   title: "Ensure source routed packets are not accepted"
+   description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
+   rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_source_route = 0    net.ipv4.conf.default.accept_source_route = 0.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_source_route=0 # sysctl -w net.ipv4.conf.default.accept_source_route=0 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.2.1"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/accept_source_route -> 1;'
+ - id: 7045
+   title: "Ensure ICMP redirects are not accepted"
+   description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting net.ipv4.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
+   rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_redirects = 0    net.ipv4.conf.default.accept_redirects = 0.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_redirects=0 # sysctl -w net.ipv4.conf.default.accept_redirects=0 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.2"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/accept_redirects -> 1;'
+     - 'f:/proc/sys/net/ipv4/conf/default/accept_redirects -> 1;'
+ - id: 7046
+   title: "Ensure secure ICMP redirects are not accepted"
+   description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
+   rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.secure_redirects = 0    net.ipv4.conf.default.secure_redirects = 0.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.secure_redirects=0 # sysctl -w net.ipv4.conf.default.secure_redirects=0 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.3"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/secure_redirects -> 1;'
+     - 'f:/proc/sys/net/ipv4/conf/default/secure_redirects -> 1;'
+ - id: 7047
+   title: "Ensure suspicious packets are logged"
+   description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
+   rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.log_martians = 1    net.ipv4.conf.default.log_martians = 1.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.log_martians=1 # sysctl -w net.ipv4.conf.default.log_martians=1 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.4"
+    - cis_csc: "6"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/log_martians -> 0;'
+ - id: 7048
+   title: "Ensure broadcast ICMP requests are ignored"
+   description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
+   rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_echo_ignore_broadcasts = 1    Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.5"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts -> 0;'
+ - id: 7049
+   title: "Ensure bogus ICMP responses are ignored"
+   description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
+   rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_ignore_bogus_error_responses = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.6"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/icmp_ignore_bogus_error_responses -> 0;'
+ - id: 7050
+   title: "Ensure Reverse Path Filtering is enabled"
+   description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
+   rationale: "Setting these flags is a good way to deter attackers from sending your system bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.rp_filter = 1    net.ipv4.conf.default.rp_filter = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.rp_filter=1 # sysctl -w net.ipv4.conf.default.rp_filter=1 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.2.7"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/rp_filter -> 0;'
+     - 'f:/proc/sys/net/ipv4/conf/default/rp_filter -> 0;'
+ - id: 7051
+   title: "Ensure TCP SYN Cookies is enabled"
+   description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
+   rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.tcp_syncookies = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.tcp_syncookies=1 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.2.8"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/tcp_syncookies -> 0;'
+# Section 5.2 - SSH Server Configuration
+ - id: 7052
+   title: "Ensure SSH Protocol is set to 2"
+   description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
+   rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Protocol 2"
+   compliance:
+    - cis: "5.2.2"
+    - cis_csc: "3.4"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;'
+ - id: 7053
+   title: "Ensure SSH LogLevel is set to INFO"
+   description: "The INFO parameter specifies that login and logout activity will be logged."
+   rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information. INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LogLevel INFO"
+   compliance:
+    - cis: "5.2.3"
+    - cis_csc: "16"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && !r:LogLevel\.+INFO;'
+ - id: 7054
+   title: "Ensure SSH MaxAuthTries is set to 4 or less"
+   description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+   rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxAuthTries 4"
+   compliance:
+    - cis: "5.2.5"
+    - cis_csc: "16"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:$sshd_file -> !r:^\s*MaxAuthTries\s+4\s*$;'
+ - id: 7055
+   title: "Ensure SSH IgnoreRhosts is enabled"
+   description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+   rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes"
+   compliance:
+    - cis: "5.2.6"
+    - cis_csc: "9"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:IgnoreRhosts\.+no;'
+ - id: 7056
+   title: "Ensure SSH HostbasedAuthentication is disabled"
+   description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts , or /etc/hosts.equiv , along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
+   rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: HostbasedAuthentication no"
+   compliance:
+    - cis: "5.2.7"
+    - cis_csc: "9"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\.+yes;'
+ - id: 7057
+   title: "Ensure SSH root login is disabled"
+   description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
+   rationale: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no.  Rationale: Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident"
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitRootLogin no"
+   compliance:
+    - cis: "5.2.8"
+    - cis_csc: "5.8"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:$sshd_file -> !r:^\s*PermitRootLogin\.+no;'
+ - id: 7058
+   title: "Ensure SSH PermitEmptyPasswords is disabled"
+   description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+   rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitEmptyPasswords no"
+   compliance:
+    - cis: "5.2.9"
+    - cis_csc: "16"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:$sshd_file -> !r:^\s*PermitEmptyPasswords\.+no;'
+# Section 6.2 - User and Group Settings
+ - id: 7059
+   title: "Ensure password fields are not empty"
+   description: "An account with an empty password field means that anybody may log in as that user without providing a password."
+   rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
+   remediation: "If any accounts in the /etc/shadow file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: # passwd -l <username>.  Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
+   compliance:
+    - cis: "6.2.1"
+    - cis_csc: "16"
+    - pci_dss: "10.2.5"
+   condition: any
+   rules:
+     - 'f:/etc/shadow -> r:^\w+::;'
+ - id: 7060
+   title: "Ensure root is the only UID 0 account"
+   description: "Any account with UID 0 has superuser privileges on the system."
+   rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
+   remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
+   compliance:
+    - cis: "6.2.5"
+    - cis_csc: "5.1"
+    - pci_dss: "10.2.5"
+   condition: any
+   rules:
+     - 'f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:;'

--- a/etc/sca/sles/12/cis_sles12_linux_rcl.yml
+++ b/etc/sca/sles/12/cis_sles12_linux_rcl.yml
@@ -1,0 +1,803 @@
+# Security Configuration assessment
+# CIS Checks for SUSE SLES 12
+# Copyright (C) 2015-2019, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# CIS Benchmark for SUSE Linux Enterprise 12 v2.1.0 - 12-28-2017
+
+policy:
+  id: "cis_sles12_linux"
+  file: "cis_sles12_linux_rcl.yml"
+  name: "CIS SUSE Linux Enterprise 12 Benchmark"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for SUSE Linux Enterprise 12 systems running on x86 and x64 platforms. This document was tested against SUSE Linux Enterprise Server 12 SP3."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check Suse 12 version"
+  description: "Requirements for running the SCA scan against SUSE Linux Enterprise Server 12"
+  condition: "any required"
+  rules:
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 12";'
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 12 SP1";'
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 12 SP2";'
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 12 SP3";'
+    - 'f:/etc/os-release -> r:^PRETTY_NAME="SUSE Linux Enterprise Server 12 SP4";'
+
+variables:
+  $rc_dirs: /etc/rc.d/rc2.d,/etc/rc.d/rc3.d,/etc/rc.d/rc4.d,/etc/rc.d/rc5.d;
+
+
+checks:
+# Section 1.1 - Filesystem Configuration
+ - id: 7500
+   title: "Ensure separate partition exists for /tmp"
+   description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+   rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /tmp.  For systems that were previously installed, create a new partition and configure /etc/fstab or the systemd tmp.mount service as appropriate."
+   compliance:
+    - cis: "1.1.2"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:/tmp;'
+ - id: 7501
+   title: "Ensure nodev option set on /tmp partition"
+   description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+   rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
+   remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information.  Run the following command to remount /tmp : # mount -o remount,nodev /tmp"
+   compliance:
+    - cis: "1.1.3"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/tmp && !r:nodev;'
+ - id: 7502
+   title: "Ensure nosuid option set on /tmp partition"
+   description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+   rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+   remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information.  Run the following command to remount /tmp : # mount -o remount,nosuid /tmp"
+   compliance:
+    - cis: "1.1.4"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/tmp && !r:nosuid;'
+ - id: 7503
+   title: "Ensure noexec option set on /tmp partition"
+   description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+   rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
+   remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information.  Run the following command to remount /tmp : # mount -o remount,noexec /tmp"
+   compliance:
+    - cis: "1.1.5"
+    - cis_csc: "2"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/tmp && !r:noexec;'
+ - id: 7504
+   title: "Ensure separate partition exists for /var"
+   description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+   rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.6"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r^# && !r:/var;'
+ - id: 7505
+   title: "Ensure separate partition exists for /var/log"
+   description: "The /var/log directory is used by system services to store log data."
+   rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.11"
+    - cis_csc: "6.3"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> ^# && !r:/var/log;'
+ - id: 7506
+   title: "Ensure separate partition exists for /var/log/audit"
+   description: "The auditing daemon, auditd , stores log data in the /var/log/audit directory."
+   rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog ) consume space in the same partition as auditd, it may not perform as desired."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log/audit.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.12"
+    - cis_csc: "6.3"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> ^# && !r:/var/log/audit;'
+ - id: 7507
+   title: "Ensure separate partition exists for /home"
+   description: "The /home directory is used to support disk storage needs of local users."
+   rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
+   remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home.  For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+   compliance:
+    - cis: "1.1.13"
+   references:
+    - https://tldp.org/HOWTO/LVM-HOWTO/
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> ^# && !r:/home;'
+ - id: 7508
+   title: "Ensure nodev option set on /home partition"
+   description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+   rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
+   remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. See the fstab(5) manual page for more information.  # mount -o remount,nodev /home. Notes: The actions in this recommendation refer to the /home partition, which is the default user partition that is defined. If you have created other user partitions, it is recommended that the Remediation and Audit steps be applied to these partitions as well."
+   compliance:
+    - cis: "1.1.14"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/home && !r:nodev;'
+ - id: 7509
+   title: "Ensure nodev option set on /dev/shm partition"
+   description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+   rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
+   remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information.  Run the following command to remount /dev/shm : # mount -o remount,nodev /dev/shm    Notes: /dev/shm is not specified in /etc/fstab despite being mounted by default. The following line will implement the recommended /dev/shm mount options in /etc/fstab: tmpfs  /dev/shm  tmpfs  defaults,nodev,nosuid,noexec  0 0. Notes: /dev/shm is not specified in /etc/fstab despite being mounted by default. The following line will implement the recommended /dev/shm mount options in /etc/fstab: tmpfs  /dev/shm  tmpfs  defaults,nodev,nosuid,noexec  0 0"
+   compliance:
+    - cis: "1.1.15"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/dev/shm && !r:nodev;'
+ - id: 7510
+   title: "Ensure nosuid option set on /dev/shm partition"
+   description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+   rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
+   remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information.  Run the following command to remount /dev/shm : # mount -o remount,nosuid /dev/shm    Notes: /dev/shm is not specified in /etc/fstab despite being mounted by default. The following line will implement the recommended /dev/shm mount options in /etc/fstab: tmpfs  /dev/shm  tmpfs  defaults,nodev,nosuid,noexec  0 0. Notes: /dev/shm is not specified in /etc/fstab despite being mounted by default. The following line will implement the recommended /dev/shm mount options in /etc/fstab: tmpfs  /dev/shm  tmpfs  defaults,nodev,nosuid,noexec  0 0"
+   compliance:
+    - cis: "1.1.16"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/dev/shm && !r:nosuid;'
+ - id: 7511
+   title: "Ensure noexec option set on /dev/shm partition"
+   description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+   rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
+   remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information.  Run the following command to remount /dev/shm : # mount -o remount,noexec /dev/shm    Notes: /dev/shm is not specified in /etc/fstab despite being mounted by default. The following line will implement the recommended /dev/shm mount options in /etc/fstab: tmpfs  /dev/shm  tmpfs  defaults,nodev,nosuid,noexec  0 0. Notes: /dev/shm is not specified in /etc/fstab despite being mounted by default. The following line will implement the recommended /dev/shm mount options in /etc/fstab: tmpfs  /dev/shm  tmpfs  defaults,nodev,nosuid,noexec  0 0"
+   compliance:
+    - cis: "1.1.17"
+    - cis_csc: "2"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/dev/shm && !r:noexec;'
+ - id: 7512
+   title: "Ensure nodev option set on removable media partitions"
+   description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+   rationale: "Removable media containing character and block special devices could be used to circumvent security controls by allowing non-root users to access sensitive device files such as /dev/kmem or the raw disk partitions."
+   remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the fstab(5) manual page for more information."
+   compliance:
+    - cis: "1.1.18"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/media && !r:nodev;'
+ - id: 7513
+   title: "Ensure nosuid option set on removable media partitions"
+   description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+   rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
+   remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the fstab(5) manual page for more information."
+   compliance:
+    - cis: "1.1.19"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/media && !r:nosuid;'
+ - id: 7514
+   title: "Ensure noexec option set on removable media partitions"
+   description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+   rationale: "Setting this option on a file system prevents users from executing programs from the removable media. This deters users from being able to introduce potentially malicious software on the system."
+   remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the fstab(5) manual page for more information."
+   compliance:
+    - cis: "1.1.20"
+    - cis_csc: "8"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/fstab -> !r:^# && r:/media && !r:noexec;'
+# Section 1.4 - Secure Boot Settings
+ - id: 7515
+   title: "Ensure bootloader password is set"
+   description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters"
+   rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
+   remediation: "Create an encrypted password with grub-mkpasswd-pbkdf2 : # grub2-mkpasswd-pbkdf2. The final message is 'Your PBKDF2 is <encrypted-password>'. Add the following into /etc/grub.d/01_users or a custom /etc/grub.d configuration file: cat <<EOF set superusers=\"<username>\" password_pbkdf2 <username> <encrypted-password> EOF    Run the following command to update the grub2 configuration: # grub2-mkconfig > /boot/grub2/grub.cfg    Notes: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
+   compliance:
+    - cis: "1.4.2"
+    - cis_csc: "5.1"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/boot/grub2/grub.cfg -> !r:^# && !r:password;'
+# Section 1.5 - Additional Process Hardening
+ - id: 7516
+   title: "Ensure core dumps are restricted"
+   description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
+   rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
+   remediation: "Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/* file: * hard core 0.  Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file:fs.suid_dumpable = 0.  Run the following command to set the active kernel parameter: # sysctl -w fs.suid_dumpable=0"
+   compliance:
+    - cis: "1.5.1"
+    - cis_csc: "13"
+   condition: any
+   rules:
+     - 'f:/etc/security/limits.conf -> !r:^# && !r:hard\.+core\.+0;'
+ - id: 7517
+   title: "Ensure address space layout randomization (ASLR) is enabled"
+   description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
+   rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: kernel.randomize_va_space = 2.  Run the following command to set the active kernel parameter: # sysctl -w kernel.randomize_va_space=2"
+   compliance:
+    - cis: "1.5.3"
+    - cis_csc: "8.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/kernel/randomize_va_space -> 2;'
+# Section 2.1 - inetd Services
+ - id: 7518
+   title: "Ensure chargen services are not enabled"
+   description: "chargen is a network service that responds with 0 to 512 ASCII characters for each connection it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable chargen and chargen-udp : # chkconfig chargen off # chkconfig chargen-udp off"
+   compliance:
+    - cis: "2.1.1"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/chargen -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/chargen-udp -> !r:^# && r:disable && r:no;'
+ - id: 7519
+   title: "Ensure daytime services are not enabled"
+   description: "daytime is a network service that responds with the server's current date and time. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable daytime and daytime-udp: # chkconfig daytime off # chkconfig daytime-udp off"
+   compliance:
+    - cis: "2.1.2"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/daytime -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/daytime-udp -> !r:^# && r:disable && r:no;'
+ - id: 7520
+   title: "Ensure discard services are not enabled"
+   description: "discard is a network service that simply discards all data it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable discard and discard-udp: # chkconfig discard off # chkconfig discard-udp off"
+   compliance:
+    - cis: "2.1.3"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/discard -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/discard-udp -> !r:^# && r:disable && r:no;'
+ - id: 7521
+   title: "Ensure echo services are not enabled"
+   description: "echo is a network service that responds to clients with the data sent to it by the client. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable echo and echo-udp: # chkconfig echo off # chkconfig echo-udp off"
+   compliance:
+    - cis: "2.1.4"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/echo -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/echo-udp -> !r:^# && r:disable && r:no;'
+ - id: 7522
+   title: "Ensure time services are not enabled"
+   description: "timeis a network service that responds with the server's current date and time as a 32 bit integer. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
+   rationale: "Disabling this service will reduce the remote attack surface of the system."
+   remediation: "Run the following commands to disable time and time-udp: # chkconfig time off # chkconfig time-udp off"
+   compliance:
+    - cis: "2.1.5"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/time -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/time-udp -> !r:^# && r:disable && r:no;'
+ - id: 7523
+   title: "Ensure rsh server is not enabled"
+   description: "The Berkeley rsh-server ( rsh , rlogin , rexec ) package contains legacy services that exchange credentials in clear-text."
+   rationale: "These legacy services contain numerous security exposures and have been replaced with the more secure SSH package."
+   remediation: "Run the following commands to disable rsh , rlogin , and rexec : # chkconfig rexec off # chkconfig rlogin off # chkconfig rsh off"
+   compliance:
+    - cis: "2.1.6"
+    - cis_csc: "3.4, 9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/rlogin -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/rsh -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/shell -> !r:^# && r:disable && r:no;'
+     - 'f:/usr/lib/systemd/system/rexec@.service -> r:ExecStart;'
+     - 'f:/usr/lib/systemd/system/rlogin@.service -> r:ExecStart;'
+     - 'f:/usr/lib/systemd/system/rsh@.service -> r:ExecStart;'
+ - id: 7524
+   title: "Ensure talk server is not enabled"
+   description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default."
+   rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+   remediation: "Run the following command to disable talk: # chkconfig talk off"
+   compliance:
+    - cis: "2.1.7"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/talk -> !r:^# && r:disable && r:no;'
+     - 'f:/usr/lib/systemd/system/ntalk.service -> r:Exec;'
+ - id: 7525
+   title: "Ensure telnet server is not enabled"
+   description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
+   rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
+   remediation: "Run the following command to disable telnet: # chkconfig telnet off"
+   compliance:
+    - cis: "2.1.8"
+    - cis_csc: "3.4, 9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/telnet -> !r:^# && r:disable && r:no;'
+     - 'f:/usr/lib/systemd/system/telnet@.service -> r:ExecStart=-/usr/sbin/in.telnetd;'
+ - id: 7526
+   title: "Ensure tftp server is not enabled"
+   description: "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package atftp is used to define and support a TFTP server."
+   rationale: "TFTP does not support authentication nor does it ensure the confidentiality or integrity of data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In that case, extreme caution must be used when configuring the services."
+   remediation: "Run the following command to disable tftp: # systemctl disable atftpd"
+   compliance:
+    - cis: "2.1.9, 2.2.17"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/tftpd -> !r:^# && r:disable && r:no;'
+     - 'f:/usr/lib/systemd/system/tftp.service -> r:Exec;'
+ - id: 7527
+   title: "Ensure rsync service is not enabled"
+   description: "The rsyncd service can be used to synchronize files between systems over network links."
+   rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
+   remediation: "Run the following command to disable rsyncd: # systemctl disable rsyncd"
+   compliance:
+    - cis: "2.1.10, 2.2.18"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\drsyncd$;'
+ - id: 7528
+   title: "Ensure xinetd is not enabled"
+   description: "The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
+   rationale: "If there are no xinetd services required, it is recommended that the daemon be disabled."
+   remediation: "Run the following command to disable xinetd : # systemctl disable xinetd"
+   compliance:
+    - cis: "2.1.11"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/usr/lib/systemd/system/xinetd.service -> r:Exec;'
+# Section 2.2 - Special Purpose Services
+ - id: 7529
+   title: "Ensure ntp is configured"
+   description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://tools.ietf.org/html/rfc958. ntp can be configured to be a client and/or a server.  This recommendation only applies if ntp is in use on the system."
+   rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
+   remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod limited nomodify notrap nopeer noquery    restrict -6 default kod limited nomodify notrap nopeer noquery    Add or edit server or pool lines to /etc/ntp.conf as appropriate: server <remote-server>    Add or edit the NTPD_OPTIONS in /etc/sysconfig/ntp to include '-u ntp:ntp': NTPD_OPTIONS='-u ntp:ntp'"
+   compliance:
+    - cis: "2.2.1.2"
+    - cis_csc: "6.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'f:/etc/ntp.conf -> r:restrict default kod nomodify notrap nopeer noquery && r:^server;'
+     - 'f:/etc/sysconfig/ntpd -> r:OPTIONS="-u ntp:ntp -p /var/run/ntpd.pid";'
+ - id: 7530
+   title: "Ensure X Window System is not installed"
+   description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+   rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+   remediation: "Run the following command to remove the X Windows System packages: # zypper remove xorg-x11*"
+   compliance:
+    - cis: "2.2.2"
+    - cis_csc: "2"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'f:/usr/lib/systemd/system/default.target -> r:Graphical;'
+     - 'p:gdm-x-session;'
+ - id: 7531
+   title: "Ensure Avahi Server is not enabled"
+   description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+   rationale: "Automatic discovery of network services is not normally required for system functionality.  It is recommended to disable the service to reduce the potential attack surface."
+   remediation: "Run the following command to disable avahi-daemon : # systemctl disable avahi-daemon"
+   compliance:
+    - cis: "2.2.3"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'p:avahi-daemon;'
+ - id: 7532
+   title: "Ensure DHCP Server is not enabled"
+   description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+   rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable dhcpd : # systemctl disable dhcpd"
+   compliance:
+    - cis: "2.2.5"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'f:/usr/lib/systemd/system/dhcpd.service -> r:Exec;'
+ - id: 7533
+   title: "Ensure NFS and RPC are not enabled"
+   description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+   rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
+   remediation: "Run the following commands to disable nfs and rpcbind : # systemctl disable nfs # systemctl disable rpcbind"
+   compliance:
+    - cis: "2.2.7"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dnfs$;'
+     - 'd:$rc_dirs -> ^S\d\dnfslock$;'
+ - id: 7534
+   title: "Ensure DNS Server is not enabled"
+   description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+   rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable named : # systemctl disable named"
+   compliance:
+    - cis: "2.2.8"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dnamed$;'
+ - id: 7535
+   title: "Ensure FTP Server is not enabled"
+   description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
+   rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable vsftpd : # systemctl disable vsftpd    Notes: Additional FTP servers also exist and should be audited."
+   compliance:
+    - cis: "2.2.9"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/vsftpd -> !r:^# && r:disable && r:no;'
+ - id: 7536
+   title: "Ensure HTTP server is not enabled"
+   description: "HTTP or web servers provide the ability to host web site content."
+   rationale: "Unless there is a need to run the system as a web server, it is recommended that the service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable apache2 : # systemctl disable apache2    Notes: Several httpd servers exist and can use other service names. apache, apache2, lighttpd, and nginx are example services that provide an HTTP server. These and other services should also be audited."
+   compliance:
+    - cis: "2.2.10"
+    - cis_csc: "9.1"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dapache2$;'
+ - id: 7537
+   title: "Ensure IMAP and POP3 server is not enabled"
+   description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
+   rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the service be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable dovecot : # systemctl disable dovecot    Notes: Several IMAP/POP3 servers exist and can use other service names. cyrus-imap is an example service that provides an IMAP/POP3 server. These and other services should also be audited."
+   compliance:
+    - cis: "2.2.11"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'f:/etc/xinetd.d/cyrus-imapd -> !r:^# && r:disable && r:no;'
+     - 'f:/etc/xinetd.d/dovecot -> !r:^# && r:disable && r:no;'
+ - id: 7538
+   title: "Ensure Samba is not enabled"
+   description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+   rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable smb : # systemctl disable smb"
+   compliance:
+    - cis: "2.2.12"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dsamba$;'
+     - 'd:$rc_dirs -> ^S\d\dsmb$;'
+ - id: 7539
+   title: "Ensure HTTP Proxy Server is not enabled"
+   description: "Squid is a standard proxy server used in many distributions and environments."
+   rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be disabled to reduce the potential attack surface."
+   remediation: "Run the following command to disable squid : # systemctl disable squid    Notes: Several HTTP proxy servers exist. These and other services should be checked."
+   compliance:
+    - cis: "2.2.13"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dsquid$;'
+ - id: 7540
+   title: "Ensure SNMP Server is not enabled"
+   description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
+   rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
+   remediation: "Run the following command to disable snmpd: # systemctl disable snmpd    Notes: Additional methods of disabling a service exist. Consult your distribution documentation for appropriate methods."
+   compliance:
+    - cis: "2.2.14"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.2"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dsnmpd$;'
+ - id: 7541
+   title: "Ensure NIS Server is not enabled"
+   description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+   rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used"
+   remediation: "Run the following command to disable ypserv : # systemctl disable ypserv"
+   compliance:
+    - cis: "2.2.16"
+    - cis_csc: "9.1"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dypserv$;'
+     - 'f:/usr/lib/systemd/system/ypserv.service -> r:Exec;'
+# Section 2.3 - Service Clients
+ - id: 7542
+   title: "Ensure NIS Client is not installed"
+   description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
+   rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+   remediation: "Run the following command to uninstall ypbind : # zypper remove ypbind"
+   compliance:
+    - cis: "2.3.1"
+    - cis_csc: "2"
+    - pci_dss: "2.2.3"
+   condition: any
+   rules:
+     - 'd:$rc_dirs -> ^S\d\dypbind$;'
+     - 'f:/usr/lib/systemd/system/ypbind.service -> r:Exec;'
+# Section 3.1 - Network Parameters (Host Only)
+ - id: 7543
+   title: "Ensure IP forwarding is disabled"
+   description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
+   rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.ip_forward = 0.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.ip_forward=0 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.1.1"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/ip_forward -> 1;'
+     - 'f:/proc/sys/net/ipv6/ip_forward -> 1;'
+ - id: 7544
+   title: "Ensure packet redirect sending is disabled"
+   description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
+   rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.send_redirects = 0    net.ipv4.conf.default.send_redirects = 0. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.send_redirects=0 # sysctl -w net.ipv4.conf.default.send_redirects=0 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.1.2"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/send_redirects -> 0;'
+     - 'f:/proc/sys/net/ipv4/conf/default/send_redirects -> 0;'
+# Section 3.2 - Network Parameters (Host and Router)
+ - id: 7545
+   title: "Ensure source routed packets are not accepted"
+   description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
+   rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_source_route = 0    net.ipv4.conf.default.accept_source_route = 0.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_source_route=0 # sysctl -w net.ipv4.conf.default.accept_source_route=0 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.2.1"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/accept_source_route -> 1;'
+ - id: 7546
+   title: "Ensure ICMP redirects are not accepted"
+   description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting net.ipv4.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
+   rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_redirects = 0    net.ipv4.conf.default.accept_redirects = 0.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_redirects=0 # sysctl -w net.ipv4.conf.default.accept_redirects=0 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.2"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/accept_redirects -> 1;'
+     - 'f:/proc/sys/net/ipv4/conf/default/accept_redirects -> 1;'
+ - id: 7547
+   title: "Ensure secure ICMP redirects are not accepted"
+   description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
+   rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.secure_redirects = 0    net.ipv4.conf.default.secure_redirects = 0.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.secure_redirects=0 # sysctl -w net.ipv4.conf.default.secure_redirects=0 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.3"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/secure_redirects -> 1;'
+     - 'f:/proc/sys/net/ipv4/conf/default/secure_redirects -> 1;'
+ - id: 7548
+   title: "nsure suspicious packets are logged"
+   description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
+   rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.log_martians = 1    net.ipv4.conf.default.log_martians = 1.  Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.log_martians=1 # sysctl -w net.ipv4.conf.default.log_martians=1 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.4"
+    - cis_csc: "6"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/log_martians -> 0;'
+ - id: 7549
+   title: "Ensure broadcast ICMP requests are ignored"
+   description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
+   rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_echo_ignore_broadcasts = 1    Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.5"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts -> 0;'
+ - id: 7550
+   title: "Ensure bogus ICMP responses are ignored"
+   description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
+   rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_ignore_bogus_error_responses = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1 # sysctl -w net.ipv4.route.flush=1."
+   compliance:
+    - cis: "3.2.6"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/icmp_ignore_bogus_error_responses -> 0;'
+ - id: 7551
+   title: "Ensure Reverse Path Filtering is enabled"
+   description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
+   rationale: "Setting these flags is a good way to deter attackers from sending your system bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
+   remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.rp_filter = 1    net.ipv4.conf.default.rp_filter = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.rp_filter=1 # sysctl -w net.ipv4.conf.default.rp_filter=1 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.2.7"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/conf/all/rp_filter -> 0;'
+     - 'f:/proc/sys/net/ipv4/conf/default/rp_filter -> 0;'
+ - id: 7552
+   title: "Ensure TCP SYN Cookies is enabled"
+   description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
+   rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
+   remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.tcp_syncookies = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.tcp_syncookies=1 # sysctl -w net.ipv4.route.flush=1"
+   compliance:
+    - cis: "3.2.8"
+    - cis_csc: "3, 11"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/proc/sys/net/ipv4/tcp_syncookies -> 0;'
+# Section 5.2 - SSH Server Configuration
+ - id: 7553
+   title: "Ensure SSH Protocol is set to 2"
+   description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
+   rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Protocol 2"
+   compliance:
+    - cis: "5.2.2"
+    - cis_csc: "3.4"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;'
+ - id: 7554
+   title: "Ensure SSH LogLevel is set to INFO"
+   description: "The INFO parameter specifies that login and logout activity will be logged."
+   rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information. INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LogLevel INFO"
+   compliance:
+    - cis: "5.2.3"
+    - cis_csc: "16"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && !r:LogLevel\.+INFO;'
+ - id: 7555
+   title: "Ensure SSH MaxAuthTries is set to 4 or less"
+   description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+   rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxAuthTries 4"
+   compliance:
+    - cis: "5.2.5"
+    - cis_csc: "16"
+    - pci_dss: "2.2.4"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:MaxAuthTries && !r:3\s*$;'
+     - 'f:/etc/ssh/sshd_config -> r:^#\s*MaxAuthTries;'
+     - 'f:/etc/ssh/sshd_config -> !r:MaxAuthTries;'
+ - id: 7556
+   title: "Ensure SSH IgnoreRhosts is enabled"
+   description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+   rationale: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes"
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes"
+   compliance:
+    - cis: "5.2.6"
+    - cis_csc: "9"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:IgnoreRhosts\.+no;'
+ - id: 7557
+   title: "Ensure SSH HostbasedAuthentication is disabled"
+   description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts , or /etc/hosts.equiv , along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
+   rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: HostbasedAuthentication no"
+   compliance:
+    - cis: "5.2.7"
+    - cis_csc: "9"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\.+yes;'
+ - id: 7558
+   title: "Ensure SSH root login is disabled"
+   description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
+   rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident"
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitRootLogin no"
+   compliance:
+    - cis: "5.2.8"
+    - cis_csc: "5.8"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\.+yes;'
+     - 'f:/etc/ssh/sshd_config -> r:^#\s*PermitRootLogin;'
+ - id: 7559
+   title: "Ensure SSH PermitEmptyPasswords is disabled"
+   description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+   rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
+   remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitEmptyPasswords no"
+   compliance:
+    - cis: "5.2.9"
+    - cis_csc: "16"
+    - pci_dss: "4.1"
+   condition: any
+   rules:
+     - 'f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;'
+     - 'f:/etc/ssh/sshd_config -> r:^#\s*PermitEmptyPasswords;'
+# Section 6.2 - User and Group Settings
+ - id: 7560
+   title: "Ensure password fields are not empty"
+   description: "An account with an empty password field means that anybody may log in as that user without providing a password."
+   rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
+   remediation: "If any accounts in the /etc/shadow file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: # passwd -l <username>.  Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
+   compliance:
+    - cis: "6.2.1"
+    - cis_csc: "16"
+    - pci_dss: "10.2.5"
+   condition: any
+   rules:
+     - 'f:/etc/shadow -> r:^\w+::;'
+ - id: 7561
+   title: "Ensure root is the only UID 0 account"
+   description: "Any account with UID 0 has superuser privileges on the system."
+   rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
+   remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
+   compliance:
+    - cis: "6.2.5"
+    - cis_csc: "5.1"
+    - pci_dss: "10.2.5"
+   condition: any
+   rules:
+     - 'f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:;'

--- a/etc/templates/config/sles/11/rootcheck.agent.template
+++ b/etc/templates/config/sles/11/rootcheck.agent.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>${INSTALLDIR}/etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>${INSTALLDIR}/etc/shared/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/sles/11/rootcheck.manager.template
+++ b/etc/templates/config/sles/11/rootcheck.manager.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>${INSTALLDIR}/etc/rootcheck/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>${INSTALLDIR}/etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/sles/11/sca.files
+++ b/etc/templates/config/sles/11/sca.files
@@ -1,0 +1,3 @@
+sles/11/cis_sles11_linux_rcl.yml
+generic/system_audit_rcl.yml
+generic/system_audit_ssh.yml

--- a/etc/templates/config/sles/11/sca.template
+++ b/etc/templates/config/sles/11/sca.template
@@ -1,0 +1,12 @@
+  <sca>
+    <enabled>yes</enabled>
+    <scan_on_start>yes</scan_on_start>
+    <interval>12h</interval>
+    <skip_nfs>yes</skip_nfs>
+
+    <policies>
+      <policy>cis_sles11_linux_rcl.yml</policy>
+      <policy>system_audit_rcl.yml</policy>
+      <policy>system_audit_ssh.yml</policy>
+    </policies>
+  </sca>

--- a/etc/templates/config/sles/12/rootcheck.agent.template
+++ b/etc/templates/config/sles/12/rootcheck.agent.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>${INSTALLDIR}/etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>${INSTALLDIR}/etc/shared/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/sles/12/rootcheck.manager.template
+++ b/etc/templates/config/sles/12/rootcheck.manager.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>${INSTALLDIR}/etc/rootcheck/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>${INSTALLDIR}/etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
+  
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/sles/12/sca.files
+++ b/etc/templates/config/sles/12/sca.files
@@ -1,0 +1,3 @@
+sles/12/cis_sles12_linux_rcl.yml
+generic/system_audit_rcl.yml
+generic/system_audit_ssh.yml

--- a/etc/templates/config/sles/12/sca.template
+++ b/etc/templates/config/sles/12/sca.template
@@ -1,0 +1,12 @@
+  <sca>
+    <enabled>yes</enabled>
+    <scan_on_start>yes</scan_on_start>
+    <interval>12h</interval>
+    <skip_nfs>yes</skip_nfs>
+
+    <policies>
+      <policy>cis_sles12_linux_rcl.yml</policy>
+      <policy>system_audit_rcl.yml</policy>
+      <policy>system_audit_ssh.yml</policy>
+    </policies>
+  </sca>


### PR DESCRIPTION
### Template files

The template and configuration files where missing when installing the `agent` on a Suse 11/12 system. Only the generic files were copied and no configuration template was applied for `sca`.

```
Wait for success...
success
Installing configuration assessment policies...
'../etc/configuration-assessment/generic/system_audit_rcl.yml' -> '/var/ossec/ruleset/configuration-assessment/system_audit_rcl.yml'
'../etc/configuration-assessment/generic/system_audit_ssh.yml' -> '/var/ossec/ruleset/configuration-assessment/system_audit_ssh.yml'
SCAP security policies not available for this OS version.
```