### PR TITLE
Fix macOS's package inventory not parsing info correctly

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -292,7 +292,22 @@ char* sys_parse_pkg(const char * app_folder, const char * folder_name, const cha
           cJSON_AddStringToObject(package, "location", app_folder);
         }
         else{
-          cJSON_AddStringToObject(package, "name", folder_name);
+
+          cJSON_DeleteItemFromObjectCaseSensitive(package, "version");
+          cJSON_DeleteItemFromObjectCaseSensitive(package, "group");
+          cJSON_DeleteItemFromObjectCaseSensitive(package, "description");
+
+          char folder_name2[30];
+
+          for (int i=0; i<30; i++){
+            folder_name2[i] = folder_name[i];
+          }
+
+          char *temp;
+          temp = strchr(folder_name2,'.');
+          *temp = '\0';
+
+          cJSON_AddStringToObject(package, "name", folder_name2);
         }
 
         char *string;

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -225,9 +225,9 @@ char* sys_parse_pkg(const char * app_folder, const char * folder_name, const cha
 
             if (strstr(read_buff, "CFBundleName")) {
                 void_file=0;
-                if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
-                    char ** parts = OS_StrBreak('>', read_buff, 2);
-                    char ** _parts = OS_StrBreak('<', parts[1], 2);
+                if (strstr(read_buff, "<string>")){
+                    char ** parts = OS_StrBreak('>', read_buff, 4);
+                    char ** _parts = OS_StrBreak('<', parts[3], 2);
 
                     cJSON_AddStringToObject(package, "name", _parts[0]);
 
@@ -238,9 +238,35 @@ char* sys_parse_pkg(const char * app_folder, const char * folder_name, const cha
                     free(parts);
                     free(_parts);
                 }
+                else if((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
+                  char ** parts = OS_StrBreak('>', read_buff, 2);
+                  char ** _parts = OS_StrBreak('<', parts[1], 2);
+
+                  cJSON_AddStringToObject(package, "name", _parts[0]);
+
+                  for (i = 0; _parts[i]; i++) {
+                      free(_parts[i]);
+                      free(parts[i]);
+                  }
+                  free(parts);
+                  free(_parts);
+                }
 
             } else if (strstr(read_buff, "CFBundleShortVersionString")){
-                if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
+                if (strstr(read_buff, "<string>")){
+                    char ** parts = OS_StrBreak('>', read_buff, 4);
+                    char ** _parts = OS_StrBreak('<', parts[3], 2);
+
+                    cJSON_AddStringToObject(package, "version", _parts[0]);
+
+                    for (i = 0; _parts[i]; i++) {
+                        free(_parts[i]);
+                        free(parts[i]);
+                    }
+                    free(parts);
+                    free(_parts);
+                }
+                else if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
                     char ** parts = OS_StrBreak('>', read_buff, 2);
                     char ** _parts = OS_StrBreak('<', parts[1], 2);
 
@@ -254,9 +280,9 @@ char* sys_parse_pkg(const char * app_folder, const char * folder_name, const cha
                     free(_parts);
                 }
             } else if (strstr(read_buff, "LSApplicationCategoryType")){
-                if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
-                    char ** parts = OS_StrBreak('>', read_buff, 2);
-                    char ** _parts = OS_StrBreak('<', parts[1], 2);
+                if (strstr(read_buff, "<string>")){
+                    char ** parts = OS_StrBreak('>', read_buff, 4);
+                    char ** _parts = OS_StrBreak('<', parts[3], 2);
 
                     cJSON_AddStringToObject(package, "group", _parts[0]);
 
@@ -267,10 +293,23 @@ char* sys_parse_pkg(const char * app_folder, const char * folder_name, const cha
                     free(parts);
                     free(_parts);
                 }
+                else if((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
+                  char ** parts = OS_StrBreak('>', read_buff, 2);
+                  char ** _parts = OS_StrBreak('<', parts[1], 2);
+
+                  cJSON_AddStringToObject(package, "group", _parts[0]);
+
+                  for (i = 0; _parts[i]; i++) {
+                      free(_parts[i]);
+                      free(parts[i]);
+                  }
+                  free(parts);
+                  free(_parts);
+                }
             } else if (strstr(read_buff, "CFBundleIdentifier")){
-                if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
-                    char ** parts = OS_StrBreak('>', read_buff, 2);
-                    char ** _parts = OS_StrBreak('<', parts[1], 2);
+                if (strstr(read_buff, "<string>")){
+                    char ** parts = OS_StrBreak('>', read_buff, 4);
+                    char ** _parts = OS_StrBreak('<', parts[3], 2);
 
                     cJSON_AddStringToObject(package, "description", _parts[0]);
 
@@ -280,6 +319,19 @@ char* sys_parse_pkg(const char * app_folder, const char * folder_name, const cha
                     }
                     free(parts);
                     free(_parts);
+                }
+                else if((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
+                  char ** parts = OS_StrBreak('>', read_buff, 2);
+                  char ** _parts = OS_StrBreak('<', parts[1], 2);
+
+                  cJSON_AddStringToObject(package, "description", _parts[0]);
+
+                  for (i = 0; _parts[i]; i++) {
+                      free(_parts[i]);
+                      free(parts[i]);
+                  }
+                  free(parts);
+                  free(_parts);
                 }
             }
         }


### PR DESCRIPTION
This PR is aimed at solving issue #2922.

**Description**

- Previously, syscollector couldn't parse `Info.plist` files with a different internal format, and it produced data that was empty or filled with garbage while trying. Now it can read files using both vertical and horizontal labels, and when they use a different format that it doesn't know how to parse, it at least tries to read the package's name from its folder and then empties the rest of the fields.

**Use case**

VirtualBox's Info.plist file por example has a format such as follows:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>CFBundlePackageType</key>              <string>APPL</string>
    <key>CFBundleSignature</key>                <string>VBOX</string>
    <key>CFBundleDevelopmentRegion</key>        <string>English</string>
    <key>CFBundleIdentifier</key>               <string>org.virtualbox.app.VirtualBox</string>
    <key>CFBundleName</key>                     <string>VirtualBox</string>
    <key>CFBundleExecutable</key>               <string>VirtualBox</string>
    <key>CFBundleVersion</key>                  <string>6.0.4</string>
.
.
.
```
syscollector wasn't ready to read labels horizontally, so it resulted in wrong data being collected, like this:

`1880543464|2019/04/05 10:16:16|pkg|VirtualBox||||||CFBundleGetInfoString||||CFBundleName||0`

Now syscollector can read the file, producing the desired outcome:

`1901203817|2019/04/05 12:05:03|pkg|VirtualBox||||||6.0.4|||applications|org.virtualbox.app.VirtualBox|/Applications/VirtualBox.app|0`

If the file coulnd't be read anyways (because of it having a not supported format or it being corrupted), it would collect its name from the `/Applications/VirtualBox.app` and leave the remaining fields empty, like this:

`115170242|2019/04/05 11:01:57|pkg|VirtualBox||||||||||||0`


**Testing**

The previous changes have been tested with the previously problematic package VirtualBox.