### PR TITLE
Add ability to correlate dynamic fields between events

### DIFF
--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -34,6 +34,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
     Eventinfo *first_lf;
     OSListNode *lf_node;
     int frequency_count = 0;
+    int i, j;
 
     /* Checking if sid search is valid */
     if (!rule->sid_search) {
@@ -91,6 +92,48 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
 
             if (strcmp(lf->srcip, my_lf->srcip) != 0) {
                 continue;
+            }
+        }
+
+        /* Check for repetitions from same dynamic fields */
+        if (rule->context_opts & SAME_FIELD) {
+            if (my_lf->nfields == 0)
+                continue;
+
+            for (i = 0; i < my_lf->nfields; i++) {
+                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
+                    if (lf->nfields == 0)
+                        continue;
+
+                    for (j = 0; j < lf->nfields; j++) {
+                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
+                            if (strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
+                                continue;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /* Check for repetitions from not same dynamic fields */
+        if (rule->context_opts & NOT_SAME_FIELD) {
+            if (my_lf->nfields == 0)
+                continue;
+
+            for (i = 0; i < my_lf->nfields; i++) {
+                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
+                    if (lf->nfields == 0)
+                        continue;
+
+                    for (j = 0; j < lf->nfields; j++) {
+                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
+                            if (!strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
+                                continue;
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -203,6 +246,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
     OSListNode *lf_node;
     Eventinfo *first_lf;
     int frequency_count = 0;
+    int i, j;
     OSList *list = rule->group_search;
 
     //w_mutex_lock(&rule->mutex);
@@ -264,6 +308,48 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
 
             if (strcmp(lf->srcip, my_lf->srcip) != 0) {
                 continue;
+            }
+        }
+
+        /* Check for repetitions from same dynamic fields */
+        if (rule->context_opts & SAME_FIELD) {
+            if (my_lf->nfields == 0)
+                continue;
+
+            for (i = 0; i < my_lf->nfields; i++) {
+                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
+                    if (lf->nfields == 0)
+                        continue;
+
+                    for (j = 0; j < lf->nfields; j++) {
+                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
+                            if (strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
+                                continue;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /* Check for repetitions from not same dynamic fields */
+        if (rule->context_opts & NOT_SAME_FIELD) {
+            if (my_lf->nfields == 0)
+                continue;
+
+            for (i = 0; i < my_lf->nfields; i++) {
+                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
+                    if (lf->nfields == 0)
+                        continue;
+
+                    for (j = 0; j < lf->nfields; j++) {
+                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
+                            if (!strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
+                                continue;
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -377,6 +463,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
     EventNode *first_pt;
     Eventinfo *lf = NULL;
     int frequency_count = 0;
+    int i, j;
 
     w_mutex_lock(&rule->mutex);
 
@@ -448,6 +535,48 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
 
             if (strcmp(lf->srcip, my_lf->srcip) != 0) {
                 goto next_it;
+            }
+        }
+
+        /* Check for repetitions from same dynamic fields */
+        if (rule->context_opts & SAME_FIELD) {
+            if (my_lf->nfields == 0)
+                goto next_it;
+
+            for (i = 0; i < my_lf->nfields; i++) {
+                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
+                    if (lf->nfields == 0)
+                        goto next_it;
+
+                    for (j = 0; j < lf->nfields; j++) {
+                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
+                            if (strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
+                                goto next_it;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /* Check for repetitions from not same dynamic fields */
+        if (rule->context_opts & NOT_SAME_FIELD) {
+            if (my_lf->nfields == 0)
+                goto next_it;
+
+            for (i = 0; i < my_lf->nfields; i++) {
+                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
+                    if (lf->nfields == 0)
+                        goto next_it;
+
+                    for (j = 0; j < lf->nfields; j++) {
+                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
+                            if (!strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
+                                goto next_it;
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -34,7 +34,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
     Eventinfo *first_lf;
     OSListNode *lf_node;
     int frequency_count = 0;
-    int i, j;
+    int i, j, k, found;
 
     /* Checking if sid search is valid */
     if (!rule->sid_search) {
@@ -97,43 +97,53 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
 
         /* Check for repetitions from same dynamic fields */
         if (rule->context_opts & SAME_FIELD) {
-            if (my_lf->nfields == 0)
+            if (my_lf->nfields == 0 || lf->nfields == 0)
                 goto next_it;
 
-            for (i = 0; i < my_lf->nfields; i++) {
-                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
-                    if (lf->nfields == 0)
-                        goto next_it;
-
-                    for (j = 0; j < lf->nfields; j++) {
-                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
-                            if (strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                goto next_it;
+            i = 0;
+            while (rule->same_fields[i]) {
+                found = 0;
+                for (j = 0; j < my_lf->nfields; j++) {
+                    if (!strcmp(rule->same_fields[i], my_lf->fields[j].key)) {
+                        for (k = 0; k < lf->nfields; k++) {
+                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
+                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
+                                    found = 1;
+                                }
                             }
                         }
                     }
                 }
+                if (!found) {
+                    goto next_it;
+                }
+                i++;
             }
         }
 
-        /* Check for repetitions from not same dynamic fields */
+        /* Check for differences from dynamic fields values (not_same_field) */
         if (rule->context_opts & NOT_SAME_FIELD) {
-            if (my_lf->nfields == 0)
+            if (my_lf->nfields == 0 && lf->nfields == 0)
                 goto next_it;
 
-            for (i = 0; i < my_lf->nfields; i++) {
-                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
-                    if (lf->nfields == 0)
-                        goto next_it;
-
-                    for (j = 0; j < lf->nfields; j++) {
-                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
-                            if (!strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                goto next_it;
+            i = 0;
+            while (rule->not_same_fields[i]) {
+                found = 0;
+                for (j = 0; j < my_lf->nfields; j++) {
+                    if (!strcmp(rule->not_same_fields[i], my_lf->fields[j].key)) {
+                        for (k = 0; k < lf->nfields; k++) {
+                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
+                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
+                                    found = 1;
+                                }
                             }
                         }
                     }
                 }
+                if (found) {
+                    goto next_it;
+                }
+                i++;
             }
         }
 
@@ -248,7 +258,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
     OSListNode *lf_node;
     Eventinfo *first_lf;
     int frequency_count = 0;
-    int i, j;
+    int i, j, k, found;
     OSList *list = rule->group_search;
 
     //w_mutex_lock(&rule->mutex);
@@ -315,43 +325,53 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
 
         /* Check for repetitions from same dynamic fields */
         if (rule->context_opts & SAME_FIELD) {
-            if (my_lf->nfields == 0)
+            if (my_lf->nfields == 0 || lf->nfields == 0)
                 goto next_it;
 
-            for (i = 0; i < my_lf->nfields; i++) {
-                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
-                    if (lf->nfields == 0)
-                        goto next_it;
-
-                    for (j = 0; j < lf->nfields; j++) {
-                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
-                            if (strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                goto next_it;
+            i = 0;
+            while (rule->same_fields[i]) {
+                found = 0;
+                for (j = 0; j < my_lf->nfields; j++) {
+                    if (!strcmp(rule->same_fields[i], my_lf->fields[j].key)) {
+                        for (k = 0; k < lf->nfields; k++) {
+                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
+                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
+                                    found = 1;
+                                }
                             }
                         }
                     }
                 }
+                if (!found) {
+                    goto next_it;
+                }
+                i++;
             }
         }
 
-        /* Check for repetitions from not same dynamic fields */
+        /* Check for differences from dynamic fields values (not_same_field) */
         if (rule->context_opts & NOT_SAME_FIELD) {
-            if (my_lf->nfields == 0)
+            if (my_lf->nfields == 0 && lf->nfields == 0)
                 goto next_it;
 
-            for (i = 0; i < my_lf->nfields; i++) {
-                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
-                    if (lf->nfields == 0)
-                        goto next_it;
-
-                    for (j = 0; j < lf->nfields; j++) {
-                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
-                            if (!strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                goto next_it;
+            i = 0;
+            while (rule->not_same_fields[i]) {
+                found = 0;
+                for (j = 0; j < my_lf->nfields; j++) {
+                    if (!strcmp(rule->not_same_fields[i], my_lf->fields[j].key)) {
+                        for (k = 0; k < lf->nfields; k++) {
+                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
+                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
+                                    found = 1;
+                                }
                             }
                         }
                     }
                 }
+                if (found) {
+                    goto next_it;
+                }
+                i++;
             }
         }
 
@@ -467,7 +487,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
     EventNode *first_pt;
     Eventinfo *lf = NULL;
     int frequency_count = 0;
-    int i, j;
+    int i, j, k, found;
 
     w_mutex_lock(&rule->mutex);
 
@@ -544,43 +564,53 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
 
         /* Check for repetitions from same dynamic fields */
         if (rule->context_opts & SAME_FIELD) {
-            if (my_lf->nfields == 0)
+            if (my_lf->nfields == 0 || lf->nfields == 0)
                 goto next_it;
 
-            for (i = 0; i < my_lf->nfields; i++) {
-                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
-                    if (lf->nfields == 0)
-                        goto next_it;
-
-                    for (j = 0; j < lf->nfields; j++) {
-                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
-                            if (strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                goto next_it;
+            i = 0;
+            while (rule->same_fields[i]) {
+                found = 0;
+                for (j = 0; j < my_lf->nfields; j++) {
+                    if (!strcmp(rule->same_fields[i], my_lf->fields[j].key)) {
+                        for (k = 0; k < lf->nfields; k++) {
+                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
+                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
+                                    found = 1;
+                                }
                             }
                         }
                     }
                 }
+                if (!found) {
+                    goto next_it;
+                }
+                i++;
             }
         }
 
-        /* Check for repetitions from not same dynamic fields */
+        /* Check for differences from dynamic fields values (not_same_field) */
         if (rule->context_opts & NOT_SAME_FIELD) {
-            if (my_lf->nfields == 0)
+            if (my_lf->nfields == 0 && lf->nfields == 0)
                 goto next_it;
 
-            for (i = 0; i < my_lf->nfields; i++) {
-                if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
-                    if (lf->nfields == 0)
-                        goto next_it;
-
-                    for (j = 0; j < lf->nfields; j++) {
-                        if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
-                            if (!strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                goto next_it;
+            i = 0;
+            while (rule->not_same_fields[i]) {
+                found = 0;
+                for (j = 0; j < my_lf->nfields; j++) {
+                    if (!strcmp(rule->not_same_fields[i], my_lf->fields[j].key)) {
+                        for (k = 0; k < lf->nfields; k++) {
+                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
+                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
+                                    found = 1;
+                                }
                             }
                         }
                     }
                 }
+                if (found) {
+                    goto next_it;
+                }
+                i++;
             }
         }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -76,39 +76,39 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
         /* Check for same ID */
         if (rule->context_opts & SAME_ID) {
             if ((!lf->id) || (!my_lf->id)) {
-                continue;
+                goto next_it;
             }
 
             if (strcmp(lf->id, my_lf->id) != 0) {
-                continue;
+                goto next_it;
             }
         }
 
         /* Check for repetitions from same src_ip */
         if (rule->context_opts & SAME_SRCIP) {
             if ((!lf->srcip) || (!my_lf->srcip)) {
-                continue;
+                goto next_it;
             }
 
             if (strcmp(lf->srcip, my_lf->srcip) != 0) {
-                continue;
+                goto next_it;
             }
         }
 
         /* Check for repetitions from same dynamic fields */
         if (rule->context_opts & SAME_FIELD) {
             if (my_lf->nfields == 0)
-                continue;
+                goto next_it;
 
             for (i = 0; i < my_lf->nfields; i++) {
                 if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
                     if (lf->nfields == 0)
-                        continue;
+                        goto next_it;
 
                     for (j = 0; j < lf->nfields; j++) {
                         if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
                             if (strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                continue;
+                                goto next_it;
                             }
                         }
                     }
@@ -119,17 +119,17 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
         /* Check for repetitions from not same dynamic fields */
         if (rule->context_opts & NOT_SAME_FIELD) {
             if (my_lf->nfields == 0)
-                continue;
+                goto next_it;
 
             for (i = 0; i < my_lf->nfields; i++) {
                 if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
                     if (lf->nfields == 0)
-                        continue;
+                        goto next_it;
 
                     for (j = 0; j < lf->nfields; j++) {
                         if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
                             if (!strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                continue;
+                                goto next_it;
                             }
                         }
                     }
@@ -142,51 +142,51 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
             /* Check for same source port */
             if (rule->context_opts & SAME_SRCPORT) {
                 if ((!lf->srcport) || (!my_lf->srcport)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->srcport, my_lf->srcport) != 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
             /* Check for same dst port */
             if (rule->context_opts & SAME_DSTPORT) {
                 if ((!lf->dstport) || (!my_lf->dstport)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->dstport, my_lf->dstport) != 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
             /* Check for repetitions on user error */
             if (rule->context_opts & SAME_USER) {
                 if ((!lf->dstuser) || (!my_lf->dstuser)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->dstuser, my_lf->dstuser) != 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
             /* Check for same location */
             if (rule->context_opts & SAME_LOCATION) {
                 if (strcmp(lf->hostname, my_lf->hostname) != 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
             /* Check for different URLs */
             if (rule->context_opts & DIFFERENT_URL) {
                 if ((!lf->url) || (!my_lf->url)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->url, my_lf->url) == 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
@@ -194,10 +194,10 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
             if (rule->context_opts & DIFFERENT_SRCGEOIP) {
 
                 if ((!lf->srcgeoip) || (!my_lf->srcgeoip)) {
-                    continue;
+                    goto next_it;
                 }
                 if (strcmp(lf->srcgeoip, my_lf->srcgeoip) == 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
@@ -219,7 +219,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
 
         if (frequency_count < rule->frequency) {
             frequency_count++;
-            continue;
+            goto next_it;
         }
         frequency_count++;
         /* If reached here, we matched */
@@ -227,6 +227,8 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
         lf->matched = rule->level;
         first_lf->matched = rule->level;
         goto end;
+    next_it:
+        continue;
     } while ((lf_node = lf_node->prev) != NULL);
 
     lf = NULL;
@@ -292,39 +294,39 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         /* Check for same ID */
         if (rule->context_opts & SAME_ID) {
             if ((!lf->id) || (!my_lf->id)) {
-                continue;
+                goto next_it;
             }
 
             if (strcmp(lf->id, my_lf->id) != 0) {
-                continue;
+                goto next_it;
             }
         }
 
         /* Check for repetitions from same src_ip */
         if (rule->context_opts & SAME_SRCIP) {
             if ((!lf->srcip) || (!my_lf->srcip)) {
-                continue;
+                goto next_it;
             }
 
             if (strcmp(lf->srcip, my_lf->srcip) != 0) {
-                continue;
+                goto next_it;
             }
         }
 
         /* Check for repetitions from same dynamic fields */
         if (rule->context_opts & SAME_FIELD) {
             if (my_lf->nfields == 0)
-                continue;
+                goto next_it;
 
             for (i = 0; i < my_lf->nfields; i++) {
                 if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
                     if (lf->nfields == 0)
-                        continue;
+                        goto next_it;
 
                     for (j = 0; j < lf->nfields; j++) {
                         if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
                             if (strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                continue;
+                                goto next_it;
                             }
                         }
                     }
@@ -335,17 +337,17 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         /* Check for repetitions from not same dynamic fields */
         if (rule->context_opts & NOT_SAME_FIELD) {
             if (my_lf->nfields == 0)
-                continue;
+                goto next_it;
 
             for (i = 0; i < my_lf->nfields; i++) {
                 if (!strcmp(rule->same_fields, my_lf->fields[i].key)) {
                     if (lf->nfields == 0)
-                        continue;
+                        goto next_it;
 
                     for (j = 0; j < lf->nfields; j++) {
                         if (!strcmp(my_lf->fields[i].key, lf->fields[j].key)) {
                             if (!strcmp(my_lf->fields[i].value, lf->fields[j].value)) {
-                                continue;
+                                goto next_it;
                             }
                         }
                     }
@@ -358,51 +360,51 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             /* Check for same source port */
             if (rule->context_opts & SAME_SRCPORT) {
                 if ((!lf->srcport) || (!my_lf->srcport)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->srcport, my_lf->srcport) != 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
             /* Check for same dst port */
             if (rule->context_opts & SAME_DSTPORT) {
                 if ((!lf->dstport) || (!my_lf->dstport)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->dstport, my_lf->dstport) != 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
             /* Check for repetitions on user error */
             if (rule->context_opts & SAME_USER) {
                 if ((!lf->dstuser) || (!my_lf->dstuser)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->dstuser, my_lf->dstuser) != 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
             /* Check for same location */
             if (rule->context_opts & SAME_LOCATION) {
                 if (strcmp(lf->hostname, my_lf->hostname) != 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
             /* Check for different URLs */
             if (rule->context_opts & DIFFERENT_URL) {
                 if ((!lf->url) || (!my_lf->url)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->url, my_lf->url) == 0) {
-                    continue;
+                    goto next_it;
                 }
             }
 
@@ -410,11 +412,11 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             if (rule->context_opts & DIFFERENT_SRCGEOIP) {
 
                 if ((!lf->srcgeoip) || (!my_lf->srcgeoip)) {
-                    continue;
+                    goto next_it;
                 }
 
                 if (strcmp(lf->srcgeoip, my_lf->srcgeoip) == 0) {
-                    continue;
+                    goto next_it;
                 }
             }
         }
@@ -434,7 +436,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             }
 
             frequency_count++;
-            continue;
+            goto next_it;
         }
 
         /* If reached here, we matched */
@@ -442,6 +444,8 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         lf->matched = rule->level;
         first_lf->matched = rule->level;
         goto end;
+    next_it:
+        continue;
     } while ((lf_node = lf_node->prev) != NULL);
 
     lf = NULL;

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -34,7 +34,10 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
     Eventinfo *first_lf;
     OSListNode *lf_node;
     int frequency_count = 0;
-    int i, j, k, found;
+    int i;
+    int found;
+    const char * my_field;
+    const char * field;
 
     /* Checking if sid search is valid */
     if (!rule->sid_search) {
@@ -103,17 +106,11 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
             found = 1;
             for (i = 0; rule->same_fields[i] && found; ++i) {
                 found = 0;
-                for (j = 0; j < my_lf->nfields; j++) {
-                    if (!strcmp(rule->same_fields[i], my_lf->fields[j].key)) {
-                        for (k = 0; k < lf->nfields; k++) {
-                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
-                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
-                                    found = 1;
-                                }
-                                break;
-                            }
-                        }
-                        break;
+                my_field = FindField(my_lf, rule->same_fields[i]);
+                if (my_field) {
+                    field = FindField(lf, rule->same_fields[i]);
+                    if (field && strcmp(my_field, field) == 0) {
+                        found = 1;
                     }
                 }
             }
@@ -130,17 +127,11 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
 
             found = 0;
             for (i = 0; rule->not_same_fields[i] && !found; ++i) {
-                for (j = 0; j < my_lf->nfields; j++) {
-                    if (!strcmp(rule->not_same_fields[i], my_lf->fields[j].key)) {
-                        for (k = 0; k < lf->nfields; k++) {
-                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
-                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
-                                    found = 1;
-                                }
-                                break;
-                            }
-                        }
-                        break;
+                my_field = FindField(my_lf, rule->not_same_fields[i]);
+                if (my_field) {
+                    field = FindField(lf, rule->not_same_fields[i]);
+                    if (field && strcmp(my_field, field) == 0) {
+                        found = 1;
                     }
                 }
             }
@@ -259,8 +250,11 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
     OSListNode *lf_node;
     Eventinfo *first_lf;
     int frequency_count = 0;
-    int i, j, k, found;
+    int i;
+    int found;
     OSList *list = rule->group_search;
+    const char * my_field;
+    const char * field;
 
     //w_mutex_lock(&rule->mutex);
 
@@ -333,17 +327,11 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             found = 1;
             for (i = 0; rule->same_fields[i] && found; ++i) {
                 found = 0;
-                for (j = 0; j < my_lf->nfields; j++) {
-                    if (!strcmp(rule->same_fields[i], my_lf->fields[j].key)) {
-                        for (k = 0; k < lf->nfields; k++) {
-                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
-                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
-                                    found = 1;
-                                }
-                                break;
-                            }
-                        }
-                        break;
+                my_field = FindField(my_lf, rule->same_fields[i]);
+                if (my_field) {
+                    field = FindField(lf, rule->same_fields[i]);
+                    if (field && strcmp(my_field, field) == 0) {
+                        found = 1;
                     }
                 }
             }
@@ -361,17 +349,11 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
 
             found = 0;
             for (i = 0; rule->not_same_fields[i] && !found; ++i) {
-                for (j = 0; j < my_lf->nfields; j++) {
-                    if (!strcmp(rule->not_same_fields[i], my_lf->fields[j].key)) {
-                        for (k = 0; k < lf->nfields; k++) {
-                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
-                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
-                                    found = 1;
-                                }
-                                break;
-                            }
-                        }
-                        break;
+                my_field = FindField(my_lf, rule->not_same_fields[i]);
+                if (my_field) {
+                    field = FindField(lf, rule->not_same_fields[i]);
+                    if (field && strcmp(my_field, field) == 0) {
+                        found = 1;
                     }
                 }
             }
@@ -491,7 +473,10 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
     EventNode *first_pt;
     Eventinfo *lf = NULL;
     int frequency_count = 0;
-    int i, j, k, found;
+    int i;
+    int found;
+    const char * my_field;
+    const char * field;
 
     w_mutex_lock(&rule->mutex);
 
@@ -574,17 +559,11 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
             found = 1;
             for (i = 0; rule->same_fields[i] && found; ++i) {
                 found = 0;
-                for (j = 0; j < my_lf->nfields; j++) {
-                    if (!strcmp(rule->same_fields[i], my_lf->fields[j].key)) {
-                        for (k = 0; k < lf->nfields; k++) {
-                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
-                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
-                                    found = 1;
-                                }
-                                break;
-                            }
-                        }
-                        break;
+                my_field = FindField(my_lf, rule->same_fields[i]);
+                if (my_field) {
+                    field = FindField(lf, rule->same_fields[i]);
+                    if (field && strcmp(my_field, field) == 0) {
+                        found = 1;
                     }
                 }
             }
@@ -601,17 +580,11 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
 
             found = 0;
             for (i = 0; rule->not_same_fields[i] && !found; ++i) {
-                for (j = 0; j < my_lf->nfields; j++) {
-                    if (!strcmp(rule->not_same_fields[i], my_lf->fields[j].key)) {
-                        for (k = 0; k < lf->nfields; k++) {
-                            if (!strcmp(my_lf->fields[j].key, lf->fields[k].key)) {
-                                if (!strcmp(my_lf->fields[j].value, lf->fields[k].value)) {
-                                    found = 1;
-                                }
-                                break;
-                            }
-                        }
-                        break;
+                my_field = FindField(my_lf, rule->not_same_fields[i]);
+                if (my_field) {
+                    field = FindField(lf, rule->not_same_fields[i]);
+                    if (field && strcmp(my_field, field) == 0) {
+                        found = 1;
                     }
                 }
             }

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -121,6 +121,7 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_same_location = "same_location";
     const char *xml_same_id = "same_id";
     const char *xml_dodiff = "check_diff";
+    const char *xml_same_field = "same_field";
 
     const char *xml_different_url = "different_url";
     const char *xml_different_srcip = "different_srcip";
@@ -130,6 +131,7 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_notsame_user = "not_same_user";
     const char *xml_notsame_agent = "not_same_agent";
     const char *xml_notsame_id = "not_same_id";
+    const char *xml_notsame_field = "not_same_field";
 
     const char *xml_options = "options";
 
@@ -922,6 +924,18 @@ int Rules_OP_ReadRules(const char *rulefile)
                                           xml_notsame_agent) == 0) {
                         config_ruleinfo->context_opts &= NOT_SAME_AGENT;
                     } else if (strcasecmp(rule_opt[k]->element,
+                                          xml_same_field) == 0) {
+
+                        config_ruleinfo->context_opts |= SAME_FIELD;
+                        os_strdup(rule_opt[k]->content, config_ruleinfo->same_fields);
+
+                    } else if (strcasecmp(rule_opt[k]->element,
+                                          xml_notsame_field) == 0) {
+
+                        config_ruleinfo->context_opts |= NOT_SAME_FIELD;
+                        os_strdup(rule_opt[k]->content, config_ruleinfo->not_same_fields);
+
+                    } else if (strcasecmp(rule_opt[k]->element,
                                           xml_options) == 0) {
                         if (strcmp("alert_by_email",
                                    rule_opt[k]->content) == 0) {
@@ -1580,6 +1594,9 @@ RuleInfo *zerorulemember(int id, int level,
     ruleinfo_pt->action = NULL;
     ruleinfo_pt->location = NULL;
     os_calloc(Config.decoder_order_size, sizeof(FieldInfo*), ruleinfo_pt->fields);
+
+    ruleinfo_pt->same_fields = NULL;
+    ruleinfo_pt->not_same_fields = NULL;
 
     /* Zeroing the list of previous matches */
     ruleinfo_pt->sid_prev_matched = NULL;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -926,14 +926,44 @@ int Rules_OP_ReadRules(const char *rulefile)
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_field) == 0) {
 
-                        config_ruleinfo->context_opts |= SAME_FIELD;
-                        os_strdup(rule_opt[k]->content, config_ruleinfo->same_fields);
+                        if (config_ruleinfo->context_opts & SAME_FIELD) {
+
+                            int size;
+                            for (size = 0; config_ruleinfo->same_fields[size] != NULL; size++);
+
+                            os_realloc(config_ruleinfo->same_fields, (size + 2) * sizeof(char *), config_ruleinfo->same_fields);
+                            os_strdup(rule_opt[k]->content, config_ruleinfo->same_fields[size]);
+                            config_ruleinfo->same_fields[size + 1] = NULL;
+
+                        } else {
+
+                            config_ruleinfo->context_opts |= SAME_FIELD;
+                            os_calloc(2, sizeof(char *), config_ruleinfo->same_fields);
+                            os_strdup(rule_opt[k]->content, config_ruleinfo->same_fields[0]);
+                            config_ruleinfo->same_fields[1] = NULL;
+
+                        }
 
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_notsame_field) == 0) {
 
-                        config_ruleinfo->context_opts |= NOT_SAME_FIELD;
-                        os_strdup(rule_opt[k]->content, config_ruleinfo->not_same_fields);
+                        if (config_ruleinfo->context_opts & NOT_SAME_FIELD) {
+                            
+                            int size;
+                            for (size = 0; config_ruleinfo->not_same_fields[size] != NULL; size++);
+
+                            os_realloc(config_ruleinfo->not_same_fields, (size + 2) * sizeof(char *), config_ruleinfo->not_same_fields);
+                            os_strdup(rule_opt[k]->content, config_ruleinfo->not_same_fields[size]);
+                            config_ruleinfo->not_same_fields[size + 1] = NULL;
+
+                        } else {
+
+                            config_ruleinfo->context_opts |= NOT_SAME_FIELD;
+                            os_calloc(2, sizeof(char *), config_ruleinfo->not_same_fields);
+                            os_strdup(rule_opt[k]->content, config_ruleinfo->not_same_fields[0]);
+                            config_ruleinfo->not_same_fields[1] = NULL;
+
+                        }
 
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_options) == 0) {

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -27,11 +27,13 @@
 #define DIFFERENT_SRCGEOIP  0x400
 #define SAME_SRCPORT        0x020
 #define SAME_DSTPORT        0x040
+#define SAME_FIELD          0x080
 #define SAME_DODIFF         0x100
 #define NOT_SAME_USER       0xffe /* 0xfff - 0x001  */
 #define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002  */
 #define NOT_SAME_ID         0xffb /* 0xfff - 0x004  */
 #define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
+#define NOT_SAME_FIELD      0xf7f /* 0xfff - 0x080 */
 
 /* Alert options  - store on a uint16 */
 #define DO_FTS          0x0001
@@ -176,6 +178,10 @@ typedef struct _RuleInfo {
 
     /* Pointer to the previous rule matched */
     void *prev_rule;
+
+    /* Dynamic fields to compare between events */
+    char *same_fields;
+    char *not_same_fields;
 } RuleInfo;
 
 
@@ -250,7 +256,7 @@ int _setlevels(RuleNode *node, int nnode);
 #define SYSCOLLECTOR_MOD    "syscollector"
 #define CISCAT_MOD          "ciscat"
 #define WINEVT_MOD          "windows_eventchannel"
-#define SCA_MOD "sca"
+#define SCA_MOD             "sca"
 /* Global variables */
 extern int _max_freq;
 extern int default_timeframe;

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -27,13 +27,13 @@
 #define DIFFERENT_SRCGEOIP  0x400
 #define SAME_SRCPORT        0x020
 #define SAME_DSTPORT        0x040
-#define SAME_FIELD          0x080
 #define SAME_DODIFF         0x100
+#define SAME_FIELD          0x200
+#define NOT_SAME_FIELD      0x400
 #define NOT_SAME_USER       0xffe /* 0xfff - 0x001  */
 #define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002  */
 #define NOT_SAME_ID         0xffb /* 0xfff - 0x004  */
 #define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
-#define NOT_SAME_FIELD      0xf7f /* 0xfff - 0x080 */
 
 /* Alert options  - store on a uint16 */
 #define DO_FTS          0x0001
@@ -180,8 +180,8 @@ typedef struct _RuleInfo {
     void *prev_rule;
 
     /* Dynamic fields to compare between events */
-    char *same_fields;
-    char *not_same_fields;
+    char ** same_fields;
+    char ** not_same_fields;
 } RuleInfo;
 
 

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -25,11 +25,13 @@
 #define DIFFERENT_SRCGEOIP  0x400
 #define SAME_SRCPORT        0x020
 #define SAME_DSTPORT        0x040
+#define SAME_FIELD          0x080
 #define SAME_DODIFF         0x100
 #define NOT_SAME_USER       0xffe /* 0xfff - 0x001 */
 #define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002 */
 #define NOT_SAME_ID         0xffb /* 0xfff - 0x004 */
 #define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
+#define NOT_SAME_FIELD      0xf7f /* 0xfff - 0x080 */
 
 /* Alert options - stored in a uint8 */
 #define DO_FTS          0x0001
@@ -149,6 +151,10 @@ typedef struct _RuleInfo {
 
     void **ar;
     pthread_mutex_t mutex;
+
+    /* Dynamic fields to compare between events */
+    char *same_fields;
+    char *not_same_fields;
 
 } RuleInfo;
 

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -25,13 +25,13 @@
 #define DIFFERENT_SRCGEOIP  0x400
 #define SAME_SRCPORT        0x020
 #define SAME_DSTPORT        0x040
-#define SAME_FIELD          0x080
 #define SAME_DODIFF         0x100
+#define SAME_FIELD          0x200
+#define NOT_SAME_FIELD      0x400
 #define NOT_SAME_USER       0xffe /* 0xfff - 0x001 */
 #define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002 */
 #define NOT_SAME_ID         0xffb /* 0xfff - 0x004 */
 #define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
-#define NOT_SAME_FIELD      0xf7f /* 0xfff - 0x080 */
 
 /* Alert options - stored in a uint8 */
 #define DO_FTS          0x0001
@@ -153,8 +153,8 @@ typedef struct _RuleInfo {
     pthread_mutex_t mutex;
 
     /* Dynamic fields to compare between events */
-    char *same_fields;
-    char *not_same_fields;
+    char ** same_fields;
+    char ** not_same_fields;
 
 } RuleInfo;
 

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -91,6 +91,7 @@ int OS_ReadXMLRules(const char *rulefile,
     const char *xml_same_location = "same_location";
     const char *xml_same_id = "same_id";
     const char *xml_dodiff = "check_diff";
+    const char *xml_same_field = "same_field";
 
     const char *xml_different_url = "different_url";
 
@@ -98,6 +99,7 @@ int OS_ReadXMLRules(const char *rulefile,
     const char *xml_notsame_user = "not_same_user";
     const char *xml_notsame_agent = "not_same_agent";
     const char *xml_notsame_id = "not_same_id";
+    const char *xml_notsame_field = "not_same_field";
 
     const char *xml_options = "options";
 
@@ -546,6 +548,18 @@ int OS_ReadXMLRules(const char *rulefile,
                                       xml_notsame_agent) == 0) {
                     config_ruleinfo->context_opts &= NOT_SAME_AGENT;
                 } else if (strcasecmp(rule_opt[k]->element,
+                                      xml_same_field) == 0) {
+
+                    config_ruleinfo->context_opts |= SAME_FIELD;
+                    os_strdup(rule_opt[k]->content, config_ruleinfo->same_fields);
+
+                } else if (strcasecmp(rule_opt[k]->element,
+                                        xml_notsame_field) == 0) {
+
+                    config_ruleinfo->context_opts |= NOT_SAME_FIELD;
+                    os_strdup(rule_opt[k]->content, config_ruleinfo->not_same_fields);
+
+                } else if (strcasecmp(rule_opt[k]->element,
                                       xml_options) == 0) {
                     if (strcmp("alert_by_email",
                                rule_opt[k]->content) == 0) {
@@ -976,6 +990,9 @@ static RuleInfo *_OS_AllocateRule()
     ruleinfo_pt->action = NULL;
     ruleinfo_pt->location = NULL;
 
+    ruleinfo_pt->same_fields = NULL;
+    ruleinfo_pt->not_same_fields = NULL;
+
     /* Zero the list of previous matches */
     ruleinfo_pt->sid_prev_matched = NULL;
     ruleinfo_pt->group_prev_matched = NULL;
@@ -1141,6 +1158,14 @@ void _OS_FreeRule(RuleInfo *ruleinfo) {
     free(ruleinfo->if_sid);
     free(ruleinfo->if_level);
     free(ruleinfo->if_group);
+
+    if (ruleinfo->same_fields) {
+        free(ruleinfo->same_fields);
+    }
+
+    if (ruleinfo->not_same_fields) {
+        free(ruleinfo->not_same_fields);
+    }
 
     free(ruleinfo);
 }

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -550,14 +550,44 @@ int OS_ReadXMLRules(const char *rulefile,
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_same_field) == 0) {
 
-                    config_ruleinfo->context_opts |= SAME_FIELD;
-                    os_strdup(rule_opt[k]->content, config_ruleinfo->same_fields);
+                    if (config_ruleinfo->context_opts & SAME_FIELD) {
+
+                        int size;
+                        for (size = 0; config_ruleinfo->same_fields[size] != NULL; size++);
+
+                        os_realloc(config_ruleinfo->same_fields, (size + 2) * sizeof(char *), config_ruleinfo->same_fields);
+                        os_strdup(rule_opt[k]->content, config_ruleinfo->same_fields[size]);
+                        config_ruleinfo->same_fields[size + 1] = NULL;
+
+                    } else {
+
+                        config_ruleinfo->context_opts |= SAME_FIELD;
+                        os_calloc(2, sizeof(char *), config_ruleinfo->same_fields);
+                        os_strdup(rule_opt[k]->content, config_ruleinfo->same_fields[0]);
+                        config_ruleinfo->same_fields[1] = NULL;
+
+                    }
 
                 } else if (strcasecmp(rule_opt[k]->element,
                                         xml_notsame_field) == 0) {
 
-                    config_ruleinfo->context_opts |= NOT_SAME_FIELD;
-                    os_strdup(rule_opt[k]->content, config_ruleinfo->not_same_fields);
+                    if (config_ruleinfo->context_opts & NOT_SAME_FIELD) {
+                            
+                        int size;
+                        for (size = 0; config_ruleinfo->not_same_fields[size] != NULL; size++);
+
+                        os_realloc(config_ruleinfo->not_same_fields, (size + 2) * sizeof(char *), config_ruleinfo->not_same_fields);
+                        os_strdup(rule_opt[k]->content, config_ruleinfo->not_same_fields[size]);
+                        config_ruleinfo->not_same_fields[size + 1] = NULL;
+
+                    } else {
+
+                        config_ruleinfo->context_opts |= NOT_SAME_FIELD;
+                        os_calloc(2, sizeof(char *), config_ruleinfo->not_same_fields);
+                        os_strdup(rule_opt[k]->content, config_ruleinfo->not_same_fields[0]);
+                        config_ruleinfo->not_same_fields[1] = NULL;
+
+                    }
 
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_options) == 0) {
@@ -1160,10 +1190,16 @@ void _OS_FreeRule(RuleInfo *ruleinfo) {
     free(ruleinfo->if_group);
 
     if (ruleinfo->same_fields) {
+        for (i = 0; ruleinfo->same_fields[i] != NULL; i++) {
+            free(ruleinfo->same_fields[i]);
+        }
         free(ruleinfo->same_fields);
     }
 
     if (ruleinfo->not_same_fields) {
+        for (i = 0; ruleinfo->not_same_fields[i] != NULL; i++) {
+            free(ruleinfo->not_same_fields[i]);
+        }
         free(ruleinfo->not_same_fields);
     }
 


### PR DESCRIPTION
This PR aims to solve the use case of #2531 and cover the misfunction reported at #2524.

### Description

Two options have been added to the rule options:

- `same_field`: It matches when the value of a dynamic field from an incoming event is the same as the one of a previous event which matched the same rule.
- `not_same_field`: The same case but when the value is different between both events.

### Use case

Here we can see a simple example of using these two new options:

```xml
<rule id="100001" level="3">
    <if_sid>221</if_sid>
    <field name="netinfo.iface.name">ens33</field>
    <description>Testing interface alert</description>
  </rule>

  <rule id="100002" level="7" frequency="3" timeframe="300">
    <if_matched_sid>100001</if_matched_sid>
    <same_field>netinfo.iface.name</same_field>
    <same_field>netinfo.iface.mac</same_field>
    <not_same_field>netinfo.iface.rx_bytes</not_same_field>
    <options>no_full_log</options>
    <description>Testing options for correlating repeated fields</description>
  </rule>
```

Rule 10002 matches when the third network inventory scan reports the same MAC address for the interface `ens33` but the amount of received packets has changed between events. Here we have the associated alert:

```json
{
  "timestamp": "2019-02-25T07:49:50.581-0800",
  "rule": {
    "level": 7,
    "description": "Testing options for correlating repeated fields",
    "id": "100002",
    "frequency": 3,
    "firedtimes": 3,
  ...
  "data": {
    "type": "network",
    "netinfo": {
      "iface": {
        "name": "ens33",
        "type": "ethernet",
        "state": "up",
        "mtu": "1500",
        "mac": "00:0c:29:58:1c:4c",
        "tx_packets": "8718126",
        "rx_packets": "9207404",
        "tx_bytes": "2070054274",
        "rx_bytes": "1340293681",
        "tx_errors": "0",
        "rx_errors": "0",
        "tx_dropped": "0",
        "rx_dropped": "0",
        "ipv4": {
          "gateway": "unknown",
          "dhcp": "disabled",
          "address": "172.16.98.128",
          "netmask": "255.255.255.0",
          "broadcast": "172.16.98.255"
        },
        "ipv6": {
          "dhcp": "enabled",
          "address": "fe80::20c:29ff:fe58:1c4c",
          "netmask": "ffff:ffff:ffff:ffff::"
        }
      }
    }
  },
  "location": "syscollector"
}
```

### Valgrind report

It has been tested by using `valgrind` on the Analysis daemon and this is the result:

```
==89372== LEAK SUMMARY:
==89372==    definitely lost: 100 bytes in 9 blocks
==89372==    indirectly lost: 0 bytes in 0 blocks
==89372==      possibly lost: 7,072 bytes in 26 blocks
==89372==    still reachable: 10,214,019 bytes in 46,925 blocks
==89372==         suppressed: 0 bytes in 0 blocks
==89372== Reachable blocks (those to which a pointer was found) are not shown.
==89372== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

Lost memory is related to known issues when creating the child threads.