### PR TITLE
Improve exceptions used in API active-response endpoints

### DIFF
--- a/framework/wazuh/active_response.py
+++ b/framework/wazuh/active_response.py
@@ -41,11 +41,11 @@ def run_command(agent_id=None, command=None, arguments=[], custom=False):
         raise WazuhException(1650)
 
     if not agent_id:
-        raise WazuhException(1655)
+        raise WazuhException(1653)
 
     commands = get_commands()
     if not custom and command not in commands:
-        raise WazuhException(1656, command)
+        raise WazuhException(1655, command)
 
     # Create message
     msg_queue = command
@@ -58,21 +58,19 @@ def run_command(agent_id=None, command=None, arguments=[], custom=False):
         msg_queue += " - -"
 
     # Send
-    if agent_id == "000" or agent_id == "all":
+    if agent_id == "000":
         oq = OssecQueue(common.EXECQ)
         ret_msg = oq.send_msg_to_agent(msg=msg_queue, agent_id=agent_id, msg_type=OssecQueue.AR_TYPE)
         oq.close()
 
-    if agent_id != "000" or agent_id == "all":
-
+    else:
         if agent_id != "all":
             # Check if agent exists and it is active
             agent_info = Agent(agent_id).get_basic_information()
 
             if agent_info['status'].lower() != 'active':
                 raise WazuhException(1651)
-
-        if agent_id == "all":
+        else:
             agent_id = None
 
         oq = OssecQueue(common.ARQUEUE)

--- a/framework/wazuh/active_response.py
+++ b/framework/wazuh/active_response.py
@@ -38,14 +38,14 @@ def run_command(agent_id=None, command=None, arguments=[], custom=False):
     :return: Message.
     """
     if not command:
-        raise WazuhException(1650, "Command not specified")
+        raise WazuhException(1650)
 
     if not agent_id:
-        raise WazuhException(1650, "Agent ID not specified")
+        raise WazuhException(1655)
 
     commands = get_commands()
     if not custom and command not in commands:
-        raise WazuhException(1650, "Command not available")
+        raise WazuhException(1656, command)
 
     # Create message
     msg_queue = command

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -89,11 +89,13 @@ class WazuhException(Exception):
         1603: 'Invalid status. Valid statuses are: all, solved and outstanding',
         1604: 'Impossible to run FIM scan due to agent is not active',
         1605: 'Impossible to run policy monitoring scan due to agent is not active',
-        1650: 'Active response - Bad arguments',
+        1650: 'Active response - Command not specified',
         1651: 'Active response - Agent is not active',
         1652: 'Active response - Unable to run command',
         1653: 'Active response - Agent not available',
         1654: 'Unable to clear rootcheck database',
+        1655: 'Active response - Agent ID not specified',
+        1656: 'Active response - Command not available',
 
         # Agents: 1700 - 1799
         1700: 'Bad arguments. Accepted arguments: [id] or [name and ip]',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -92,10 +92,9 @@ class WazuhException(Exception):
         1650: 'Active response - Command not specified',
         1651: 'Active response - Agent is not active',
         1652: 'Active response - Unable to run command',
-        1653: 'Active response - Agent not available',
+        1653: 'Active response - Agent ID not specified',
         1654: 'Unable to clear rootcheck database',
-        1655: 'Active response - Agent ID not specified',
-        1656: 'Active response - Command not available',
+        1655: 'Active response - Command not available',
 
         # Agents: 1700 - 1799
         1700: 'Bad arguments. Accepted arguments: [id] or [name and ip]',

--- a/framework/wazuh/ossec_queue.py
+++ b/framework/wazuh/ossec_queue.py
@@ -83,9 +83,6 @@ class OssecQueue:
         # AR
         if msg_type == OssecQueue.AR_TYPE:
 
-            if not agent_id:
-                raise WazuhException(1653)
-
             if agent_id != "000":
                 # Example restart 'msg': restart-ossec0 - null (from_the_server) (no_rule_id)
                 socket_msg = "{0} {1}{2}{3} {4} {5}".format("(msg_to_agent) []", str_all_agents, NONE_C, str_agent, str_agent_id, msg)

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from unittest.mock import patch
+import pytest
+from wazuh.exception import WazuhException
+from wazuh import active_response
+
+
+@patch('wazuh.active_response.OssecQueue')
+@patch('wazuh.active_response.Agent')
+@patch('wazuh.active_response.get_commands', return_value=['valid_cmd', 'another_valid_cmd', 'one_more'])
+@pytest.mark.parametrize('expected_exception, agent_id, command, arguments, custom', [
+    (1650, '000', None, [], False),
+    (1653, None, 'random', [], False),
+    (1655, '000', 'invalid_cmd', [], False),
+    (1651, '001', 'valid_cmd', [], False),
+    (None, '001', 'valid_cmd', [], False),
+    (None, '001', 'valid_cmd', ["arg1", "arg2"], False)
+])
+def test_run_command(cmd_patch, agent_patch, queue_patch, expected_exception, agent_id, command, arguments, custom):
+    """
+    Tests run_command function
+    """
+    agent_patch.return_value.get_basic_information.return_value = {'status': 'disconnected' if expected_exception else 'active'}
+    queue_patch.return_value.send_msg_to_agent.return_value = "success"
+    queue_patch.AR_TYPE = "AR"
+
+    if expected_exception is not None:
+        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+            active_response.run_command(agent_id, command, arguments, custom)
+    else:
+        ret = active_response.run_command(agent_id, command, arguments, custom)
+        assert ret == "success"
+        handle = queue_patch()
+        msg = f'{"!" if custom else ""}{command} {"- -" if not arguments else " ".join(arguments)}'
+        handle.send_msg_to_agent.assert_called_with(agent_id=agent_id, msg=msg, msg_type='AR')


### PR DESCRIPTION
Hello team,

This PR closes #3024.

Some examples of the new errors returned by the API:
```javascript
# curl -u foo:bar -k -X PUT -d '{"command":"firewall-drop120", "arguments": ["-", "10.0.0.80", "(from_the_server)", "(no_rule_id)"]}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/active-response/001?pretty"
{
   "error": 1655,
   "message": "Active response - Command not available"
}
# curl -u foo:bar -k -X PUT -d '{"command":"firewall-drop120", "arguments": ["-", "10.0.0.80", "(from_the_server)", "(no_rule_id)"]}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/active-response/005?pretty"
{
   "error": 1701,
   "message": "Agent does not exist"
}
# curl -u foo:bar -k -X PUT -d '{"command":"restart-ossec0", "arguments": []}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/active-response/002?pretty"
{
   "error": 1651,
   "message": "Active response - Agent is not active"
}
# rm /var/ossec/queue/alerts/ar
# curl -u foo:bar -k -X PUT -d '{"command":"restart-ossec0", "arguments": []}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/active-response/001?pretty"
{
   "error": 1010,
   "message": "Unable to connect to queue"
}
# curl -u foo:bar -k -X PUT -d '{"command":"restart-ossec0", "arguments": []}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/active-response/001?pretty"
{
   "error": 0,
   "data": "Command sent."
}
```

It also fixes a bug when calling the framework function `wazuh.active_response.run_command` using `all` as `agent_id` parameter. The parameter `all` is only supposed to restart all agents, but not the manager.

Unit tests:
```
# /var/ossec/framework/python/bin/pytest wazuh/tests/test_active_response.py -vv
======================================================= test session starts ========================================================
platform linux -- Python 3.7.2, pytest-4.4.0, py-1.8.0, pluggy-0.9.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/vagrant/GitHub/wazuh/framework
collected 6 items

wazuh/tests/test_active_response.py::test_run_command[1650-000-None-arguments0-False] PASSED                                 [ 16%]
wazuh/tests/test_active_response.py::test_run_command[1653-None-random-arguments1-False] PASSED                              [ 33%]
wazuh/tests/test_active_response.py::test_run_command[1655-000-invalid_cmd-arguments2-False] PASSED                          [ 50%]
wazuh/tests/test_active_response.py::test_run_command[1651-001-valid_cmd-arguments3-False] PASSED                            [ 66%]
wazuh/tests/test_active_response.py::test_run_command[None-001-valid_cmd-arguments4-False] PASSED                            [ 83%]
wazuh/tests/test_active_response.py::test_run_command[None-001-valid_cmd-arguments5-False] PASSED                            [100%]

===================================================== 6 passed in 0.37 seconds =====================================================
```

Best regards,
Marta