### PR TITLE
Fix whodata mode on devices other than the main one

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -45,11 +45,11 @@ int fim_find_child_depth(const char *parent, const char *child) {
 
     char *diff_str;
 
-    if(parent[length_A - 1] == PATH_SEP){
+    if(parent[length_A - 1] == PATH_SEP && length_A >= 2 && parent[length_A - 2] != ':') {
         p_first[length_A - 1] = '\0';
     }
 
-    if(child[length_B - 1] == PATH_SEP){
+    if(child[length_B - 1] == PATH_SEP && length_B >= 2 && child[length_B - 2] != ':') {
         p_second[length_B - 1] = '\0';
     }
 
@@ -86,7 +86,7 @@ int fim_find_child_depth(const char *parent, const char *child) {
 
     os_free(p_first);
     os_free(p_second);
-    return child_depth;
+    return child_depth ? child_depth : 1;
 }
 
 void normalize_path(char * path) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -766,6 +766,13 @@ int read_dir(const char *dir_name, int dir_position, whodata_evt *evt, int max_d
         return 0;
     }
 
+#ifdef WIN32
+    if (check_removed_file(dir_name)) {
+        mdebug2("'%s' will not be read.", dir_name);
+        return 0;
+    }
+#endif
+
     // 3.8 - We can't follow symlinks in Windows
 #ifndef WIN32
     switch(read_links(dir_name, dir_position, max_depth, is_link)) {

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -143,4 +143,8 @@ int w_update_sacl(const char *obj_path);
 int print_hash_table();
 int fim_delete_hashes(char *file_name);
 
+#ifdef WIN32
+#define check_removed_file(x) ({ strstr(x, ":\\$recycle.bin") ? 1 : 0; })
+#endif
+
 #endif


### PR DESCRIPTION
Whodata is still unable to monitor directories on external drives, despite https://github.com/wazuh/wazuh/pull/2930. There are several combined reasons for this error:

- If the monitored folder has a format like `DRIVE:/folder`, its depth will not be calculated correctly due to a bug in `fim_find_child_depth`. In addition, its parent folder will not be found due to a bug in the `find_dir_pos` function. This affects all FIM modes.
- Agent dies due to invalid reading caused by incorrect use of the file path in `replace_device_path`.

This PR resolves these invalid behaviours.