### PR TITLE
Agent: check if an Internet connection is available before resolving hostnames.

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -511,12 +511,12 @@ int OS_CheckInternetConnection()
     PMIB_IPFORWARDTABLE pRoutingTable = NULL;
 
     /* Get the required buffer size */
-    if (ERROR_INSUFFICIENT_BUFFER == GetIpForwardTable(NULL, &dwBufferSize, false)) {
+    if (ERROR_INSUFFICIENT_BUFFER == GetIpForwardTable(NULL, &dwBufferSize, FALSE)) {
         os_malloc(dwBufferSize, pByte);
         pRoutingTable = (PMIB_IPFORWARDTABLE)pByte;
 
         /* Attempt to fill buffer with routing table information */
-        if (NO_ERROR == GetIpForwardTable(pRoutingTable, &dwBufferSize, false)) {
+        if (NO_ERROR == GetIpForwardTable(pRoutingTable, &dwBufferSize, FALSE)) {
             /* Look for default route to gateway */
             for (dwIndex = 0; dwIndex < pRoutingTable->dwNumEntries; dwIndex++)
             {

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -66,6 +66,11 @@ int OS_SendUnix(int socket, const char *msg, int size) __attribute__((nonnull));
 
 int OS_SendUDPbySize(int socket, int size, const char *msg) __attribute__((nonnull));
 
+/* OS_CheckInternetConnection
+ * Checks for the presence of the default route 0.0.0.0 in the routing table
+ */
+int OS_CheckInternetConnection();
+
 /* OS_GetHost
  * Calls gethostbyname
  */


### PR DESCRIPTION
This PR aims to fix issue #2770 by introducing the following changes:

* Check if an Internet connection is available before resolving hostnames (on agents) while reading the configuration file, before calling `OS_GetHost()`.
* The check looks for the default route (0.0.0.0) in the OS routing table.