### PR TITLE
SCA: Send the whole scan only when it's the first time

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -675,6 +675,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
     cJSON *file = NULL;
     cJSON *policy = NULL;
     cJSON *first_scan = NULL;
+    cJSON *force_alert = NULL;
 
     pm_scan_id = cJSON_GetObjectItem(event, "scan_id");
     policy_id =  cJSON_GetObjectItem(event, "policy_id");
@@ -689,6 +690,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
     file = cJSON_GetObjectItem(event,"file");
     policy = cJSON_GetObjectItem(event,"name");
     first_scan = cJSON_GetObjectItem(event,"first_scan");
+    force_alert = cJSON_GetObjectItem(event,"force_alert");
 
     if(!policy_id) {
         return;
@@ -799,6 +801,10 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
                         FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,score,file,policy_id);
                     }
                 }
+
+                if (force_alert) {
+                    FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,score,file,policy_id);
+                }
             }
             break;
         case 1: // It not exists, insert
@@ -819,6 +825,10 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
                         mdebug1("Requesting dump first scan for policy: %s",policy_id->valuestring);
                         PushDumpRequest(lf->agent_id,policy_id->valuestring,1);
                     }
+                }
+
+                if (force_alert) {
+                    FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,score,file,policy_id);
                 }
             }
             

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2348,21 +2348,14 @@ static void *wm_sca_dump_db_thread(wm_sca_t * data) {
             }
 
             unsigned int time = random;
-            
-
-            if (!request->first_scan) {
-                minfo("Integration checksum failed for policy: '%s'. Resending scan results in %d seconds.", data->profile[request->policy_index]->profile,random);
-            } else {
-                /* Delete this */
-                mdebug1("Sending dump first scan: '%s'. Resending scan results in 2 seconds.", data->profile[request->policy_index]->profile);
-            }
 
             if (request->first_scan) {
-                mdebug1("Dumping DB for policy index: '%u' in 2 seconds.",request->policy_index);
                 wm_delay(2000);
+                mdebug1("Sending first scan results for policy '%s'.", data->profile[request->policy_index]->profile);
             } else {
-                mdebug1("Dumping DB for policy index: '%u' in %d seconds.",request->policy_index,random);
+                minfo("Integration checksum failed for policy '%s'. Resending scan results in %d seconds.", data->profile[request->policy_index]->profile,random);
                 wm_delay(1000 * time);
+                mdebug1("Dumping results to SCA DB for policy index '%u'",request->policy_index,random);
             }
           
             int scan_id = -1;
@@ -2391,7 +2384,7 @@ static void *wm_sca_dump_db_thread(wm_sca_t * data) {
             sleep(5);
            
             int elements_sent = i - 1;
-            mdebug1("Sending dump ended event");
+            mdebug1("Sending end of dump control event");
 
             wm_sca_send_dump_end(data,elements_sent,data->profile[request->policy_index]->policy_id,scan_id);
 
@@ -2407,7 +2400,7 @@ static void *wm_sca_dump_db_thread(wm_sca_t * data) {
                 wm_sca_send_alert(data,last_summary_json[request->policy_index]);
             }
 
-            mdebug1("Finished dumping DB for policy index: %u",request->policy_index);
+            mdebug1("Finished dumping scan results to SCA DB for policy index '%u'",request->policy_index);
             os_free(request);
         }
     }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2401,6 +2401,9 @@ static void *wm_sca_dump_db_thread(wm_sca_t * data) {
             if (request->first_scan) {
                 /* Send summary */
                 cJSON_DeleteItemFromObject(last_summary_json[request->policy_index],"first_scan");
+                /* Force alert */
+                cJSON_AddStringToObject(last_summary_json[request->policy_index], "force_alert", "1");
+
                 wm_sca_send_alert(data,last_summary_json[request->policy_index]);
             }
 
@@ -2441,7 +2444,7 @@ void wm_sca_push_request_win(char * msg){
 
         if (!first_scan) {
             mdebug1("First scan flag missing");
-            continue;
+            return;
         }
 
         *first_scan++ = '\0';


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/3006. Now if the agent is restarted and the scan information is stored at the database and there are no changes, it won't be alerted. Fixed by @TJOSERAFAEL.