### PR TITLE
Fix SCA segfault with 255 or more rules

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -454,6 +454,6 @@ https://www.gnu.org/licenses/gpl.html\n"
 
 #define SECURITY_CONFIGURATION_ASSESSMENT_DIR   "/ruleset/sca"
 
-#define SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN   "ruleset/sca"
+#define SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN   "ruleset\\sca"
 
 #endif /* __OS_HEADERS */

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -643,7 +643,7 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
 
                 if (rules_n > 255) {
                     free(read_id);
-                    merror("Invalid check %d: Maximum number of rules is 255", check_id->valueint);
+                    merror("Invalid check %d: Maximum number of rules is 255.", check_id->valueint);
                     return retval;
                 }
             }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -369,7 +369,7 @@ static void wm_sca_read_files(wm_sca_t * data) {
 
 #ifdef WIN32
             if (data->profile[i]->profile[1] && data->profile[i]->profile[2]) {
-                if (data->profile[i]->profile[1] == ':') {
+                if ((data->profile[i]->profile[1] == ':') || (data->profile[i]->profile[0] == '\\' && data->profile[i]->profile[1] == '\\')) {
                     sprintf(path,"%s", data->profile[i]->profile);
                 } else{
                     sprintf(path,"%s\\%s",SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN, data->profile[i]->profile);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -632,21 +632,26 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
 
             rules_id = cJSON_GetObjectItem(check, "rules");
 
-            cJSON_ArrayForEach(rule, rules_id){
-                if (rules_id == NULL) {
-                    merror("Rules not found.");
-                    free(read_id);
-                    return retval;
-                }
+            if (rules_id == NULL) {
+                merror("Invalid check %d: no rules found.", check_id->valueint);
+                free(read_id);
+                return retval;
+            }
 
+            cJSON_ArrayForEach(rule, rules_id){
                 rules_n++;
 
                 if (rules_n > 255) {
-                    retval = 1;
                     free(read_id);
-                    mwarn("Policy check with more than 255 rules. Ignoring it.");
+                    merror("Invalid check %d: Maximum number of rules is 255", check_id->valueint);
                     return retval;
                 }
+            }
+
+            if (rules_n == 0) {
+                merror("Invalid check %d: no rules found.", check_id->valueint);
+                free(read_id);
+                return retval;
             }
 
             rules_n = 0;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -540,6 +540,8 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
     cJSON *description;
     cJSON *check;
     cJSON *check_id;
+    cJSON *rule;
+    cJSON *rules_id;
     int * read_id;
 
     retval = 1;
@@ -599,6 +601,8 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
     } else {
         os_calloc(1, sizeof(int), read_id);
         read_id[0] = 0;
+        int rules_n = 0;
+
         cJSON_ArrayForEach(check, profiles){
 
             check_id = cJSON_GetObjectItem(check, "id");
@@ -625,6 +629,27 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
             read_id = (int *) realloc(read_id, sizeof(int) * (i + 2));
             read_id[i] = check_id->valueint;
             read_id[i + 1] = 0;
+
+            rules_id = cJSON_GetObjectItem(check, "rules");
+
+            cJSON_ArrayForEach(rule, rules_id){
+                if (rules_id == NULL) {
+                    merror("Rules not found.");
+                    free(read_id);
+                    return retval;
+                }
+
+                rules_n++;
+
+                if (rules_n > 255) {
+                    retval = 1;
+                    free(read_id);
+                    mwarn("Policy check with more than 255 rules. Ignoring it.");
+                    return retval;
+                }
+            }
+
+            rules_n = 0;
         }
         free(read_id);
     }


### PR DESCRIPTION
This PR fixes the SCA crash when defining more than 255 rules. To fix it, at the 'check policy' from the beginning, it is verified if the number of rules from each check is higher than 256.
Related issue: https://github.com/wazuh/wazuh/issues/2945