### PR TITLE
Fix for getting SCA configuration

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -96,6 +96,10 @@ conf_sections = {
     'labels': {
         'type': 'duplicate',
         'list_options': ['label']
+    },
+    'sca': {
+       'type': 'merge',
+       'list_options': ['policies']
     }
 }
 
@@ -185,6 +189,8 @@ def _read_option(section_name, opt):
         opt_value = {'value': opt.text}
         for a in opt.attrib:
             opt_value[a] = opt.attrib[a]
+    elif section_name == 'sca' and opt_name == 'policies':
+        opt_value = [child.text for child in opt]
     else:
         if opt.attrib:
             opt_value = {}

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -183,14 +183,13 @@ def _read_option(section_name, opt):
             json_path = json_attribs.copy()
             json_path['path'] = path.strip()
             opt_value.append(json_path)
-    elif section_name == 'cluster' and opt_name == 'nodes':
+    elif (section_name == 'cluster' and opt_name == 'nodes') or \
+        (section_name == 'sca' and opt_name == 'policies'):
         opt_value = [child.text for child in opt]
     elif section_name == 'labels' and opt_name == 'label':
         opt_value = {'value': opt.text}
         for a in opt.attrib:
             opt_value[a] = opt.attrib[a]
-    elif section_name == 'sca' and opt_name == 'policies':
-        opt_value = [child.text for child in opt]
     else:
         if opt.attrib:
             opt_value = {}


### PR DESCRIPTION
Hi team,

This PR closes #2939. I made a fix for getting `SCA` configuration properly:

###### SCA configuration

```bash
  <sca>
    <enabled>yes</enabled>
    <scan_on_start>yes</scan_on_start>
    <interval>12h</interval>
    <skip_nfs>yes</skip_nfs>

    <policies>
      <policy>cis_debian_linux_rcl.yml</policy>
      <policy>system_audit_rcl.yml</policy>
      <policy>system_audit_ssh.yml</policy>
    </policies>
  </sca>
```

###### before

```bash
# curl -u foo:bar "http://localhost:55000/manager/configuration?pretty&section=sca&wait_for_complete=false"
{
   "error": 0,
   "data": {
      "enabled": "yes",
      "scan_on_start": "yes",
      "interval": "1m",
      "skip_nfs": "yes",
      "policies": [
         "\n      ",
         "\n      "
      ]
   }
}
```

###### after
```bash
# curl -u foo:bar "http://localhost:55000/manager/configuration?pretty=true&section=sca&wait_for_complete=false"
{
   "error": 0,
   "data": {
      "enabled": "yes",
      "scan_on_start": "yes",
      "interval": "12h",
      "skip_nfs": "yes",
      "policies": [
         "cis_debian_linux_rcl.yml",
         "system_audit_rcl.yml",
         "system_audit_ssh.yml"
      ]
   }
}
```

#### Unit tests

```bash
# /var/ossec/framework/python/bin/python3 -m pytest framework/wazuh
======================================================== test session starts ========================================================
platform linux -- Python 3.7.2, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /root/wazuh/framework, inifile:
collected 175 items                                                                                                                 

framework/wazuh/cluster/tests/test_cluster.py ...............                                                                 [  8%]
framework/wazuh/cluster/tests/test_worker.py ...........                                                                      [ 14%]
framework/wazuh/tests/test_agent.py .........................                                                                 [ 29%]
framework/wazuh/tests/test_cdb_list.py ...........                                                                            [ 35%]
framework/wazuh/tests/test_decoders.py ........................................                                               [ 58%]
framework/wazuh/tests/test_group.py ........                                                                                  [ 62%]
framework/wazuh/tests/test_manager.py .................                                                                       [ 72%]
framework/wazuh/tests/test_rules.py ........................................                                                  [ 95%]
framework/wazuh/tests/test_security_configuration_assessment.py .....                                                         [ 98%]
framework/wazuh/tests/test_wdb.py ...                                                                                         [100%]

============================================= 175 passed, 140 warnings in 2.11 seconds ==============================================
```


Best regards,

Demetrio.