### PR TITLE
Allow empty fields in Syscollector

### DIFF
--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -584,7 +584,17 @@ int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_tim
         sqlite3_bind_null(stmt, 5);
     }
 
-    sqlite3_bind_text(stmt, 6, cpu_mhz, -1, NULL);
+    double cpumhz = 0;
+    if (cpu_mhz == NULL || strlen(cpu_mhz) == 0) {
+        cpumhz = 0;
+    } else {
+        cpumhz = atof(cpu_mhz);
+    }
+    if (cpumhz > 0) {
+        sqlite3_bind_double(stmt, 6, cpumhz);
+    } else {
+        sqlite3_bind_null(stmt, 6);
+    }
 
     if (ram_total > 0) {
         sqlite3_bind_int64(stmt, 7, ram_total);


### PR DESCRIPTION
Hi, Team,

This PR fixes the issue https://github.com/wazuh/wazuh/issues/2716.

Bug description
--
When a record is going to be inserted in the table `sys_hwinfo` with the field `cpu_mhz` containing `0`, an error is thrown, because of a constraint in the schema of the table. Namely: `cpu_mhz REAL CHECK (cpu_mhz > 0)`; the accepted values must be `> 0`. 

The error is reproduced in the issue: https://github.com/wazuh/wazuh/issues/2716#issuecomment-468647820.

Solution
--
Check the value in the Syscollector decoder. Allow the value `cpu_mhz` to be `0`, and send an empty field in this case.


Testing
--
See below.
