### PR TITLE
Fix for skipping empty lines in CDB lists

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -289,7 +289,7 @@ def upload_list(list_file, path):
         # create temporary file
         with open(tmp_file_path, 'w') as tmp_file:
             # write json in tmp_file_path
-            for element in list_file.split('\n')[:-1]:
+            for element in list_file.splitlines()[:-1]:
                 # skip empty lines
                 if not element:
                     continue

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -289,7 +289,7 @@ def upload_list(list_file, path):
         # create temporary file
         with open(tmp_file_path, 'w') as tmp_file:
             # write json in tmp_file_path
-            for element in list_file.splitlines()[:-1]:
+            for element in list_file.splitlines():
                 # skip empty lines
                 if not element:
                     continue

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -290,7 +290,10 @@ def upload_list(list_file, path):
         with open(tmp_file_path, 'w') as tmp_file:
             # write json in tmp_file_path
             for element in list_file.split('\n')[:-1]:
-                tmp_file.write(element + '\n')
+                # skip empty lines
+                if not element:
+                    continue
+                tmp_file.write(element.strip() + '\n')
         chmod(tmp_file_path, 0o640)
     except IOError:
         raise WazuhException(1005)


### PR DESCRIPTION
Hi team,

This PR (and API PR [#355](https://github.com/wazuh/wazuh-api/pull/355)) closes #2879. I made changes to accept empty lines:

```bash
# cat /root/list.txt               
audit-wazuh-w:write
audit-wazuh-r:read
audit-wazuh-a:attribute

audit-wazuh-x:execute
     key:value

audit-wazuh-c:command
1.1.1.1:list
2.3.4.4:#
# curl -u foo:bar -X POST -H 'Content-type: application/octet-stream' --data-binary @/root/list.txt "http://127.0.0.1:55000/manager/files?path=etc/lists/new-list&overwrite=true"
{"error":0,"data":"File updated successfully"}
# cat /var/ossec/etc/lists/new-list
audit-wazuh-w:write
audit-wazuh-r:read
audit-wazuh-a:attribute
audit-wazuh-x:execute
key:value
audit-wazuh-c:command
1.1.1.1:list
2.3.4.4:#
```

#### Tests performed

```javascript

 # mocha test/test_manager.js


  Manager
    GET/manager/status
      ✓ Request (463ms)
    GET/manager/info
      ✓ Request (203ms)
    GET/manager/configuration
      ✓ Request (223ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (384ms)
      ✓ Errors: Invalid Section (224ms)
      ✓ Filters: Section - field (191ms)
      ✓ Errors: Invalid field (190ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (201ms)
      ✓ Filters: date (200ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (190ms)
    GET/manager/stats/weekly
      ✓ Request (217ms)
    GET/manager/stats/analysisd
      ✓ Request (207ms)
    GET/manager/stats/remoted
      ✓ Request (192ms)
    GET/manager/logs
      ✓ Request (249ms)
      ✓ Pagination (236ms)
      ✓ Retrieve all elements with limit=0 (234ms)
      ✓ Sort (230ms)
      ✓ SortField (229ms)
      ✓ Search (277ms)
      ✓ Filters: type_log (232ms)
      ✓ Filters: category (223ms)
      ✓ Filters: type_log and category (227ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (219ms)
    POST/manager/files
      ✓ Upload ossec.conf (198ms)
      ✓ Upload ossec.conf (overwrite=false) (193ms)
      ✓ Upload rules (new rule) (201ms)
      ✓ Upload rules (overwrite=true) (192ms)
      ✓ Upload rules (overwrite=false) (191ms)
      ✓ Upload decoder (overwrite=true) (203ms)
      ✓ Upload decoder (without overwrite parameter) (189ms)
      ✓ Upload list (overwrite=true) (192ms)
      ✓ Upload list (without overwrite parameter) (226ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
    GET/manager/files
      ✓ Request ossec.conf (384ms)
      ✓ Request rules (215ms)
      ✓ Request decoders (193ms)
      ✓ Request lists (190ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (202ms)
      ✓ Request file with empty path
    DELETE/manager/files
      ✓ Delete rules
      ✓ Delete decoders
      ✓ Delete CDB list
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (873ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (209ms)
    PUT/manager/restart
      ✓ Request (189ms)


  60 passing (11s)
```
Best regards,

Demetrio.