### PR TITLE
Fixes for Docker listener module

### DIFF
--- a/src/config/wmodules-docker.c
+++ b/src/config/wmodules-docker.c
@@ -76,8 +76,8 @@ int wm_docker_read(xml_node **nodes, wmodule *module)
                 return OS_INVALID;
             }
 
-            if (docker->interval < 5) {
-                merror("At module '%s': Interval must be greater than 5 seconds.", WM_DOCKER_CONTEXT.name);
+            if (docker->interval < 1) {
+                merror("At module '%s': Interval must be a positive number.", WM_DOCKER_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_ATTEMPTS)) {

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -76,8 +76,13 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
                 break;
             default:
                 mterror(WM_DOCKER_LOGTAG, "Internal calling. Exiting...");
+                free(command);
+                free(output);
                 pthread_exit(NULL);
         }
+
+        os_free(output);
+        free(command);
 
         if (attempts > docker_conf->attempts) {
             mtinfo(WM_DOCKER_LOGTAG, "Maximum attempts reached to run the listener. Exiting...");

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -85,13 +85,12 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
         free(command);
 
         if (attempts > docker_conf->attempts) {
-            mtinfo(WM_DOCKER_LOGTAG, "Maximum attempts reached to run the listener. Exiting...");
+            mterror(WM_DOCKER_LOGTAG, "Maximum attempts reached to run the listener. Exiting...");
             pthread_exit(NULL);
         }
 
-        mtinfo(WM_DOCKER_LOGTAG, "Docker-listener finished unexpected. Retrying to run it in %u seconds...", docker_conf->interval);
+        mtwarn(WM_DOCKER_LOGTAG, "Docker-listener finished unexpectedly (code %d). Retrying to run it in %u seconds...", status, docker_conf->interval);
         sleep(docker_conf->interval);
-
     }
 
     return NULL;

--- a/src/wazuh_modules/wm_docker.h
+++ b/src/wazuh_modules/wm_docker.h
@@ -16,7 +16,7 @@
 #define WM_DOCKER_LOGTAG ARGV0 ":docker-listener"
 #define WM_DOCKER_SCRIPT_PATH WM_DEFAULT_DIR "/docker/DockerListener"
 
-#define WM_DOCKER_DEF_INTERVAL 600
+#define WM_DOCKER_DEF_INTERVAL 60
 
 typedef struct wm_docker_flags_t {
     unsigned int enabled:1;


### PR DESCRIPTION
|Fixes|Documentation|
|---|---|
|#2678|wazuh/wazuh-documentation#946|

This PR aims to introduce these changes in the Docker listener module:
- Free the memory allocated in the main loop, to prevent the module from leaking memory when relaunching the module helper.
- Set default interval to 1 minute.
- Let the interval be a positive number.