### PR TITLE
Escape XML entities for logcollector

### DIFF
--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -504,10 +504,10 @@ def load_wazuh_xml(xml_path):
     data = re.sub(r"<(?!/?\w+.+>|!--)", "&lt;", data)
 
     # replace \< by &lt
-    data = re.sub(r'\\\<', '&lt', data)
+    data = re.sub(r'\\<', '&lt', data)
 
     # replace \> by &gt
-    data = re.sub(r'\\\>', '&gt', data)
+    data = re.sub(r'\\>', '&gt', data)
 
     # & characters should be scaped if they don't represent an &entity;
     data = re.sub(r"&(?!(amp|lt|gt|apos|quot);)", "&amp;", data)

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -503,10 +503,10 @@ def load_wazuh_xml(xml_path):
     # < characters should be scaped as &lt; unless < is starting a <tag> or a comment
     data = re.sub(r"<(?!/?\w+.+>|!--)", "&lt;", data)
 
-    # replace \< by &lt
+    # replace \< by &lt;
     data = re.sub(r'\\<', '&lt;', data)
 
-    # replace \> by &gt
+    # replace \> by &gt;
     data = re.sub(r'\\>', '&gt;', data)
 
     # & characters should be scaped if they don't represent an &entity;

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -504,10 +504,10 @@ def load_wazuh_xml(xml_path):
     data = re.sub(r"<(?!/?\w+.+>|!--)", "&lt;", data)
 
     # replace \< by &lt
-    data = re.sub(r'\\<', '&lt', data)
+    data = re.sub(r'\\<', '&lt;', data)
 
     # replace \> by &gt
-    data = re.sub(r'\\>', '&gt', data)
+    data = re.sub(r'\\>', '&gt;', data)
 
     # & characters should be scaped if they don't represent an &entity;
     data = re.sub(r"&(?!(amp|lt|gt|apos|quot);)", "&amp;", data)

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -503,6 +503,12 @@ def load_wazuh_xml(xml_path):
     # < characters should be scaped as &lt; unless < is starting a <tag> or a comment
     data = re.sub(r"<(?!/?\w+.+>|!--)", "&lt;", data)
 
+    # replace \< by &lt
+    data = re.sub(r'\\\<', '&lt', data)
+
+    # replace \> by &gt
+    data = re.sub(r'\\\>', '&gt', data)
+
     # & characters should be scaped if they don't represent an &entity;
     data = re.sub(r"&(?!(amp|lt|gt|apos|quot);)", "&amp;", data)
 


### PR DESCRIPTION
Hi team,

An error happens when we configure `logcollector` with content as the next in `prefix` tag: 

```XML
<prefix>\<13\></prefix> 
```

I made a fix for replacing `\<` by `&lt;` (and `\>` by `&gt;`) that solves it.

#### Unit tests

```bash
# /var/ossec/framework/python/bin/python3 -m pytest framework/wazuh
============================================ test session starts ============================================
platform linux -- Python 3.7.2, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /root/wazuh/framework, inifile:
collected 172 items                                                                                         

framework/wazuh/cluster/tests/test_cluster.py ...............                                         [  8%]
framework/wazuh/cluster/tests/test_worker.py ...........                                              [ 15%]
framework/wazuh/tests/test_agent.py .........................                                         [ 29%]
framework/wazuh/tests/test_cdb_list.py ...........                                                    [ 36%]
framework/wazuh/tests/test_decoders.py ........................................                       [ 59%]
framework/wazuh/tests/test_group.py ........                                                          [ 63%]
framework/wazuh/tests/test_manager.py ..............                                                  [ 72%]
framework/wazuh/tests/test_rules.py ........................................                          [ 95%]
framework/wazuh/tests/test_security_configuration_assessment.py .....                                 [ 98%]
framework/wazuh/tests/test_wdb.py ... 

================================= 172 passed, 140 warnings in 1.79 seconds ==================================
```
#### Mocha tests

```javascript
# mocha test/test_manager.js --timeout=10000


  Manager
    GET/manager/status
      ✓ Request (327ms)
    GET/manager/info
      ✓ Request (560ms)
    GET/manager/configuration
      ✓ Request (834ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (911ms)
      ✓ Errors: Invalid Section (415ms)
      ✓ Filters: Section - field (399ms)
      ✓ Errors: Invalid field (297ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (307ms)
      ✓ Filters: date (275ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (276ms)
    GET/manager/stats/weekly
      ✓ Request (265ms)
    GET/manager/stats/analysisd
      ✓ Request (299ms)
    GET/manager/stats/remoted
      ✓ Request (275ms)
    GET/manager/logs
      ✓ Request (371ms)
      ✓ Pagination (302ms)
      ✓ Retrieve all elements with limit=0 (374ms)
      ✓ Sort (292ms)
      ✓ SortField (312ms)
      ✓ Search (324ms)
      ✓ Filters: type_log (320ms)
      ✓ Filters: category (319ms)
      ✓ Filters: type_log and category (320ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (284ms)
    POST/manager/files
      ✓ Upload ossec.conf (314ms)
      ✓ Upload ossec.conf (overwrite=false) (260ms)
      ✓ Upload rules (new rule) (287ms)
      ✓ Upload rules (overwrite=true) (287ms)
      ✓ Upload rules (overwrite=false) (279ms)
      ✓ Upload decoder (overwrite=true) (308ms)
      ✓ Upload decoder (without overwrite parameter) (296ms)
      ✓ Upload list (overwrite=true) (278ms)
      ✓ Upload list (without overwrite parameter) (261ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
    GET/manager/files
      ✓ Request ossec.conf (501ms)
      ✓ Request rules (323ms)
      ✓ Request decoders (265ms)
      ✓ Request lists (290ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (256ms)
      ✓ Request file with empty path
    DELETE/manager/files
      ✓ Delete rules (526ms)
      ✓ Delete decoders (265ms)
      ✓ Delete CDB list (261ms)
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (1173ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (347ms)
    PUT/manager/restart
      ✓ Request (619ms)


  60 passing (18s)
```

Best regards,

Demetrio.