### PR TITLE
 Replaced strtoul() using NULL arguments with atol() in wodles' config files.

### DIFF
--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -91,7 +91,7 @@ int wm_azure_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             merror(XML_ELEMNULL);
             return OS_INVALID;
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
-            azure->timeout = strtoul(nodes[i]->content, NULL, 0);
+            azure->timeout = atol(nodes[i]->content);
 
             if (azure->timeout == 0 || azure->timeout == UINT_MAX) {
                 merror("At module '%s': Invalid timeout.", WM_AZURE_CONTEXT.name);
@@ -443,7 +443,7 @@ int wm_azure_request_read(XML_NODE nodes, wm_azure_request_t * request, unsigned
                 minfo("At module '%s': Workspace ID only available for Log Analytics API. Skipping it...", WM_AZURE_CONTEXT.name);
             }
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
-            request->timeout = strtoul(nodes[i]->content, NULL, 0);
+            request->timeout = atol(nodes[i]->content);
 
             if (request->timeout == 0 || request->timeout == UINT_MAX) {
                 merror("At module '%s': Invalid timeout.", WM_AZURE_CONTEXT.name);
@@ -662,7 +662,7 @@ int wm_azure_container_read(XML_NODE nodes, wm_azure_container_t * container) {
             os_strdup(nodes[i]->content, container->time_offset);
 
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
-            container->timeout = strtoul(nodes[i]->content, NULL, 0);
+            container->timeout = atol(nodes[i]->content);
 
             if (container->timeout == 0 || container->timeout == UINT_MAX) {
                 merror("At module '%s': Invalid timeout.", WM_AZURE_CONTEXT.name);

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -93,7 +93,7 @@ int wm_azure_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
             azure->timeout = atol(nodes[i]->content);
 
-            if (azure->timeout == 0 || azure->timeout == UINT_MAX) {
+            if (azure->timeout <= 0 || azure->timeout >= UINT_MAX) {
                 merror("At module '%s': Invalid timeout.", WM_AZURE_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -101,7 +101,7 @@ int wm_azure_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             char *endptr;
             azure->interval = strtoul(nodes[i]->content, &endptr, 0);
 
-            if (azure->interval == 0 || azure->interval == UINT_MAX) {
+            if (azure->interval <= 0 || azure->interval >= UINT_MAX) {
                 merror("At module '%s': Invalid interval.", WM_AZURE_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -132,8 +132,8 @@ int wm_azure_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             }
 
             if (azure->interval < 60) {
-                merror("At module '%s': Interval must be greater than 60 seconds.", WM_AZURE_CONTEXT.name);
-                return OS_INVALID;
+                merror("At module '%s': Interval must be greater than 60 seconds. New interval value: 60s.", WM_AZURE_CONTEXT.name);
+                azure->interval = 60;
             }
         } else if (!strcmp(nodes[i]->element, XML_RUN_DAY)) {
             if (!OS_StrIsNum(nodes[i]->content)) {
@@ -423,7 +423,7 @@ int wm_azure_request_read(XML_NODE nodes, wm_azure_request_t * request, unsigned
             char *endptr;
             unsigned int offset = strtoul(nodes[i]->content, &endptr, 0);
 
-            if (offset == 0 || offset == UINT_MAX) {
+            if (offset <= 0 || offset >= UINT_MAX) {
                 merror("At module '%s': Invalid time offset.", WM_AZURE_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -445,7 +445,7 @@ int wm_azure_request_read(XML_NODE nodes, wm_azure_request_t * request, unsigned
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
             request->timeout = atol(nodes[i]->content);
 
-            if (request->timeout == 0 || request->timeout == UINT_MAX) {
+            if (request->timeout <= 0 || request->timeout >= UINT_MAX) {
                 merror("At module '%s': Invalid timeout.", WM_AZURE_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -649,7 +649,7 @@ int wm_azure_container_read(XML_NODE nodes, wm_azure_container_t * container) {
             char *endptr;
             unsigned int offset = strtoul(nodes[i]->content, &endptr, 0);
 
-            if (offset == 0 || offset == UINT_MAX) {
+            if (offset <= 0 || offset >= UINT_MAX) {
                 merror("At module '%s': Invalid time offset.", WM_AZURE_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -664,7 +664,7 @@ int wm_azure_container_read(XML_NODE nodes, wm_azure_container_t * container) {
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
             container->timeout = atol(nodes[i]->content);
 
-            if (container->timeout == 0 || container->timeout == UINT_MAX) {
+            if (container->timeout <= 0 || container->timeout >= UINT_MAX) {
                 merror("At module '%s': Invalid timeout.", WM_AZURE_CONTEXT.name);
                 return OS_INVALID;
             }

--- a/src/config/wmodules-ciscat.c
+++ b/src/config/wmodules-ciscat.c
@@ -62,7 +62,7 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
             ciscat->timeout = atol(nodes[i]->content);
 
-            if (ciscat->timeout == 0 || ciscat->timeout == UINT_MAX) {
+            if (ciscat->timeout <= 0 || ciscat->timeout >= UINT_MAX) {
                 merror("Invalid timeout at module '%s'", WM_CISCAT_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -129,7 +129,7 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 } else if (!strcmp(children[j]->element, XML_TIMEOUT)) {
                     cur_eval->timeout = atol(children[j]->content);
 
-                    if (cur_eval->timeout == 0 || cur_eval->timeout == UINT_MAX) {
+                    if (cur_eval->timeout <= 0 || cur_eval->timeout >= UINT_MAX) {
                         merror("Invalid timeout at module '%s'", WM_CISCAT_CONTEXT.name);
                         OS_ClearNode(children);
                         return OS_INVALID;
@@ -159,7 +159,7 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             char *endptr;
             ciscat->interval = strtoul(nodes[i]->content, &endptr, 0);
 
-            if (ciscat->interval == 0 || ciscat->interval == UINT_MAX) {
+            if (ciscat->interval <= 0 || ciscat->interval >= UINT_MAX) {
                 merror("Invalid interval at module '%s'", WM_CISCAT_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -190,8 +190,8 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             }
 
             if (ciscat->interval < 60) {
-                merror("At module '%s': Interval must be greater than 60 seconds.", WM_CISCAT_CONTEXT.name);
-                return OS_INVALID;
+                mwarn("At module '%s': Interval must be greater than 60 seconds. New interval value: 60s.", WM_CISCAT_CONTEXT.name);
+                ciscat->interval = 60;
             }
         } else if (!strcmp(nodes[i]->element, XML_SCAN_DAY)) {
             if (!OS_StrIsNum(nodes[i]->content)) {

--- a/src/config/wmodules-ciscat.c
+++ b/src/config/wmodules-ciscat.c
@@ -60,7 +60,7 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             merror(XML_ELEMNULL);
             return OS_INVALID;
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
-            ciscat->timeout = strtoul(nodes[i]->content, NULL, 0);
+            ciscat->timeout = atol(nodes[i]->content);
 
             if (ciscat->timeout == 0 || ciscat->timeout == UINT_MAX) {
                 merror("Invalid timeout at module '%s'", WM_CISCAT_CONTEXT.name);
@@ -127,7 +127,7 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
 
                     cur_eval->profile = strdup(children[j]->content);
                 } else if (!strcmp(children[j]->element, XML_TIMEOUT)) {
-                    cur_eval->timeout = strtoul(children[j]->content, NULL, 0);
+                    cur_eval->timeout = atol(children[j]->content);
 
                     if (cur_eval->timeout == 0 || cur_eval->timeout == UINT_MAX) {
                         merror("Invalid timeout at module '%s'", WM_CISCAT_CONTEXT.name);

--- a/src/config/wmodules-docker.c
+++ b/src/config/wmodules-docker.c
@@ -81,9 +81,9 @@ int wm_docker_read(xml_node **nodes, wmodule *module)
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_ATTEMPTS)) {
-            docker->attempts = strtoul(nodes[i]->content, NULL, 0);
+            docker->attempts = atol(nodes[i]->content);
 
-            if (docker->attempts < 0 || docker->attempts == INT_MAX) {
+            if (docker->attempts <= 0 || docker->attempts == INT_MAX) {
                 merror("At module '%s': Invalid content for tag '%s'.", WM_DOCKER_CONTEXT.name, XML_ATTEMPTS);
                 return OS_INVALID;
             }

--- a/src/config/wmodules-docker.c
+++ b/src/config/wmodules-docker.c
@@ -50,7 +50,7 @@ int wm_docker_read(xml_node **nodes, wmodule *module)
             char *endptr;
             docker->interval = strtoul(nodes[i]->content, &endptr, 0);
 
-            if (docker->interval == 0 || docker->interval == UINT_MAX) {
+            if (docker->interval <= 0 || docker->interval >= UINT_MAX) {
                 merror("At module '%s': Invalid interval.", WM_DOCKER_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -83,7 +83,7 @@ int wm_docker_read(xml_node **nodes, wmodule *module)
         } else if (!strcmp(nodes[i]->element, XML_ATTEMPTS)) {
             docker->attempts = atol(nodes[i]->content);
 
-            if (docker->attempts <= 0 || docker->attempts == INT_MAX) {
+            if (docker->attempts <= 0 || docker->attempts >= INT_MAX) {
                 merror("At module '%s': Invalid content for tag '%s'.", WM_DOCKER_CONTEXT.name, XML_ATTEMPTS);
                 return OS_INVALID;
             }

--- a/src/config/wmodules-key-request.c
+++ b/src/config/wmodules-key-request.c
@@ -82,7 +82,7 @@ int wm_key_request_read(xml_node **nodes, wmodule *module)
         }
         else if(!strcmp(nodes[i]->element, XML_TIMEOUT))
         {
-            key_request->timeout = strtoul(nodes[i]->content, NULL, 0);
+            key_request->timeout = atol(nodes[i]->content);
 
             if (key_request->timeout < 1 || key_request->timeout >= UINT_MAX) {
                 merror("Invalid interval at module '%s'", WM_KEY_REQUEST_CONTEXT.name);
@@ -93,7 +93,7 @@ int wm_key_request_read(xml_node **nodes, wmodule *module)
         }
         else if (!strcmp(nodes[i]->element, XML_THREADS))
         {
-            key_request->threads = strtoul(nodes[i]->content, NULL, 0);
+            key_request->threads = atol(nodes[i]->content);
 
             if (key_request->threads < 1 || key_request->threads > 32) {
                 merror("Invalid number of threads at module '%s'", WM_KEY_REQUEST_CONTEXT.name);
@@ -102,7 +102,7 @@ int wm_key_request_read(xml_node **nodes, wmodule *module)
         }
         else if (!strcmp(nodes[i]->element, XML_QUEUE_SIZE))
         {
-            key_request->queue_size = strtoul(nodes[i]->content, NULL, 0);
+            key_request->queue_size = atol(nodes[i]->content);
 
             if (key_request->queue_size < 1 || key_request->queue_size > 220000) {
                 merror("Invalid queue size at module '%s'", WM_KEY_REQUEST_CONTEXT.name);

--- a/src/config/wmodules-oscap.c
+++ b/src/config/wmodules-oscap.c
@@ -57,7 +57,7 @@ int wm_oscap_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             merror(XML_ELEMNULL);
             return OS_INVALID;
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
-            oscap->timeout = strtoul(nodes[i]->content, NULL, 0);
+            oscap->timeout = atol(nodes[i]->content);
 
             if (oscap->timeout == 0 || oscap->timeout == UINT_MAX) {
                 merror("Invalid timeout at module '%s'", WM_OSCAP_CONTEXT.name);
@@ -139,7 +139,7 @@ int wm_oscap_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
 
                     cur_profile->name = strdup(children[j]->content);
                 } else if (!strcmp(children[j]->element, XML_TIMEOUT)) {
-                    cur_eval->timeout = strtoul(children[j]->content, NULL, 0);
+                    cur_eval->timeout = atol(children[j]->content);
 
                     if (cur_eval->timeout == 0 || cur_eval->timeout == UINT_MAX) {
                         merror("Invalid timeout at module '%s'", WM_OSCAP_CONTEXT.name);

--- a/src/config/wmodules-oscap.c
+++ b/src/config/wmodules-oscap.c
@@ -59,7 +59,7 @@ int wm_oscap_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         } else if (!strcmp(nodes[i]->element, XML_TIMEOUT)) {
             oscap->timeout = atol(nodes[i]->content);
 
-            if (oscap->timeout == 0 || oscap->timeout == UINT_MAX) {
+            if (oscap->timeout <= 0 || oscap->timeout >= UINT_MAX) {
                 merror("Invalid timeout at module '%s'", WM_OSCAP_CONTEXT.name);
                 return OS_INVALID;
             }
@@ -141,7 +141,7 @@ int wm_oscap_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 } else if (!strcmp(children[j]->element, XML_TIMEOUT)) {
                     cur_eval->timeout = atol(children[j]->content);
 
-                    if (cur_eval->timeout == 0 || cur_eval->timeout == UINT_MAX) {
+                    if (cur_eval->timeout <= 0 || cur_eval->timeout >= UINT_MAX) {
                         merror("Invalid timeout at module '%s'", WM_OSCAP_CONTEXT.name);
                         OS_ClearNode(children);
                         return OS_INVALID;
@@ -217,7 +217,7 @@ int wm_oscap_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             char *endptr;
             oscap->interval = strtoul(nodes[i]->content, &endptr, 0);
 
-            if (oscap->interval == 0 || oscap->interval == UINT_MAX) {
+            if (oscap->interval <= 0 || oscap->interval >= UINT_MAX) {
                 merror("Invalid interval at module '%s'", WM_OSCAP_CONTEXT.name);
                 return OS_INVALID;
             }


### PR DESCRIPTION
strtoul() was causing some issues (specially in the docker wodle), as it was reading characters as numeric values, causing unexpected behaviour. The solution was replacing it with atol(), which only reads numeric values.

This PR fixes the issue https://github.com/wazuh/wazuh/issues/2768