### PR TITLE
A more descriptive message for SSL error when agent-auth fails

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -343,10 +343,11 @@ int main(int argc, char **argv)
     sbio = BIO_new_socket(sock, BIO_NOCLOSE);
     SSL_set_bio(ssl, sbio, sbio);
 
+    ERR_clear_error();
     ret = SSL_connect(ssl);
     if (ret <= 0) {
-        ERR_print_errors_fp(stderr);
-        merror("SSL error (%d). Exiting.", ret);
+        merror("SSL error (%d). Connection refused by the manager. Maybe the port specified is incorrect. Exiting.", SSL_get_error(ssl, ret));
+        ERR_print_errors_fp(stderr);  // This function empties the error queue
         free(buf);
         exit(1);
     }


### PR DESCRIPTION
Hi, Team,

This PR should fix the issue https://github.com/wazuh/wazuh/issues/2905.

Problem description
--
When `remoted` is configured to use protocol `tcp` in the manager's `ossec.conf`:
```
  <remote>
    <connection>secure</connection>
    <port>1514</port>
    <protocol>tcp</protocol>
    <queue_size>131072</queue_size>
  </remote>
```
registering the agent on the `remoted` port (by accident, by error, for testing purposes) returns a very generic message:
```
# /var/ossec/bin/agent-auth -m 172.16.1.2 -p 1514 -P TopSecret
2019/03/25 18:18:04 agent-auth: INFO: Started (pid: 5408).
2019/03/25 18:18:04 agent-auth: ERROR: SSL error (-1). Exiting.
```

Problem explanation
--
The code in `src/os_auth/main-client.c` in v3.9 reads:
```
333     /* Connect via TCP */
334     sock = OS_ConnectTCP(port, ipaddress, 0);
335     if (sock <= 0) {
336         merror("Unable to connect to %s:%d", ipaddress, port);
337         free(buf);
338         exit(1);
339     }
340 
341     /* Connect the SSL socket */
342     ssl = SSL_new(ctx);
343     sbio = BIO_new_socket(sock, BIO_NOCLOSE);
344     SSL_set_bio(ssl, sbio, sbio);
345 
346     ret = SSL_connect(ssl);
347     if (ret <= 0) {
348         ERR_print_errors_fp(stderr);
349         merror("SSL error (%d). Exiting.", ret);
350         free(buf);
351         exit(1);
352     }
```
1. `OS_ConnectTCP()` (line 334) returns a valid socket because the port is open.
2. `SSL_Connect()` (line 346) returns `-1` because `remoted` can't handle the message. On the manager, `ossec.log` gets a warning message such as this one:
```
2019/03/27 12:58:39 ossec-remoted: WARNING: Too big message size from 192.168.56.114 [12].
```



Solution
--
As decribed in a comment in the issue (https://github.com/wazuh/wazuh/issues/2905#issuecomment-477142922), there is no easy way to get a descriptive message by just using the error functions provided by SSL.
So the easiest solution is to change the error message to something like:
```
SSL error (<SSL error code>). Connection refused by the manager. Maybe the port specified is incorrect. Exiting.
```

Testing
--
See below.
