### PR TITLE
Prevent agent removal process to fail and leave useless data

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -450,17 +450,17 @@ class Agent:
 
         try:
             agent_found = False
-            with open(common.client_keys) as f_k, open(f_keys_temp, 'w') as f_tmp:
-                for line in f_k.readlines():
+            with open(common.client_keys) as client_keys, open(f_keys_temp, 'w') as client_keys_tmp:
+                for line in client_keys.readlines():
                     id, name, ip, key = line.strip().split(' ')  # 0 -> id, 1 -> name, 2 -> ip, 3 -> key
 
                     if self.id == id and name[0] not in ('#!'):
                         if not purge:
-                            f_tmp.write('{0} !{1} {2} {3}\n'.format(id, name, ip, key))
+                            client_keys_tmp.write('{0} !{1} {2} {3}\n'.format(id, name, ip, key))
 
                         agent_found = True
                     else:
-                        f_tmp.write(line)
+                        client_keys_tmp.write(line)
 
             if not agent_found:
                 remove(f_keys_temp)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -451,16 +451,19 @@ class Agent:
         try:
             agent_found = False
             with open(common.client_keys) as client_keys, open(f_keys_temp, 'w') as client_keys_tmp:
-                for line in client_keys.readlines():
-                    id, name, ip, key = line.strip().split(' ')  # 0 -> id, 1 -> name, 2 -> ip, 3 -> key
+                try:
+                    for line in client_keys.readlines():
+                        id, name, ip, key = line.strip().split(' ')  # 0 -> id, 1 -> name, 2 -> ip, 3 -> key
+                        if self.id == id and name[0] not in ('#!'):
+                            if not purge:
+                                client_keys_tmp.write('{0} !{1} {2} {3}\n'.format(id, name, ip, key))
 
-                    if self.id == id and name[0] not in ('#!'):
-                        if not purge:
-                            client_keys_tmp.write('{0} !{1} {2} {3}\n'.format(id, name, ip, key))
-
-                        agent_found = True
-                    else:
-                        client_keys_tmp.write(line)
+                            agent_found = True
+                        else:
+                            client_keys_tmp.write(line)
+                except Exception as e:
+                    remove(f_keys_temp)
+                    raise e
 
             if not agent_found:
                 remove(f_keys_temp)

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -142,6 +142,9 @@ class WazuhException(Exception):
         1743: 'Error running Wazuh syntax validator',
         1744: 'Invalid chunk size',
         1745: "Agent only belongs to 'default' and it cannot be unset from this group.",
+        1746: "Could not parse current client.keys file",
+        1747: "Could not remove agent group assigment from database",
+        1748: "Could not remove agent files",
 
         # CDB List: 1800 - 1899
         1800: 'Bad format in CDB list {path}',

--- a/framework/wazuh/tests/data/schema_global_test.sql
+++ b/framework/wazuh/tests/data/schema_global_test.sql
@@ -37,6 +37,19 @@ CREATE TABLE IF NOT EXISTS agent (
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
 CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
 
+CREATE TABLE IF NOT EXISTS `group`
+    (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT
+    );
+
+CREATE TABLE IF NOT EXISTS belongs
+    (
+    id_agent INTEGER,
+    id_group INTEGER,
+    PRIMARY KEY (id_agent, id_group)
+);
+
 -- manager
 INSERT INTO agent (id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_uname, os_arch,
                    version, manager_host, node_name, date_add, last_keepalive, status, `group`) VALUES

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -208,3 +208,50 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
             backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any')
             makedirs_mock.assert_called_once_with(backup_path)
             chmod_r_mock.assert_called_once_with(backup_path, 0o750)
+
+
+@pytest.mark.parametrize('agent_id, expected_exception', [
+    ('001', 1746),
+    ('100', 1701),
+    ('001', 1600),
+    ('001', 1748),
+    ('001', 1747)
+])
+@patch('wazuh.agent.remove')
+@patch('wazuh.agent.rmtree')
+@patch('wazuh.agent.move')
+@patch('wazuh.agent.chown')
+@patch('wazuh.agent.chmod')
+@patch('wazuh.agent.stat')
+@patch('wazuh.agent.glob')
+@patch('wazuh.agent.path.exists', side_effect=lambda x: not (common.backup_path in x))
+@patch('wazuh.database.isfile', return_value=True)
+@patch('wazuh.agent.path.isdir', return_value=True)
+@patch('wazuh.agent.rename')
+@patch('wazuh.agent.makedirs')
+@patch('wazuh.agent.chmod_r')
+@freeze_time('1975-01-01')
+def test_remove_manual_error(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isfile_mock, exists_mock, glob_mock,
+                             stat_mock, chmod_mock, chown_mock, move_mock, rmtree_mock, remove_mock, test_data,
+                             agent_id, expected_exception):
+    """
+    Test the _remove_manual function error cases
+    """
+    client_keys_text = '\n'.join([f'{str(aid).zfill(3)} {name} {ip} '
+                                  f'{key + "" if expected_exception != 1746 else " random"}' for aid, name, ip, key in
+                                  test_data.global_db.execute(
+                                      'select id, name, register_ip, internal_key from agent where id > 0')])
+
+    glob_mock.return_value = ['/var/db/global.db'] if expected_exception != 1600 else []
+    rmtree_mock.side_effect = Exception("Boom!")
+
+    with patch('wazuh.agent.open', mock_open(read_data=client_keys_text)) as m:
+        with patch('sqlite3.connect') as mock_db:
+            mock_db.return_value = test_data.global_db
+            if expected_exception == 1747:
+                mock_db.return_value.execute("drop table belongs")
+            with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
+                Agent(agent_id)._remove_manual()
+
+    if expected_exception == 1746:
+        remove_mock.assert_any_call('/var/ossec/etc/client.keys.tmp')


### PR DESCRIPTION
Hello team,

This PR closes #2865.

The agent must be removed from `client.keys` file when all its files and information have been correctly removed. Otherwise, the removal process can't be retried and there will be agent files left in the manager.

Unit tests:
```python
# /var/ossec/framework/python/bin/pytest wazuh/tests/test_agent.py -vv
============================================================================================================================ test session starts ============================================================================================================================
platform linux -- Python 3.7.2, pytest-4.3.1, py-1.8.0, pluggy-0.9.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/vagrant/GitHub/wazuh/framework, inifile:
collected 28 items

wazuh/tests/test_agent.py::test_get_agents_overview_default PASSED                                                                                                                                                                                                    [  3%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select0-all-None-0] PASSED                                                                                                                                                                                 [  7%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select1-all-None-1] PASSED                                                                                                                                                                                 [ 10%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select2-all-None-1] PASSED                                                                                                                                                                                 [ 14%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select3-Active,Pending-None-0] PASSED                                                                                                                                                                      [ 17%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select4-Disconnected-None-1] PASSED                                                                                                                                                                        [ 21%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select5-Disconnected-1s-1] PASSED                                                                                                                                                                          [ 25%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select6-Disconnected-2h-0] PASSED                                                                                                                                                                          [ 28%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select7-all-15m-2] PASSED                                                                                                                                                                                  [ 32%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select8-Active-15m-0] PASSED                                                                                                                                                                               [ 35%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select9-Active,Pending-15m-1] PASSED                                                                                                                                                                       [ 39%]
wazuh/tests/test_agent.py::test_get_agents_overview_select[select10-status10-15m-1] PASSED                                                                                                                                                                            [ 42%]
wazuh/tests/test_agent.py::test_get_agents_overview_query[ip=172.17.0.201] PASSED                                                                                                                                                                                     [ 46%]
wazuh/tests/test_agent.py::test_get_agents_overview_query[ip=172.17.0.202] PASSED                                                                                                                                                                                     [ 50%]
wazuh/tests/test_agent.py::test_get_agents_overview_query[ip=172.17.0.202;registerIP=any] PASSED                                                                                                                                                                      [ 53%]
wazuh/tests/test_agent.py::test_get_agents_overview_query[status=Disconnected;lastKeepAlive>34m] PASSED                                                                                                                                                               [ 57%]
wazuh/tests/test_agent.py::test_get_agents_overview_query[(status=Active,status=Pending);lastKeepAlive>5m] PASSED                                                                                                                                                     [ 60%]
wazuh/tests/test_agent.py::test_get_agents_overview_search[search0-3] PASSED                                                                                                                                                                                          [ 64%]
wazuh/tests/test_agent.py::test_get_agents_overview_search[search1-3] PASSED                                                                                                                                                                                          [ 67%]
wazuh/tests/test_agent.py::test_get_agents_overview_search[search2-1] PASSED                                                                                                                                                                                          [ 71%]
wazuh/tests/test_agent.py::test_get_agents_overview_search[search3-5] PASSED                                                                                                                                                                                          [ 75%]
wazuh/tests/test_agent.py::test_get_agents_overview_search[search4-2] PASSED                                                                                                                                                                                          [ 78%]
wazuh/tests/test_agent.py::test_get_agents_overview_status_olderthan[active-9m-1-None] PASSED                                                                                                                                                                         [ 82%]
wazuh/tests/test_agent.py::test_get_agents_overview_status_olderthan[all-1s-5-None] PASSED                                                                                                                                                                            [ 85%]
wazuh/tests/test_agent.py::test_get_agents_overview_status_olderthan[pending,neverconnected-30m-1-None] PASSED                                                                                                                                                        [ 89%]
wazuh/tests/test_agent.py::test_get_agents_overview_status_olderthan[55-30m-0-1729] PASSED                                                                                                                                                                            [ 92%]
wazuh/tests/test_agent.py::test_remove_manual[False] PASSED                                                                                                                                                                                                           [ 96%]
wazuh/tests/test_agent.py::test_remove_manual[True] PASSED                                                                                                                                                                                                            [100%]

========================================================================================================================= 28 passed in 0.76 seconds =========================================================================================================================
```

After adding the change, the code is much more stable:
```javascript
# curl -u foo:bar "localhost:55000/agents/001?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "001"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents/002?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "002"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents/003?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "003"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents/004?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "004"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents/005?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "005"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents/006?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "006"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents/007?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "007"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents/008?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "008"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents/009?pretty" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "009"
      ]
   }
}
# curl -u foo:bar "localhost:55000/agents?pretty&status=all&older_than=1s" -XDELETE
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "010",
         "011",
         "012",
         "013",
         "014",
         "015",
         "016",
         "017",
         "018",
         "019",
         "020",
         "021",
         "022",
         "023",
         "024",
         "025",
         "026",
         "027",
         "028",
         "029",
         "030",
         "031",
         "032",
         "033",
         "034",
         "035",
         "036",
         "037",
         "038",
         "039",
         "040",
         "041",
         "042",
         "043",
         "044",
         "045",
         "046",
         "047",
         "048",
         "049",
         "050",
         "051",
         "052",
         "053",
         "054",
         "055",
         "056",
         "057",
         "058",
         "059",
         "060",
         "061",
         "062",
         "063",
         "064",
         "065",
         "066",
         "067",
         "068",
         "069",
         "070",
         "071",
         "072",
         "073",
         "074",
         "075",
         "076",
         "077",
         "078",
         "079",
         "080",
         "081",
         "082",
         "083",
         "084",
         "085",
         "086",
         "087",
         "088",
         "089",
         "090",
         "091",
         "092",
         "093",
         "094",
         "095",
         "096",
         "097",
         "098",
         "099",
         "100",
         "101",
         "102",
         "103",
         "104",
         "105",
         "106",
         "107",
         "108",
         "109",
         "110",
         "111",
         "112",
         "113",
         "114",
         "115",
         "116",
         "117",
         "118",
         "119",
         "120",
         "121",
         "122",
         "123",
         "124",
         "125",
         "126",
         "127",
         "128",
         "129",
         "130",
         "131",
         "132",
         "133",
         "134",
         "135",
         "136",
         "137",
         "138",
         "139",
         "140",
         "141",
         "142",
         "143",
         "144",
         "145",
         "146",
         "147",
         "148",
         "149",
         "150",
         "151",
         "152",
         "153",
         "154",
         "155",
         "156",
         "157",
         "158",
         "159",
         "160",
         "161",
         "162",
         "163",
         "164",
         "165",
         "166",
         "167",
         "168",
         "169",
         "170",
         "171",
         "172",
         "173",
         "174",
         "175",
         "176",
         "177",
         "178",
         "179",
         "180",
         "181",
         "182",
         "183",
         "184",
         "185",
         "186",
         "187",
         "188",
         "189",
         "190",
         "191",
         "192",
         "193",
         "194",
         "195",
         "196",
         "197",
         "198",
         "199",
         "200",
         "201",
         "202",
         "203",
         "204",
         "205",
         "206",
         "207",
         "208",
         "209",
         "210",
         "211",
         "212",
         "213",
         "214",
         "215",
         "216",
         "217",
         "218",
         "219",
         "220",
         "221",
         "222",
         "223",
         "224",
         "225",
         "226",
         "227",
         "228",
         "229",
         "230",
         "231",
         "232",
         "233",
         "234",
         "235",
         "236",
         "237",
         "238",
         "239",
         "240",
         "241",
         "242",
         "243",
         "244",
         "245",
         "246",
         "247",
         "248",
         "249",
         "250",
         "251",
         "252",
         "253",
         "254",
         "255",
         "256",
         "257",
         "258",
         "259",
         "260",
         "261",
         "262",
         "263",
         "264",
         "265",
         "266",
         "267",
         "268",
         "269",
         "270",
         "271",
         "272",
         "273",
         "274",
         "275",
         "276",
         "277",
         "278",
         "279",
         "280",
         "281",
         "282",
         "283",
         "284",
         "285",
         "286",
         "287",
         "288",
         "289",
         "290",
         "291",
         "292",
         "293",
         "294",
         "295",
         "296",
         "297",
         "298",
         "299",
         "300",
         "301",
         "302",
         "303",
         "304",
         "305",
         "306",
         "307",
         "308",
         "309",
         "310",
         "311",
         "312",
         "313",
         "314",
         "315",
         "316",
         "317",
         "318",
         "319",
         "320",
         "321",
         "322",
         "323",
         "324",
         "325",
         "326",
         "327",
         "328",
         "329",
         "330",
         "331",
         "332",
         "333",
         "334",
         "335",
         "336",
         "337",
         "338",
         "339",
         "340",
         "341",
         "342",
         "343",
         "344",
         "345",
         "346",
         "347",
         "348",
         "349",
         "350",
         "351",
         "352",
         "353",
         "354",
         "355",
         "356",
         "357",
         "358",
         "359",
         "360",
         "361",
         "362",
         "363",
         "364",
         "365",
         "366",
         "367",
         "368",
         "369",
         "370",
         "371",
         "372",
         "373",
         "374",
         "375",
         "376",
         "377",
         "378",
         "379",
         "380",
         "381",
         "382",
         "383",
         "384",
         "385",
         "386",
         "387",
         "388",
         "389",
         "390",
         "391",
         "392",
         "393",
         "394",
         "395",
         "396",
         "397",
         "398",
         "399",
         "400",
         "401",
         "402",
         "403",
         "404",
         "405",
         "406",
         "407",
         "408",
         "409",
         "410",
         "411",
         "412",
         "413",
         "414",
         "415",
         "416",
         "417",
         "418",
         "419",
         "420",
         "421",
         "422",
         "423",
         "424",
         "425",
         "426",
         "427",
         "428",
         "429",
         "430",
         "431",
         "432",
         "433",
         "434",
         "435",
         "436",
         "437",
         "438",
         "439",
         "440",
         "441",
         "442",
         "443",
         "444",
         "445",
         "446",
         "447",
         "448",
         "449",
         "450",
         "451",
         "452",
         "453",
         "454",
         "455",
         "456",
         "457",
         "458",
         "459",
         "460",
         "461",
         "462",
         "463",
         "464",
         "465",
         "466",
         "467",
         "468",
         "469",
         "470",
         "471",
         "472",
         "473",
         "474",
         "475",
         "476",
         "477",
         "478",
         "479",
         "480",
         "481",
         "482",
         "483",
         "484",
         "485",
         "486",
         "487",
         "488",
         "489",
         "490",
         "491",
         "492",
         "493",
         "494",
         "495",
         "496",
         "497",
         "498",
         "499",
         "500",
         "501",
         "502",
         "503",
         "504",
         "505"
      ],
      "older_than": "1s",
      "total_affected_agents": 496
   }
}
```

Best regards,
Marta