### PR TITLE
Remove install path information from decoders and rules API calls

### DIFF
--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -8,6 +8,7 @@ import wazuh.configuration as configuration
 from wazuh.exception import WazuhException
 from wazuh import common
 from wazuh.utils import cut_array, sort_array, search_array, load_wazuh_xml
+import os
 from sys import version_info
 
 class Rule:
@@ -159,7 +160,7 @@ class Rule:
 
         tmp_data = []
         tags = ['rule_include', 'rule_exclude']
-        exclude_filenames =[]
+        exclude_filenames = []
         for tag in tags:
             if tag in ruleset_conf:
                 item_status = Rule.S_DISABLED if tag == 'rule_exclude' else Rule.S_ENABLED
@@ -170,17 +171,12 @@ class Rule:
                     items = [ruleset_conf[tag]]
 
                 for item in items:
-                    if '/' in item:
-                        item_split = item.split('/')
-                        item_name = item_split[-1]
-                        item_dir = "{0}/{1}".format(common.ossec_path, "/".join(item_split[:-1]))
-                    else:
-                        item_name = item
-                        item_dir = "{0}/{1}".format(common.ruleset_rules_path, item)
-
+                    item_name = os.path.basename(item)
+                    full_dir = os.path.dirname(item)
+                    item_dir = os.path.relpath(full_dir if full_dir else common.ruleset_rules_path,
+                                               start=common.ossec_path)
                     if tag == 'rule_exclude':
                         exclude_filenames.append(item_name)
-                        # tmp_data.append({'file': item_name, 'path': '-', 'status': item_status})
                     else:
                         tmp_data.append({'file': item_name, 'path': item_dir, 'status': item_status})
 
@@ -195,9 +191,8 @@ class Rule:
                 all_rules = "{0}/{1}/*.xml".format(common.ossec_path, item_dir)
 
                 for item in glob(all_rules):
-                    item_split = item.split('/')
-                    item_name = item_split[-1]
-                    item_dir = "/".join(item_split[:-1])
+                    item_name = os.path.basename(item)
+                    item_dir = os.path.relpath(os.path.dirname(item), start=common.ossec_path)
                     if item_name in exclude_filenames:
                         item_status = Rule.S_DISABLED
                     else:
@@ -385,7 +380,7 @@ class Rule:
         try:
             rules = []
 
-            root = load_wazuh_xml("{}/{}".format(rule_path, rule_file))
+            root = load_wazuh_xml(os.path.join(common.ossec_path, rule_path, rule_file))
 
             for xml_group in root.getchildren():
                 if xml_group.tag.lower() == "group":

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from unittest.mock import patch
+import pytest
+
+from wazuh.decoder import Decoder
+from wazuh.exception import WazuhException
+
+decoder_ossec_conf = {
+    'decoder_dir': ['ruleset/decoders'],
+    'decoder_exclude': 'decoders1.xml'
+}
+
+
+def decoders_files(file_path):
+    """
+    Returns a list of decoders names
+    :param file_path: A glob file path containing *.xml in the end.
+    :return: A generator
+    """
+    return map(lambda x: file_path.replace('*.xml', f'decoders{x}.xml'), range(2))
+
+
+@pytest.mark.parametrize('status', [
+    None,
+    'all',
+    'enabled',
+    'disabled',
+    'random'
+])
+@patch('wazuh.decoder.glob', side_effect=decoders_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
+def test_get_decoders_file_status(mock_config, mock_glob, status):
+    """
+    Tests getting decoders file using status filter
+    """
+    if status == 'random':
+        with pytest.raises(WazuhException, match='.* 1202 .*'):
+            Decoder.get_decoders_files(status=status)
+    else:
+        d_files = Decoder.get_decoders_files(status=status)
+        if status is None or status == 'all':
+            assert d_files['totalItems'] == 2
+            assert d_files['items'][0]['status'] == 'enabled'
+            assert d_files['items'][1]['status'] == 'disabled'
+        else:
+            assert d_files['totalItems'] == 1
+            assert d_files['items'][0]['status'] == status
+
+
+@pytest.mark.parametrize('path', [
+    None,
+    'ruleset/decoders',
+    'random'
+])
+@patch('wazuh.decoder.glob', side_effect=decoders_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
+def test_get_decoders_file_path(mock_config, mock_glob, path):
+    """
+    Tests getting decoders files filtering by path
+    """
+    d_files = Decoder.get_decoders_files(path=path)
+    if path == 'random':
+        assert d_files['totalItems'] == 0
+        assert len(d_files['items']) == 0
+    else:
+        assert d_files['totalItems'] == 2
+        assert d_files['items'][0]['path'] == 'ruleset/decoders'
+
+
+@pytest.mark.parametrize('offset, limit', [
+    (0, 0),
+    (0, 1),
+    (0, 500),
+    (1, 500),
+    (2, 500),
+    (3, 500)
+])
+@patch('wazuh.decoder.glob', side_effect=decoders_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
+def test_get_decoders_file_pagination(mock_config, mock_glob, offset, limit):
+    """
+    Tests getting decoders files using offset and limit
+    """
+    if limit > 0:
+        d_files = Decoder.get_decoders_files(offset=offset, limit=limit)
+        limit = d_files['totalItems'] if limit > d_files['totalItems'] else limit
+        assert d_files['totalItems'] == 2
+        assert len(d_files['items']) == (limit - offset if limit > offset else 0)
+    else:
+        with pytest.raises(WazuhException, match='.* 1406 .*'):
+            Decoder.get_decoders_files(offset=offset, limit=limit)
+
+
+@pytest.mark.parametrize('sort', [
+    None,
+    {"fields": ["file"], "order": "asc"},
+    {"fields": ["file"], "order": "desc"}
+])
+@patch('wazuh.decoder.glob', side_effect=decoders_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
+def test_get_decoders_file_pagination(mock_config, mock_glob, sort):
+    """
+    Tests getting decoders files and sorting results
+    """
+    d_files = Decoder.get_decoders_files(sort=sort)
+    if sort is not None:
+        assert d_files['items'][0]['file'] == f"decoders{'0' if sort['order'] == 'asc' else '1'}.xml"
+
+
+@pytest.mark.parametrize('search', [
+    None,
+    {"value": "1", "negation": 0},
+    {"value": "1", "negation": 1}
+])
+@patch('wazuh.decoder.glob', side_effect=decoders_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
+def test_get_decoders_file_pagination(mock_config, mock_glob, search):
+    """
+    Tests getting decoders files and searching results
+    """
+    d_files = Decoder.get_decoders_files(search=search)
+    if search is not None:
+        assert d_files['items'][0]['file'] == f"decoders{'0' if search['negation'] else '1'}.xml"

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -24,7 +24,9 @@ decoder_contents = '''
 
 
 @pytest.fixture()
-def open_mock():
+def open_mock(monkeypatch):
+    monkeypatch.setattr("wazuh.decoder.glob", decoders_files)
+    monkeypatch.setattr("wazuh.configuration.get_ossec_conf", lambda section: decoder_ossec_conf)
     return mock_open(read_data=decoder_contents)
 
 
@@ -48,9 +50,7 @@ def decoders_files(file_path):
     'disabled',
     'random'
 ])
-@patch('wazuh.decoder.glob', side_effect=decoders_files)
-@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_status(mock_config, mock_glob, status, func, open_mock):
+def test_get_decoders_file_status(status, func, open_mock):
     """
     Tests getting decoders using status filter
     """
@@ -80,9 +80,7 @@ def test_get_decoders_file_status(mock_config, mock_glob, status, func, open_moc
     'ruleset/decoders',
     'random'
 ])
-@patch('wazuh.decoder.glob', side_effect=decoders_files)
-@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_path(mock_config, mock_glob, path, func, open_mock):
+def test_get_decoders_file_path(path, func, open_mock):
     """
     Tests getting decoders files filtering by path
     """
@@ -110,9 +108,7 @@ def test_get_decoders_file_path(mock_config, mock_glob, path, func, open_mock):
     (2, 500),
     (3, 500)
 ])
-@patch('wazuh.decoder.glob', side_effect=decoders_files)
-@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_pagination(mock_config, mock_glob, offset, limit, func, open_mock):
+def test_get_decoders_file_pagination(offset, limit, func, open_mock):
     """
     Tests getting decoders files using offset and limit
     """
@@ -136,9 +132,7 @@ def test_get_decoders_file_pagination(mock_config, mock_glob, offset, limit, fun
     {"fields": ["file"], "order": "asc"},
     {"fields": ["file"], "order": "desc"}
 ])
-@patch('wazuh.decoder.glob', side_effect=decoders_files)
-@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_sort(mock_config, mock_glob, sort, func, open_mock):
+def test_get_decoders_file_sort(sort, func, open_mock):
     """
     Tests getting decoders files and sorting results
     """
@@ -159,9 +153,7 @@ def test_get_decoders_file_sort(mock_config, mock_glob, sort, func, open_mock):
     {"value": "1", "negation": 0},
     {"value": "1", "negation": 1}
 ])
-@patch('wazuh.decoder.glob', side_effect=decoders_files)
-@patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_search(mock_config, mock_glob, search, func, open_mock):
+def test_get_decoders_file_search(search, func, open_mock):
     """
     Tests getting decoders files and searching results
     """

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -23,6 +23,11 @@ decoder_contents = '''
     '''
 
 
+@pytest.fixture()
+def open_mock():
+    return mock_open(read_data=decoder_contents)
+
+
 def decoders_files(file_path):
     """
     Returns a list of decoders names
@@ -45,16 +50,15 @@ def decoders_files(file_path):
 ])
 @patch('wazuh.decoder.glob', side_effect=decoders_files)
 @patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_status(mock_config, mock_glob, status, func):
+def test_get_decoders_file_status(mock_config, mock_glob, status, func, open_mock):
     """
     Tests getting decoders using status filter
     """
-    m = mock_open(read_data=decoder_contents)
     if status == 'random':
         with pytest.raises(WazuhException, match='.* 1202 .*'):
             func(status=status)
     else:
-        with patch('builtins.open', m):
+        with patch('builtins.open', open_mock):
             d_files = func(status=status)
             if isinstance(d_files['items'][0], Decoder):
                 d_files['items'] = list(map(lambda x: x.to_dict(), d_files['items']))
@@ -78,12 +82,11 @@ def test_get_decoders_file_status(mock_config, mock_glob, status, func):
 ])
 @patch('wazuh.decoder.glob', side_effect=decoders_files)
 @patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_path(mock_config, mock_glob, path, func):
+def test_get_decoders_file_path(mock_config, mock_glob, path, func, open_mock):
     """
     Tests getting decoders files filtering by path
     """
-    m = mock_open(read_data=decoder_contents)
-    with patch('builtins.open', m):
+    with patch('builtins.open', open_mock):
         d_files = func(path=path)
         if path == 'random':
             assert d_files['totalItems'] == 0
@@ -109,13 +112,12 @@ def test_get_decoders_file_path(mock_config, mock_glob, path, func):
 ])
 @patch('wazuh.decoder.glob', side_effect=decoders_files)
 @patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_pagination(mock_config, mock_glob, offset, limit, func):
+def test_get_decoders_file_pagination(mock_config, mock_glob, offset, limit, func, open_mock):
     """
     Tests getting decoders files using offset and limit
     """
     if limit > 0:
-        m = mock_open(read_data=decoder_contents)
-        with patch('builtins.open', m):
+        with patch('builtins.open', open_mock):
             d_files = func(offset=offset, limit=limit)
             limit = d_files['totalItems'] if limit > d_files['totalItems'] else limit
             assert d_files['totalItems'] == 2
@@ -136,12 +138,11 @@ def test_get_decoders_file_pagination(mock_config, mock_glob, offset, limit, fun
 ])
 @patch('wazuh.decoder.glob', side_effect=decoders_files)
 @patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_sort(mock_config, mock_glob, sort, func):
+def test_get_decoders_file_sort(mock_config, mock_glob, sort, func, open_mock):
     """
     Tests getting decoders files and sorting results
     """
-    m = mock_open(read_data=decoder_contents)
-    with patch('builtins.open', m):
+    with patch('builtins.open', open_mock):
         d_files = func(sort=sort)
         if isinstance(d_files['items'][0], Decoder):
             d_files['items'] = list(map(lambda x: x.to_dict(), d_files['items']))
@@ -160,12 +161,11 @@ def test_get_decoders_file_sort(mock_config, mock_glob, sort, func):
 ])
 @patch('wazuh.decoder.glob', side_effect=decoders_files)
 @patch('wazuh.configuration.get_ossec_conf', return_value=decoder_ossec_conf)
-def test_get_decoders_file_search(mock_config, mock_glob, search, func):
+def test_get_decoders_file_search(mock_config, mock_glob, search, func, open_mock):
     """
     Tests getting decoders files and searching results
     """
-    m = mock_open(read_data=decoder_contents)
-    with patch('builtins.open', m):
+    with patch('builtins.open', open_mock):
         d_files = Decoder.get_decoders_files(search=search)
         if isinstance(d_files['items'][0], Decoder):
             d_files['items'] = list(map(lambda x: x.to_dict(), d_files['items']))

--- a/framework/wazuh/tests/test_rules.py
+++ b/framework/wazuh/tests/test_rules.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from unittest.mock import patch
+import pytest
+
+from wazuh.rule import Rule
+from wazuh.exception import WazuhException
+
+rule_ossec_conf = {
+    'rule_dir': ['ruleset/rules'],
+    'rule_exclude': 'rules1.xml'
+}
+
+
+def rules_files(file_path):
+    """
+    Returns a list of rules names
+    :param file_path: A glob file path containing *.xml in the end.
+    :return: A generator
+    """
+    return map(lambda x: file_path.replace('*.xml', f'rules{x}.xml'), range(2))
+
+
+@pytest.mark.parametrize('status', [
+    None,
+    'all',
+    'enabled',
+    'disabled',
+    'random'
+])
+@patch('wazuh.rule.glob', side_effect=rules_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)
+def test_get_rules_file_status(mock_config, mock_glob, status):
+    """
+    Tests getting rules file using status filter
+    """
+    if status == 'random':
+        with pytest.raises(WazuhException, match='.* 1202 .*'):
+            Rule.get_rules_files(status=status)
+    else:
+        d_files = Rule.get_rules_files(status=status)
+        if status is None or status == 'all':
+            assert d_files['totalItems'] == 2
+            assert d_files['items'][0]['status'] == 'enabled'
+            assert d_files['items'][1]['status'] == 'disabled'
+        else:
+            assert d_files['totalItems'] == 1
+            assert d_files['items'][0]['status'] == status
+
+
+@pytest.mark.parametrize('path', [
+    None,
+    'ruleset/rules',
+    'random'
+])
+@patch('wazuh.rule.glob', side_effect=rules_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)
+def test_get_rules_file_path(mock_config, mock_glob, path):
+    """
+    Tests getting rules files filtering by path
+    """
+    d_files = Rule.get_rules_files(path=path)
+    if path == 'random':
+        assert d_files['totalItems'] == 0
+        assert len(d_files['items']) == 0
+    else:
+        assert d_files['totalItems'] == 2
+        assert d_files['items'][0]['path'] == 'ruleset/rules'
+
+
+@pytest.mark.parametrize('offset, limit', [
+    (0, 0),
+    (0, 1),
+    (0, 500),
+    (1, 500),
+    (2, 500),
+    (3, 500)
+])
+@patch('wazuh.rule.glob', side_effect=rules_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)
+def test_get_rules_file_pagination(mock_config, mock_glob, offset, limit):
+    """
+    Tests getting rules files using offset and limit
+    """
+    if limit > 0:
+        d_files = Rule.get_rules_files(offset=offset, limit=limit)
+        limit = d_files['totalItems'] if limit > d_files['totalItems'] else limit
+        assert d_files['totalItems'] == 2
+        assert len(d_files['items']) == (limit - offset if limit > offset else 0)
+    else:
+        with pytest.raises(WazuhException, match='.* 1406 .*'):
+            Rule.get_rules_files(offset=offset, limit=limit)
+
+
+@pytest.mark.parametrize('sort', [
+    None,
+    {"fields": ["file"], "order": "asc"},
+    {"fields": ["file"], "order": "desc"}
+])
+@patch('wazuh.rule.glob', side_effect=rules_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)
+def test_get_rules_file_pagination(mock_config, mock_glob, sort):
+    """
+    Tests getting rules files and sorting results
+    """
+    d_files = Rule.get_rules_files(sort=sort)
+    if sort is not None:
+        assert d_files['items'][0]['file'] == f"rules{'0' if sort['order'] == 'asc' else '1'}.xml"
+
+
+@pytest.mark.parametrize('search', [
+    None,
+    {"value": "1", "negation": 0},
+    {"value": "1", "negation": 1}
+])
+@patch('wazuh.rule.glob', side_effect=rules_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)
+def test_get_rules_file_pagination(mock_config, mock_glob, search):
+    """
+    Tests getting rules files and searching results
+    """
+    d_files = Rule.get_rules_files(search=search)
+    if search is not None:
+        assert d_files['items'][0]['file'] == f"rules{'0' if search['negation'] else '1'}.xml"


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh/issues/2722.

The API call results now look like this:
```javascript
# curl -u foo:bar "localhost:55000/rules?limit=1&pretty"
{
   "error": 0,
   "data": {
      "items": [
         {
            "file": "0010-rules_config.xml",
            "path": "ruleset/rules",
            "id": 1,
            "level": 0,
            "description": "Generic template for all syslog rules.",
            "status": "enabled",
            "groups": [
               "syslog"
            ],
            "pci": [],
            "gdpr": [],
            "details": {
               "noalert": "1",
               "category": "syslog"
            }
         }
      ],
      "totalItems": 2115
   }
}
# curl -u foo:bar "localhost:55000/decoders?limit=1&pretty"
{
   "error": 0,
   "data": {
      "items": [
         {
            "file": "0005-wazuh_decoders.xml",
            "path": "ruleset/decoders",
            "name": "wazuh",
            "position": 0,
            "status": "enabled",
            "details": {
               "prematch": "^wazuh: "
            }
         }
      ],
      "totalItems": 571
   }
}
# curl -u foo:bar "localhost:55000/rules/files?limit=1&pretty"
{
   "error": 0,
   "data": {
      "items": [
         {
            "file": "0010-rules_config.xml",
            "path": "ruleset/rules",
            "status": "enabled"
         }
      ],
      "totalItems": 112
   }
}
# curl -u foo:bar "localhost:55000/decoders/files?limit=1&pretty"
{
   "error": 0,
   "data": {
      "items": [
         {
            "file": "0005-wazuh_decoders.xml",
            "path": "ruleset/decoders",
            "status": "enabled"
         }
      ],
      "totalItems": 96
   }
}
```

Unit tests done:
```python
# /var/ossec/framework/python/bin/pytest tests/test_rules.py -vv
============================================================================================================================ test session starts ============================================================================================================================platforplatform linux -- Python 3.7.2, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/vagrant/GitHub/wazuh/framework, inifile:
collected 40 items

tests/test_rules.py::test_get_rules_file_status[None-get_rules_files] PASSED                                                                                                                                                                                          [  2%]
tests/test_rules.py::test_get_rules_file_status[None-get_rules] PASSED                                                                                                                                                                                                [  5%]
tests/test_rules.py::test_get_rules_file_status[all-get_rules_files] PASSED                                                                                                                                                                                           [  7%]
tests/test_rules.py::test_get_rules_file_status[all-get_rules] PASSED                                                                                                                                                                                                 [ 10%]
tests/test_rules.py::test_get_rules_file_status[enabled-get_rules_files] PASSED                                                                                                                                                                                       [ 12%]
tests/test_rules.py::test_get_rules_file_status[enabled-get_rules] PASSED                                                                                                                                                                                             [ 15%]
tests/test_rules.py::test_get_rules_file_status[disabled-get_rules_files] PASSED                                                                                                                                                                                      [ 17%]
tests/test_rules.py::test_get_rules_file_status[disabled-get_rules] PASSED                                                                                                                                                                                            [ 20%]
tests/test_rules.py::test_get_rules_file_status[random-get_rules_files] PASSED                                                                                                                                                                                        [ 22%]
tests/test_rules.py::test_get_rules_file_status[random-get_rules] PASSED                                                                                                                                                                                              [ 25%]
tests/test_rules.py::test_get_rules_file_path[None-get_rules_files] PASSED                                                                                                                                                                                            [ 27%]
tests/test_rules.py::test_get_rules_file_path[None-get_rules] PASSED                                                                                                                                                                                                  [ 30%]
tests/test_rules.py::test_get_rules_file_path[ruleset/rules-get_rules_files] PASSED                                                                                                                                                                                   [ 32%]
tests/test_rules.py::test_get_rules_file_path[ruleset/rules-get_rules] PASSED                                                                                                                                                                                         [ 35%]
tests/test_rules.py::test_get_rules_file_path[random-get_rules_files] PASSED                                                                                                                                                                                          [ 37%]
tests/test_rules.py::test_get_rules_file_path[random-get_rules] PASSED                                                                                                                                                                                                [ 40%]
tests/test_rules.py::test_get_rules_file_pagination[0-0-get_rules_files] PASSED                                                                                                                                                                                       [ 42%]
tests/test_rules.py::test_get_rules_file_pagination[0-0-get_rules] PASSED                                                                                                                                                                                             [ 45%]
tests/test_rules.py::test_get_rules_file_pagination[0-1-get_rules_files] PASSED                                                                                                                                                                                       [ 47%]
tests/test_rules.py::test_get_rules_file_pagination[0-1-get_rules] PASSED                                                                                                                                                                                             [ 50%]
tests/test_rules.py::test_get_rules_file_pagination[0-500-get_rules_files] PASSED                                                                                                                                                                                     [ 52%]
tests/test_rules.py::test_get_rules_file_pagination[0-500-get_rules] PASSED                                                                                                                                                                                           [ 55%]
tests/test_rules.py::test_get_rules_file_pagination[1-500-get_rules_files] PASSED                                                                                                                                                                                     [ 57%]
tests/test_rules.py::test_get_rules_file_pagination[1-500-get_rules] PASSED                                                                                                                                                                                           [ 60%]
tests/test_rules.py::test_get_rules_file_pagination[2-500-get_rules_files] PASSED                                                                                                                                                                                     [ 62%]
tests/test_rules.py::test_get_rules_file_pagination[2-500-get_rules] PASSED                                                                                                                                                                                           [ 65%]
tests/test_rules.py::test_get_rules_file_pagination[3-500-get_rules_files] PASSED                                                                                                                                                                                     [ 67%]
tests/test_rules.py::test_get_rules_file_pagination[3-500-get_rules] PASSED                                                                                                                                                                                           [ 70%]
tests/test_rules.py::test_get_rules_file_sort[None-get_rules_files] PASSED                                                                                                                                                                                            [ 72%]
tests/test_rules.py::test_get_rules_file_sort[None-get_rules] PASSED                                                                                                                                                                                                  [ 75%]
tests/test_rules.py::test_get_rules_file_sort[sort1-get_rules_files] PASSED                                                                                                                                                                                           [ 77%]
tests/test_rules.py::test_get_rules_file_sort[sort1-get_rules] PASSED                                                                                                                                                                                                 [ 80%]
tests/test_rules.py::test_get_rules_file_sort[sort2-get_rules_files] PASSED                                                                                                                                                                                           [ 82%]
tests/test_rules.py::test_get_rules_file_sort[sort2-get_rules] PASSED                                                                                                                                                                                                 [ 85%]
tests/test_rules.py::test_get_rules_file_search[None-get_rules_files] PASSED                                                                                                                                                                                          [ 87%]
tests/test_rules.py::test_get_rules_file_search[None-get_rules] PASSED                                                                                                                                                                                                [ 90%]
tests/test_rules.py::test_get_rules_file_search[search1-get_rules_files] PASSED                                                                                                                                                                                       [ 92%]
tests/test_rules.py::test_get_rules_file_search[search1-get_rules] PASSED                                                                                                                                                                                             [ 95%]
tests/test_rules.py::test_get_rules_file_search[search2-get_rules_files] PASSED                                                                                                                                                                                       [ 97%]
tests/test_rules.py::test_get_rules_file_search[search2-get_rules] PASSED

========================================================================================================================= 11 passed in 0.36 seconds =========================================================================================================================
# /var/ossec/framework/python/bin/pytest tests/test_decoders.py -vv
============================================================================================================================ test session starts ============================================================================================================================platfortests/test_decoders.py::test_get_decoders_file_status[None-get_decoders_files] PASSED                                                                                                                                                                                 [  2%]
tests/test_decoders.py::test_get_decoders_file_status[None-get_decoders] PASSED                                                                                                                                                                                       [  5%]
tests/test_decoders.py::test_get_decoders_file_status[all-get_decoders_files] PASSED                                                                                                                                                                                  [  7%]
tests/test_decoders.py::test_get_decoders_file_status[all-get_decoders] PASSED                                                                                                                                                                                        [ 10%]
tests/test_decoders.py::test_get_decoders_file_status[enabled-get_decoders_files] PASSED                                                                                                                                                                              [ 12%]
tests/test_decoders.py::test_get_decoders_file_status[enabled-get_decoders] PASSED                                                                                                                                                                                    [ 15%]
tests/test_decoders.py::test_get_decoders_file_status[disabled-get_decoders_files] PASSED                                                                                                                                                                             [ 17%]
tests/test_decoders.py::test_get_decoders_file_status[disabled-get_decoders] PASSED                                                                                                                                                                                   [ 20%]
tests/test_decoders.py::test_get_decoders_file_status[random-get_decoders_files] PASSED                                                                                                                                                                               [ 22%]
tests/test_decoders.py::test_get_decoders_file_status[random-get_decoders] PASSED                                                                                                                                                                                     [ 25%]
tests/test_decoders.py::test_get_decoders_file_path[None-get_decoders_files] PASSED                                                                                                                                                                                   [ 27%]
tests/test_decoders.py::test_get_decoders_file_path[None-get_decoders] PASSED                                                                                                                                                                                         [ 30%]
tests/test_decoders.py::test_get_decoders_file_path[ruleset/decoders-get_decoders_files] PASSED                                                                                                                                                                       [ 32%]
tests/test_decoders.py::test_get_decoders_file_path[ruleset/decoders-get_decoders] PASSED                                                                                                                                                                             [ 35%]
tests/test_decoders.py::test_get_decoders_file_path[random-get_decoders_files] PASSED                                                                                                                                                                                 [ 37%]
tests/test_decoders.py::test_get_decoders_file_path[random-get_decoders] PASSED                                                                                                                                                                                       [ 40%]
tests/test_decoders.py::test_get_decoders_file_pagination[0-0-get_decoders_files] PASSED                                                                                                                                                                              [ 42%]
tests/test_decoders.py::test_get_decoders_file_pagination[0-0-get_decoders] PASSED                                                                                                                                                                                    [ 45%]
tests/test_decoders.py::test_get_decoders_file_pagination[0-1-get_decoders_files] PASSED                                                                                                                                                                              [ 47%]
tests/test_decoders.py::test_get_decoders_file_pagination[0-1-get_decoders] PASSED                                                                                                                                                                                    [ 50%]
tests/test_decoders.py::test_get_decoders_file_pagination[0-500-get_decoders_files] PASSED                                                                                                                                                                            [ 52%]
tests/test_decoders.py::test_get_decoders_file_pagination[0-500-get_decoders] PASSED                                                                                                                                                                                  [ 55%]
tests/test_decoders.py::test_get_decoders_file_pagination[1-500-get_decoders_files] PASSED                                                                                                                                                                            [ 57%]
tests/test_decoders.py::test_get_decoders_file_pagination[1-500-get_decoders] PASSED                                                                                                                                                                                  [ 60%]
tests/test_decoders.py::test_get_decoders_file_pagination[2-500-get_decoders_files] PASSED                                                                                                                                                                            [ 62%]
tests/test_decoders.py::test_get_decoders_file_pagination[2-500-get_decoders] PASSED                                                                                                                                                                                  [ 65%]
tests/test_decoders.py::test_get_decoders_file_pagination[3-500-get_decoders_files] PASSED                                                                                                                                                                            [ 67%]
tests/test_decoders.py::test_get_decoders_file_pagination[3-500-get_decoders] PASSED                                                                                                                                                                                  [ 70%]
tests/test_decoders.py::test_get_decoders_file_sort[None-get_decoders_files] PASSED                                                                                                                                                                                   [ 72%]
tests/test_decoders.py::test_get_decoders_file_sort[None-get_decoders] PASSED                                                                                                                                                                                         [ 75%]
tests/test_decoders.py::test_get_decoders_file_sort[sort1-get_decoders_files] PASSED                                                                                                                                                                                  [ 77%]
tests/test_decoders.py::test_get_decoders_file_sort[sort1-get_decoders] PASSED                                                                                                                                                                                        [ 80%]
tests/test_decoders.py::test_get_decoders_file_sort[sort2-get_decoders_files] PASSED                                                                                                                                                                                  [ 82%]
tests/test_decoders.py::test_get_decoders_file_sort[sort2-get_decoders] PASSED                                                                                                                                                                                        [ 85%]
tests/test_decoders.py::test_get_decoders_file_search[None-get_decoders_files] PASSED                                                                                                                                                                                 [ 87%]
tests/test_decoders.py::test_get_decoders_file_search[None-get_decoders] PASSED                                                                                                                                                                                       [ 90%]
tests/test_decoders.py::test_get_decoders_file_search[search1-get_decoders_files] PASSED                                                                                                                                                                              [ 92%]
tests/test_decoders.py::test_get_decoders_file_search[search1-get_decoders] PASSED                                                                                                                                                                                    [ 95%]
tests/test_decoders.py::test_get_decoders_file_search[search2-get_decoders_files] PASSED                                                                                                                                                                              [ 97%]
tests/test_decoders.py::test_get_decoders_file_search[search2-get_decoders] PASSED

========================================================================================================================= 11 passed in 0.34 seconds =========================================================================================================================
```

Best regards,
Marta