### PR TITLE
Fix agent-auth options without argument

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    while ((c = getopt(argc, argv, "VdhtG:m:p:A:c:v:x:k:D:P:a:I:i"
+    while ((c = getopt(argc, argv, "VdhtG:m:p:A:cv:x:k:D:P:aI:i"
 #ifndef WIN32
     "g:D:"
 #endif

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    while ((c = getopt(argc, argv, "VdhtG:m:p:A:cv:x:k:D:P:aI:i"
+    while ((c = getopt(argc, argv, "VdhtG:m:p:A:c:v:x:k:D:P:aI:i"
 #ifndef WIN32
     "g:D:"
 #endif

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -51,7 +51,7 @@ static void help_agent_auth()
     print_out("    -m <addr>   Manager IP address");
     print_out("    -p <port>   Manager port (default: %d)", DEFAULT_PORT);
     print_out("    -A <name>   Agent name (default: hostname)");
-    print_out("    -c          SSL cipher list (default: %s)", DEFAULT_CIPHERS);
+    print_out("    -c <cipher> SSL cipher list (default: %s)", DEFAULT_CIPHERS);
     print_out("    -v <path>   Full path to CA certificate used to verify the server");
     print_out("    -x <path>   Full path to agent certificate");
     print_out("    -k <path>   Full path to agent key");


### PR DESCRIPTION
This PR solves the issue at https://github.com/wazuh/wazuh/issues/2789, where option '-a' needed an argument. This was caused because of the way the legitimate options were being passed  to the function `getopt`: https://github.com/wazuh/wazuh/blob/8a34d85662154d324cd4c01455e205dc34367f04/src/os_auth/main-client.c#L109

If the character is followed by a colon it means that this option requires an argument, which is not the case for option '-a', autonegotiate TLS method.