### PR TITLE
Add **get_agent** and  **get_agent_config** controllers

### DIFF
--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -165,12 +165,73 @@ def delete_agent():
     pass
 
 
-def get_agent():
-    pass
+def get_agent(agent_id, pretty=False, wait_for_complete=False, select=None):  # noqa: E501
+    """Get an agent
+
+    Returns various information from an agent.'  # noqa: E501
+
+    :param pretty: Show results in human-readable format
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response
+    :type wait_for_complete: bool
+    :param agent_id: Agent ID. All posible values since 000 onwards.
+    :type agent_id: str
+    :param select: Select which fields to return (separated by comma)
+    :type select: List[str]
+
+    :rtype: AgentData
+    """
+    f_kwargs = {'agent_id': agent_id,
+                'select': select
+                }
+
+    dapi = DistributedAPI(f=Agent.get_agent,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          pretty=pretty,
+                          logger=logger
+                          )
+    data = loop.run_until_complete(dapi.distribute_function())
+
+    return data, 200
 
 
-def get_agent_config():
-    pass
+def get_agent_config(agent_id, component, configuration, pretty=False, wait_for_complete=False):  # noqa: E501
+    """Get active configuration
+
+    Returns the active configuration in JSON format.'  # noqa: E501
+
+    :param pretty: Show results in human-readable format
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response
+    :type wait_for_complete: bool
+    :param agent_id: Agent ID. All posible values since 000 onwards.
+    :type agent_id: str
+    :param component: Selected agent's component.
+    :type component: str
+    :param configuration: Selected agent's configuration to read.
+    :type configuration: str
+
+    :rtype: AgentConfigurationData
+        """
+    f_kwargs = {'agent_id': agent_id,
+                'component': component,
+                'configuration': configuration
+                }
+
+    dapi = DistributedAPI(f=Agent.get_config,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='distributed_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          pretty=pretty,
+                          logger=logger
+                          )
+    data = loop.run_until_complete(dapi.distribute_function())
+
+    return data, 200
 
 
 def delete_agent_group():

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -201,7 +201,9 @@ def get_agent(agent_id, pretty=False, wait_for_complete=False, select=None):  # 
 def get_agent_config(agent_id, component, configuration, pretty=False, wait_for_complete=False):  # noqa: E501
     """Get active configuration
 
-    Returns the active configuration in JSON format.'  # noqa: E501
+    Returns the active configuration the agent is currently using. This can be different from the 
+    configuration present in the configuration file, if it has been modified and the agent has 
+    not been restarted yet.  # noqa: E501
 
     :param pretty: Show results in human-readable format
     :type pretty: bool

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -110,6 +110,8 @@ components:
         lastKeepAlive:
           type: string
           format: date-time
+        registerIP:
+          type: string
         os:
           type: object
           properties:
@@ -1410,55 +1412,51 @@ components:
       description: Selected agent's component.
       required: true
       schema:
-        type: array
-        items:
-          type: string
-          enum:
-          - agent
-          - agentless
-          - analysis
-          - auth
-          - com
-          - csyslog
-          - integrator
-          - logcollector
-          - mail
-          - monitor
-          - request
-          - syscheck
-          - wmodules
+        type: string
+        enum:
+        - agent
+        - agentless
+        - analysis
+        - auth
+        - com
+        - csyslog
+        - integrator
+        - logcollector
+        - mail
+        - monitor
+        - request
+        - syscheck
+        - wmodules
     configuration:
       in: path
       name: configuration
       description: Selected agent's configuration to read.
       required: true
       schema:
-        type: array
-        items:
-          type: string
-          enum:
-          - client
-          - buffer
-          - labels
-          - internal
-          - agentless
-          - global
-          - active_response
-          - alerts
-          - command
-          - rules
-          - decoders
-          - auth
-          - active-response
-          - cluster
-          - csyslog
-          - integration
-          - localfile
-          - socket
-          - remote
-          - syscheck
-          - rootcheck
-          - wmodules
+        type: string
+        enum:
+        - client
+        - buffer
+        - labels
+        - internal
+        - agentless
+        - global
+        - active_response
+        - alerts
+        - command
+        - rules
+        - decoders
+        - auth
+        - active-response
+        - cluster
+        - csyslog
+        - integration
+        - localfile
+        - socket
+        - remote
+        - syscheck
+        - rootcheck
+        - wmodules
     decoder_name:
       in: path
       name: decoder_name
@@ -2721,25 +2719,30 @@ paths:
               example:
                 error: 0
                 data:
-                    lastKeepAlive: '9999-12-31 23:59:59'
-                    ip: 127.0.0.1
-                    manager: manager
-                    os:
-                      arch: x86_64
-                      codename: Bionic Beaver
-                      major: '18'
-                      minor: '04'
-                      name: Ubuntu
-                      platform: ubuntu
-                      uname: Linux |manager |4.15.0-36-generic |#39-Ubuntu SMP Mon Sep 24 16:19:09
-                        UTC 2018 |x86_64
-                      version: 18.04.1 LTS
-                    status: Active
-                    version: Wazuh v3.8.0
-                    dateAdd: '2018-10-11 09:37:23'
-                    name: manager
-                    node_name: node01
-                    id: '000'
+                  configSum: "ab73af41699f13fdd81903b5f23d8d00"
+                  dateAdd: "2019-03-14 09:43:51"
+                  group:
+                    - default
+                  id: "002"
+                  ip: "172.18.0.6"
+                  lastKeepAlive: "2019-03-14 11:36:55"
+                  manager: "9f393e777dfb"
+                  mergedSum: "f8d49771911ed9d5c45b03a40babd065"
+                  name: "176772c37776"
+                  node_name: "worker1"
+                  os:
+                    arch: "x86_64"
+                    codename: "Bionic Beaver"
+                    major: "18"
+                    minor: "04"
+                    name: "Ubuntu"
+                    platform: "ubuntu"
+                    uname: "Linux |176772c37776 |4.15.0-46-generic |#49~16.04.1-Ubuntu SMP Tue Feb 12 17:45:24 UTC 2019 |x86_64"
+                    version: "18.04.2 LTS"
+                  registerIP: "172.18.0.6"
+                  status: "Active"
+                  version: "Wazuh v3.8.2"
+
   /agents/{agent_id}/config/{component}/{configuration}:
     get:
       tags:
@@ -2764,8 +2767,7 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/AgentConfiguration'
+                      type: object
               example:
                 error: 0
                 data:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2767,7 +2767,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/AgentConfiguration'
               example:
                 error: 0
                 data:


### PR DESCRIPTION
Hello team,

This PR adds 2 agent controller, get  **get_agent** and  **get_agent_config**.

Some examples:

* get_agent
  - Resquest: `curl -u wazuh:wazuh -X GET "http://localhost:55000/agents/001"`
  - Response:
```
  {
  "data": {
    "configSum": "ab73af41699f13fdd81903b5f23d8d00",
    "dateAdd": "2019-03-14 12:57:49",
    "group": [
      "default"
    ],
    "id": "001",
    "ip": "172.18.0.3",
    "lastKeepAlive": "2019-03-14 13:12:11",
    "manager": "9acf3ac7cbf8",
    "mergedSum": "f8d49771911ed9d5c45b03a40babd065",
    "name": "95619e3691b5",
    "node_name": "master-node",
    "os": {
      "arch": "x86_64",
      "codename": "Bionic Beaver",
      "major": "18",
      "minor": "04",
      "name": "Ubuntu",
      "platform": "ubuntu",
      "uname": "Linux |95619e3691b5 |4.15.0-46-generic |#49~16.04.1-Ubuntu SMP Tue Feb 12 17:45:24 UTC 2019 |x86_64",
      "version": "18.04.2 LTS"
    },
    "registerIP": "172.18.0.3",
    "status": "Active",
    "version": "Wazuh v3.8.2"
  },
  "error": 0
}
```
* get_agent_config
  - Resquest: `curl -u wazuh:wazuh -X GET "http://localhost:55000/agents/001/config/logcollector/localfile"`
  - Response:
```
{
  "data": {
    "localfile": [
      {
        "alias": "df -P",
        "command": "df -P",
        "frequency": 360,
        "logformat": "command",
        "target": [
          "agent"
        ]
      },
      {
        "alias": "netstat listening ports",
        "command": "netstat -tulpn | sed 's/\\([[:alnum:]]\\+\\)\\ \\+[[:digit:]]\\+\\ \\+[[:digit:]]\\+\\ \\+\\(.*\\):\\([[:digit:]]*\\)\\ \\+\\([0-9\\.\\:\\*]\\+\\).\\+\\ \\([[:digit:]]*\\/[[:alnum:]\\-]*\\).*/\\1 \\2 == \\3 == \\4 \\5/' | sort -k 4 -g | sed 's/ == \\(.*\\) ==/:\\1/' | sed 1,2d",
        "frequency": 360,
        "logformat": "full_command",
        "target": [
          "agent"
        ]
      },
      {
        "alias": "last -n 20",
        "command": "last -n 20",
        "frequency": 360,
        "logformat": "full_command",
        "target": [
          "agent"
        ]
      },
      {
        "file": "/var/ossec/logs/active-responses.log",
        "logformat": "syslog",
        "target": [
          "agent"
        ]
      },
      {
        "file": "/var/log/dpkg.log",
        "logformat": "syslog",
        "target": [
          "agent"
        ]
      }
    ]
  },
  "error": 0
}

```

  - Resquest: `curl -u wazuh:wazuh -X GET "http://localhost:55000/agents/001/config/agent/client"`
  - Response:
```
{
  "data": {
    "client": {
      "auto_restart": "yes",
      "config-profile": "ubuntu, ubuntu18, ubuntu18.04",
      "crypto_method": "aes",
      "notify_time": 10,
      "remote_conf": "yes",
      "server": [
        {
          "address": "wazuh-master/172.18.0.2",
          "port": 1514,
          "protocol": "udp"
        }
      ],
      "time-reconnect": 60
    }
  },
  "error": 0
}
```

  - Resquest: `curl -u wazuh:wazuh -X GET "http://localhost:55000/agents/000/config/auth/auth"`
  - Response:
```
{
  "data": {
    "auth": {
      "ciphers": "HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH",
      "disabled": "no",
      "force_insert": "yes",
      "force_time": "always",
      "limit_maxagents": "yes",
      "port": 1515,
      "purge": "yes",
      "ssl_auto_negotiate": "no",
      "ssl_manager_cert": "/var/ossec/etc/sslmanager.cert",
      "ssl_manager_key": "/var/ossec/etc/sslmanager.key",
      "ssl_verify_host": "no",
      "use_password": "no",
      "use_source_ip": "yes"
    }
  },
  "error": 0
}

```
Best regards,
Jesús