### PR TITLE
GET/manager/status:  Add missing processes and sort the list by alphabetical order 

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -25,10 +25,10 @@ from wazuh.utils import previous_month, cut_array, sort_array, search_array, tai
 _re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
 
 
-def status():
+def status() -> Dict:
     """
     Returns the Manager processes that are running.
-    :return: Array of dictionaries (keys: status, daemon).
+    :return: Dictionary (keys: status, daemon).
     """
 
     processes = ['ossec-agentlessd', 'ossec-analysisd', 'ossec-authd', 'ossec-csyslogd', 'ossec-dbd', 'ossec-monitord',

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -31,10 +31,9 @@ def status():
     :return: Array of dictionaries (keys: status, daemon).
     """
 
-    processes = ['ossec-monitord', 'ossec-logcollector', 'ossec-remoted',
-                 'ossec-syscheckd', 'ossec-analysisd', 'ossec-maild',
-                 'ossec-execd', 'wazuh-modulesd', 'ossec-authd',
-                 'wazuh-clusterd']
+    processes = ['ossec-agentlessd', 'ossec-analysisd', 'ossec-authd', 'ossec-csyslogd', 'ossec-dbd', 'ossec-monitord',
+                 'ossec-execd', 'ossec-integratord', 'ossec-logcollector', 'ossec-maild', 'ossec-remoted',
+                 'ossec-reportd', 'ossec-syscheckd', 'wazuh-clusterd', 'wazuh-modulesd']
 
     data = {}
     for process in processes:

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -53,7 +53,11 @@ def test_restart_ok(test_manager):
     ('input_lists_file', 'output_lists_file')
 ])
 @patch('wazuh.common.ossec_path', test_data_path)
-def test_upload_file(test_manager, input_file, output_file):
+@patch('time.time', lambda: 0)
+@patch('random.randint', lambda x, y: 0)
+@patch('wazuh.manager.chmod')
+@patch('wazuh.manager.move')
+def test_upload_file(move_mock, chmod_mock, test_manager, input_file, output_file):
     """
     Tests uploading a file to the manager
     """
@@ -63,13 +67,7 @@ def test_upload_file(test_manager, input_file, output_file):
         xml_file = f.read()
     m = mock_open(read_data=xml_file)
     with patch('builtins.open', m):
-        with patch('wazuh.manager.chmod'):
-            with patch('wazuh.manager.move') as move_mock:
-                with patch('time.time') as time_mock:
-                    with patch('random.randint') as random_mock:
-                        time_mock.return_value = 0
-                        random_mock.return_value = 0
-                        upload_file(input_file, output_file, 'application/xml')
+        upload_file(input_file, output_file, 'application/xml')
 
     m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'))
     m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 'w')

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -46,6 +46,16 @@ def test_manager():
 @patch('wazuh.manager.exists')
 @patch('wazuh.manager.glob')
 def test_status(manager_glob, manager_exists, test_manager, process_status):
+    """
+    Tests manager.status() function in two cases:
+        * PID files are created and processed are running,
+        * No process is running and therefore no PID files have been created
+    :param manager_glob: mock of glob.glob function
+    :param manager_exists: mock of os.path.exists function
+    :param test_manager: pytest fixture
+    :param process_status: status to test (valid values: running/stopped).
+    :return:
+    """
     def mock_glob(path_to_check):
         return [path_to_check.replace('*', '0234')] if process_status == 'running' else []
 
@@ -71,12 +81,12 @@ def test_restart_ok(test_manager):
     ('input_decoders_file', 'output_decoders_file'),
     ('input_lists_file', 'output_lists_file')
 ])
-@patch('wazuh.common.ossec_path', test_data_path)
-@patch('time.time', lambda: 0)
-@patch('random.randint', lambda x, y: 0)
+@patch('wazuh.common.ossec_path', new=test_data_path)
+@patch('time.time', return_value=0)
+@patch('random.randint', return_value=0)
 @patch('wazuh.manager.chmod')
 @patch('wazuh.manager.move')
-def test_upload_file(move_mock, chmod_mock, test_manager, input_file, output_file):
+def test_upload_file(move_mock, chmod_mock, mock_rand, mock_time, test_manager, input_file, output_file):
     """
     Tests uploading a file to the manager
     """

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -7,8 +7,8 @@ import os
 import pytest
 from unittest.mock import patch, mock_open
 
-from wazuh import WazuhException
-from wazuh.manager import upload_file, get_file, restart, validation
+from wazuh.exception import WazuhException
+from wazuh.manager import upload_file, get_file, restart, validation, status
 
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -37,6 +37,25 @@ def test_manager():
     # Set up
     test_manager = InitManager()
     return test_manager
+
+
+@pytest.mark.parametrize('process_status', [
+    'running',
+    'stopped'
+])
+@patch('wazuh.manager.exists')
+@patch('wazuh.manager.glob')
+def test_status(manager_glob, manager_exists, test_manager, process_status):
+    def mock_glob(path_to_check):
+        return [path_to_check.replace('*', '0234')] if process_status == 'running' else []
+
+    manager_glob.side_effect = mock_glob
+    manager_exists.return_value = True
+    manager_status = status()
+    assert isinstance(manager_status, dict)
+    assert all(process_status == x for x in manager_status.values())
+    if process_status == 'running':
+        manager_exists.assert_any_call("/proc/0234")
 
 
 @patch('socket.socket')


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh/issues/2703.

Before:
```javascript
# curl -u foo:bar "localhost:55000/manager/status?pretty"
{
   "error": 0,
   "data": {
      "ossec-monitord": "running",
      "ossec-logcollector": "running",
      "ossec-remoted": "running",
      "ossec-syscheckd": "running",
      "ossec-analysisd": "running",
      "ossec-maild": "stopped",
      "ossec-execd": "running",
      "wazuh-modulesd": "running",
      "ossec-authd": "running",
      "wazuh-clusterd": "running"
   }
}
```

After:
```javascript
# curl -u foo:bar "localhost:55000/manager/status?pretty"
{
   "error": 0,
   "data": {
      "ossec-agentlessd": "running",
      "ossec-analysisd": "running",
      "ossec-authd": "running",
      "ossec-csyslogd": "running",
      "ossec-dbd": "stopped",
      "ossec-monitord": "running",
      "ossec-execd": "running",
      "ossec-integratord": "running",
      "ossec-logcollector": "running",
      "ossec-maild": "stopped",
      "ossec-remoted": "running",
      "ossec-reportd": "stopped",
      "ossec-syscheckd": "running",
      "wazuh-clusterd": "running",
      "wazuh-modulesd": "running"
   }
}
```
As you can see, missing daemons have been added to the dictionary and keys are inserted in alphabetical order, making it easier to read the result.

Unit tests:
```python
# /var/ossec/framework/python/bin/pytest tests/test_manager.py -vv
============================================================================================================================ test session starts ============================================================================================================================platform linux -- Python 3.7.2, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/vagrant/GitHub/wazuh/framework, inifile:
collected 13 items

tests/test_manager.py::test_status[running] PASSED                                                                                                                                                                                                                    [  7%]
tests/test_manager.py::test_status[stopped] PASSED                                                                                                                                                                                                                    [ 15%]
tests/test_manager.py::test_restart_ok PASSED                                                                                                                                                                                                                         [ 23%]
tests/test_manager.py::test_upload_file[input_rules_file-output_rules_file] PASSED                                                                                                                                                                                    [ 30%]
tests/test_manager.py::test_upload_file[input_decoders_file-output_decoders_file] PASSED                                                                                                                                                                              [ 38%]
tests/test_manager.py::test_upload_file[input_lists_file-output_lists_file] PASSED                                                                                                                                                                                    [ 46%]
tests/test_manager.py::test_restart_ko_socket PASSED                                                                                                                                                                                                                  [ 53%]
tests/test_manager.py::test_get_file[input_rules_file] PASSED                                                                                                                                                                                                         [ 61%]
tests/test_manager.py::test_get_file[input_decoders_file] PASSED                                                                                                                                                                                                      [ 69%]
tests/test_manager.py::test_get_file[input_lists_file] PASSED                                                                                                                                                                                                         [ 76%]
tests/test_manager.py::test_validation[0-] PASSED                                                                                                                                                                                                                     [ 84%]
tests/test_manager.py::test_validation[1-2019/02/27 11:30:07 wazuh-clusterd: ERROR: [Cluster] [Main] Error 3004 - Error in cluster configuration: Unspecified key] PASSED                                                                                             [ 92%]
tests/test_manager.py::test_validation[1-2019/02/27 11:30:24 ossec-authd: ERROR: (1230): Invalid element in the configuration: 'use_source_i'.\n2019/02/27 11:30:24 ossec-authd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.] PASSED           [100%]

========================================================================================================================= 13 passed in 0.33 seconds =========================================================================================================================
```

Best regards,
Marta