### PR TITLE
Add -t and -c options in wazuh-clusterd daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - The real agent IP is reported by the agent and shown in alerts and the App interface. ([#2577](https://github.com/wazuh/wazuh/pull/2577))
 - Added support for organizations in AWS wodle. ([#2627](https://github.com/wazuh/wazuh/pull/2627))
 - Added support for hot added symbolic links in _Whodata_. ([#2466](https://github.com/wazuh/wazuh/pull/2466))
+- Added `-t` option to `wazuh-clusterd` binary ([#2691](https://github.com/wazuh/wazuh/pull/2691)).
 
 ### Changed
 

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -121,6 +121,8 @@ if __name__ == '__main__':
     parser.add_argument('-V', help="Print version", action='store_true', dest="version")
     parser.add_argument('-r', help="Run as root", action='store_true', dest='root')
     parser.add_argument('-t', help="Test configuration", action='store_true', dest='test_config')
+    parser.add_argument('-c', help="Configuration file to use", type=str, metavar='config', dest='config_file',
+                        default=common.ossec_conf)
     args = parser.parse_args()
 
     my_wazuh = Wazuh(get_init=True)
@@ -128,10 +130,6 @@ if __name__ == '__main__':
     if args.version:
         print_version()
         sys.exit(0)
-
-    # Foreground/Daemon
-    if not args.foreground:
-        pyDaemonModule.pyDaemon()
 
     # Set logger
     try:
@@ -146,7 +144,7 @@ if __name__ == '__main__':
 
     main_logger = set_logging(args.foreground, debug_mode)
 
-    cluster_configuration = cluster.read_config()
+    cluster_configuration = cluster.read_config(config_file=args.config_file)
     cluster_items = cluster.get_cluster_items()
     try:
         cluster.check_cluster_config(cluster_configuration)
@@ -159,6 +157,10 @@ if __name__ == '__main__':
 
     # clean
     cluster.clean_up()
+
+    # Foreground/Daemon
+    if not args.foreground:
+        pyDaemonModule.pyDaemon()
 
     # Drop privileges to ossec
     if not args.root:

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -85,7 +85,7 @@ def get_cluster_items_worker_intervals():
     return get_cluster_items()['intervals']['worker']
 
 
-def read_config():
+def read_config(config_file=common.ossec_conf):
     cluster_default_configuration = {
         'disabled': False,
         'node_type': 'master',
@@ -99,7 +99,7 @@ def read_config():
     }
 
     try:
-        config_cluster = get_ossec_conf('cluster')
+        config_cluster = get_ossec_conf(section='cluster', conf_file=config_file)
     except WazuhException as e:
         if e.code == 1106:
             # if no cluster configuration is present in ossec.conf, return default configuration but disabling it.

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -61,9 +61,6 @@ def check_cluster_config(config):
     if len(invalid_elements) != 0:
         raise WazuhException(3004, "Invalid elements in node fields: {0}.".format(', '.join(invalid_elements)))
 
-    if not isinstance(config['port'], int):
-        raise WazuhException(3004, "Cluster port must be an integer.")
-
 
 def get_cluster_items():
     try:
@@ -116,6 +113,9 @@ def read_config():
     # if any value is missing from user's cluster configuration, add the default one:
     for value_name in set(cluster_default_configuration.keys()) - set(config_cluster.keys()):
         config_cluster[value_name] = cluster_default_configuration[value_name]
+
+    if isinstance(config_cluster['port'], str) and not config_cluster['port'].isdigit():
+        raise WazuhException(3004, "Cluster port must be an integer.")
 
     config_cluster['port'] = int(config_cluster['port'])
     if config_cluster['disabled'] == 'no':

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -51,6 +51,9 @@ def check_cluster_config(config):
         raise WazuhException(3004, 'Invalid node type {0}. Correct values are master and worker'.format(
             config['node_type']))
 
+    elif not 1024 < config['port'] < 65535:
+        raise WazuhException(3004, "Port must be higher than 1024 and lower than 65535.")
+
     if len(config['nodes']) > 1:
         logger.warning(
             "Found more than one node in configuration. Only master node should be specified. Using {} as master.".

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -122,7 +122,7 @@ def read_config():
         config_cluster['disabled'] = False
     elif config_cluster['disabled'] == 'yes':
         config_cluster['disabled'] = True
-    else:
+    elif not isinstance(config_cluster['disabled'], bool):
         raise WazuhException(3004, "Allowed values for 'disabled' field are 'yes' and 'no'. Found: '{}'".format(
             config_cluster['disabled']))
 

--- a/framework/wazuh/cluster/tests/test_cluster.py
+++ b/framework/wazuh/cluster/tests/test_cluster.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from unittest.mock import patch
+from wazuh.exception import WazuhException
+from wazuh.cluster import cluster
+import pytest
+
+# Valid configurations
+default_cluster_configuration = {
+    'disabled': 'yes',
+    'node_type': 'master',
+    'name': 'wazuh',
+    'node_name': 'node01',
+    'key': '',
+    'port': 1516,
+    'bind_addr': '0.0.0.0',
+    'nodes': ['NODE_IP'],
+    'hidden': 'no'
+}
+
+custom_cluster_configuration = {
+    'disabled': 'no',
+    'node_type': 'master',
+    'name': 'wazuh',
+    'node_name': 'node01',
+    'key': 'a'*32,
+    'port': 1516,
+    'bind_addr': '0.0.0.0',
+    'nodes': ['172.10.0.100'],
+    'hidden': False
+}
+
+custom_incomplete_configuration = {
+    'key': 'a'*32,
+    'node_name': 'master'
+}
+
+
+def test_read_empty_configuration():
+    """
+    Tests reading an empty cluster configuration
+    """
+    with patch('wazuh.cluster.cluster.get_ossec_conf') as m:
+        m.side_effect = WazuhException(1106)
+        configuration = cluster.read_config()
+        configuration['disabled'] = 'yes' if configuration['disabled'] else 'no'
+        assert configuration == default_cluster_configuration
+
+
+@pytest.mark.parametrize('read_config', [
+    default_cluster_configuration,
+    custom_cluster_configuration,
+    custom_incomplete_configuration
+])
+def test_read_configuration(read_config):
+    """
+    Tests reading the cluster configuration from ossec.conf
+    """
+    with patch('wazuh.cluster.cluster.get_ossec_conf') as m:
+        m.return_value = read_config.copy()
+        configuration = cluster.read_config()
+        configuration['disabled'] = 'yes' if configuration['disabled'] else 'no'
+        for k in read_config.keys():
+            assert configuration[k] == read_config[k]
+
+        # values not present in the read user configuration will be filled with default values
+        if 'disabled' not in read_config and read_config != {}:
+            default_cluster_configuration['disabled'] = 'no'
+        for k in default_cluster_configuration.keys() - read_config.keys():
+            assert configuration[k] == default_cluster_configuration[k]
+
+
+@pytest.mark.parametrize('read_config', [
+    {'disabled': 'yay'},
+    {'key': ''},
+    {'key': 'a'*15},
+    {'port': 'string'},
+    {'node_type': 'random'},
+    {'nodes': ['NODE_IP']},
+    {'nodes': ['localhost']},
+    {'nodes': ['0.0.0.0']},
+    {'nodes': ['172.0.1.1']}
+])
+def test_checking_configuration(read_config):
+    """
+    Checks wrong configurations to check the proper exceptions are raised
+    """
+    with patch('wazuh.cluster.cluster.get_ossec_conf') as m:
+        m.return_value = read_config.copy()
+        with pytest.raises(WazuhException, match=r'3004'):
+            configuration = cluster.read_config()
+            cluster.check_cluster_config(configuration)

--- a/framework/wazuh/cluster/tests/test_cluster.py
+++ b/framework/wazuh/cluster/tests/test_cluster.py
@@ -74,14 +74,16 @@ def test_read_configuration(read_config):
 
 @pytest.mark.parametrize('read_config', [
     {'disabled': 'yay'},
-    {'key': ''},
-    {'key': 'a'*15},
-    {'port': 'string'},
-    {'node_type': 'random'},
-    {'nodes': ['NODE_IP']},
-    {'nodes': ['localhost']},
-    {'nodes': ['0.0.0.0']},
-    {'nodes': ['172.0.1.1']}
+    {'key': '', 'nodes': ['192.158.35.13']},
+    {'key': 'a'*15, 'nodes': ['192.158.35.13']},
+    {'port': 'string', 'key': 'a'*32, 'nodes': ['192.158.35.13']},
+    {'port': 90, 'key': 'a'*32, 'nodes': ['192.158.35.13']},
+    {'port': 70000, 'key': 'a'*32, 'nodes': ['192.158.35.13']},
+    {'node_type': 'random', 'key': 'a'*32, 'nodes': ['192.158.35.13']},
+    {'nodes': ['NODE_IP'], 'key': 'a'*32},
+    {'nodes': ['localhost'], 'key': 'a'*32},
+    {'nodes': ['0.0.0.0'], 'key': 'a'*32},
+    {'nodes': ['127.0.1.1'], 'key': 'a'*32}
 ])
 def test_checking_configuration(read_config):
     """
@@ -89,6 +91,6 @@ def test_checking_configuration(read_config):
     """
     with patch('wazuh.cluster.cluster.get_ossec_conf') as m:
         m.return_value = read_config.copy()
-        with pytest.raises(WazuhException, match=r'3004'):
+        with pytest.raises(WazuhException, match=r'.* 3004 .*'):
             configuration = cluster.read_config()
             cluster.check_cluster_config(configuration)

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -431,18 +431,18 @@ def _ar_conf2json(file_path):
 
 
 # Main functions
-def get_ossec_conf(section=None, field=None):
+def get_ossec_conf(section=None, field=None, conf_file=common.ossec_conf):
     """
     Returns ossec.conf (manager) as dictionary.
 
     :param section: Filters by section (i.e. rules).
     :param field: Filters by field in section (i.e. included).
+    :param conf_file: Path of the configuration file to read.
     :return: ossec.conf (manager) as dictionary.
     """
-
     try:
         # Read XML
-        xml_data = load_wazuh_xml(common.ossec_conf)
+        xml_data = load_wazuh_xml(conf_file)
 
         # Parse XML to JSON
         data = _ossecconf2json(xml_data)

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -249,9 +249,6 @@ testconfig()
 {
     # We first loop to check the config.
     for i in ${SDAEMONS}; do
-        if [ X"$i" = "Xwazuh-clusterd" ]; then
-            continue
-        fi
         ${DIR}/bin/${i} -t ${DEBUG_CLI};
         if [ $? != 0 ]; then
             if [ $USE_JSON = true ]; then


### PR DESCRIPTION
Hello team,

This PR closes #2687. It also adds unit tests to test cluster how cluster configuration is read and checked.

If cluster configuration is wrong, wazuh won't start any other binary:
```shellsession
# /var/ossec/bin/ossec-control start
2019/02/25 17:17:48 ossec-analysisd: ERROR: Detected a not allowed node type 'pepe'. Valid types are 'master' and 'worker'.
2019/02/25 17:17:48 ossec-analysisd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
2019/02/25 17:17:48 ossec-analysisd: CRITICAL: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
ossec-analysisd: Configuration error. Exiting
# ps aux | grep ossec
ossec     7767  0.0  9.7 931964 48092 ?        Ssl  17:13   0:00 /usr/bin/nodejs /var/ossec/api/app.js
root     14963  0.0  0.2  14856  1056 pts/0    S+   17:18   0:00 grep --color=auto ossec
```

Best regards,
Marta