### PR TITLE
Flask API: Add OpenAPI specs for /rules endpoints

### DIFF
--- a/api/api/controllers/rules_controllers.py
+++ b/api/api/controllers/rules_controllers.py
@@ -27,6 +27,8 @@ def get_rules(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=
     :type level: str
     :param file: Filters by filename.
     :type file: str
+    :param path: Filters by rule path.
+    :type path: str
     :param pci: Filters by PCI requirement name.
     :type pci: str
     :param gdpr: Filters by GDPR requirement.
@@ -87,5 +89,32 @@ def get_rules_gdpr(pretty=False, wait_for_complete=False, offset=0, limit=None, 
     :type sort: str
     :param search: Looks for elements with the specified string
     :type search: str
+    """
+    pass
+
+
+def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, 
+              search=None, status=None, file=None, path=None, download=None):
+    """
+    :param pretty: Show results in human-readable format 
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response 
+    :type wait_for_complete: bool
+    :param offset: First element to return in the collection
+    :type offset: int
+    :param limit: Maximum number of elements to return
+    :type limit: int
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order. 
+    :type sort: str
+    :param search: Looks for elements with the specified string
+    :type search: str
+    :param status: Filters by rules status.
+    :type status: List[str]
+    :param file: Filters by filename.
+    :type file: str
+    :param path: Filters by rule path.
+    :type path: str
+    :param download: Download the specified file.
+    :type download: str
     """
     pass

--- a/api/api/controllers/rules_controllers.py
+++ b/api/api/controllers/rules_controllers.py
@@ -94,7 +94,7 @@ def get_rules_gdpr(pretty=False, wait_for_complete=False, offset=0, limit=None, 
 
 
 def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, 
-              search=None, status=None, file=None, path=None, download=None):
+                    search=None, status=None, file=None, path=None, download=None):
     """
     :param pretty: Show results in human-readable format 
     :type pretty: bool
@@ -116,5 +116,25 @@ def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None,
     :type path: str
     :param download: Download the specified file.
     :type download: str
+    """
+    pass
+
+def get_rules_id(rule_id, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, 
+                 search=None):
+    """
+    :param rule_id: Filters by rule ID.
+    :type rule_id: str
+    :param pretty: Show results in human-readable format 
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response 
+    :type wait_for_complete: bool
+    :param offset: First element to return in the collection
+    :type offset: int
+    :param limit: Maximum number of elements to return
+    :type limit: int
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order. 
+    :type sort: str
+    :param search: Looks for elements with the specified string
+    :type search: str
     """
     pass

--- a/api/api/controllers/rules_controllers.py
+++ b/api/api/controllers/rules_controllers.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+
+def get_rules(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, 
+              search=None, status=None, group=None, level=None, file=None, path=None,
+              pci=None, gdpr=None):
+    """
+    :param pretty: Show results in human-readable format 
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response 
+    :type wait_for_complete: bool
+    :param offset: First element to return in the collection
+    :type offset: int
+    :param limit: Maximum number of elements to return
+    :type limit: int
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order. 
+    :type sort: str
+    :param search: Looks for elements with the specified string
+    :type search: str
+    :param status: Filters by rules status.
+    :type status: List[str]
+    :param group: Filters by rule group.
+    :type group: str
+    :param level: Filters by rule level. Can be a single level (4) or an interval (2-4)
+    :type level: str
+    :param file: Filters by filename.
+    :type file: str
+    :param pci: Filters by PCI requirement name.
+    :type pci: str
+    :param gdpr: Filters by GDPR requirement.
+    :type gdpr: str
+    """
+    pass
+

--- a/api/api/controllers/rules_controllers.py
+++ b/api/api/controllers/rules_controllers.py
@@ -34,3 +34,20 @@ def get_rules(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=
     """
     pass
 
+def get_rules_groups(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, 
+                     search=None):
+    """
+    :param pretty: Show results in human-readable format 
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response 
+    :type wait_for_complete: bool
+    :param offset: First element to return in the collection
+    :type offset: int
+    :param limit: Maximum number of elements to return
+    :type limit: int
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order. 
+    :type sort: str
+    :param search: Looks for elements with the specified string
+    :type search: str
+    """
+    pass

--- a/api/api/controllers/rules_controllers.py
+++ b/api/api/controllers/rules_controllers.py
@@ -51,3 +51,22 @@ def get_rules_groups(pretty=False, wait_for_complete=False, offset=0, limit=None
     :type search: str
     """
     pass
+
+
+def get_rules_pci(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, 
+                  search=None):
+    """
+    :param pretty: Show results in human-readable format 
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response 
+    :type wait_for_complete: bool
+    :param offset: First element to return in the collection
+    :type offset: int
+    :param limit: Maximum number of elements to return
+    :type limit: int
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order. 
+    :type sort: str
+    :param search: Looks for elements with the specified string
+    :type search: str
+    """
+    pass

--- a/api/api/controllers/rules_controllers.py
+++ b/api/api/controllers/rules_controllers.py
@@ -70,3 +70,22 @@ def get_rules_pci(pretty=False, wait_for_complete=False, offset=0, limit=None, s
     :type search: str
     """
     pass
+
+
+def get_rules_gdpr(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, 
+                   search=None):
+    """
+    :param pretty: Show results in human-readable format 
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response 
+    :type wait_for_complete: bool
+    :param offset: First element to return in the collection
+    :type offset: int
+    :param limit: Maximum number of elements to return
+    :type limit: int
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order. 
+    :type sort: str
+    :param search: Looks for elements with the specified string
+    :type search: str
+    """
+    pass

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -274,7 +274,42 @@ components:
           type: integer
         unknown:
           type: integer
-          
+
+    Rules:
+      type: object
+      properties:
+        file:
+          type: string
+        path:
+          type: string
+        id:
+          type: integer
+        level:
+          type: integer
+          minimum: 0
+          maximum: 15
+        description:
+          type: string
+        status:
+          type: string
+          enum:
+          - enabled
+          - disabled
+        groups:
+          type: array
+          items:
+            type: string
+        pci:
+          type: array
+          items:
+            type: string
+        gdpr:
+          type: array
+          items:
+            type: string
+        details:
+          type: object
+
     # SCA models
     SCAChecks:
       type: object
@@ -451,7 +486,7 @@ components:
       name: file
       description: Filters by filename.
       schema:
-        type: integer
+        type: string
     file_name:
       in: path
       name: file_name
@@ -698,6 +733,47 @@ components:
       schema:
         type: boolean
         default: false
+    group:
+      in: query
+      name: group
+      description: Filters by rule group.
+      schema:
+        type: string
+    level:
+      in: query
+      name: level
+      description: Filters by rule level. Can be a single level (4) or an interval (2-4)
+      schema:
+        type: string
+        format: \d(?>-\d)?  # 4 or 4-5
+    path:
+      in: query
+      name: path
+      description: Filters by rule path.
+      schema:
+        type: string
+    rulestatus:
+      in: query
+      name: status
+      description: Filters by rule status.
+      schema:
+        type: string
+        enum:
+        - enabled
+        - disabled
+        - all
+    pci:
+      in: query
+      name: pci
+      description: Filters by PCI requirement name.
+      schema:
+        type: string
+    gdpr:
+      in: query
+      name: gdpr
+      description: Filters by GDPR requirement.
+      schema:
+        type: string
 
 tags:
   - name: active-response
@@ -725,7 +801,7 @@ tags:
   - name: rootcheck
     description: ''
   - name: rules
-    description: ''
+    description: 'Wazuh ruleset management'
   - name: syscheck
     description: ''
   - name: syscollector
@@ -2599,6 +2675,85 @@ paths:
                     notchecked: 71
                     unknown: 0
   
+  /rules:
+    get:
+      tags:
+      - rules
+      summary: Get information about all Wazuh rules.
+      description: Returns a list containing information about each rule such as file where it's defined, description, rule group, status, etc.
+      operationId: api.controllers.rules_controllers.get_rules
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/group'
+        - $ref: '#/components/parameters/level'
+        - $ref: '#/components/parameters/file'
+        - $ref: '#/components/parameters/path'
+        - $ref: '#/components/parameters/rulestatus'
+        - $ref: '#/components/parameters/pci'
+        - $ref: '#/components/parameters/gdpr'
+      responses:
+        '200':
+          description: "Rules"
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      allOf:
+                        - $ref: '#/components/schemas/ListMetadata'
+                        - type: object
+                          properties:
+                            items:
+                              type: array
+                              items:
+                                $ref: '#/components/schemas/Rules'
+              example:
+                error: 0
+                data:
+                  totalItems: 2
+                  items:
+                    - file: 0016-wazuh_rules.xml
+                      path: ruleset/rules
+                      id: 203
+                      level: 9
+                      description: Agent event queue is full. Events may be lost.
+                      status: enabled
+                      groups:
+                      - agent_flooding
+                      - wazuh
+                      pci:
+                      -
+                      gdpr:
+                      - IV_35.7.d
+                      details:
+                        if_sid: "201"
+                        level: "full"
+                    - file: 0015-ossec_rules.xml
+                      path: ruleset/rules
+                      id: 513
+                      level: 9
+                      description: Windows malware detected.
+                      status: enabled
+                      groups:
+                      - rootcheck
+                      - gpg13_4.2
+                      - ossec
+                      pci:
+                      -
+                      gdpr:
+                      - IV_35.7.d
+                      details:
+                        if_sid: "510"
+                        match: "^Windows Malware"
+
   /sca/{agent_id}:
     get:
       tags:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -274,41 +274,47 @@ components:
           type: integer
         unknown:
           type: integer
-
-    Rules:
+    
+    RulesFiles:
       type: object
       properties:
         file:
           type: string
         path:
           type: string
-        id:
-          type: integer
-        level:
-          type: integer
-          minimum: 0
-          maximum: 15
-        description:
-          type: string
         status:
           type: string
           enum:
           - enabled
           - disabled
-        groups:
-          type: array
-          items:
-            type: string
-        pci:
-          type: array
-          items:
-            type: string
-        gdpr:
-          type: array
-          items:
-            type: string
-        details:
-          type: object
+    
+    Rules:
+      allOf:
+        - $ref: '#/components/schemas/RulesFiles'
+        - type: object
+          properties:
+            id:
+              type: integer
+            level:
+              type: integer
+              minimum: 0
+              maximum: 15
+            description:
+              type: string
+            groups:
+              type: array
+              items:
+                type: string
+            pci:
+              type: array
+              items:
+                type: string
+            gdpr:
+              type: array
+              items:
+                type: string
+            details:
+              type: object
 
     # SCA models
     SCAChecks:
@@ -772,6 +778,12 @@ components:
       in: query
       name: gdpr
       description: Filters by GDPR requirement.
+      schema:
+        type: string
+    download:
+      in: query
+      name: download
+      description: Downloads the specified file.
       schema:
         type: string
 
@@ -2882,6 +2894,61 @@ paths:
                     - "IV_30.1.g"
                     - "IV_32.2"
                     - "IV_35.7.d"
+
+  /rules/files:
+    get:
+      tags:
+      - rules
+      summary: Get all files which defines rules.
+      description: Returns a list containing all files used to define rules and their status.
+      operationId: api.controllers.rules_controllers.get_rules_files
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/path'
+        - $ref: '#/components/parameters/file'
+        - $ref: '#/components/parameters/rulestatus'
+        - $ref: '#/components/parameters/download'
+      responses:
+        '200':
+          description: 'SCA database elements'
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      allOf:
+                        - $ref: '#/components/schemas/ListMetadata'
+                        - type: object
+                          properties:
+                            items:
+                              type: array
+                              items:
+                                $ref: '#/components/schemas/RulesFiles'
+              example:
+                error: 0
+                data:
+                  totalItems: 4
+                  items:
+                    - file: 0010-rules_config.xml
+                      path: ruleset/rules
+                      status: enabled
+                    - file: 0015-ossec_rules.xml
+                      path: ruleset/rules
+                      status: enabled
+                    - file: 0016-wazuh_rules.xml
+                      path: ruleset/rules
+                      status: enabled
+                    - file: 0020-syslog_rules.xml
+                      path: ruleset/rules
+                      status: enabled
 
   /sca/{agent_id}:
     get:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -786,6 +786,12 @@ components:
       description: Downloads the specified file.
       schema:
         type: string
+    rule_id:
+      in: path
+      name: rule_id
+      description: Filters by rule ID.
+      schema:
+        type: integer
 
 tags:
   - name: active-response
@@ -2765,6 +2771,62 @@ paths:
                       details:
                         if_sid: "510"
                         match: "^Windows Malware"
+
+  /rules/{rule_id}:
+    get:
+      tags:
+      - rules
+      summary: Filters rules by ID.
+      description: Filters results of /rules endpoint filtering by ID.
+      operationId: api.controllers.rules_controllers.get_rules_id
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/rule_id'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+      responses:
+        '200':
+          description: "Rules"
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      allOf:
+                        - $ref: '#/components/schemas/ListMetadata'
+                        - type: object
+                          properties:
+                            items:
+                              type: array
+                              items:
+                                $ref: '#/components/schemas/Rules'
+              example:
+                error: 0
+                data:
+                  totalItems: 1
+                  items:
+                    - file: 0225-mcafee_av_rules.xml
+                      path: ruleset/rules
+                      id: 7514
+                      level: 5
+                      description: McAfee Windows AV - EICAR test file detected.
+                      status: enabled
+                      groups:
+                      - mcafee
+                      pci:
+                      -
+                      gdpr:
+                      -
+                      details:
+                        if_sid: "7505"
+                        match: contains the EICAR test file
+                        options: alert_by_email
 
   /rules/groups:
     get:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2840,6 +2840,49 @@ paths:
                     - "1.4"
                     - "10.1"
 
+  /rules/gdpr:
+    get:
+      tags:
+      - rules
+      summary: Get all GDPR requirements.
+      description: Returns all PCI requirements names defined in the Wazuh ruleset.
+      operationId: api.controllers.rules_controllers.get_rules_gdpr
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+      responses:
+        '200':
+          description: 'PCI requirements names'
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      allOf:
+                        - $ref: '#/components/schemas/ListMetadata'
+                        - type: object
+                          properties:
+                            items:
+                              type: array
+                              items:
+                                type: string
+              example:
+                error: 0
+                data:
+                  totalItems: 4
+                  items:
+                    - "II_5.1.f"
+                    - "IV_30.1.g"
+                    - "IV_32.2"
+                    - "IV_35.7.d"
+
   /sca/{agent_id}:
     get:
       tags:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2797,6 +2797,49 @@ paths:
                     - accesslog
                     - account_changed
 
+  /rules/pci:
+    get:
+      tags:
+      - rules
+      summary: Get all PCI requirements.
+      description: Returns all PCI requirements names defined in the Wazuh ruleset.
+      operationId: api.controllers.rules_controllers.get_rules_pci
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+      responses:
+        '200':
+          description: 'PCI requirements names'
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      allOf:
+                        - $ref: '#/components/schemas/ListMetadata'
+                        - type: object
+                          properties:
+                            items:
+                              type: array
+                              items:
+                                type: string
+              example:
+                error: 0
+                data:
+                  totalItems: 4
+                  items:
+                    - "1.1.1"
+                    - "1.3.4"
+                    - "1.4"
+                    - "10.1"
+
   /sca/{agent_id}:
     get:
       tags:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2754,6 +2754,49 @@ paths:
                         if_sid: "510"
                         match: "^Windows Malware"
 
+  /rules/groups:
+    get:
+      tags:
+      - rules
+      summary: Get all rule groups names.
+      description: Returns a list containing all rule groups names.
+      operationId: api.controllers.rules_controllers.get_rules_groups
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+      responses:
+        '200':
+          description: 'Rule groups names'
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      allOf:
+                        - $ref: '#/components/schemas/ListMetadata'
+                        - type: object
+                          properties:
+                            items:
+                              type: array
+                              items:
+                                type: string
+              example:
+                error: 0
+                data:
+                  totalItems: 4
+                  items:
+                    - access_control
+                    - access_denied
+                    - accesslog
+                    - account_changed
+
   /sca/{agent_id}:
     get:
       tags:


### PR DESCRIPTION
Hello team,

This PR adds OpenAPI specs for `/rules` endpoints.

Best regards,
Marta