### PR TITLE
Fix for getting CDB lists

### DIFF
--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -41,8 +41,6 @@ def _iterate_lists(absolute_path, only_names=False):
     """
     Get the content of all CDB lists
     :param absolute_path: Full path of directory to get CDB lists
-    :param relative_path: Relative path of directory
-    :param dir_content: Content of the directory
     :param only_names: If this parameter is true, only the name of all lists will be showed
     :return: List with all CDB lists
     """

--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -61,11 +61,11 @@ def _iterate_lists(absolute_path, only_names=False):
             and ('.cdb' not in name)  \
             and ('~' not in name) \
             and not pattern.search(name):
-            items = get_list_from_file(new_relative_path)
             if only_names:
                 relative_path = _get_relative_path(absolute_path)
                 output.append({'path': relative_path, 'name': name})
             else:
+                items = get_list_from_file(new_relative_path)
                 output.append({'path': new_relative_path, 'items': items})
         elif isdir(new_absolute_path):
             if only_names:


### PR DESCRIPTION
Hi team,

This PR closes #2709. With this fix it is possible getting the name of CDB lists although one list was corrupted:

```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/lists?path=etc/lists/new-list&pretty"
{
   "error": 1800,
   "message": "Bad format in CDB list etc/lists/new-list"
}
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/lists/files?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 6,
      "items": [
         {
            "path": "etc/lists/amazon",
            "name": "aws-eventnames"
         },
         {
            "path": "etc/lists/amazon",
            "name": "aws-sources"
         },
         {
            "path": "etc/lists",
            "name": "audit-keys"
         },
         {
            "path": "etc/lists",
            "name": "security-eventchannel"
         },
         {
            "path": "etc/lists",
            "name": "new_list"
         },
         {
            "path": "etc/lists",
            "name": "new-list"
         }
      ]
   }
}
```

Best regards,

Demetrio.