### PR TITLE
Windows wildcard support for Logcollector

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -189,7 +189,11 @@
 #define NEW_GLOB_FILE   "(1957): New file that matches the '%s' pattern: '%s'."
 #define DUP_FILE        "(1958): Log file '%s' is duplicated."
 #define FORGET_FILE     "(1959): File '%s' no longer exists."
+#ifndef WIN32
 #define FILE_LIMIT      "(1960): File limit has been reached (%d). Please reduce the number of files or increase \"logcollector.max_files\"."
+#else
+#define FILE_LIMIT      "(1960): File limit has been reached (%d)."
+#endif
 #define CURRENT_FILES   "(1961): Files being monitored: %i/%i."
 #define OPEN_ATTEMPT    "(1962): Unable to open file '%s'. Remaining attempts: %d"
 #define OPEN_UNABLE     "(1963): Unable to open file '%s'."

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -65,6 +65,9 @@ int LogCollectorConfig(const char *cfgfile)
         merror("Definition 'logcollector.max_files' must be lower than ('logcollector.rlimit_nofile' - 100).");
         return OS_SIZELIM;
     }
+#else
+    /* Limit files on Windows as file descriptors are shared */
+    maximum_files = WIN32_MAX_FILES;
 #endif
 
     if (ReadConfig(modules, cfgfile, &log_config, NULL) < 0) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -241,6 +241,15 @@ void LogCollectorStart()
             /* Mutexes are not previously initialized under Windows*/
             w_mutex_init(&current->mutex, &win_el_mutex_attr);
 #endif
+        } else {
+            /* On Windows we need to forward the seek for wildcard files */
+#ifdef WIN32
+            set_read(current, i, j);
+
+            if (current->fp) {
+                current->read(current, &r, 1);
+            }
+#endif
         }
 
         if (current->alias) {

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -18,6 +18,7 @@
 #define N_MIN_INPUT_THREADS 1
 #define N_OUPUT_THREADS 1
 #define OUTPUT_MIN_QUEUE_SIZE 128
+#define WIN32_MAX_FILES 200
 
 #include "shared.h"
 #include "config/localfile-config.h"


### PR DESCRIPTION
### Wildcard support

As the _logcollector_ daemon does support wildcards on Unix systems, this feature was missing on Windows operating systems. 

### Resolution

The function `check_pattern_expand` has been implemented using the following Windows functions:

- `FindFirstFile`
- `FindNextFile`

Wildcards supported are `*` and `?`. Related issue: https://github.com/wazuh/wazuh/issues/2898