### PR TITLE
Control the socket message of the control module when the Agent IP is NULL

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -164,7 +164,7 @@ void run_notify()
     }
 
     /* Create message */
-    if(*agent_ip){
+    if(strcmp(agent_ip,"Err")){
         if ((File_DateofChange(AGENTCONFIGINT) > 0 ) &&
                 (OS_MD5_File(AGENTCONFIGINT, md5sum, OS_TEXT) == 0)) {
             snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%s%s%s\n%s",

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -40,6 +40,7 @@ char* getPrimaryIP(){
 
     if (getifaddrs(&ifaddr) == -1) {
         mterror(WM_CONTROL_LOGTAG, "at getPrimaryIP(): getifaddrs() failed.");
+        return agent_ip;
     }
     else {
         for (ifa = ifaddr; ifa; ifa = ifa->ifa_next){
@@ -177,8 +178,13 @@ void *send_ip(){
 
         default:
             response = getPrimaryIP();
-            OS_SendUnix(peer, response, 0);
-            free(response);
+            if(response){
+                OS_SendUnix(peer, response, 0);
+                free(response);
+            }
+            else{
+                OS_SendUnix(peer,"Err",4);
+            }
             close(peer);
         }
         free(buffer);

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -725,6 +725,8 @@ void send_win32_info(time_t curr_time)
         } else {
             snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s\n%s%s%s\n", __win32_uname, tmp_labels, __win32_shared, label_ip);
         }
+
+        free(agent_ip);
     }
     else{
         if (File_DateofChange(AGENTCONFIGINT) > 0) {


### PR DESCRIPTION
In case that the function `getPrimaryIP` of the control module fails the socket was trying to send a NULL string.
This PR modify the way the module send the IP to send an error message when the module couldn't obatin the IP of the agent.
