### PR TITLE
SonicWall decoder: fix support for firewalls with additional whitespaces and UTC timestamps.

### DIFF
--- a/etc/decoders/0295-sonicwall_decoders.xml
+++ b/etc/decoders/0295-sonicwall_decoders.xml
@@ -17,6 +17,6 @@
   -->
 <decoder name="sonicwall">
   <type>firewall</type>
-  <prematch>^id=\w+ sn=\w+ time=\S+ \S+ fw=\S+ pri=\d </prematch>
+  <prematch>^\s*id=\w+\s+sn=\w+ time="\.+" fw=\S+ pri=\d </prematch>
   <plugin_decoder>SonicWall_Decoder</plugin_decoder>
 </decoder>


### PR DESCRIPTION
This PR aims to fix issue #2757 by modifying the `<prematch>` expression in the SonicWall decoder to add support for message strings from firewalls that introduce additional whitespaces and/or use UTC timestamps.