### PR TITLE
Remove error message when attempting to launch a vulnerability scan without database

### DIFF
--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -2812,6 +2812,11 @@ int wm_vuldet_db_empty() {
     sqlite3_stmt *stmt = NULL;
     int result;
 
+    if (wm_vuldet_check_db()) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_CHECK_DB_ERROR);
+        return OS_INVALID;
+    }
+
     if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK) {
         return wm_vuldet_sql_error(db, NULL);
     }


### PR DESCRIPTION
When vulnerability-detector tries to launch a vulnerability scan without database this error is displayed:

> 2019/03/19 15:26:13 wazuh-modulesd:vulnerability-detector ERROR: (5405): SQL error: unable to open database file

This PR adds the check that the database exists before launching the scan. 

To replicate the issue, you can remove the vulnerability-detector's database between scans. No errors should be visible.

It only happens at Wazuh 3.9.0.