### PR TITLE
Fix aws wodle installation in agents

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1063,7 +1063,7 @@ InstallAgent()
 
     if [ ! -d ${PREFIX}/wodles/aws ]; then
         ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/wodles/aws
-        ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/aws/aws-s3.py ${PREFIX}/wodles/aws/aws-s3
+        ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/aws/aws_s3.py ${PREFIX}/wodles/aws/aws-s3
     fi
 
     if [ ! -d ${PREFIX}/wodles/docker ]; then


### PR DESCRIPTION
Hi team,

Fixes a problem installing agents because of renamed aws-s3 wodle.

Sorry for any inconvenience.

Regards,
Dani
