### PR TITLE
Fix permission extraction in Windows

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1004,7 +1004,7 @@ int w_get_file_permissions(const char *file_path, char *permissions, int perm_si
         goto end;
     }
 
-    if (!has_dacl) {
+    if (!has_dacl || !f_acl) {
         mdebug1("'%s' has no DACL, so no permits can be extracted.", file_path);
         goto end;
     }


### PR DESCRIPTION
Wazuh stops when trying to monitor a directory or file that has no associated security policies. 

![imagen](https://user-images.githubusercontent.com/20266121/54702033-6406df80-4b36-11e9-8c12-626dc6c38175.png)


This is because the `GetSecurityDescriptorDacl` function was not being controlled when returning a null DACL if the variable to check the existence of DACL (`has_dacl` in the code) was set to true. 

In other words, FIM were trying to access permissions that did not exist.

To reproduce this issue, you can monitor a folder inside a external drive, for which we do not have access to the permissions. The `CHECK_PERM` tag must be enabled in the directories field.