### PR TITLE
Avoid to create a corrupted merged.md if there is an invalid file in the group folder

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -133,4 +133,6 @@ int w_remove_line_from_file(char *file, int line);
 int w_compress_gzfile(const char *filesrc, const char *filedst);
 int w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst);
 
+int checkBinaryFile(const char *f_name);
+
 #endif /* __FILE_H */

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -410,7 +410,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                     last_modify = gmtime(&(attrib.st_mtime));
                     OSHash_Add(invalid_files, file, last_modify);
                     ignored = 1;
-                    merror("File %s was detected as an invalid file",file);
+                    merror("Ivalid shared file %s in group %s. Ignoring it.",files[i],group);
                 }
             }
             if (!logr.nocmerged && !ignored) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -389,11 +389,11 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                 if( modified != last_modify){
                     if(checkBinaryFile(file)){
                         OSHash_Set(invalid_files, file, last_modify);
-                        mdebug1("File %s in group %s changed but it is still invalid.", file, group);
+                        mdebug1("File %s in group %s changed but it is still invalid.", files[i], group);
                     }
                     else{
                         OSHash_Delete(invalid_files, file);
-                        mdebug1("File %s in group %s is valid now. Added to the merged.md", file, group);
+                        mdebug1("File %s in group %s is valid now. Added to the merged.md", files[i], group);
                         ignored = 0;
                     }
                 }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -363,7 +363,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                 last_modify = gmtime(&(attrib.st_mtime));
                 if( modified != last_modify){
                     if(checkBinaryFile(DEFAULTAR)){
-                        OSHash_Update(invalid_files, DEFAULTAR, last_modify);
+                        OSHash_Set(invalid_files, DEFAULTAR, last_modify);
                         ignored = 1;
                     }
                     else{
@@ -421,7 +421,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                 last_modify = gmtime(&(attrib.st_mtime));
                 if( modified != last_modify){
                     if(checkBinaryFile(file)){
-                        OSHash_Add(invalid_files, file, last_modify);
+                        OSHash_Set(invalid_files, file, last_modify);
                         ignored = 1;
                     }
                     else{
@@ -556,7 +556,7 @@ next:
         }
     }
 
-    /* Open de multi-group files and generate merged */
+    /* Open the multi-group files and generate merged */
     dp = opendir(MULTIGROUPS_DIR);
 
     if (!dp) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -355,36 +355,8 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
             strncpy(f_sum[f_size]->sum, md5sum, 32);
             os_strdup(DEFAULTAR_FILE, f_sum[f_size]->name);
 
-            if(modified = (struct tm *) OSHash_Get(invalid_files,DEFAULTAR)){
-                struct stat attrib;
-                struct tm *last_modify;
-
-                stat(DEFAULTAR, &attrib);
-                last_modify = gmtime(&(attrib.st_mtime));
-                if( modified != last_modify){
-                    if(checkBinaryFile(DEFAULTAR)){
-                        OSHash_Set(invalid_files, DEFAULTAR, last_modify);
-                        ignored = 1;
-                    }
-                    else{
-                        OSHash_Delete(invalid_files, DEFAULTAR);
-                    }
-                }
-            } else {
-                if(checkBinaryFile(DEFAULTAR)){
-                    struct stat attrib;
-                    struct tm *last_modify;
-
-                    stat(DEFAULTAR, &attrib);
-                    last_modify = gmtime(&(attrib.st_mtime));
-                    OSHash_Add(invalid_files, DEFAULTAR, last_modify);
-                    ignored = 1;
-                    merror("File ar.conf was detected as an invalid file");
-                }
-            }
-            
-            if (!logr.nocmerged && !ignored) {
-                    MergeAppendFile(merged_tmp, DEFAULTAR, NULL, -1);
+            if (!logr.nocmerged) {
+                MergeAppendFile(merged_tmp, DEFAULTAR, NULL, -1);
             }
 
             f_size++;
@@ -413,7 +385,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
             strncpy(f_sum[f_size]->sum, md5sum, 32);
             os_strdup(files[i], f_sum[f_size]->name);
             
-            if(modified = (struct tm *) OSHash_Get(invalid_files,file)){
+            if(modified = (struct tm *) OSHash_Get(invalid_files,file), modified){
                 struct stat attrib;
                 struct tm *last_modify;
 
@@ -533,7 +505,7 @@ void c_multi_group(char *multi_group,file_sum ***_f_sum,char *hash_multigroup) {
 
                 snprintf(source_path, PATH_MAX + 1, "%s/%s/%s", SHAREDCFG_DIR, group, files[i]);
                 snprintf(destination_path, PATH_MAX + 1, "%s/%s/%s", MULTIGROUPS_DIR, hash_multigroup, files[i]);
-                if(modified = (struct tm *) OSHash_Get(invalid_files,source_path)){
+                if(modified = (struct tm *) OSHash_Get(invalid_files,source_path), modified){
                    ignored = 1;
                 }
                 if(!ignored) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -391,13 +391,14 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
 
                 stat(file, &attrib);
                 last_modify = gmtime(&(attrib.st_mtime));
+                ignored = 1;
                 if( modified != last_modify){
                     if(checkBinaryFile(file)){
                         OSHash_Set(invalid_files, file, last_modify);
-                        ignored = 1;
                     }
                     else{
                         OSHash_Delete(invalid_files, file);
+                        ignored = 0;
                     }
                 }
             }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -379,12 +379,6 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                 continue;
             }
 
-            os_realloc(f_sum, (f_size + 2) * sizeof(file_sum *), f_sum);
-            *_f_sum = f_sum;
-            os_calloc(1, sizeof(file_sum), f_sum[f_size]);
-            strncpy(f_sum[f_size]->sum, md5sum, 32);
-            os_strdup(files[i], f_sum[f_size]->name);
-            
             if(modified = (struct tm *) OSHash_Get(invalid_files,file), modified){
                 struct stat attrib;
                 struct tm *last_modify;
@@ -411,14 +405,23 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                     last_modify = gmtime(&(attrib.st_mtime));
                     OSHash_Add(invalid_files, file, last_modify);
                     ignored = 1;
-                    merror("Ivalid shared file %s in group %s. Ignoring it.",files[i],group);
+                    merror("Invalid shared file %s in group %s. Ignoring it.",files[i],group);
                 }
             }
-            if (!logr.nocmerged && !ignored) {
-                MergeAppendFile(merged_tmp, file, NULL, -1);
-            }
 
-            f_size++;
+            if(!ignored){
+                os_realloc(f_sum, (f_size + 2) * sizeof(file_sum *), f_sum);
+                *_f_sum = f_sum;
+                os_calloc(1, sizeof(file_sum), f_sum[f_size]);
+                strncpy(f_sum[f_size]->sum, md5sum, 32);
+                os_strdup(files[i], f_sum[f_size]->name);
+                
+                if (!logr.nocmerged) {
+                    MergeAppendFile(merged_tmp, file, NULL, -1);
+                }
+
+                f_size++;
+            }
         }
 
         f_sum[f_size] = NULL;

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -340,7 +340,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
     }
     else{
         // Merge ar.conf always
-        struct tm *modified;
+        time_t modified;
         int ignored = 0;
         if (!logr.nocmerged) {
             snprintf(merged_tmp, PATH_MAX + 1, "%s.tmp", merged);
@@ -379,19 +379,21 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                 continue;
             }
 
-            if(modified = (struct tm *) OSHash_Get(invalid_files,file), modified){
+            if(modified = (time_t) OSHash_Get(invalid_files,file), modified){
                 struct stat attrib;
-                struct tm *last_modify;
+                time_t last_modify;
 
                 stat(file, &attrib);
-                last_modify = gmtime(&(attrib.st_mtime));
+                last_modify = attrib.st_mtime;
                 ignored = 1;
                 if( modified != last_modify){
                     if(checkBinaryFile(file)){
                         OSHash_Set(invalid_files, file, last_modify);
+                        mdebug1("File %s in group %s changed but it is still invalid.", file, group);
                     }
                     else{
                         OSHash_Delete(invalid_files, file);
+                        mdebug1("File %s in group %s is valid now. Added to the merged.md", file, group);
                         ignored = 0;
                     }
                 }
@@ -399,13 +401,13 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
             else {
                 if(checkBinaryFile(file)){
                     struct stat attrib;
-                    struct tm *last_modify;
+                    time_t last_modify;
 
                     stat(file, &attrib);
-                    last_modify = gmtime(&(attrib.st_mtime));
+                    last_modify = attrib.st_mtime;
                     OSHash_Add(invalid_files, file, last_modify);
                     ignored = 1;
-                    merror("Invalid shared file %s in group %s. Ignoring it.",files[i],group);
+                    merror("Invalid shared file %s in group %s. Ignoring it.",files[i], group);
                 }
             }
 

--- a/src/remoted/shared_download.h
+++ b/src/remoted/shared_download.h
@@ -32,6 +32,7 @@
 typedef struct _file{
     char *name;
     char *url;
+    int ignored;
 } file;
 
 typedef struct _remote_files_group{

--- a/src/remoted/shared_download.h
+++ b/src/remoted/shared_download.h
@@ -32,7 +32,6 @@
 typedef struct _file{
     char *name;
     char *url;
-    int ignored;
 } file;
 
 typedef struct _remote_files_group{

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -866,6 +866,44 @@ int MergeAppendFile(const char *finalpath, const char *files, const char *tag, i
     return (1);
 }
 
+int checkBinaryFile(const char *f_name){
+    FILE *fp;
+    char str[OS_MAXSTR + 1];
+    fpos_t fp_pos;
+    long offset;
+    long rbytes;
+
+    str[OS_MAXSTR] = '\0';
+
+    fp = fopen(f_name,"r");
+
+     if (!fp) {
+        merror("Unable to open file '%s' due to [(%d)-(%s)].", f_name, errno, strerror(errno));
+        return 1;
+    }
+
+    /* Get initial file location */
+    fgetpos(fp, &fp_pos);
+
+    for (offset = w_ftell(fp); fgets(str, OS_MAXSTR + 1, fp) != NULL; offset += rbytes) {
+        rbytes = w_ftell(fp) - offset;
+
+        /* Get the last occurrence of \n */
+        if (str[rbytes - 1] == '\n') {
+            str[rbytes - 1] = '\0';
+
+            if ((long)strlen(str) != rbytes - 1)
+            {
+                mdebug2("Line contains some zero-bytes (valid=%ld / total=%ld).", (long)strlen(str), rbytes - 1);
+                fclose(fp);
+                return 1;
+            }
+        }
+    }
+    fclose(fp);
+    return 0;
+}
+
 int MergeFiles(const char *finalpath, char **files, const char *tag)
 {
     int i = 0, ret = 1;


### PR DESCRIPTION
This is the PR for the issue: https://github.com/wazuh/wazuh/issues/2862

Now if an invalid file is detected in the group folder an error is logged in the `ossec.log`

![image](https://user-images.githubusercontent.com/9034923/54835542-9c3b2900-4cc2-11e9-8bb5-e305736225ca.png)

That files will be added to a ignored files table.
In the case the invalid file is a corrupted plain text file it will be added again to the merged when it is modified and fixed.