### PR TITLE
Fix Windows escape format affecting non-format messages

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -413,7 +413,18 @@ int DecodeWinevt(Eventinfo *lf){
         if(strcmp(join_data,"")){
             cJSON_AddStringToObject(json_eventdata_in, "data", join_data);
         }
-        cJSON_AddItemToObject(json_event, "eventdata", json_eventdata_in);
+
+        cJSON *element;
+        int n_elements=0;
+
+        cJSON_ArrayForEach(element, json_eventdata_in){
+            n_elements+=1;
+        }
+
+        if(n_elements > 0){
+            cJSON_AddItemToObject(json_event, "eventdata", json_eventdata_in);
+        }
+        cJSON_Delete(element);
     }
     if (extra){
         *extra = tolower(*extra);

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -50,22 +50,16 @@ void WinevtInit(){
 char *replace_win_format(char *str){
     char *ret1 = NULL;
     char *ret2 = NULL;
-    char *ret3 = NULL;
-    char *ret4 = NULL;
-    char *ret5 = NULL;
     char *end = NULL;
     int spaces = 0;
 
     // Remove undesired characters from the string
-    ret1 = wstr_replace(str, "\\r", "");
-    ret2 = wstr_replace(ret1, "\\t", "");
-    ret3 = wstr_replace(ret2, "\\n", "");
-    ret4 = wstr_replace(ret3, "\\\"", "\"");
-    ret5 = wstr_replace(ret4, "\\\\", "\\");
+    ret1 = wstr_replace(str, "\\\"", "\"");
+    ret2 = wstr_replace(ret1, "\\\\", "\\");
 
     // Remove trailing spaces at the end of the string
-    end = ret5 + strlen(ret5) - 1;
-    while(end > ret5 && isspace((unsigned char)*end)) {
+    end = ret2 + strlen(ret2) - 1;
+    while(end > ret2 && isspace((unsigned char)*end)) {
         end--;
         spaces = 1;
     }
@@ -74,11 +68,8 @@ char *replace_win_format(char *str){
         end[1] = '\0';
 
     os_free(ret1);
-    os_free(ret2);
-    os_free(ret3);
-    os_free(ret4);
 
-    return ret5;
+    return ret2;
 }
 
 /* Special decoder for Windows eventchannel */

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -538,6 +538,8 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
         cJSON_AddStringToObject(event_json, "Message", "No message");
     }
 
+    win_format_event_string(xml_event);
+
     cJSON_AddStringToObject(event_json, "Event", xml_event);
     msg_sent = cJSON_PrintUnformatted(event_json);
 


### PR DESCRIPTION
This PR fixes the issue https://github.com/wazuh/wazuh/issues/2715

We have finally removed the lines to replace the formatting characters '\r', '\n' and '\t', as they were not being parsed at the actual implemented version of `eventchannel`. 

As shown in the issue, Windows returns a huge string that contains a `message` and some extra data. The previous version for `eventchannel` retrieved this information without parsing it to JSON, but the current implemented version gets the message in one field and the extra data in JSON format; this means that it is not necessary to replace these formatting characters.

Testing
---------
- Valgrind on analysisd.
- Generate process termination and process creation events.
- Generate any other event that contains `'\\\\'` or `'\\"'`