### PR TITLE
Avoid giving an error when one of the file permissions cannot be extracted

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1043,6 +1043,7 @@ end:
 
 int copy_ace_info(void *ace, char *perm, int perm_size) {
     SID *sid;
+    char *sid_str = NULL;
     char *account_name = NULL;
     char *domain_name = NULL;
     int mask;
@@ -1074,18 +1075,20 @@ int copy_ace_info(void *ace, char *perm, int perm_size) {
 
     if (error = w_get_account_info(sid, &account_name, &domain_name), error) {
         mdebug2("No information could be extracted from the account linked to the SID. Error: %d.", error);
-        /*if (!ConvertSidToStringSid(sid, &sid_str)) {
+        if (!ConvertSidToStringSid(sid, &sid_str)) {
             mdebug2("Could not extract the SID.");
             goto end;
-        }*/
-        goto end;
+        }
     }
 
     if (written + 1 < perm_size) {
-        written = snprintf(perm, perm_size, "|%s,%d,%d", account_name, ace_type, mask);
+        written = snprintf(perm, perm_size, "|%s,%d,%d", sid_str ? sid_str : account_name, ace_type, mask);
     }
 
 end:
+    if (sid_str) {
+        LocalFree(sid_str);
+    }
     free(account_name);
     free(domain_name);
     return written;

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1032,10 +1032,7 @@ int w_get_file_permissions(const char *file_path, char *permissions, int perm_si
                 continue;
             }
         }
-        *permissions = '\0';
-        retval = -3;
-        mdebug1("The parameters of ACE number %d could not be extracted. %d bytes remaining.", i, perm_size);
-        goto end;
+        mdebug1("The parameters of ACE number %d from '%s' could not be extracted. %d bytes remaining.", i, file_path, perm_size);
     }
 
     mdebug2("The ACL extracted from '%s' is [%s].", file_path, permissions);
@@ -1074,8 +1071,13 @@ int copy_ace_info(void *ace, char *perm, int perm_size) {
 		return 0;
 	}
 
+
     if (error = w_get_account_info(sid, &account_name, &domain_name), error) {
         mdebug2("No information could be extracted from the account linked to the SID. Error: %d.", error);
+        /*if (!ConvertSidToStringSid(sid, &sid_str)) {
+            mdebug2("Could not extract the SID.");
+            goto end;
+        }*/
         goto end;
     }
 


### PR DESCRIPTION
When a file has permissions for an account whose name is unknown, this error appeared:

> ossec-agent: ERROR: It was not possible to extract the permissions of 'c:\file_path'. Error: -3.

![imagen](https://user-images.githubusercontent.com/20266121/55072761-3f59bd00-508c-11e9-9086-b96d398aa5c8.png)

Since 463857e0ca0770311e4ff78b005e370c6f4a9027, if the permission of a file cannot be extracted, it ignores it and shows the rest of the permissions.

``` JSON

{
    "syscheck":{
        "path":"c:\\windows\\sysnative\\drivers\\wd\\wdboot.sys",
        "size_after":"46680",
        "win_perm_after":[
            {
                "name":"ALL APPLICATION PACKAGES",
                "allowed":[
                    "READ_CONTROL",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_READ_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES"
                ]
            },
            {
                "name":"Users",
                "allowed":[
                    "READ_CONTROL",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_READ_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES"
                ]
            },
            {
                "name":"TrustedInstaller",
                "allowed":[
                    "DELETE",
                    "READ_CONTROL",
                    "WRITE_DAC",
                    "WRITE_OWNER",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_WRITE_DATA",
                    "FILE_APPEND_DATA",
                    "FILE_READ_EA",
                    "FILE_WRITE_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES",
                    "FILE_WRITE_ATTRIBUTES"
                ]
            },
            {
                "name":"SYSTEM",
                "allowed":[
                    "DELETE",
                    "READ_CONTROL",
                    "WRITE_DAC",
                    "WRITE_OWNER",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_WRITE_DATA",
                    "FILE_APPEND_DATA",
                    "FILE_READ_EA",
                    "FILE_WRITE_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES",
                    "FILE_WRITE_ATTRIBUTES"
                ]
            },
            {
                "name":"Administrators",
                "allowed":[
                    "DELETE",
                    "READ_CONTROL",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_WRITE_DATA",
                    "FILE_APPEND_DATA",
                    "FILE_READ_EA",
                    "FILE_WRITE_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES",
                    "FILE_WRITE_ATTRIBUTES"
                ]
            }
        ],
        "uid_after":"S-1-5-18",
        "md5_after":"e7e16778c8440bb459c94b5ad8282491",
        "sha1_after":"263274388b2e3f9adbcdf42b8eaadbb8cb5689b6",
        "sha256_after":"728b2208884b4244e3481ddd82f9b353fc27dac77488dbc8224ab1630616676a",
        "attrs_after":[
            "ARCHIVE"
        ],
        "uname_after":"SYSTEM",
        "mtime_after":"2018-12-12T09:36:00",
        "event":"added"
    }
}

```

Since 92e3c994def63148be6b7213bfba6ddf95c844d6, for this type of permissions the SID of the applied account will be shown.

``` JSON
{
    "syscheck":{
        "path":"c:\\windows\\sysnative\\drivers\\wd\\wdboot.sys",
        "size_after":"46680",
        "win_perm_after":[
            {
                "name":"ALL APPLICATION PACKAGES",
                "allowed":[
                    "READ_CONTROL",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_READ_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES"
                ]
            },
            {
                "name":"S-1-15-3-1024-3153509613-960666767-3724611135-2725662640-12138253-543910227-1950414635-4190290187",
                "allowed":[
                    "READ_CONTROL",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_READ_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES"
                ]
            },
            {
                "name":"Users",
                "allowed":[
                    "READ_CONTROL",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_READ_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES"
                ]
            },
            {
                "name":"TrustedInstaller",
                "allowed":[
                    "DELETE",
                    "READ_CONTROL",
                    "WRITE_DAC",
                    "WRITE_OWNER",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_WRITE_DATA",
                    "FILE_APPEND_DATA",
                    "FILE_READ_EA",
                    "FILE_WRITE_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES",
                    "FILE_WRITE_ATTRIBUTES"
                ]
            },
            {
                "name":"SYSTEM",
                "allowed":[
                    "DELETE",
                    "READ_CONTROL",
                    "WRITE_DAC",
                    "WRITE_OWNER",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_WRITE_DATA",
                    "FILE_APPEND_DATA",
                    "FILE_READ_EA",
                    "FILE_WRITE_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES",
                    "FILE_WRITE_ATTRIBUTES"
                ]
            },
            {
                "name":"Administrators",
                "allowed":[
                    "DELETE",
                    "READ_CONTROL",
                    "SYNCHRONIZE",
                    "FILE_READ_DATA",
                    "FILE_WRITE_DATA",
                    "FILE_APPEND_DATA",
                    "FILE_READ_EA",
                    "FILE_WRITE_EA",
                    "FILE_EXECUTE",
                    "FILE_READ_ATTRIBUTES",
                    "FILE_WRITE_ATTRIBUTES"
                ]
            }
        ],
        "uid_after":"S-1-5-18",
        "md5_after":"e7e16778c8440bb459c94b5ad8282491",
        "sha1_after":"263274388b2e3f9adbcdf42b8eaadbb8cb5689b6",
        "sha256_after":"728b2208884b4244e3481ddd82f9b353fc27dac77488dbc8224ab1630616676a",
        "attrs_after":[
            "ARCHIVE"
        ],
        "uname_after":"SYSTEM",
        "mtime_after":"2018-12-12T09:36:00",
        "event":"added"
    }
}
```

It affects Wazuh 3.8.X.