### PR TITLE
Added predecoder.timestamp and predecoder.program_name

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -293,6 +293,18 @@
             }
           }
         },
+        "predecoder": {
+          "properties": {
+            "program_name": {
+              "type": "keyword",
+              "doc_values": "true"
+            },
+            "timestamp": {
+              "type": "keyword",
+              "doc_values": "true"
+            }
+          }
+        },
         "decoder": {
           "properties": {
             "parent": {


### PR DESCRIPTION
Closes https://github.com/wazuh/wazuh/issues/2513

- Added `predecoder.program_name` and `predecoder.timestamp` to the template
- Both are `keyword` because the timestamp is not well formatted for a `date` type
- Tested using the Wazuh App, all seems to be fine