### PR TITLE
Validate the check ID of SCA policies before start

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1361,13 +1361,20 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
 }
 
 static void PushDumpRequest(char * agent_id, char * policy_id) {
+    int result;
     char request_db[OS_SIZE_4096 + 1] = {0};
 
     snprintf(request_db,OS_SIZE_4096,"%s:sca-dump:%s",agent_id,policy_id);
     char *msg = NULL;
 
     os_strdup(request_db,msg);
-    queue_push_ex(request_queue,msg);
+    
+    result = queue_push_ex(request_queue,msg);
+
+    if (result < 0) {
+        mwarn("SCA request queue is full.");
+        free(msg);
+    }
 }
 
 int pm_send_db(char *msg, char *response, int *sock)

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2377,7 +2377,10 @@ void wm_sca_push_request_win(char * msg){
                         unsigned int *policy_index;
                         os_calloc(1, sizeof(unsigned int), policy_index);
                         *policy_index = i;
-                        queue_push_ex(request_queue,policy_index);
+                        if(queue_push_ex(request_queue,policy_index) < 0) {
+                            os_free(policy_index);
+                            mdebug1("Could not push policy index to queue");
+                        }
                         break;
                     }
                 }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -106,8 +106,12 @@ void * wm_sca_main(wm_sca_t * data) {
         minfo("Module started.");
     } else {
         minfo("Module disabled. Exiting.");
+            }
+
+    if (!data->profile || data->profile[0] == NULL) {
+        minfo("No policies defined. Exiting.");
         pthread_exit(NULL);
-    }
+    }     
 
     data->msg_delay = 1000000 / wm_max_eps;
     data->summary_delay = 3; /* Seconds to wait for summary sending */


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/2844

It validates the check ID looking for invalid or duplicated IDs before scan a policy.

Here we can see a couple of examples when the validation fails:

```
2019/03/18 03:37:12 sca: ERROR: Duplicated check ID: 1003
2019/03/18 03:37:12 sca: ERROR: Validating policy file: '/var/ossec/ruleset/sca/system_audit_rcl.yml'. Skipping it.
---------------------------------------------------------------------------
2019/03/18 03:37:56 sca: ERROR: Invalid check ID: -1009
2019/03/18 03:37:56 sca: ERROR: Validating policy file: '/var/ossec/ruleset/sca/system_audit_rcl.yml'. Skipping it.
```

It has been fixed a defect reported by Coverity. It was not being checked the return value of the function `queue_push_ex()` in two cases.

### Update

It has been added a new commit (edb2790dc2baac1c8f300d4bb8025a283fa7aa8c) by adding more checks when starting the module:

- When the defined interval is lower than 60 seconds, it is forced to be 60 seconds instead of firing a critical error.

```
2019/03/18 06:25:46 wazuh-modulesd: WARNING: At module 'sca': Interval must be greater than 60 seconds. New interval value: 60s.
```

- When the policy option is empty, it triggers an error:

```
<policies>
      <policy></policy>
</policies>
2019/03/18 06:25:46 wazuh-modulesd: ERROR: Empty policy value at 'sca'.
```

- When no policies are defined, the SCA module stops.
```
2019/03/18 06:32:25 sca: INFO: Module started.
2019/03/18 06:32:25 sca: INFO: No policies defined. Exiting.
```