### PR TITLE
Fix typo in error message

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -19,7 +19,7 @@
 #define FOPEN_ERROR   "(1103): Could not open file '%s' due to [(%d)-(%s)]."
 #define SIZE_ERROR    "(1104): Maximum string size reached for: %s."
 #define NULL_ERROR    "(1105): Attempted to use null string. "
-#define FORMAT_ERROR  "(1106): String not correctly formated."
+#define FORMAT_ERROR  "(1106): String not correctly formatted."
 #define MKDIR_ERROR   "(1107): Could not create directory '%s' due to [(%d)-(%s)]."
 //#define PERM_ERROR    "%s(1108): ERROR: Permission error. Operation not completed."
 #define THREAD_ERROR  "(1109): Unable to create new pthread."


### PR DESCRIPTION
This fixes #2675 
- Fixed typo in defined error message `FORMAT_ERROR`.