### PR TITLE
Log unhandled exceptions in cluster.log file

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -180,3 +180,5 @@ if __name__ == '__main__':
         asyncio.run(main_function(args, cluster_configuration, cluster_items, main_logger))
     except KeyboardInterrupt:
         main_logger.info("SIGINT received. Bye!")
+    except Exception as e:
+        main_logger.error(f"Unhandled exception: {e}")


### PR DESCRIPTION
Hello team,

This PR adds a very important feature: log unhandled exceptions in cluster.log file. If there's an exception that makes the cluster crush, this must be **at least** logged so it can be easily reported and addressed.

Best regards,
Marta