### PR TITLE
Prevent the key updating thread from starving in Remoted

### DIFF
--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -112,6 +112,8 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length);
 
 int check_keyupdate(void);
 
+void key_lock_init(void);
+
 void key_lock_read(void);
 
 void key_lock_write(void);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -64,7 +64,10 @@ void HandleSecure()
     // Initialize messag equeue
     rem_msginit(logr.queue_size);
 
-    /* Create Active Response forwarder thread */
+    /* Initialize the agent key table mutex */
+    key_lock_init();
+
+    /* Create shared file updating thread */
     w_create_thread(update_shared_files, NULL);
 
     /* Create Active Response forwarder thread */

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -14,7 +14,23 @@
 #include "os_net/os_net.h"
 
 /* pthread key update mutex */
-static pthread_rwlock_t keyupdate_rwlock = PTHREAD_RWLOCK_INITIALIZER;
+static pthread_rwlock_t keyupdate_rwlock;
+
+void key_lock_init()
+{
+    pthread_rwlockattr_t attr;
+    pthread_rwlockattr_init(&attr);
+
+#ifdef __linux__
+    /* PTHREAD_RWLOCK_PREFER_WRITER_NP is ignored.
+     * Do not use recursive locking.
+     */
+    pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+#endif
+
+    pthread_rwlock_init(&keyupdate_rwlock, &attr);
+    pthread_rwlockattr_destroy(&attr);
+}
 
 void key_lock_read()
 {


### PR DESCRIPTION
## Problem

Let the key update interval in Remoted be 1 second:
```shell
remoted.keyupdate_interval=1
```

If a bunch of agents gets registered and connected to the manager, we expect that Remoted updates the _client.keys_ file every second. But this is an actual log:
```shellsession
$ grep "INFO: (1410):" /var/ossec/logs/ossec.log | tail -n 6
2019/03/06 18:30:45 ossec-remoted: INFO: (1410): Reading authentication keys file.
2019/03/06 18:30:46 ossec-remoted: INFO: (1410): Reading authentication keys file.
2019/03/06 18:30:48 ossec-remoted: INFO: (1410): Reading authentication keys file.
2019/03/06 18:31:03 ossec-remoted: INFO: (1410): Reading authentication keys file.
2019/03/06 18:31:04 ossec-remoted: INFO: (1410): Reading authentication keys file.
2019/03/06 18:46:44 ossec-remoted: INFO: (1410): Reading authentication keys file.
```

There is a 15-minute waiting.

GDB blames that the key updating thread is waiting for its mutex —a read/write lock—.

## Explanation

Remoted builds an agent table in memory when it reads the client keys file. It works as a cache.
There are many components that read that data:
- 4 input stream dispatcher threads: they decrypt incoming messages.
- 8 threads for shared configuration (agent.conf) delivery: they encrypt outcoming messages.
And one thread that updates that agent list (reloading the client.keys file).

The POSIX specification mentions the sporadic scheduling: 

> If the Threads Execution Scheduling option is supported, and the threads involved in the lock are executing with the SCHED_SPORADIC scheduling policy, the calling thread shall not acquire the lock if a writer holds the lock or if writers of higher or equal priority are blocked on the lock; otherwise, the calling thread shall acquire the lock.

([Lock a read-write lock object for reading | Open Group Base Specifications Issue 6](http://pubs.opengroup.org/onlinepubs/009604499/functions/pthread_rwlock_rdlock.html))

However, the Linux implementation gives preference to readers: [Set/get the read-write lock kind of the thread read-write lock attribute object | man7.org](http://man7.org/linux/man-pages/man3/pthread_rwlockattr_setkind_np.3.html).

That means that if Remoted has a high load, the key update component may suffer starvation.

## Fix

Set the read/write lock preference to writer threads in Linux. The function `pthread_rwlockattr_setkind_np()` is not a GNU standard function so we can only call it on Linux.