### PR TITLE
Validation for CDB list (get)

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -314,22 +314,43 @@ def upload_list(list_file, path):
 
 def get_file(path):
     """
-    Returns a file as dictionary.
+    Returns the content of a file.
     :param path: Relative path of file from origin
-    :return: File as string.
+    :return: Content file.
     """
 
-    file_path = join(common.ossec_path, path)
+    full_path = join(common.ossec_path, path)
+
+    # validate CDB lists files
+    if re.match(r'^etc/lists', path) and not validate_cdb_list(path):
+        raise WazuhException(1800, {'path': path})
 
     try:
-        with open(file_path) as f:
+        with open(full_path) as f:
             output = f.read()
     except IOError:
         raise WazuhException(1005)
-    except Exception:
-        raise WazuhException(1000)
 
     return output
+
+
+def validate_cdb_list(path):
+    """
+    Validates a CDB list
+    :param path: Relative path of file from origin
+    :return: Content file.
+    """
+    full_path = join(common.ossec_path, path)
+    regex_cdb = re.compile(r'^[^:]+:[^:]*$|^$')
+    try:
+        with open(full_path) as f:
+            for line in f:
+                if not re.match(regex_cdb, line):
+                    return False
+    except IOError:
+        raise WazuhException(1005)
+
+    return True
 
 
 def delete_file(path):


### PR DESCRIPTION
Hi team,

This PR closes #2920. I added functions for validating files (`XML` and `CDB` lists) if `validation` parameter is used in query:

```bash
# cat /var/ossec/etc/lists/new-list
:
cdb:list
# curl -u foo:bar -X GET "http://127.0.0.1:55000/manager/files?path=etc/lists/new-list&pretty"  
{
   "error": 0,
   "data": ":\ncdb:list\n" -----> LIST IS WRONG!!
}
# curl -u foo:bar -X GET "http://127.0.0.1:55000/manager/files?path=etc/lists/new-list&validation=true&pretty" 
{
   "error": 1800,
   "message": "Bad format in CDB list etc/lists/new-list"
}

```
```bash
# cat /var/ossec/etc/rules/local_rules.xml 
<!-- Local rules -->

<!-- Modify it at your will. -->
<!-- Copyright (C) 2015-2019, Wazuh Inc. -->

<!-- Example -->
<group name="local,syslog,sshd,">
<tag>
  <!--
  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
  -->
  <rule id="100001" level="5">
    <if_sid>5716</if_sid>
    <srcip>1.1.1.1</srcip>
    <description>sshd: authentication failed from IP 1.1.1.1.</description>
    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>

</group>

# curl -u foo:bar -X GET "http://127.0.0.1:55000/manager/files?path=etc/rules/local_rules.xml&pretty"                       
{
   "error": 0,
   "data": "<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n<tag>\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n  -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n" -----> XML IS WRONG!!! (<tag> is unclosed)
}
# curl -u foo:bar -X GET "http://127.0.0.1:55000/manager/files?path=etc/rules/local_rules.xml&validation=true&pretty"
{
   "error": 1113,
   "message": "XML syntax error"
}
```

```bash
# curl -u foo:bar -X GET "http://127.0.0.1:55000/cluster/master/files?path=etc/lists/new-list&validation=false&pretty"
{
   "error": 0,
   "data": ":\ncdb:list\n" ----> LIST IS WRONG!!!!
}
# curl -u foo:bar -X GET "http://127.0.0.1:55000/cluster/master/files?path=etc/lists/new-list&validation=true&pretty" 
{
   "error": 1800,
   "message": "Bad format in CDB list etc/lists/new-list"
}
```

```bash
# curl -u foo:bar -X GET "http://127.0.0.1:55000/cluster/master/files?path=etc/rules/local_rules.xml&validation=true&pretty"
{
   "error": 1113,
   "message": "XML syntax error"
}
# curl -u foo:bar -X GET "http://127.0.0.1:55000/cluster/master/files?path=etc/rules/local_rules.xml&validation=false&pretty"
{
   "error": 0,
   "data": "<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n<tag>\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n  -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n"
}

```

Best regards,

Demetrio.