### PR TITLE
Fix compilation warnings in gcc-8

### DIFF
--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -78,7 +78,7 @@ extern char shost[];
 /* Internal defines */
 #define USER_SIZE       514
 #define FILE_SIZE       257
-#define STR_SIZE        66
+#define STR_SIZE        590
 
 /* Internal strings */
 #define QUIT                "\\q"

--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -131,7 +131,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
     }
 
     /* Create alert */
-    snprintf(diff_alert, BUFFER_SIZE - 1, "ossec: agentless: Change detected:\n%s", buf);
+    snprintf(diff_alert, BUFFER_SIZE + 36, "ossec: agentless: Change detected:\n%s", buf);
     snprintf(buf, 1024, "(%s) %s->agentless", script, host);
 
     if (SendMSG(lessdc.queue, diff_alert, buf, LOCALFILE_MQ) < 0) {

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -332,7 +332,7 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
 // Parse timestamp
 void W_JSON_AddTimestamp(cJSON* root, const Eventinfo* lf)
 {
-    char timestamp[64];
+    char timestamp[150];
     char datetime[64];
     char timezone[64];
     struct tm tm;

--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -46,7 +46,7 @@ int Lists_OP_LoadList(char *listfile)
         snprintf(a_filename, sizeof(a_filename) - 1, "%.4094s", b_filename);
     }
 
-    snprintf(b_filename, sizeof(b_filename) - 1, "%4090s.cdb", a_filename);
+    snprintf(b_filename, sizeof(b_filename) - 1, "%.4090s.cdb", a_filename);
     
     /* Check if the CDB list file is actually available */
     FILE *txt_fd = fopen(a_filename, "r");

--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -23,7 +23,7 @@ int Lists_OP_LoadList(char *listfile)
 {
     /* XXX Jeremy: I hate this.  I think I'm missing something dumb here */
     char *holder;
-    char a_filename[OS_MAXSTR];
+    char a_filename[OS_MAXSTR + 4];
     char b_filename[OS_MAXSTR];
     ListNode *tmp_listnode_pt = NULL;
 
@@ -35,18 +35,18 @@ int Lists_OP_LoadList(char *listfile)
         merror_exit(MEM_ERROR, errno, strerror(errno));
     }
 
-    snprintf(a_filename, OS_MAXSTR - 1, "%s", listfile);
+    snprintf(a_filename, sizeof(a_filename) -1 , "%s", listfile);
     if ((strchr(a_filename, '/') == NULL)) {
         /* default to ruleset/rules/ if a path is not given */
-        snprintf(b_filename, OS_MAXSTR - 1, "ruleset/rules/%s", a_filename);
-        snprintf(a_filename, OS_MAXSTR - 1, "%s", b_filename);
+        snprintf(b_filename, sizeof(b_filename) - 1, "ruleset/rules/%s", a_filename);
+        snprintf(a_filename, sizeof(a_filename) - 1, "%s", b_filename);
     }
     if ((holder = strstr(a_filename, ".cdb"))) {
         snprintf(b_filename, (size_t)(holder - a_filename) + 1, "%s", a_filename);
-        snprintf(a_filename, OS_MAXSTR - 1, "%s", b_filename);
+        snprintf(a_filename, sizeof(a_filename) - 1, "%s", b_filename);
     }
 
-    snprintf(b_filename, OS_MAXSTR - 1, "%s.cdb", a_filename);
+    snprintf(b_filename, sizeof(b_filename) - 1, "%s.cdb", a_filename);
     
     /* Check if the CDB list file is actually available */
     FILE *txt_fd = fopen(a_filename, "r");

--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -23,12 +23,12 @@ int Lists_OP_LoadList(char *listfile)
 {
     /* XXX Jeremy: I hate this.  I think I'm missing something dumb here */
     char *holder;
-    char a_filename[OS_MAXSTR + 4];
-    char b_filename[OS_MAXSTR];
+    char a_filename[PATH_MAX];
+    char b_filename[PATH_MAX];
     ListNode *tmp_listnode_pt = NULL;
 
-    a_filename[OS_MAXSTR - 2] = '\0';
-    b_filename[OS_MAXSTR - 2] = '\0';
+    a_filename[PATH_MAX - 2] = '\0';
+    b_filename[PATH_MAX - 2] = '\0';
 
     tmp_listnode_pt = (ListNode *)calloc(1, sizeof(ListNode));
     if (tmp_listnode_pt == NULL) {
@@ -38,15 +38,15 @@ int Lists_OP_LoadList(char *listfile)
     snprintf(a_filename, sizeof(a_filename) -1 , "%s", listfile);
     if ((strchr(a_filename, '/') == NULL)) {
         /* default to ruleset/rules/ if a path is not given */
-        snprintf(b_filename, sizeof(b_filename) - 1, "ruleset/rules/%s", a_filename);
-        snprintf(a_filename, sizeof(a_filename) - 1, "%s", b_filename);
+        snprintf(b_filename, sizeof(b_filename) - 1, "ruleset/rules/%.4080s", a_filename);
+        snprintf(a_filename, sizeof(a_filename) - 1, "%.4094s", b_filename);
     }
     if ((holder = strstr(a_filename, ".cdb"))) {
         snprintf(b_filename, (size_t)(holder - a_filename) + 1, "%s", a_filename);
-        snprintf(a_filename, sizeof(a_filename) - 1, "%s", b_filename);
+        snprintf(a_filename, sizeof(a_filename) - 1, "%.4094s", b_filename);
     }
 
-    snprintf(b_filename, sizeof(b_filename) - 1, "%s.cdb", a_filename);
+    snprintf(b_filename, sizeof(b_filename) - 1, "%4090s.cdb", a_filename);
     
     /* Check if the CDB list file is actually available */
     FILE *txt_fd = fopen(a_filename, "r");

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -85,7 +85,7 @@ void * w_analysisd_state_main(){
 
 int w_analysisd_write_state(){
     FILE * fp;
-    char path[PATH_MAX + 1];
+    char path[PATH_MAX - 4];
     char path_temp[PATH_MAX + 1];
 
     if (!strcmp(__local_name, "unset")) {

--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -127,7 +127,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
     char warn_msg[OS_MAXSTR];
     char normal_msg[OS_MAXSTR];
 
-    char warn_str[OS_MAXSTR];
+    char warn_str[OS_BUFFER_SIZE];
     int wait_ms = 1000 / agt->events_persec;
 
     while(1){
@@ -179,7 +179,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
 
             buff.warn = 0;
             mwarn(WARN_BUFFER, warn_level);
-            snprintf(warn_str, OS_MAXSTR, OS_WARN_BUFFER, warn_level);
+            snprintf(warn_str, OS_BUFFER_SIZE, OS_WARN_BUFFER, warn_level);
             snprintf(warn_msg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "ossec-agent", warn_str);
             delay(wait_ms);
             send_msg(warn_msg, -1);

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -165,20 +165,20 @@ void run_notify()
     if(agent_ip){
         if ((File_DateofChange(AGENTCONFIGINT) > 0 ) &&
                 (OS_MD5_File(AGENTCONFIGINT, md5sum, OS_TEXT) == 0)) {
-            snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%s%s%s\n%s",
+            snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%.62000s%s%s\n%s",
                     getuname(), md5sum, tmp_labels, shared_files, label_ip, keep_alive_random);
         } else {
-            snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s\n%s%s%s\n%s",
+            snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s\n%.62000s%s%s\n%s",
                     getuname(), tmp_labels, shared_files, label_ip, keep_alive_random);
         }
     }
     else{
         if ((File_DateofChange(AGENTCONFIGINT) > 0 ) &&
                 (OS_MD5_File(AGENTCONFIGINT, md5sum, OS_TEXT) == 0)) {
-            snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%s%s\n%s",
+            snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%.62000s%s\n%s",
                     getuname(), md5sum, tmp_labels, shared_files, keep_alive_random);
         } else {
-            snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s\n%s%s\n%s",
+            snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s\n%.62000s%s\n%s",
                     getuname(), tmp_labels, shared_files, keep_alive_random);
         }
     }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -253,7 +253,7 @@ void start_agent(int is_startup)
                         snprintf(msg, OS_MAXSTR, OS_AG_STARTED,
                                  keys.keyentries[0]->name,
                                  keys.keyentries[0]->ip->ip);
-                        snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,
+                        snprintf(fmsg, OS_MAXSTR, "%c:%s:%.65500s", LOCALFILE_MQ,
                                  "ossec", msg);
                         send_msg(fmsg, -1);
                     }

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -54,7 +54,7 @@ int write_state() {
     FILE * fp;
     struct tm tm;
     const char * status;
-    char path[PATH_MAX + 1];
+    char path[PATH_MAX - 4];
     char last_keepalive[1024] = "";
     char last_ack[1024] = "";
 

--- a/src/monitord/manage_files.c
+++ b/src/monitord/manage_files.c
@@ -45,7 +45,7 @@ void manage_files(int cday, int cmon, int cyear)
 void manage_log(const char * logdir, int cday, int cmon, int cyear, const struct tm * pp_old, const char * tag, const char * ext) {
     int i;
     char logfile[OS_FLSIZE + 1];
-    char logfile_r[OS_FLSIZE + 1];
+    char logfile_r[OS_FLSIZE + 6];
     char logfile_old[OS_FLSIZE + 1];
 
     snprintf(logfile, OS_FLSIZE + 1, "%s/%d/%s/ossec-%s-%02d", logdir, cyear, months[cmon], tag, cday);
@@ -54,10 +54,10 @@ void manage_log(const char * logdir, int cday, int cmon, int cyear, const struct
     OS_SignLog(logfile, logfile_old, ext);
 
     if (mond.compress) {
-        snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext);
+        snprintf(logfile_r, OS_FLSIZE + 6, "%s.%s", logfile, ext);
         OS_CompressLog(logfile_r);
 
-        for (i = 1; snprintf(logfile_r, OS_FLSIZE + 1, "%s-%.3d.%s", logfile, i, ext), !IsFile(logfile_r) && FileSize(logfile_r) > 0; i++) {
+        for (i = 1; snprintf(logfile_r, OS_FLSIZE + 6, "%s-%.3d.%s", logfile, i, ext), !IsFile(logfile_r) && FileSize(logfile_r) > 0; i++) {
             OS_CompressLog(logfile_r);
         }
     }

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -38,11 +38,11 @@ static void remove_old_logs_m(const char * base_dir, int year, int month, time_t
 void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json, int daily_rotations) {
     char old_path[PATH_MAX];
     char old_path_json[PATH_MAX];
-    char base_dir[PATH_MAX];
-    char year_dir[PATH_MAX];
-    char month_dir[PATH_MAX];
-    char new_path[PATH_MAX];
-    char new_path_json[PATH_MAX];
+    char base_dir[PATH_MAX - 32];
+    char year_dir[PATH_MAX - 28];
+    char month_dir[PATH_MAX - 24];
+    char new_path[PATH_MAX - 3];
+    char new_path_json[PATH_MAX - 3];
     char compressed_path[PATH_MAX];
     char rename_path[PATH_MAX];
     char old_rename_path[PATH_MAX];
@@ -79,13 +79,13 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
     // /var/ossec/logs/ossec.json
     snprintf(old_path_json, PATH_MAX, "%s%s", isChroot() ? "" : DEFAULTDIR, LOGJSONFILE);
     // /var/ossec/logs/ossec
-    snprintf(base_dir, PATH_MAX, "%s/logs/ossec", isChroot() ? "" : DEFAULTDIR);
+    snprintf(base_dir, PATH_MAX - 24, "%s/logs/ossec", isChroot() ? "" : DEFAULTDIR);
 #endif
 
-    snprintf(year_dir, PATH_MAX, "%s/%d", base_dir, tm.tm_year + 1900);
-    snprintf(month_dir, PATH_MAX, "%s/%s", year_dir, MONTHS[tm.tm_mon]);
-    snprintf(new_path, PATH_MAX, "%s/ossec-%02d.log", month_dir, tm.tm_mday);
-    snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d.json", month_dir, tm.tm_mday);
+    snprintf(year_dir, PATH_MAX - 28, "%s/%d", base_dir, tm.tm_year + 1900);
+    snprintf(month_dir, PATH_MAX - 24, "%s/%s", year_dir, MONTHS[tm.tm_mon]);
+    snprintf(new_path, PATH_MAX - 3, "%s/ossec-%02d.log", month_dir, tm.tm_mday);
+    snprintf(new_path_json, PATH_MAX - 3, "%s/ossec-%02d.json", month_dir, tm.tm_mday);
     snprintf(compressed_path, PATH_MAX, "%s.gz", new_path);
 
     // Create folders
@@ -103,14 +103,14 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
         /* Count rotated log files of the current day */
         while(!IsFile(compressed_path)){
             counter++;
-            snprintf(new_path, PATH_MAX, "%s/ossec-%02d-%03d.log", month_dir, tm.tm_mday, counter);
+            snprintf(new_path, PATH_MAX - 3, "%s/ossec-%02d-%03d.log", month_dir, tm.tm_mday, counter);
             snprintf(compressed_path, PATH_MAX, "%s.gz", new_path);
         }
 
         /* Rotate compressed logs if needed */
         if (counter == daily_rotations) {
             if (daily_rotations == 1 && counter == 1) {
-                snprintf(new_path, PATH_MAX, "%s/ossec-%02d.log", month_dir, tm.tm_mday);
+                snprintf(new_path, PATH_MAX - 3, "%s/ossec-%02d.log", month_dir, tm.tm_mday);
             } else {
                 snprintf(rename_path, PATH_MAX, "%s/ossec-%02d.log.gz", month_dir, tm.tm_mday);
                 snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-001.log.gz", month_dir, tm.tm_mday);
@@ -124,7 +124,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                     snprintf(rename_path, PATH_MAX, "%s", old_rename_path);
                     snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-%03d.log.gz", month_dir, tm.tm_mday, counter);
                 }
-                snprintf(new_path, PATH_MAX, "%s/ossec-%02d-%03d.log", month_dir, tm.tm_mday, counter - 1);
+                snprintf(new_path, PATH_MAX - 3, "%s/ossec-%02d-%03d.log", month_dir, tm.tm_mday, counter - 1);
             }
         }
 
@@ -147,14 +147,14 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
         /* Count rotated log files of the current day */
         while(!IsFile(compressed_path)) {
             counter++;
-            snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d-%03d.json", month_dir, tm.tm_mday, counter);
+            snprintf(new_path_json, PATH_MAX - 3, "%s/ossec-%02d-%03d.json", month_dir, tm.tm_mday, counter);
             snprintf(compressed_path, PATH_MAX, "%s.gz", new_path_json);
         }
 
         /* Rotate compressed logs if needed */
         if (counter == daily_rotations) {
             if (daily_rotations == 1 && counter == 1) {
-                snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d.json", month_dir, tm.tm_mday);
+                snprintf(new_path_json, PATH_MAX - 3, "%s/ossec-%02d.json", month_dir, tm.tm_mday);
             } else {
                 snprintf(rename_path, PATH_MAX, "%s/ossec-%02d.json.gz", month_dir, tm.tm_mday);
                 snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-001.json.gz", month_dir, tm.tm_mday);
@@ -168,7 +168,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                     snprintf(rename_path, PATH_MAX, "%s", old_rename_path);
                     snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-%03d.json.gz", month_dir, tm.tm_mday, counter);
                 }
-                snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d-%03d.json", month_dir, tm.tm_mday, counter - 1);
+                snprintf(new_path_json, PATH_MAX - 3, "%s/ossec-%02d-%03d.json", month_dir, tm.tm_mday, counter - 1);
             }
         }
 

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -35,7 +35,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
     MD5_CTX md5_ctx;
     SHA256_CTX sha256_ctx;
 
-    char logfilesum[OS_FLSIZE + 1];
+    char logfilesum[OS_FLSIZE + 6];
     char logfilesum_old[OS_FLSIZE + 1];
     char logfile_r[OS_FLSIZE + 1];
     char buffer[4096];
@@ -47,7 +47,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
     unsigned char md256[SHA256_DIGEST_LENGTH];
 
     /* Clear the memory */
-    memset(logfilesum, '\0', OS_FLSIZE + 1);
+    memset(logfilesum, '\0', OS_FLSIZE + 6);
     memset(logfilesum_old, '\0', OS_FLSIZE + 1);
 
     /* Set umask */
@@ -55,7 +55,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     /* Create the checksum file names */
     snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext);
-    snprintf(logfilesum, OS_FLSIZE, "%s.sum", logfile_r);
+    snprintf(logfilesum, OS_FLSIZE + 5, "%s.sum", logfile_r);
     snprintf(logfilesum_old, OS_FLSIZE, "%s.%s.sum", logfile_old, ext);
 
     MD5_Init(&md5_ctx);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -405,7 +405,7 @@ int main(int argc, char **argv)
     }
 
     /* Append new line character */
-    strncat(buf,"\n",1);
+    strncat(buf,"\n",2);
     ret = SSL_write(ssl, buf, strlen(buf));
     if (ret < 0) {
         printf("SSL write error (unable to send message.)\n");

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -850,7 +850,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                     DIR *group_dir = opendir(group_path);
                     if (!group_dir) {
                         merror("Invalid group: %.255s",centralized_group);
-                        snprintf(response, 2048, "ERROR: Invalid group: %s\n\n", centralized_group);
+                        snprintf(response, 2048, "ERROR: Invalid group: %.255s\n\n", centralized_group);
                         SSL_write(ssl, response, strlen(response));
                         snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
                         SSL_write(ssl, response, strlen(response));
@@ -1098,7 +1098,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                     merror("At set_agent_group(): file path too large for agent '%s'.", keys.keyentries[index]->id);
                     OS_RemoveAgent(keys.keyentries[index]->id);
                     merror("Unable to set agent centralized group: %s (internal error)", centralized_group);
-                    snprintf(response, 2048, "ERROR: Internal manager error setting agent centralized group: %s\n\n", centralized_group);
+                    snprintf(response, 2048, "ERROR: Internal manager error setting agent centralized group: %.255s\n\n", centralized_group);
                     SSL_write(ssl, response, strlen(response));
                     snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
                     SSL_write(ssl, response, strlen(response));

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -123,7 +123,7 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
         OS_MD5_Str(key, -1, filesum2);
 
         /* Generate final key */
-        snprintf(_finalstr, 49, "%s%s", filesum2, filesum1);
+        snprintf(_finalstr, 49, "%s%.16s", filesum2, filesum1);
 
         /* Final key is 48 * 4 = 192bits */
         os_strdup(_finalstr, keys->keyentries[keys->keysize]->key);

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -384,7 +384,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             {
                 int dbg_lvl = isDebug();
                 snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL?"":integrator_config[s]->apikey, integrator_config[s]->hookurl==NULL?"":integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
-                if (dbg_lvl <= 0) strncat(exec_full_cmd, " > /dev/null 2>&1", 17);
+                if (dbg_lvl <= 0) strncat(exec_full_cmd, " > /dev/null 2>&1", 18);
 				
                 mdebug1("Running: %s", exec_full_cmd);
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -20,8 +20,8 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
 {
     int i = 0, sms_set = 0, donotgroup = 0;
     size_t body_size = OS_MAXSTR - 3, log_size;
-    char logs[OS_MAXSTR + 1];
-    char extra_data[OS_MAXSTR + 1];
+    char logs[OS_SIZE_4096 + 1];
+    char extra_data[OS_MAXSTR - OS_SIZE_6144 + 1];
     char log_string[OS_MAXSTR / 4 + 1];
     char *subject_host;
 #ifdef LIBGEOIP_ENABLED
@@ -65,54 +65,54 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
     }
 
     if (al_data->old_md5) {
-        log_size = strlen(al_data->old_md5) + 16 + 4;
+        log_size = strlen(al_data->old_md5) + 17 + 4;
         if (body_size > log_size) {
-            strncat(logs, "Old md5sum was: ", 16);
+            strncat(logs, "Old md5sum was: ", 17);
             strncat(logs, al_data->old_md5, body_size);
             strncat(logs, "\r\n", 4);
             body_size -= log_size;
         }
     }
     if (al_data->new_md5) {
-        log_size = strlen(al_data->new_md5) + 16 + 4;
+        log_size = strlen(al_data->new_md5) + 17 + 4;
         if (body_size > log_size) {
-            strncat(logs, "New md5sum is : ", 16);
+            strncat(logs, "New md5sum is : ", 17);
             strncat(logs, al_data->new_md5, body_size);
             strncat(logs, "\r\n", 4);
             body_size -= log_size;
         }
     }
     if (al_data->old_sha1) {
-        log_size = strlen(al_data->old_sha1) + 17 + 4;
+        log_size = strlen(al_data->old_sha1) + 18 + 4;
         if (body_size > log_size) {
-            strncat(logs, "Old sha1sum was: ", 17);
+            strncat(logs, "Old sha1sum was: ", 18);
             strncat(logs, al_data->old_sha1, body_size);
             strncat(logs, "\r\n", 4);
             body_size -= log_size;
         }
     }
     if (al_data->new_sha1) {
-        log_size = strlen(al_data->new_sha1) + 17 + 4;
+        log_size = strlen(al_data->new_sha1) + 18 + 4;
         if (body_size > log_size) {
-            strncat(logs, "New sha1sum is : ", 17);
+            strncat(logs, "New sha1sum is : ", 18);
             strncat(logs, al_data->new_sha1, body_size);
             strncat(logs, "\r\n", 4);
             body_size -= log_size;
         }
     }
     if (al_data->old_sha256) {
-        log_size = strlen(al_data->old_sha256) + 19 + 4;
+        log_size = strlen(al_data->old_sha256) + 20 + 4;
         if (body_size > log_size) {
-            strncat(logs, "Old sha256sum was: ", 19);
+            strncat(logs, "Old sha256sum was: ", 20);
             strncat(logs, al_data->old_sha256, body_size);
             strncat(logs, "\r\n", 4);
             body_size -= log_size;
         }
     }
     if (al_data->new_sha256) {
-        log_size = strlen(al_data->new_sha256) + 19 + 4;
+        log_size = strlen(al_data->new_sha256) + 20 + 4;
         if (body_size > log_size) {
-            strncat(logs, "New sha256sum is : ", 1256);
+            strncat(logs, "New sha256sum is : ", 20);
             strncat(logs, al_data->new_sha256, body_size);
             strncat(logs, "\r\n", 4);
             body_size -= log_size;
@@ -412,7 +412,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 16 + 4;
             if (body_size > log_size) {
-                strncat(logs, "Old md5sum was: ", 16);
+                strncat(logs, "Old md5sum was: ", 17);
                 strncat(logs, json_field->valuestring, body_size);
                 strncat(logs, "\r\n", 4);
                 body_size -= log_size;
@@ -423,7 +423,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 15 + 4;
             if (body_size > log_size) {
-                strncat(logs, "New md5sum is: ", 15);
+                strncat(logs, "New md5sum is: ", 16);
                 strncat(logs, json_field->valuestring, body_size);
                 strncat(logs, "\r\n", 4);
                 body_size -= log_size;
@@ -434,7 +434,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 16 + 4;
             if (body_size > log_size) {
-                strncat(logs, "Old sh1sum was: ", 16);
+                strncat(logs, "Old sh1sum was: ", 17);
                 strncat(logs, json_field->valuestring, body_size);
                 strncat(logs, "\r\n", 4);
                 body_size -= log_size;
@@ -445,7 +445,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 15 + 4;
             if (body_size > log_size) {
-                strncat(logs, "New sh1sum is: ", 15);
+                strncat(logs, "New sh1sum is: ", 16);
                 strncat(logs, json_field->valuestring, body_size);
                 strncat(logs, "\r\n", 4);
                 body_size -= log_size;

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -48,7 +48,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
     /* Generate the logs */
     logs[0] = '\0';
     extra_data[0] = '\0';
-    logs[OS_MAXSTR] = '\0';
+    logs[OS_SIZE_4096] = '\0';
 
     while (al_data->log[i]) {
         log_size = strlen(al_data->log[i]) + 4;

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -298,7 +298,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     int socket = -1;
     unsigned int i = 0;
     char *msg;
-    char snd_msg[128];
+    char snd_msg[256];
 
     MailNode *mailmsg;
 
@@ -340,11 +340,11 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         free(msg);
 
         /* Send HELO message */
-        memset(snd_msg, '\0', 128);
+        memset(snd_msg, '\0', 256);
         if (mail->heloserver) {
-            snprintf(snd_msg, 127, "Helo %s\r\n", mail->heloserver);
+            snprintf(snd_msg, 255, "Helo %s\r\n", mail->heloserver);
         } else {
-            snprintf(snd_msg, 127, "Helo %s\r\n", "notify.ossec.net");
+            snprintf(snd_msg, 255, "Helo %s\r\n", "notify.ossec.net");
         }
         OS_SendTCP(socket, snd_msg);
         msg = OS_RecvTCP(socket, OS_SIZE_1024);
@@ -383,8 +383,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         free(msg);
 
         /* Build "Mail from" msg */
-        memset(snd_msg, '\0', 128);
-        snprintf(snd_msg, 127, MAILFROM, mail->from);
+        memset(snd_msg, '\0', 256);
+        snprintf(snd_msg, 255, MAILFROM, mail->from);
         OS_SendTCP(socket, snd_msg);
         msg = OS_RecvTCP(socket, OS_SIZE_1024);
         if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
@@ -408,8 +408,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
                 }
                 break;
             }
-            memset(snd_msg, '\0', 128);
-            snprintf(snd_msg, 127, RCPTTO, mail->to[i++]);
+            memset(snd_msg, '\0', 256);
+            snprintf(snd_msg, 255, RCPTTO, mail->to[i++]);
             OS_SendTCP(socket, snd_msg);
             msg = OS_RecvTCP(socket, OS_SIZE_1024);
             if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
@@ -433,8 +433,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
                     continue;
                 }
 
-                memset(snd_msg, '\0', 128);
-                snprintf(snd_msg, 127, RCPTTO, mail->gran_to[i]);
+                memset(snd_msg, '\0', 256);
+                snprintf(snd_msg, 255, RCPTTO, mail->gran_to[i]);
                 OS_SendTCP(socket, snd_msg);
                 msg = OS_RecvTCP(socket, OS_SIZE_1024);
                 if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
@@ -470,8 +470,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     }
 
     /* Building "From" and "To" in the e-mail header */
-    memset(snd_msg, '\0', 128);
-    snprintf(snd_msg, 127, TO, mail->to[0]);
+    memset(snd_msg, '\0', 256);
+    snprintf(snd_msg, 255, TO, mail->to[0]);
 
     if (sendmail) {
         fprintf(sendmail, "%s", snd_msg);
@@ -479,8 +479,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         OS_SendTCP(socket, snd_msg);
     }
 
-    memset(snd_msg, '\0', 128);
-    snprintf(snd_msg, 127, FROM, mail->from);
+    memset(snd_msg, '\0', 256);
+    snprintf(snd_msg, 255, FROM, mail->from);
 
     if (sendmail) {
         fprintf(sendmail, "%s", snd_msg);
@@ -490,8 +490,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 
     /* Send reply-to if set */
     if (mail->reply_to){
-        memset(snd_msg, '\0', 128);
-        snprintf(snd_msg, 127, REPLYTO, mail->reply_to);
+        memset(snd_msg, '\0', 256);
+        snprintf(snd_msg, 255, REPLYTO, mail->reply_to);
         if (sendmail) {
             fprintf(sendmail, "%s", snd_msg);
         } else {
@@ -507,8 +507,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
                 break;
             }
 
-            memset(snd_msg, '\0', 128);
-            snprintf(snd_msg, 127, TO, mail->to[i]);
+            memset(snd_msg, '\0', 256);
+            snprintf(snd_msg, 255, TO, mail->to[i]);
 
             if (sendmail) {
                 fprintf(sendmail, "%s", snd_msg);
@@ -529,8 +529,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
                 continue;
             }
 
-            memset(snd_msg, '\0', 128);
-            snprintf(snd_msg, 127, TO, mail->gran_to[i]);
+            memset(snd_msg, '\0', 256);
+            snprintf(snd_msg, 255, TO, mail->gran_to[i]);
 
             if (sendmail) {
                 fprintf(sendmail, "%s", snd_msg);
@@ -544,13 +544,13 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     }
 
     /* Send date */
-    memset(snd_msg, '\0', 128);
+    memset(snd_msg, '\0', 256);
 
     /* Solaris doesn't have the "%z", so we set the timezone to 0 */
 #ifdef SOLARIS
-    strftime(snd_msg, 127, "Date: %a, %d %b %Y %T -0000\r\n", p);
+    strftime(snd_msg, 255, "Date: %a, %d %b %Y %T -0000\r\n", p);
 #else
-    strftime(snd_msg, 127, "Date: %a, %d %b %Y %T %z\r\n", p);
+    strftime(snd_msg, 255, "Date: %a, %d %b %Y %T %z\r\n", p);
 #endif
 
     if (sendmail) {
@@ -561,8 +561,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 
     if (mail->idsname) {
         /* Send server name header */
-        memset(snd_msg, '\0', 128);
-        snprintf(snd_msg, 127, XHEADER, mail->idsname);
+        memset(snd_msg, '\0', 256);
+        snprintf(snd_msg, 255, XHEADER, mail->idsname);
 
         if (sendmail) {
             fprintf(sendmail, "%s", snd_msg);
@@ -572,17 +572,17 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     }
 
     /* Send subject */
-    memset(snd_msg, '\0', 128);
+    memset(snd_msg, '\0', 256);
 
     /* Check if global subject is available */
     if ((_g_subject_level != 0) && (_g_subject[0] != '\0')) {
-        snprintf(snd_msg, 127, SUBJECT, _g_subject);
+        snprintf(snd_msg, 255, SUBJECT, _g_subject);
 
         /* Clear global values */
         _g_subject[0] = '\0';
         _g_subject_level = 0;
     } else {
-        snprintf(snd_msg, 127, SUBJECT, mailmsg->mail->subject);
+        snprintf(snd_msg, 255, SUBJECT, mailmsg->mail->subject);
     }
 
     if (sendmail) {
@@ -638,6 +638,6 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         close(socket);
     }
 
-    memset_secure(snd_msg, '\0', 128);
+    memset_secure(snd_msg, '\0', 256);
     return (0);
 }

--- a/src/os_xml/os_xml_variables.c
+++ b/src/os_xml/os_xml_variables.c
@@ -181,7 +181,7 @@ int OS_ApplyVariables(OS_XML *_lxml)
                             if ((j == s) && (strlen(lvar) >= 1)) {
                                 snprintf(_lxml->err, XML_ERR_LENGTH,
                                          "XMLERR: Unknown variable"
-                                         ": '%s'.", lvar);
+                                         ": '%.98s'.", lvar);
                                 _lxml->err_line = _lxml->ln[i];
                                 goto fail;
                             } else if (j == s) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -340,7 +340,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
         // Merge ar.conf always
 
         if (!logr.nocmerged) {
-            snprintf(merged_tmp, PATH_MAX + 1, "%s.tmp", merged);
+            snprintf(merged_tmp, PATH_MAX + 1, "%.4092s.tmp", merged);
             // First call, truncate merged file
             MergeAppendFile(merged_tmp, NULL, group, -1);
         }

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -47,7 +47,7 @@ void * rem_state_main() {
 
 int rem_write_state() {
     FILE * fp;
-    char path[PATH_MAX + 1];
+    char path[PATH_MAX - 4];
     char path_temp[PATH_MAX + 1];
     remoted_state_t state_cpy;
 

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -163,10 +163,10 @@ void check_rc_files(const char *basedir, FILE *fp)
         snprintf(file_path, OS_SIZE_1024, "%s/%s", basedir, file);
 
         if (is_file(file_path)) {
-            char op_msg[OS_SIZE_1024 + 1];
+            char op_msg[(OS_SIZE_1024 * 2) + 1];
 
             _errors = 1;
-            snprintf(op_msg, OS_SIZE_1024, "Rootkit '%s' detected "
+            snprintf(op_msg, OS_SIZE_1024 * 2, "Rootkit '%s' detected "
                      "by the presence of file '%s'.", name, file_path);
 
             notify_rk(ALERT_ROOTKIT_FOUND, op_msg);

--- a/src/rootcheck/check_rc_pids.c
+++ b/src/rootcheck/check_rc_pids.c
@@ -315,8 +315,8 @@ void check_rc_pids()
     loop_all_pids(ps, max_pid, &_errors, &_total);
 
     if (_errors == 0) {
-        char op_msg[OS_SIZE_1024 + 1];
-        snprintf(op_msg, OS_SIZE_1024, "No hidden process by Kernel-level "
+        char op_msg[OS_SIZE_1024 + 101];
+        snprintf(op_msg, OS_SIZE_1024 + 100, "No hidden process by Kernel-level "
                  "rootkits.\n      %s is not trojaned. "
                  "Analyzed %d processes.", ps, _total);
         notify_rk(ALERT_OK, op_msg);

--- a/src/rootcheck/check_rc_trojans.c
+++ b/src/rootcheck/check_rc_trojans.c
@@ -89,10 +89,10 @@ void check_rc_trojans(const char *basedir, FILE *fp)
 
             /* Check if entry is found */
             if (is_file(file_path) && os_string(file_path, string_to_look)) {
-                char op_msg[OS_SIZE_1024 + 1];
+                char op_msg[(OS_SIZE_1024 * 2) + 1];
                 _errors = 1;
 
-                snprintf(op_msg, OS_SIZE_1024, "Trojaned version of file "
+                snprintf(op_msg, OS_SIZE_1024 * 2, "Trojaned version of file "
                          "'%s' detected. Signature used: '%s' (%s).",
                          file_path,
                          string_to_look,

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -605,16 +605,16 @@ char *OS_IsValidTime(const char *time_str)
         return (NULL);
     }
 
-    os_calloc(13, sizeof(char), ret);
+    os_calloc(15, sizeof(char), ret);
 
     /* Fix dump hours */
     if (strcmp(first_hour, second_hour) > 0) {
-        snprintf(ret, 12, "!%s%s", second_hour, first_hour);
+        snprintf(ret, 14, "!%s%s", second_hour, first_hour);
         return (ret);
     }
 
     /* For the normal times */
-    snprintf(ret, 12, "%c%s%s", ng == 0 ? '.' : '!', first_hour, second_hour);
+    snprintf(ret, 14, "%c%s%s", ng == 0 ? '.' : '!', first_hour, second_hour);
 
     return (ret);
 }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -342,7 +342,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
     if (lstat(file_name, &statbuf) < 0)
 #endif
     {
-        char alert_msg[OS_SIZE_6144 + 1];
+        char alert_msg[OS_SIZE_6144 + 6];
         char wd_sum[OS_SIZE_6144 + 1];
 
         alert_msg[sizeof(alert_msg) - 1] = '\0';

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -85,14 +85,14 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             if (buf[SK_DB_REPORT_CHANG] == '+') {
                 fullalert = seechanges_addfile(file_name);
                 if (fullalert) {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s\n%s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name, fullalert);
+                    snprintf(alert_msg, OS_MAXSTR, "%.58000s!%s:%s %s\n%s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name, fullalert);
                     free(fullalert);
                     fullalert = NULL;
                 } else {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
+                    snprintf(alert_msg, OS_MAXSTR, "%.58000s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
                 }
             } else {
-                snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
+                snprintf(alert_msg, OS_MAXSTR, "%.58000s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
             }
 
             send_syscheck_msg(alert_msg);

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -100,7 +100,7 @@ int init_auditd_socket(void);
 int audit_add_rule(const char *path, const char *key);
 int audit_delete_rule(const char *path, const char *key);
 void *audit_main(int *audit_sock);
-void *audit_reload_thread(void);
+void *audit_reload_thread();
 void *audit_healthcheck_thread(int *audit_sock);
 void audit_reload_rules(void);
 int audit_health_check(int audit_socket);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -921,7 +921,7 @@ void audit_reload_rules(void) {
 }
 
 
-void *audit_reload_thread(void) {
+void *audit_reload_thread() {
 
     sleep(RELOAD_RULES_INTERVAL);
     while (audit_thread_active) {

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -371,11 +371,11 @@ int main(int argc, char **argv)
     /* Print information from an agent */
     if (info_agent) {
         agent_status_t agt_status = 0;
-        char final_ip[128 + 1];
-        char final_mask[128 + 1];
+        char final_ip[19 + 1];
+        char final_mask[4 + 1];
         agent_info *agt_info;
-        final_ip[128] = '\0';
-        final_mask[128] = '\0';
+        final_ip[19] = '\0';
+        final_mask[4] = '\0';
         cJSON *json_data = cJSON_CreateObject();
 
         if (!csv_output && !json_output) {
@@ -391,8 +391,8 @@ int main(int argc, char **argv)
                                       agent_id);
 
             /* Get netmask from IP */
-            getNetmask(keys.keyentries[agt_id]->ip->netmask, final_mask, 128);
-            snprintf(final_ip, 128, "%s%s", keys.keyentries[agt_id]->ip->ip,
+            getNetmask(keys.keyentries[agt_id]->ip->netmask, final_mask, 4);
+            snprintf(final_ip, 19, "%s%s", keys.keyentries[agt_id]->ip->ip,
                      final_mask);
 
             if (!csv_output && !json_output) {

--- a/src/util/clear_stats.c
+++ b/src/util/clear_stats.c
@@ -123,11 +123,11 @@ int main(int argc, char **argv)
         int i = 0;
         while (i <= 6) {
             const char *daily_dir = STATWQUEUE;
-            char dir_path[OS_MAXSTR + 1];
+            char dir_path[PATH_MAX + 1];
             DIR *daily;
             struct dirent *entry;
 
-            snprintf(dir_path, OS_MAXSTR, "%s/%d", daily_dir, i);
+            snprintf(dir_path, PATH_MAX, "%s/%d", daily_dir, i);
             daily = opendir(dir_path);
             if (!daily) {
                 merror_exit("Unable to open: '%s' (no stats)", dir_path);

--- a/src/util/rootcheck_control.c
+++ b/src/util/rootcheck_control.c
@@ -303,8 +303,8 @@ int main(int argc, char **argv)
     /* Print information from an agent */
     if (info_agent) {
         int i;
-        char final_ip[128 + 1];
-        char final_mask[128 + 1];
+        char final_ip[19 + 1];
+        char final_mask[4 + 1];
         keystore keys = KEYSTORE_INITIALIZER;
         cJSON *json_events = NULL;
 
@@ -343,11 +343,11 @@ int main(int argc, char **argv)
                 }
             }
 
-            final_ip[128] = '\0';
-            final_mask[128] = '\0';
+            final_ip[19] = '\0';
+            final_mask[4] = '\0';
             getNetmask(keys.keyentries[i]->ip->netmask,
-                       final_mask, 128);
-            snprintf(final_ip, 128, "%s%s", keys.keyentries[i]->ip->ip,
+                       final_mask, 4);
+            snprintf(final_ip, 19, "%s%s", keys.keyentries[i]->ip->ip,
                      final_mask);
 
             if (!(csv_output || json_output))

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -369,16 +369,16 @@ int wdb_create_agent_db(int id, const char *name) {
 /* Create database for agent from profile. Returns 0 on success or -1 on error. */
 int wdb_remove_agent_db(int id, const char * name) {
     char path[OS_FLSIZE + 1];
-    char path_aux[OS_FLSIZE + 1];
+    char path_aux[OS_FLSIZE + 6];
 
     snprintf(path, OS_FLSIZE, "%s%s/agents/%03d-%s.db", isChroot() ? "/" : "", WDB_DIR, id, name);
 
     if (!remove(path)) {
-        snprintf(path_aux, OS_FLSIZE, "%s-shm", path);
+        snprintf(path_aux, OS_FLSIZE + 5, "%s-shm", path);
         if (remove(path_aux) < 0) {
             mdebug2(DELETE_ERROR, path_aux, errno, strerror(errno));
         }
-        snprintf(path_aux, OS_FLSIZE, "%s-wal", path);
+        snprintf(path_aux, OS_FLSIZE + 5, "%s-wal", path);
         if (remove(path_aux) < 0) {
             mdebug2(DELETE_ERROR, path_aux, errno, strerror(errno));
         }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -275,7 +275,7 @@ int wdb_parse_syscheck(wdb_t * wdb, char * input, char * output) {
     char * curr;
     char * next;
     char * checksum;
-    char buffer[OS_MAXSTR + 1];
+    char buffer[OS_MAXSTR - 2];
     int ftype;
     int result;
     long ts;

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -24,7 +24,7 @@ cJSON *wm_sys_dump(const wm_sys_t *sys);
 const wm_context WM_SYS_CONTEXT = {
     "syscollector",
     (wm_routine)wm_sys_main,
-    (wm_routine)wm_sys_destroy,
+    (wm_routine)(void *)wm_sys_destroy,
     (cJSON * (*)(const void *))wm_sys_dump
 };
 

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -398,7 +398,7 @@ char * sys_rpm_packages(int queue_fd, const char* LOCATION, int random_id){
     int epoch;
     char version[TYPE_LENGTH];
     char release[TYPE_LENGTH];
-    char final_version[V_LENGTH+6];
+    char final_version[V_LENGTH + 6];
 
     // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
@@ -553,7 +553,7 @@ char * sys_rpm_packages(int queue_fd, const char* LOCATION, int random_id){
         }
 
         if (epoch) {
-            snprintf(final_version, V_LENGTH+5, "%d:%s-%s", epoch, version, release);
+            snprintf(final_version, V_LENGTH + 5, "%d:%s-%s", epoch, version, release);
         } else {
             snprintf(final_version, V_LENGTH, "%s-%s", version, release);
         }

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -398,7 +398,7 @@ char * sys_rpm_packages(int queue_fd, const char* LOCATION, int random_id){
     int epoch;
     char version[TYPE_LENGTH];
     char release[TYPE_LENGTH];
-    char final_version[V_LENGTH];
+    char final_version[V_LENGTH+6];
 
     // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
@@ -553,9 +553,9 @@ char * sys_rpm_packages(int queue_fd, const char* LOCATION, int random_id){
         }
 
         if (epoch) {
-            snprintf(final_version, V_LENGTH - 1, "%d:%s-%s", epoch, version, release);
+            snprintf(final_version, V_LENGTH+5, "%d:%s-%s", epoch, version, release);
         } else {
-            snprintf(final_version, V_LENGTH - 1, "%s-%s", version, release);
+            snprintf(final_version, V_LENGTH, "%s-%s", version, release);
         }
         cJSON_AddStringToObject(package, "version", final_version);
 

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -30,7 +30,7 @@ cJSON *wm_aws_dump(const wm_aws *aws_config);
 const wm_context WM_AWS_CONTEXT = {
     "aws-s3",
     (wm_routine)wm_aws_main,
-    (wm_routine)wm_aws_destroy,
+    (wm_routine)(void *)wm_aws_destroy,
     (cJSON * (*)(const void *))wm_aws_dump
 };
 

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -35,7 +35,7 @@ cJSON *wm_azure_dump(const wm_azure_t *azure);                          // Dump 
 const wm_context WM_AZURE_CONTEXT = {
     AZ_WM_NAME,
     (wm_routine)wm_azure_main,
-    (wm_routine)wm_azure_destroy,
+    (wm_routine)(void *)wm_azure_destroy,
     (cJSON * (*)(const void *))wm_azure_dump
 };
 

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -44,7 +44,7 @@ const char *WM_CISCAT_LOCATION = "wodle_cis-cat";  // Location field for event s
 const wm_context WM_CISCAT_CONTEXT = {
     "cis-cat",
     (wm_routine)wm_ciscat_main,
-    (wm_routine)wm_ciscat_destroy,
+    (wm_routine)(void *)wm_ciscat_destroy,
     (cJSON * (*)(const void *))wm_ciscat_dump
 };
 

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -20,7 +20,7 @@ cJSON *wm_command_dump(const wm_command_t * command);
 const wm_context WM_COMMAND_CONTEXT = {
     "command",
     (wm_routine)wm_command_main,
-    (wm_routine)wm_command_destroy,
+    (wm_routine)(void *)wm_command_destroy,
     (cJSON * (*)(const void *))wm_command_dump
 };
 

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -25,7 +25,7 @@ cJSON *wm_control_dump(void);
 const wm_context WM_CONTROL_CONTEXT = {
     "control",
     (wm_routine)wm_control_main,
-    (wm_routine)wm_control_destroy,
+    (wm_routine)(void *)wm_control_destroy,
     (cJSON * (*)(const void *))wm_control_dump
 };
 

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -107,7 +107,7 @@ static int wm_extract_agent(const char *fname, char *name, char *addr, int *regi
 const wm_context WM_DATABASE_CONTEXT = {
     "database",
     (wm_routine)wm_database_main,
-    (wm_routine)wm_database_destroy,
+    (wm_routine)(void *)wm_database_destroy,
     (cJSON * (*)(const void *))wm_database_dump
 };
 

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -27,7 +27,7 @@ cJSON *wm_docker_dump(const wm_docker_t *docker_conf);         // Dump docker co
 const wm_context WM_DOCKER_CONTEXT = {
     "docker-listener",
     (wm_routine)wm_docker_main,
-    (wm_routine)wm_docker_destroy,
+    (wm_routine)(void *)wm_docker_destroy,
     (cJSON * (*)(const void *))wm_docker_dump
 };
 

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -26,7 +26,7 @@
 
 static void * wm_download_main(wm_download_t * data);   // Module main function. It won't return
 static void wm_download_destroy(wm_download_t * data);  // Destroy data
-cJSON *wm_download_dump(void);     // Read config
+cJSON *wm_download_dump();     // Read config
 
 // Dispatch request. Write the output into the same input buffer.
 static void wm_download_dispatch(char * buffer);
@@ -34,7 +34,7 @@ static void wm_download_dispatch(char * buffer);
 const wm_context WM_DOWNLOAD_CONTEXT = {
     "download",
     (wm_routine)wm_download_main,
-    (wm_routine)wm_download_destroy,
+    (wm_routine)(void *)wm_download_destroy,
     (cJSON * (*)(const void *))wm_download_dump
 };
 
@@ -208,7 +208,7 @@ wmodule * wm_download_read() {
 #endif
 }
 
-cJSON *wm_download_dump(void) {
+cJSON *wm_download_dump() {
     cJSON *root = cJSON_CreateObject();
     cJSON *wm_wd = cJSON_CreateObject();
     cJSON_AddStringToObject(wm_wd,"enabled","yes");

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -51,7 +51,7 @@ const char *exec_params[2] = { "id", "ip" };
 const wm_context WM_KEY_REQUEST_CONTEXT = {
     KEY_WM_NAME,
     (wm_routine)wm_key_request_main,
-    (wm_routine)wm_key_request_destroy,
+    (wm_routine)(void *)wm_key_request_destroy,
     (cJSON * (*)(const void *))wm_key_request_dump
 };
 

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -20,7 +20,7 @@ cJSON *wm_oscap_dump(const wm_oscap *oscap);
 const wm_context WM_OSCAP_CONTEXT = {
     "open-scap",
     (wm_routine)wm_oscap_main,
-    (wm_routine)wm_oscap_destroy,
+    (wm_routine)(void *)wm_oscap_destroy,
     (cJSON * (*)(const void *))wm_oscap_dump
 };
 

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -49,7 +49,7 @@ static volatile int active = 1;
 const wm_context WM_OSQUERYMONITOR_CONTEXT = {
     "osquery",
     (wm_routine)wm_osquery_monitor_main,
-    (wm_routine)wm_osquery_monitor_destroy,
+    (wm_routine)(void *)wm_osquery_monitor_destroy,
     (cJSON * (*)(const void *))wm_osquery_dump
 };
 

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -62,7 +62,7 @@ int *vu_queue;
 const wm_context WM_VULNDETECTOR_CONTEXT = {
     "vulnerability-detector",
     (wm_routine)wm_vuldet_main,
-    (wm_routine)wm_vuldet_destroy,
+    (wm_routine)(void *)wm_vuldet_destroy,
     (cJSON * (*)(const void *))wm_vuldet_dump
 };
 

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -1789,7 +1789,7 @@ error:
 
 int check_timestamp(const char *OS, char *timst, char *ret_timst) {
     int retval = VU_TIMESTAMP_FAIL;
-    char stored_timestamp[KEY_SIZE];
+    char stored_timestamp[OS_SIZE_256];
     int i;
     sqlite3_stmt *stmt = NULL;
     sqlite3 *db = NULL;
@@ -1802,7 +1802,7 @@ int check_timestamp(const char *OS, char *timst, char *ret_timst) {
         }
         sqlite3_bind_text(stmt, 1, OS, -1, NULL);
         if (wm_vuldet_step(stmt) == SQLITE_ROW) {
-            snprintf(stored_timestamp, KEY_SIZE, "%s", sqlite3_column_text(stmt, 0));
+            snprintf(stored_timestamp, OS_SIZE_256, "%s", sqlite3_column_text(stmt, 0));
             for (i = 0; stored_timestamp[i] != '\0'; i++) {
                  if (stored_timestamp[i] == '-' ||
                  stored_timestamp[i] == ' ' ||


### PR DESCRIPTION
Fixes #1869 
- Fixed several compilation warnings that occurred while compiling with gcc-8.
- In most cases, we truncate some strings to make it fit in another (this is what was happening already). In other cases we allocate more memory for some strings to be large enough. In the last case, we allocate less memory for some strings (that didn't need it) to make them fit into another string.
- Another compilation warning occurred in a cast in every module in `wazuh_modules`:
https://github.com/wazuh/wazuh/blob/65cef5eb7ffe15930177ba57587d29ef3bc6e094/src/wazuh_modules/wm_database.c#L110
https://github.com/wazuh/wazuh/blob/ca3d237bbac951c703dce7e9bbddb46b209a8555/src/wazuh_modules/wm_database.c#L110
- `void` argument had to be taken out in some cases to avoid the compilation warnings:
https://github.com/wazuh/wazuh/blob/65cef5eb7ffe15930177ba57587d29ef3bc6e094/src/syscheckd/syscheck_audit.c#L924
https://github.com/wazuh/wazuh/blob/ca3d237bbac951c703dce7e9bbddb46b209a8555/src/syscheckd/syscheck_audit.c#L924
