### PR TITLE
Add a docker compose environment for API integration tests

### DIFF
--- a/api/test/integration/environment/docker-compose.yml
+++ b/api/test/integration/environment/docker-compose.yml
@@ -1,0 +1,83 @@
+version: '3.7'
+
+services:
+        wazuh-master:
+                build:
+                        args:
+                                INSTALL_TYPE: pre_release
+                        context: ./wazuh-manager
+                image: wazuh-manager:3.9
+                ports:
+                        - "2222:22"
+                        - "8080:8080"
+                        - "55000:55000"
+                entrypoint:
+                        - /scripts/entrypoint.sh
+                        - wazuh-master
+                        - master-node
+                        - master
+
+        wazuh-worker1:
+                build:
+                        args:
+                                INSTALL_TYPE: pre_release
+                        context: ./wazuh-manager
+                image: wazuh-manager:3.9
+                depends_on:
+                        - wazuh-master
+                entrypoint:
+                        - /scripts/entrypoint.sh
+                        - wazuh-master
+                        - worker1
+                        - worker
+        wazuh-worker2:
+                build:
+                        args:
+                                INSTALL_TYPE: pre_release
+                        context: ./wazuh-manager
+                image: wazuh-manager:3.9
+                depends_on:
+                        - wazuh-master
+                entrypoint:
+                        - /scripts/entrypoint.sh
+                        - wazuh-master
+                        - worker2
+                        - worker
+
+
+        wazuh-agent1:
+                build:
+                        context: ./wazuh-agent
+                image: wazuh-agent:3.9
+                entrypoint: 
+                        - /scripts/entrypoint.sh 
+                        - wazuh-master
+                        - wazuh-master
+                depends_on:
+                        - wazuh-master
+
+        
+        wazuh-agent2:
+                build:
+                        context: ./wazuh-agent
+                image: wazuh-agent:3.9
+                entrypoint: 
+                        - /scripts/entrypoint.sh
+                        - wazuh-master
+                        - wazuh-worker1
+                depends_on:
+                        - wazuh-master
+                        - wazuh-worker1
+
+
+        wazuh-agent3:
+                build:
+                        context: ./wazuh-agent
+                image: wazuh-agent:3.9
+                entrypoint:
+                        - /scripts/entrypoint.sh
+                        - wazuh-master
+                        - wazuh-worker2
+                depends_on:
+                        - wazuh-master
+                        - wazuh-worker2

--- a/api/test/integration/environment/wazuh-agent/Dockerfile
+++ b/api/test/integration/environment/wazuh-agent/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install curl apt-transport-https lsb-release gnupg2 -y && \
+    curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && \
+    echo "deb https://packages.wazuh.com/3.x/apt/ stable main" | tee /etc/apt/sources.list.d/wazuh.list && \
+    apt-get update
+
+RUN apt-get install wazuh-agent -y
+
+ADD entrypoint.sh /scripts/entrypoint.sh

--- a/api/test/integration/environment/wazuh-agent/entrypoint.sh
+++ b/api/test/integration/environment/wazuh-agent/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+until /var/ossec/bin/agent-auth -m $1; do
+  echo "Wazuh manager is unavailable - sleeping for 5 seconds"
+  sleep 5
+done
+
+sed -i "s:MANAGER_IP:$2:g" /var/ossec/etc/ossec.conf
+
+sleep 5
+
+/var/ossec/bin/ossec-control stop
+/var/ossec/bin/ossec-control start
+tail -f /var/ossec/logs/ossec.log

--- a/api/test/integration/environment/wazuh-manager/Dockerfile
+++ b/api/test/integration/environment/wazuh-manager/Dockerfile
@@ -1,0 +1,11 @@
+ARG TEST_IMAGE=centos:7
+FROM $TEST_IMAGE
+
+ARG INSTALL_TYPE=stable
+ARG BRANCH=master
+ARG PACKAGE_VERSION
+
+ADD install_wazuh_manager.sh /install_wazuh_manager.sh
+RUN /install_wazuh_manager.sh $INSTALL_TYPE $BRANCH $PACKAGE_VERSION
+
+ADD entrypoint.sh /scripts/entrypoint.sh

--- a/api/test/integration/environment/wazuh-manager/entrypoint.sh
+++ b/api/test/integration/environment/wazuh-manager/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+. /etc/ossec-init.conf
+sed -i "s:<key></key>:<key>9d273b53510fef702b54a92e9cffc82e</key>:g" "${DIRECTORY}/etc/ossec.conf"
+sed -i "s:<node>NODE_IP</node>:<node>$1</node>:g" "${DIRECTORY}/etc/ossec.conf"
+sed -i -e "/<cluster>/,/<\/cluster>/ s|<disabled>[a-z]\+</disabled>|<disabled>no</disabled>|g" "${DIRECTORY}/etc/ossec.conf"
+sed -i "s:<node_name>node01</node_name>:<node_name>$2</node_name>:g" "${DIRECTORY}/etc/ossec.conf"
+
+if [ "X$3" != "Xmaster" ]; then
+    sed -i "s:<node_type>master</node_type>:<node_type>worker</node_type>:g" "${DIRECTORY}/etc/ossec.conf"
+fi
+
+/var/ossec/bin/ossec-control restart
+
+node /var/ossec/api/app.js &
+tail -f /var/ossec/logs/cluster.log

--- a/api/test/integration/environment/wazuh-manager/entrypoint.sh
+++ b/api/test/integration/environment/wazuh-manager/entrypoint.sh
@@ -10,7 +10,7 @@ if [ "X$3" != "Xmaster" ]; then
     sed -i "s:<node_type>master</node_type>:<node_type>worker</node_type>:g" "${DIRECTORY}/etc/ossec.conf"
 fi
 
-/var/ossec/bin/ossec-control restart
+"${DIRECTORY}/bin/ossec-control" restart
 
-node /var/ossec/api/app.js &
-tail -f /var/ossec/logs/cluster.log
+node "${DIRECTORY}/api/app.js" &
+tail -f "${DIRECTORY}/logs/cluster.log"

--- a/api/test/integration/environment/wazuh-manager/install_wazuh_manager.sh
+++ b/api/test/integration/environment/wazuh-manager/install_wazuh_manager.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# install wazuh server
+# Wazuh documentation - https://documentation.wazuh.com/current/installation-guide/installing-wazuh-server/index.html
+#######################################
+
+# Versions to install
+WAZUH_MANAGER_PKG="wazuh-manager"
+WAZUH_API_PKG="wazuh-api"
+
+# Configuration variables
+PKG_MANAGER=""
+PKG_INSTALL=""
+PKG_OPTIONS=""
+OS_FAMILY=""
+REPO_FILE=""
+SOURCE_INSTALL=0
+
+# Variables from command line
+INSTALL_TYPE=${1:-stable}
+BRANCH=${2:-master}
+PACKAGE_VERSION=$3
+
+set_global_parameters() {
+    echo "Received arguments: Install type: ${INSTALL_TYPE}. Branch: ${BRANCH}. Package version: ${PACKAGE_VERSION}."
+    if command -v apt-get > /dev/null 2>&1 ; then
+        PKG_MANAGER="apt-get"
+        PKG_OPTIONS="-y"
+        OS_FAMILY="Debian"
+        REPO_FILE="/etc/apt/sources.list.d/wazuh.list"
+        if [ ! -z "$PACKAGE_VERSION" ]; then
+            WAZUH_MANAGER_PKG="${WAZUH_MANAGER_PKG}=${PACKAGE_VERSION}"
+            WAZUH_API_PKG="${WAZUH_API_PKG}=${PACKAGE_VERSION}"
+        fi
+
+    elif command -v yum > /dev/null 2>&1 ; then
+        PKG_MANAGER="yum"
+        PKG_OPTIONS="-y -q -e 0"
+        OS_FAMILY="RHEL"
+        REPO_FILE="/etc/yum.repos.d/wazuh.repo"
+        if [ ! -z "$PACKAGE_VERSION" ]; then
+            WAZUH_MANAGER_PKG="${WAZUH_MANAGER_PKG}-${PACKAGE_VERSION}"
+            WAZUH_API_PKG="${WAZUH_API_PKG}-${PACKAGE_VERSION}"
+        fi
+    elif command -v zypper > /dev/null 2>&1 ; then
+        PKG_MANAGER="zypper"
+        PKG_OPTIONS="-y -l"
+        OS_FAMILY="SUSE"
+        REPO_FILE="/etc/zypp/repos.d/wazuh.repo"
+        if [ ! -z "$PACKAGE_VERSION" ]; then
+            WAZUH_MANAGER_PKG="${WAZUH_MANAGER_PKG}-${PACKAGE_VERSION}"
+            WAZUH_API_PKG="${WAZUH_API_PKG}-${PACKAGE_VERSION}"
+        fi
+    fi
+
+    PKG_INSTALL="${PKG_MANAGER} install"
+
+    return 0
+}
+
+install_dependencies() {
+    ## RHEL/CentOS/Fedora/Amazon/SUSE based OS
+    if [ "${OS_FAMILY}" == "RHEL" ] || [ "${OS_FAMILY}" == "SUSE" ]; then
+        ${PKG_INSTALL} ${PKG_OPTIONS} openssl wget which
+    ## Debian/Ubuntu based OS
+    else
+        ${PKG_MANAGER} update
+        ${PKG_INSTALL} ${PKG_OPTIONS} curl apt-transport-https lsb-release \
+        openssl software-properties-common dirmngr
+    fi
+}
+
+add_nodejs_repository() {
+  if [ "${OS_FAMILY}" == "RHEL" ]; then
+    curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
+  elif [ "${OS_FAMILY}" == "SUSE" ]; then
+    ${PKG_MANAGER} addrepo http://download.opensuse.org/distribution/leap/15.0/repo/oss/ node8
+    ${PKG_MANAGER} --gpg-auto-import-keys refresh
+  else
+    curl -sL https://deb.nodesource.com/setup_8.x | bash -
+  fi
+}
+
+add_wazuh_stable_repository() {
+    # Add Wazuh Repository
+    ## RHEL/CentOS/Fedora/Amazon/SUSE based OS
+    if [ "${OS_FAMILY}" == "RHEL" ] || [ "${OS_FAMILY}" == "SUSE" ]; then
+        rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
+        echo -ne "[wazuh_repo]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=Wazuh epository\nbaseurl=https://packages.wazuh.com/3.x/yum/\nprotect=1" > ${REPO_FILE}
+
+    ## Debian/Ubuntu based OS
+    else
+        curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+        echo "deb https://packages.wazuh.com/3.x/apt/ stable main" | tee -a ${REPO_FILE}
+        ${PKG_MANAGER} update
+    fi
+}
+
+add_wazuh_pre_release_repository() {
+    # Add Wazuh Repository
+    ## RHEL/CentOS/Fedora/Amazon/SUSE based OS
+    if [ "${OS_FAMILY}" == "RHEL" ] || [ "${OS_FAMILY}" == "SUSE" ]; then
+        rpm --import https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/key/GPG-KEY-WAZUH
+        echo -ne "[wazuh_pre_release]\ngpgcheck=1\ngpgkey=https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/yum/\nprotect=1" > ${REPO_FILE}
+
+    ## Debian/Ubuntu based OS
+    else
+        curl -s https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+        echo "deb https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/apt/ unstable main" | tee -a ${REPO_FILE}
+        ${PKG_MANAGER} update
+    fi
+}
+
+add_wazuh_repository() {
+    case "$INSTALL_TYPE" in
+    stable)
+        echo "Installing from stable repositories"
+        add_wazuh_stable_repository
+        ;;
+    pre_release)
+        echo "Installing from pre release repositories"
+        add_wazuh_pre_release_repository
+        ;;
+    sources)
+        echo "Installing from sources"
+        SOURCE_INSTALL=1
+        ;;
+    *)
+        echo "Install type not valid: ${INSTALL_TYPE}. Valid ones are stable, pre_release and sources."
+        exit 1
+    ;;
+    esac
+}
+
+install_wazuh_from_packages() {
+    # Install the Wazuh Manager and enable integrator module
+    ${PKG_INSTALL} ${PKG_OPTIONS} ${WAZUH_MANAGER_PKG}
+    # The auth module only needs to be enabled in
+    # versions prior to v3.8.0
+    . /etc/ossec-init.conf
+    if [[ ${VERSION} < "v3.8.0" ]]; then
+        echo "Version inferior to v3.8.0"
+        /var/ossec/bin/ossec-control enable auth
+    fi
+    if [[ ${VERSION} < "v3.9.0" ]]; then
+        echo "Version inferior to v3.9.0"
+        ${PKG_INSTALL} ${PKG_OPTIONS} python-cryptography python-setuptools
+    fi
+    if [[ ${VERSION} < "v4.0.0" ]]; then
+        echo "Version inferior to v4.0.0"
+        # Install NodeJS and Wazuh API
+        ${PKG_INSTALL} ${PKG_OPTIONS} nodejs
+        ${PKG_INSTALL} ${PKG_OPTIONS} ${WAZUH_API_PKG}
+    fi
+}
+
+install_wazuh_from_sources() {
+    ${PKG_INSTALL} ${PKG_OPTIONS} git make automake autoconf libtool
+    git clone https://github.com/wazuh/wazuh -b $BRANCH
+    cd wazuh
+    cat <<EOT >> etc/preloaded-vars.conf
+USER_LANGUAGE="en"
+USER_NO_STOP="y"
+USER_INSTALL_TYPE="server"
+USER_DIR="/var/ossec"
+USER_ENABLE_EMAIL="n"
+USER_ENABLE_SYSCHECK="y"
+USER_ENABLE_ROOTCHECK="y"
+USER_ENABLE_OPENSCAP="y"
+USER_WHITE_LIST="n"
+USER_ENABLE_SYSLOG="y"
+USER_ENABLE_AUTHD="y"
+USER_AUTO_START="y"
+EOT
+    ./install.sh
+    cd ..
+
+    . /etc/ossec-init.conf
+    if [[ ${VERSION} < "v3.8.0" ]]; then
+        echo "Version inferior to v3.8.0"
+        /var/ossec/bin/ossec-control enable auth
+    fi
+    if [[ ${VERSION} < "v3.9.0" ]]; then
+        echo "Version inferior to v3.9.0"
+        ${PKG_INSTALL} ${PKG_OPTIONS} python-cryptography python-setuptools
+    fi
+    # if [[ ${VERSION} < "v4.0.0" ]]; then
+    if [[ ! -d "${DIRECTORY}/api" ]]; then
+        echo "Version inferior to v4.0.0"
+        # Install NodeJS and Wazuh API
+        git clone https://github.com/wazuh/wazuh-api -b $BRANCH
+        cd wazuh-api
+        ${PKG_INSTALL} ${PKG_OPTIONS} nodejs
+        npm config set user 0
+        ./install_api.sh
+    fi
+}
+
+install_wazuh() {
+    if [ $SOURCE_INSTALL == 0 ]; then
+        install_wazuh_from_packages
+    else
+        install_wazuh_from_sources
+    fi
+}
+
+main() {
+    set_global_parameters
+    install_dependencies
+    add_nodejs_repository
+    add_wazuh_repository
+    install_wazuh
+}
+
+main


### PR DESCRIPTION
Hello team,

This PR adds a docker environment to run API integration tests. The environment includes a Wazuh installation script (originally made @BraulioV for https://github.com/sonofagl1tch/AWSDetonationLab/pull/67) that has the following configuration parameters:
* Install type:
     * **`stable`**: Installs from stable repositories.
     * `pre_release`: Installs from pre_release repositories.
     * `sources`: Compiles from our GitHub repository. If no branch is specified, the master one will be used.
* Branch: When compiling from sources, specifies which branch to use.
* Package version: When using `stable` or `pre_release` repositories, specify which package version to install.

The environment is defined in a docker compose file (originally made by @crd1985 ) which creates 3 worker nodes and 3 agents, one connected to each cluster node.

Best regards,
Marta