### PR TITLE
Fix for Slack integration

### DIFF
--- a/integrations/slack
+++ b/integrations/slack
@@ -41,7 +41,7 @@ def main(args):
 
     # Read args
     alert_file_location = args[1]
-    webhook = args[3]
+    webhook = args[2]
 
     debug("# Webhook")
     debug(webhook)


### PR DESCRIPTION
Hi team,

This PR closes #2670. Integration with Slack was not working properly after upgrade to 3.9 version. This PR fixes this error.

Best regards,

Demetrio.