### PR TITLE
Fix invalid interpretation of pending vulnerabilities

### DIFF
--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -1554,7 +1554,7 @@ int wm_vuldet_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_oval, 
                             double_condition = 0;
                         }
                     } else {
-                        if (strstr(node[i]->values[j], pending_state)) {
+                        if (wstr_end(node[i]->values[j], pending_state)) {
                             parsed_oval->vulnerabilities->pending = 1;
                         } else {
                             parsed_oval->vulnerabilities->pending = 0;


### PR DESCRIPTION
This PR fixes an invalid interpretation of vulnerabilities that have not yet been confirmed, which generated alerts without verifying the version of the packages. The vulnerability has not been confirmed only if its internal reference code ends with `tst:10`, not if it contains this string.

This check affects the vulnerability reporting of Ubuntu and Debian feeds whose internal code contains the string `tst:10`.

If an alert is affected by this bug, its condition field will contain `Pending confirmation`. This condition by itself is not a false positive.

Related PR https://github.com/wazuh/wazuh/pull/2301.