### PR TITLE
Fixed rootcheck's frequency value being modified in syscheck code.

### DIFF
--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -159,7 +159,6 @@ void start_daemon()
     if (syscheck.scan_time || syscheck.scan_day) {
         /* At least once a week */
         syscheck.time = 604800;
-        rootcheck.time = 604800;
     }
     /* Printing syscheck properties */
 


### PR DESCRIPTION
This PR is aimed at solving issue #3033. The syscheck module was modifying rootcheck's frequency. Said modification has been removed and the module has been tested by modifying the `scan_time` and `scan_day` options to ensure they still work correctly.