### PR TITLE
Fix nodiff configuration error

### DIFF
--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -123,8 +123,7 @@ int is_nodiff(const char *filename){
     if (syscheck.nodiff){
         int i;
         for (i = 0; syscheck.nodiff[i] != NULL; i++){
-            if (strncasecmp(syscheck.nodiff[i], filename,
-                            strlen(syscheck.nodiff[i])) == 0) {
+            if ((strcmp(syscheck.nodiff[i], filename)) == 0) {
                 return (TRUE);
             }
         }


### PR DESCRIPTION
This fixes #2949 

Configuration
---
- **Linux**:
```
<directories check_all="yes" realtime="yes" report_changes="yes">/home/virus</directories>
...
<nodiff>/home/virus/filenew</nodiff>
```

- **Windows**:
```
<directories check_all="yes" realtime="yes" report_changes="yes">D:\Libraries\Escritorio\testn</directories>
...
<nodiff>D:\Libraries\Escritorio\testn\filenew</nodiff>
```

Testing
---
We won't include files like `filenew123` as nodiff anymore. We've checked the following cases:

- Linux:

| Filename | Result | Output |
| --- | --- | --- |
| `filenew` | This will generate a `nodiff` alert | (1) |
| `filenew123` | This won't generate a `nodiff` alert | (2) |
| `FILEnew` | This won't generate a `nodiff` alert | (3) |
| `fileNEW123` | This won't generate a `nodiff` alert | (4) |

(1)
```
** Alert 1554363380.18530: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 04 07:36:20 (vm-ubuntu3) 10.0.0.123->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/home/virus/filenew' checksum changed.
Size changed from '0' to '10'
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : 'f7d07c28fa2eaa609881cf8545df8ac4'
Old sha1sum was: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
New sha1sum is : 'a0835ba6e52da4edc03efd67a44f120e23f5a616'
Old sha256sum was: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
New sha256sum is : 'aaefc330803a83c2ddabc71fb4ee83ee8828142b57b6c7122ce23609ad4ea8d8'
Old modification time was: 'Thu Apr  4 07:36:09 2019', now it is 'Thu Apr  4 07:36:20 2019'
What changed:
<Diff truncated because nodiff option>
Attributes:
 - Size: 10
 - Date: Thu Apr  4 07:36:20 2019
 - Inode: 257938
 - User: root (0)
 - Group: root (0)
 - MD5: f7d07c28fa2eaa609881cf8545df8ac4
 - SHA1: a0835ba6e52da4edc03efd67a44f120e23f5a616
 - SHA256: aaefc330803a83c2ddabc71fb4ee83ee8828142b57b6c7122ce23609ad4ea8d8
 - Permissions: 100644
```

(2)
```
** Alert 1554365687.20171: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 04 08:14:47 (vm-ubuntu3) 10.0.0.123->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/home/virus/filenew123' checksum changed.
Size changed from '0' to '10'
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : 'f7d07c28fa2eaa609881cf8545df8ac4'
Old sha1sum was: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
New sha1sum is : 'a0835ba6e52da4edc03efd67a44f120e23f5a616'
Old sha256sum was: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
New sha256sum is : 'aaefc330803a83c2ddabc71fb4ee83ee8828142b57b6c7122ce23609ad4ea8d8'
Old modification time was: 'Thu Apr  4 08:14:39 2019', now it is 'Thu Apr  4 08:14:47 2019'
What changed:
0a1
> 123123131

Attributes:
 - Size: 10
 - Date: Thu Apr  4 08:14:47 2019
 - Inode: 258055
 - User: root (0)
 - Group: root (0)
 - MD5: f7d07c28fa2eaa609881cf8545df8ac4
 - SHA1: a0835ba6e52da4edc03efd67a44f120e23f5a616
 - SHA256: aaefc330803a83c2ddabc71fb4ee83ee8828142b57b6c7122ce23609ad4ea8d8
 - Permissions: 100644
```

(3)
```
** Alert 1554365737.21790: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 04 08:15:37 (vm-ubuntu3) 10.0.0.123->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/home/virus/FILEnew' checksum changed.
Size changed from '0' to '10'
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : 'f7d07c28fa2eaa609881cf8545df8ac4'
Old sha1sum was: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
New sha1sum is : 'a0835ba6e52da4edc03efd67a44f120e23f5a616'
Old sha256sum was: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
New sha256sum is : 'aaefc330803a83c2ddabc71fb4ee83ee8828142b57b6c7122ce23609ad4ea8d8'
Old modification time was: 'Thu Apr  4 08:15:30 2019', now it is 'Thu Apr  4 08:15:38 2019'
What changed:
0a1
> 123123131

Attributes:
 - Size: 10
 - Date: Thu Apr  4 08:15:38 2019
 - Inode: 284286
 - User: root (0)
 - Group: root (0)
 - MD5: f7d07c28fa2eaa609881cf8545df8ac4
 - SHA1: a0835ba6e52da4edc03efd67a44f120e23f5a616
 - SHA256: aaefc330803a83c2ddabc71fb4ee83ee8828142b57b6c7122ce23609ad4ea8d8
 - Permissions: 100644
```

(4)
```
** Alert 1554365779.23409: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 04 08:16:19 (vm-ubuntu3) 10.0.0.123->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/home/virus/fileNEW123' checksum changed.
Size changed from '0' to '10'
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : 'f7d07c28fa2eaa609881cf8545df8ac4'
Old sha1sum was: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
New sha1sum is : 'a0835ba6e52da4edc03efd67a44f120e23f5a616'
Old sha256sum was: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
New sha256sum is : 'aaefc330803a83c2ddabc71fb4ee83ee8828142b57b6c7122ce23609ad4ea8d8'
Old modification time was: 'Thu Apr  4 08:16:13 2019', now it is 'Thu Apr  4 08:16:19 2019'
What changed:
0a1
> 123123131

Attributes:
 - Size: 10
 - Date: Thu Apr  4 08:16:19 2019
 - Inode: 297988
 - User: root (0)
 - Group: root (0)
 - MD5: f7d07c28fa2eaa609881cf8545df8ac4
 - SHA1: a0835ba6e52da4edc03efd67a44f120e23f5a616
 - SHA256: aaefc330803a83c2ddabc71fb4ee83ee8828142b57b6c7122ce23609ad4ea8d8
 - Permissions: 100644
```

- Windows:

| Filename | Result | Output |
| --- | --- | --- |
| `filenew` | This will generate a `nodiff` alert | (1) |
| `filenew123` | This won't generate a `nodiff` alert | (2) |
| `FILEnew` | This will generate a `nodiff` alert | (3) |
| `fileNEW123` | This won't generate a `nodiff` alert | (4) |

(1)
```
** Alert 1554366937.35953: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 04 08:35:37 (Windows) 10.0.0.1->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File 'd:\libraries\escritorio\testn\filenew' checksum changed.
Size changed from '0' to '22'
Ownership was ' ((null))', now it is 'DaveVG (S-1-5-21-4218398017-4192086937-1907420761-1001)'
Old md5sum was: 'n/a'
New md5sum is : '8d4c3fd0773d6fd46aa263a95ec48a97'
Old sha1sum was: 'n/a'
New sha1sum is : '4fddbd91f1492eef11747e29b7e640fd40525d8a'
Old sha256sum was: 'n/a'
New sha256sum is : '49442c64ce706bf4df8ccc4373fb8ade31326574240274848b23f8f49fd7f412'

Attributes:
 - Size: 22
 - Date: Thu Apr  4 08:49:49 2019
 - User: DaveVG (S-1-5-21-4218398017-4192086937-1907420761-1001)
 - MD5: 8d4c3fd0773d6fd46aa263a95ec48a97
 - SHA1: 4fddbd91f1492eef11747e29b7e640fd40525d8a
 - SHA256: 49442c64ce706bf4df8ccc4373fb8ade31326574240274848b23f8f49fd7f412
 - File attributes: ARCHIVE
 - Permissions:
   Administradores  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   SYSTEM  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   Authenticated Users  (ALLOWED) - DELETE, READ_CONTROL, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   Usuarios  (ALLOWED) - READ_CONTROL, SYNCHRONIZE, FILE_READ_DATA, FILE_READ_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES
```

(2)
```
** Alert 1554367116.48732: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 04 08:38:36 (Windows) 10.0.0.1->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File 'd:\libraries\escritorio\testn\filenew123' checksum changed.
Ownership was 'DaveVG (S-1-5-21-4218398017-4192086937-1907420761-1001)', now it is ' ((null))'
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : 'n/a'
Old sha1sum was: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
New sha1sum is : 'n/a'
Old sha256sum was: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
New sha256sum is : 'n/a'
Old modification time was: 'Thu Apr  4 08:52:34 2019', now it is 'Thu Apr  4 08:52:48 2019'
What changed:
***** QUEUE\DIFF\LOCAL\LIBRARIES\ESCRITORIO\TESTN\FILENEW123\state.1554367968
***** QUEUE\DIFF\LOCAL\LIBRARIES\ESCRITORIO\TESTN\FILENEW123\LAST-ENTRY
dsfasdsdasdasdsaa
*****


Attributes:
 - Size: 0
 - Date: Thu Apr  4 08:52:48 2019
 - MD5: n/a
 - SHA1: n/a
 - SHA256: n/a
 - File attributes: ARCHIVE
 - Permissions:
   Administradores  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   SYSTEM  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   Authenticated Users  (ALLOWED) - DELETE, READ_CONTROL, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   Usuarios  (ALLOWED) - READ_CONTROL, SYNCHRONIZE, FILE_READ_DATA, FILE_READ_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES
```

(3)
```
** Alert 1554367049.44127: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 04 08:37:29 (Windows) 10.0.0.1->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File 'd:\libraries\escritorio\testn\filenew' checksum changed.
Size changed from '0' to '13'
Ownership was ' ((null))', now it is 'DaveVG (S-1-5-21-4218398017-4192086937-1907420761-1001)'
Old md5sum was: 'n/a'
New md5sum is : '5f10b12e7af3b7db399fc4b34af1fc74'
Old sha1sum was: 'n/a'
New sha1sum is : '0bde445998db75e529d54370ba31b41d34b2278c'
Old sha256sum was: 'n/a'
New sha256sum is : 'e9656fa9ad63589aa15f001b2c102a527cfb1d88e256662c2ab7a40e160426dd'

Attributes:
 - Size: 13
 - Date: Thu Apr  4 08:51:42 2019
 - User: DaveVG (S-1-5-21-4218398017-4192086937-1907420761-1001)
 - MD5: 5f10b12e7af3b7db399fc4b34af1fc74
 - SHA1: 0bde445998db75e529d54370ba31b41d34b2278c
 - SHA256: e9656fa9ad63589aa15f001b2c102a527cfb1d88e256662c2ab7a40e160426dd
 - File attributes: ARCHIVE
 - Permissions:
   Administradores  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   SYSTEM  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   Authenticated Users  (ALLOWED) - DELETE, READ_CONTROL, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   Usuarios  (ALLOWED) - READ_CONTROL, SYNCHRONIZE, FILE_READ_DATA, FILE_READ_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES
```

(4)
```
** Alert 1554367228.55947: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 04 08:40:28 (Windows) 10.0.0.1->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File 'd:\libraries\escritorio\testn\filenew123' checksum changed.
Ownership was 'DaveVG (S-1-5-21-4218398017-4192086937-1907420761-1001)', now it is ' ((null))'
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : 'n/a'
Old sha1sum was: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
New sha1sum is : 'n/a'
Old sha256sum was: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
New sha256sum is : 'n/a'
Old modification time was: 'Thu Apr  4 08:54:19 2019', now it is 'Thu Apr  4 08:54:41 2019'
What changed:
***** QUEUE\DIFF\LOCAL\LIBRARIES\ESCRITORIO\TESTN\FILENEW123\state.1554368081
***** QUEUE\DIFF\LOCAL\LIBRARIES\ESCRITORIO\TESTN\FILENEW123\LAST-ENTRY
sdxfsfdsfsfds
*****


Attributes:
 - Size: 0
 - Date: Thu Apr  4 08:54:41 2019
 - MD5: n/a
 - SHA1: n/a
 - SHA256: n/a
 - File attributes: ARCHIVE
 - Permissions:
   Administradores  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   SYSTEM  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   Authenticated Users  (ALLOWED) - DELETE, READ_CONTROL, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
   Usuarios  (ALLOWED) - READ_CONTROL, SYNCHRONIZE, FILE_READ_DATA, FILE_READ_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES
```

Behavior
---

- As can be seen, the behavior in Windows is slightly different from Linux. This is because the file names in Windows aren't case sensitive (`filenew` and `FILEnew` are the same file name in Windows, you can't have those two files in the same folder).

- This also means that the following configuration produces the same behavior in Windows (not in Linux):
```
<directories check_all="yes" report_changes="yes" realtime="yes">D:\Libraries\Escritorio\testn</directories>
...
<nodiff>D:\Libraries\Escritorio\testn\fileNEW</nodiff>
```