### PR TITLE
Improve exception messages when there is an error unsseting an agent from a group

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1685,19 +1685,17 @@ class Agent:
                 Agent.unset_group(agent_id=agent_id, group_id=group_id)
                 affected_agents.append(agent_id)
             except Exception as e:
-                failed_ids.append(agent_id)
+                failed_ids.append(create_exception_dic(agent_id, e))
 
             if not failed_ids:
                 message = 'All selected agents were removed to group ' + group_id
             else:
-                message = 'Some agents were not removed to group ' + group_id
+                message = 'Some agents were not removed from group ' + group_id
 
-            final_dict = {}
-
-            if failed_ids:
-                final_dict = {'msg': message, 'affected_agents': affected_agents, 'failed_ids': failed_ids}
-            else:
-                final_dict = {'msg': message, 'affected_agents': affected_agents}
+        if failed_ids:
+            final_dict = {'msg': message, 'affected_agents': affected_agents, 'failed_ids': failed_ids}
+        else:
+            final_dict = {'msg': message, 'affected_agents': affected_agents}
 
         return final_dict
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1840,8 +1840,6 @@ class Agent:
             # check agent belongs to group group_id
             if group_id == 'default':
                 raise WazuhException(1745)
-            elif len(group_list) == 0:
-                raise WazuhException(1746)
             elif group_id not in group_list:
                 raise WazuhException(1734, "Agent {} doesn't belong to group {}".format(agent_id, group_id))
             # remove group from group_list

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1841,7 +1841,7 @@ class Agent:
             if group_id == 'default':
                 raise WazuhException(1745)
             elif group_id not in group_list:
-                raise WazuhException(1734, "Agent {} doesn't belong to group {}".format(agent_id, group_id))
+                raise WazuhException(1734)
             # remove group from group_list
             group_list.remove(group_id)
             if len(group_list) > 1:
@@ -1853,7 +1853,7 @@ class Agent:
             Agent.unset_all_groups_agent(agent_id, True, multigroup_name)
             return f"Group '{group_id}' unset for agent '{agent_id}'."
         else:
-            raise WazuhException(1734, "Agent {} doesn't belong to any group".format(agent_id))
+            raise WazuhException(1746)
 
 
     @staticmethod
@@ -1894,7 +1894,7 @@ class Agent:
 
             return "Group unset for agent '{0}'.".format(agent_id)
         else:
-            raise WazuhException(1734, "Agent {} doesn't belong to any group".format(agent_id))
+            raise WazuhException(1746)
 
 
     @staticmethod

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1841,7 +1841,11 @@ class Agent:
         if group_name:
             group_list = group_name.split(',')
             # check agent belongs to group group_id
-            if group_id not in group_list:
+            if group_id == 'default':
+                raise WazuhException(1745)
+            elif len(group_list) == 0:
+                raise WazuhException(1746)
+            elif group_id not in group_list:
                 raise WazuhException(1734, "Agent {} doesn't belong to group {}".format(agent_id, group_id))
             # remove group from group_list
             group_list.remove(group_id)
@@ -1852,14 +1856,7 @@ class Agent:
             else:
                 multigroup_name = 'default' if not group_list else group_list[0]
             Agent.unset_all_groups_agent(agent_id, True, multigroup_name)
-            # for show the return message properly it is necessary to get the original group list
-            original_group_list = group_name.split(',')
-            if len(original_group_list) > 1:
-                return f"Group '{group_id}' unset for agent '{agent_id}'."
-            elif 'default' in original_group_list:
-                return "Agent only belongs to 'default' and it cannot be unset from this group."
-            else:
-                return "Agent must belong to a group at least. Adding to default group."
+            return f"Group '{group_id}' unset for agent '{agent_id}'."
         else:
             raise WazuhException(1734, "Agent {} doesn't belong to any group".format(agent_id))
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1680,7 +1680,7 @@ class Agent:
         if not Agent.group_exists(group_id):
             raise WazuhException(1710)
 
-        message = f'All selected agents were removed to group {group_id}'
+        message = f'All selected agents were removed from group {group_id}'
         for agent_id in agent_id_list:
             try:
                 Agent.unset_group(agent_id=agent_id, group_id=group_id)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1849,8 +1849,11 @@ class Agent:
                 Agent.create_multi_group(multigroup_name)
         else:
             multigroup_name = 'default' if not group_list else group_list[0]
+
         Agent.unset_all_groups_agent(agent_id, True, multigroup_name)
-        return f"Group '{group_id}' unset for agent '{agent_id}'."
+
+        return f"Group '{group_id}' unset for agent '{agent_id}'." if multigroup_name != 'default' else \
+               f"Agent {agent_id} set to group default."
 
 
     @staticmethod

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1835,25 +1835,22 @@ class Agent:
 
         # get agent's group
         group_name = Agent.get_agents_group_file(agent_id)
-        if group_name:
-            group_list = group_name.split(',')
-            # check agent belongs to group group_id
-            if group_id == 'default':
-                raise WazuhException(1745)
-            elif group_id not in group_list:
-                raise WazuhException(1734)
-            # remove group from group_list
-            group_list.remove(group_id)
-            if len(group_list) > 1:
-                multigroup_name = ','.join(group_list)
-                if not Agent.multi_group_exists(multigroup_name):
-                    Agent.create_multi_group(multigroup_name)
-            else:
-                multigroup_name = 'default' if not group_list else group_list[0]
-            Agent.unset_all_groups_agent(agent_id, True, multigroup_name)
-            return f"Group '{group_id}' unset for agent '{agent_id}'."
+        group_list = group_name.split(',')
+        # check agent belongs to group group_id
+        if group_id not in group_list:
+            raise WazuhException(1734)
+        elif group_id == 'default' and len(group_list) == 1:
+            raise WazuhException(1745)
+        # remove group from group_list
+        group_list.remove(group_id)
+        if len(group_list) > 1:
+            multigroup_name = ','.join(group_list)
+            if not Agent.multi_group_exists(multigroup_name):
+                Agent.create_multi_group(multigroup_name)
         else:
-            raise WazuhException(1746)
+            multigroup_name = 'default' if not group_list else group_list[0]
+        Agent.unset_all_groups_agent(agent_id, True, multigroup_name)
+        return f"Group '{group_id}' unset for agent '{agent_id}'."
 
 
     @staticmethod

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1680,6 +1680,7 @@ class Agent:
         if not Agent.group_exists(group_id):
             raise WazuhException(1710)
 
+        message = f'All selected agents were removed to group {group_id}'
         for agent_id in agent_id_list:
             try:
                 Agent.unset_group(agent_id=agent_id, group_id=group_id)
@@ -1687,10 +1688,8 @@ class Agent:
             except Exception as e:
                 failed_ids.append(create_exception_dic(agent_id, e))
 
-            if not failed_ids:
-                message = 'All selected agents were removed to group ' + group_id
-            else:
-                message = 'Some agents were not removed from group ' + group_id
+            if failed_ids:
+                message = f'Some agents were not removed from group {group_id}'
 
         if failed_ids:
             final_dict = {'msg': message, 'affected_agents': affected_agents, 'failed_ids': failed_ids}

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -139,7 +139,6 @@ class WazuhException(Exception):
         1743: 'Error running Wazuh syntax validator',
         1744: 'Invalid chunk size',
         1745: "Agent only belongs to 'default' and it cannot be unset from this group.",
-        1746: "Agent doesn't belong to any group",
 
         # CDB List: 1800 - 1899
         1800: 'Bad format in CDB list {path}',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -138,6 +138,8 @@ class WazuhException(Exception):
         1742: 'Error running XML syntax validator',
         1743: 'Error running Wazuh syntax validator',
         1744: 'Invalid chunk size',
+        1745: "Agent only belongs to 'default' and it cannot be unset from this group.",
+        1746: "Agent must belong to a group at least.",
 
         # CDB List: 1800 - 1899
         1800: 'Bad format in CDB list {path}',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -139,7 +139,6 @@ class WazuhException(Exception):
         1743: 'Error running Wazuh syntax validator',
         1744: 'Invalid chunk size',
         1745: "Agent only belongs to 'default' and it cannot be unset from this group.",
-        1746: "Agent must belong to a group at least.",
 
         # CDB List: 1800 - 1899
         1800: 'Bad format in CDB list {path}',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -127,7 +127,7 @@ class WazuhException(Exception):
         1731: 'Agent is not eligible for removal',
         1732: 'No agents selected',
         1733: 'Bad formatted version. Version must follow this pattern: vX.Y.Z .',
-        1734: 'Error unsetting agent group',
+        1734: 'Agent does not belong to the specified group',
         1735: 'Agent version is not compatible with this feature',
         1736: 'Error getting all groups',
         1737: 'Maximum number of groups per multigroup is 256',
@@ -139,6 +139,7 @@ class WazuhException(Exception):
         1743: 'Error running Wazuh syntax validator',
         1744: 'Invalid chunk size',
         1745: "Agent only belongs to 'default' and it cannot be unset from this group.",
+        1746: "Agent doesn't belong to any group",
 
         # CDB List: 1800 - 1899
         1800: 'Bad format in CDB list {path}',

--- a/framework/wazuh/tests/test_group.py
+++ b/framework/wazuh/tests/test_group.py
@@ -21,7 +21,8 @@ class AgentMock:
 @pytest.mark.parametrize('agent_groups, agent_id, group_id, expected_new_group', [
     ('dmz', '005', 'dmz', 'default'),
     ('dmz,webserver', '005', 'dmz', 'webserver'),
-    ('dmz,webserver,database', '005', 'dmz', 'webserver,database')
+    ('dmz,webserver,database', '005', 'dmz', 'webserver,database'),
+    ('dmz,default', '005', 'default', 'dmz')
 ])
 @patch('wazuh.agent.Agent.get_agents_group_file')
 @patch('wazuh.agent.Agent.create_multi_group')
@@ -48,8 +49,9 @@ def test_sucessfully_remove_single_group_agent(agent_patch, unset_groups_patch, 
 
 
 @pytest.mark.parametrize('agent_groups, agent_id, group_id, expected_exception', [
-    ('', '005', 'dmz', 1746),
-    ('dmz', '005', 'default', 1745),
+    ('', '005', 'dmz', 1734),
+    ('dmz', '005', 'default', 1734),
+    ('default', '005', 'default', 1745),
     ('dmz', '005', 'webserver,database', 1734)
 ])
 @patch('wazuh.agent.Agent.get_agents_group_file')

--- a/framework/wazuh/tests/test_group.py
+++ b/framework/wazuh/tests/test_group.py
@@ -48,7 +48,7 @@ def test_sucessfully_remove_single_group_agent(agent_patch, unset_groups_patch, 
 
 
 @pytest.mark.parametrize('agent_groups, agent_id, group_id, expected_exception', [
-    ('', '005', 'dmz', 1734),
+    ('', '005', 'dmz', 1746),
     ('dmz', '005', 'default', 1745),
     ('dmz', '005', 'webserver,database', 1734)
 ])

--- a/framework/wazuh/tests/test_group.py
+++ b/framework/wazuh/tests/test_group.py
@@ -40,7 +40,10 @@ def test_sucessfully_remove_single_group_agent(agent_patch, unset_groups_patch, 
     agent_patch.return_value = AgentMock(agent_id, agent_groups)
 
     with patch('wazuh.agent.Agent.multi_group_exists', return_value=False):
-        Agent.unset_single_group_agent(agent_id, group_id, False)
+        ret_msg = Agent.unset_single_group_agent(agent_id, group_id, False)
+
+    assert ret_msg == (f"Agent {agent_id} set to group default." if expected_new_group == 'default' else
+                       f"Group '{group_id}' unset for agent '{agent_id}'.")
 
     if ',' in expected_new_group:
         create_multigroup_patch.assert_called_with(expected_new_group)

--- a/framework/wazuh/tests/test_group.py
+++ b/framework/wazuh/tests/test_group.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from unittest.mock import patch
+import pytest
+
+from wazuh.agent import Agent
+from wazuh.exception import WazuhException
+
+
+class AgentMock:
+    def __init__(self, agent_id, agent_groups):
+        self.id = agent_id
+        self.group = agent_groups.split(',')
+
+    def get_basic_information(self):
+        return True
+
+
+@pytest.mark.parametrize('agent_groups, agent_id, group_id, expected_new_group', [
+    ('dmz', '005', 'dmz', 'default'),
+    ('dmz,webserver', '005', 'dmz', 'webserver'),
+    ('dmz,webserver,database', '005', 'dmz', 'webserver,database')
+])
+@patch('wazuh.agent.Agent.get_agents_group_file')
+@patch('wazuh.agent.Agent.create_multi_group')
+@patch('wazuh.agent.Agent.unset_all_groups_agent')
+@patch('wazuh.agent.Agent')
+def test_sucessfully_remove_single_group_agent(agent_patch, unset_groups_patch, create_multigroup_patch,
+                                               get_groups_patch, agent_groups, agent_id, group_id, expected_new_group):
+    """
+    Tests sucessfully unsseting a group from an agent. Test cases:
+        * The agent only belongs to one group. It must be assigned to the default one.
+        * The agent belongs to two groups, it must be assigned to the remaining group.
+        * The agent belongs to three groups, the group to remove must be removed from the multigroup.
+    """
+    get_groups_patch.return_value = agent_groups
+    agent_patch.return_value = AgentMock(agent_id, agent_groups)
+
+    with patch('wazuh.agent.Agent.multi_group_exists', return_value=False):
+        Agent.unset_single_group_agent(agent_id, group_id, False)
+
+    if ',' in expected_new_group:
+        create_multigroup_patch.assert_called_with(expected_new_group)
+
+    unset_groups_patch.assert_called_with(agent_id, True, expected_new_group)
+
+
+@pytest.mark.parametrize('agent_groups, agent_id, group_id, expected_exception', [
+    ('', '005', 'dmz', 1734),
+    ('dmz', '005', 'default', 1745),
+    ('dmz', '005', 'webserver,database', 1734)
+])
+@patch('wazuh.agent.Agent.get_agents_group_file')
+@patch('wazuh.agent.Agent')
+def test_failed_remove_single_group_agent(agent_patch, get_groups_patch, agent_groups, agent_id, group_id,
+                                          expected_exception):
+    with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+        get_groups_patch.return_value = agent_groups
+        agent_patch.return_value = AgentMock(agent_id, agent_groups)
+
+        Agent.unset_single_group_agent(agent_id, group_id, False)


### PR DESCRIPTION
Hello team,

This PR fixes #2826.

Some examples:

Removing an agent from the default group:
```javascript
# curl -u foo:bar "localhost:55000/agents/001/group/default?pretty" -XDELETE
{
   "error": 1745,
   "message": "Agent only belongs to 'default' and it cannot be unset from this group."
}
```

Removing multiple agents from the default group. The format of this function is now the same as the `POST/agents/restart` and `POST/agents/delete`:
```javascript
# curl -u foo:bar -X DELETE -H "Content-Type:application/json" -d '{"ids":["001"]}' "http://localhost:55000/agents/group/default?pretty"
{
   "error": 0,
   "data": {
      "msg": "Some agents were not removed from group default",
      "affected_agents": [],
      "failed_ids": [
         {
            "id": "001",
            "error": {
               "message": "Agent only belongs to 'default' and it cannot be unset from this group.",
               "code": 1745
            }
         }
      ]
   }
}
```

Removing an agent from a group it doesn't belong to:
```javascript
# curl -u foo:bar "localhost:55000/agents/001/group/defaulffdft?pretty" -XDELETE
{
   "error": 1734,
   "message": "Agent does not belong to the specified group"
}
```

Removing an agent from a group when it doesn't belong to any group at all:
```javascript
# curl -u foo:bar "localhost:55000/agents/002/group/defaulffdft?pretty" -XDELETE
{
   "error": 1734,
   "message": "Agent does not belong to the specified group"
}
```

Unit tests implemented:
```python
# /var/ossec/framework/python/bin/pytest tests/test_group.py -vv
============================================================================================================================ test session starts ============================================================================================================================
platform linux -- Python 3.7.2, pytest-4.3.1, py-1.8.0, pluggy-0.9.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/vagrant/GitHub/wazuh/framework, inifile:
collected 8 items

tests/test_group.py::test_sucessfully_remove_single_group_agent[dmz-005-dmz-default] PASSED                                                                                                                                                                           [ 12%]
tests/test_group.py::test_sucessfully_remove_single_group_agent[dmz,webserver-005-dmz-webserver] PASSED                                                                                                                                                               [ 25%]
tests/test_group.py::test_sucessfully_remove_single_group_agent[dmz,webserver,database-005-dmz-webserver,database] PASSED                                                                                                                                             [ 37%]
tests/test_group.py::test_sucessfully_remove_single_group_agent[dmz,default-005-default-dmz] PASSED                                                                                                                                                                   [ 50%]
tests/test_group.py::test_failed_remove_single_group_agent[-005-dmz-1734] PASSED                                                                                                                                                                                      [ 62%]
tests/test_group.py::test_failed_remove_single_group_agent[dmz-005-default-1734] PASSED                                                                                                                                                                               [ 75%]
tests/test_group.py::test_failed_remove_single_group_agent[default-005-default-1745] PASSED                                                                                                                                                                           [ 87%]
tests/test_group.py::test_failed_remove_single_group_agent[dmz-005-webserver,database-1734] PASSED                                                                                                                                                                    [100%]

========================================================================================================================= 8 passed in 0.31 seconds ==========================================================================================================================
```

Best regards,
Marta