### PR TITLE
Change diff output in Windows

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -753,7 +753,8 @@ int fim_alert (char *f_name, sk_sum_t *oldsum, sk_sum_t *newsum, Eventinfo *lf, 
     if(lf->data) {
         snprintf(localsdb->comment+comment_buf, OS_MAXSTR-comment_buf, "What changed:\n%s",
                 lf->data);
-        os_strdup(lf->data, lf->diff);
+        lf->diff = lf->data;
+        lf->data = NULL;
     }
 
     // Create a new log message

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -751,7 +751,7 @@ int fim_alert (char *f_name, sk_sum_t *oldsum, sk_sum_t *newsum, Eventinfo *lf, 
     }
 
     if(lf->data) {
-        snprintf(localsdb->comment+comment_buf, OS_MAXSTR-comment_buf, "What changed:\n%s",
+        snprintf(localsdb->comment+comment_buf, OS_MAXSTR-comment_buf, "%s",
                 lf->data);
         lf->diff = lf->data;
         lf->data = NULL;

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1528,5 +1528,4 @@ void whodata_clean_rlist() {
     }
 }
 
-
 #endif


### PR DESCRIPTION
This PR unify the output of the `FC` command in Windows, used by `report_changes` option in FIM, solving https://github.com/wazuh/wazuh/issues/2952.

It also removes the `data.data` field, which contained the same information as `syscheck.diff`.

## Alert example

```
"syscheck":{
    "path":"c:\\file_path",
    "size_after":"13",
    "win_perm_after":[
        {
            "name":"username",
            "denied":[
                "DELETE",
                "FILE_WRITE_EA"
            ],
            "allowed":[
                "DELETE",
                "READ_CONTROL",
                "WRITE_DAC",
                "WRITE_OWNER",
                "SYNCHRONIZE",
                "FILE_READ_DATA",
                "FILE_WRITE_DATA",
                "FILE_APPEND_DATA",
                "FILE_READ_EA",
                "FILE_WRITE_EA",
                "FILE_EXECUTE",
                "FILE_READ_ATTRIBUTES",
                "FILE_WRITE_ATTRIBUTES"
            ]
        },
        {
            "name":"SYSTEM",
            "allowed":[
                "DELETE",
                "READ_CONTROL",
                "WRITE_DAC",
                "WRITE_OWNER",
                "SYNCHRONIZE",
                "FILE_READ_DATA",
                "FILE_WRITE_DATA",
                "FILE_APPEND_DATA",
                "FILE_READ_EA",
                "FILE_WRITE_EA",
                "FILE_EXECUTE",
                "FILE_READ_ATTRIBUTES",
                "FILE_WRITE_ATTRIBUTES"
            ]
        },
        {
            "name":"Administrators",
            "allowed":[
                "DELETE",
                "READ_CONTROL",
                "WRITE_DAC",
                "WRITE_OWNER",
                "SYNCHRONIZE",
                "FILE_READ_DATA",
                "FILE_WRITE_DATA",
                "FILE_APPEND_DATA",
                "FILE_READ_EA",
                "FILE_WRITE_EA",
                "FILE_EXECUTE",
                "FILE_READ_ATTRIBUTES",
                "FILE_WRITE_ATTRIBUTES"
            ]
        },
        {
            "name":"Administrator",
            "allowed":[
                "DELETE",
                "READ_CONTROL",
                "WRITE_DAC",
                "WRITE_OWNER",
                "SYNCHRONIZE",
                "FILE_READ_DATA",
                "FILE_WRITE_DATA",
                "FILE_APPEND_DATA",
                "FILE_READ_EA",
                "FILE_WRITE_EA",
                "FILE_EXECUTE",
                "FILE_READ_ATTRIBUTES",
                "FILE_WRITE_ATTRIBUTES"
            ]
        }
    ],
    "uid_after":"S-1-5-32-544",
    "md5_before":"622e9f7f585adb048dd3e55a4f228b03",
    "md5_after":"c0969c388d2e621d3ef402312c80fd9d",
    "sha1_before":"a5c91d3cc789776d859161bffc9965054cf924f3",
    "sha1_after":"263f086f350ba6a649ddaa7f2e55f4ea7f68f056",
    "sha256_before":"f63dba41a19787980e28ee51144d658c08eb334a219ea780816560a9ad0a45cb",
    "sha256_after":"a0f4f2add27744444e2f149e47c819e23fc5d3547ec6c05424ac84d9f01d7664",
    "attrs_after":[
        "ARCHIVE"
    ],
    "uname_after":"Administrators",
    "mtime_before":"2019-03-28T17:12:27",
    "mtime_after":"2019-03-28T17:13:17",
    "diff":"< 2\n< 3\n< 4\n< 5\n---\n> 2\n> A\n> B\n> 5\n",
    "event":"modified",
    "audit":{
        "user":{
            "id":"S-1-5-21-3292556202-24657078-706277677-500",
            "name":"Administrator"
        },
        "process":{
            "id":"3284",
            "name":"C:\\Program Files\\Notepad++\\notepad++.exe"
        }
    }
}
```