### PR TITLE
Get minor version in CentOS

### DIFF
--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -25,7 +25,9 @@ if [ -r "/etc/os-release" ]; then
     if [ "X$DIST_SUBVER" = "X" ]; then
         DIST_SUBVER="0"
     fi
-else
+fi
+
+if [ ! -r "/etc/os-release" ] || [ "$DIST_NAME" = "centos" ]; then
     # CentOS
     if [ -r "/etc/centos-release" ]; then
         DIST_NAME="centos"

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -308,6 +308,7 @@ os_info *get_unix_version()
     os_info *info;
 
     os_calloc(1,sizeof(os_info),info);
+    info->os_platform = NULL;
 
     // Try to open /etc/os-release
     os_release = fopen("/etc/os-release", "r");
@@ -345,8 +346,8 @@ os_info *get_unix_version()
         }
         fclose(os_release);
     }
-    // Linux old distributions without 'os-release' file
-    else {
+    // Linux old distributions without 'os-release' file or CentOS systems
+    if (!os_release || (info->os_platform && strcmp(info->os_platform, "centos") == 0)) {
         regex_t regexCompiled;
         regmatch_t match[2];
         int match_size;


### PR DESCRIPTION
This PR solves the issue: https://github.com/wazuh/wazuh/issues/2909

Previous version detected:
```
Version detected -> Linux |centos7.localdomain |3.10.0-957.5.1.el7.x86_64 |#1 SMP Fri Feb 1 14:54:57 UTC 2019 |x86_64 [CentOS Linux|centos: 7 (Core)] - Wazuh v3.9.0
```

New version detected:
```
Version detected -> Linux |centos7.localdomain |3.10.0-957.5.1.el7.x86_64 |#1 SMP Fri Feb 1 14:54:57 UTC 2019 |x86_64 [CentOS Linux|centos: 7.6] - Wazuh v3.9.0
```
```
Version detected -> Linux |centos6 |2.6.32-754.6.3.el6.x86_64 |#1 SMP Tue Oct 9 17:27:49 UTC 2018 |x86_64 [CentOS Linux|centos: 6.10] - Wazuh v3.9.0
```