### PR TITLE
Added command execution capability for Security Configuration Assessment

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -373,9 +373,16 @@ wazuh_command.remote_commands=0
 # Wazuh default stack size for child threads in KiB (2048..65536)
 wazuh.thread_stack_size=8192
 
-# Security Configuration Assessment DB request interval in minutes
+# Security Configuration Assessment DB request interval in minutes [0..60]
+# This option sets the maximum waiting time to resend a scan when the DB integrity check fails
 sca.request_db_interval=5
 
+# Enable it to accept execute commands from SCA policies pushed from the manager in the shared configuration
+# Local policies ignore this option
+sca.remote_commands=0
+
+# Default timeout for executed commands during a SCA scan in seconds [1..300]
+sca.commands_timeout=30
 
 # Network timeout for Authd clients
 auth.timeout_seconds=1

--- a/etc/sca/generic/system_audit_ssh.yml
+++ b/etc/sca/generic/system_audit_ssh.yml
@@ -36,7 +36,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^# && r:Port\.+22;'
+     - 'c:sshd -T -> !r:^# && r:port\.+22;'
  - id: 1501
    title: "SSH Hardening - 2: Protocol 1"
    description: "The SSH protocol should not be 1."
@@ -46,7 +46,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^# && r:Protocol\.+1;'
+     - 'c:sshd -T -> !r:^# && r:protocol\.+1;'
  - id: 1502
    title: "SSH Hardening - 3: Root can log in"
    description: "The option PermitRootLogin should be set to no."
@@ -54,7 +54,7 @@ checks:
    remediation: "Change the PermitRootLogin option value in the sshd_config file."
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^\s*PermitRootLogin\.+no;'
+     - 'c:sshd -T -> !r:^\s*permitrootlogin\.+no;'
  - id: 1503
    title: "SSH Hardening - 4: No Public Key authentication"
    description: "The option PubkeyAuthentication should be set yes."
@@ -64,7 +64,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^\s*PubkeyAuthentication\.+yes;'
+     - 'c:sshd -T -> !r:^\s*pubkeyauthentication\.+yes;'
  - id: 1504
    title: "SSH Hardening - 5: Password Authentication"
    description: "The option PasswordAuthentication should be set to no."
@@ -74,7 +74,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^\s*PasswordAuthentication\.+no;'
+     - 'c:sshd -T -> !r:^\s*passwordauthentication\.+no;'
  - id: 1505
    title: "SSH Hardening - 6: Empty passwords allowed"
    description: "The option PermitEmptyPasswords should be set to no."
@@ -84,7 +84,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^\s*PermitEmptyPasswords\.+no;'
+     - 'c:sshd -T -> !r:^\s*permitemptypasswords\.+no;'
  - id: 1506
    title: "SSH Hardening - 7: Rhost or shost used for authentication"
    description: "The option IgnoreRhosts should be set to yes."
@@ -94,7 +94,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^\s*IgnoreRhosts\.+yes;'
+     - 'c:sshd -T -> !r:^\s*ignorerhosts\.+yes;'
  - id: 1507
    title: "SSH Hardening - 8: Wrong Grace Time."
    description: "The option LoginGraceTime should be set to 30."
@@ -104,7 +104,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^\s*LoginGraceTime\s+30\s*$;'
+     - 'c:sshd -T -> !r:^\s*logingracetime\s+30\s*$;'
  - id: 1508
    title: "SSH Hardening - 9: Wrong Maximum number of authentication attempts"
    description: "The option MaxAuthTries should be set to 4."
@@ -114,4 +114,4 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'f:$sshd_file -> !r:^\s*MaxAuthTries\s+4\s*$;'
+     - 'c:sshd -T -> !r:^\s*maxauthtries\s+4\s*$;'

--- a/etc/sca/generic/system_audit_ssh.yml
+++ b/etc/sca/generic/system_audit_ssh.yml
@@ -36,7 +36,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^# && r:port\.+22;'
+     - 'f:$sshd_file -> !r:^# && r:Port\.+22;'
  - id: 1501
    title: "SSH Hardening - 2: Protocol 1"
    description: "The SSH protocol should not be 1."
@@ -46,7 +46,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^# && r:protocol\.+1;'
+     - 'f:$sshd_file -> !r:^# && r:Protocol\.+1;'
  - id: 1502
    title: "SSH Hardening - 3: Root can log in"
    description: "The option PermitRootLogin should be set to no."
@@ -54,7 +54,7 @@ checks:
    remediation: "Change the PermitRootLogin option value in the sshd_config file."
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^\s*permitrootlogin\.+no;'
+     - 'f:$sshd_file -> !r:^\s*PermitRootLogin\.+no;'
  - id: 1503
    title: "SSH Hardening - 4: No Public Key authentication"
    description: "The option PubkeyAuthentication should be set yes."
@@ -64,7 +64,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^\s*pubkeyauthentication\.+yes;'
+     - 'f:$sshd_file -> !r:^\s*PubkeyAuthentication\.+yes;'
  - id: 1504
    title: "SSH Hardening - 5: Password Authentication"
    description: "The option PasswordAuthentication should be set to no."
@@ -74,7 +74,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^\s*passwordauthentication\.+no;'
+     - 'f:$sshd_file -> !r:^\s*PasswordAuthentication\.+no;'
  - id: 1505
    title: "SSH Hardening - 6: Empty passwords allowed"
    description: "The option PermitEmptyPasswords should be set to no."
@@ -84,7 +84,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^\s*permitemptypasswords\.+no;'
+     - 'f:$sshd_file -> !r:^\s*PermitEmptyPasswords\.+no;'
  - id: 1506
    title: "SSH Hardening - 7: Rhost or shost used for authentication"
    description: "The option IgnoreRhosts should be set to yes."
@@ -94,7 +94,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^\s*ignorerhosts\.+yes;'
+     - 'f:$sshd_file -> !r:^\s*IgnoreRhosts\.+yes;'
  - id: 1507
    title: "SSH Hardening - 8: Wrong Grace Time."
    description: "The option LoginGraceTime should be set to 30."
@@ -104,7 +104,7 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^\s*logingracetime\s+30\s*$;'
+     - 'f:$sshd_file -> !r:^\s*LoginGraceTime\s+30\s*$;'
  - id: 1508
    title: "SSH Hardening - 9: Wrong Maximum number of authentication attempts"
    description: "The option MaxAuthTries should be set to 4."
@@ -114,4 +114,4 @@ checks:
     - pci_dss: "2.2.4"
    condition: any
    rules:
-     - 'c:sshd -T -> !r:^\s*maxauthtries\s+4\s*$;'
+     - 'f:$sshd_file -> !r:^\s*MaxAuthTries\s+4\s*$;'

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -39,10 +39,10 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event);
 static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event);
 static void HandlePoliciesInfo(Eventinfo *lf,int *socket,cJSON *event);
 static void HandleDumpEvent(Eventinfo *lf,int *socket,cJSON *event);
-static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,cJSON **title,cJSON **description,cJSON **rationale,cJSON **remediation,cJSON **compliance,cJSON **check,cJSON **reference,cJSON **file,cJSON **directory,cJSON **process,cJSON **registry,cJSON **result,cJSON **policy_id);
+static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,cJSON **title,cJSON **description,cJSON **rationale,cJSON **remediation,cJSON **compliance,cJSON **check,cJSON **reference,cJSON **file,cJSON **directory,cJSON **process,cJSON **registry,cJSON **result,cJSON **policy_id,cJSON **command);
 static int CheckPoliciesJSON(cJSON *event,cJSON **policies);
 static int CheckDumpJSON(cJSON *event,cJSON **elements_sent,cJSON **policy_id,cJSON **scan_id);
-static void FillCheckEventInfo(Eventinfo *lf,cJSON *scan_id,cJSON *id,cJSON *name,cJSON *title,cJSON *description,cJSON *rationale,cJSON *remediation,cJSON *compliance,cJSON *reference,cJSON *file,cJSON *directory,cJSON *process,cJSON *registry,cJSON *result,char *old_result);
+static void FillCheckEventInfo(Eventinfo *lf,cJSON *scan_id,cJSON *id,cJSON *name,cJSON *title,cJSON *description,cJSON *rationale,cJSON *remediation,cJSON *compliance,cJSON *reference,cJSON *file,cJSON *directory,cJSON *process,cJSON *registry,cJSON *result,char *old_result,cJSON *command);
 static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *description,cJSON *pass,cJSON *failed,cJSON *score,cJSON *file,cJSON *policy_id);
 static void PushDumpRequest(char * agent_id, char * policy_id);
 static int pm_send_db(char *msg, char *response, int *sock);
@@ -585,10 +585,11 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
     cJSON *directory = NULL;
     cJSON *process = NULL;
     cJSON *registry = NULL;
+    cJSON *command = NULL;
     cJSON *result = NULL;
     cJSON *policy_id = NULL;
 
-    if(!CheckEventJSON(event,&scan_id,&id,&name,&title,&description,&rationale,&remediation,&compliance,&check,&reference,&file,&directory,&process,&registry,&result,&policy_id)) {
+    if(!CheckEventJSON(event,&scan_id,&id,&name,&title,&description,&rationale,&remediation,&compliance,&check,&reference,&file,&directory,&process,&registry,&result,&policy_id,&command)) {
        
         int result_event = 0;
         char *wdb_response = NULL;
@@ -605,7 +606,7 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
                 result_event = SaveEventcheck(lf, 1, socket,id->valueint,scan_id ? scan_id->valueint : -1,title ? title->valuestring : NULL,description ? description->valuestring : NULL,rationale ? rationale->valuestring : NULL,remediation ? remediation->valuestring : NULL,file ? file->valuestring : NULL,directory ? directory->valuestring : NULL,process ? process->valuestring : NULL,registry ? registry->valuestring : NULL,reference ? reference->valuestring : NULL,result ? result->valuestring : NULL,policy_id ? policy_id->valuestring : NULL,event);
                
                 if(strcmp(wdb_response,result->valuestring)) {
-                    FillCheckEventInfo(lf,scan_id,id,name,title,description,rationale,remediation,compliance,reference,file,directory,process,registry,result,wdb_response);
+                    FillCheckEventInfo(lf,scan_id,id,name,title,description,rationale,remediation,compliance,reference,file,directory,process,registry,result,wdb_response,command);
                 }
                 if (result_event < 0)
                 {
@@ -616,7 +617,7 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
                 result_event = SaveEventcheck(lf, 0, socket,id->valueint,scan_id ? scan_id->valueint : -1,title ? title->valuestring : NULL,description ? description->valuestring : NULL,rationale ? rationale->valuestring : NULL,remediation ? remediation->valuestring : NULL,file ? file->valuestring : NULL,directory ? directory->valuestring : NULL,process ? process->valuestring : NULL,registry ? registry->valuestring : NULL,reference ? reference->valuestring : NULL,result ? result->valuestring : NULL,policy_id ? policy_id->valuestring : NULL,event);
 
                 if(strcmp(wdb_response,result->valuestring)) {
-                    FillCheckEventInfo(lf,scan_id,id,name,title,description,rationale,remediation,compliance,reference,file,directory,process,registry,result,NULL);
+                    FillCheckEventInfo(lf,scan_id,id,name,title,description,rationale,remediation,compliance,reference,file,directory,process,registry,result,NULL,command);
                 }
 
                 if (result_event < 0)
@@ -962,7 +963,7 @@ static int CheckDumpJSON(cJSON *event,cJSON **elements_sent,cJSON **policy_id,cJ
     return retval;
 }
 
-static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,cJSON **title,cJSON **description,cJSON **rationale,cJSON **remediation,cJSON **compliance,cJSON **check,cJSON **reference,cJSON **file,cJSON **directory,cJSON **process,cJSON **registry,cJSON **result,cJSON **policy_id) {
+static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,cJSON **title,cJSON **description,cJSON **rationale,cJSON **remediation,cJSON **compliance,cJSON **check,cJSON **reference,cJSON **file,cJSON **directory,cJSON **process,cJSON **registry,cJSON **result,cJSON **policy_id,cJSON **command) {
     int retval = 1;
     cJSON *obj;
 
@@ -1088,6 +1089,13 @@ static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,c
             merror("Malformed JSON: field 'registry' must be a string");
             return retval;
         }
+
+        *command = cJSON_GetObjectItem(*check, "command");
+        obj = *command;
+        if( obj && !obj->valuestring ) {
+            merror("Malformed JSON: field 'command' must be a string");
+            return retval;
+        }
         
         if( *result = cJSON_GetObjectItem(*check, "result"), !*result) {
             merror("Malformed JSON: field 'result' not found");
@@ -1178,7 +1186,7 @@ static int CheckPoliciesJSON(cJSON *event,cJSON **policies) {
     return retval;
 }
 
-static void FillCheckEventInfo(Eventinfo *lf,cJSON *scan_id,cJSON *id,cJSON *name,cJSON *title,cJSON *description,cJSON *rationale,cJSON *remediation,cJSON *compliance,cJSON *reference,cJSON *file,cJSON *directory,cJSON *process,cJSON *registry,cJSON *result,char *old_result) {
+static void FillCheckEventInfo(Eventinfo *lf,cJSON *scan_id,cJSON *id,cJSON *name,cJSON *title,cJSON *description,cJSON *rationale,cJSON *remediation,cJSON *compliance,cJSON *reference,cJSON *file,cJSON *directory,cJSON *process,cJSON *registry,cJSON *result,char *old_result,cJSON *command) {
     
     fillData(lf, "sca.type", "check");
 
@@ -1281,6 +1289,10 @@ static void FillCheckEventInfo(Eventinfo *lf,cJSON *scan_id,cJSON *id,cJSON *nam
 
     if(process){
         fillData(lf, "sca.check.process", process->valuestring);
+    }
+
+    if(command){
+        fillData(lf, "sca.check.command", command->valuestring);
     }
 
     if(result) {

--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -214,6 +214,12 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
 
                         policy->enabled = enabled;
                         policy->policy_id= NULL;
+
+                        if (strstr(children[j]->content, "etc/shared/") != NULL ) {
+                            policy->remote = 1;
+                        } else {
+                            policy->remote = 0;
+                        }
                         
                         os_strdup(children[j]->content,policy->profile);
                         sca->profile[profiles] = policy;
@@ -274,14 +280,6 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
             sca->interval = WM_DEF_INTERVAL;  // 1 day
             mwarn("At module '%s': Interval must be a multiple of one day. New interval value: 1d.", WM_SCA_CONTEXT.name);
         }
-    }
-
-    sca->request_db_interval = getDefine_Int("sca","request_db_interval",0,60) * 60;
-
-    /* Maximum request interval is the scan interval */
-    if(sca->request_db_interval > sca->interval) {
-       sca->request_db_interval = sca->interval;
-       minfo("The request_db_interval is higher than the interval.");
     }
 
     return 0;

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -253,6 +253,7 @@ CREATE TABLE IF NOT EXISTS sca_check (
    process TEXT,
    directory TEXT,
    registry TEXT,
+   command TEXT,
    `references` TEXT,
    result TEXT NOT NULL
 );

--- a/src/wazuh_db/schema_upgrade_v2.sql
+++ b/src/wazuh_db/schema_upgrade_v2.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS sca_check (
    process TEXT,
    directory TEXT,
    registry TEXT,
+   command TEXT,
    `references` TEXT,
    result TEXT NOT NULL
 );

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -68,7 +68,7 @@ static const char *SQL_STMT[] = {
     "SELECT fim_third_check FROM scan_info WHERE module = ?;",
     "SELECT id,result FROM sca_check WHERE id = ?;",
     "UPDATE sca_check SET result = ?, scan_id = ? WHERE id = ?;",
-    "INSERT INTO sca_check (id,scan_id,title,description,rationale,remediation,file,directory,process,registry,`references`,result,policy_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?);",
+    "INSERT INTO sca_check (id,scan_id,title,description,rationale,remediation,file,directory,process,registry,`references`,result,policy_id,command) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
     "INSERT INTO sca_scan_info (start_scan,end_scan,id,policy_id,pass,fail,score,hash) VALUES (?,?,?,?,?,?,?,?);",
     "UPDATE sca_scan_info SET start_scan = ?, end_scan = ?, id = ?, pass = ?, fail = ? , score = ?, hash = ? WHERE policy_id = ?;",
     "INSERT INTO sca_global (scan_id,name,description,`references`,pass,failed,score) VALUES(?,?,?,?,?,?,?);",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -208,7 +208,7 @@ int wdb_sca_find(wdb_t * wdb, int pm_id, char * output);
 int wdb_sca_update(wdb_t * wdb, char * result, int pm_id,int scan_id);
 
 /* Insert configuration assessment entry. Returns ID on success or -1 on error (new) */
-int wdb_sca_save(wdb_t * wdb, int id,int scan_id,char * title,char *description,char *rationale,char *remediation, char * file,char * directory,char * process,char * registry,char * reference,char * result,char * policy_id);
+int wdb_sca_save(wdb_t * wdb, int id,int scan_id,char * title,char *description,char *rationale,char *remediation, char * file,char * directory,char * process,char * registry,char * reference,char * result,char * policy_id,char * command);
 
 /* Insert scan info configuration assessment entry. Returns ID on success or -1 on error (new) */
 int wdb_sca_scan_info_save(wdb_t * wdb, int start_scan, int end_scan, int scan_id,char * policy_id,int pass,int fail,int score,char * hash);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -528,6 +528,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         cJSON *directory;
         cJSON *process;
         cJSON *registry;
+        cJSON *command;
         cJSON *reference;
         cJSON *result_check;
         cJSON *policy_id;
@@ -633,6 +634,12 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
                 mdebug1("Malformed JSON: field 'registry' must be a string");
                 return -1;
             }
+
+            command = cJSON_GetObjectItem(check, "command");
+            if( command && !command->valuestring ) {
+                mdebug1("Malformed JSON: field 'command' must be a string");
+                return -1;
+            }
             
             if( result_check = cJSON_GetObjectItem(check, "result"), !result_check) {
                 mdebug1("Malformed JSON: field 'result' not found");
@@ -645,7 +652,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             }
         }
 
-        if (result = wdb_sca_save(wdb,id->valueint,scan_id->valueint,title->valuestring,description ? description->valuestring : NULL,rationale ? rationale->valuestring : NULL,remediation ? remediation->valuestring : NULL,file ? file->valuestring : NULL,directory ? directory->valuestring : NULL,process ? process->valuestring : NULL,registry ? registry->valuestring : NULL,reference ? reference->valuestring : NULL ,result_check->valuestring ? result_check->valuestring : NULL,policy_id->valuestring), result < 0) {
+        if (result = wdb_sca_save(wdb,id->valueint,scan_id->valueint,title->valuestring,description ? description->valuestring : NULL,rationale ? rationale->valuestring : NULL,remediation ? remediation->valuestring : NULL,file ? file->valuestring : NULL,directory ? directory->valuestring : NULL,process ? process->valuestring : NULL,registry ? registry->valuestring : NULL,reference ? reference->valuestring : NULL ,result_check->valuestring ? result_check->valuestring : NULL,policy_id->valuestring,command ? command->valuestring : NULL), result < 0) {
             mdebug1("Cannot save Security Configuration Assessment information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save Security Configuration Assessment information.");
         } else {

--- a/src/wazuh_db/wdb_sca.c
+++ b/src/wazuh_db/wdb_sca.c
@@ -131,7 +131,7 @@ int wdb_sca_find(wdb_t * wdb, int pm_id, char * output) {
 }
 
 /* Insert configuration assessment entry. Returns 0 on success or -1 on error (new) */
-int wdb_sca_save(wdb_t * wdb, int id,int scan_id,char * title,char *description,char *rationale,char *remediation, char * file,char * directory,char * process,char * registry,char * reference,char * result,char * policy_id) {
+int wdb_sca_save(wdb_t * wdb, int id,int scan_id,char * title,char *description,char *rationale,char *remediation, char * file,char * directory,char * process,char * registry,char * reference,char * result,char * policy_id,char * command) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
         mdebug1("at wdb_rootcheck_save(): cannot begin transaction");
@@ -160,6 +160,7 @@ int wdb_sca_save(wdb_t * wdb, int id,int scan_id,char * title,char *description,
     sqlite3_bind_text(stmt, 11, reference, -1, NULL);
     sqlite3_bind_text(stmt, 12, result, -1, NULL);
     sqlite3_bind_text(stmt, 13, policy_id, -1, NULL);
+    sqlite3_bind_text(stmt, 14, command, -1, NULL);
     
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return 0;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -623,7 +623,7 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
                     return retval;
                 }
             }
-            read_id = (int *) realloc(read_id, sizeof(int) * (i + 2));
+            os_realloc(read_id, sizeof(int) * (i + 2), read_id);
             read_id[i] = check_id->valueint;
             read_id[i + 1] = 0;
         }

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -24,6 +24,7 @@
 #define WM_SCA_TYPE_REGISTRY  2
 #define WM_SCA_TYPE_PROCESS   3
 #define WM_SCA_TYPE_DIR       4
+#define WM_SCA_TYPE_COMMAND   5
 
 #define WM_SCA_COND_ALL       0x001
 #define WM_SCA_COND_ANY       0x002

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -40,6 +40,7 @@ HKEY wm_sca_sub_tree;
 
 typedef struct wm_sca_profile_t {
     unsigned int enabled:1;
+    unsigned int remote:1;
     char *profile;
     char *policy_id;
 } wm_sca_profile_t;
@@ -59,6 +60,8 @@ typedef struct wm_sca_t {
     wm_sca_profile_t** profile;
     char **alert_msg;
     int queue;
+    int remote_commands:1;
+    int commands_timeout;
 } wm_sca_t;
 
 extern const wm_context WM_SCA_CONTEXT;


### PR DESCRIPTION
### Command execution

As described in this issue https://github.com/wazuh/wazuh/issues/2667, the `sca` needs to be able to read the output of the execution of a command for a better hardening support.

To achieve this a new function has been implemented in the `sca` module called `wm_sca_read_command`. It executes a given command and checks the output against a pattern.

As for the decoder, a new field `command` is added to the `sca_check` database table. 

An example alert is shown below:

```xml
** Alert 1551189470.523377: - wazuh,sca,gdpr_IV_35.7.d
2019 Feb 26 14:57:50 rafa-GS63-7RD->sca
Rule: 19007 (level 7) -> 'System audit for SSH hardening: SSH Hardening - 9: Wrong Maximum number of authentication attempts'
{"type":"check","id":862330025,"policy":"System audit for SSH hardening","policy_id":"system_audit_ssh","check":{"id":1508,"title":"SSH Hardening - 9: Wrong Maximum number of authentication attempts","description":"The option MaxAuthTries should be set to 4.","rationale":"The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. Once the number of failures reaches half this value, additional failures are logged. This should be set to 4.","remediation":"Change the MaxAuthTries option value in the sshd_config file.","compliance":{"pci_dss":"2.2.4"},"command":"sshd -T","result":"failed"}}
sca.type: check
sca.scan_id: 862330025
sca.policy: System audit for SSH hardening
sca.check.id: 1508
sca.check.title: SSH Hardening - 9: Wrong Maximum number of authentication attempts
sca.check.description: The option MaxAuthTries should be set to 4.
sca.check.rationale: The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. Once the number of failures reaches half this value, additional failures are logged. This should be set to 4.
sca.check.remediation: Change the MaxAuthTries option value in the sshd_config file.
sca.check.compliance.pci_dss: 2.2.4
sca.check.command: sshd -T
sca.check.result: failed
```

The file `sca` policy file `system_audit_ssh.yml` has all the checks working with the new command execution feature.

```yaml
- id: 1508
   title: "SSH Hardening - 9: Wrong Maximum number of authentication attempts"
   description: "The option MaxAuthTries should be set to 4."
   rationale: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. Once the number of failures reaches half this value, additional failures are logged. This should be set to 4."
   remediation: "Change the MaxAuthTries option value in the sshd_config file."
   compliance:
    - pci_dss: "2.2.4"
   condition: any
   rules:
     - 'c:sshd -T -> !r:^\s*maxauthtries\s+4\s*$;'
```

As shown above, the '`c`' character is used for this purpose.

### New options

It has been added (2973676251e9526f972c12dcb7c804338f5d077a) two new internal options to control the command execution in agents. 

Local policies in agents don't have any restriction for executing the command present in the policies. However, for policies shared from the manager (pushed remotely), the command execution is disabled by default for security reasons. To be able to execute commands present at these policies, the internal option `sca.remote_commands` should be enabled in the agent.

In addition, the `sca.commands_timeout` option sets a timeout for the command execution. Its default value is 30 seconds.