### PR TITLE
Update ossec.log parsing from the Python framework

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -58,7 +58,7 @@ def status() -> Dict:
 
 
 def __get_ossec_log_fields(log):
-    regex_category = re.compile(r"^(\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d)\s(\S+):\s(\S+):\s(.*)$")
+    regex_category = re.compile(r"^(\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d)\s(.*):\s(DEBUG|INFO|CRITICAL|ERROR|WARNING):\s(.*)$")
 
     match = re.search(regex_category, log)
 
@@ -71,8 +71,6 @@ def __get_ossec_log_fields(log):
         if "rootcheck" in category:  # Unify rootcheck category
             category = "ossec-rootcheck"
 
-        if "(" in category:  # Remove ()
-            category = re.sub(r"\(\d\d\d\d\)", "", category)
     else:
         return None
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -58,7 +58,7 @@ def status() -> Dict:
 
 
 def __get_ossec_log_fields(log):
-    regex_category = re.compile(r"^(\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d)\s(.*):\s(DEBUG|INFO|CRITICAL|ERROR|WARNING):\s(.*)$")
+    regex_category = re.compile(r"^(\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d)\s(\S+)(?:\[.*)?:\s(DEBUG|INFO|CRITICAL|ERROR|WARNING):(.*)$")
 
     match = re.search(regex_category, log)
 


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh/issues/2767.

Unit tests done:
```
wazuh/tests/test_manager.py::test_ossec_log[all-all-6] PASSED                                                                                                                                                                                                         [ 64%]
wazuh/tests/test_manager.py::test_ossec_log[wazuh-modulesd:database-all-2] PASSED                                                                                                                                                                                     [ 67%]
wazuh/tests/test_manager.py::test_ossec_log[wazuh-modulesd:syscollector-all-1] PASSED                                                                                                                                                                                 [ 71%]
wazuh/tests/test_manager.py::test_ossec_log[wazuh-modulesd:aws-s3-all-1] PASSED                                                                                                                                                                                       [ 75%]
wazuh/tests/test_manager.py::test_ossec_log[ossec-execd-all-1] PASSED                                                                                                                                                                                                 [ 78%]
wazuh/tests/test_manager.py::test_ossec_log[ossec-csyslogd-all-1] PASSED                                                                                                                                                                                              [ 82%]
wazuh/tests/test_manager.py::test_ossec_log[random-all-0] PASSED                                                                                                                                                                                                      [ 85%]
wazuh/tests/test_manager.py::test_ossec_log[all-info-2] PASSED                                                                                                                                                                                                        [ 89%]
wazuh/tests/test_manager.py::test_ossec_log[all-error-2] PASSED                                                                                                                                                                                                       [ 92%]
wazuh/tests/test_manager.py::test_ossec_log[all-debug-2] PASSED                                                                                                                                                                                                       [ 96%]
wazuh/tests/test_manager.py::test_ossec_log[all-random-0] PASSED                                                                                                                                                                                                      [100%]
```

Best regards,
Marta