### PR TITLE
Fix bug occurred in the database while removing an agent

### DIFF
--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -838,10 +838,6 @@ void OS_RemoveAgentGroup(const char *id)
             }
 
         }
-#ifndef CLIENT
-        /* Remove from the 'belongs' table groups which the agent belongs to*/
-        wdb_delete_agent_belongs(atoi(id));
-#endif
 
         if(fp){
             fclose(fp);

--- a/src/analysisd/labels.c
+++ b/src/analysisd/labels.c
@@ -111,7 +111,12 @@ wlabel_t* labels_find(const Eventinfo *lf) {
 
         if (mtime == -1) {
             if (!data->error_flag) {
-                minfo("Cannot get agent-info file for agent %s (%s). Using old labels.", hostname, ip);
+                if (errno == ENOENT) {
+                    mdebug1("Cannot get agent-info file for agent %s (%s). It could have been removed.", hostname, ip);
+
+                } else {
+                    minfo("Cannot get agent-info file for agent %s (%s). Using old labels.", hostname, ip);
+                }
                 data->error_flag = 1;
             }
         } else if (mtime > data->mtime + Config.label_cache_maxage) {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -870,7 +870,11 @@ int wm_sync_file(const char *dirname, const char *fname) {
         }
 
         if (stat(path, &buffer) < 0) {
-            mterror(WM_DATABASE_LOGTAG, FSTAT_ERROR, path, errno, strerror(errno));
+            if (errno == ENOENT) {
+                mtdebug2(WM_DATABASE_LOGTAG, FSTAT_ERROR, path, errno, strerror(errno));
+            } else {
+                mterror(WM_DATABASE_LOGTAG, FSTAT_ERROR, path, errno, strerror(errno));
+            }
             return -1;
         }
     }


### PR DESCRIPTION
This PR fixes #2968 and partially #2388 
- A useless call to `wdb_delete_agent_belongs` has been removed. It was causing the database to be blocked (when `authd` or `manage_agents` was calling it) when it shouldn't (other write operations were trying to access the database and they couldn't, causing a database inconsistency).

Testing
---
All tests have been made with a CentOS 7 manager and agent (1 GB RAM and 1 core each):
- Groups / Multiple groups section from: https://github.com/wazuh/wazuh-qa/issues/43

The following test has been made the following way:

1. Add the agent with the mentioned method (or re-register it).
2. Restart the agent.
3. (If `Group` is set) Add a group to the agent.
4. Check the following is correct:
    4.1. `agent`  and `belongs` tables from `global.db`.
    4.2. `agent-info`, `agent-groups` and `rootcheck` agent files.



| `authd `| Add | Group |
| --- | --- | --- |
| ON | `agent-auth` | NO | 
| ON | `agent-auth` | YES |
| ON | `agent-auth` (Re-registered) | YES| 
| OFF | `manage_agents` | NO |
| OFF | `manage_agents` | YES |
| OFF | `manage_agents` (Re-registered) | YES |