### PR TITLE
Remote upgrades: upgrade agents to the manager version by default

### DIFF
--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -117,7 +117,7 @@ def main():
     # WPK upgrade file
     else:
         prev_ver = agent.version
-        upgrade_command_result = agent.upgrade(wpk_repo=args.repository, debug=args.debug, version=myWazuh.version,
+        upgrade_command_result = agent.upgrade(wpk_repo=args.repository, debug=args.debug, version=args.version,
                                                force=args.force,
                                                show_progress=print_progress if not args.silent else None,
                                                chunk_size=args.chunk_size,

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -117,7 +117,7 @@ def main():
     # WPK upgrade file
     else:
         prev_ver = agent.version
-        upgrade_command_result = agent.upgrade(wpk_repo=args.repository, debug=args.debug, version=args.version,
+        upgrade_command_result = agent.upgrade(wpk_repo=args.repository, debug=args.debug, version=myWazuh.version,
                                                force=args.force,
                                                show_progress=print_progress if not args.silent else None,
                                                chunk_size=args.chunk_size,

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1932,6 +1932,7 @@ class Agent:
 
         if result.ok:
             versions = [version.split() for version in result.text.split('\n')]
+            versions = list(filter(None, versions))
         else:
             error = "Can't access to the versions file in {}".format(versions_url)
             raise WazuhException(1713, error)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1932,7 +1932,7 @@ class Agent:
 
         if result.ok:
             versions = [version.split() for version in result.text.split('\n')]
-            versions = list(filter(None, versions))
+            versions = list(filter(lambda x: len(x) > 0, versions))
         else:
             error = "Can't access to the versions file in {}".format(versions_url)
             raise WazuhException(1713, error)
@@ -1975,7 +1975,7 @@ class Agent:
             raise WazuhException(1717, "Manager: {0} / Agent: {1} -> {2}".format(manager_ver.split(" ")[1], agent_ver.split(" ")[1], agent_new_ver))
 
         if (WazuhVersion(agent_ver.split(" ")[1]) >= WazuhVersion(agent_new_ver) and not force):
-            raise WazuhException(1716, "Agent ver: {0} / Agent new ver: {1}".format(agent_ver.split(" ")[1], agent_new_ver))
+            raise WazuhException(1749, "Agent: {0} -> {1}".format(agent_ver.split(" ")[1], agent_new_ver))
 
         if debug:
             print("Agent version: {0}".format(agent_ver.split(" ")[1]))

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1969,8 +1969,6 @@ class Agent:
 
 
         if WazuhVersion(manager_ver.split(" ")[1]) < WazuhVersion(agent_new_ver):
-            #agent_new_ver = manager_ver.split(" ")[1]
-            #agent_new_shasum
             for versions in versions:
                 if versions[0] == manager_ver.split(" ")[1]:
                     agent_new_ver = versions[0]

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1966,15 +1966,23 @@ class Agent:
 
         # Comparing versions
         agent_ver = self.version
-        if debug:
-            print("Agent version: {0}".format(agent_ver.split(" ")[1]))
-            print("Agent new version: {0}".format(agent_new_ver))
+
 
         if WazuhVersion(manager_ver.split(" ")[1]) < WazuhVersion(agent_new_ver):
-            raise WazuhException(1717, "Manager: {0} / Agent: {1} -> {2}".format(manager_ver.split(" ")[1], agent_ver.split(" ")[1], agent_new_ver))
+            #agent_new_ver = manager_ver.split(" ")[1]
+            #agent_new_shasum
+            for versions in versions:
+                if versions[0] == manager_ver.split(" ")[1]:
+                    agent_new_ver = versions[0]
+                    agent_new_shasum = versions[1]
+                    break
 
         if (WazuhVersion(agent_ver.split(" ")[1]) >= WazuhVersion(agent_new_ver) and not force):
             raise WazuhException(1716, "Agent ver: {0} / Agent new ver: {1}".format(agent_ver.split(" ")[1], agent_new_ver))
+
+        if debug:
+            print("Agent version: {0}".format(agent_ver.split(" ")[1]))
+            print("Agent new version: {0}".format(agent_new_ver))
 
         protocol = self._get_protocol(wpk_repo, use_http)
         # Generating file name

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1943,11 +1943,21 @@ class Agent:
         """
         Searchs latest Wazuh WPK file for its distribution and version. Downloads the WPK if it is not in the upgrade folder.
         """
+        # Get manager version
+        manager = Agent(id=0)
+        manager._load_info_from_DB()
+        manager_ver = manager.version
+        if debug:
+            print("Manager version: {0}".format(manager_ver.split(" ")[1]))
+
         agent_new_ver = None
         versions = self._get_versions(wpk_repo=wpk_repo, version=version, use_http=use_http)
         if not version:
-            agent_new_ver = versions[0][0]
-            agent_new_shasum = versions[0][1]
+            for versions in versions:
+                if versions[0] == manager_ver.split(" ")[1]:
+                    agent_new_ver = versions[0]
+                    agent_new_shasum = versions[1]
+                    break
         else:
             for versions in versions:
                 if versions[0] == version:
@@ -1957,23 +1967,11 @@ class Agent:
         if not agent_new_ver:
             raise WazuhException(1718, version)
 
-        # Get manager version
-        manager = Agent(id=0)
-        manager._load_info_from_DB()
-        manager_ver = manager.version
-        if debug:
-            print("Manager version: {0}".format(manager_ver.split(" ")[1]))
-
         # Comparing versions
         agent_ver = self.version
 
-
-        if WazuhVersion(manager_ver.split(" ")[1]) < WazuhVersion(agent_new_ver):
-            for versions in versions:
-                if versions[0] == manager_ver.split(" ")[1]:
-                    agent_new_ver = versions[0]
-                    agent_new_shasum = versions[1]
-                    break
+        if (WazuhVersion(manager_ver.split(" ")[1]) < WazuhVersion(agent_new_ver) and not force):
+            raise WazuhException(1717, "Manager: {0} / Agent: {1} -> {2}".format(manager_ver.split(" ")[1], agent_ver.split(" ")[1], agent_new_ver))
 
         if (WazuhVersion(agent_ver.split(" ")[1]) >= WazuhVersion(agent_new_ver) and not force):
             raise WazuhException(1716, "Agent ver: {0} / Agent new ver: {1}".format(agent_ver.split(" ")[1], agent_new_ver))

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -117,7 +117,7 @@ class WazuhException(Exception):
         1714: 'Error downloading WPK file',
         1715: 'Error sending WPK file',
         1716: 'Error upgrading agent',
-        1717: 'Cannot upgrade to a version higher than the manager',
+        1717: 'Upgrading an agent to a version higher than the manager requires the force flag. Use -F to force the upgrade',
         1718: 'Version not available',
         1719: 'Remote upgrade is not available for this agent version',
         1720: 'Agent disconnected',
@@ -149,6 +149,7 @@ class WazuhException(Exception):
         1746: "Could not parse current client.keys file",
         1747: "Could not remove agent group assigment from database",
         1748: "Could not remove agent files",
+        1749: "Downgrading an agent requires the force flag. Use -F to force the downgrade",
 
         # CDB List: 1800 - 1899
         1800: 'Bad format in CDB list {path}',


### PR DESCRIPTION
Edited agent.py so that the agent's maximum version when upgrading by default is always the manager's, allowing the option to select a different version if so desired.