### PR TITLE
Prevent debug messages from being flooded

### DIFF
--- a/src/headers/vector_op.h
+++ b/src/headers/vector_op.h
@@ -33,6 +33,7 @@ int W_Vector_length(W_Vector *v);
 
 void W_Vector_free(W_Vector *v);
 
-void W_Vector_insert_unique(W_Vector *v, const char *element);
+// Returns 1 if the element is duplicated, 0 otherwise.
+int W_Vector_insert_unique(W_Vector *v, const char *element);
 
 #endif /* __VECTOR_OP_H */

--- a/src/shared/vector_op.c
+++ b/src/shared/vector_op.c
@@ -68,7 +68,7 @@ void W_Vector_free(W_Vector *v) {
 }
 
 
-void W_Vector_insert_unique(W_Vector *v, const char *element) {
+int W_Vector_insert_unique(W_Vector *v, const char *element) {
     int i;
     int found = 0;
 
@@ -84,4 +84,6 @@ void W_Vector_insert_unique(W_Vector *v, const char *element) {
             W_Vector_insert(v, element);
         }
     }
+
+    return found;
 }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -251,11 +251,14 @@ int realtime_start()
 int realtime_adddir(const char *dir, __attribute__((unused)) int whodata)
 {
     if (whodata && audit_thread_active) {
-        mdebug1("Monitoring with Audit: '%s'.", dir);
 
         // Save dir into saved rules list
         w_mutex_lock(&audit_mutex);
-        W_Vector_insert(audit_added_dirs, dir);
+
+        if(!W_Vector_insert_unique(audit_added_dirs, dir)){
+            mdebug1("Monitoring with Audit: '%s'.", dir);
+        }
+
         w_mutex_unlock(&audit_mutex);
 
     } else {

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -212,18 +212,20 @@ int add_audit_rules_syscheck(void) {
                 int found = search_audit_rule(syscheck.dir[i], "wa", AUDIT_KEY);
                 if (found == 0) {
                     if (retval = audit_add_rule(syscheck.dir[i], AUDIT_KEY), retval > 0) {
-                        mdebug1("Added audit rule for monitoring directory: '%s'.", syscheck.dir[i]);
                         w_mutex_lock(&audit_rules_mutex);
-                        W_Vector_insert_unique(audit_added_rules, syscheck.dir[i]);
+                        if(!W_Vector_insert_unique(audit_added_rules, syscheck.dir[i])) {
+                            mdebug1("Added audit rule for monitoring directory: '%s'.", syscheck.dir[i]);
+                        }
                         w_mutex_unlock(&audit_rules_mutex);
                         rules_added++;
                     } else {
                         merror("Error adding audit rule for directory (%i): %s .",retval, syscheck.dir[i]);
                     }
                 } else if (found == 1) {
-                    mdebug1("Audit rule for monitoring directory '%s' already added.", syscheck.dir[i]);
                     w_mutex_lock(&audit_rules_mutex);
-                    W_Vector_insert_unique(audit_added_rules, syscheck.dir[i]);
+                    if(!W_Vector_insert_unique(audit_added_rules, syscheck.dir[i])) {
+                        mdebug1("Audit rule for monitoring directory '%s' already added.", syscheck.dir[i]);
+                    }
                     w_mutex_unlock(&audit_rules_mutex);
                     rules_added++;
                 } else {


### PR DESCRIPTION
Hi team,

This PR fixes:
- Prevent flooding of debug messages when adding folders with a lot of folders inside. 
- Optimizes memory usage for the list of directories monitored by Audit.

Best regards,
Cerv1.