### PR TITLE
Improve cluster logs

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -20,7 +20,10 @@ def set_logging(debug_mode=0):
     logger.propagate = False
     # configure logger
     fh = cluster.CustomFileRotatingHandler(filename="{}/logs/cluster.log".format(common.ossec_path), when='midnight')
-    formatter = logging.Formatter('%(asctime)s %(levelname)-8s: [%(tag)-15s] [%(subtag)-15s] %(message)s')
+    formatter = logging.Formatter(
+        fmt='%(asctime)s wazuh-clusterd: %(levelname)-8s: [%(tag)-15s] [%(subtag)-15s] %(message)s',
+        datefmt="%Y/%m/%d %H:%M:%S"
+    )
     fh.setFormatter(formatter)
     logger.addHandler(fh)
 

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -22,7 +22,7 @@ def set_logging(debug_mode=0):
     # configure logger
     fh = cluster.CustomFileRotatingHandler(filename="{}/logs/cluster.log".format(common.ossec_path), when='midnight')
     formatter = logging.Formatter(
-        fmt='%(asctime)s wazuh-clusterd: %(levelname)-8s: [%(tag)-15s] [%(subtag)-15s] %(message)s',
+        fmt='%(asctime)s wazuh-clusterd: %(levelname)s: [%(tag)s] [%(subtag)s] %(message)s',
         datefmt="%Y/%m/%d %H:%M:%S"
     )
     formatter.converter = time.gmtime

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -145,7 +145,6 @@ if __name__ == '__main__':
 
     cluster_configuration = cluster.read_config(config_file=args.config_file)
     if cluster_configuration['disabled']:
-        main_logger.info("Cluster disabled. Exiting.")
         sys.exit(0)
     cluster_items = cluster.get_cluster_items()
     try:

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -8,6 +8,7 @@ import asyncio
 import argparse
 import os
 import sys
+import time
 from wazuh.cluster import cluster, __version__, __author__, __ossec_name__, __licence__, master, local_server, worker
 from wazuh import common, configuration, pyDaemonModule, Wazuh
 
@@ -24,6 +25,7 @@ def set_logging(debug_mode=0):
         fmt='%(asctime)s wazuh-clusterd: %(levelname)-8s: [%(tag)-15s] [%(subtag)-15s] %(message)s',
         datefmt="%Y/%m/%d %H:%M:%S"
     )
+    formatter.converter = time.gmtime
     fh.setFormatter(formatter)
     logger.addHandler(fh)
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -21,9 +21,6 @@ from wazuh import common
 from wazuh.exception import WazuhException
 from wazuh.utils import previous_month, cut_array, sort_array, search_array, tail, load_wazuh_xml
 
-re_logtest = re.compile(r"^.*(?:ERROR *: |CRITICAL *: )(.*)$")
-
-
 def status():
     """
     Returns the Manager processes that are running.
@@ -439,6 +436,7 @@ def validation():
 
 
 def _parse_execd_output(output):
+    re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
     json_output = json.loads(output)
     error_flag = json_output['error']
     if error_flag != 0:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -16,6 +16,7 @@ from os.path import exists, join
 from shutil import move, Error
 from xml.dom.minidom import parseString
 from xml.parsers.expat import ExpatError
+from typing import Dict
 
 from wazuh import common
 from wazuh.exception import WazuhException
@@ -438,7 +439,12 @@ def validation():
     return response
 
 
-def _parse_execd_output(output):
+def _parse_execd_output(output: str) -> Dict:
+    """
+    Parses output from execd socket to fetch log message and remove log date, log daemon, log level, etc.
+    :param output: Raw output from execd
+    :return: Cleaned log message in a dictionary structure
+    """
     json_output = json.loads(output)
     error_flag = json_output['error']
     if error_flag != 0:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -55,15 +55,16 @@ def status():
 
     return data
 
+
 def __get_ossec_log_fields(log):
     regex_category = re.compile(r"^(\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d)\s(\S+):\s(\S+):\s(.*)$")
 
     match = re.search(regex_category, log)
 
     if match:
-        date        = match.group(1)
-        category    = match.group(2)
-        type_log    = match.group(3)
+        date = match.group(1)
+        category = match.group(2)
+        type_log = match.group(3)
         description = match.group(4)
 
         if "rootcheck" in category:  # Unify rootcheck category
@@ -124,7 +125,7 @@ def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.d
             else:
                 continue
         else:
-            if logs != []:
+            if logs:
                 logs[-1]['description'] += "\n" + line
 
     if search:
@@ -185,8 +186,9 @@ def upload_file(tmp_file, path, content_type):
     """
     Updates a group file
 
-    :param file: Relative path of file name from origin
+    :param tmp_file: Relative path of file name from origin
     :param path: Path of destination of the new file
+    :param content_type: Content type of the uploaded file (valid values: application/xml and application/octet-stream)
     :return: Confirmation message in string
     """
     try:
@@ -222,13 +224,13 @@ def upload_xml(xml_file, path):
     try:
         with open(tmp_file_path, 'w') as tmp_file:
             # beauty xml file
-            xml = parseString('<root>' +  xml_file + '</root>')
+            xml = parseString('<root>' + xml_file + '</root>')
             # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
             pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent='  ').split('\n')[2:-2])) + '\n'
             # revert xml.dom replacings
             # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
-            pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"",)\
-                                   .replace("&gt;", ">").replace('&apos', "'")
+            pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
+                .replace("&gt;", ">").replace('&apos', "'")
             tmp_file.write(pretty_xml)
         chmod(tmp_file_path, 0o640)
     except IOError:
@@ -236,7 +238,7 @@ def upload_xml(xml_file, path):
     except ExpatError:
         raise WazuhException(1113)
     except Exception as e:
-        raise WazuhException(1000)
+        raise WazuhException(1000, str(e))
 
     try:
         # check xml format
@@ -251,7 +253,7 @@ def upload_xml(xml_file, path):
             move(tmp_file_path, new_conf_path)
         except Error:
             raise WazuhException(1016)
-        except Exception :
+        except Exception:
             raise WazuhException(1000)
 
         return 'File updated successfully'
@@ -304,7 +306,6 @@ def get_file(path):
     """
 
     file_path = join(common.ossec_path, path)
-    output = {}
 
     try:
         with open(file_path) as f:
@@ -358,13 +359,14 @@ def _check_wazuh_xml(files):
             subprocess.check_output(['{}/bin/verify-agent-conf'.format(common.ossec_path), '-f', f],
                                     stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            # extract error message from output.
-            # Example of raw output
-            # 2019/01/08 14:51:09 verify-agent-conf: ERROR: (1230): Invalid element in the configuration: 'agent_conf'.\n2019/01/08 14:51:09 verify-agent-conf: ERROR: (1207): Syscheck remote configuration in '/var/ossec/tmp/api_tmp_file_2019-01-08-01-1546959069.xml' is corrupted.\n\n
-            # Example of desired output:
-            # Invalid element in the configuration: 'agent_conf'. Syscheck remote configuration in '/var/ossec/tmp/api_tmp_file_2019-01-08-01-1546959069.xml' is corrupted.
+            # extract error message from output. Example of raw output 2019/01/08 14:51:09 verify-agent-conf: ERROR:
+            # (1230): Invalid element in the configuration: 'agent_conf'.\n2019/01/08 14:51:09 verify-agent-conf:
+            # ERROR: (1207): Syscheck remote configuration in
+            # '/var/ossec/tmp/api_tmp_file_2019-01-08-01-1546959069.xml' is corrupted.\n\n Example of desired output:
+            # Invalid element in the configuration: 'agent_conf'. Syscheck remote configuration in
+            # '/var/ossec/tmp/api_tmp_file_2019-01-08-01-1546959069.xml' is corrupted.
             output_regex = re.findall(pattern=r"\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} verify-agent-conf: ERROR: "
-                                                r"\(\d+\): ([\w \/ \_ \- \. ' :]+)", string=e.output.decode())
+                                              r"\(\d+\): ([\w \/ \_ \- \. ' :]+)", string=e.output.decode())
             raise WazuhException(1114, ' '.join(output_regex))
         except Exception as e:
             raise WazuhException(1743, str(e))
@@ -433,7 +435,7 @@ def validation():
 
     try:
         response = _parse_execd_output(buffer.decode('utf-8').rstrip('\0'))
-    except (KeyError, json.decoder.JSONDecodeError) as e:
+    except (KeyError, json.decoder.JSONDecodeError):
         raise WazuhException(1904)
 
     return response

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -21,6 +21,9 @@ from wazuh import common
 from wazuh.exception import WazuhException
 from wazuh.utils import previous_month, cut_array, sort_array, search_array, tail, load_wazuh_xml
 
+_re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
+
+
 def status():
     """
     Returns the Manager processes that are running.
@@ -436,14 +439,13 @@ def validation():
 
 
 def _parse_execd_output(output):
-    re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
     json_output = json.loads(output)
     error_flag = json_output['error']
     if error_flag != 0:
         errors = []
         log_lines = json_output['message'].splitlines(keepends=False)
         for line in log_lines:
-            match = re_logtest.match(line)
+            match = _re_logtest.match(line)
             if match:
                 errors.append(match.group(1))
         errors = list(OrderedDict.fromkeys(errors))

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -2,11 +2,10 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
-
+import json
 import os
-import re
-from unittest import TestCase
-from unittest.mock import patch
+import pytest
+from unittest.mock import patch, mock_open
 
 from wazuh import WazuhException
 from wazuh.manager import upload_file, get_file, restart, validation
@@ -15,20 +14,11 @@ from wazuh.manager import upload_file, get_file, restart, validation
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 
-class TestManager(TestCase):
-
-    @patch('socket.socket')
-    def test_restart_ok(self, mock1):
-        self.assertEqual(restart(), 'Manager is going to restart now')
-
-    @patch('wazuh.manager.exists', return_value=False)
-    def test_restart_ko_socket(self, mock1):
-        with self.assertRaises(WazuhException) as cm:
-            restart()
-
-        self.assertEqual(cm.exception.code, 1901)
-
-    def setUp(self):
+class InitManager:
+    def __init__(self):
+        """
+        Sets up necessary environment to test manager functions
+        """
         # path for temporary API files
         self.api_tmp_path = os.path.join(os.getcwd(), 'tests/data/tmp')
         # rules
@@ -41,40 +31,97 @@ class TestManager(TestCase):
         self.input_lists_file = 'test_lists'
         self.output_lists_file = 'uploaded_test_lists'
 
-    def tearDown(self):
-        regex = re.compile(r'^uploaded')
-        for filename in os.listdir(os.path.join(os.getcwd(), 'tests/data')):
-            if regex.match(filename):
-                os.remove(os.path.join(os.getcwd(), 'tests/data', filename))
-        if os.listdir(self.api_tmp_path):
-            os.remove(self.api_tmp_path + '*')
 
-    @patch('wazuh.common.ossec_path', test_data_path)
-    def test_upload_file(self):
-        # rules
-        upload_file(self.input_rules_file, self.output_rules_file, 'application/xml')
-        self.assertTrue(os.path.isfile(os.path.join(test_data_path, self.output_rules_file)))
-        # decoders
-        upload_file(self.input_decoders_file, self.output_decoders_file, 'application/xml')
-        self.assertTrue(os.path.isfile(os.path.join(test_data_path, self.output_decoders_file)))
-        # CDB lists
-        upload_file(self.input_lists_file, self.output_lists_file, 'application/octet-stream')
-        self.assertTrue(os.path.isfile(os.path.join(test_data_path, self.output_lists_file)))
+@pytest.fixture(scope='module')
+def test_manager():
+    # Set up
+    test_manager = InitManager()
+    return test_manager
 
-    @patch('wazuh.common.ossec_path', test_data_path)
-    def test_get_file(self):
-        # rules
-        result = get_file(os.path.join(os.getcwd(), 'tests/data/test_rules.xml'))
-        self.assertIsInstance(result, str)
-        # decoders
-        result = get_file(os.path.join(os.getcwd(), 'tests/data/test_decoders.xml'))
-        self.assertIsInstance(result, str)
-        # CDB lists
-        result = get_file(os.path.join(os.getcwd(), 'tests/data/test_lists'))
-        self.assertIsInstance(result, str)
 
-    @patch('socket.socket')
-    def test_validation(self, mock1):
+@patch('socket.socket')
+def test_restart_ok(test_manager):
+    """
+    Tests restarting a manager
+    """
+    assert restart() == 'Restarting manager'
+
+
+@pytest.mark.parametrize('input_file, output_file', [
+    ('input_rules_file', 'output_rules_file'),
+    ('input_decoders_file', 'output_decoders_file'),
+    ('input_lists_file', 'output_lists_file')
+])
+@patch('wazuh.common.ossec_path', test_data_path)
+def test_upload_file(test_manager, input_file, output_file):
+    """
+    Tests uploading a file to the manager
+    """
+    input_file, output_file = getattr(test_manager, input_file), getattr(test_manager, output_file)
+
+    with open(os.path.join(test_data_path, input_file)) as f:
+        xml_file = f.read()
+    m = mock_open(read_data=xml_file)
+    with patch('builtins.open', m):
+        with patch('wazuh.manager.chmod'):
+            with patch('wazuh.manager.move') as move_mock:
+                with patch('time.time') as time_mock:
+                    with patch('random.randint') as random_mock:
+                        time_mock.return_value = 0
+                        random_mock.return_value = 0
+                        upload_file(input_file, output_file, 'application/xml')
+
+    m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'))
+    m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 'w')
+    m.assert_any_call(os.path.join(test_data_path, input_file))
+    move_mock.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'),
+                                      os.path.join(test_data_path, output_file))
+
+
+@patch('wazuh.manager.exists', return_value=False)
+def test_restart_ko_socket(test_manager):
+    """
+    Tests restarting a manager when the socket is not created
+    """
+    with pytest.raises(WazuhException, match='.* 1901 .*'):
+        restart()
+
+
+@pytest.mark.parametrize('input_file', [
+    'input_rules_file',
+    'input_decoders_file',
+    'input_lists_file'
+])
+@patch('wazuh.common.ossec_path', test_data_path)
+def test_get_file(test_manager, input_file):
+    input_file = getattr(test_manager, input_file)
+    with open(os.path.join(test_data_path, input_file)) as f:
+        xml_file = f.read()
+
+    with patch('builtins.open', mock_open(read_data=xml_file)):
+        result = get_file(input_file)
+    assert result == xml_file
+
+
+@pytest.mark.parametrize('error_flag, error_msg', [
+    (0, ""),
+    (1, "2019/02/27 11:30:07 wazuh-clusterd: ERROR: [Cluster] [Main] Error 3004 - Error in cluster configuration: "
+        "Unspecified key"),
+    (1, "2019/02/27 11:30:24 ossec-authd: ERROR: (1230): Invalid element in the configuration: "
+        "'use_source_i'.\n2019/02/27 11:30:24 ossec-authd: ERROR: (1202): Configuration error at "
+        "'/var/ossec/etc/ossec.conf'.")
+])
+def test_validation(test_manager, error_flag, error_msg):
+    """
+    Tests configuration validation function with multiple scenarios:
+        * No errors found in configuration
+        * Error found in cluster configuration
+        * Error found in any other configuration
+    """
+    json_response = json.dumps({'error': error_flag, 'message': error_msg}).encode()
+    with patch('socket.socket') as sock:
+        sock.return_value.recv.return_value = json_response
         result = validation()
-        self.assertIsInstance(result, dict)
-        self.assertIsInstance(result['status'], str)
+    assert result['status'] == ('KO' if error_flag > 0 else 'OK')
+    if error_flag:
+        assert all(map(lambda x: x[0] in x[1], zip(result['details'], error_msg.split('\n'))))


### PR DESCRIPTION
Hello team,

This PR includes several improvements in cluster logs:
1. Removes the INFO log when the cluster is disabled. When using `ossec-control` a message was displayed indicating the cluster wasn't enabled:
    ```shellsession
    # /var/ossec/bin/ossec-control start
    2019-02-27 09:54:46,670 INFO    : [Cluster        ] [Main           ] Cluster disabled. Exiting.
    Starting Wazuh v3.9.0...
    Started ossec-authd...
    Started wazuh-db...
    Started ossec-execd...
    Started ossec-analysisd...
    Started ossec-syscheckd...
    Started ossec-remoted...
    Started ossec-logcollector...
    Started ossec-monitord...
    Started wazuh-modulesd...
    Completed.
    ```
2. Updates cluster logs to match ossec.log format. The logs now look like this:
    ```shellsession
    # tail /var/ossec/logs/cluster.log
    2019/02/27 11:17:33 wazuh-clusterd: DEBUG: [Local Server] [Keep alive] Calculated.
    2019/02/27 11:17:33 wazuh-clusterd: INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
    2019/02/27 11:17:33 wazuh-clusterd: DEBUG: [Master] [Keep alive] Calculating.
    2019/02/27 11:17:33 wazuh-clusterd: DEBUG: [Master] [Keep alive] Calculated.
    2019/02/27 11:17:33 wazuh-clusterd: DEBUG: [Master] [File integrity] Calculating
    2019/02/27 11:17:33 wazuh-clusterd: DEBUG: [Master] [File integrity] Calculated.
    2019/02/27 11:17:34 wazuh-clusterd: INFO: [Cluster] [Main] SIGINT received. Bye!
    2019/02/27 11:18:45 wazuh-clusterd: INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
    2019/02/27 11:18:45 wazuh-clusterd: INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
    2019/02/27 11:19:04 wazuh-clusterd: ERROR: [Cluster] [Main] Error 3004 - Error in cluster configuration: Unspecified key
    # tail /var/ossec/logs/ossec.log
    2019/02/27 11:18:55 sca: INFO: Starting evaluation of policy: 'system_audit_ssh.yml
    2019/02/27 11:18:58 sca: INFO: Evaluation finished for policy 'system_audit_ssh.yml'.
    2019/02/27 11:18:59 sca: INFO: Security Configuration Assessment scan finished. Duration: 14 seconds.
    2019/02/27 11:19:03 ossec-syscheckd: INFO: Syscheck scan frequency: 43200 seconds
    2019/02/27 11:19:03 ossec-syscheckd: INFO: Starting syscheck scan.
    2019/02/27 11:19:03 rootcheck: INFO: Starting rootcheck scan.
    2019/02/27 11:19:08 ossec-syscheckd: INFO: Starting syscheck database (pre-scan).
    2019/02/27 11:19:27 rootcheck: INFO: Ending rootcheck scan.
    2019/02/27 11:19:42 ossec-syscheckd: INFO: Finished creating syscheck database (pre-scan completed).
    2019/02/27 11:19:47 ossec-syscheckd: INFO: Ending syscheck scan. Database completed.
    ```

    The old format was:
    ```
    2019-02-27 10:49:43 INFO    : [Master         ] [Main           ] Serving on ('0.0.0.0', 1516)
    2019-02-27 10:49:43 DEBUG   : [Master         ] [Keep alive     ] Calculating.
    2019-02-27 10:49:43 DEBUG   : [Master         ] [Keep alive     ] Calculated.
    2019-02-27 10:49:43 DEBUG   : [Master         ] [File integrity ] Calculating
    2019-02-27 10:49:43 DEBUG   : [Master         ] [File integrity ] Calculated.
    ```
3. Results returned by GET/manager/configuration/validation show the log message and not the cluster tags:
    * Before:
        ```javascript
        # curl -u foo:bar "localhost:55000/manager/configuration/validation?pretty"
        {
           "error": 0,
           "data": {
              "status": "KO",
              "details": [
                 "[Cluster        ] [Main           ] Error 3004 - Error in cluster configuration: Unspecified key"
              ]
           }
        }
        ```
    * After:
        ```javascript
        # curl -u foo:bar "localhost:55000/manager/configuration/validation?pretty"
        {
           "error": 0,
           "data": {
              "status": "KO",
              "details": [
                 "Error 3004 - Error in cluster configuration: Unspecified key"
              ]
           }
        }
        ```
    This changes doesn't affect errors reported by other daemons:
    ```javascript
    # curl -u foo:bar "localhost:55000/manager/configuration/validation?pretty"
    {
       "error": 0,
       "data": {
          "status": "KO",
          "details": [
             "(1230): Invalid element in the configuration: 'use_source_i'.",
             "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
          ]
       }
    }
    ```

Best regards,
Marta