### PR TITLE
Fix pytest warnings

### DIFF
--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -202,7 +202,7 @@ class Decoder:
 
             root = load_wazuh_xml(os.path.join(common.ossec_path, decoder_path, decoder_file))
 
-            for xml_decoder in root.getchildren():
+            for xml_decoder in list(root):
                 # New decoder
                 if xml_decoder.tag.lower() == "decoder":
                     decoder          = Decoder()

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -217,7 +217,7 @@ class Decoder:
                         if k != 'name':
                             decoder.details[k] = xml_decoder.attrib[k]
 
-                    for xml_decoder_tags in xml_decoder.getchildren():
+                    for xml_decoder_tags in list(xml_decoder):
                         decoder.add_detail(xml_decoder_tags.tag.lower(), xml_decoder_tags.text)
 
                     decoders.append(decoder)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -382,10 +382,10 @@ class Rule:
 
             root = load_wazuh_xml(os.path.join(common.ossec_path, rule_path, rule_file))
 
-            for xml_group in root.getchildren():
+            for xml_group in list(root):
                 if xml_group.tag.lower() == "group":
                     general_groups = xml_group.attrib['name'].split(',')
-                    for xml_rule in xml_group.getchildren():
+                    for xml_rule in list(xml_group):
                         # New rule
                         if xml_rule.tag.lower() == "rule":
                             groups = []
@@ -400,7 +400,7 @@ class Rule:
                                 if k != 'id' and k != 'level':
                                     rule.details[k] = xml_rule.attrib[k]
 
-                            for xml_rule_tags in xml_rule.getchildren():
+                            for xml_rule_tags in list(xml_rule):
                                 tag = xml_rule_tags.tag.lower()
                                 value = xml_rule_tags.text
                                 if value == None:


### PR DESCRIPTION
Hi team,

This PR closes #2733. I replaced `getchildren` method by `list(elem)` for avoid warning when we execute our unit tests:

```bash
# /var/ossec/framework/python/bin/python3 -m pytest framework/wazuh
======================================================== test session starts ========================================================
platform linux -- Python 3.7.2, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /root/wazuh/framework, inifile:
collected 186 items                                                                                                                 

framework/wazuh/cluster/tests/test_cluster.py ...............                                                                 [  8%]
framework/wazuh/cluster/tests/test_worker.py ...........                                                                      [ 13%]
framework/wazuh/tests/test_agent.py .........................                                                                 [ 27%]
framework/wazuh/tests/test_cdb_list.py ...........                                                                            [ 33%]
framework/wazuh/tests/test_decoders.py ........................................                                               [ 54%]
framework/wazuh/tests/test_group.py ........                                                                                  [ 59%]
framework/wazuh/tests/test_manager.py ............................                                                            [ 74%]
framework/wazuh/tests/test_rules.py ........................................                                                  [ 95%]
framework/wazuh/tests/test_security_configuration_assessment.py .....                                                         [ 98%]
framework/wazuh/tests/test_wdb.py ...                                                                                         [100%]

==================================================== 186 passed in 2.79 seconds =====================================================
```

Best regards,

Demetrio.