### PR TITLE
Remove null values from sca output

### DIFF
--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -11,6 +11,7 @@ import re
 import json
 import struct
 
+
 class WazuhDBConnection:
     """
     Represents a connection to the wdb socket
@@ -28,7 +29,6 @@ class WazuhDBConnection:
             self.__conn.connect(self.socket_path)
         except OSError as e:
             raise WazuhException(2005, e)
-
 
     def __query_input_validation(self, query):
         """
@@ -50,7 +50,6 @@ class WazuhDBConnection:
             if not check:
                 raise WazuhException(2004, error_text)
 
-
     def _send(self, msg):
         """
         Sends a message to the wdb socket
@@ -67,8 +66,7 @@ class WazuhDBConnection:
         if data[0] == "err":
             raise WazuhException(2003, data[1])
         else:
-            return json.loads(data[1])
-
+            return json.loads(data[1], object_hook=lambda dct: {k: v for k, v in dct.items() if v != "(null)"})
 
     def __query_lower(self, query):
         """
@@ -91,8 +89,6 @@ class WazuhDBConnection:
                 to_lower = True
 
         return new_query
-
-
 
     def execute(self, query, count=False, delete=False, update=False):
         """


### PR DESCRIPTION
This PR fixes #2806 . 

This fix is very simple. I have modified the json decoding so as to delete keys with a "(null)".

I have included a small unit test to verify the correctness of the new code.
```
root@42860e4a39f9:/# /var/ossec/framework/python/bin/pytest /var/ossec//framework/python/lib/python3.7/site-packages/wazuh/tests/test_wdb.py 
================================================ test session starts =================================================
platform linux -- Python 3.7.2, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /var/ossec/framework/python/lib/python3.7/site-packages/wazuh/tests, inifile:
collected 3 items                                                                                                    

var/ossec/framework/python/lib/python3.7/site-packages/wazuh/tests/test_wdb.py ...                             [100%]

============================================== 3 passed in 0.07 seconds ==============================================
```
```
root@42860e4a39f9:/# curl -u foo:bar "http://localhost:55000/sca/000?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "name": "CIS benchmark for Debian/Linux",
            "end_scan": "2019-03-13 08:08:43",
            "pass": 35,
            "fail": 6,
            "start_scan": "2019-03-13 08:08:42",
            "description": "This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.",
            "policy_id": "cis_debian",
            "score": 85
         }
      ]
   }
}
```
