### PR TITLE
SCA checks DB array is now dynamic

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -640,7 +640,7 @@ static int wm_sca_check_requirements(cJSON *requirements) {
 static int wm_sca_do_scan(OSList *p_list,cJSON *profile_check,OSStore *vars,wm_sca_t * data,int id,cJSON *policy,int requirements_scan,int cis_db_index) {
 
     int type = 0, condition = 0;
-    char *nbuf;
+    char *nbuf = NULL;
     char buf[OS_SIZE_1024 + 2];
     char root_dir[OS_SIZE_1024 + 2];
     char final_file[2048 + 1];

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -127,13 +127,9 @@ void * wm_sca_main(wm_sca_t * data) {
             /* DB for calculating hash only */
             os_realloc(cis_db_for_hash, (i + 2) * sizeof(cis_db_hash_info_t), cis_db_for_hash);
 
-            /* 1000 IDs for each policy file */
-            os_calloc(1000,sizeof(cis_db_info_t *),cis_db_for_hash[i].elem);
-
-            int j = 0;
-            for(j = 0; j < 1000;j++) {
-                cis_db_for_hash[i].elem[j] = NULL;
-            }
+            /* Prepare first ID for each policy file */
+            os_calloc(1,sizeof(cis_db_info_t *),cis_db_for_hash[i].elem);
+            cis_db_for_hash[i].elem[0] = NULL;
         }
     }
 
@@ -668,8 +664,17 @@ static int wm_sca_do_scan(OSList *p_list,cJSON *profile_check,OSStore *vars,wm_s
     }
 #endif
     cJSON *profile = NULL;
+    int check_count = 0;
 
     cJSON_ArrayForEach(profile,profile_check){
+
+        if(!cis_db_for_hash[cis_db_index].elem[check_count]) {
+            os_realloc(cis_db_for_hash[cis_db_index].elem, sizeof(cis_db_info_t *) * (check_count + 2), cis_db_for_hash[cis_db_index].elem);
+            cis_db_for_hash[cis_db_index].elem[check_count] = NULL;
+            cis_db_for_hash[cis_db_index].elem[check_count + 1] = NULL;
+        }
+
+        check_count++;
 
         c_title = cJSON_GetObjectItem(profile, "title");
         c_condition = cJSON_GetObjectItem(profile, "condition");

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -495,13 +495,12 @@ static void wm_sca_read_files(wm_sca_t * data) {
                     os_free(integrity_hash);
                 }
 
+                minfo("Evaluation finished for policy '%s'.",data->profile[i]->profile);
                 wm_sca_reset_summary();
             }
 
             w_del_plist(plist);
             plist = NULL;
-
-            minfo("Evaluation finished for policy '%s'.",data->profile[i]->profile);
 
     next:
             if(fp){


### PR DESCRIPTION
### Internal DB for checks

As explained in this issue https://github.com/wazuh/wazuh/issues/2778, the array for the internal DB was allocated with 1000 elements, regardless of the number of checks of the policy file scanned.

As this line was causing the allocation https://github.com/wazuh/wazuh/blob/3.9/src/wazuh_modules/wm_sca.c#L131, much of the memory wasn't used. This also could lead to a buffer overrun when using policy files with more than 1000 checks and a potential segfault.

### Resolution

Make the array to reallocate only the needed elements for each policy file.