### PR TITLE
Fix control of the frequency counter in the alerts

### DIFF
--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -211,7 +211,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
-        else if (lf->matched >= rule->level) {
+        if (lf->matched >= rule->level) {
             lf = NULL;
             goto end;
         }
@@ -431,7 +431,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
-        else if (lf->matched >= rule->level) {
+        if (lf->matched >= rule->level) {
             lf = NULL;
             goto end;
         }
@@ -619,7 +619,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
-        else if (lf->matched >= rule->level) {
+        if (lf->matched >= rule->level) {
             lf = NULL;
             goto end;
         }


### PR DESCRIPTION
This PR solves https://github.com/wazuh/wazuh/issues/2850.

When a rule is dependent on another rule (_if_matched_sid_), it will look for that dependency in the list of previously matched rules. This is done in the _Search_LastSids_ function.

If the rule must be triggered several times before it is displayed (_frequency_), this function must count several past occurrences of the rule that have not been matched.

The reason for the fix is because the event iterator it is not stopping when it found alerts that had been reported whose options include _SAME_SRCPORT_, _SAME_DSTPORT_, _DIFFERENT_URL_, _SAME_USER_ or _SAME_LOCATION_.

Following the use case of the issue mentioned above, the new output of `ossec-logtest` would be:

> [root@manager rules]# /var/ossec/bin/ossec-logtest
> 2019/03/18 11:30:05 ossec-testrule: INFO: Started (pid: 28097).
> ossec-testrule: Type one log per line.
> 
> Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
> 
> 
> **Phase 1: Completed pre-decoding.
>        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
>        timestamp: 'Dec 10 01:02:02'
>        hostname: 'host'
>        program_name: 'sshd'
>        log: 'Failed none for root from 1.1.1.1 port 1066 ssh2'
> 
> **Phase 2: Completed decoding.
>        decoder: 'sshd'
>        dstuser: 'root'
>        srcip: '1.1.1.1'
>        srcport: '1066'
> 
> **Phase 3: Completed filtering (rules).
>        Rule id: '100001'
>        Level: '5'
>        Description: 'sshd: authentication failed from IP 1.1.1.1.'
> **Alert to be generated.
> 
> 
> Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
> 
> 
> **Phase 1: Completed pre-decoding.
>        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
>        timestamp: 'Dec 10 01:02:02'
>        hostname: 'host'
>        program_name: 'sshd'
>        log: 'Failed none for root from 1.1.1.1 port 1066 ssh2'
> 
> **Phase 2: Completed decoding.
>        decoder: 'sshd'
>        dstuser: 'root'
>        srcip: '1.1.1.1'
>        srcport: '1066'
> 
> **Phase 3: Completed filtering (rules).
>        Rule id: '100001'
>        Level: '5'
>        Description: 'sshd: authentication failed from IP 1.1.1.1.'
> **Alert to be generated.
> 
> Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
> 
> 
> **Phase 1: Completed pre-decoding.
>        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
>        timestamp: 'Dec 10 01:02:02'
>        hostname: 'host'
>        program_name: 'sshd'
>        log: 'Failed none for root from 1.1.1.1 port 1066 ssh2'
> 
> **Phase 2: Completed decoding.
>        decoder: 'sshd'
>        dstuser: 'root'
>        srcip: '1.1.1.1'
>        srcport: '1066'
> 
> **Phase 3: Completed filtering (rules).
>        Rule id: '100002'
>        Level: '10'
>        Description: 'Test rule.'
> **Alert to be generated.
> 
> Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
> 
> 
> **Phase 1: Completed pre-decoding.
>        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
>        timestamp: 'Dec 10 01:02:02'
>        hostname: 'host'
>        program_name: 'sshd'
>        log: 'Failed none for root from 1.1.1.1 port 1066 ssh2'
> 
> **Phase 2: Completed decoding.
>        decoder: 'sshd'
>        dstuser: 'root'
>        srcip: '1.1.1.1'
>        srcport: '1066'
> 
> **Phase 3: Completed filtering (rules).
>        Rule id: '100001'
>        Level: '5'
>        Description: 'sshd: authentication failed from IP 1.1.1.1.'
> **Alert to be generated.
> 
> 
> Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
> 
> 
> **Phase 1: Completed pre-decoding.
>        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
>        timestamp: 'Dec 10 01:02:02'
>        hostname: 'host'
>        program_name: 'sshd'
>        log: 'Failed none for root from 1.1.1.1 port 1066 ssh2'
> 
> **Phase 2: Completed decoding.
>        decoder: 'sshd'
>        dstuser: 'root'
>        srcip: '1.1.1.1'
>        srcport: '1066'
> 
> **Phase 3: Completed filtering (rules).
>        Rule id: '100001'
>        Level: '5'
>        Description: 'sshd: authentication failed from IP 1.1.1.1.'
> **Alert to be generated.
> 
> Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
> 
> 
> **Phase 1: Completed pre-decoding.
>        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
>        timestamp: 'Dec 10 01:02:02'
>        hostname: 'host'
>        program_name: 'sshd'
>        log: 'Failed none for root from 1.1.1.1 port 1066 ssh2'
> 
> **Phase 2: Completed decoding.
>        decoder: 'sshd'
>        dstuser: 'root'
>        srcip: '1.1.1.1'
>        srcport: '1066'
> 
> **Phase 3: Completed filtering (rules).
>        Rule id: '100002'
>        Level: '10'
>        Description: 'Test rule.'
> **Alert to be generated.
> 

