### PR TITLE
Prevent manager unit tests to delete test data files

### DIFF
--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -20,7 +20,7 @@ class InitManager:
         Sets up necessary environment to test manager functions
         """
         # path for temporary API files
-        self.api_tmp_path = os.path.join(os.getcwd(), 'tests/data/tmp')
+        self.api_tmp_path = os.path.join(test_data_path, 'tmp')
         # rules
         self.input_rules_file = 'test_rules.xml'
         self.output_rules_file = 'uploaded_test_rules.xml'
@@ -86,7 +86,8 @@ def test_restart_ok(test_manager):
 @patch('random.randint', return_value=0)
 @patch('wazuh.manager.chmod')
 @patch('wazuh.manager.move')
-def test_upload_file(move_mock, chmod_mock, mock_rand, mock_time, test_manager, input_file, output_file):
+@patch('wazuh.manager.remove')
+def test_upload_file(remove_mock, move_mock, chmod_mock, mock_rand, mock_time, test_manager, input_file, output_file):
     """
     Tests uploading a file to the manager
     """
@@ -103,6 +104,7 @@ def test_upload_file(move_mock, chmod_mock, mock_rand, mock_time, test_manager, 
     m.assert_any_call(os.path.join(test_data_path, input_file))
     move_mock.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'),
                                       os.path.join(test_data_path, output_file))
+    remove_mock.assert_called_once_with(os.path.join(test_data_path, input_file))
 
 
 @patch('wazuh.manager.exists', return_value=False)


### PR DESCRIPTION
Hello team,

The manager.py unit tests weren't working because test data files were accidentally removed:
```python
tests/test_manager.py .......FFF....                                                                                                                                                                                                                                  [100%]

================================================================================================================================= FAILURES ==================================================================================================================================
______________________________________________________________________________________________________________________ test_get_file[input_rules_file] ______________________________________________________________________________________________________________________
test_manager = <wazuh.tests.test_manager.InitManager object at 0x7f37b76da470>, input_file = 'test_rules.xml'

    @pytest.mark.parametrize('input_file', [
        'input_rules_file',
        'input_decoders_file',
        'input_lists_file'
    ])
    @patch('wazuh.common.ossec_path', test_data_path)
    def test_get_file(test_manager, input_file):
        input_file = getattr(test_manager, input_file)
>       with open(os.path.join(test_data_path, input_file)) as f:
E       FileNotFoundError: [Errno 2] No such file or directory: '/home/vagrant/GitHub/wazuh/framework/wazuh/tests/data/test_rules.xml'

tests/test_manager.py:125: FileNotFoundError
____________________________________________________________________________________________________________________ test_get_file[input_decoders_file] _____________________________________________________________________________________________________________________
test_manager = <wazuh.tests.test_manager.InitManager object at 0x7f37b76da470>, input_file = 'test_decoders.xml'

    @pytest.mark.parametrize('input_file', [
        'input_rules_file',
        'input_decoders_file',
        'input_lists_file'
    ])
    @patch('wazuh.common.ossec_path', test_data_path)
    def test_get_file(test_manager, input_file):
        input_file = getattr(test_manager, input_file)
>       with open(os.path.join(test_data_path, input_file)) as f:
E       FileNotFoundError: [Errno 2] No such file or directory: '/home/vagrant/GitHub/wazuh/framework/wazuh/tests/data/test_decoders.xml'

tests/test_manager.py:125: FileNotFoundError
______________________________________________________________________________________________________________________ test_get_file[input_lists_file] ______________________________________________________________________________________________________________________
test_manager = <wazuh.tests.test_manager.InitManager object at 0x7f37b76da470>, input_file = 'test_lists'

    @pytest.mark.parametrize('input_file', [
        'input_rules_file',
        'input_decoders_file',
        'input_lists_file'
    ])
    @patch('wazuh.common.ossec_path', test_data_path)
    def test_get_file(test_manager, input_file):
        input_file = getattr(test_manager, input_file)
>       with open(os.path.join(test_data_path, input_file)) as f:
E       FileNotFoundError: [Errno 2] No such file or directory: '/home/vagrant/GitHub/wazuh/framework/wazuh/tests/data/test_lists'

tests/test_manager.py:125: FileNotFoundError
==================================================================================================================== 3 failed, 11 passed in 0.39 seconds ====================================================================================================================
```

This PR fixes that.

Best regards,
Marta