### PR TITLE
Ignore encoding errors when reading data from Wazuh DB socket

### DIFF
--- a/framework/wazuh/tests/test_wdb.py
+++ b/framework/wazuh/tests/test_wdb.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from unittest.mock import patch
+import pytest
+
+from wazuh import exception
+from wazuh.wdb import WazuhDBConnection
+
+
+def test_failed_connection():
+    """
+    Tests an exception is properly raised when it's not possible to connect to wdb
+    """
+    # tests the socket path doesn't exists
+    with patch('wazuh.common.wdb_socket_path', '/this/path/doesnt/exist'):
+        with pytest.raises(exception.WazuhException, match=".* 2005 .*"):
+            WazuhDBConnection()
+    # tests an exception is properly raised when a connection error is raised
+    with patch('socket.socket') as socket_patch:
+        with pytest.raises(exception.WazuhException, match=".* 2005 .*"):
+            socket_patch.return_value.connect.side_effect = ConnectionError
+            WazuhDBConnection()
+
+
+@patch('wazuh.wdb.WazuhDBConnection')
+def test_wrong_character_encodings_wdb(wdb_mock):
+    """
+    Tests receiving a text with a bad character encoding from wazuh db
+    """
+    def recv_mock(size_to_receive):
+        bad_string = b' {"bad": "\x96bad"}'
+        return bytes(len(bad_string)) if size_to_receive == 4 else bad_string
+
+    with patch('socket.socket.recv', side_effect=recv_mock):
+        mywdb = WazuhDBConnection()
+        received = mywdb._send("test")
+        assert received == {"bad": "bad"}

--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -63,7 +63,7 @@ class WazuhDBConnection:
         data = self.__conn.recv(4)
         data_size = struct.unpack('<I',data[0:4])[0]
 
-        data = self.__conn.recv(data_size).decode('utf-8').split(" ", 1)
+        data = self.__conn.recv(data_size).decode('utf-8', 'ignore').split(" ", 1)
 
         if data[0] == "err":
             raise WazuhException(2003, data[1])

--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -6,7 +6,6 @@
 
 from wazuh import common
 from wazuh.exception import WazuhException
-from os import strerror
 import socket
 import re
 import json
@@ -27,8 +26,8 @@ class WazuhDBConnection:
         self.__conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
             self.__conn.connect(self.socket_path)
-        except socket.error as e:
-            raise WazuhException(2005, strerror(e[0]))
+        except OSError as e:
+            raise WazuhException(2005, e)
 
 
     def __query_input_validation(self, query):
@@ -61,7 +60,7 @@ class WazuhDBConnection:
 
         # Get the data size (4 bytes)
         data = self.__conn.recv(4)
-        data_size = struct.unpack('<I',data[0:4])[0]
+        data_size = struct.unpack('<I', data[0:4])[0]
 
         data = self.__conn.recv(data_size).decode('utf-8', 'ignore').split(" ", 1)
 

--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -52,7 +52,7 @@ class WazuhDBConnection:
                 raise WazuhException(2004, error_text)
 
 
-    def __send(self, msg):
+    def _send(self, msg):
         """
         Sends a message to the wdb socket
         """
@@ -102,7 +102,7 @@ class WazuhDBConnection:
         def send_request_to_wdb(query_lower, step, off, response):
             try:
                 request = "{} limit {} offset {}".format(query_lower, step, off)
-                response.extend(self.__send(request))
+                response.extend(self._send(request))
             except ValueError:
                 # if the step is already 1, it can't be divided
                 if step == 1:
@@ -119,7 +119,7 @@ class WazuhDBConnection:
             regex = re.compile(r"\w+ \d+? sql delete from ([a-z0-9,_ ]+)")
             if regex.match(query_lower) is None:
                 raise WazuhException(2004, "Delete query is wrong")
-            return self.__send(query_lower)
+            return self._send(query_lower)
 
         # only for update queries
         if update:
@@ -128,7 +128,7 @@ class WazuhDBConnection:
                                r" '([a-z0-9,*_%\- ]+)'")
             if regex.match(query_lower) is None:
                 raise WazuhException(2004, "Update query is wrong")
-            return self.__send(query_lower)
+            return self._send(query_lower)
 
         # if the query has already a parameter limit / offset, divide using it
         offset = 0
@@ -145,7 +145,7 @@ class WazuhDBConnection:
             regex = re.compile(r"\w+ \d+? sql select ([A-Z a-z0-9,*_` \.\-%\(\):\']+) from")
             select = regex.match(query_lower).group(1)
             countq = query_lower.replace(select, "count(*)", 1)
-            total = list(self.__send(countq)[0].values())[0]
+            total = list(self._send(countq)[0].values())[0]
 
             limit = lim if lim != 0 else total
 
@@ -164,4 +164,4 @@ class WazuhDBConnection:
             else:
                 return response
         else:
-            return list(self.__send(query_lower)[0].values())[0]
+            return list(self._send(query_lower)[0].values())[0]

--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -62,7 +62,7 @@ class WazuhDBConnection:
         data = self.__conn.recv(4)
         data_size = struct.unpack('<I', data[0:4])[0]
 
-        data = self.__conn.recv(data_size).decode('utf-8', 'ignore').split(" ", 1)
+        data = self.__conn.recv(data_size).decode(encoding='utf-8', errors='ignore').split(" ", 1)
 
         if data[0] == "err":
             raise WazuhException(2003, data[1])


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh-api/issues/333 and closes https://github.com/wazuh/wazuh/issues/1202.

It also updates how socket errors are managed when initializing a `WazuhDBConnection` object: from Python 3.3 `OSError` exceptions are raised instead of `socket.error` exceptions. More info about this: https://docs.python.org/3.7/library/socket.html#socket.error.

In order to correctly test send function inside `WazuhDBConnection`, it had to be renamed from `__send` to `_send`.

Unit tests:
```
# /var/ossec/framework/python/bin/pytest tests/test_wdb.py -vv
============================================================================================================================ test session starts ============================================================================================================================
platform linux -- Python 3.7.2, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/vagrant/GitHub/wazuh/framework, inifile:
collected 2 items

tests/test_wdb.py::test_failed_connection PASSED                                                                                                                                                                                                                      [ 50%]
tests/test_wdb.py::test_wrong_character_encodings_wdb PASSED                                                                                                                                                                                                          [100%]

========================================================================================================================= 2 passed in 0.12 seconds ==========================================================================================================================
```

Best regards,
Marta