### PR TITLE
Update windows installer

### DIFF
--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -183,7 +183,7 @@ Section "Wazuh Agent (required)" MainSec
     File ossec-agent.exe
     File ossec-agent-eventchannel.exe
     File default-ossec.conf
-    File ossec-vista.conf
+    File ossec-pre6.conf
     File manage_agents.exe
     File /oname=win32ui.exe os_win32ui.exe
     File ossec-rootcheck.exe

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -183,6 +183,7 @@ Section "Wazuh Agent (required)" MainSec
     File ossec-agent.exe
     File ossec-agent-eventchannel.exe
     File default-ossec.conf
+    File ossec-vista.conf
     File manage_agents.exe
     File /oname=win32ui.exe os_win32ui.exe
     File ossec-rootcheck.exe
@@ -295,7 +296,11 @@ Section "Wazuh Agent (required)" MainSec
     ConfInstallOSSEC:
         ClearErrors
         IfFileExists "$INSTDIR\ossec.conf" ConfPresentOSSEC
+        ${If} ${AtLeastWinVista}
         Rename "$INSTDIR\default-ossec.conf" "$INSTDIR\ossec.conf"
+        ${Else}
+        Rename "$INSTDIR\ossec-pre6.conf" "$INSTDIR\ossec.conf"
+        ${EndIf}
         IfErrors ConfErrorOSSEC ConfPresentOSSEC
     ConfErrorOSSEC:
         MessageBox MB_ABORTRETRYIGNORE|MB_ICONSTOP "$\r$\n\

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -28,21 +28,20 @@
   <!-- Log analysis -->
   <localfile>
     <location>Application</location>
-    <log_format>eventchannel</log_format>
+    <log_format>eventlog</log_format>
   </localfile>
 
   <localfile>
     <location>Security</location>
-    <log_format>eventchannel</log_format>
+    <log_format>eventlog</log_format>
     <query>Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and
       EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and
-      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and
-      EventID != 5152 and EventID != 5157]</query>
+      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907]</query>
   </localfile>
 
   <localfile>
     <location>System</location>
-    <log_format>eventchannel/log_format>
+    <log_format>eventlog</log_format>
   </localfile>
 
   <localfile>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -177,10 +177,17 @@
                         <File Id="LOCAL_INTERNAL_OPTIONS.CONF" Name="local_internal_options.conf" Source="default-local_internal_options.conf" KeyPath="yes" />
                     </Component>
 
-                    <Component Id="OSSEC.CONF" DiskId="1" Guid="26C3265E-EFC8-488D-8D19-397A0C44C071" NeverOverwrite="yes" Permanent="yes">
+                    <Component Id="OSSEC_PRE6.CONF" DiskId="1" Guid="26C3265E-EFC8-488D-8D19-397A0C44C071" NeverOverwrite="yes" Permanent="yes">
+                        <File Id="OSSEC_PRE6.CONF" Name="ossec.conf" Source="ossec-pre6.conf" KeyPath="yes">
+                            <util:PermissionEx User="Everyone" GenericRead="yes" GenericWrite="yes" />
+                        </File>
+                        <Condition>VersionNT &lt; 600</Condition>
+                    </Component>
+                    <Component Id="OSSEC.CONF" DiskId="1" Guid="71947f0e-56d6-4e14-8539-214dff6ca2be" NeverOverwrite="yes" Permanent="yes">
                         <File Id="OSSEC.CONF" Name="ossec.conf" Source="default-ossec.conf" KeyPath="yes">
                             <util:PermissionEx User="Everyone" GenericRead="yes" GenericWrite="yes" />
                         </File>
+                        <Condition>VersionNT &gt;= 600</Condition>
                     </Component>
                     <Component Id="INTERNAL_OPTIONS.CONF" DiskId="1" Guid="D2F2A5B9-1A98-4BB8-8AC4-D948CA97DD0E">
                         <File Id="INTERNAL_OPTIONS.CONF" Name="internal_options.conf" Source="internal_options.conf" />
@@ -421,6 +428,7 @@
             <ComponentRef Id="LIBWAZUHEXT_DLL" />
             <ComponentRef Id="LOCAL_INTERNAL_OPTIONS.CONF" />
             <ComponentRef Id="OSSEC.CONF" />
+            <ComponentRef Id="OSSEC_PRE6.CONF" />
             <ComponentRef Id="INTERNAL_OPTIONS.CONF" />
             <ComponentRef Id="LICENSE.TXT" />
             <ComponentRef Id="LIBWINPTHREAD_1.DLL" />


### PR DESCRIPTION
Update the windows installer to set Eventchannel as the default channel in Windows with version 6.0.0 or higher. Also it would set Eventlog as default channel when the Windows version is lower than 6.0.0

This PR is the development of the issue: https://github.com/wazuh/wazuh/issues/2760