### PR TITLE
Fix docker wodle memory leak

### DIFF
--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -36,7 +36,7 @@ const wm_context WM_DOCKER_CONTEXT = {
 void* wm_docker_main(wm_docker_t *docker_conf) {
 
     int status = 0;
-    char * command = NULL;
+    char * command = WM_DOCKER_SCRIPT_PATH;
     char * output = NULL;
     int attempts = 0;
 
@@ -58,8 +58,6 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
         // Running the docker listener script
 
-        command = strdup(WM_DOCKER_SCRIPT_PATH);
-
         mtdebug1(WM_DOCKER_LOGTAG, "Launching command '%s'.", command);
 
         switch (wm_exec(command, &output, &status, 0, NULL)) {
@@ -76,13 +74,11 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
                 break;
             default:
                 mterror(WM_DOCKER_LOGTAG, "Internal calling. Exiting...");
-                free(command);
                 free(output);
                 pthread_exit(NULL);
         }
 
         os_free(output);
-        free(command);
 
         if (attempts > docker_conf->attempts) {
             mterror(WM_DOCKER_LOGTAG, "Maximum attempts reached to run the listener. Exiting...");


### PR DESCRIPTION
### Memory leaking

Inside the main function of the docker module memory is leaking due to string allocation for the path (see line https://github.com/wazuh/wazuh/blob/3.9/src/wazuh_modules/wm_docker.c#L61) 

As the valgrind report shows:

```
==6532== 40 bytes in 1 blocks are definitely lost in loss record 79 of 164
==6532==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==6532==    by 0x5CD19B9: strdup (strdup.c:42)
==6532==    by 0x49299E: wm_docker_main (wm_docker.c:61)
==6532==    by 0x5A1C6DA: start_thread (pthread_create.c:463)
==6532==    by 0x5D5588E: clone (clone.S:95)
==6532== 
```

### Resolution

As the path never changes through execution, we don't need the `strdup`.
