### PR TITLE
Check if OS_RecvSecureTCP returns SOCKTERR

### DIFF
--- a/src/agentlessd/lessdcom.c
+++ b/src/agentlessd/lessdcom.c
@@ -109,6 +109,10 @@ void * lessdcom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At lessdcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At lessdcom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/agentlessd/lessdcom.c
+++ b/src/agentlessd/lessdcom.c
@@ -110,7 +110,7 @@ void * lessdcom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At lessdcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At lessdcom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/analysisd/asyscom.c
+++ b/src/analysisd/asyscom.c
@@ -193,6 +193,10 @@ void * asyscom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
 
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At asyscom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At asyscom_main(): OS_RecvSecureTCP: %s", strerror(errno));
             break;

--- a/src/analysisd/asyscom.c
+++ b/src/analysisd/asyscom.c
@@ -194,7 +194,7 @@ void * asyscom_main(__attribute__((unused)) void * arg) {
 
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At asyscom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At asyscom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1456,7 +1456,7 @@ int pm_send_db(char *msg, char *response, int *sock)
     switch (length)
     {
     case OS_SOCKTERR:
-        merror("at OS_RecvSecureTCP(): Got a message with invalid length.");
+        merror("OS_RecvSecureTCP() response size is bigger than expected");
         break;
     case -1:
         merror("at OS_RecvSecureTCP(): %s (%d)", strerror(errno), errno);

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1456,7 +1456,7 @@ int pm_send_db(char *msg, char *response, int *sock)
     switch (length)
     {
     case OS_SOCKTERR:
-        merror("OS_RecvSecureTCP() response size is bigger than expected");
+        merror("OS_RecvSecureTCP(): response size is bigger than expected");
         break;
     case -1:
         merror("at OS_RecvSecureTCP(): %s (%d)", strerror(errno), errno);

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1615,7 +1615,7 @@ int sc_send_db(char *msg, int *sock) {
     length = OS_RecvSecureTCP(*sock, response, OS_SIZE_128);
     switch (length) {
         case OS_SOCKTERR:
-            merror("At sc_send_db(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At sc_send_db(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1614,6 +1614,10 @@ int sc_send_db(char *msg, int *sock) {
     // Receive response from socket
     length = OS_RecvSecureTCP(*sock, response, OS_SIZE_128);
     switch (length) {
+        case OS_SOCKTERR:
+            merror("At sc_send_db(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("at sc_send_db(): at OS_RecvSecureTCP(): %s (%d)", strerror(errno), errno);
             goto end;

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -132,6 +132,10 @@ void * lccom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At lccom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At lccom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -133,7 +133,7 @@ void * lccom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At lccom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At lccom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/monitord/moncom.c
+++ b/src/monitord/moncom.c
@@ -120,6 +120,10 @@ void * moncom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At moncom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At moncom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/monitord/moncom.c
+++ b/src/monitord/moncom.c
@@ -121,7 +121,7 @@ void * moncom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At moncom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At moncom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -121,7 +121,7 @@ void* run_local_server(__attribute__((unused)) void *arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("OS_RecvSecureTCP() response size is bigger than expected");
+            merror("OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -121,7 +121,7 @@ void* run_local_server(__attribute__((unused)) void *arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            mwarn("OS_RecvSecureTCP(): Got a message with invalid length.");
+            merror("OS_RecvSecureTCP() response size is bigger than expected");
             break;
 
         case -1:

--- a/src/os_csyslogd/csyscom.c
+++ b/src/os_csyslogd/csyscom.c
@@ -108,6 +108,10 @@ void * csyscom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At csyscom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At csyscom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/os_csyslogd/csyscom.c
+++ b/src/os_csyslogd/csyscom.c
@@ -109,7 +109,7 @@ void * csyscom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At csyscom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At csyscom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -679,6 +679,10 @@ void * wcom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At wcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At wcom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -680,7 +680,7 @@ void * wcom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At wcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At wcom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/os_integrator/intgcom.c
+++ b/src/os_integrator/intgcom.c
@@ -108,6 +108,10 @@ void * intgcom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At intgcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At intgcom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/os_integrator/intgcom.c
+++ b/src/os_integrator/intgcom.c
@@ -109,7 +109,7 @@ void * intgcom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At intgcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At intgcom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/os_maild/mailcom.c
+++ b/src/os_maild/mailcom.c
@@ -139,7 +139,7 @@ void * mailcom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At mailcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At mailcom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/os_maild/mailcom.c
+++ b/src/os_maild/mailcom.c
@@ -138,6 +138,10 @@ void * mailcom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At mailcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At mailcom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/syscheckd/syscom.c
+++ b/src/syscheckd/syscom.c
@@ -134,7 +134,7 @@ void * syscom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At syscom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At syscom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:

--- a/src/syscheckd/syscom.c
+++ b/src/syscheckd/syscom.c
@@ -133,6 +133,10 @@ void * syscom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At syscom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At syscom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -119,6 +119,10 @@ void * wmcom_main(__attribute__((unused)) void * arg) {
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+        case OS_SOCKTERR:
+            merror("At wmcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            break;
+
         case -1:
             merror("At wmcom_main(): OS_RecvSecureTCP(): %s", strerror(errno));
             break;

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -120,7 +120,7 @@ void * wmcom_main(__attribute__((unused)) void * arg) {
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
         case OS_SOCKTERR:
-            merror("At wmcom_main(): OS_RecvSecureTCP() response size is bigger than expected");
+            merror("At wmcom_main(): OS_RecvSecureTCP(): response size is bigger than expected");
             break;
 
         case -1:


### PR DESCRIPTION
The function `OS_RecvSecureTCP` can return `OS_SOCKTERR` and some parts of the code will have a segmentation fault because they aren't prepared to process the value -6. This is the issue: https://github.com/wazuh/wazuh/issues/2823


The PR add the code to log an error when the function `OS_RecvSecureTCP` returns a socket error because the size of the message is bigger than expected.