### PR TITLE
Changed "Reading rules" log level to debug

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -536,7 +536,7 @@ int main_analysisd(int argc, char **argv)
                 listfiles = Config.lists;
                 while (listfiles && *listfiles) {
                     if (!test_config) {
-                        minfo("Reading the lists file: '%s'", *listfiles);
+                        mdebug1("Reading the lists file: '%s'", *listfiles);
                     }
                     if (Lists_OP_LoadList(*listfiles) < 0) {
                         merror_exit(LISTS_ERROR, *listfiles);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -512,7 +512,7 @@ int main_analysisd(int argc, char **argv)
                 decodersfiles = Config.decoders;
                 while ( decodersfiles && *decodersfiles) {
                     if (!test_config) {
-                        minfo("Reading decoder file %s.", *decodersfiles);
+                        mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
                     if (!ReadDecodeXML(*decodersfiles)) {
                         merror_exit(CONFIG_ERROR, *decodersfiles);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -565,7 +565,7 @@ int main_analysisd(int argc, char **argv)
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     if (!test_config) {
-                        minfo("Reading rules file: '%s'", *rulesfiles);
+                        mdebug1("Reading rules file: '%s'", *rulesfiles);
                     }
                     if (Rules_OP_ReadRules(*rulesfiles) < 0) {
                         merror_exit(RULES_ERROR, *rulesfiles);

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -227,7 +227,7 @@ int main(int argc, char **argv)
                 decodersfiles = Config.decoders;
                 while ( decodersfiles && *decodersfiles) {
                     if (!test_config) {
-                        minfo("Reading decoder file %s.", *decodersfiles);
+                        mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
                     if (!ReadDecodeXML(*decodersfiles)) {
                         merror_exit(CONFIG_ERROR, *decodersfiles);


### PR DESCRIPTION
Hi team,

This small change is related to this kind of logs:

```
...
2019/03/21 10:09:28 ossec-analysisd: INFO: Reading rules file: 'ruleset/rules/0485-cylance_rules.xml'
2019/03/21 10:09:28 ossec-analysisd: INFO: Reading rules file: 'ruleset/rules/0490-virustotal_rules.xml'
2019/03/21 10:09:28 ossec-analysisd: INFO: Reading rules file: 'ruleset/rules/0495-proxmox-ve_rules.xml'
2019/03/21 10:09:28 ossec-analysisd: INFO: Reading rules file: 'ruleset/rules/0500-owncloud_rules.xml'
2019/03/21 10:09:28 ossec-analysisd: INFO: Reading rules file: 'ruleset/rules/0505-vuls_rules.xml'
2019/03/21 10:09:28 ossec-analysisd: INFO: Reading rules file: 'ruleset/rules/0510-ciscat_rules.xml'
2019/03/21 10:09:28 ossec-analysisd: INFO: Reading rules file: 'ruleset/rules/0515-exim_rules.xml'
....
```
They should be _DEBUG_ instead of _INFO_.