### PR TITLE
Prevent single cluster node from waiting for forwarded API requests

### DIFF
--- a/framework/wazuh/cluster/local_client.py
+++ b/framework/wazuh/cluster/local_client.py
@@ -98,6 +98,8 @@ class LocalClient(client.AbstractClientManager):
         elif result.startswith('WazuhException'):
             _, code, message = result.split(' ', 2)
             raise exception.WazuhException(int(code), message)
+        elif result == 'There are no connected worker nodes':
+            request_result = '{}'
         else:
             if self.command == b'dapi' or self.command == b'dapi_forward' or self.command == b'send_file' or \
                     result == 'Sent request to master node':

--- a/framework/wazuh/cluster/local_server.py
+++ b/framework/wazuh/cluster/local_server.py
@@ -105,9 +105,12 @@ class LocalServerHandlerMaster(LocalServerHandler):
             node_name, request = data.split(b' ', 1)
             node_name = node_name.decode()
             if node_name == 'fw_all_nodes':
-                for node_name, node in self.server.node.clients.items():
-                    asyncio.create_task(node.send_request(b'dapi', self.name.encode() + b' ' + request))
-                return b'ok', b'Request forwarded to all worker nodes'
+                if len(self.server.node.clients) > 0:
+                    for node_name, node in self.server.node.clients.items():
+                        asyncio.create_task(node.send_request(b'dapi', self.name.encode() + b' ' + request))
+                    return b'ok', b'Request forwarded to all worker nodes'
+                else:
+                    return b'ok', b'There are no connected worker nodes'
             elif node_name in self.server.node.clients:
                 asyncio.create_task(
                     self.server.node.clients[node_name].send_request(b'dapi', self.name.encode() + b' ' + request))


### PR DESCRIPTION
Hello team,

This PR fixes #2662.

When there are no worker nodes connected in the cluster, requests such as `GET/cluster/configuration/validation` raised a timeout error since the cluster wasn't checking if there were connected worker nodes. This is why it kept waiting for responses even thought no requests were forwarded at all:
```javascript
# curl -u foo:bar "localhost:55000/cluster/configuration/validation?pretty"
{
   "error": 3020,
   "message": "Timeout sending request"
}
```
The `PUT/cluster/restart` API request returned a `CancelledError` since the asyncio task waiting for a forwarded response was cancelled before the timeout exception was raised.

All this can be fixed simply by checking if there are connected worker nodes to forward a request to:
```javascript
# curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/cluster/restart?pretty"
{
   "error": 0,
   "data": "Restarting cluster"
}
# curl -u foo:bar "localhost:55000/cluster/configuration/validation?pretty"
{
   "error": 0,
   "data": {
      "status": "OK"
   }
}
```

Best regards,
Marta