### PR TITLE
Fix for uploading XML files

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -237,14 +237,15 @@ def upload_xml(xml_file, path):
             # beauty xml file
             xml = parseString('<root>' + xml_file + '</root>')
             # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
-            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent='  ').split('\n')[2:-2])) + '\n'
+            indent = '  '  # indent parameter for toprettyxml function
+            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent=indent).split('\n')[2:-2])) + '\n'
             # revert xml.dom replacings
             # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
             pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
                 .replace("&gt;", ">").replace('&apos', "'")
             # delete two first spaces of each line
-            pretty_xml = re.sub(r'^  ', '', pretty_xml)
-            tmp_file.write(pretty_xml)
+            final_xml = re.sub(fr'^{indent}', '', pretty_xml, flags=re.MULTILINE)
+            tmp_file.write(final_xml)
         chmod(tmp_file_path, 0o640)
     except IOError:
         raise WazuhException(1005)

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -242,6 +242,7 @@ def upload_xml(xml_file, path):
             # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
             pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
                 .replace("&gt;", ">").replace('&apos', "'")
+            re.sub(r'^  ', '', pretty_xml)
             tmp_file.write(pretty_xml)
         chmod(tmp_file_path, 0o640)
     except IOError:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -242,7 +242,7 @@ def upload_xml(xml_file, path):
             # revert xml.dom replacings
             # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
             pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
-                .replace("&gt;", ">").replace('&apos', "'")
+                .replace("&gt;", ">").replace('&apos;', "'")
             # delete two first spaces of each line
             final_xml = re.sub(fr'^{indent}', '', pretty_xml, flags=re.MULTILINE)
             tmp_file.write(final_xml)

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -243,7 +243,7 @@ def upload_xml(xml_file, path):
             pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
                 .replace("&gt;", ">").replace('&apos', "'")
             # delete two first spaces of each line
-            re.sub(r'^  ', '', pretty_xml)
+            pretty_xml = re.sub(r'^  ', '', pretty_xml)
             tmp_file.write(pretty_xml)
         chmod(tmp_file_path, 0o640)
     except IOError:


### PR DESCRIPTION
Hi team,

This PR closes #2882. `XML` comments were bad formatted when we upload a file and I fix it. It is necessary to use `--data-binary` parameter with `curl`:

```bash
# cat /root/new_rules.xml                
<!-- NEW RULES -->

<!-- Modify it at your will.
     
	 WAZUH
	 WAZUH
	 WAZUH
	 WAZUH

-->

<!-- Copyright (C) 2015-2019, Wazuh Inc. -->

<!-- Example -->
<group name="local,syslog,sshd,">

  <!--
  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
  -->
  <rule id="100001" level="5">
    <if_sid>5716</if_sid>
    <srcip>1.1.1.1</srcip>
    <description>sshd: authentication failed from IP 1.1.1.1.</description>
    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>

</group>
```

```bash
# curl -u foo:bar -X POST -H 'Content-type: application/xml' --data-binary @/root/new_rules.xml "http://127.0.0.1:55000/manager/files?path=etc/rules/new_rules.xml&overwrite=true"
{"error":0,"data":"File updated successfully"}
```

```bash
# cat /var/ossec/etc/rules/new_rules.xml 
<!-- NEW RULES -->

<!-- Modify it at your will.
     
	 WAZUH
	 WAZUH
	 WAZUH
	 WAZUH

-->

<!-- Copyright (C) 2015-2019, Wazuh Inc. -->

<!-- Example -->
<group name="local,syslog,sshd,">

  <!--
  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
  -->
  <rule id="100001" level="5">
    <if_sid>5716</if_sid>
    <srcip>1.1.1.1</srcip>
    <description>sshd: authentication failed from IP 1.1.1.1.</description>
    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>

</group>
```

Best regards,

Demetrio.