### PR TITLE
Let CIS-CAT decoder reuse the Wazuh DB connection socket

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -57,7 +57,7 @@ int DecodeSyscheck(Eventinfo *lf, _sdb *sdb);
 int DecodeRootcheck(Eventinfo *lf);
 int DecodeHostinfo(Eventinfo *lf);
 int DecodeSyscollector(Eventinfo *lf,int *socket);
-int DecodeCiscat(Eventinfo *lf);
+int DecodeCiscat(Eventinfo *lf, int *socket);
 int DecodeWinevt(Eventinfo *lf);
 int DecodeSCA(Eventinfo *lf,int *socket);
 
@@ -2092,6 +2092,7 @@ void * w_decode_event_thread(__attribute__((unused)) void * args){
     char * msg = NULL;
     regex_matching decoder_match;
     memset(&decoder_match, 0, sizeof(regex_matching));
+    int sock = -1;
 
     while(1){
 
@@ -2111,7 +2112,7 @@ void * w_decode_event_thread(__attribute__((unused)) void * args){
             }
 
             if (msg[0] == CISCAT_MQ) {
-                if (!DecodeCiscat(lf)) {
+                if (!DecodeCiscat(lf, &sock)) {
                     w_free_event_info(lf);
                     free(msg);
                     continue;

--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -33,7 +33,7 @@ void CiscatInit(){
 }
 
 /* Special decoder for CIS-CAT events */
-int DecodeCiscat(Eventinfo *lf)
+int DecodeCiscat(Eventinfo *lf, int *socket)
 {
     cJSON *logJSON;
     char *msg_type = NULL;
@@ -76,7 +76,6 @@ int DecodeCiscat(Eventinfo *lf)
     }
 
     if (strcmp(msg_type, "scan_info") == 0) {
-        int socket = -1;
         char *msg = NULL;
         cJSON * cis_data;
 
@@ -172,7 +171,7 @@ int DecodeCiscat(Eventinfo *lf)
                 wm_strcat(&msg, "NULL", '|');
             }
 
-            if (sc_send_db(msg,&socket) < 0) {
+            if (sc_send_db(msg, socket) < 0) {
                 cJSON_Delete(logJSON);
                 return (0);
             }

--- a/src/analysisd/decoders/plugin_decoders.h
+++ b/src/analysisd/decoders/plugin_decoders.h
@@ -13,9 +13,6 @@
 
 #include "eventinfo.h"
 
-/* Decoder for Cis-cat events */
-int DecodeCiscat(Eventinfo *lf);
-
 /* Plugin decoder for OpenBSD PF */
 void *PF_Decoder_Init(void);
 void *PF_Decoder_Exec(Eventinfo *lf, regex_matching *decoder_match);


### PR DESCRIPTION
This will prevent it from causing a file descriptor leak.

## Valgrind report

Valgrind complaing about an invalid file descriptor 1031. This may be related either `select()` or the current file descriptor limit:
```
==21728== Warning: invalid file descriptor 1031 in syscall socket()
==21728==    at 0x5D2DCD7: socket (syscall-template.S:84)
==21728==    by 0x1E2909: OS_ConnectUnixDomain (os_net.c:199)
==21728==    by 0x14F657: sc_send_db (syscollector.c:1560)
==21728==    by 0x156141: DecodeCiscat (ciscat.c:175)
==21728==    by 0x134369: w_decode_event_thread (analysisd.c:2114)
==21728==    by 0x5A2E493: start_thread (pthread_create.c:333)
==21728== Warning: invalid file descriptor 1031 in syscall open()
==21728==    at 0x5D1F4CD: ??? (syscall-template.S:84)
==21728==    by 0x5CB7292: _IO_file_open (fileops.c:229)
==21728==    by 0x5CB7432: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:336)
==21728==    by 0x5CAB5B3: __fopen_internal (iofopen.c:86)
==21728==    by 0x1DE18F: _log (debug_op.c:154)
==21728==    by 0x1DF113: _mtinfo (debug_op.c:400)
==21728==    by 0x14F629: sc_send_db (syscollector.c:1566)
==21728==    by 0x156141: DecodeCiscat (ciscat.c:175)
==21728==    by 0x134369: w_decode_event_thread (analysisd.c:2114)
==21728==    by 0x5A2E493: start_thread (pthread_create.c:333)
```

At the end of the execution, Valgrind reported a lot of open file descriptors:
```
==21772== Open AF_UNIX socket 1022: <unknown>
==21772==    at 0x5D2DCD7: socket (syscall-template.S:84)
==21772==    by 0x1E2909: OS_ConnectUnixDomain (os_net.c:199)
==21772==    by 0x14F657: sc_send_db (syscollector.c:1560)
==21772==    by 0x156141: DecodeCiscat (ciscat.c:175)
==21772==    by 0x134369: w_decode_event_thread (analysisd.c:2114)
==21772==    by 0x5A2E493: start_thread (pthread_create.c:333)
```