### PR TITLE
accept ] as a terminal prompt character

### DIFF
--- a/src/agentlessd/scripts/sshlogin.exp
+++ b/src/agentlessd/scripts/sshlogin.exp
@@ -33,4 +33,7 @@ expect {
     "*>" {
         send_user "\nINFO: Started.\n"
     }
+    "*]" {
+        send_user "\nINFO: Started.\n"
+    }
 }


### PR DESCRIPTION
The agentless capability relies on detecting the last character of the prompt to determine that it has successfully logged on to the agentless system via SSH.

VMWare ESXi 6.5 devices (and very likely other systems as well) do not add a `$`, `#` or `>` symbol after the box containing the user and host information but otherwise their initial prompt looks just like: 
`[root@localhost:~ ] `

In order to be able to use the agentless capability with this type of terminal, another case was added in this PR to the already existing allowed characters, with the character `]`.