### PR TITLE
Fixed several inconsistencies in FIM

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -831,8 +831,9 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         syscheck->disabled = SK_CONF_UNDEFINED;
     }
 
-    os_calloc(1, sizeof(char *), syscheck->audit_key);
-
+    if(!syscheck->audit_key) {
+        os_calloc(1, sizeof(char *), syscheck->audit_key);
+    }
     while (node && node[i]) {
         if (!node[i]->element) {
             merror(XML_ELEMNULL);
@@ -1276,7 +1277,6 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                     int keyit = 0;
                     char delim = ',';
                     char *key;
-                    syscheck->audit_key[keyit] = NULL;
                     key = strtok(children[j]->content, &delim);
 
                     while (key) {

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -15,7 +15,7 @@
 
 static int get_interval(char *source, unsigned long *interval);
 static int is_valid_year(char *source, int *date);
-static int set_oval_version(char *feed, char *version, update_node **upd_list, update_node *upd);
+static int set_oval_version(char *feed, const char *version, update_node **upd_list, update_node *upd);
 
 //Options
 static const char *XML_DISABLED = "disabled";
@@ -83,7 +83,7 @@ int format_os_version(char *OS, char **os_name, char **os_ver) {
     return 0;
 }
 
-int set_oval_version(char *feed, char *version, update_node **upd_list, update_node *upd) {
+int set_oval_version(char *feed, const char *version, update_node **upd_list, update_node *upd) {
     cve_db os_index;
 
     if (!strcmp(feed, vu_dist_tag[DIS_UBUNTU])) {
@@ -285,7 +285,7 @@ int wm_vuldet_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
             upd->attempted = 0;
             upd->json_format = 0;
             upd->update_from_year = RED_HAT_REPO_DEFAULT_MIN_YEAR;
-            
+
 
             if (os_index = set_oval_version(feed, version, vulnerability_detector->updates, upd), os_index == OS_INVALID) {
                 return OS_INVALID;

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -78,7 +78,6 @@
 #define FIM_NATTR 11
 // Number of options in checksum hash table
 #define FIM_NOPTS 10
-
 /* Fields for rules */
 typedef enum sk_syscheck {
     SK_FILE,
@@ -90,10 +89,10 @@ typedef enum sk_syscheck {
     SK_SHA1,
     SK_UNAME,
     SK_GNAME,
+    SK_MTIME,
     SK_INODE,
     SK_SHA256,
     SK_ATTRS,
-    SK_MTIME,
     SK_CHFIELDS,
     SK_USER_ID,
     SK_USER_NAME,

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -522,9 +522,9 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 if (inode_path = OSHash_Get_ex(syscheck.inode_hash, str_inode), inode_path) {
 
                     if(!strcmp(inode_path, file_name)) { // FILE_NAME == INODE_PATH
-                        minfo("Found an inode with same path: path in inode-ht:'%s' filename:'%s'", inode_path, file_name);
+                        mdebug1("Found inode '%s' with same path: '%s'", str_inode, file_name);
                     } else {
-                        minfo("Updating path in inode hash: %s (%s) ", inode_path, str_inode);
+                        mdebug1("Updating path in inode hash table: %s (%s) ", inode_path, str_inode);
                         OSHash_Update_ex(syscheck.inode_hash, str_inode, (void*)file_name);
                     }
                 }
@@ -749,6 +749,13 @@ end:
 
 int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_depth, __attribute__((unused))unsigned int is_link)
 {
+    char *f_name;
+    short is_nfs;
+    DIR *dp;
+    struct dirent *entry;
+    int opts;
+    size_t dir_size;
+
     if(max_depth < 0){
         mdebug2("Max level of recursion reached. File '%s' out of bounds.", dir_name);
         return 0;
@@ -771,15 +778,7 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
     }
 #endif
 
-    int opts;
-    size_t dir_size;
-    char *f_name;
-    short is_nfs;
     os_calloc(PATH_MAX + 2, sizeof(char), f_name);
-
-    DIR *dp;
-    struct dirent *entry;
-
     opts = syscheck.opts[dir_position];
 
     /* Directory should be valid */

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -224,7 +224,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             send_syscheck_msg(alert_msg);
 
 #ifndef WIN32
-            fim_delete_hashes(file_name);
+            fim_delete_hashes((char*)file_name);
 #else
             // Delete from hash table
             if (s_node = OSHash_Delete_ex(syscheck.fp, file_name), s_node) {
@@ -1205,7 +1205,7 @@ int read_links(const char *dir_name, int dir_position, int max_depth, unsigned i
     return 0;
 }
 
-int fim_delete_hashes(const char *file_name) {
+int fim_delete_hashes(char *file_name) {
     char *checksum_inode;
     char *inode_str;
     char *w_inode;
@@ -1241,8 +1241,9 @@ int fim_delete_hashes(const char *file_name) {
         }
 
         os_free(checksum_inode);
-        free(data->checksum);
-        free(data);
+        os_free(data->checksum);
+        os_free(data);
+        os_free(file_name);
     }
 
     return 0;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -513,6 +513,12 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                         read_file(inode_path, dir_position, evt, max_depth);
                         os_free(inode_path);
                     }
+                    else {
+                        os_free(hash_file_name);
+                    }
+                }
+                else {
+                    os_free(hash_file_name);
                 }
             }
 #endif

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -513,17 +513,14 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
 
             switch (ret) {
             case 0:
-                free(hash_file_name);
+                os_free(hash_file_name);
                 mdebug2("Not enough memory to add inode to db: %s (%s) ", file_name, str_inode);
                 break;
             case 1:
-                free(hash_file_name);
+                os_free(hash_file_name);
 
                 if (inode_path = OSHash_Get_ex(syscheck.inode_hash, str_inode), inode_path) {
-
-                    if(!strcmp(inode_path, file_name)) { // FILE_NAME == INODE_PATH
-                        mdebug1("Found inode '%s' with same path: '%s'", str_inode, file_name);
-                    } else {
+                    if(strcmp(inode_path, file_name)) {
                         mdebug1("Updating path in inode hash table: %s (%s) ", inode_path, str_inode);
                         OSHash_Update_ex(syscheck.inode_hash, str_inode, (void*)file_name);
                     }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -224,7 +224,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             send_syscheck_msg(alert_msg);
 
 #ifndef WIN32
-            fim_delete_hashes((char*)file_name);
+            fim_delete_hashes(strdup(file_name));
 #else
             // Delete from hash table
             if (s_node = OSHash_Delete_ex(syscheck.fp, file_name), s_node) {
@@ -508,9 +508,10 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             case 1:
                 if (inode_path = OSHash_Get_ex(syscheck.inode_hash, str_inode), inode_path) {
                     if(strcmp(inode_path, file_name)) {
-                        mdebug1("Updating path in inode hash table: %s (%s) ", inode_path, str_inode);
+                        mdebug2("Updating path '%s' in inode hash table: %s (%s) ", file_name, inode_path, str_inode);
                         OSHash_Update_ex(syscheck.inode_hash, str_inode, (void*)hash_file_name);
                         read_file(inode_path, dir_position, evt, max_depth);
+                        os_free(inode_path);
                     }
                 }
             }
@@ -947,7 +948,7 @@ int run_dbcheck()
             snprintf(alert_msg, OS_SIZE_6144 - 1, "-1!:::::::::::%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", curr_node->key);
             send_syscheck_msg(alert_msg);
 #ifndef WIN32
-            fim_delete_hashes(curr_node->key);
+            fim_delete_hashes(strdup(curr_node->key));
 #endif
             OSHash_Delete_ex(syscheck.last_check, curr_node->key);
         }
@@ -1243,8 +1244,8 @@ int fim_delete_hashes(char *file_name) {
         os_free(checksum_inode);
         os_free(data->checksum);
         os_free(data);
-        os_free(file_name);
     }
+    os_free(file_name);
 
     return 0;
 }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -946,9 +946,9 @@ int run_dbcheck()
             mdebug2("Sending delete msg for file: %s", curr_node->key);
             snprintf(alert_msg, OS_SIZE_6144 - 1, "-1!:::::::::::%s %s", syscheck.tag[pos] ? syscheck.tag[pos] : "", curr_node->key);
             send_syscheck_msg(alert_msg);
-
+#ifndef WIN32
             fim_delete_hashes(curr_node->key);
-
+#endif
             OSHash_Delete_ex(syscheck.last_check, curr_node->key);
         }
         os_free(i);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -296,11 +296,11 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                     } else if (S_ISDIR(statbuf_lnk.st_mode)) { /* This points to a directory */
                         if (!(opts & CHECK_FOLLOW)) {
                             mdebug2("Follow symbolic links disabled.");
-                            free(alert_msg);
-                            free(wd_sum);
+                            os_free(alert_msg);
+                            os_free(wd_sum);
                             return 0;
                         } else {
-                            free(alert_msg);
+                            os_free(alert_msg);
                             os_free(wd_sum);
                             return (read_dir(file_name, dir_position, NULL, max_depth-1, 1));
                         }
@@ -728,7 +728,7 @@ end:
     if (sid) {
         LocalFree(sid);
     }
-    free(str_perm);
+    os_free(str_perm);
 #endif
     return 0;
 }
@@ -895,7 +895,7 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
         read_file(f_name, dir_position, evt, max_depth);
     }
 
-    free(f_name);
+    os_free(f_name);
     closedir(dp);
     return (0);
 }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -324,7 +324,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
     char *str_perm = NULL;
     char *user;
 #else
-    char *w_inode;
+    char *w_inode = NULL;
     char str_owner[50], str_group[50], str_perm[50];
 #endif
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -387,8 +387,8 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
                 }
                 if(inode_str){
                     w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str);
-                    os_free(checksum_inode);
                 }
+                os_free(checksum_inode);
             }
         }
 #endif
@@ -468,7 +468,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
 
     /* Generate new checksum */
     newsum[0] = '\0';
-    newsum[OS_MAXSTR] = '\0';
+    newsum[OS_SIZE_4096] = '\0';
     if (S_ISREG(statbuf.st_mode))
     {
         if (sha1sum || md5sum || sha256sum) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -468,7 +468,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
 
     /* Generate new checksum */
     newsum[0] = '\0';
-    newsum[OS_SIZE_4096] = '\0';
+    newsum[OS_MAXSTR] = '\0';
     if (S_ISREG(statbuf.st_mode))
     {
         if (sha1sum || md5sum || sha256sum) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -386,9 +386,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
                     os_free(i);
                 }
                 if(inode_str){
-                    if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str), w_inode) {
-                        os_free(w_inode);
-                    }
+                    w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str);
                     os_free(checksum_inode);
                 }
             }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -362,9 +362,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
 
 #ifndef WIN32
         if(evt && evt->inode) {
-            if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), w_inode) {
-                os_free(w_inode);
-            }
+            w_inode = OSHash_Delete_ex(syscheck.inode_hash, evt->inode);
         }
         else {
             if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, file_name), s_node) {
@@ -372,14 +370,14 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
                 char *checksum_inode;
 
                 os_strdup(s_node->checksum, checksum_inode);
-                if(inode_str = get_attr_from_checksum(checksum_inode, SK_INODE), !inode_str || *inode_str == '\0'){
+                if(inode_str = get_attr_from_checksum(checksum_inode, SK_INODE), !inode_str || *inode_str == '\0') {
                     OSHashNode *s_inode;
                     unsigned int *i;
                     os_calloc(1, sizeof(unsigned int), i);
 
                     for (s_inode = OSHash_Begin(syscheck.inode_hash, i); s_inode; s_inode = OSHash_Next(syscheck.inode_hash, i, s_inode)) {
                         if(s_inode && s_inode->data){
-                            if(!strcmp(s_inode->data, file_name)){
+                            if(!strcmp(s_inode->data, file_name)) {
                                 inode_str = s_inode->key;
                                 break;
                             }
@@ -401,6 +399,8 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             free(s_node->checksum);
             free(s_node);
         }
+
+        os_free(w_inode);
 
         struct timeval timeout = {0, syscheck.rt_delay * 1000};
         select(0, NULL, NULL, NULL, &timeout);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -394,8 +394,8 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
 #endif
         // Delete from hash table
         if (s_node = OSHash_Delete_ex(syscheck.fp, file_name), s_node) {
-            free(s_node->checksum);
-            free(s_node);
+            os_free(s_node->checksum);
+            os_free(s_node);
         }
 #ifndef WIN32
         os_free(w_inode);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -399,8 +399,9 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             free(s_node->checksum);
             free(s_node);
         }
-
+#ifndef WIN32
         os_free(w_inode);
+#endif
 
         struct timeval timeout = {0, syscheck.rt_delay * 1000};
         select(0, NULL, NULL, NULL, &timeout);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -363,7 +363,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
 #ifndef WIN32
         if(evt && evt->inode) {
             if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, evt->inode), w_inode) {
-                free(w_inode);
+                os_free(w_inode);
             }
         }
         else {
@@ -389,7 +389,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
                 }
                 if(inode_str){
                     if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str), w_inode) {
-                        free(w_inode);
+                        os_free(w_inode);
                     }
                     os_free(checksum_inode);
                 }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -372,12 +372,27 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
                 char *checksum_inode;
 
                 os_strdup(s_node->checksum, checksum_inode);
-                inode_str = get_attr_from_checksum(checksum_inode, SK_INODE);
-                
-                if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str), w_inode) {
-                    free(w_inode);
+                if(inode_str = get_attr_from_checksum(checksum_inode, SK_INODE), !inode_str || *inode_str == '\0'){
+                    OSHashNode *s_inode;
+                    unsigned int *i;
+                    os_calloc(1, sizeof(unsigned int), i);
+
+                    for (s_inode = OSHash_Begin(syscheck.inode_hash, i); s_inode; s_inode = OSHash_Next(syscheck.inode_hash, i, s_inode)) {
+                        if(s_inode && s_inode->data){
+                            if(!strcmp(s_inode->data, file_name)){
+                                inode_str = s_inode->key;
+                                break;
+                            }
+                        }
+                    }
+                    os_free(i);
                 }
-                os_free(checksum_inode);
+                if(inode_str){
+                    if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str), w_inode) {
+                        free(w_inode);
+                    }
+                    os_free(checksum_inode);
+                }
             }
         }
 #endif

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -47,7 +47,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
     syscheck_node *s_node;
 
     // To obtain path without symbolic links
-    real_path = calloc(sizeof(char), PATH_MAX);
+    os_calloc(PATH_MAX, sizeof(char), real_path);
 
     if (realpath(file_name, real_path) == NULL) {
         os_strdup(file_name, path);
@@ -68,6 +68,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         // If it returns < 0, we've already alerted the deleted file
         if (c_read_file(file_name, buf, c_sum, evt) < 0) {
             os_free(path);
+            print_hash_table();
             return (0);
         }
 
@@ -110,6 +111,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
 
             os_free(buf);
             os_free(path);
+            print_hash_table();
 
             return (1);
         } else {
@@ -117,6 +119,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         }
 
         os_free(path);
+        print_hash_table();
 
         return (0);
     } else {
@@ -148,9 +151,11 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
                 if (S_ISLNK(statbuf.st_mode) && (syscheck.opts[pos] & CHECK_FOLLOW)) {
                     read_dir(path, pos, evt, depth, 1);
                     os_free(path);
+                    print_hash_table();
                     return 0;
                 } else if (S_ISLNK(statbuf.st_mode) && !(syscheck.opts[pos] & CHECK_FOLLOW)) {
                     os_free(path);
+                    print_hash_table();
                     return 0;
                 }
             }
@@ -161,6 +166,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
     }
 
     os_free(path);
+    print_hash_table();
 
     return (0);
 }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -68,7 +68,6 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         // If it returns < 0, we've already alerted the deleted file
         if (c_read_file(file_name, buf, c_sum, evt) < 0) {
             os_free(path);
-            print_hash_table();
             return (0);
         }
 
@@ -111,7 +110,6 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
 
             os_free(buf);
             os_free(path);
-            print_hash_table();
 
             return (1);
         } else {
@@ -119,7 +117,6 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         }
 
         os_free(path);
-        print_hash_table();
 
         return (0);
     } else {
@@ -151,11 +148,9 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
                 if (S_ISLNK(statbuf.st_mode) && (syscheck.opts[pos] & CHECK_FOLLOW)) {
                     read_dir(path, pos, evt, depth, 1);
                     os_free(path);
-                    print_hash_table();
                     return 0;
                 } else if (S_ISLNK(statbuf.st_mode) && !(syscheck.opts[pos] & CHECK_FOLLOW)) {
                     os_free(path);
-                    print_hash_table();
                     return 0;
                 }
             }
@@ -166,8 +161,6 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
     }
 
     os_free(path);
-    print_hash_table();
-
     return (0);
 }
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -49,6 +49,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
     // To obtain path without symbolic links
     os_calloc(PATH_MAX, sizeof(char), real_path);
 
+#ifndef WIN32
     if (realpath(file_name, real_path) == NULL) {
         os_strdup(file_name, path);
         os_free(real_path);
@@ -56,6 +57,9 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         os_strdup(real_path, path);
         os_free(real_path);
     }
+#else
+    os_strdup(file_name, path);
+#endif
 
     if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, path), s_node) {
         char c_sum[OS_SIZE_4096 + 1];

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -62,12 +62,12 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
 #endif
 
     if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, path), s_node) {
-        char c_sum[OS_SIZE_4096 + 1];
+        char c_sum[OS_MAXSTR + 1];
         size_t c_sum_size;
 
         buf = s_node->checksum;
         c_sum[0] = '\0';
-        c_sum[OS_SIZE_4096] = '\0';
+        c_sum[OS_MAXSTR] = '\0';
 
         // If it returns < 0, we've already alerted the deleted file
         if (c_read_file(path, buf, c_sum, evt) < 0) {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -42,25 +42,29 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt) __attribute__
 int realtime_checksumfile(const char *file_name, whodata_evt *evt)
 {
     char *buf;
+    char *real_path;
     syscheck_node *s_node;
 
-    s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, file_name);
+    // To obtain path without symbolic links
+    real_path = calloc(sizeof(char), PATH_MAX);
 
-    if (s_node != NULL) {
-        char c_sum[OS_MAXSTR + 1];
+    if (realpath(file_name, real_path) == NULL) {
+        mdebug2("Checking realpath in realtime_checksumfile path: '%s'", file_name);
+    }
+
+    if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, real_path), s_node) {
+        char c_sum[OS_SIZE_4096 + 1];
         size_t c_sum_size;
 
         buf = s_node->checksum;
         c_sum[0] = '\0';
-        c_sum[OS_MAXSTR] = '\0';
-
+        c_sum[OS_SIZE_4096] = '\0';
 
         // If it returns < 0, we've already alerted the deleted file
         if (c_read_file(file_name, buf, c_sum, evt) < 0) {
-
+            os_free(real_path);
             return (0);
         }
-
 
         c_sum_size = strlen(buf + SK_DB_NATTR);
         if (strncmp(c_sum, buf + SK_DB_NATTR, c_sum_size)) {
@@ -69,11 +73,11 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
 
             // Extract the whodata sum here to not include it in the hash table
             if (extract_whodata_sum(evt, wd_sum, OS_SIZE_6144)) {
-                merror("The whodata sum for '%s' file could not be included in the alert as it is too large.", file_name);
+                merror("The whodata sum for '%s' file could not be included in the alert as it is too large.", real_path);
             }
 
             /* Find tag position for the evaluated file name */
-            int pos = find_dir_pos(file_name, 1, 0, 0);
+            int pos = find_dir_pos(real_path, 1, 0, 0);
 
             // Update database
             snprintf(alert_msg, sizeof(alert_msg), "%.*s%.*s", SK_DB_NATTR, buf, (int)strcspn(c_sum, " "), c_sum);
@@ -83,70 +87,73 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             char *fullalert = NULL;
 
             if (buf[SK_DB_REPORT_CHANG] == '+') {
-                fullalert = seechanges_addfile(file_name);
+                fullalert = seechanges_addfile(real_path);
                 if (fullalert) {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s\n%s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name, fullalert);
+                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s\n%s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", real_path, fullalert);
                     free(fullalert);
                     fullalert = NULL;
                 } else {
-                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
+                    snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", real_path);
                 }
             } else {
-                snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", file_name);
+                snprintf(alert_msg, OS_MAXSTR, "%s!%s:%s %s", c_sum, wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", real_path);
             }
 
             send_syscheck_msg(alert_msg);
             struct timeval timeout = {0, syscheck.rt_delay * 1000};
             select(0, NULL, NULL, NULL, &timeout);
 
-            free(buf);
+            os_free(buf);
+            os_free(real_path);
 
             return (1);
         } else {
-            mdebug2("Inotify event with same checksum for file: '%s'. Ignoring it.", file_name);
+            mdebug2("Inotify event with same checksum for file: '%s'. Ignoring it.", real_path);
         }
 
+        os_free(real_path);
         return (0);
     } else {
         /* New file */
         int pos;
+        int is_link = 0;
 #ifdef WIN_WHODATA
         if (evt) {
             pos = evt->dir_position;
         } else {
 #endif
-        pos = find_dir_pos(file_name, 1, 0, 0);
+        pos = find_dir_pos(real_path, 1, 0, 0);
 #ifdef WIN_WHODATA
         }
 #endif
         if (pos >= 0) {
-            mdebug1("Scanning new file '%s' with options for directory '%s'.", file_name, syscheck.dir[pos]);
-            int diff = fim_find_child_depth(syscheck.dir[pos], file_name);
-            int depth = syscheck.recursion_level[pos] - diff+1;
+            mdebug1("Scanning new file '%s' with options for directory '%s'.", real_path, syscheck.dir[pos]);
+            int diff = fim_find_child_depth(syscheck.dir[pos], real_path);
+            int depth = syscheck.recursion_level[pos] - diff + 1;
 
-            if(check_path_type(file_name) == 2){
+            if(check_path_type(real_path) == 2){
                 depth = depth - 1;
             }
 #ifndef WIN32
             struct stat statbuf;
 
-            if (lstat(file_name, &statbuf) < 0) {
-                mdebug2("Stat() function failed on: %s. File may have been deleted", file_name);
+            if (lstat(real_path, &statbuf) < 0) {
+                mdebug2("Stat() function failed on: %s. File may have been deleted", real_path);
             } else {
                 if (S_ISLNK(statbuf.st_mode) && (syscheck.opts[pos] & CHECK_FOLLOW)) {
-                    read_dir(file_name, pos, evt, depth, 1);
+                    read_dir(real_path, pos, evt, depth, 1);
                     return 0;
                 } else if (S_ISLNK(statbuf.st_mode) && !(syscheck.opts[pos] & CHECK_FOLLOW)) {
                     return 0;
                 }
             }
 #endif
-            read_dir(file_name, pos, evt, depth, 0);
+            read_dir(real_path, pos, evt, depth, 0);
         }
 
     }
 
-
+    os_free(real_path);
     return (0);
 }
 
@@ -213,7 +220,7 @@ int realtime_start()
     }
     syscheck.realtime->dirtb = OSHash_Create();
     if (syscheck.realtime->dirtb == NULL) merror_exit(MEM_ERROR, errno, strerror(errno));
-    
+
     syscheck.realtime->fd = -1;
 
 #ifdef INOTIFY_ENABLED
@@ -427,12 +434,12 @@ int realtime_start()
 {
     minfo("Initializing real time file monitoring engine.");
     os_calloc(1, sizeof(rtfim), syscheck.realtime);
-    
+
     syscheck.realtime->dirtb = OSHash_Create();
     if (syscheck.realtime->dirtb == NULL) merror_exit(MEM_ERROR, errno, strerror(errno));
-    
+
     OSHash_SetFreeDataPointer(syscheck.realtime->dirtb, (void (*)(void *))free_win32rtfim_data);
-    
+
     syscheck.realtime->fd = -1;
     syscheck.realtime->evt = CreateEvent(NULL, TRUE, FALSE, NULL);
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -132,7 +132,9 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         }
 #endif
         if (pos >= 0) {
-            mdebug1("Scanning new file '%s' with options for directory '%s'.", path, syscheck.dir[pos]);
+            if(IsFile(path) == 0){
+                mdebug1("Scanning new file '%s' with options for directory '%s'.", path, syscheck.dir[pos]);
+            }
             int diff = fim_find_child_depth(syscheck.dir[pos], path);
             int depth = syscheck.recursion_level[pos] - diff + 1;
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -70,7 +70,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         c_sum[OS_SIZE_4096] = '\0';
 
         // If it returns < 0, we've already alerted the deleted file
-        if (c_read_file(file_name, buf, c_sum, evt) < 0) {
+        if (c_read_file(path, buf, c_sum, evt) < 0) {
             os_free(path);
             return (0);
         }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -67,6 +67,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
 
         // If it returns < 0, we've already alerted the deleted file
         if (c_read_file(file_name, buf, c_sum, evt) < 0) {
+            os_free(path);
             return (0);
         }
 
@@ -108,11 +109,14 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             select(0, NULL, NULL, NULL, &timeout);
 
             os_free(buf);
+            os_free(path);
 
             return (1);
         } else {
             mdebug2("Inotify event with same checksum for file: '%s'. Ignoring it.", real_path);
         }
+
+        os_free(path);
 
         return (0);
     } else {
@@ -143,8 +147,10 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             } else {
                 if (S_ISLNK(statbuf.st_mode) && (syscheck.opts[pos] & CHECK_FOLLOW)) {
                     read_dir(path, pos, evt, depth, 1);
+                    os_free(path);
                     return 0;
                 } else if (S_ISLNK(statbuf.st_mode) && !(syscheck.opts[pos] & CHECK_FOLLOW)) {
+                    os_free(path);
                     return 0;
                 }
             }
@@ -153,6 +159,8 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         }
 
     }
+
+    os_free(path);
 
     return (0);
 }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -116,7 +116,6 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
     } else {
         /* New file */
         int pos;
-        int is_link = 0;
 #ifdef WIN_WHODATA
         if (evt) {
             pos = evt->dir_position;

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -137,6 +137,6 @@ size_t syscom_dispatch(char *command, char ** output);
 size_t syscom_getconfig(const char * section, char ** output);
 
 int print_hash_table();
-int fim_delete_hashes(const char *file_name);
+int fim_delete_hashes(char *file_name);
 
 #endif

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -106,7 +106,6 @@ void audit_reload_rules(void);
 int audit_health_check(int audit_socket);
 void clean_rules(void);
 int filterkey_audit_events(char *buffer);
-int filterpath_audit_events(char *path);
 extern W_Vector *audit_added_dirs;
 extern volatile int audit_thread_active;
 extern volatile int whodata_alerts;

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -136,4 +136,6 @@ int read_links(const char *dir_name, int dir_position, int max_depth, unsigned i
 size_t syscom_dispatch(char *command, char ** output);
 size_t syscom_getconfig(const char * section, char ** output);
 
+int print_hash_table();
+
 #endif

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -137,5 +137,6 @@ size_t syscom_dispatch(char *command, char ** output);
 size_t syscom_getconfig(const char * section, char ** output);
 
 int print_hash_table();
+int fim_delete_hashes(const char *file_name);
 
 #endif

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -689,9 +689,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
-                            if (filterpath_audit_events(w_evt->path)) {
-                                realtime_checksumfile(w_evt->path, w_evt);
-                            } else if (w_evt->inode) {
+                            if (w_evt->inode) {
                                 if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
                                     realtime_checksumfile(inode_temp, w_evt);
                                 } else {
@@ -725,9 +723,7 @@ void audit_parse(char *buffer) {
                             free(file_path);
                             w_evt->path = real_path;
 
-                            if (filterpath_audit_events(w_evt->path)) {
-                                realtime_checksumfile(w_evt->path, w_evt);
-                            } else if (w_evt->inode) {
+                            if (w_evt->inode) {
                                 if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
                                     realtime_checksumfile(inode_temp, w_evt);
                                 } else {
@@ -758,9 +754,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
-                            if (filterpath_audit_events(w_evt->path)) {
-                                realtime_checksumfile(w_evt->path, w_evt);
-                            } else if (w_evt->inode) {
+                            if (w_evt->inode) {
                                 if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
                                     realtime_checksumfile(inode_temp, w_evt);
                                 } else {
@@ -800,9 +794,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
-                            if (filterpath_audit_events(w_evt->path)) {
-                                realtime_checksumfile(w_evt->path, w_evt);
-                            } else if (w_evt->inode) {
+                            if (w_evt->inode) {
                                 if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
                                     realtime_checksumfile(inode_temp, w_evt);
                                 } else {
@@ -828,9 +820,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
-                            if (filterpath_audit_events(w_evt->path)) {
-                                realtime_checksumfile(w_evt->path, w_evt);
-                            } else if (w_evt->inode) {
+                            if (w_evt->inode) {
                                 if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
                                     realtime_checksumfile(inode_temp, w_evt);
                                 } else {
@@ -864,9 +854,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
-                            if (filterpath_audit_events(w_evt->path)) {
-                                realtime_checksumfile(w_evt->path, w_evt);
-                            } else if (w_evt->inode) {
+                            if (w_evt->inode) {
                                 if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
                                     realtime_checksumfile(inode_temp, w_evt);
                                 } else {
@@ -1272,24 +1260,6 @@ exit_err:
     hc_thread_active = 0;
     return -1;
 
-}
-
-
-int filterpath_audit_events(char *path) {
-    int i = 0;
-    char *dir_path;
-
-    for(i = 0; i < W_Vector_length(audit_added_dirs); i++) {
-        os_strdup(W_Vector_get(audit_added_dirs, i), dir_path);
-        wm_strcat(&dir_path, "/", '\0');
-        if (strstr(path, dir_path)) {
-            mdebug2("Found '%s' in '%s'", dir_path, path);
-            free(dir_path);
-            return 1;
-        }
-        free(dir_path);
-    }
-    return 0;
 }
 
 #endif


### PR DESCRIPTION
## Related issues:
- https://github.com/wazuh/wazuh/issues/2782
- https://github.com/wazuh/wazuh/issues/2779
## Fixes
- Incorrect order in FIM attributes (mtime)
- Deactivating the check_inode option stored an incorrect value in the hash table of inodes
- Fix memory leaks from hash tables
- Check and update inode paths when an inode is re-used
- Show delete alerts when executing mv command over folders