### PR TITLE
Add Control module to Mac OS X agents

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -130,7 +130,7 @@ void run_notify()
 
     rand_keepalive_str2(keep_alive_random, KEEPALIVE_SIZE);
 
-#ifdef __linux__
+#if defined (__linux__) || defined (__MACH__)
     char *agent_ip;
     int sock;
     char label_ip[50];

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -85,7 +85,7 @@ int auth_add_agent(int sock, char *id, const char *name, const char *ip, const c
 char * get_agent_id_from_name(const char *agent_name);
 
 /* Check control module availability */
-#ifdef __linux__
+#if defined (__linux__) || defined (__MACH__)
 int control_check_connection();
 #endif
 

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -771,7 +771,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 }
 
 /* Connect to the control socket if available */
-#ifdef __linux__
+#if defined (__linux__) || defined (__MACH__)
 int control_check_connection() {
     int sock = OS_ConnectUnixDomain(CONTROL_SOCK, SOCK_STREAM, OS_SIZE_128);
 

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -138,6 +138,11 @@ struct link_stats
     unsigned int tx_dropped;    /* no space available in linux */
 };
 
+typedef struct gateway {
+    char *addr;
+    int isdefault;
+} gateway;
+
 extern const wm_context WM_SYS_CONTEXT;     // Context
 
 // Parse XML configuration
@@ -174,6 +179,9 @@ void list_users(HKEY hKey, int usec, const char * timestamp, int ID, const char 
 #if defined(__FreeBSD__) || defined(__MACH__)
 // Installed programs inventory for BSD based systems
 void sys_packages_bsd(int queue_fd, const char* LOCATION);
+
+int getGatewayList(OSHash *gateway_list);
+
 #endif
 
 // Hardware inventory for Linux
@@ -215,8 +223,9 @@ int read_entry(u_int8_t* bytes, rpm_data *info);
 
 // Get the inventory for a network interface in the object passed as parameter
 struct ifaddrs;
-void getNetworkIface(cJSON *object, char *iface_name, struct ifaddrs *ifaddr);
+void getNetworkIface_linux(cJSON *object, char *iface_name, struct ifaddrs *ifaddr);
 
+void getNetworkIface_bsd(cJSON *object, char *iface_name, struct ifaddrs *ifaddrs_ptr, OSHash *gateways);
 // Create the interface list
 int getIfaceslist(char **ifaces_list, struct ifaddrs *ifaddr);
 

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -225,7 +225,7 @@ int read_entry(u_int8_t* bytes, rpm_data *info);
 struct ifaddrs;
 void getNetworkIface_linux(cJSON *object, char *iface_name, struct ifaddrs *ifaddr);
 
-void getNetworkIface_bsd(cJSON *object, char *iface_name, struct ifaddrs *ifaddrs_ptr, OSHash *gateways);
+void getNetworkIface_bsd(cJSON *object, char *iface_name, struct ifaddrs *ifaddrs_ptr, __attribute__((unused)) gateway *gate);
 // Create the interface list
 int getIfaceslist(char **ifaces_list, struct ifaddrs *ifaddr);
 

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -180,6 +180,9 @@ void list_users(HKEY hKey, int usec, const char * timestamp, int ID, const char 
 // Installed programs inventory for BSD based systems
 void sys_packages_bsd(int queue_fd, const char* LOCATION);
 
+#endif
+
+#ifdef __MACH__
 int getGatewayList(OSHash *gateway_list);
 
 #endif

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -731,7 +731,7 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
     #if defined(__MACH__)
     gateways = OSHash_Create();
     if (getGatewayList(gateways) < 0){
-        merror("Error creating the list of gateways");
+        mterror(WM_SYS_LOGTAG, "Unable to obtain the Default Gateway list");
     }
     #endif
 

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -728,13 +728,12 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
         return;
     }
 
-    #if defined(__MACH__)
+#if defined(__MACH__)
     gateways = OSHash_Create();
     if (getGatewayList(gateways) < 0){
-        mterror(WM_SYS_LOGTAG, "Unable to obtain the Default Gateway list");
+        mtwarn(WM_SYS_LOGTAG, "Unable to obtain the Default Gateway list");
     }
-    #endif
-
+#endif
 
     for (i=0; i < size_ifaces; i++){
 
@@ -760,9 +759,9 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
         free(string);
     }
 
-    #if defined(__MACH__)
-        OSHash_Free(gateways);
-    #endif
+#if defined(__MACH__)
+    OSHash_Free(gateways);
+#endif
     freeifaddrs(ifaddrs_ptr);
     for (i=0; ifaces_list[i]; i++){
         free(ifaces_list[i]);
@@ -1209,7 +1208,7 @@ int getGatewayList(OSHash *gateway_list){
                     gate->isdefault = 1;
                 #endif
                     OSHash_Add(gateway_list, ifname, gate);
-                    mdebug2("Gateway of interface %s : %s Default: %d\n", ifname, gate->addr, gate->isdefault);
+                    mdebug2("Gateway of interface %s : %s Default: %d", ifname, gate->addr, gate->isdefault);
                 }
             }
 

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -11,15 +11,18 @@
 
 #include "syscollector.h"
 
+#if defined(__linux__) || defined(__MACH__)
+#include <ifaddrs.h>
+#include <net/if.h>
+#endif
+
 #if defined(__linux__)
 
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <net/if_arp.h>
-#include <net/if.h>
 #include <netinet/tcp.h>
-#include <ifaddrs.h>
 #include <linux/if_packet.h>
 #include "external/procps/readproc.h"
 #include "external/libdb/build_unix/db.h"
@@ -1953,6 +1956,9 @@ void getNetworkIface_linux(cJSON *object, char *iface_name, struct ifaddrs *ifad
 
 }
 
+#endif /* __linux__ */
+
+#if defined(__linux__) || defined(__MACH__)
 int getIfaceslist(char **ifaces_list, struct ifaddrs *ifaddr){
 
     int found;
@@ -1985,4 +1991,4 @@ int getIfaceslist(char **ifaces_list, struct ifaddrs *ifaddr){
 
 }
 
-#endif /* __linux__ */
+#endif

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -953,7 +953,7 @@ char* get_broadcast_addr(char* ip, char* netmask){
 void sys_network_linux(int queue_fd, const char* LOCATION){
 
     char ** ifaces_list;
-    int i = 0, j = 0;
+    int i = 0, size_ifaces = 0;
     struct ifaddrs *ifaddr, *ifa;
     int random_id = os_random();
     char *timestamp;
@@ -989,7 +989,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
     os_calloc(i, sizeof(char *), ifaces_list);
 
     /* Create interfaces list */
-    j = getIfaceslist(ifaces_list, ifaddr);
+    size_ifaces = getIfaceslist(ifaces_list, ifaddr);
 
     if(!ifaces_list[0]){
         mterror(WM_SYS_LOGTAG, "No interface found. Network inventory suspended.");
@@ -999,7 +999,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
     }
 
     /* Collect all information for each interface */
-    for (i=0; i<j; i++){
+    for (i=0; i < size_ifaces; i++){
 
         char *string;
         cJSON *object = cJSON_CreateObject();
@@ -1007,7 +1007,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
         cJSON_AddNumberToObject(object, "ID", random_id);
         cJSON_AddStringToObject(object, "timestamp", timestamp);
 
-        getNetworkIface(object, ifaces_list[i], ifaddr);
+        getNetworkIface_linux(object, ifaces_list[i], ifaddr);
 
         /* Send interface data in JSON format */
         string = cJSON_PrintUnformatted(object);
@@ -1685,7 +1685,7 @@ int read_entry(u_int8_t* bytes, rpm_data *info) {
 
 }
 
-void getNetworkIface(cJSON *object, char *iface_name, struct ifaddrs *ifaddr){
+void getNetworkIface_linux(cJSON *object, char *iface_name, struct ifaddrs *ifaddr){
     
     struct ifaddrs *ifa;
     int k = 0;

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -11,7 +11,7 @@
 
 #include "syscollector.h"
 
-#if defined(__linux__) || defined(__MACH__)
+#if defined(__linux__) || defined(__MACH__) || defined (__FreeBSD__) || defined (__OpenBSD__)
 #include <ifaddrs.h>
 #include <net/if.h>
 #endif
@@ -1958,7 +1958,7 @@ void getNetworkIface_linux(cJSON *object, char *iface_name, struct ifaddrs *ifad
 
 #endif /* __linux__ */
 
-#if defined(__linux__) || defined(__MACH__)
+#if defined(__linux__) || defined(__MACH__) || defined (__FreeBSD__) || defined (__OpenBSD__)
 int getIfaceslist(char **ifaces_list, struct ifaddrs *ifaddr){
 
     int found;

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -58,13 +58,11 @@ char* getPrimaryIP(){
         }
     }
 
-    #if defined (__linux__) || defined (__MACH__)
     OSHash *gateways = OSHash_Create();
     if (getGatewayList(gateways) < 0){
         merror("Error creating the list of gateways");
     }
     gateway *gate;
-    #endif
 
     for (i=0; i<size; i++) {
         cJSON *object = cJSON_CreateObject();

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -36,7 +36,9 @@ char* getPrimaryIP(){
     struct ifaddrs *ifaddr, *ifa;
     int size;
     int i = 0;
+    #ifdef __linux__
     int min_metric = INT_MAX;
+    #endif
 
     if (getifaddrs(&ifaddr) == -1) {
         mterror(WM_CONTROL_LOGTAG, "at getPrimaryIP(): getifaddrs() failed.");

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -57,12 +57,13 @@ char* getPrimaryIP(){
             return agent_ip;
         }
     }
-
+    #ifdef __MACH__
     OSHash *gateways = OSHash_Create();
     if (getGatewayList(gateways) < 0){
-        merror("Error creating the list of gateways");
+        mterror(WM_CONTROL_LOGTAG, "Unable to obtain the Default Gateway list");
     }
     gateway *gate;
+    #endif
 
     for (i=0; i<size; i++) {
         cJSON *object = cJSON_CreateObject();

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -70,12 +70,16 @@ char* getPrimaryIP(){
             getNetworkIface_linux(object, ifaces_list[i], ifaddr);
         #elif defined __MACH__
             if(gate = OSHash_Get(gateways, ifaces_list[i]), gate){
-                if(!gate->isdefault)
+                if(!gate->isdefault){
+                    free(gate);
                     continue;
-                if(gate->addr[0]=='l')
+                }
+                if(gate->addr[0]=='l'){
+                    free(gate);
                     continue;
+                }
+                getNetworkIface_bsd(object, ifaces_list[i], ifaddr, gate);
             }
-            getNetworkIface_bsd(object, ifaces_list[i], ifaddr, gateways);
         #endif
         cJSON *interface = cJSON_GetObjectItem(object, "iface");
         cJSON *ipv4 = cJSON_GetObjectItem(interface, "IPv4");
@@ -98,6 +102,7 @@ char* getPrimaryIP(){
                 cJSON *addresses = cJSON_GetObjectItem(ipv4, "address");
                 cJSON *address = cJSON_GetArrayItem(addresses,0);
                 os_strdup(address->valuestring, agent_ip);
+                cJSON_Delete(object);
                 break;
             #endif
             

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -72,6 +72,8 @@ char* getPrimaryIP(){
             if(gate = OSHash_Get(gateways, ifaces_list[i]), gate){
                 if(!gate->isdefault)
                     continue;
+                if(gate->addr[0]=='l')
+                    continue;
             }
             getNetworkIface_bsd(object, ifaces_list[i], ifaddr, gateways);
         #endif

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -36,9 +36,9 @@ char* getPrimaryIP(){
     struct ifaddrs *ifaddr, *ifa;
     int size;
     int i = 0;
-    #ifdef __linux__
+#ifdef __linux__
     int min_metric = INT_MAX;
-    #endif
+#endif
 
     if (getifaddrs(&ifaddr) == -1) {
         mterror(WM_CONTROL_LOGTAG, "at getPrimaryIP(): getifaddrs() failed.");
@@ -55,66 +55,68 @@ char* getPrimaryIP(){
 
         if(!ifaces_list[0]){
             mtdebug1(WM_CONTROL_LOGTAG, "No network interface found when reading agent IP.");
-            free(ifaces_list);
+            os_free(ifaces_list);
             return agent_ip;
         }
     }
-    #ifdef __MACH__
+#ifdef __MACH__
     OSHash *gateways = OSHash_Create();
     if (getGatewayList(gateways) < 0){
-        mterror(WM_CONTROL_LOGTAG, "Unable to obtain the Default Gateway list");
+        mtdebug1(WM_CONTROL_LOGTAG, "Unable to obtain the Default Gateway list");
+        os_free(ifaces_list);
+        return agent_ip;
     }
     gateway *gate;
-    #endif
+#endif
 
     for (i=0; i<size; i++) {
         cJSON *object = cJSON_CreateObject();
-        #ifdef __linux__
-            getNetworkIface_linux(object, ifaces_list[i], ifaddr);
-        #elif defined __MACH__
-            if(gate = OSHash_Get(gateways, ifaces_list[i]), gate){
-                if(!gate->isdefault){
-                    free(gate);
-                    continue;
-                }
-                if(gate->addr[0]=='l'){
-                    free(gate);
-                    continue;
-                }
-                getNetworkIface_bsd(object, ifaces_list[i], ifaddr, gate);
+#ifdef __linux__
+        getNetworkIface_linux(object, ifaces_list[i], ifaddr);
+#elif defined __MACH__
+        if(gate = OSHash_Get(gateways, ifaces_list[i]), gate){
+            if(!gate->isdefault){
+                free(gate);
+                continue;
             }
-        #endif
+            if(gate->addr[0]=='l'){
+                free(gate);
+                continue;
+            }
+            getNetworkIface_bsd(object, ifaces_list[i], ifaddr, gate);
+        }
+#endif
         cJSON *interface = cJSON_GetObjectItem(object, "iface");
         cJSON *ipv4 = cJSON_GetObjectItem(interface, "IPv4");
         if(ipv4){
-            #ifdef __linux__
+#ifdef __linux__
             cJSON * gateway = cJSON_GetObjectItem(ipv4, "gateway");
             if (gateway) {
-                    cJSON * metric = cJSON_GetObjectItem(ipv4, "metric");
-                    if (metric && metric->valueint < min_metric) {
-                        cJSON *addresses = cJSON_GetObjectItem(ipv4, "address");
-                        cJSON *address = cJSON_GetArrayItem(addresses,0);
-                        if(agent_ip != NULL){
-                            free(agent_ip);
-                        }
-                        os_strdup(address->valuestring, agent_ip);
-                        min_metric = metric->valueint;
+                cJSON * metric = cJSON_GetObjectItem(ipv4, "metric");
+                if (metric && metric->valueint < min_metric) {
+                    cJSON *addresses = cJSON_GetObjectItem(ipv4, "address");
+                    cJSON *address = cJSON_GetArrayItem(addresses,0);
+                    if(agent_ip != NULL){
+                        free(agent_ip);
                     }
+                    os_strdup(address->valuestring, agent_ip);
+                    min_metric = metric->valueint;
+                }
             }
-            #elif defined __MACH__
-                cJSON *addresses = cJSON_GetObjectItem(ipv4, "address");
-                cJSON *address = cJSON_GetArrayItem(addresses,0);
-                os_strdup(address->valuestring, agent_ip);
-                cJSON_Delete(object);
-                break;
-            #endif
+#elif defined __MACH__
+            cJSON *addresses = cJSON_GetObjectItem(ipv4, "address");
+            cJSON *address = cJSON_GetArrayItem(addresses,0);
+            os_strdup(address->valuestring, agent_ip);
+            cJSON_Delete(object);
+            break;
+#endif
             
         }
         cJSON_Delete(object);
     }
-    #if defined __MACH__
+#if defined __MACH__
     OSHash_Free(gateways);
-    #endif
+#endif
 
     freeifaddrs(ifaddr);
     for (i=0; ifaces_list[i]; i++){

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -44,7 +44,7 @@ int wm_config() {
     // Read configuration: agent.conf
     agent_cfg = 1;
     ReadConfig(CWMODULE | CAGENT_CONFIG, AGENTCONFIG, &wmodules, &agent_cfg);
-#ifdef __linux__
+#if defined (__linux__) || (__MACH__)
     wmodule *module;
     module = wm_control_read();
     wm_add(module);


### PR DESCRIPTION
This PR is the development of the issue: https://github.com/wazuh/wazuh/issues/2921

This PR add to the syscollector scan of Mac OS agents the capability of extract the gateway of a network interface as it is done in Linux agents.
Also it add the control module to the Mac OS agents in order to get the default agent ip as it is done in the Linux and Windows agents, through the keep-alive message.

To test the PR I've checked that:
- [x] The agent IP is sent in the keep alive and store in the agent-info
- [x] The syscollector network scan is working and the agent db is filled
- [X] The agent ip is stored in the global db as reporting_ip
- [X] The code still compile and is working in FreeBSD as it was doing before.