### PR TITLE
Fix the remoted deadlock that causes the keyentries structure can not be updated

### DIFF
--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -85,6 +85,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
 
     /* If we don't have the agent id, ignore it */
     if (keys.keyentries[key_id]->rcvd < (time(0) - DISCON_TIME)) {
+        key_unlock();
         mwarn(SEND_DISCON, keys.keyentries[key_id]->id);
         return (-1);
     }


### PR DESCRIPTION
## Related issue 
https://github.com/wazuh/wazuh/issues/2954

It has been verified that adding the call to `key_unlock()` and causing in the same case of use that in the issue previously indicated, the blocking condition is not entered. 
As you can see in the following messages the agent registered after the message of:

`Sending message to disconnected agent '002'.` 

The agent connects and the `keyentries` structure is updated correctly.
```
ossec-remoted[18061] manager.c:945 at read_controlmsg(): WARNING: (1246): Unable to send file 'merged.mg' to agent ID '002'.
ossec-remoted[18061] sendmsg.c:73 at send_msg(): WARNING: (1245): Sending message to disconnected agent '002'.
ossec-remoted[18061] sendmsg.c:73 at send_msg(): WARNING: (1245): Sending message to disconnected agent '002'.
ossec-remoted[18061] manager.c:932 at read_controlmsg(): DEBUG: Sending file 'default/merged.mg' to agent '002'.
ossec-remoted[18061] sendmsg.c:73 at send_msg(): WARNING: (1245): Sending message to disconnected agent '002'.
ossec-remoted[18061] sendmsg.c:73 at send_msg(): WARNING: (1245): Sending message to disconnected agent '002'.
ossec-remoted[18061] manager.c:945 at read_controlmsg(): WARNING: (1246): Unable to send file 'merged.mg' to agent ID '002'.
ossec-remoted[18061] secure.c:323 at HandleSecureMessage(): WARNING: (1213): Message from '10.0.0.51' not allowed.
ossec-remoted[18061] manager.c:932 at read_controlmsg(): DEBUG: Sending file 'default/merged.mg' to agent '002'.
ossec-remoted[18061] secure.c:323 at HandleSecureMessage(): WARNING: (1213): Message from '10.0.0.51' not allowed.
ossec-remoted[18061] secure.c:323 at HandleSecureMessage(): WARNING: (1213): Message from '10.0.0.51' not allowed.
ossec-remoted[18061] keys.c:409 at OS_UpdateKeys(): DEBUG: Reloading keys
ossec-remoted[18061] keys.c:419 at OS_UpdateKeys(): INFO: (1410): Reading authentication keys file.
ossec-remoted[18061] msgs.c:79 at OS_StartCounter(): DEBUG: OS_StartCounter: keysize: 2
ossec-remoted[18061] msgs.c:135 at OS_StartCounter(): DEBUG: Assigning counter for agent agentubuntu18: '0:4014'.
ossec-remoted[18061] msgs.c:130 at OS_StartCounter(): DEBUG: Assigning sender counter: 0:3750
ossec-remoted[18061] keys.c:431 at OS_UpdateKeys(): DEBUG: Key reloading completed
ossec-remoted[18061] sendmsg.c:45 at check_keyupdate(): INFO: (1409): Authentication file changed. Updating.
``` 
