### PR TITLE
Removed unused directory /ossec/queue/agents from installation

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -782,7 +782,6 @@ InstallCommon()
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/alerts
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/ossec
   ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/diff
-  ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/agents
 
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/ruleset
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/ruleset/sca


### PR DESCRIPTION
Hi team,

This PR closes #2927 by removing the line that creates the directory from the instalation script. This issue was continued on https://github.com/wazuh/wazuh-packages/issues/144 that is related to the problems this caused on the packaging.

Regards.
Daniel Folch 