### PR TITLE
Added wazuh-cluster test

### DIFF
--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -654,7 +654,7 @@ static int CheckManagerConfiguration(char ** output) {
     int timeout = 2000;
     char command_in[PATH_MAX] = {0};
     char *output_msg = NULL;
-    char *daemons[] = { "bin/ossec-authd", "bin/ossec-remoted", "bin/ossec-execd", "bin/ossec-analysisd", "bin/ossec-logcollector", "bin/ossec-integratord",  "bin/ossec-syscheckd", "bin/ossec-maild", "bin/wazuh-modulesd", NULL };
+    char *daemons[] = { "bin/ossec-authd", "bin/ossec-remoted", "bin/ossec-execd", "bin/ossec-analysisd", "bin/ossec-logcollector", "bin/ossec-integratord",  "bin/ossec-syscheckd", "bin/ossec-maild", "bin/wazuh-modulesd", "bin/wazuh-clusterd", NULL };
     int i;
     ret_val = 0;
 


### PR DESCRIPTION
### Cluster test

When checking the manager configuration, the cluster section wasn't tested. This could let the API apply a wrong configuration.