### PR TITLE
SCA: Make agent log whenever it can't find read a registry key

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1827,7 +1827,7 @@ static int wm_check_registry_entry(char * const value, wm_sca_t * const data)
     char *entry = wm_sca_get_pattern(value);
     char *pattern = entry ? wm_sca_get_pattern(entry) : NULL;
 
-    minfo("Checking registry: '%s\\%s'...", value, entry);
+    mdebug1("Checking registry: '%s\\%s'...", value, entry);
     
     char _b_msg[OS_SIZE_1024 + 1];
     _b_msg[OS_SIZE_1024] = '\0';
@@ -1837,10 +1837,10 @@ static int wm_check_registry_entry(char * const value, wm_sca_t * const data)
 
     const int ret = wm_sca_is_registry(value, entry, pattern);
     if (ret == 1) {
-        minfo("registry found.");
+        mdebug2("registry found.");
         return 1;
     } else if (ret == -1) {
-        minfo("registry not found.");
+        mdebug2("registry not found.");
     }
 
     return 0;


### PR DESCRIPTION
This PR was motivated by #2981 
* Agent will report on its log keys that can't be found or read.
 ```
2019/04/09 10:14:11 sca: ERROR: Checking registry: HKEY_CURRENT_USER\Software\test4\r1...
2019/04/09 10:14:11 sca: ERROR: registry not found.
```
* Encapsulates registry checking, formely part of `wm_sca_do_scan()` into  `wm_check_registry_entry()`.
* Removes duplicated code.
   * Includes function to further simplify some sections (`append_msg_to_vm_scat`)