### PR TITLE
Avoid a segfault in maild due to the XML tags order in ossec.conf

### DIFF
--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -515,11 +515,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
         } else if (strcmp(node[i]->element, xml_smtpserver) == 0) {
 #ifndef WIN32
             if (Mail) {
-                if (node[i]->content[0] == '/') {
-                    os_strdup(node[i]->content, Mail->smtpserver);
-                } else {
-                    Mail->smtpserver = OS_GetHost(node[i]->content, 5);
-                }
+                os_strdup(node[i]->content, Mail->smtpserver);
             }
 #endif
         } else if (strcmp(node[i]->element, xml_heloserver) == 0) {

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -519,10 +519,6 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                     os_strdup(node[i]->content, Mail->smtpserver);
                 } else {
                     Mail->smtpserver = OS_GetHost(node[i]->content, 5);
-                    if (!Mail->smtpserver) {
-                        merror(INVALID_SMTP, node[i]->content);
-                        return (OS_INVALID);
-                    }
                 }
             }
 #endif

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -172,10 +172,6 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     Config = (_Config *)configp;
     Mail = (MailConfig *)mailp;
 
-    // Temporary copies for the contents of xml_smtpserver and xml_heloserver
-    char * tmp_smtpserver = NULL;
-    char * tmp_heloserver = NULL;
-
     /* Get right white_size */
     if (Config && Config->white_list) {
         os_ip **ww;
@@ -229,31 +225,6 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                 }
                 if (Mail) {
                     Mail->mn = 1;
-
-                    // This XML tag has been read after xml_smtpserver,
-                    // set the value for this server now that we know we need it.
-                    if (tmp_smtpserver) {
-                        if (tmp_smtpserver[0] == '/') {
-                            os_strdup(tmp_smtpserver, Mail->smtpserver);
-                        } else {
-                            Mail->smtpserver = OS_GetHost(tmp_smtpserver, 5);
-                            if (!Mail->smtpserver) {
-                                merror(INVALID_SMTP, tmp_smtpserver);
-                                return (OS_INVALID);
-                            }
-                        }
-                        os_free(tmp_smtpserver);
-                        tmp_smtpserver = NULL;
-                    }
-
-                    // This XML tag has been read after xml_heloserver,
-                    // set the value for this server now that weknow we need it.
-                    if (tmp_heloserver) {
-                        os_strdup(tmp_heloserver, Mail->heloserver);
-                        os_free(tmp_heloserver);
-                        tmp_heloserver = NULL;
-                    }
-
                 }
             } else if (strcmp(node[i]->content, "no") == 0) {
                 if (Config) {
@@ -261,17 +232,6 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                 }
                 if (Mail) {
                     Mail->mn = 0;
-
-                    // This temporary values are not needed, after all.
-                    if (tmp_smtpserver) {
-                        os_free(tmp_smtpserver);
-                        tmp_smtpserver = NULL;
-                    }
-                    if (tmp_heloserver) {
-                        os_free(tmp_heloserver);
-                        tmp_heloserver = NULL;
-                    }
-
                 }
             } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
@@ -554,13 +514,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
             }
         } else if (strcmp(node[i]->element, xml_smtpserver) == 0) {
 #ifndef WIN32
-            if (Mail && !Mail->mn) {
-                // It might happen that Mail->mn is set to 1 later, due to the order of the XML tags in ossec.conf.
-                // Keep a temporary copy of the contents of this XML tag, in case it is needed later.
-                os_strdup(node[i]->content, tmp_smtpserver);
-            }
-
-            if (Mail && (Mail->mn)) {
+            if (Mail) {
                 if (node[i]->content[0] == '/') {
                     os_strdup(node[i]->content, Mail->smtpserver);
                 } else {
@@ -573,11 +527,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
             }
 #endif
         } else if (strcmp(node[i]->element, xml_heloserver) == 0) {
-            if (Mail && !Mail->mn) {
-                // Keep a temporary copy of the contents of this XML tag, in case it is needed later.
-                os_strdup(node[i]->content, tmp_heloserver);
-            }
-            if (Mail && (Mail->mn)) {
+            if (Mail) {
                 os_strdup(node[i]->content, Mail->heloserver);
             }
         } else if (strcmp(node[i]->element, xml_mailmaxperhour) == 0) {

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -9,6 +9,7 @@
  */
 
 #include "shared.h"
+#include "os_net/os_net.h"
 #include "maild.h"
 #include "mail_list.h"
 
@@ -161,11 +162,26 @@ int main(int argc, char **argv)
         merror_exit(SETGID_ERROR, group, errno, strerror(errno));
     }
 
-    if (!mail.smtpserver) {
-        merror(INVALID_SMTP, "E-mail notification not configured properly... Clean exit.");
+    if (!mail.mn) {
+        minfo("Mail notifications are disabled. Exiting.");
         exit(0);
     }
-    if (mail.smtpserver[0] != '/') {
+
+    if (!mail.smtpserver) {
+        merror_exit("SMTP server not set. Exiting.");
+    }
+    else if (mail.smtpserver[0] != '/') {
+
+        char * aux_smtp_server;
+        aux_smtp_server = mail.smtpserver;
+
+        mail.smtpserver = OS_GetHost(aux_smtp_server, 5);
+        if (!mail.smtpserver) {
+            merror_exit(INVALID_SMTP, aux_smtp_server);
+        }
+
+        free(aux_smtp_server);
+
         /* chroot */
         if (Privsep_Chroot(dir) < 0) {
             merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -161,6 +161,10 @@ int main(int argc, char **argv)
         merror_exit(SETGID_ERROR, group, errno, strerror(errno));
     }
 
+    if (!mail.smtpserver) {
+        merror(INVALID_SMTP, "E-mail notification not configured properly... Clean exit.");
+        exit(0);
+    }
     if (mail.smtpserver[0] != '/') {
         /* chroot */
         if (Privsep_Chroot(dir) < 0) {


### PR DESCRIPTION
This PR fixes the issue https://github.com/wazuh/wazuh/issues/2688.

Bug description
--
Copy-paste from a comment in the issue.

Source code involved:
`src/os_maild_maild.c`
```
121     /* Read configuration */
122     if (MailConf(test_config, cfg, &mail) < 0) {
123         merror_exit(CONFIG_ERROR, cfg);
124     }
(...)
164     if (mail.smtpserver[0] != '/') {
(...)
```

`src/os_maild/config.c`
```
30     Mail->mn = 0;
```

`src/config/global-config.c`
```
221         else if (strcmp(node[i]->element, xml_mailnotify) == 0) {
222             if (strcmp(node[i]->content, "yes") == 0) {
223                 if (Config) {
224                     Config->mailnotify = 1;
225                 }
226                 if (Mail) {
227                     Mail->mn = 1;
228                 }
229             } else if (strcmp(node[i]->content, "no") == 0) {
230                 if (Config) {
231                     Config->mailnotify = 0;
232                 }
233                 if (Mail) {
234                     Mail->mn = 0;
235                 }
(...)
515         } else if (strcmp(node[i]->element, xml_smtpserver) == 0) {
516 #ifndef WIN32
517             if (Mail && (Mail->mn)) {
518                 if (node[i]->content[0] == '/') {
519                     os_strdup(node[i]->content, Mail->smtpserver);
520                 } else {
521                     Mail->smtpserver = OS_GetHost(node[i]->content, 5);
522                     if (!Mail->smtpserver) {
523                         merror(INVALID_SMTP, node[i]->content);
524                         return (OS_INVALID);
525                     }
526                 }
527             }
```

With this configuration in `ossec.conf`:
```
  <global>
    (...)
    <smtp_server>smtp.gmail.com</smtp_server>
    <email_notification>yes</email_notification>
    (...)
  </global>
```
A segmentation fault is produced when `ossec-maild` starts.

In order for `Mail->smtpserver` to contain a significant value, `Mail->mn` must be `1` (`= yes`).
By default, `Mail->mn` is `0`. If `<email_notification>yes` is placed after `<smtp_server>`, the value of `Mail->smtpserver` will not be set.
After that, `Mail->mn` will be set to `1`. Later, in `if (mail.smtpserver[0] != '/') {`, the variable `mail.smtpserver` is `NULL`, hence the segmentation fault.
It `Mail->mn` is still `0`, because `<email_notification>no`, the `ossec-maild` process will not be started, no attempt to read `mail.smtpserver` will be performed, and no segmentation will never occur with that configuration.


Solution
--
Before accessing the variable in `if (mail.smtpserver[0] != '/') {`, check that the variable is not `NULL`. If it is, exit giving an error in `ossec.log`. The `ossec-maild` process will terminate before the segmentation fault occurs.

Testing
--
See below.
