### PR TITLE
Fix memory leak when adding multi-groups to hash table

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -532,7 +532,7 @@ static void c_files()
     char *key = NULL;
     char *data = NULL;
     os_sha256 multi_group_hash;
-    char _hash[9] = {0};
+    char * _hash = NULL;
 
     mdebug2("Updating shared files sums.");
 
@@ -693,8 +693,12 @@ static void c_files()
             }
 
             OS_SHA256_String(groups_info,multi_group_hash);
-            strncpy(_hash,multi_group_hash,8);
-            if(OSHash_Add_ex(m_hash, groups_info, strdup(_hash)) != 2){
+
+            os_calloc(9, sizeof(char), _hash);
+            snprintf(_hash, 8, "%s", multi_group_hash);
+
+            if(OSHash_Add_ex(m_hash, groups_info, _hash) != 2){
+                os_free(_hash);
                 mdebug2("Couldn't add multigroup '%s' to hash table 'm_hash'", groups_info);
             }
         }


### PR DESCRIPTION
Valgrind report shows us a memory leak when adding a multi-group to the hash table at:

https://github.com/wazuh/wazuh/blob/3.9/src/remoted/manager.c#L697

```
==100639== 18 bytes in 2 blocks are definitely lost in loss record 20 of 71
==100639==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==100639==    by 0x5B1C9B9: strdup (strdup.c:42)
==100639==    by 0x113D82: c_files (manager.c:697)
==100639==    by 0x115BBC: update_shared_files (manager.c:1160)
==100639==    by 0x58676DA: start_thread (pthread_create.c:463)
==100639==    by 0x5BA088E: clone (clone.S:95)
```

It is visible since this PR https://github.com/wazuh/wazuh/pull/2440 which was merged at 3.9, before that PR, the hash table was cleaned each iteration. After that, the cleaning of the hash table happens once a day, defined by `remoted.group_data_flush`.

Here we can see the valgrind report after the fix:

```
==54489== LEAK SUMMARY:
==54489==    definitely lost: 0 bytes in 0 blocks
==54489==    indirectly lost: 0 bytes in 0 blocks
==54489==      possibly lost: 5,168 bytes in 19 blocks
==54489==    still reachable: 1,115,952 bytes in 218 blocks
==54489==         suppressed: 0 bytes in 0 blocks
```