### PR TITLE
Prevent Execd from becoming defunct when Active Response disabled

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -149,7 +149,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     /* Connect to the execd queue */
     if (agt->execdq == 0) {
         if ((agt->execdq = StartMQ(EXECQUEUE, WRITE)) < 0) {
-            merror("Unable to connect to the active response "
+            minfo("Unable to connect to the active response "
                    "queue (disabled).");
             agt->execdq = -1;
         }

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -81,6 +81,7 @@ int main(int argc, char **argv)
     gid_t gid;
     int m_queue = 0;
     int debug_level = 0;
+    pthread_t wcom_thread;
 
     const char *group = GROUPGLOBAL;
     const char *cfg = DEFAULTCPATH;
@@ -178,14 +179,17 @@ int main(int argc, char **argv)
 #endif
 
     // Start com request thread
-    w_create_thread(wcom_main, NULL);
+    if (CreateThreadJoinable(&wcom_thread, wcom_main, NULL) < 0) {
+        exit(EXIT_FAILURE);
+    }
 
     /* Start up message */
     minfo(STARTUP_MSG, (int)getpid());
 
-    /* If AR is disabled, close this thread */
+    /* If AR is disabled, do not continue */
     if (c == 1) {
-        pthread_exit(NULL);
+        pthread_join(wcom_thread, NULL);
+        exit(EXIT_SUCCESS);
     }
 
     /* Start exec queue */


### PR DESCRIPTION
Execd performs two main tasks:

- Active Response.
- Command dispatching.

This means that Execd must run either Active Response is enabled or disabled.

But, if We disable Active Response:
```xml
<active-response>
  <disabled>yes</disabled>
</active-response>
```

Then, Execd appears as *defunct*:
```
# ps -ef | grep defu
root     29916     1  0 13:12 ?        00:00:00 [ossec-execd] <defunct>
```

## Rationale

Execd starts the command dispatching thread after parsing its configuration. Then, if Active Response is disabled, it closes its main thread (`pthread_exit()`). This works but lets Execd appear as defunct.

## Proposed fix
Let Execd join the command dispatcher thread instead of closing the main thread.