### PR TITLE
Fix Clusterd configuration validation

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -21,7 +21,7 @@ from wazuh import common
 from wazuh.exception import WazuhException
 from wazuh.utils import previous_month, cut_array, sort_array, search_array, tail, load_wazuh_xml
 
-re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(.*)$")
+re_logtest = re.compile(r"^.*(?:ERROR *: |CRITICAL *: )(.*)$")
 
 
 def status():


### PR DESCRIPTION
|Fixes|
|---|
|#2704|

This PR aims to apply two changes:
1. Let Clusterd log configuration errors into _stderr_ so that they may get picked by the API.
2. Fix log filter in the Framework, this allows the API show configuration errors from Clusterd.