### PR TITLE
Fix memory leak when extracting IP from Windows agents

### DIFF
--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -652,6 +652,11 @@ char *get_win_agent_ip(){
             }
         }
     }
+
+    if (pAddresses) {
+        win_free((HLOCAL)pAddresses);
+    }
+
     return agent_ip;
 }
 


### PR DESCRIPTION
The `pAddresses` structure was not being released after use.

After this PR I have not seen the memory leak and the manager still has the dynamic IP of the agent in `global.db`.

Tested in Windows Server 2016.