### PR TITLE
Fix compilation errors when building the manager in Arch Linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -750,7 +750,7 @@ $(EXTERNAL_CURL)Makefile:
 	cd $(EXTERNAL_CURL) && ./configure --with-darwinssl --disable-ldap --without-libidn2
 else
 $(EXTERNAL_CURL)Makefile: $(OPENSSL_LIB)
-	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-ldl -lpthread" ./configure --disable-ldap --without-libidn2
+	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-ldl -lpthread" ./configure --disable-ldap --without-libidn2  --without-libpsl --without-nghttp2 --without-librtmp --without-brotli
 endif
 
 


### PR DESCRIPTION
Hi team,

this PR closes #3012. This commit adds some new parameters to the `configure` script from `libcurl` that disables some modules that are not available in Arch Linux.

Regards.
