### PR TITLE
Improve message when deleting agent from a group

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1852,7 +1852,14 @@ class Agent:
             else:
                 multigroup_name = 'default' if not group_list else group_list[0]
             Agent.unset_all_groups_agent(agent_id, True, multigroup_name)
-            return "Group '{}' unset for agent '{}'.".format(group_id, agent_id)
+            # for show the return message properly it is necessary to get the original group list
+            original_group_list = group_name.split(',')
+            if len(original_group_list) > 1:
+                return f"Group '{group_id}' unset for agent '{agent_id}'."
+            elif 'default' in original_group_list:
+                return "Agent only belongs to 'default' and it cannot be unset from this group."
+            else:
+                return "Agent must belong to a group at least. Adding to default group."
         else:
             raise WazuhException(1734, "Agent {} doesn't belong to any group".format(agent_id))
 


### PR DESCRIPTION
Hi team,

This PR closes [346](https://github.com/wazuh/wazuh-api/issues/346). This was the message when you delete an agent if it only has a group (last call):

```bash
# curl -u foo:bar -k -X GET "https://192.168.122.111:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "registerIP": "192.168.122.141",
      "dateAdd": "2019-02-12 13:22:38",
      "os": {
         "arch": "x86_64",
         "codename": "Core",
         "major": "7",
         "name": "CentOS Linux",
         "platform": "centos",
         "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
         "version": "7"
      },
      "id": "001",
      "lastKeepAlive": "2019-02-13 08:34:05",
      "mergedSum": "1b2e87fd26ac100d4b4a034913410308",
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "name": "agente3.5",
      "group": [
         "default",
         "dmz"
      ],
      "version": "Wazuh v3.5.0",
      "status": "Disconnected",
      "ip": "192.168.122.141",
      "node_name": "unknown"
   }
}
localhost:~/wazuh (3.9*%=) # curl -u foo:bar -k -X DELETE "https://192.168.122.111:55000/agents/001/group/default?pretty"
{
   "error": 0,
   "data": "Group 'default' unset for agent '001'."
}
localhost:~/wazuh (3.9*%=) # curl -u foo:bar -k -X GET "https://192.168.122.111:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "os": {
         "arch": "x86_64",
         "codename": "Core",
         "major": "7",
         "name": "CentOS Linux",
         "platform": "centos",
         "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
         "version": "7"
      },
      "ip": "192.168.122.141",
      "version": "Wazuh v3.5.0",
      "dateAdd": "2019-02-12 13:22:38",
      "mergedSum": "1b2e87fd26ac100d4b4a034913410308",
      "registerIP": "192.168.122.141",
      "group": [
         "dmz"
      ],
      "id": "001",
      "lastKeepAlive": "2019-02-13 08:34:05",
      "node_name": "unknown",
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "name": "agente3.5",
      "status": "Disconnected"
   }
}
localhost:~/wazuh (3.9*%=) # curl -u foo:bar -k -X DELETE "https://192.168.122.111:55000/agents/001/group/dmz?pretty"
{
   "error": 0,
   "data": "Group 'dmz' unset for agent '001'." -----> Agent is added into 'default' group
}
```

I improved the message for showing what happens:
```bash
# curl -u foo:bar -k -X GET "https://192.168.122.111:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "os": {
         "arch": "x86_64",
         "codename": "Core",
         "major": "7",
         "name": "CentOS Linux",
         "platform": "centos",
         "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
         "version": "7"
      },
      "lastKeepAlive": "2019-02-13 08:34:05",
      "status": "Disconnected",
      "version": "Wazuh v3.5.0",
      "group": [
         "dmz",
         "default"
      ],
      "dateAdd": "2019-02-12 13:22:38",
      "ip": "192.168.122.141",
      "name": "agente3.5",
      "id": "001",
      "registerIP": "192.168.122.141",
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "mergedSum": "1b2e87fd26ac100d4b4a034913410308",
      "node_name": "unknown"
   }
}
# curl -u foo:bar -k -X DELETE "https://192.168.122.111:55000/agents/001/group/default?pretty"                                        
{
   "error": 0,
   "data": "Group 'default' unset for agent '001'."
}
# curl -u foo:bar -k -X GET "https://192.168.122.111:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "id": "001",
      "name": "agente3.5",
      "mergedSum": "1b2e87fd26ac100d4b4a034913410308",
      "os": {
         "arch": "x86_64",
         "codename": "Core",
         "major": "7",
         "name": "CentOS Linux",
         "platform": "centos",
         "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
         "version": "7"
      },
      "ip": "192.168.122.141",
      "registerIP": "192.168.122.141",
      "status": "Disconnected",
      "lastKeepAlive": "2019-02-13 08:34:05",
      "node_name": "unknown",
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "group": [
         "dmz"
      ],
      "dateAdd": "2019-02-12 13:22:38",
      "version": "Wazuh v3.5.0"
   }
}
# curl -u foo:bar -k -X DELETE "https://192.168.122.111:55000/agents/001/group/dmz?pretty"    
{
   "error": 0,
   "data": "Agent must belong to a group at least. Adding to default group." --------> New message
}
# curl -u foo:bar -k -X GET "https://192.168.122.111:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "dateAdd": "2019-02-12 13:22:38",
      "os": {
         "arch": "x86_64",
         "codename": "Core",
         "major": "7",
         "name": "CentOS Linux",
         "platform": "centos",
         "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
         "version": "7"
      },
      "node_name": "unknown",
      "status": "Disconnected",
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "id": "001",
      "version": "Wazuh v3.5.0",
      "name": "agente3.5",
      "lastKeepAlive": "2019-02-13 08:34:05",
      "group": [
         "default"
      ],
      "ip": "192.168.122.141",
      "mergedSum": "1b2e87fd26ac100d4b4a034913410308",
      "registerIP": "192.168.122.141"
   }
}
```

Other example could be the next:

```bash
# curl -u foo:bar -k -X GET "https://192.168.122.111:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "os": {
         "arch": "x86_64",
         "codename": "Core",
         "major": "7",
         "name": "CentOS Linux",
         "platform": "centos",
         "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
         "version": "7"
      },
      "registerIP": "192.168.122.141",
      "version": "Wazuh v3.5.0",
      "mergedSum": "1b2e87fd26ac100d4b4a034913410308",
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "node_name": "unknown",
      "lastKeepAlive": "2019-02-13 08:34:05",
      "dateAdd": "2019-02-12 13:22:38",
      "status": "Disconnected",
      "name": "agente3.5",
      "ip": "192.168.122.141",
      "id": "001",
      "group": [
         "default"
      ]
   }
}
# curl -u foo:bar -k -X DELETE "https://192.168.122.111:55000/agents/001/group/default?pretty"
{
   "error": 0,
   "data": "Agent only belongs to 'default' and it cannot be unset from this group." --------> New message
}
```

Best regards,

Demetrio.