### PR TITLE
Set "-" to the alerts severity when it is unknown

### DIFF
--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -142,7 +142,8 @@ const char *vu_severities[] = {
     "Critical",
     "None",
     "Negligible",
-    "Untriaged"
+    "Untriaged",
+    "-"
 };
 
 const char *wm_vuldet_set_oval(const char *os_name, const char *os_version, update_node **updates, distribution *agent_dist) {
@@ -2840,7 +2841,7 @@ int wm_vuldet_db_empty() {
 
 const char *wm_vuldet_get_unified_severity(char *severity) {
     if (!severity || strcasestr(severity, vu_severities[VU_UNKNOWN]) || strcasestr(severity, vu_severities[VU_UNTR])) {
-        return vu_severities[VU_UNKNOWN];
+        return vu_severities[VU_UNDEFINED_SEV];
     } else if (strcasestr(severity, vu_severities[VU_LOW]) || strcasestr(severity, vu_severities[VU_NEGL])) {
         return vu_severities[VU_LOW];
     } else if (strcasestr(severity, vu_severities[VU_MEDIUM]) || strcasestr(severity, vu_severities[VU_MODERATE])) {
@@ -2868,7 +2869,7 @@ const char *wm_vuldet_get_unified_severity(char *severity) {
             sev_count++;
         }
     }
-    return vu_severities[VU_UNKNOWN];
+    return vu_severities[VU_UNDEFINED_SEV];
 }
 
 #endif

--- a/src/wazuh_modules/wm_vuln_detector.h
+++ b/src/wazuh_modules/wm_vuln_detector.h
@@ -66,7 +66,8 @@ typedef enum vu_severity {
     VU_CRITICAL,
     VU_NONE,
     VU_NEGL,
-    VU_UNTR
+    VU_UNTR,
+    VU_UNDEFINED_SEV
 } vu_severity;
 
 typedef enum vu_logic {


### PR DESCRIPTION
This PR changes the `unknown` severity of the vulnerability-detector alerts to `-`.

## Alert before

``` JSON
{
    "vulnerability":{
        "cve":"CVE-2018-5407",
        "title":"CVE-2018-5407",
        "severity":"Unknown",
        "published":"2019-03-26",
        "state":"Fixed",
        "package":{
            "name":"openssl",
            "version":"1.1.0f-3+deb9u2",
            "condition":"less than 0:1.1.0j-1~deb9u1"
        },
        "reference":"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5407"
    }
}
```

## Alert now

``` JSON
{
    "vulnerability":{
        "cve":"CVE-2018-5407",
        "title":"CVE-2018-5407",
        "severity":"-",
        "published":"2019-03-26",
        "state":"Fixed",
        "package":{
            "name":"openssl",
            "version":"1.1.0f-3+deb9u2",
            "condition":"less than 0:1.1.0j-1~deb9u1"
        },
        "reference":"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5407"
    }
}
```


Tested with Debian 9 agents.