### PR TITLE
Fix memory leak in vulnerability-detector

### DIFF
--- a/src/agentlessd/lessdcom.c
+++ b/src/agentlessd/lessdcom.c
@@ -50,7 +50,7 @@ size_t lessdcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/analysisd/asyscom.c
+++ b/src/analysisd/asyscom.c
@@ -51,7 +51,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -63,7 +63,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -75,7 +75,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -87,7 +87,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -99,7 +99,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -111,7 +111,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -123,7 +123,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -135,7 +135,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/client-agent/agcom.c
+++ b/src/client-agent/agcom.c
@@ -51,7 +51,7 @@ size_t agcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -62,7 +62,7 @@ size_t agcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -73,7 +73,7 @@ size_t agcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -84,7 +84,7 @@ size_t agcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -158,6 +158,8 @@ cJSON *getLocalfileConfig(void) {
 
     if (cJSON_GetArraySize(localfiles) > 0) {
         cJSON_AddItemToObject(root,"localfile",localfiles);
+    } else {
+        cJSON_free(localfiles);
     }
 
     return root;
@@ -190,6 +192,8 @@ cJSON *getSocketConfig(void) {
 
     if (cJSON_GetArraySize(targets) > 0) {
         cJSON_AddItemToObject(root,"target",targets);
+    } else {
+        cJSON_free(targets);
     }
 
     return root;

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -51,7 +51,7 @@ size_t lccom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -62,7 +62,7 @@ size_t lccom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -73,7 +73,7 @@ size_t lccom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/monitord/moncom.c
+++ b/src/monitord/moncom.c
@@ -50,7 +50,7 @@ size_t moncom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -62,7 +62,7 @@ size_t moncom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/os_auth/authcom.c
+++ b/src/os_auth/authcom.c
@@ -50,7 +50,7 @@ size_t authcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/os_csyslogd/csyscom.c
+++ b/src/os_csyslogd/csyscom.c
@@ -50,7 +50,7 @@ size_t csyscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -568,7 +568,7 @@ size_t wcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -579,7 +579,7 @@ size_t wcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -590,7 +590,7 @@ size_t wcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/os_integrator/intgcom.c
+++ b/src/os_integrator/intgcom.c
@@ -50,7 +50,7 @@ size_t intgcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/os_maild/mailcom.c
+++ b/src/os_maild/mailcom.c
@@ -50,7 +50,7 @@ size_t mailcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -61,7 +61,7 @@ size_t mailcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -72,7 +72,7 @@ size_t mailcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -420,7 +420,7 @@ size_t rem_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -431,7 +431,7 @@ size_t rem_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -722,7 +722,7 @@ next_it:
     return writted;
 error:
     if (perm_type) {
-        cJSON_free(perm_type);
+        cJSON_Delete(perm_type);
     }
     os_free(account_name);
     mdebug1("The file permissions could not be decoded: '%s'", raw_perm);

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -218,6 +218,8 @@ cJSON *getSyscheckConfig(void) {
         }
         if (cJSON_GetArraySize(audkey) > 0) {
             cJSON_AddItemToObject(whodata,"audit_key",audkey);
+        } else {
+            cJSON_free(audkey);
         }
     }
     if (syscheck.audit_healthcheck) {

--- a/src/syscheckd/syscom.c
+++ b/src/syscheckd/syscom.c
@@ -52,7 +52,7 @@ size_t syscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -63,7 +63,7 @@ size_t syscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -74,7 +74,7 @@ size_t syscom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -148,7 +148,11 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
             if (iter->remove_from_bucket) cJSON_AddStringToObject(buck,"remove_from_bucket","yes"); else cJSON_AddStringToObject(buck,"remove_from_bucket","no");
             cJSON_AddItemToArray(arr_buckets,buck);
         }
-        if (cJSON_GetArraySize(arr_buckets) > 0) cJSON_AddItemToObject(wm_aws,"buckets",arr_buckets);
+        if (cJSON_GetArraySize(arr_buckets) > 0) {
+            cJSON_AddItemToObject(wm_aws,"buckets",arr_buckets);
+        } else {
+            cJSON_free(arr_buckets);
+        }
     }
     if (aws_config->services) {
         wm_aws_service *iter;
@@ -166,7 +170,11 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
             if (iter->regions) cJSON_AddStringToObject(service,"regions",iter->regions);
             cJSON_AddItemToArray(arr_services,service);
         }
-        if (cJSON_GetArraySize(arr_services) > 0) cJSON_AddItemToObject(wm_aws,"services",arr_services);
+        if (cJSON_GetArraySize(arr_services) > 0) {
+            cJSON_AddItemToObject(wm_aws,"services",arr_services);
+        } else {
+            cJSON_free(arr_services);
+        }
     }
     cJSON_AddItemToObject(root,"aws-s3",wm_aws);
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -517,7 +517,7 @@ static void wm_sca_read_files(wm_sca_t * data) {
             }
 
             if(requirements_array){
-                cJSON_free(requirements_array);
+                cJSON_Delete(requirements_array);
             }
 
             if(vars) {

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -2809,7 +2809,6 @@ int wm_vuldet_db_empty() {
     int result;
 
     if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_GLOBALDB_OPEN_ERROR);
         return wm_vuldet_sql_error(db, NULL);
     }
 

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -2781,7 +2781,11 @@ cJSON *wm_vuldet_dump(const wm_vuldet_t * vulnerability_detector){
             cJSON_AddItemToArray(feeds,feed);
         }
     }
-    if (cJSON_GetArraySize(feeds) > 0) cJSON_AddItemToObject(wm_vd,"feeds",feeds);
+    if (cJSON_GetArraySize(feeds) > 0) {
+        cJSON_AddItemToObject(wm_vd,"feeds",feeds);
+    } else {
+        cJSON_free(feeds);
+    }
 
     cJSON_AddItemToObject(root,"vulnerability-detector",wm_vd);
 

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -1738,7 +1738,7 @@ int wm_vuldet_update_feed(update_node *update) {
     success = 1;
 free_mem:
     if (json_feed) {
-        cJSON_free(json_feed);
+        cJSON_Delete(json_feed);
     }
     if (tmp_file) {
         free(tmp_file);

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -583,7 +583,7 @@ int wm_vuldet_report_agent_vulnerabilities(agent_software *agents, sqlite3 *db, 
         }
 
         if (sqlite3_prepare_v2(db, query, -1, &stmt, NULL) != SQLITE_OK) {
-            cJSON_free(alert);
+            cJSON_Delete(alert);
             return OS_INVALID;
         }
         sqlite3_bind_text(stmt, 1, agents_it->agent_OS, -1, NULL);

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -50,7 +50,7 @@ size_t wmcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;
@@ -61,7 +61,7 @@ size_t wmcom_getconfig(const char * section, char ** output) {
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
-            cJSON_free(cfg);
+            cJSON_Delete(cfg);
             return strlen(*output);
         } else {
             goto error;


### PR DESCRIPTION
This PR replaces `cJSON_free` by `cJSON_delete` in the Red Hat feed update process. 

`cJSON_free` does not make a full release.