### PR TITLE
Fix empty email_to configuration

### DIFF
--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -400,6 +400,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 
         /* Build "RCPT TO" msg */
         while (1) {
+            if (mail->to == NULL) break;
             if (mail->to[i] == NULL) {
                 if (i == 0) {
                     merror(INTERNAL_ERROR);
@@ -469,14 +470,16 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         free(msg);
     }
 
-    /* Building "From" and "To" in the e-mail header */
-    memset(snd_msg, '\0', 128);
-    snprintf(snd_msg, 127, TO, mail->to[0]);
+    if (mail->to) {
+        /* Building "From" and "To" in the e-mail header */
+        memset(snd_msg, '\0', 128);
+        snprintf(snd_msg, 127, TO, mail->to[0]);
 
-    if (sendmail) {
-        fprintf(sendmail, "%s", snd_msg);
-    } else {
-        OS_SendTCP(socket, snd_msg);
+        if (sendmail) {
+            fprintf(sendmail, "%s", snd_msg);
+        } else {
+            OS_SendTCP(socket, snd_msg);
+        }
     }
 
     memset(snd_msg, '\0', 128);
@@ -499,24 +502,26 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         }
     }
 
-    /* Add CCs */
-    if (mail->to[1]) {
-        i = 1;
-        while (1) {
-            if (mail->to[i] == NULL) {
-                break;
+    if (mail->to) {
+        /* Add CCs */
+        if (mail->to[1]) {
+            i = 1;
+            while (1) {
+                if (mail->to[i] == NULL) {
+                    break;
+                }
+
+                memset(snd_msg, '\0', 128);
+                snprintf(snd_msg, 127, TO, mail->to[i]);
+
+                if (sendmail) {
+                    fprintf(sendmail, "%s", snd_msg);
+                } else {
+                    OS_SendTCP(socket, snd_msg);
+                }
+
+                i++;
             }
-
-            memset(snd_msg, '\0', 128);
-            snprintf(snd_msg, 127, TO, mail->to[i]);
-
-            if (sendmail) {
-                fprintf(sendmail, "%s", snd_msg);
-            } else {
-                OS_SendTCP(socket, snd_msg);
-            }
-
-            i++;
         }
     }
 


### PR DESCRIPTION
This fixes #2744 
- Fixes a segmentation fault caused by an empty `email_to`  in `global` configuration.

Testing
---

- [X] Configure `email_to` only in `email_alerts` (issue configuration). It sends a mail with every alert which rule matches the groups indicated.

- [X] Configure `email_to` in `global` and `email_alerts` with different email.  It sends a mail with every alert (with a level equal or greater to the indicated)  to the global email. It sends a mail with every alert which rule matches the groups indicated to the email configured in email alerts.

- [X] Configure `email_to` in `global` and `email_alerts` with the same email. It sends just one mail per alert (all rules with a level equal or higher to the indicated) to the specified mail.

- [x] Different combinations of rule groups in the email alerts configuration (like `ossec`, `syscheck`, `audit`).