### PR TITLE
Increase the allowed size of the message read from the socket and to be sent to Wazuh DB

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1452,7 +1452,7 @@ int pm_send_db(char *msg, char *response, int *sock)
     }
 
     // Receive response from socket
-    length = OS_RecvSecureTCP(*sock, response, OS_SIZE_128);
+    length = OS_RecvSecureTCP(*sock, response, OS_SIZE_6144);
     switch (length)
     {
     case OS_SOCKTERR:


### PR DESCRIPTION
Hi, Team,

This PR is somewhat related to the issue https://github.com/wazuh/wazuh/issues/2629. The bug has been seen during a testing session.


Bug Description
--
While testing the new `yml` CIS policy files on a Windows 2012 agent, a warning message (and a subsequent error message) is shown in `ossec.log` on the manager saying:
```
2019/03/14 09:06:07 ossec-analysisd[11427] security_configuration_assessment.c:1459 at pm_send_db(): WARNING: OS_RecvSecureTCP(): Got a message with invalid length.
2019/03/14 09:06:07 ossec-analysisd[11427] security_configuration_assessment.c:1121 at HandlePoliciesInfo(): ERROR: Error querying policy monitoring database for agent 002
```
On the Windows agent, the contents of `ossec.conf` is:
```
  <!-- Configuration Assessment -->
  <sca>
    <enabled>yes</enabled>
    <scan_on_start>yes</scan_on_start>
    <interval>12h</interval>
    <skip_nfs>yes</skip_nfs>

    <policies>
      <policy>cis_win2012r2_domainL1_rcl.yml</policy>
      <policy>cis_win2012r2_memberL1_rcl.yml</policy>
      <policy>cis_win10_enterprise_L1_rcl.yml</policy>
      <policy>cis_win2012r2_domainL2_rcl.yml</policy>
      <policy>cis_win10_enterprise_L2_rcl.yml</policy>
      <policy>win_audit_rcl.yml</policy>
    </policies>
  </sca>
```

It turns out that when one of the policies is removed, leaving only five policies, no error is thrown. But with six policies, there is an error.


Bug explanation
--
1. In `src/analysisd/decoders/security_configuration_assessment.c`, function `pm_send_db`():
   Call to the function: `length = OS_RecvSecureTCP(*sock, response, OS_SIZE_128);`

2. In `src/os_net/os_net.c`, function `OS_RecvSecureTCP()`:
   Calls the function `os_recv_waitall()`, where a string is built (in the variable `buf`).
   The final contents of the string is:
   `ok found cis_win2012r2_domainL1,cis_win2012r2_memberL1,cis_win10_enterprise_L1,cis_win2012r2_domainL2,cis_win10_enterprise_L2,win_audit`
   This string has a length of 135 characters (actually 139, ¿but maybe the five commas are not taken into account?).
   This is a concatenation of the `id:` fields of the `yml` files specified in the `<sca><policies>` elements in the agent's `ossec.conf` file (in the same order as they have been evaluated).
   For example in file `cis_win2012r2_domainL1_rcl.yml`:
   ```
   ...
   policy:
     id: "cis_win2012r2_domainL1"    <- this is added to the string
     file: "cis_win2012r2_domainL1_rcl.yml"
     name: "CIS benchmark for Windows 2012 R2 Domain Controller L1"
   ...
   ```

3. Back in function `OS_RecvSecureTCP()`, the size of the string is compared to 128 (`OS_SIZE_128`), and the error is thrown:
   ```
   if(msgsize > size){
       /* Error: the payload length is too long */
       return OS_SOCKTERR;
   }
   ```


Solution
--
Increase the allowed/expected string length from `OS_SIZE_128` to `OS_SIZE_6144`.


Testing
--
Same way as explained above: Windows 2012 agent, set up `ossec.conf` as described, register the agent, start the agent:
- In `alerts.log`: check that the policies are evaluated.
- In `ossec.log`: check that no error is shown. OK.


Regards.