### PR TITLE
Fix ignoring paths on rootcheck

### DIFF
--- a/src/config/rootcheck-config.c
+++ b/src/config/rootcheck-config.c
@@ -167,7 +167,11 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
                     return OS_INVALID;
                 }
                 os_calloc(1, sizeof(OSMatch), rootcheck->ignore_sregex[j]);
+#ifndef WIN32
                 if (!OSMatch_Compile(rootcheck->ignore[j], rootcheck->ignore_sregex[j], 0)) {
+#else
+                if (!OSMatch_Compile(rootcheck->ignore[j], rootcheck->ignore_sregex[j], OS_CASE_SENSITIVE)) {
+#endif
                     merror(REGEX_COMPILE, rootcheck->ignore[j], rootcheck->ignore_sregex[j]->error);
                     return OS_INVALID;
                 }

--- a/src/config/rootcheck-config.c
+++ b/src/config/rootcheck-config.c
@@ -150,12 +150,28 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
                 j++;
             }
 
-            os_realloc(rootcheck->ignore, sizeof(char *) * (j + 2),
-                       rootcheck->ignore);
-            rootcheck->ignore[j] = NULL;
+            os_realloc(rootcheck->ignore, sizeof(char *) * (j + 2), rootcheck->ignore);
+            os_strdup(node[i]->content, rootcheck->ignore[j]);
             rootcheck->ignore[j + 1] = NULL;
 
-            os_strdup(node[i]->content, rootcheck->ignore[j]);
+            os_realloc(rootcheck->ignore_sregex, sizeof(OSMatch *) * (j + 2), rootcheck->ignore_sregex);
+            rootcheck->ignore_sregex[j] = NULL;
+            rootcheck->ignore_sregex[j + 1] = NULL;
+
+            if (node[i]->attributes && node[i]->values && *node[i]->attributes && *node[i]->values) {
+                if (strcmp(*node[i]->attributes, "type")) {
+                    merror("Invalid attribute for '%s': '%s'.", node[i]->element, *node[i]->attributes);
+                    return OS_INVALID;
+                } else if (strcmp(*node[i]->values, "sregex")) {
+                    merror("Invalid value for '%s': '%s'.", *node[i]->attributes, *node[i]->values);
+                    return OS_INVALID;
+                }
+                os_calloc(1, sizeof(OSMatch), rootcheck->ignore_sregex[j]);
+                if (!OSMatch_Compile(rootcheck->ignore[j], rootcheck->ignore_sregex[j], 0)) {
+                    merror(REGEX_COMPILE, rootcheck->ignore[j], rootcheck->ignore_sregex[j]->error);
+                    return OS_INVALID;
+                }
+            }
         } else if (strcmp(node[i]->element, xml_winmalware) == 0) {
 #ifdef WIN32
             rootcheck->checks.rc_winmalware = 1;

--- a/src/config/rootcheck-config.h
+++ b/src/config/rootcheck-config.h
@@ -12,6 +12,7 @@
 #define __CROOTCHECK_H
 
 #include <stdio.h>
+#include "os_regex/os_regex.h"
 
 #define RK_CONF_UNPARSED -2
 #define RK_CONF_UNDEFINED -1
@@ -23,6 +24,7 @@ typedef struct _rkconfig {
     char *rootkit_trojans;
     char **unixaudit;
     char **ignore;
+    OSMatch **ignore_sregex;
     char *winaudit;
     char *winmalware;
     char *winapps;

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -120,6 +120,12 @@ static int read_dev_dir(const char *dir_name)
         f_name[PATH_MAX + 1] = '\0';
         snprintf(f_name, PATH_MAX + 1, "%s/%s", dir_name, entry->d_name);
 
+        /* Ignoring user specified paths*/
+        if(rootcheck.ignore){
+            if(check_ignore( dir_name, &rootcheck))
+                continue;
+        }
+
         /* Do not look for the full ignored files */
         for (i = 0; ignore_dev_full_path[i] != NULL; i++) {
             if (strcmp(ignore_dev_full_path[i], f_name) == 0) {

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -22,9 +22,23 @@ static int _dev_total;
 
 
 static int read_dev_file(const char *file_name)
-{
+{   /* Do not look for the user ignored paths and files */
+    if (rootcheck.ignore) {
+        if (check_ignore(file_name, &rootcheck)) {
+            return (0);
+        }
+        else {
+            char *_file_name = strrchr(file_name, '/');
+            if (*_file_name == '/') {
+                _file_name++;
+                if (check_ignore(_file_name, &rootcheck)) {
+                    return(0);    
+                }
+            }
+        }
+    }
     struct stat statbuf;
-
+    
     if (lstat(file_name, &statbuf) < 0) {
         return (-1);
     }

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -121,8 +121,8 @@ static int read_dev_dir(const char *dir_name)
         snprintf(f_name, PATH_MAX + 1, "%s/%s", dir_name, entry->d_name);
 
         /* Ignoring user specified files and paths*/
-        if(rootcheck.ignore){
-            if(check_ignore(f_name, &rootcheck) || check_ignore(dir_name , &rootcheck))
+        if (rootcheck.ignore) {
+            if (check_ignore(f_name, &rootcheck) || check_ignore(dir_name , &rootcheck))
                 continue;
         }
 

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -120,9 +120,9 @@ static int read_dev_dir(const char *dir_name)
         f_name[PATH_MAX + 1] = '\0';
         snprintf(f_name, PATH_MAX + 1, "%s/%s", dir_name, entry->d_name);
 
-        /* Ignoring user specified paths*/
+        /* Ignoring user specified files and paths*/
         if(rootcheck.ignore){
-            if(check_ignore( dir_name, &rootcheck))
+            if(check_ignore(f_name, &rootcheck) || check_ignore(dir_name , &rootcheck))
                 continue;
         }
 

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -22,23 +22,9 @@ static int _dev_total;
 
 
 static int read_dev_file(const char *file_name)
-{   /* Do not look for the user ignored paths and files */
-    if (rootcheck.ignore) {
-        if (check_ignore(file_name, &rootcheck)) {
-            return (0);
-        }
-        else {
-            char *_file_name = strrchr(file_name, '/');
-            if (*_file_name == '/') {
-                _file_name++;
-                if (check_ignore(_file_name, &rootcheck)) {
-                    return(0);    
-                }
-            }
-        }
-    }
+{
     struct stat statbuf;
-    
+
     if (lstat(file_name, &statbuf) < 0) {
         return (-1);
     }
@@ -69,6 +55,8 @@ static int read_dev_dir(const char *dir_name)
     int i;
     DIR *dp;
     struct dirent *entry;
+    char f_name[PATH_MAX + 2];
+    char f_dir[PATH_MAX + 2];
 
     /* When will these people learn that /dev is not
      * meant to store log files or other kind of texts?
@@ -91,10 +79,10 @@ static int read_dev_dir(const char *dir_name)
                                  };
 
     /* Full path ignore */
-    const char *(ignore_dev_full_path[]) = {"/dev/shm/sysconfig",
-                                            "/dev/bus/usb/.usbfs",
-                                            "/dev/shm",
-                                            "/dev/gpmctl",
+    const char *(ignore_dev_full_path[]) = {"shm/sysconfig",
+                                            "bus/usb/.usbfs",
+                                            "shm",
+                                            "gpmctl",
                                             NULL
                                            };
 
@@ -111,8 +99,6 @@ static int read_dev_dir(const char *dir_name)
 
     /* Iterate over all files in the directory */
     while ((entry = readdir(dp)) != NULL) {
-        char f_name[PATH_MAX + 2];
-
         /* Ignore . and ..  */
         if (strcmp(entry->d_name, ".") == 0 ||
                 strcmp(entry->d_name, "..") == 0) {
@@ -131,24 +117,24 @@ static int read_dev_dir(const char *dir_name)
             continue;
         }
 
-        f_name[PATH_MAX + 1] = '\0';
+        *f_name = '\0';
         snprintf(f_name, PATH_MAX + 1, "%s/%s", dir_name, entry->d_name);
-
-        /* Ignoring user specified files and paths*/
-        if (rootcheck.ignore) {
-            if (check_ignore(f_name, &rootcheck) || check_ignore(dir_name , &rootcheck))
-                continue;
-        }
 
         /* Do not look for the full ignored files */
         for (i = 0; ignore_dev_full_path[i] != NULL; i++) {
-            if (strcmp(ignore_dev_full_path[i], f_name) == 0) {
+            snprintf(f_dir, PATH_MAX + 1, "%s/%s", dir_name, ignore_dev_full_path[i]);
+            if (strcmp(f_dir, f_name) == 0) {
                 break;
             }
         }
 
         /* Check against the full path */
         if (ignore_dev_full_path[i] != NULL) {
+            continue;
+        }
+
+        /* Do not look for the user ignored paths and files */
+        if (check_ignore(f_name)) {
             continue;
         }
 

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -159,9 +159,18 @@ void check_rc_files(const char *basedir, FILE *fp)
             continue;
         }
 
-        snprintf(file_path, OS_SIZE_1024, "%s/%s", basedir, file);
+        // Check if it is a full path
+#ifdef WIN32
+        if (strlen(file) > 3 && file[1] == ':' && file[2] == '\\') {
+#else
+        if (*file == '/') {
+#endif
+            snprintf(file_path, OS_SIZE_1024, "%s", file);
+        } else {
+            snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
+        }
 
-        char * _file_name = strrchr(file_path, '/');
+        char * _file_name = strrchr(file_path, PATH_SEP);
         _file_name++;
 
         char _path[OS_SIZE_1024 + 1];

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -116,9 +116,8 @@ void check_rc_files(const char *basedir, FILE *fp)
                 *nbuf = '\0';
             }
         }
-
+       
         _total++;
-
         /* Check if it is a file to search everywhere */
         if (*file == '*') {
             /* Maximum number of global files reached */
@@ -132,7 +131,12 @@ void check_rc_files(const char *basedir, FILE *fp)
                 if (*file == '/') {
                     file++;
                 }
-
+                /* Do not look for the user ignored files */
+                if (rootcheck.ignore) {
+                    if (check_ignore(file, &rootcheck)) {
+                        continue;
+                    }
+                }
                 rk_sys_file[rk_sys_count] = strdup(file);
                 rk_sys_name[rk_sys_count] = strdup(name);
 
@@ -161,6 +165,24 @@ void check_rc_files(const char *basedir, FILE *fp)
         }
 
         snprintf(file_path, OS_SIZE_1024, "%s/%s", basedir, file);
+
+        minfo("FULL PATH  %s ",file_path);
+
+        char * _file_name = strrchr(file_path, '/');
+        _file_name++;
+        minfo("NAME  %s ",_file_name);
+
+        char _path[OS_SIZE_1024 + 1];
+        snprintf(_path, OS_SIZE_1024 ,file_path );
+        _path[strlen(file) - strlen(_file_name)] = '\0';
+
+        minfo("ONLY ROUTE  %s ",_path);
+
+        if (rootcheck.ignore) {  
+            if (check_ignore(file_path, &rootcheck) || check_ignore(_file_name, &rootcheck) || check_ignore(_path,&rootcheck )) {
+                continue;
+            }
+        }
 
         if (is_file(file_path)) {
             char op_msg[OS_SIZE_1024 + 1];

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -116,7 +116,7 @@ void check_rc_files(const char *basedir, FILE *fp)
                 *nbuf = '\0';
             }
         }
-       
+
         _total++;
         /* Check if it is a file to search everywhere */
         if (*file == '*') {
@@ -131,12 +131,7 @@ void check_rc_files(const char *basedir, FILE *fp)
                 if (*file == '/') {
                     file++;
                 }
-                /* Do not look for the user ignored files */
-                if (rootcheck.ignore) {
-                    if (check_ignore(file, &rootcheck)) {
-                        continue;
-                    }
-                }
+
                 rk_sys_file[rk_sys_count] = strdup(file);
                 rk_sys_name[rk_sys_count] = strdup(name);
 
@@ -173,15 +168,13 @@ void check_rc_files(const char *basedir, FILE *fp)
         minfo("NAME  %s ",_file_name);
 
         char _path[OS_SIZE_1024 + 1];
-        snprintf(_path, OS_SIZE_1024 ,file_path );
+        strncpy(_path, file_path, OS_SIZE_1024 + 1);
         _path[strlen(file) - strlen(_file_name)] = '\0';
 
         minfo("ONLY ROUTE  %s ",_path);
 
-        if (rootcheck.ignore) {  
-            if (check_ignore(file_path, &rootcheck) || check_ignore(_file_name, &rootcheck) || check_ignore(_path,&rootcheck )) {
-                continue;
-            }
+        if (check_ignore(file_path)) {
+            continue;
         }
 
         if (is_file(file_path)) {

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -161,17 +161,12 @@ void check_rc_files(const char *basedir, FILE *fp)
 
         snprintf(file_path, OS_SIZE_1024, "%s/%s", basedir, file);
 
-        minfo("FULL PATH  %s ",file_path);
-
         char * _file_name = strrchr(file_path, '/');
         _file_name++;
-        minfo("NAME  %s ",_file_name);
 
         char _path[OS_SIZE_1024 + 1];
         strncpy(_path, file_path, OS_SIZE_1024 + 1);
         _path[strlen(file) - strlen(_file_name)] = '\0';
-
-        minfo("ONLY ROUTE  %s ",_path);
 
         if (check_ignore(file_path)) {
             continue;

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -171,13 +171,9 @@ static int read_sys_dir(const char *dir_name, int do_read)
 
     /* Ignore user-supplied list */
     if (rootcheck.ignore) {
-        while (rootcheck.ignore[i]) {
-            if (strcmp(dir_name, rootcheck.ignore[i]) == 0) {
-                return (1);
-            }
-            i++;
+        if (check_ignore(dir_name, &rootcheck)) {
+            return(1);
         }
-        i = 0;
     }
 
     /* Should we check for NFS? */

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -351,6 +351,8 @@ void check_rc_sys(const char *basedir)
         /* Scan the whole file system -- may be slow */
 #ifndef WIN32
         snprintf(file_path, 3, "%s", "/");
+#else
+        snprintf(file_path, 5, "%s", "C:\\");
 #endif
         read_sys_dir(file_path, rootcheck.readall, 0);
     } else {

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -31,8 +31,8 @@ static int read_sys_file(const char *file_name, int do_read)
     _sys_total++;
 
     /* Ignoring user specified files */
-    if(rootcheck.ignore){
-        if(check_ignore(file_name, &rootcheck)){
+    if (rootcheck.ignore) {
+        if (check_ignore(file_name, &rootcheck)) {
             return (0);
         }
     }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -34,7 +34,7 @@ static int read_sys_file(const char *file_name, int do_read)
     if (rootcheck.ignore) {
         if (check_ignore(file_name, &rootcheck)) {
             return (0);
-        }
+        }    
     }
 #ifdef WIN32
     /* Check for NTFS ADS on Windows */
@@ -277,6 +277,11 @@ static int read_sys_dir(const char *dir_name, int do_read)
                 break;
             }
 
+            if (rootcheck.ignore) {
+                if (check_ignore(entry->d_name, &rootcheck)) {
+                    break;
+                }
+            }
             if (strcmp(rk_sys_file[i], entry->d_name) == 0) {
                 char op_msg[OS_SIZE_1024 + 1];
 

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -30,6 +30,12 @@ static int read_sys_file(const char *file_name, int do_read)
 
     _sys_total++;
 
+    /* Ignoring user specified files */
+    if(rootcheck.ignore){
+        if(check_ignore(file_name, &rootcheck)){
+            return (0);
+        }
+    }
 #ifdef WIN32
     /* Check for NTFS ADS on Windows */
     os_check_ads(file_name);

--- a/src/rootcheck/check_rc_trojans.c
+++ b/src/rootcheck/check_rc_trojans.c
@@ -26,7 +26,7 @@ void check_rc_trojans(const char *basedir, FILE *fp)
 #ifndef WIN32
     const char *(all_paths[]) = {"bin", "sbin", "usr/bin", "usr/sbin", NULL};
 #else
-    const char *(all_paths[]) = {"C:\\Windows\\", "D:\\Windows\\", NULL};
+    const char *(all_paths[]) = {"Windows\\", NULL};
 #endif
 
     mtdebug1(ARGV0, "Starting on check_rc_trojans");
@@ -78,9 +78,9 @@ void check_rc_trojans(const char *basedir, FILE *fp)
 
         /* Try with all possible paths */
         while (all_paths[i] != NULL) {
-            if (*file != '/') {
-                snprintf(file_path, OS_SIZE_1024, "%s/%s/%s", basedir,
-                         all_paths[i],
+            if (*file != PATH_SEP) {
+                snprintf(file_path, OS_SIZE_1024, "%s%c%s%c%s", basedir, PATH_SEP,
+                         all_paths[i], PATH_SEP,
                          file);
             } else {
                 strncpy(file_path, file, OS_SIZE_1024);

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -253,17 +253,21 @@ void rootcheck_connect() {
 #endif
 }
 
-/* Do not look for the user ignored files and paths */
+/* Do not look for the user ignored paths */
  int check_ignore(const char *path_to_ignore, rkconfig *rootcheck) {
     int i, ignore = 0;
 
     for (i = 0; rootcheck->ignore[i] != NULL; i++) {
-
+        
         int lenght = strlen(path_to_ignore);
+        int lenght_ignore = strlen(rootcheck->ignore[i]);
+
         char _path_to_ignore[lenght+1];
         snprintf( _path_to_ignore, lenght+2, "%s/", path_to_ignore);
-
-        if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0 || strcmp( rootcheck->ignore[i],  _path_to_ignore) == 0  ) {
+        if (strncmp(_path_to_ignore, rootcheck->ignore[i], lenght_ignore) == 0) {
+            break;
+        }
+        if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0 || strcmp(rootcheck->ignore[i], _path_to_ignore) == 0) {
             break;
         }
     }

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -255,17 +255,15 @@ void rootcheck_connect() {
 
 /* Do not look for the user ignored files and paths */
  int check_ignore(const char *path_to_ignore, rkconfig *rootcheck) {
-     int ignore = 0, i = 0;
+    int ignore = 0, i = 0;
 
-            for ( i = 0; rootcheck->ignore[i] != NULL; i++) {
-                if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0 ) {
-                    break;
-                }
-            }
-            if (rootcheck->ignore[i] != NULL){
-                 ignore=1;
-            }
-
-
+    for (i = 0; rootcheck->ignore[i] != NULL; i++) {
+        if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0 ) {
+            break;
+        }
+    }
+    if (rootcheck->ignore[i] != NULL) {
+        ignore=1;
+    }
     return ignore;
  }

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -254,25 +254,24 @@ void rootcheck_connect() {
 }
 
 /* Do not look for the user ignored paths */
- int check_ignore(const char *path_to_ignore, rkconfig *rootcheck) {
-    int i, ignore = 0;
+ int check_ignore(const char *path_to_ignore) {
+    int i;
 
-    for (i = 0; rootcheck->ignore[i] != NULL; i++) {
-        
-        int lenght = strlen(path_to_ignore);
-        int lenght_ignore = strlen(rootcheck->ignore[i]);
+    if (!rootcheck.ignore) {
+        return 0;
+    }
 
-        char _path_to_ignore[lenght+1];
-        snprintf( _path_to_ignore, lenght+2, "%s/", path_to_ignore);
-        if (strncmp(_path_to_ignore, rootcheck->ignore[i], lenght_ignore) == 0) {
-            break;
-        }
-        if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0 || strcmp(rootcheck->ignore[i], _path_to_ignore) == 0) {
-            break;
+    for (i = 0; rootcheck.ignore[i] != NULL; i++) {
+        if (rootcheck.ignore_sregex[i]) {
+            if (OSMatch_Execute(path_to_ignore, strlen(path_to_ignore), rootcheck.ignore_sregex[i])) {
+                mdebug1("File '%s' matches the '%s' pattern, so it will be ignored.", path_to_ignore, rootcheck.ignore_sregex[i]->raw);
+                return 1;
+            }
+        } else if (!strcmp(path_to_ignore, rootcheck.ignore[i])) {
+            mdebug1("The '%s' file has been marked as ignored", path_to_ignore);
+            return 1;
         }
     }
-    if (rootcheck->ignore[i] != NULL) {
-        ignore=1;
-    }
-    return ignore;
+
+    return 0;
  }

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -255,10 +255,15 @@ void rootcheck_connect() {
 
 /* Do not look for the user ignored files and paths */
  int check_ignore(const char *path_to_ignore, rkconfig *rootcheck) {
-    int ignore = 0, i = 0;
+    int i, ignore = 0;
 
     for (i = 0; rootcheck->ignore[i] != NULL; i++) {
-        if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0 ) {
+
+        int lenght = strlen(path_to_ignore);
+        char _path_to_ignore[lenght+1];
+        snprintf( _path_to_ignore, lenght+2, "%s/", path_to_ignore);
+
+        if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0 || strcmp( rootcheck->ignore[i],  _path_to_ignore) == 0  ) {
             break;
         }
     }

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -252,3 +252,20 @@ void rootcheck_connect() {
     }
 #endif
 }
+
+/* Do not look for the user ignored files and paths */
+ int check_ignore(char *path_to_ignore, rkconfig *rootcheck) {
+     int ignore = 0, i = 0;
+
+            for ( i = 0; rootcheck->ignore[i] != NULL; i++) {
+                if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0) {
+                    break;
+                }
+            }
+            if (rootcheck->ignore[i] != NULL){
+                 ignore=1;
+            }
+
+
+    return ignore;
+ }

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -264,11 +264,11 @@ void rootcheck_connect() {
     for (i = 0; rootcheck.ignore[i] != NULL; i++) {
         if (rootcheck.ignore_sregex[i]) {
             if (OSMatch_Execute(path_to_ignore, strlen(path_to_ignore), rootcheck.ignore_sregex[i])) {
-                mdebug1("File '%s' matches the '%s' pattern, so it will be ignored.", path_to_ignore, rootcheck.ignore_sregex[i]->raw);
+                mdebug1("'%s' matches the '%s' pattern, so it will be ignored.", path_to_ignore, rootcheck.ignore_sregex[i]->raw);
                 return 1;
             }
         } else if (!strcmp(path_to_ignore, rootcheck.ignore[i])) {
-            mdebug1("The '%s' file has been marked as ignored", path_to_ignore);
+            mdebug1("'%s' has been marked as ignored", path_to_ignore);
             return 1;
         }
     }

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -254,11 +254,11 @@ void rootcheck_connect() {
 }
 
 /* Do not look for the user ignored files and paths */
- int check_ignore(char *path_to_ignore, rkconfig *rootcheck) {
+ int check_ignore(const char *path_to_ignore, rkconfig *rootcheck) {
      int ignore = 0, i = 0;
 
             for ( i = 0; rootcheck->ignore[i] != NULL; i++) {
-                if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0) {
+                if (strcmp(rootcheck->ignore[i], path_to_ignore) == 0 ) {
                     break;
                 }
             }

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -267,8 +267,12 @@ void rootcheck_connect() {
                 mdebug1("'%s' matches the '%s' pattern, so it will be ignored.", path_to_ignore, rootcheck.ignore_sregex[i]->raw);
                 return 1;
             }
+#ifndef WIN32
         } else if (!strcmp(path_to_ignore, rootcheck.ignore[i])) {
-            mdebug1("'%s' has been marked as ignored", path_to_ignore);
+#else
+        } else if (!strcasecmp(path_to_ignore, rootcheck.ignore[i])) {
+#endif
+            mdebug1("'%s' has been marked as ignored.", path_to_ignore);
             return 1;
         }
     }

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -120,8 +120,8 @@ void check_rc_ports(void);
 void check_open_ports(void);
 void check_rc_if(void);
 
-/*Checks if the path is user-ignored */
- int check_ignore(char *path_to_ignore, rkconfig *rootcheck);
+/*Checks if the path or file is user-ignored */
+ int check_ignore(const char *path_to_ignore, rkconfig *rootcheck);
 
 int Read_Rootcheck_Config(const char *cfgfile);
 

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -120,6 +120,9 @@ void check_rc_ports(void);
 void check_open_ports(void);
 void check_rc_if(void);
 
+/*Checks if the path is user-ignored */
+ int check_ignore(char *path_to_ignore, rkconfig *rootcheck);
+
 int Read_Rootcheck_Config(const char *cfgfile);
 
 /* Global variables */

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -15,6 +15,12 @@
 #include "config/rootcheck-config.h"
 #include "external/cJSON/cJSON.h"
 
+#ifdef WIN32
+#define PATH_SEP '\\'
+#else
+#define PATH_SEP '/'
+#endif
+
 extern rkconfig rootcheck;
 
 /* Output types */
@@ -121,7 +127,7 @@ void check_open_ports(void);
 void check_rc_if(void);
 
 /*Checks if the path or file is user-ignored */
- int check_ignore(const char *path_to_ignore, rkconfig *rootcheck);
+ int check_ignore(const char *path_to_ignore);
 
 int Read_Rootcheck_Config(const char *cfgfile);
 

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -66,7 +66,7 @@ void run_rk_check()
 
 #ifndef WIN32
     /* On non-Windows, always start at / */
-    char basedir[] = "";
+    char basedir[] = "/";
 #else
     /* On Windows, always start at C:\ */
     char basedir[] = "C:\\";

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -73,10 +73,10 @@ void run_rk_check()
 #endif
 
     /* Set basedir */
-    if (rootcheck.basedir == NULL) {
+    if (rootcheck.basedir == NULL || !strlen(rootcheck.basedir)) {
         rootcheck.basedir = strdup(basedir);
     } else {
-        if (rootcheck.basedir[strlen(rootcheck.basedir)-1] == '/') {
+        if (rootcheck.basedir[strlen(rootcheck.basedir)-1] == PATH_SEP) {
             rootcheck.basedir[strlen(rootcheck.basedir)-1] = '\0';
         }
     }

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -69,7 +69,7 @@ void run_rk_check()
     char basedir[] = "";
 #else
     /* On Windows, always start at C:\ */
-    char basedir[] = "C:\\";
+    char basedir[] = "C:";
 #endif
 
     /* Set basedir */
@@ -119,7 +119,6 @@ void run_rk_check()
 
             else {
                 check_rc_files(rootcheck.basedir, fp);
-
                 fclose(fp);
             }
         }

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -66,7 +66,7 @@ void run_rk_check()
 
 #ifndef WIN32
     /* On non-Windows, always start at / */
-    char basedir[] = "/";
+    char basedir[] = "";
 #else
     /* On Windows, always start at C:\ */
     char basedir[] = "C:\\";
@@ -75,6 +75,10 @@ void run_rk_check()
     /* Set basedir */
     if (rootcheck.basedir == NULL) {
         rootcheck.basedir = strdup(basedir);
+    } else {
+        if (rootcheck.basedir[strlen(rootcheck.basedir)-1] == '/') {
+            rootcheck.basedir[strlen(rootcheck.basedir)-1] = '\0';
+        }
     }
 
     time1 = time(0);


### PR DESCRIPTION
The fix in this PR partially solves the issue https://github.com/wazuh/wazuh/issues/3030

- Now the **check_dev** module now **ignores the paths** specified in ossec.conf.
- The **rest of the rootcheck modules**( check_trojans, check_files, check_sys) that perform a search in the file system **still do not implement** the ignore functionality well.