### PR TITLE
API: Flask - Implement new Cache management system

### DIFF
--- a/api/api/test/test_flask_cached.py
+++ b/api/api/test/test_flask_cached.py
@@ -1,0 +1,40 @@
+import connexion
+from flask_caching import Cache
+from api.util import flask_cached
+import time
+
+
+@flask_cached
+def cached_func():
+    return time.process_time()
+
+
+def test_cache_simple():
+
+    app = connexion.App('simple_app')
+    app.app.config['CACHE_TYPE'] = 'simple'
+    app.app.config['CACHE_DEFAULT_TIMEOUT'] = 0.75    # seconds
+    app.app.cache = Cache(app.app)
+
+    with app.app.app_context():
+        answer1 = cached_func()
+        answer2 = cached_func()
+        assert answer1 == answer2
+
+        time.sleep(1)
+
+        answer3 = cached_func()
+        assert answer3 != answer2
+
+
+def test_cache_null():
+
+    app = connexion.App('simple_app')
+    app.app.config['CACHE_TYPE'] = 'null'
+    app.app.config['CACHE_DEFAULT_TIMEOUT'] = 0.75    # seconds
+    app.app.cache = Cache(app.app)
+
+    with app.app.app_context():
+        answer1 = cached_func()
+        answer2 = cached_func()
+        assert answer1 != answer2

--- a/api/api/test/test_flask_cached.py
+++ b/api/api/test/test_flask_cached.py
@@ -1,7 +1,9 @@
+import time
+
 import connexion
 from flask_caching import Cache
+
 from api.util import flask_cached
-import time
 
 
 @flask_cached

--- a/api/api/util.py
+++ b/api/api/util.py
@@ -175,7 +175,8 @@ def flask_cached(f):
     """
     @functools.wraps(f)
     def cached_function(*args, **kwargs):
-        @current_app.cache.memoize(timeout=10)
+
+        @current_app.cache.memoize()
         def decorated_function(*args, **kwargs):
             return f(*args, **kwargs)
         return decorated_function(*args, **kwargs)

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -43,8 +43,8 @@ def main(cors, port, host, ssl_context, main_logger):
         # add CORS support
         CORS(app.app)
     # add Cache support
-    cache = Cache(config={"CACHE_TYPE": "simple"})
-    cache.init_app(app.app)
+    app.app.config['CACHE_TYPE'] = 'simple'
+    app.app.cache = Cache(app.app)
     try:
         app.run(port=port, host=host, ssl_context=ssl_context)
     except Exception as e:

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -9,6 +9,7 @@ import ssl
 
 import connexion
 from flask_cors import CORS
+from flask_caching import Cache
 
 from api import alogging, encoder, configuration, __path__ as api_path
 from api import validator  # To register custom validators (do not remove)
@@ -41,6 +42,9 @@ def main(cors, port, host, ssl_context, main_logger):
     if cors:
         # add CORS support
         CORS(app.app)
+    # add Cache support
+    cache = Cache(config={"CACHE_TYPE": "simple"})
+    cache.init_app(app.app)
     try:
         app.run(port=port, host=host, ssl_context=ssl_context)
     except Exception as e:

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -4,21 +4,20 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 import argparse
 import os
-import sys
 import ssl
+import sys
 
 import connexion
-from flask_cors import CORS
-from flask_caching import Cache
-
-from api import alogging, encoder, configuration, __path__ as api_path
-from api import validator  # To register custom validators (do not remove)
 from api.api_exception import APIException
 from api.constants import CONFIG_FILE_PATH
 from api.util import to_relative_path
+from flask_caching import Cache
+from flask_cors import CORS
 from wazuh import common, pyDaemonModule, Wazuh
 from wazuh.cluster import __version__, __author__, __ossec_name__, __licence__
 
+from api import alogging, encoder, configuration, __path__ as api_path
+from api import validator  # To register custom validators (do not remove)
 
 #
 # Aux functions

--- a/api/setup.py
+++ b/api/setup.py
@@ -18,7 +18,7 @@ VERSION = "3.9.0"
 
 REQUIRES = ["connexion[swagger-ui]==2.2.0",
             "Flask-Cors==3.0.7",
-            "Flask-Caching==1.7.0"
+            "Flask-Caching==1.7.0",
             "Flask==1.0.2",
             "python_dateutil==2.6.0",
             "PyYAML==3.13",

--- a/api/setup.py
+++ b/api/setup.py
@@ -18,6 +18,7 @@ VERSION = "3.9.0"
 
 REQUIRES = ["connexion[swagger-ui]==2.2.0",
             "Flask-Cors==3.0.7",
+            "Flask-Caching==1.7.0"
             "Flask==1.0.2",
             "python_dateutil==2.6.0",
             "PyYAML==3.13",


### PR DESCRIPTION
Hi team,

This PR closes #3041 . Add a cache management system to the new API.

Best regards,

David J. Iglesias

**Api response test:**
```
root@0bf9f20fca74:~# curl -u wazuh:wazuh -X GET "http://localhost:55000/security/user/authenticate" -H "accept: application/json"
{
  "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImlhdCI6MTU1NDczMjYyMywiZXhwIjoxNTU0NzMzMjIzLCJzdWIiOiJmb28ifQ.jdMH4HGnSivxEgvJ22iO88sd54yVJcyofL6DD70HTTs"
}
```
**Unit test results:**
```
=============================== test session starts ===============================
platform linux -- Python 3.7.2, pytest-4.4.0, py-1.8.0, pluggy-0.9.0
rootdir: /var/ossec/framework/python/bin
collected 2 items                                                                 

test/test_flask_cached.py ..                                                [100%]

================================ warnings summary =================================
/var/ossec/framework/python/lib/python3.7/site-packages/jsonschema/compat.py:6
/var/ossec/framework/python/lib/python3.7/site-packages/jsonschema/compat.py:6
  /var/ossec/framework/python/lib/python3.7/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping, Sequence  # noqa

/var/ossec/framework/python/lib/python3.7/site-packages/yaml/constructor.py:126
  /var/ossec/framework/python/lib/python3.7/site-packages/yaml/constructor.py:126: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if not isinstance(key, collections.Hashable):

/var/ossec/framework/python/lib/python3.7/site-packages/jinja2/runtime.py:318
  /var/ossec/framework/python/lib/python3.7/site-packages/jinja2/runtime.py:318: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping

test/test_flask_cached.py::test_cache_null
  /var/ossec/framework/python/lib/python3.7/site-packages/flask_caching/__init__.py:202: UserWarning: Flask-Caching: CACHE_TYPE is set to null, caching is effectively disabled.
    "Flask-Caching: CACHE_TYPE is set to null, "

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================== 2 passed, 5 warnings in 1.57 seconds =======================
```
