### PR TITLE
Fix invalid behaviour when moving files in whodata mode

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -97,6 +97,7 @@ typedef struct whodata_evt {
     int dir_position;
     char deleted;
     char ignore_not_exist;
+    char ignore_remove_event;
     char scan_directory;
     whodata_event_node *wnode;
 #endif
@@ -112,19 +113,24 @@ typedef struct whodata_dir_status {
 
 typedef struct whodata_event_node {
     struct whodata_event_node *next;
-    struct whodata_event_node *previous;
-    char *handle_id;
+    struct whodata_event_node *prev;
+    char *id;
+    time_t insert_time;
 } whodata_event_node;
 
 typedef struct whodata_event_list {
-    whodata_event_node *nodes;
     whodata_event_node *first;
     whodata_event_node *last;
-    size_t current_size;
-    size_t max_size;
-    size_t alert_threshold;
-    size_t max_remove;
-    char alerted;
+    union {
+        struct {
+            size_t current_size;
+            size_t max_size;
+            size_t alert_threshold;
+            size_t max_remove;
+            char alerted;
+        };
+        time_t queue_time;
+    };
 } whodata_event_list;
 
 typedef struct whodata_directory {
@@ -208,7 +214,8 @@ typedef struct _config {
     FILE *reg_fp;
     int max_fd_win_rt;
     whodata wdata;
-    whodata_event_list wlist;
+    whodata_event_list w_clist; // List of events cached from Whodata mode in the last seconds
+    whodata_event_list w_rlist; // List of events removed from Whodata mode in the last seconds
 #endif
     int max_audit_entries;          /* Maximum entries for Audit (whodata) */
     char **audit_key;               // Listen audit keys

--- a/src/headers/hash_op.h
+++ b/src/headers/hash_op.h
@@ -17,6 +17,7 @@
 /* Node structure */
 typedef struct _OSHashNode {
     struct _OSHashNode *next;
+    struct _OSHashNode *prev;
 
     char *key;
     void *data;
@@ -27,7 +28,7 @@ typedef struct _OSHash {
     unsigned int initial_seed;
     unsigned int constant;
     pthread_rwlock_t mutex;
-    
+
     void (*free_data_function)(void *data);
     OSHashNode **table;
 } OSHash;
@@ -77,5 +78,8 @@ OSHash *OSHash_Duplicate_ex(const OSHash *hash) __attribute__((nonnull));
 OSHashNode *OSHash_Begin(const OSHash *self, unsigned int *i);
 OSHashNode *OSHash_Next(const OSHash *self, unsigned int *i, OSHashNode *current);
 void *OSHash_Clean(OSHash *self, void (*cleaner)(void*));
+
+void OSHash_It(const OSHash *hash, void *data, void (*iterating_function)(OSHashNode **row, OSHashNode **node, void *data));
+void OSHash_It_ex(const OSHash *hash, void *data, void (*iterating_function)(OSHashNode **row, OSHashNode **node, void *data));
 
 #endif

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -326,7 +326,6 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
 
         if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, file_name), !s_node) {
             char * alertdump = NULL;
-
  #ifdef WIN_WHODATA
             if (evt && evt->scan_directory == 1) {
                 if (w_update_sacl(file_name)) {
@@ -674,6 +673,13 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             os_free(alert_msg);
             os_free(alertdump);
         } else {
+#ifdef WIN_WHODATA
+            // This scan is only to find new files
+            // Modified files will be reported by the whodata flow
+            if (evt && evt->scan_directory == 1) {
+                goto end;
+            }
+#endif
             os_calloc(OS_MAXSTR + 1, sizeof(char), alert_msg);
             os_calloc(OS_MAXSTR + 1, sizeof(char), c_sum);
 
@@ -1069,11 +1075,8 @@ int create_db()
 
 int extract_whodata_sum(whodata_evt *evt, char *wd_sum, int size) {
     int retval = 0;
-#ifdef WIN_WHODATA
-    if (!evt || evt->scan_directory == 1) {
-#else
+
     if (!evt) {
-#endif
         if (snprintf(wd_sum, size, "::::::::::") >= size) {
             retval = 1;
         }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -345,6 +345,13 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
         char alert_msg[OS_SIZE_6144 + 1];
         char wd_sum[OS_SIZE_6144 + 1];
 
+#ifdef WIN_WHODATA
+        // If this flag is enable, the remove event will be notified at another point
+        if (evt && evt->ignore_remove_event) {
+            mdebug2("The '%s' file does not exist, but this will be notified when the corresponding event is received.", file_name);
+            return 0;
+        }
+#endif
         alert_msg[sizeof(alert_msg) - 1] = '\0';
 
         // Extract the whodata sum here to not include it in the hash table

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -136,6 +136,10 @@ int read_links(const char *dir_name, int dir_position, int max_depth, unsigned i
 size_t syscom_dispatch(char *command, char ** output);
 size_t syscom_getconfig(const char * section, char ** output);
 
+#ifdef WIN_WHODATA
+int update_sacl(char *obj_path);
+#endif
+
 int print_hash_table();
 int fim_delete_hashes(char *file_name);
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -137,7 +137,7 @@ size_t syscom_dispatch(char *command, char ** output);
 size_t syscom_getconfig(const char * section, char ** output);
 
 #ifdef WIN_WHODATA
-int update_sacl(char *obj_path);
+int w_update_sacl(const char *obj_path);
 #endif
 
 int print_hash_table();

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -773,13 +773,19 @@ add_whodata_evt:
                                 last_mdir_tm + WHODATA_DIR_REMOVE_INTERVAL < now) {
                                 if (w_evt->path) {
                                     char *dir_path;
+                                    char *saved_path;
+
+                                    saved_path = w_evt->path;
+
+                                    os_calloc(strlen(w_evt->path) + 2, sizeof(char), dir_path);
+                                    snprintf(dir_path, strlen(w_evt->path) + 2, "%s\\", w_evt->path);
+                                    w_evt->path = dir_path;
 
                                     // Notify removed files
-                                    os_calloc(strlen(w_evt->path) + 2, sizeof(char), dir_path);
-                                    snprintf(dir_path, strlen(w_evt->path) + 2, "%s/", dir_path);
-                                    mdebug1("Directory %s has been moved or removed.", dir_path);
+                                    mdebug1("Directory '%s' has been moved or removed.", dir_path);
                                     OSHash_It_ex(syscheck.fp, (void *) w_evt, whodata_remove_folder);
                                     free(dir_path);
+                                    w_evt->path = saved_path;
 
                                     // Find new files
                                     read_dir(syscheck.dir[w_evt->dir_position], w_evt->dir_position, w_evt, syscheck.recursion_level[w_evt->dir_position], 0);


### PR DESCRIPTION
## Files moved from outside the monitored environment

When a file is moved from an unmonitored folder to a folder monitored in whodata mode, it does not instantly inherit audit policies. For this reason, when deleting that file, a real-time removing event does not appear and will be necessary to wait for the frequency scan to detect the event.

This is a known invalid behaviour on Windows systems, which for some reason has not been fixed.

2e7c4279cba196ddbeab8773b87a60e0d9082a6e forces the update of the audit policies inherited from the monitored folder.

## Renamed folders (https://github.com/wazuh/wazuh/issues/2418)

Until now, whodata mode was not report the folders rename operation. The expected behaviour is to get one deletion and one creation alert for each file in the renamed folder. The Windows audit system does not warn of this operation, nor does it differentiate files from folders in this case. 

Since 66fcd9543e671369733c242bfe68b5f924453175 , Whodata detects the deletion of the folder and iterate the hash table to notify the removed operation of each file contained in it. After this, a scan is launched to detect new files with the new folder path.