### PR TITLE
Add agent group information in the alerts JSON files

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -32,6 +32,10 @@
         },
         "agent": {
           "properties": {
+            "groups": {
+              "type": "keyword",
+              "doc_values": "true"
+            },
             "ip": {
               "type": "keyword",
               "doc_values": "true"

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -23,6 +23,7 @@ void W_ParseJSON(cJSON* root, const Eventinfo* lf)
     if(lf->full_log && lf->hostname) {
         W_JSON_ParseHostname(root, lf);
         W_JSON_ParseAgentIP(root, lf);
+        W_JSON_ParseAgentGroups(root, lf);
     }
     // Parse Location
     if(lf->location) {
@@ -375,7 +376,33 @@ void W_JSON_ParseAgentIP(cJSON* root, const Eventinfo* lf)
     }
 
     os_free(string);
-    
+
+}
+
+// Parse agent groups from labels
+void W_JSON_ParseAgentGroups(cJSON* root, const Eventinfo* lf)
+{
+    char *string = NULL;
+    char *groups;
+    cJSON *ind_groups = cJSON_CreateArray();
+    char *pnt;
+    cJSON *agent;
+
+    groups = labels_get(lf->labels, "_agent_groups");
+
+    if (groups && strcmp(groups, "")){
+
+      agent = cJSON_GetObjectItem(root, "agent");
+
+      pnt = strtok (groups,",");
+      for(int i=0; pnt != NULL; i++, pnt = strtok (NULL, ",")){
+        cJSON_AddItemToArray(ind_groups, cJSON_CreateString(pnt));
+      }
+      cJSON_AddItemToObject(agent, "groups", ind_groups);
+    }
+
+    os_free(string);
+
 }
 
 // The file location usually comes with more information about the alert (like hostname or ip) we will extract just the

--- a/src/analysisd/format/json_extended.h
+++ b/src/analysisd/format/json_extended.h
@@ -20,6 +20,8 @@ void W_JSON_ParseHostname(cJSON *root, const Eventinfo *lf);
 void W_JSON_AddTimestamp(cJSON *root, const Eventinfo *lf);
 // Parse AgentIP
 void W_JSON_ParseAgentIP(cJSON *root, const Eventinfo *lf);
+// Parse AgentGroups
+void W_JSON_ParseAgentGroups(cJSON *root, const Eventinfo *lf);
 // Parse Location
 void W_JSON_ParseLocation(cJSON *root, const Eventinfo *lf, int archives);
 // Parse agentless devices (this may delete agent item)

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -227,6 +227,27 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
                 snprintf(nodename, OS_MAXSTR - 1, "#\"_node_name\":%s\n", node_name);
                 fprintf(fp, "%s", nodename);
 
+                /* Write agent's group to the agent-info file */
+                FILE * fp1;
+                char file [OS_SIZE_1024];
+
+                snprintf(file, OS_SIZE_1024, "%s/%s", GROUPS_DIR, key->id);
+
+                fp1 = fopen(file, "r");
+
+                if(fp1){
+                  char group_name [OS_SIZE_1024];
+
+                  fread(group_name, OS_MAXSTR, 99, fp1);
+
+                  char groupname[OS_MAXSTR];
+                  snprintf(groupname, OS_MAXSTR - 1, "#\"_agent_groups\":%s\n", group_name);
+                  fprintf(fp, "%s", groupname);
+
+                } else {
+                    merror(FOPEN_ERROR, data->keep_alive, errno, strerror(errno));
+                }
+
                 fclose(fp);
             } else {
                 merror(FOPEN_ERROR, data->keep_alive, errno, strerror(errno));


### PR DESCRIPTION
This PR is aimed at solving issue #1395.

**Description**

- The functionality to see each agent's groups in the alerts JSON file has been added, aimed at easing the visualization of each agent's groups as well as allowing an easier sorting of agents by their corresponding groups.

**Use case**

We may add an agent to a group named `arch` using the `/var/ossec/bin/agent_groups -a -i 001 -g arch` order, resulting in the following agent-info file:

```
Linux |agent-centos |3.10.0-957.1.3.el7.x86_64 |#1 SMP Thu Nov 29 14:49:43 UTC 2018 |x86_64 [CentOS Linux|c$
1b2e87fd26ac100d4b4a034913410308 merged.mg
#"_agent_ip":10.0.2.15

#"_manager_hostname":localhost.localdomain
#"_node_name":node01
#"_agent_groups":default,arch
```

`analysisd` will then extract the groups info using the `_agent_groups` label and insert it into a cJSON array, netting the following data in any of the agent's alerts:

```
"agent": {
        "groups": [
            "default",
            "arch",
        ],
        "id": "001",
        "ip": "10.0.2.15",
        "name": "agent-centos"
    },
```
**Testing**

The previous changes have been tested by assigning various numbers of groups to an agent and then removing them, checking the alerts JSON file with each change. All of them correlated with what was being shown in the JSON file. An special case is when an agent doesn't belong in any group, in which case the groups section doesn't even shown in the JSON.
