### PR TITLE
Fixing broken pipe error when manager closes TCP connection

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -160,6 +160,11 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     os_delwait();
     update_status(GA_STATUS_ACTIVE);
 
+    // Ignore SIGPIPE signal to prevent the process from crashing
+    struct sigaction act;
+    act.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &act, NULL);
+
     /* Send integrity message for agent configs */
     intcheck_file(OSSECCONF, dir);
     intcheck_file(OSSEC_DEFINES, dir);

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -46,7 +46,11 @@ int send_msg(const char *msg, ssize_t msg_length)
         error = WSAGetLastError();
         merror(SEND_ERROR, "server", win_strerror(error));
 #else
-        merror(SEND_ERROR, "server", strerror(error));
+        if(error == EPIPE) {
+            mdebug2(TCP_EPIPE);
+        } else {
+            merror(SEND_ERROR, "server", strerror(error));
+        }
 #endif
         sleep(1);
     }

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -100,6 +100,7 @@
 #define SEND_DISCON     "(1245): Sending message to disconnected agent '%s'."
 #define SHARED_ERROR    "(1246): Unable to send file '%s' to agent ID '%s'."
 #define TCP_NOT_SUPPORT "(1247): TCP not supported for this operating system."
+#define TCP_EPIPE       "(1248): Unable to send message. Connection has been closed by remote server."
 
 #define MAILQ_ERROR     "(1221): No Mail queue at %s"
 #define IMSG_ERROR      "(1222): Invalid msg: %s"

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -57,7 +57,7 @@ static int OS_Bindport(u_int16_t _port, unsigned int _proto, const char *_ip, in
     if (_proto == IPPROTO_UDP) {
 #ifndef WIN32
         if ((ossock = socket(ipv6 == 1 ? PF_INET6 : PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
-#else 
+#else
         if ((ossock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
 #endif
             return OS_SOCKTERR;
@@ -258,7 +258,7 @@ static int OS_Connect(u_int16_t _port, unsigned int protocol, const char *_ip, i
     } else if (protocol == IPPROTO_UDP) {
 #ifndef WIN32
         if ((ossock = socket(ipv6 == 1 ? PF_INET6 : PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
-#else 
+#else
         if ((ossock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
 #endif
             return (OS_SOCKTERR);
@@ -573,8 +573,11 @@ int OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
     os_malloc(bufsz, buffer);
     *(uint32_t *)buffer = wnet_order(size);
     memcpy(buffer + sizeof(uint32_t), msg, size);
+#ifdef WIN32
     retval = send(sock, buffer, bufsz, 0) == (ssize_t)bufsz ? 0 : OS_SOCKTERR;
-
+#else
+    retval = send(sock, buffer, bufsz, MSG_NOSIGNAL) == (ssize_t)bufsz ? 0 : OS_SOCKTERR;
+#endif
     free(buffer);
     return retval;
 }

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -573,11 +573,7 @@ int OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
     os_malloc(bufsz, buffer);
     *(uint32_t *)buffer = wnet_order(size);
     memcpy(buffer + sizeof(uint32_t), msg, size);
-#ifdef WIN32
     retval = send(sock, buffer, bufsz, 0) == (ssize_t)bufsz ? 0 : OS_SOCKTERR;
-#else
-    retval = send(sock, buffer, bufsz, MSG_NOSIGNAL) == (ssize_t)bufsz ? 0 : OS_SOCKTERR;
-#endif
     free(buffer);
     return retval;
 }


### PR DESCRIPTION
## Related issue
#2875 

We've changed the way the `SIGPIPE` signal is handled. 

Before this fix, if the `wazuh-manager` closed a _TCP_ connection for the `wazuh-agent`, it received the `SIGPIPE` signal and the process exited. 

Now, this behavior is handled properly and not only doesn't exit, but it also doesn't show the _Broken pipe_ error that could mislead some users.

Best regards,
Cerv1.