### PR TITLE
Return the master node as the first one when listing all nodes

### DIFF
--- a/framework/wazuh/cluster/server.py
+++ b/framework/wazuh/cluster/server.py
@@ -171,7 +171,7 @@ class AbstractServer:
             if not filter_node.issubset(set(itertools.chain(self.clients.keys(), [self.configuration['node_name']]))):
                 raise exception.WazuhException(1730)
 
-        res = [val.to_dict()['info'] for val in itertools.chain(self.clients.values(), [self])
+        res = [val.to_dict()['info'] for val in itertools.chain([self], self.clients.values())
                if return_node(val.to_dict()['info'])]
 
         if sort is not None:


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh-api/issues/365.

Mocha tests:
```javascript
# mocha test/test_cluster.js --grep /cluster/nodes


  Cluster
    GET/cluster/nodes
      ✓ Request (469ms)
      ✓ Pagination (293ms)
      ✓ Retrieve all elements with limit=0 (278ms)
      ✓ Sort (271ms)
      ✓ Search (281ms)
      ✓ Filters: type (274ms)
      ✓ Filters: invalid type (271ms)
      ✓ Select (273ms)
      ✓ Select 2 (274ms)
      ✓ Wrong select (278ms)
    GET/cluster/nodes/:node_name
      ✓ Request (265ms)
      ✓ Request wrong name (272ms)


  12 passing (4s)
```

This is an example of the output:
```shellsession
# curl -u foo:bar "localhost:55000/cluster/nodes?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "name": "master",
            "type": "master",
            "version": "3.9.0",
            "ip": "172.17.0.100"
         },
         {
            "name": "worker-1",
            "type": "worker",
            "version": "3.9.0",
            "ip": "172.17.0.101"
         }
      ]
   }
}
# /var/ossec/bin/cluster_control -l
NAME      TYPE    VERSION  ADDRESS
master    master  3.9.0    172.17.0.100
worker-1  worker  3.9.0    172.17.0.101
```

Best regards,
Marta