### PR TITLE
Fix NULL value for labels variable

### DIFF
--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -67,6 +67,8 @@ static void format_labels(char *buffer, size_t size, const Eventinfo *lf) {
                 buffer[0] = '\0';
                 return;
             }
+        } else {
+            buffer[0] = '\0';
         }
     }
 }
@@ -303,7 +305,6 @@ void OS_Log(Eventinfo *lf)
         }
     }
 #endif
-
     if (lf->labels && lf->labels[0].key) {
         format_labels(labels, OS_MAXSTR, lf);
     } else {

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -69,10 +69,6 @@ static void format_labels(char *buffer, size_t size, const Eventinfo *lf) {
             }
         }
     }
-
-    if (*buffer == NULL){
-        buffer[0] = '\0';
-    }
 }
 
 /* Store the events in a file
@@ -109,8 +105,7 @@ void OS_Store_Flush(){
 void OS_LogOutput(Eventinfo *lf)
 {
     int i;
-    char labels[OS_MAXSTR];
-    *labels = NULL;
+    char labels[OS_MAXSTR] = {0};
 
 #ifdef LIBGEOIP_ENABLED
     if (Config.geoipdb_file) {
@@ -296,8 +291,7 @@ void OS_LogOutput(Eventinfo *lf)
 void OS_Log(Eventinfo *lf)
 {
     int i;
-    char labels[OS_MAXSTR];
-    *labels = NULL;
+    char labels[OS_MAXSTR] = {0};
 
 #ifdef LIBGEOIP_ENABLED
     if (Config.geoipdb_file) {

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -67,9 +67,11 @@ static void format_labels(char *buffer, size_t size, const Eventinfo *lf) {
                 buffer[0] = '\0';
                 return;
             }
-        } else {
-            buffer[0] = '\0';
         }
+    }
+
+    if (*buffer == NULL){
+        buffer[0] = '\0';
     }
 }
 
@@ -108,6 +110,7 @@ void OS_LogOutput(Eventinfo *lf)
 {
     int i;
     char labels[OS_MAXSTR];
+    *labels = NULL;
 
 #ifdef LIBGEOIP_ENABLED
     if (Config.geoipdb_file) {
@@ -294,6 +297,7 @@ void OS_Log(Eventinfo *lf)
 {
     int i;
     char labels[OS_MAXSTR];
+    *labels = NULL;
 
 #ifdef LIBGEOIP_ENABLED
     if (Config.geoipdb_file) {


### PR DESCRIPTION
This PR fixes the issue https://github.com/wazuh/wazuh/issues/2728.

The variable `labels` had a NULL value due to the [format_labels](https://github.com/wazuh/wazuh/blob/019b411a5721df5382cfe5998bf72475a5086b42/src/analysisd/alerts/log.c#L56) function, as the new `lf->labels[i].flags.system` may have a non-zero value, that is why the `labels` variable was not being initialized.