### PR TITLE
Fix error logging on Windows agent

### DIFF
--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -42,7 +42,12 @@ int send_msg(const char *msg, ssize_t msg_length)
     if (!retval) {
         agent_state.msg_sent++;
     } else {
+#ifdef WIN32
+        error = WSAGetLastError();
+        merror(SEND_ERROR, "server", win_strerror(error));
+#else
         merror(SEND_ERROR, "server", strerror(error));
+#endif
         sleep(1);
     }
 

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -366,7 +366,7 @@ int SendMSG(__attribute__((unused)) int queue, const char *message, const char *
         if (dwWaitResult != WAIT_OBJECT_0) {
             switch (dwWaitResult) {
                 case WAIT_TIMEOUT:
-                    merror("Error waiting mutex (timeout).");
+                    mdebug2("Sending mutex timeout.");
                     sleep(5);
                     continue;
                 case WAIT_ABANDONED:
@@ -520,7 +520,7 @@ int StartMQ(__attribute__((unused)) const char *path, __attribute__((unused)) sh
 }
 
 char *get_win_agent_ip(){
-    
+
     typedef char* (*CallFunc)(PIP_ADAPTER_ADDRESSES pCurrAddresses, int ID, char * timestamp);
 
     char *agent_ip = NULL;


### PR DESCRIPTION
|Related mailing thread|
|---|
|[Windows XP and Wazuh Agent 3.8.2](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/wazuh/QtdOk8Fp6XM/0PUDD0RgBAAJ)|

This PR aims to fix two issues:
1. If an agent connected in UDP gets disconnected, this error appears:
```
2019/03/08 14:31:33 ossec-agent[3608] win_agent.c:369 at SendMSG(): ERROR: Error waiting mutex (timeout).
```
That is an alternative result of the sending mutex locking operation: another thread is waiting for agent reconnection to send a message. But it's not an error condition: the agent will simply reattempt the operation.
That log should not be an error but a debugging message.

2. If an agent connected in TCP gets disconnected, this error appears:
```
2019/03/08 14:19:58 ossec-agent: ERROR: (1218): Unable to send message to 'server': No such file or directory
```
However, that description is not correct. The error code for networking operations should not be obtained with `errno` but `WSAGetLastError()`.
This is the correct error description:
```
2019/03/08 14:39:21 ossec-agent[4572] sendmsg.c:47 at send_msg(): ERROR: (1218): Unable to send message to 'server': An established connection was aborted by the software in your host machine.
```