### PR TITLE
Add GET/{manager,cluster/:node_id}/config/:component/:configuration endpoints

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -14,8 +14,7 @@ from wazuh.ossec_socket import OssecSocket, OssecSocketJSON
 from wazuh.database import Connection
 from wazuh.wdb import WazuhDBConnection
 from wazuh.InputValidator import InputValidator
-from wazuh import manager
-from wazuh import common
+from wazuh import manager, common, configuration
 from glob import glob
 from datetime import date, datetime, timedelta
 from base64 import b64encode
@@ -2576,3 +2575,45 @@ class Agent:
                 return {'synced': False}
             except Exception as e:
                 raise WazuhException(1739, str(e))
+
+    @staticmethod
+    def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filename='agent.conf', return_format=None):
+        """
+        Returns agent.conf as dictionary.
+
+        :return: agent.conf as dictionary.
+        """
+        if group_id:
+            if not Agent.group_exists(group_id):
+                raise WazuhException(1710, group_id)
+
+        return configuration.get_agent_conf(group_id, offset, limit, filename, return_format)
+
+    @staticmethod
+    def get_file_conf(filename, group_id=None, type_conf=None, return_format=None):
+        """
+        Returns the configuration file as dictionary.
+
+        :return: configuration file as dictionary.
+        """
+
+        if group_id:
+            if not Agent.group_exists(group_id):
+                raise WazuhException(1710, group_id)
+
+        return configuration.get_file_conf(filename, group_id, type_conf, return_format)
+
+    @staticmethod
+    def upload_group_file(group_id, tmp_file, file_name='agent.conf'):
+        """
+        Updates a group file
+        :param group_id: Group to update
+        :param tmp_file: Relative path of temporary file to upload
+        :param file_name: File name to update
+        :return: Confirmation message in string
+        """
+        # check if the group exists
+        if not Agent.group_exists(group_id):
+            raise WazuhException(1710)
+
+        return configuration.upload_group_file(group_id, tmp_file, file_name)

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -349,6 +349,11 @@ functions = {
         'type': 'distributed_master',
         'is_async': False
     },
+    '/cluster/:node_id/config/:component/:configuration': {
+        'function': manager.get_config,
+        'type': 'distributed_master',
+        'is_async': False
+    },
     '/cluster/:node_id/configuration': {
         'function': configuration.get_ossec_conf,
         'type': 'distributed_master',

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -149,7 +149,7 @@ functions = {
         'is_async': False
     },
     '/agents/groups/:group_id/configuration': {
-        'function': configuration.get_agent_conf,
+        'function': Agent.get_agent_conf,
         'type': 'local_master',
         'is_async': False
     },
@@ -159,7 +159,7 @@ functions = {
         'is_async': False
     },
     '/agents/groups/:group_id/files/:filename': {
-        'function': configuration.get_file_conf,
+        'function': Agent.get_file_conf,
         'type': 'local_master',
         'is_async': False
     },
@@ -179,12 +179,12 @@ functions = {
         'is_async': False
     },
     'POST/agents/groups/:group_id/configuration': {
-        'function': configuration.upload_group_file,
+        'function': Agent.upload_group_file,
         'type': 'local_master',
         'is_async': False
     },
     'POST/agents/groups/:group_id/files/:file_name': {
-        'function': configuration.upload_group_file,
+        'function': Agent.upload_group_file,
         'type': 'local_master',
         'is_async': False
     },

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -237,6 +237,11 @@ functions = {
         'type': 'local_any',
         'is_async': False
     },
+    '/manager/config/:component/:configuration': {
+        'function': manager.get_config,
+        'type': 'local_any',
+        'is_async': False
+    },
     '/manager/configuration': {
         'function': configuration.get_ossec_conf,
         'type': 'local_any',

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -713,10 +713,8 @@ def get_active_configuration(agent_id, component, configuration):
     if not component or not configuration:
         raise WazuhException(1307)
 
-    sockets_path = common.ossec_path + "/queue/ossec/"
-
-    components = ["agent", "agentless", "analysis", "auth", "com", "csyslog", "integrator", "logcollector", "mail",
-                  "monitor", "request", "syscheck", "wmodules"]
+    components = {"agent", "agentless", "analysis", "auth", "com", "csyslog", "integrator", "logcollector", "mail",
+                  "monitor", "request", "syscheck", "wmodules"}
 
     # checks if the component is correct
     if component not in components:

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -725,12 +725,14 @@ def get_active_configuration(agent_id, component, configuration):
     if component == "analysis" and (configuration == "rules" or configuration == "decoders"):
         raise WazuhException(1101, "Could not get requested section")
 
+    sockets_path = os_path.join(common.ossec_path, "queue/ossec/")
+
     if agent_id == '000':
-        dest_socket = sockets_path + component
-        command = "getconfig " + configuration
+        dest_socket = os_path.join(sockets_path, component)
+        command = f"getconfig {configuration}"
     else:
-        dest_socket = sockets_path + "request"
-        command = str(agent_id).zfill(3) + " " + component + " getconfig " + configuration
+        dest_socket = os_path.join(sockets_path, "request")
+        command = f"{str(agent_id).zfill(3)} {component} getconfig {configuration}"
 
     # Socket connection
     try:

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -737,7 +737,7 @@ def get_active_configuration(agent_id, component, configuration):
         s = OssecSocket(dest_socket)
     except Exception as e:
         if agent_id == '000':
-            raise WazuhException(1013, "The component might be disabled")
+            raise WazuhException(1013, f"The component might be disabled, {e}")
         else:
             raise WazuhException(1013, str(e))
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -22,6 +22,7 @@ import fcntl
 from wazuh import common
 from wazuh.exception import WazuhException
 from wazuh.utils import previous_month, cut_array, sort_array, search_array, tail, load_wazuh_xml
+from wazuh import configuration
 
 _re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
 execq_lockfile = join(common.ossec_path, "var/run/.api_execq_lock")
@@ -557,3 +558,10 @@ def _parse_execd_output(output: str) -> Dict:
         response = {'status': 'OK'}
 
     return response
+
+
+def get_config(component, config):
+    """
+    Returns active configuration loaded in manager
+    """
+    return configuration.get_active_configuration(agent_id='000', component=component, configuration=config)

--- a/framework/wazuh/tests/data/schema_global_test.sql
+++ b/framework/wazuh/tests/data/schema_global_test.sql
@@ -63,7 +63,7 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
-                   'Wazuh v3.8.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
+                   'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',datetime(CURRENT_TIMESTAMP, '-3 days', 'localtime'),
                     datetime(CURRENT_TIMESTAMP, '-10 minutes', 'localtime'),'updated');
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -172,7 +172,8 @@ def test_get_agents_overview_status_olderthan(test_data, status, older_than, tot
     ('000', 'analysis', 'rules', 1101),
     ('000', 'analysis', 'internal', 1013),
     ('000', 'analysis', 'internal', 1014),
-    ('000', 'analysis', 'internal', 1101)
+    ('000', 'analysis', 'internal', 1101),
+    ('000', 'analysis', 'internal', None)
 ])
 @patch('wazuh.configuration.OssecSocket')
 def test_get_config_error(ossec_socket_mock, test_data, agent_id, component, configuration, expected_exception):
@@ -182,10 +183,14 @@ def test_get_config_error(ossec_socket_mock, test_data, agent_id, component, con
     if expected_exception == 1013:
         ossec_socket_mock.side_effect = Exception('Boom!')
 
-    ossec_socket_mock.return_value.receive.return_value = b'string_without_spaces' if expected_exception == 1014 else \
-                                                          b'random random'
+    ossec_socket_mock.return_value.receive.return_value = b'string_without_spaces' if expected_exception == 1014 \
+        else (b'random random' if expected_exception is not None else b'ok {"message":"value"}')
 
     with patch('sqlite3.connect') as mock_db:
         mock_db.return_value = test_data.global_db
-        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
-            Agent.get_config(agent_id=agent_id, component=component, configuration=configuration)
+        if expected_exception:
+            with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+                Agent.get_config(agent_id=agent_id, component=component, configuration=configuration)
+        else:
+            res = Agent.get_config(agent_id=agent_id, component=component, configuration=configuration)
+            assert res == {"message": "value"}


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh/issues/2988.

Unit tests:
```python
# /var/ossec/framework/python/bin/pytest tests/test_agent.py -vv
============================================================================================================================ test session starts ============================================================================================================================
platform linux -- Python 3.7.2, pytest-4.4.0, py-1.8.0, pluggy-0.9.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/vagrant/wazuh_api/wazuh/framework
collected 35 items

tests/test_agent.py::test_get_agents_overview_default PASSED                                                                                                                                                                                                          [  2%]
tests/test_agent.py::test_get_agents_overview_select[select0-all-None-0] PASSED                                                                                                                                                                                       [  5%]
tests/test_agent.py::test_get_agents_overview_select[select1-all-None-1] PASSED                                                                                                                                                                                       [  8%]
tests/test_agent.py::test_get_agents_overview_select[select2-all-None-1] PASSED                                                                                                                                                                                       [ 11%]
tests/test_agent.py::test_get_agents_overview_select[select3-Active,Pending-None-0] PASSED                                                                                                                                                                            [ 14%]
tests/test_agent.py::test_get_agents_overview_select[select4-Disconnected-None-1] PASSED                                                                                                                                                                              [ 17%]
tests/test_agent.py::test_get_agents_overview_select[select5-Disconnected-1s-1] PASSED                                                                                                                                                                                [ 20%]
tests/test_agent.py::test_get_agents_overview_select[select6-Disconnected-2h-0] PASSED                                                                                                                                                                                [ 22%]
tests/test_agent.py::test_get_agents_overview_select[select7-all-15m-2] PASSED                                                                                                                                                                                        [ 25%]
tests/test_agent.py::test_get_agents_overview_select[select8-Active-15m-0] PASSED                                                                                                                                                                                     [ 28%]
tests/test_agent.py::test_get_agents_overview_select[select9-Active,Pending-15m-1] PASSED                                                                                                                                                                             [ 31%]
tests/test_agent.py::test_get_agents_overview_select[select10-status10-15m-1] PASSED                                                                                                                                                                                  [ 34%]
tests/test_agent.py::test_get_agents_overview_query[ip=172.17.0.201] PASSED                                                                                                                                                                                           [ 37%]
tests/test_agent.py::test_get_agents_overview_query[ip=172.17.0.202] PASSED                                                                                                                                                                                           [ 40%]
tests/test_agent.py::test_get_agents_overview_query[ip=172.17.0.202;registerIP=any] PASSED                                                                                                                                                                            [ 42%]
tests/test_agent.py::test_get_agents_overview_query[status=Disconnected;lastKeepAlive>34m] PASSED                                                                                                                                                                     [ 45%]
tests/test_agent.py::test_get_agents_overview_query[(status=Active,status=Pending);lastKeepAlive>5m] PASSED                                                                                                                                                           [ 48%]
tests/test_agent.py::test_get_agents_overview_search[search0-3] PASSED                                                                                                                                                                                                [ 51%]
tests/test_agent.py::test_get_agents_overview_search[search1-3] PASSED                                                                                                                                                                                                [ 54%]
tests/test_agent.py::test_get_agents_overview_search[search2-1] PASSED                                                                                                                                                                                                [ 57%]
tests/test_agent.py::test_get_agents_overview_search[search3-5] PASSED                                                                                                                                                                                                [ 60%]
tests/test_agent.py::test_get_agents_overview_search[search4-2] PASSED                                                                                                                                                                                                [ 62%]
tests/test_agent.py::test_get_agents_overview_status_olderthan[active-9m-1-None] PASSED                                                                                                                                                                               [ 65%]
tests/test_agent.py::test_get_agents_overview_status_olderthan[all-1s-5-None] PASSED                                                                                                                                                                                  [ 68%]
tests/test_agent.py::test_get_agents_overview_status_olderthan[pending,neverconnected-30m-1-None] PASSED                                                                                                                                                              [ 71%]
tests/test_agent.py::test_get_agents_overview_status_olderthan[55-30m-0-1729] PASSED                                                                                                                                                                                  [ 74%]
tests/test_agent.py::test_get_config_error[100-logcollector-internal-1701] PASSED                                                                                                                                                                                     [ 77%]
tests/test_agent.py::test_get_config_error[005-logcollector-internal-1740] PASSED                                                                                                                                                                                     [ 80%]
tests/test_agent.py::test_get_config_error[002-logcollector-internal-1735] PASSED                                                                                                                                                                                     [ 82%]
tests/test_agent.py::test_get_config_error[000-None-None-1307] PASSED                                                                                                                                                                                                 [ 85%]
tests/test_agent.py::test_get_config_error[000-random-random-1101] PASSED                                                                                                                                                                                             [ 88%]
tests/test_agent.py::test_get_config_error[000-analysis-rules-1101] PASSED                                                                                                                                                                                            [ 91%]
tests/test_agent.py::test_get_config_error[000-analysis-internal-1013] PASSED                                                                                                                                                                                         [ 94%]
tests/test_agent.py::test_get_config_error[000-analysis-internal-1014] PASSED                                                                                                                                                                                         [ 97%]
tests/test_agent.py::test_get_config_error[000-analysis-internal-1101] PASSED                                                                                                                                                                                         [100%]

========================================================================================================================= 35 passed in 0.54 seconds =========================================================================================================================
```

Best regards,
Marta