### PR TITLE
Coverity Scan Fixes for Windows

### DIFF
--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -216,7 +216,6 @@ int add_agent(int json_output, int no_limit)
         if (!OS_IsValidIP(ip, &c_ip)) {
             printf(IP_ERROR, ip);
             _ip = NULL;
-            free(c_ip.ip);
             c_ip.ip = NULL;
         } else if (!authd_running && (id_exist = IPExist(ip))) {
             double antiquity = OS_AgentAntiquity_ID(id_exist);

--- a/src/client-agent/request.c
+++ b/src/client-agent/request.c
@@ -368,7 +368,7 @@ void * req_receiver(__attribute__((unused)) void * arg) {
         w_mutex_unlock(&mutex_table);
 
         // Delete node
-        free(buffer);
+        os_free(buffer);
         req_free(node);
     }
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -900,10 +900,12 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                             snprintf(arch, 6, "%s", "both");
                         } else {
                             merror(XML_INVATTR, node[i]->attributes[j], node[i]->content);
+                            free(tag);
                             return OS_INVALID;
                         }
                     } else {
                         merror(XML_INVATTR, node[i]->attributes[j], node[i]->content);
+                        free(tag);
                         return OS_INVALID;
                     }
                     j++;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -268,6 +268,7 @@ int read_reg(syscheck_config *syscheck, char *entries, int arch, char *tag)
             if (syscheck->registry[i].arch == arch && strcmp(syscheck->registry[i].entry, tmp_entry) == 0) {
                 mdebug2("Overwriting the registration entry: %s", syscheck->registry[i].entry);
                 dump_syscheck_entry(syscheck, tmp_entry, arch, 1, NULL, 0, clean_tag, i);
+                free_strarray(entry);
                 return (1);
             }
             i++;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -915,14 +915,23 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
             if (strcmp(arch, "both") == 0) {
                 if (!(read_reg(syscheck, node[i]->content, ARCH_32BIT, tag) &&
-                read_reg(syscheck, node[i]->content, ARCH_64BIT, tag)))
-                return (OS_INVALID);
+                read_reg(syscheck, node[i]->content, ARCH_64BIT, tag))) {
+                    free(tag);
+                    return (OS_INVALID);
+                }
+                
             } else if (strcmp(arch, "64bit") == 0) {
-                if (!read_reg(syscheck, node[i]->content, ARCH_64BIT, tag))
-                return (OS_INVALID);
+                if (!read_reg(syscheck, node[i]->content, ARCH_64BIT, tag)) {
+                    free(tag);
+                    return (OS_INVALID);
+                }
+                
             } else {
-                if (!read_reg(syscheck, node[i]->content, ARCH_32BIT, tag))
-                return (OS_INVALID);
+                if (!read_reg(syscheck, node[i]->content, ARCH_32BIT, tag)) {
+                    free(tag);
+                    return (OS_INVALID);
+                }
+                
             }
 
             if (tag)

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1016,6 +1016,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
             if(!ExpandEnvironmentStrings(node[i]->content, new_ig, 2047)){
                 merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
+                free(new_ig);
                 continue;
             }
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1140,6 +1140,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
             if(!ExpandEnvironmentStrings(node[i]->content, new_nodiff, 2047)){
                 merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
+                free(new_nodiff);
                 continue;
             }
 

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -55,12 +55,20 @@ static int OS_Bindport(u_int16_t _port, unsigned int _proto, const char *_ip, in
 #endif
 
     if (_proto == IPPROTO_UDP) {
+#ifndef WIN32
         if ((ossock = socket(ipv6 == 1 ? PF_INET6 : PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+#else 
+        if ((ossock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+#endif
             return OS_SOCKTERR;
         }
     } else if (_proto == IPPROTO_TCP) {
         int flag = 1;
+#ifndef WIN32
         if ((ossock = socket(ipv6 == 1 ? PF_INET6 : PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+#else
+        if ((ossock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+#endif
             return (int)(OS_SOCKTERR);
         }
 
@@ -240,11 +248,19 @@ static int OS_Connect(u_int16_t _port, unsigned int protocol, const char *_ip, i
 #endif
 
     if (protocol == IPPROTO_TCP) {
+#ifndef WIN32
         if ((ossock = socket(ipv6 == 1 ? PF_INET6 : PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+#else
+        if ((ossock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+#endif
             return (OS_SOCKTERR);
         }
     } else if (protocol == IPPROTO_UDP) {
+#ifndef WIN32
         if ((ossock = socket(ipv6 == 1 ? PF_INET6 : PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+#else 
+        if ((ossock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+#endif
             return (OS_SOCKTERR);
         }
     } else {

--- a/src/shared/exec_op.c
+++ b/src/shared/exec_op.c
@@ -84,6 +84,10 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
             CloseHandle(hPipe[1]);
         }
 
+        if(lpCommandLine) {
+            free(lpCommandLine);
+        }
+
         return NULL;
     }
 

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -17,7 +17,7 @@ w_queue_t * queue_init(size_t size) {
     os_malloc(size * sizeof(void *), queue->data);
     queue->size = size;
     queue->elements = 0;
-    pthread_mutex_init(&queue->mutex, NULL);
+    w_mutex_init(&queue->mutex, NULL);
     pthread_cond_init(&queue->available, NULL);
     pthread_cond_init(&queue->available_not_empty, NULL);
     return queue;

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -319,6 +319,10 @@ int OS_ReadXMLRules(const char *rulefile,
                                              realloc(config_ruleinfo->srcip,
                                                      (ip_s + 2) * sizeof(os_ip *));
 
+                    if(config_ruleinfo->srcip == NULL) {
+                        merror_exit(MEM_ERROR, errno, strerror(errno));
+                    }
+                    
                     /* Allocate memory for the individual entries */
                     os_calloc(1, sizeof(os_ip),
                               config_ruleinfo->srcip[ip_s]);

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -54,6 +54,8 @@ os_info *get_win_version()
     if (!(bOsVersionInfoEx = GetVersionEx ((OSVERSIONINFO *) &osvi))) {
         osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
         if (!GetVersionEx((OSVERSIONINFO *)&osvi)) {
+            free(info);
+            free(subkey);
             return (NULL);
         }
     }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -511,6 +511,7 @@ int realtime_adddir(const char *dir, int whodata)
     /* Maximum limit for realtime on Windows */
     if (syscheck.realtime->fd > syscheck.max_fd_win_rt) {
         merror("Unable to add directory to real time monitoring: '%s' - Maximum size permitted.", dir);
+        w_mutex_unlock(&adddir_mutex);
         return (0);
     }
 
@@ -537,6 +538,7 @@ int realtime_adddir(const char *dir, int whodata)
             free(rtlocald);
             rtlocald = NULL;
             merror("Unable to add directory to real time monitoring: '%s'.", dir);
+            w_mutex_unlock(&adddir_mutex);
             return (0);
         }
         syscheck.realtime->fd++;

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -338,7 +338,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch, const char *
     } else if (fullkey_name && syscheck.registry_ignore_regex) {
         i = 0;
         while (syscheck.registry_ignore_regex[i].regex != NULL) {
-            if (syscheck.registry_ignore[i].arch == arch &&
+            if (syscheck.registry_ignore_regex[i].arch == arch &&
                 OSMatch_Execute(fullkey_name, strlen(fullkey_name),
                                 syscheck.registry_ignore_regex[i].regex)) {
                 mdebug1("Ignoring registry '%s' ignore '%s', continuing...", fullkey_name, syscheck.registry_ignore_regex[i].regex->raw);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -557,7 +557,7 @@ wdb_t * wdb_init(sqlite3 * db, const char * agent_id) {
     wdb_t * wdb;
     os_calloc(1, sizeof(wdb_t), wdb);
     wdb->db = db;
-    pthread_mutex_init(&wdb->mutex, NULL);
+    w_mutex_init(&wdb->mutex, NULL);
     os_strdup(agent_id, wdb->agent_id);
     return wdb;
 }

--- a/src/wazuh_modules/syscollector/syscollector_win_ext.c
+++ b/src/wazuh_modules/syscollector/syscollector_win_ext.c
@@ -33,6 +33,10 @@ __declspec( dllexport ) char* wm_inet_ntop(UCHAR ucLocalAddr[]){
     char *address;
     address = calloc(129, sizeof(char));
 
+    if(address == NULL) {
+        return NULL;
+    }
+
     inet_ntop(AF_INET6,(struct in6_addr *)ucLocalAddr, address, 128);
 
     return address;
@@ -363,6 +367,10 @@ char* get_broadcast_addr(char* ip, char* netmask){
 
     struct in_addr host, mask, broadcast;
     char* broadcast_addr = calloc(NI_MAXHOST, sizeof(char));
+
+    if(broadcast_addr == NULL) {
+        return NULL;
+    }
 
     if (inet_pton(AF_INET, ip, &host) == 1 && inet_pton(AF_INET, netmask, &mask) == 1){
         broadcast.s_addr = host.s_addr | ~mask.s_addr;

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1241,7 +1241,9 @@ void sys_hw_windows(const char* LOCATION){
                 }
             }
         }
-        FreeLibrary(sys_library);
+        if(sys_library) {
+            FreeLibrary(sys_library);
+        }
     } else {
         
         char *command;

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1884,7 +1884,12 @@ void sys_network_windows(const char* LOCATION){
 
                 if (checkVista()) {
                     /* Call function get_network_vista() in syscollector_win_ext.dll */
-                    string = _get_network_vista(pCurrAddresses, ID, timestamp);
+                    if(_get_network_vista) {
+                        string = _get_network_vista(pCurrAddresses, ID, timestamp);
+                    }
+                    else {
+                        os_strdup("UNKNOWN",string);
+                    }
                 } else {
                     /* Call function get_network_xp() */
                     string = get_network_xp(pCurrAddresses, AdapterInfo, ID, timestamp);

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1756,6 +1756,11 @@ void sys_network_windows(const char* LOCATION){
         }
     }
 
+    if (sys_library)  { 
+        FreeLibrary(sys_library);
+        sys_library = NULL;
+    }
+
     if (dwRetVal != NO_ERROR) return;
 
     // Define time to sleep between messages sent
@@ -1915,8 +1920,6 @@ void sys_network_windows(const char* LOCATION){
     if (pAddresses) {
         win_free(pAddresses);
     }
-
-    if (sys_library) FreeLibrary(sys_library);
 
     cJSON *object = cJSON_CreateObject();
     cJSON_AddStringToObject(object, "type", "network_end");

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -159,7 +159,9 @@ char* get_process_name(DWORD pid){
                     if (pBuffer != NULL) HeapFree(hHeap, 0, pBuffer);
                 }
             }
-            FreeLibrary(ntdll);
+            if(ntdll) {
+                FreeLibrary(ntdll);
+            }
         } else {
             mtwarn(WM_SYS_LOGTAG, "At get_process_name(): Unable to retrieve handle for process with PID %lu (%lu).", pid, GetLastError());
         }

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1741,6 +1741,7 @@ void sys_network_windows(const char* LOCATION){
                 dwRetVal = GetLastError();
                 mterror(WM_SYS_LOGTAG, "Unable to access 'get_network_vista' on syscollector_win_ext.dll.");
             }
+            FreeLibrary(sys_library);
         } else {
             dwRetVal = GetLastError();
             LPSTR messageBuffer = NULL;
@@ -1755,11 +1756,6 @@ void sys_network_windows(const char* LOCATION){
             mterror(WM_SYS_LOGTAG, "Unable to load syscollector_win_ext.dll: %s (%lu)", messageBuffer, dwRetVal);
             LocalFree(messageBuffer);
         }
-    }
-
-    if (sys_library)  { 
-        FreeLibrary(sys_library);
-        sys_library = NULL;
     }
 
     if (dwRetVal != NO_ERROR) return;

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -159,6 +159,7 @@ char* get_process_name(DWORD pid){
                     if (pBuffer != NULL) HeapFree(hHeap, 0, pBuffer);
                 }
             }
+            FreeLibrary(ntdll);
         } else {
             mtwarn(WM_SYS_LOGTAG, "At get_process_name(): Unable to retrieve handle for process with PID %lu (%lu).", pid, GetLastError());
         }

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1239,7 +1239,7 @@ void sys_hw_windows(const char* LOCATION){
                 }
             }
         }
-    
+        FreeLibrary(sys_library);
     } else {
         
         char *command;

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -485,6 +485,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
 
     free(output);
     free(command);
+    free(ciscat_script);
 }
 
 #else

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -249,7 +249,7 @@ void wm_kill_children() {
 
     w_mutex_lock(&wm_children_mutex);
 
-    for (i = 0; wm_children[i] && i < WM_POOL_SIZE; i++)  {
+    for (i = 0; i < WM_POOL_SIZE && wm_children[i]; i++)  {
         TerminateProcess(wm_children[i], 127);
     }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -358,7 +358,7 @@ static void wm_sca_read_files(wm_sca_t * data) {
                 continue;
             }
 
-            char path[PATH_MAX];
+            char path[PATH_MAX] = {0};
             OSStore *vars = NULL;
             cJSON * object = NULL;
             OSList *plist = NULL;


### PR DESCRIPTION
### Fixed Coverity Errors

As the Coverity report showed, there where some errors in different files of Wazuh, leading for memleaks and program hangs.