### PR TITLE
Added SCA and Syscollector merging configurations

### DIFF
--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -21,6 +21,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     int agent_cfg = d2 ? *(int *)d2 : 0;
     wmodule *cur_wmodule;
     xml_node **children = NULL;
+    wmodule *cur_wmodule_exists;
 
     if (!node->attributes[0]) {
         merror("No such attribute '%s' at module.", XML_NAME);
@@ -35,11 +36,25 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     // Allocate memory
 
     if ((cur_wmodule = *wmodules)) {
-        while (cur_wmodule->next)
-            cur_wmodule = cur_wmodule->next;
+        cur_wmodule_exists = *wmodules;
+        int found = 0;
 
-        os_calloc(1, sizeof(wmodule), cur_wmodule->next);
-        cur_wmodule = cur_wmodule->next;
+        while (cur_wmodule_exists) {
+            if(strcmp(cur_wmodule_exists->tag,node->element) == 0) {
+                cur_wmodule = cur_wmodule_exists;
+                found = 1;
+                break;
+            }
+            cur_wmodule_exists = cur_wmodule_exists->next;
+        }
+
+        if(!found) {
+            while (cur_wmodule->next)
+                cur_wmodule = cur_wmodule->next;
+
+            os_calloc(1, sizeof(wmodule), cur_wmodule->next);
+            cur_wmodule = cur_wmodule->next;
+        }
     } else
         *wmodules = cur_wmodule = calloc(1, sizeof(wmodule));
 
@@ -151,14 +166,29 @@ int Read_SCA(const OS_XML *xml, xml_node *node, void *d1)
     wmodule **wmodules = (wmodule**)d1;
     wmodule *cur_wmodule;
     xml_node **children = NULL;
+    wmodule *cur_wmodule_exists;
 
     // Allocate memory
     if ((cur_wmodule = *wmodules)) {
-        while (cur_wmodule->next)
-            cur_wmodule = cur_wmodule->next;
+        cur_wmodule_exists = *wmodules;
+        int found = 0;
 
-        os_calloc(1, sizeof(wmodule), cur_wmodule->next);
-        cur_wmodule = cur_wmodule->next;
+        while (cur_wmodule_exists) {
+            if(strcmp(cur_wmodule_exists->tag,node->element) == 0) {
+                cur_wmodule = cur_wmodule_exists;
+                found = 1;
+                break;
+            }
+            cur_wmodule_exists = cur_wmodule_exists->next;
+        }
+
+        if(!found) {
+            while (cur_wmodule->next)
+                cur_wmodule = cur_wmodule->next;
+
+            os_calloc(1, sizeof(wmodule), cur_wmodule->next);
+            cur_wmodule = cur_wmodule->next;
+        }
     } else
         *wmodules = cur_wmodule = calloc(1, sizeof(wmodule));
 
@@ -169,7 +199,7 @@ int Read_SCA(const OS_XML *xml, xml_node *node, void *d1)
 
     // Get children
     if (children = OS_GetElementsbyNode(xml, node), !children) {
-        mdebug1("Empty configuration for module '%s'.", node->values[0]);
+        mdebug1("Empty configuration for module '%s'.", node->element);
     }
 
     //Policy Monitoring Module

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -40,7 +40,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
         int found = 0;
 
         while (cur_wmodule_exists) {
-            if(strcmp(cur_wmodule_exists->tag,node->element) == 0) {
+            if(strcmp(cur_wmodule_exists->tag,node->values[0]) == 0) {
                 cur_wmodule = cur_wmodule_exists;
                 found = 1;
                 break;

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -40,10 +40,12 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
         int found = 0;
 
         while (cur_wmodule_exists) {
-            if(strcmp(cur_wmodule_exists->tag,node->values[0]) == 0) {
-                cur_wmodule = cur_wmodule_exists;
-                found = 1;
-                break;
+            if(cur_wmodule_exists->tag) {
+                if(strcmp(cur_wmodule_exists->tag,node->values[0]) == 0) {
+                    cur_wmodule = cur_wmodule_exists;
+                    found = 1;
+                    break;
+                }
             }
             cur_wmodule_exists = cur_wmodule_exists->next;
         }
@@ -174,10 +176,12 @@ int Read_SCA(const OS_XML *xml, xml_node *node, void *d1)
         int found = 0;
 
         while (cur_wmodule_exists) {
-            if(strcmp(cur_wmodule_exists->tag,node->element) == 0) {
-                cur_wmodule = cur_wmodule_exists;
-                found = 1;
-                break;
+            if(cur_wmodule_exists->tag) {
+                if(strcmp(cur_wmodule_exists->tag,node->element) == 0) {
+                    cur_wmodule = cur_wmodule_exists;
+                    found = 1;
+                    break;
+                }
             }
             cur_wmodule_exists = cur_wmodule_exists->next;
         }

--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -19,6 +19,7 @@ static const char *XML_SCAN_ON_START= "scan_on_start";
 static const char *XML_POLICIES = "policies";
 static const char *XML_POLICY = "policy";
 static const char *XML_SKIP_NFS = "skip_nfs";
+static unsigned int profiles = 0;
 
 static short eval_bool(const char *str)
 {
@@ -29,7 +30,6 @@ static short eval_bool(const char *str)
 int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
 {
     unsigned int i;
-    unsigned int profiles = 0;
     int month_interval = 0;
     wm_sca_t *sca;
 

--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -33,28 +33,35 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
     int month_interval = 0;
     wm_sca_t *sca;
 
-    os_calloc(1, sizeof(wm_sca_t), sca);
-    sca->enabled = 1;
-    sca->scan_on_start = 1;
-    sca->scan_wday = -1;
-    sca->scan_day = 0;
-    sca->scan_time = NULL;
-    sca->skip_nfs = 1;
-    sca->alert_msg = NULL;
-    sca->queue = -1;
-    module->context = &WM_SCA_CONTEXT;
-    module->tag = strdup(module->context->name);
-    module->data = sca;
+    if(!module->data) {
+        os_calloc(1, sizeof(wm_sca_t), sca);
+        sca->enabled = 1;
+        sca->scan_on_start = 1;
+        sca->scan_wday = -1;
+        sca->scan_day = 0;
+        sca->scan_time = NULL;
+        sca->skip_nfs = 1;
+        sca->alert_msg = NULL;
+        sca->queue = -1;
+        module->context = &WM_SCA_CONTEXT;
+        module->tag = strdup(module->context->name);
+        module->data = sca;
+    } 
+
+    sca = module->data;
+    
 
     if (!nodes)
         return 0;
 
-    /* We store up to 255 alerts in there */
-    os_calloc(256, sizeof(char *), sca->alert_msg);
-    int c = 0;
-    while (c <= 255) {
-        sca->alert_msg[c] = NULL;
-        c++;
+    if(!sca->alert_msg) {
+        /* We store up to 255 alerts in there */
+        os_calloc(256, sizeof(char *), sca->alert_msg);
+        int c = 0;
+        while (c <= 255) {
+            sca->alert_msg[c] = NULL;
+            c++;
+        }
     }
 
     for(i = 0; nodes[i]; i++)

--- a/src/config/wmodules_syscollector.c
+++ b/src/config/wmodules_syscollector.c
@@ -27,19 +27,23 @@ int wm_sys_read(XML_NODE node, wmodule *module) {
     wm_sys_t *syscollector;
     int i;
 
-    os_calloc(1, sizeof(wm_sys_t), syscollector);
-    syscollector->flags.enabled = 1;
-    syscollector->flags.scan_on_start = 1;
-    syscollector->flags.netinfo = 1;
-    syscollector->flags.osinfo = 1;
-    syscollector->flags.hwinfo = 1;
-    syscollector->flags.programinfo = 1;
-    syscollector->flags.portsinfo = 1;
-    syscollector->flags.allports = 0;
-    syscollector->flags.procinfo = 1;
-    module->context = &WM_SYS_CONTEXT;
-    module->tag = strdup(module->context->name);
-    module->data = syscollector;
+    if(!module->data) {
+        os_calloc(1, sizeof(wm_sys_t), syscollector);
+        syscollector->flags.enabled = 1;
+        syscollector->flags.scan_on_start = 1;
+        syscollector->flags.netinfo = 1;
+        syscollector->flags.osinfo = 1;
+        syscollector->flags.hwinfo = 1;
+        syscollector->flags.programinfo = 1;
+        syscollector->flags.portsinfo = 1;
+        syscollector->flags.allports = 0;
+        syscollector->flags.procinfo = 1;
+        module->context = &WM_SYS_CONTEXT;
+        module->tag = strdup(module->context->name);
+        module->data = syscollector;
+    }
+
+    syscollector = module->data;
 
     if (!node)
         return 0;


### PR DESCRIPTION
### Merging configurations from shared

When sending a configuration with the `agent.conf`, the modules like SCA and syscollector are overwritten, not allowing for example to add a policy file without sending the entire module configuration as explained in this issue https://github.com/wazuh/wazuh/issues/2755

### Resolution

When reading the configuration tag from a module twice, we first look for it, and if it exists we use the current existing pointer to that configuration.