### PR TITLE
Deprecate global option <queue_size> for Analysisd

### DIFF
--- a/etc/templates/config/generic/global.template
+++ b/etc/templates/config/generic/global.template
@@ -9,5 +9,4 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <queue_size>131072</queue_size>
   </global>

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -631,6 +631,10 @@ int main_analysisd(int argc, char **argv)
         exit(0);
     }
 
+    if (Config.queue_size != 0) {
+        minfo("The option <queue_size> is deprecated and won't apply. Set up each queue size in the internal_options file.");
+    }
+
     /* Verbose message */
     mdebug1(PRIVSEP_MSG, dir, user);
 

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -86,7 +86,6 @@ int GlobalConf(const char *cfgfile)
     Config.rotate_interval = 0;
     Config.min_rotate_interval = 0;
     Config.max_output_size = 0;
-    Config.queue_size = 131072;
 
     os_calloc(1, sizeof(wlabel_t), Config.labels);
 
@@ -116,15 +115,6 @@ int GlobalConf(const char *cfgfile)
     if (Config.max_output_size && (Config.max_output_size < 1000000 || Config.max_output_size > 1099511627776)) {
         merror("Maximum output size must be between 1 MiB and 1 TiB.");
         return (OS_INVALID);
-    }
-
-    if (Config.queue_size < 1) {
-        merror("Queue size is invalid. Review configuration.");
-        return OS_INVALID;
-    }
-
-    if (Config.queue_size > 262144) {
-        mwarn("Queue size is very high. The application may run out of memory.");
     }
 
     return (0);

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -86,6 +86,7 @@ int GlobalConf(const char *cfgfile)
     Config.rotate_interval = 0;
     Config.min_rotate_interval = 0;
     Config.max_output_size = 0;
+    Config.queue_size = 0;
 
     os_calloc(1, sizeof(wlabel_t), Config.labels);
 

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -651,17 +651,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                 }
             }
         } else if (strcmp(node[i]->element, xml_queue_size) == 0) {
-            if (Config) {
-                char * end;
-
-                Config->queue_size = strtol(node[i]->content, &end, 10);
-
-                if (*end || Config->queue_size < 1) {
-                    merror("Invalid value for option '<%s>'", xml_queue_size);
-                    return OS_INVALID;
-                }
-
-            }
+            minfo("Option <%s> is deprecated and won't apply. Set up each queue size in the internal_options file.", xml_queue_size);
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -651,7 +651,17 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                 }
             }
         } else if (strcmp(node[i]->element, xml_queue_size) == 0) {
-            minfo("Option <%s> is deprecated and won't apply. Set up each queue size in the internal_options file.", xml_queue_size);
+            if (Config) {
+                char * end;
+
+                Config->queue_size = strtol(node[i]->content, &end, 10);
+
+                if (*end || Config->queue_size < 1) {
+                    merror("Invalid value for option '<%s>'", xml_queue_size);
+                    return OS_INVALID;
+                }
+
+            }
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);


### PR DESCRIPTION
From Wazuh v3.7 on, each queue can have its size set in the internal_options file.

This PR removes this option:
```xml
<global>
  <queue_size>131072</queue_size>
</global>
```

And makes Analysisd show this message if it finds such option:
> ossec-analysisd: INFO: Option <queue_size> is deprecated and won't apply. Set up each queue size in the internal_options file.