### PR TITLE
Improve cluster exception "Malformed agent-info.merged file"

### DIFF
--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -457,7 +457,8 @@ def unmerge_agent_info(merge_type, path_file, filename):
                 st_size, name, st_mtime = header[:-1].split(' ', 2)
                 st_size = int(st_size)
             except ValueError as e:
-                logger.error("Malformed agent-info.merged file ({}). Parsed line: {}".format(e, header))
+                logger.warning(f"Malformed agent-info.merged file ({e}). Parsed line: {header}. "
+                               f"Some agent statuses won't be synced")
                 break
 
             # read data

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -447,7 +447,7 @@ def unmerge_agent_info(merge_type, path_file, filename):
     dst_agent_info_path = os.path.join("queue", merge_type)
 
     bytes_read = 0
-    total_bytes = os.stat(src_agent_info_path).st_size
+    total_bytes = stat(src_agent_info_path).st_size
     with open(src_agent_info_path, 'rb') as src_f:
         while bytes_read < total_bytes:
             # read header

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -456,8 +456,9 @@ def unmerge_agent_info(merge_type, path_file, filename):
             try:
                 st_size, name, st_mtime = header[:-1].split(' ', 2)
                 st_size = int(st_size)
-            except ValueError:
-                raise Exception("Malformed agent-info.merged file")
+            except ValueError as e:
+                logger.error("Malformed agent-info.merged file ({}). Parsed line: {}".format(e, header))
+                break
 
             # read data
             data = src_f.read(st_size)

--- a/framework/wazuh/cluster/tests/test_cluster.py
+++ b/framework/wazuh/cluster/tests/test_cluster.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
-
-from unittest.mock import patch
+import time
+from datetime import datetime
+from unittest.mock import patch, mock_open
 from wazuh.exception import WazuhException
 from wazuh.cluster import cluster
 import pytest
@@ -94,3 +95,43 @@ def test_checking_configuration(read_config):
         with pytest.raises(WazuhException, match=r'.* 3004 .*'):
             configuration = cluster.read_config()
             cluster.check_cluster_config(configuration)
+
+
+agent_info = """Linux |agent1 |3.10.0-862.el7.x86_64 |#1 SMP Fri Apr 20 16:44:24 UTC 2018 |x86_64 [CentOS Linux|centos: 7 (Core)] - Wazuh v3.7.2 / d10d46b48c280384e8773a5fa24ecacb
+5b458d5fa953a391de1130a2625f3df2 merged.mg
+
+
+#"manager_hostname":centos
+#"node_name":worker-1
+"""
+
+
+@patch('os.listdir', return_value=['agent1-any', 'agent2-any'])
+@patch('wazuh.cluster.cluster.stat')
+def test_merge_agent_info(stat_mock, listdir_mock):
+    """
+    Tests merge agent info function
+    """
+    stat_mock.return_value.st_mtime = time.time()
+    stat_mock.return_value.st_size = len(agent_info)
+
+    with patch('builtins.open', mock_open(read_data=agent_info)) as m:
+        cluster.merge_agent_info('agent-info', 'worker1')
+        m.assert_any_call('/var/ossec/queue/cluster/worker1/agent-info.merged', 'w')
+        m.assert_any_call('/var/ossec/queue/agent-info/agent1-any', 'r')
+        m.assert_any_call('/var/ossec/queue/agent-info/agent2-any', 'r')
+        handle = m()
+        handle.write.assert_any_call(f'{len(agent_info)} agent1-any '
+                                     f'{datetime.utcfromtimestamp(stat_mock.return_value.st_mtime)}\n{agent_info}')
+
+
+@pytest.mark.parametrize('agent_info, exception', [
+    (f"258 agent1-any 2019-03-29 14:57:29.610934\n{agent_info}".encode(), None),
+    (f"2i58 agent1-any 2019-03-29 14:57:29.610934\n{agent_info}".encode(), ValueError)
+])
+@patch('wazuh.cluster.cluster.stat')
+def test_unmerge_agent_info(stat_mock, agent_info, exception):
+    stat_mock.return_value.st_size = len(agent_info)
+    with patch('builtins.open', mock_open(read_data=agent_info)) as m:
+        agent_infos = list(cluster.unmerge_agent_info('agent-info', '/random/path', 'agent-info.merged'))
+        assert len(agent_infos) == (1 if exception is None else 0)


### PR DESCRIPTION
Hello team,

This PR closes #2743.

Now the error shows the line that failed to be parsed and, instead of raising an exception it just breaks the loop but still returns the elements that were successfully parsed.

Best regards,
Marta