### PR TITLE
Fix Syscheck hang when monitoring system directories

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -280,6 +280,10 @@ syscheck.max_audit_entries=256
 # Maximum level of recursivity allowed [1..320]
 syscheck.default_max_depth=256
 
+# Maximum file size for calcuting integrity hashes in MBytes [0..4095]
+# A value of 0 MB means to disable this filter
+syscheck.max_size=1024
+
 # Rootcheck checking/usage speed. The default is to sleep 50 milliseconds
 # per each PID or suspictious port.
 rootcheck.sleep=50

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -282,7 +282,7 @@ syscheck.default_max_depth=256
 
 # Maximum file size for calcuting integrity hashes in MBytes [0..4095]
 # A value of 0 MB means to disable this filter
-syscheck.max_size=1024
+syscheck.file_max_size=1024
 
 # Rootcheck checking/usage speed. The default is to sleep 50 milliseconds
 # per each PID or suspictious port.

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -27,9 +27,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
     <ignore>/dev/core</ignore>
-    <ignore>/proc</ignore>
 
     <!-- File types to ignore -->
+    <ignore type="sregex">^/proc</ignore>
     <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -26,6 +26,8 @@
     <ignore>/etc/svc/volatile</ignore>
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
+    <ignore>/dev/core</ignore>
+    <ignore>/proc</ignore>
 
     <!-- File types to ignore -->
     <ignore type="sregex">.log$|.swp$</ignore>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -33,9 +33,9 @@
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
     <ignore>/dev/core</ignore>
-    <ignore>/proc</ignore>
 
     <!-- File types to ignore -->
+    <ignore type="sregex">^/proc</ignore>
     <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -32,6 +32,8 @@
     <ignore>/etc/svc/volatile</ignore>
     <ignore>/sys/kernel/security</ignore>
     <ignore>/sys/kernel/debug</ignore>
+    <ignore>/dev/core</ignore>
+    <ignore>/proc</ignore>
 
     <!-- File types to ignore -->
     <ignore type="sregex">.log$|.swp$</ignore>

--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -57,9 +57,7 @@ int intcheck_file(const char *file_name, const char *dir)
 #endif
     {
         if (OS_MD5_SHA1_SHA256_File(file_name, NULL, mf_sum, sf_sum, sf256_sum, OS_BINARY, 0) < 0) {
-            strncpy(mf_sum, "n/a", 4);
-            strncpy(sf_sum, "n/a", 4);
-            strncpy(sf256_sum, "n/a", 4);
+            return 1;
         }
     }
 

--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -56,7 +56,7 @@ int intcheck_file(const char *file_name, const char *dir)
     if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))
 #endif
     {
-        if (OS_MD5_SHA1_SHA256_File(file_name, NULL, mf_sum, sf_sum, sf256_sum, OS_BINARY) < 0) {
+        if (OS_MD5_SHA1_SHA256_File(file_name, NULL, mf_sum, sf_sum, sf256_sum, OS_BINARY, 0) < 0) {
             strncpy(mf_sum, "n/a", 4);
             strncpy(sf_sum, "n/a", 4);
             strncpy(sf256_sum, "n/a", 4);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -179,7 +179,7 @@ typedef struct _config {
     int scan_on_start;
     int realtime_count;
     int max_depth;                  /* max level of recursivity allowed */
-    size_t max_size;                /* max file size for calculating hashes */
+    size_t file_max_size;           /* max file size for calculating hashes */
 
     short skip_nfs;
     int rt_delay;                   /* Delay before real-time dispatching (ms) */

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -179,6 +179,7 @@ typedef struct _config {
     int scan_on_start;
     int realtime_count;
     int max_depth;                  /* max level of recursivity allowed */
+    size_t max_size;                /* max file size for calculating hashes */
 
     short skip_nfs;
     int rt_delay;                   /* Delay before real-time dispatching (ms) */

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -136,6 +136,6 @@ int w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst);
 int checkBinaryFile(const char *f_name);
 
 #ifndef WIN32
-size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, const char * filename, int timeout);
+size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, int timeout);
 #endif
 #endif /* __FILE_H */

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -135,4 +135,7 @@ int w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst);
 
 int checkBinaryFile(const char *f_name);
 
+#ifndef WIN32
+size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, const char * filename, int timeout);
+#endif
 #endif /* __FILE_H */

--- a/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
+++ b/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
@@ -62,7 +62,11 @@ int OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5
     SHA256_Init(&sha256_ctx);
 
     /* Update for each one */
+#ifdef WIN32
     while ((n = fread(buf, 1, 2048, fp)) > 0) {
+#else
+    while ((n = w_fread_timeout(buf, 1, 2048, fp, fname, 5)) > 0) {
+#endif
         buf[n] = '\0';
         if (max_size > 0) {
             read = read + n;

--- a/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
+++ b/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
@@ -22,7 +22,7 @@ int OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5
 {
     size_t n, read = 0;
     FILE *fp;
-    unsigned char buf[2048 + 2];
+    unsigned char buf[OS_BUFFER_SIZE + 2];
     unsigned char sha1_digest[SHA_DIGEST_LENGTH];
     unsigned char md5_digest[16];
     unsigned char sha256_digest[SHA256_DIGEST_LENGTH];
@@ -35,7 +35,7 @@ int OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5
     md5output[0] = '\0';
     sha1output[0] = '\0';
     sha256output[0] = '\0';
-    buf[2048 + 1] = '\0';
+    buf[OS_BUFFER_SIZE + 1] = '\0';
 
     /* Use prefilter_cmd if set */
     if (prefilter_cmd == NULL) {
@@ -63,11 +63,11 @@ int OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5
 
     /* Update for each one */
 #ifdef WIN32
-    while ((n = fread(buf, 1, 2048, fp)) > 0) {
+    while ((n = fread(buf, 1, OS_BUFFER_SIZE, fp)) > 0) {
 #else
-    while ((n = w_fread_timeout(buf, 1, 2048, fp, 5)) > 0) {
+    while ((n = w_fread_timeout(buf, 1, OS_BUFFER_SIZE, fp, 5)) > 0) {
 #endif
-        if (n == 2049) {    // Timeout error
+        if (n == OS_BUFFER_SIZE + 1) {    // Timeout error
             mwarn("Timeout when scanning file '%s'. File skipped.", fname);
             if (prefilter_cmd == NULL) {
                 fclose(fp);
@@ -80,7 +80,7 @@ int OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5
         if (max_size > 0) {
             read = read + n;
             if (read >= max_size) {     // Maximum filesize error
-                mwarn("Filesize of '%s' is higher than the maximum allowed (%d MB). File skipped.", fname, (int)max_size/1048576); // max_size is in bytes
+                mwarn("'%s' filesize is larger than the maximum allowed (%d MB). File skipped.", fname, (int)max_size/1048576); // max_size is in bytes
                 if (prefilter_cmd == NULL) {
                     fclose(fp);
                 } else {

--- a/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.h
+++ b/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.h
@@ -14,9 +14,10 @@
 #include "../md5/md5_op.h"
 #include "../sha1/sha1_op.h"
 #include "../sha256/sha256_op.h"
+#include "config/syscheck-config.h"
 
 
-int OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output, os_sha256 sha256output, int mode) __attribute((nonnull(1, 3, 4)));
+int OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output, os_sha256 sha256output, int mode, size_t max_size) __attribute((nonnull(1, 3, 4)));
 
 #endif
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2722,9 +2722,9 @@ size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, int 
 
     } else {
         errno = EINTR;
-        /* To escalate the timeout error to the calling function, we set read_count to 2049
-        since the maximum possible read count is 2048 */
-        read_count = 2049;
+        /* To escalate the timeout error to the calling function, we set read_count to
+        the first value which fread cannot return ever */
+        read_count = (size * nitems) + 1;
     }
 
     /* unset signal handler and alarm */

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -25,12 +25,12 @@
 #ifndef WIN32
 #include <setjmp.h>
 
-static __thread jmp_buf env_alrm;
+static __thread sigjmp_buf env_alrm;
 static void sigalrm_handler(int signo)
 {
     (void)signo;
     /* restore env */
-    longjmp(env_alrm, 5);
+    siglongjmp(env_alrm, 5);
 }
 #endif
 
@@ -2706,7 +2706,7 @@ size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, cons
     size_t read_count = 0;
 
     /* set long jump */
-    int val = setjmp(env_alrm);
+    int val = sigsetjmp(env_alrm, 1);
 
     if (!val) {
         

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2701,7 +2701,7 @@ int w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst) {
 }
 
 #ifndef WIN32
-size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, const char * filename, int timeout){
+size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, int timeout){
 
     size_t read_count = 0;
 
@@ -2722,7 +2722,9 @@ size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, cons
 
     } else {
         errno = EINTR;
-        merror("Timeout when calling fread() expired for file '%s'", filename);
+        /* To escalate the timeout error to the calling function, we set read_count to 2049
+        since the maximum possible read count is 2048 */
+        read_count = 2049;
     }
 
     /* unset signal handler and alarm */

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -273,6 +273,7 @@ cJSON *getSyscheckInternalOptions(void) {
     cJSON_AddNumberToObject(syscheckd,"rt_delay",syscheck.rt_delay);
     cJSON_AddNumberToObject(syscheckd,"default_max_depth",syscheck.max_depth);
     cJSON_AddNumberToObject(syscheckd,"debug",sys_debug_level);
+    cJSON_AddNumberToObject(syscheckd,"max_size",syscheck.max_size);
 #ifdef WIN32
     cJSON_AddNumberToObject(syscheckd,"max_fd_win_rt",syscheck.max_fd_win_rt);
 #else

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -273,7 +273,7 @@ cJSON *getSyscheckInternalOptions(void) {
     cJSON_AddNumberToObject(syscheckd,"rt_delay",syscheck.rt_delay);
     cJSON_AddNumberToObject(syscheckd,"default_max_depth",syscheck.max_depth);
     cJSON_AddNumberToObject(syscheckd,"debug",sys_debug_level);
-    cJSON_AddNumberToObject(syscheckd,"max_size",syscheck.max_size);
+    cJSON_AddNumberToObject(syscheckd,"file_max_size",syscheck.file_max_size);
 #ifdef WIN32
     cJSON_AddNumberToObject(syscheckd,"max_fd_win_rt",syscheck.max_fd_win_rt);
 #else

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -288,7 +288,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             if (S_ISLNK(statbuf.st_mode)) {
                 if (stat(file_name, &statbuf_lnk) == 0) {
                     if (S_ISREG(statbuf_lnk.st_mode)) {
-                        if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum,sf_sum, sf256_sum, OS_BINARY) < 0) {
+                        if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum,sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
                             strncpy(mf_sum, "n/a", 4);
                             strncpy(sf_sum, "n/a", 4);
                             strncpy(sf256_sum, "n/a", 4);
@@ -313,9 +313,9 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                     os_free(alert_msg);
                     return -1;
                 }
-            } else if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY) < 0)
+            } else if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0)
 #else
-            if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY) < 0)
+            if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0)
 #endif
             {
                 snprintf(mf_sum, 4, "n/a");

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -288,7 +288,7 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             if (S_ISLNK(statbuf.st_mode)) {
                 if (stat(file_name, &statbuf_lnk) == 0) {
                     if (S_ISREG(statbuf_lnk.st_mode)) {
-                        if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum,sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
+                        if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum,sf_sum, sf256_sum, OS_BINARY, syscheck.file_max_size) < 0) {
                             os_free(wd_sum);
                             os_free(alert_msg);
                             return 0;
@@ -313,9 +313,9 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                     os_free(alert_msg);
                     return -1;
                 }
-            } else if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0)
+            } else if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.file_max_size) < 0)
 #else
-            if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0)
+            if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.file_max_size) < 0)
 #endif
             {
                 os_free(wd_sum);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -289,9 +289,9 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
                 if (stat(file_name, &statbuf_lnk) == 0) {
                     if (S_ISREG(statbuf_lnk.st_mode)) {
                         if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum,sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
-                            strncpy(mf_sum, "n/a", 4);
-                            strncpy(sf_sum, "n/a", 4);
-                            strncpy(sf256_sum, "n/a", 4);
+                            os_free(wd_sum);
+                            os_free(alert_msg);
+                            return 0;
                         }
                     } else if (S_ISDIR(statbuf_lnk.st_mode)) { /* This points to a directory */
                         if (!(opts & CHECK_FOLLOW)) {
@@ -318,9 +318,9 @@ static int read_file(const char *file_name, int dir_position, whodata_evt *evt, 
             if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0)
 #endif
             {
-                snprintf(mf_sum, 4, "n/a");
-                snprintf(sf_sum, 4, "n/a");
-                snprintf(sf256_sum, 4, "n/a");
+                os_free(wd_sum);
+                os_free(alert_msg);
+                return 0;
             }
         }
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -481,9 +481,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
         if (sha1sum || md5sum || sha256sum) {
             /* Generate checksums of the file */
             if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
-                strncpy(sf_sum, "n/a", 4);
-                strncpy(mf_sum, "n/a", 4);
-                strncpy(sf256_sum, "n/a", 4);
+                return 0;
             }
         }
     }
@@ -496,9 +494,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
                 if (sha1sum || md5sum || sha256sum) {
                     /* Generate checksums of the file */
                     if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
-                        strncpy(sf_sum, "n/a", 4);
-                        strncpy(mf_sum, "n/a", 4);
-                        strncpy(sf256_sum, "n/a", 4);
+                        return 0;
                     }
                 }
             }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -480,7 +480,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
     {
         if (sha1sum || md5sum || sha256sum) {
             /* Generate checksums of the file */
-            if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
+            if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.file_max_size) < 0) {
                 return 0;
             }
         }
@@ -493,7 +493,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             if (S_ISREG(statbuf_lnk.st_mode)) {
                 if (sha1sum || md5sum || sha256sum) {
                     /* Generate checksums of the file */
-                    if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
+                    if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.file_max_size) < 0) {
                         return 0;
                     }
                 }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -480,7 +480,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
     {
         if (sha1sum || md5sum || sha256sum) {
             /* Generate checksums of the file */
-            if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY) < 0) {
+            if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
                 strncpy(sf_sum, "n/a", 4);
                 strncpy(mf_sum, "n/a", 4);
                 strncpy(sf256_sum, "n/a", 4);
@@ -495,7 +495,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum, whodata
             if (S_ISREG(statbuf_lnk.st_mode)) {
                 if (sha1sum || md5sum || sha256sum) {
                     /* Generate checksums of the file */
-                    if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY) < 0) {
+                    if (OS_MD5_SHA1_SHA256_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, sf256_sum, OS_BINARY, syscheck.max_size) < 0) {
                         strncpy(sf_sum, "n/a", 4);
                         strncpy(mf_sum, "n/a", 4);
                         strncpy(sf256_sum, "n/a", 4);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -55,6 +55,7 @@ static void read_internal(int debug_level)
     syscheck.sleep_after = getDefine_Int("syscheck", "sleep_after", 1, 9999);
     syscheck.rt_delay = getDefine_Int("syscheck", "rt_delay", 1, 1000);
     syscheck.max_depth = getDefine_Int("syscheck", "default_max_depth", 1, 320);
+    syscheck.max_size = (size_t)getDefine_Int("syscheck", "max_size", 0, 4095) * 1024 * 1024;
 
 #ifndef WIN32
     syscheck.max_audit_entries = getDefine_Int("syscheck", "max_audit_entries", 1, 4096);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -55,7 +55,7 @@ static void read_internal(int debug_level)
     syscheck.sleep_after = getDefine_Int("syscheck", "sleep_after", 1, 9999);
     syscheck.rt_delay = getDefine_Int("syscheck", "rt_delay", 1, 1000);
     syscheck.max_depth = getDefine_Int("syscheck", "default_max_depth", 1, 320);
-    syscheck.max_size = (size_t)getDefine_Int("syscheck", "max_size", 0, 4095) * 1024 * 1024;
+    syscheck.file_max_size = (size_t)getDefine_Int("syscheck", "file_max_size", 0, 4095) * 1024 * 1024;
 
 #ifndef WIN32
     syscheck.max_audit_entries = getDefine_Int("syscheck", "max_audit_entries", 1, 4096);


### PR DESCRIPTION
This PR fixes issue https://github.com/wazuh/wazuh/issues/3007.

It includes three measures to solve the hanging of Syscheck when analyzing directories such as `/proc` or `/dev` which contain kernel owned files, as well as other troubles, explained more detailed [here](https://github.com/wazuh/wazuh/issues/3007#issuecomment-479579016). 

### Fix description

- It has been added a filesize limit when calculating the hashes (md5, sha1, and sha256) for monitored files at the Syscheck pre-scan. It is set to 1GB by default, that can be disabled or expandable to 4GB by the internal option `syscheck.max_size`.

- For Unix agents, it has been included a timeout of five seconds when `fread()` is reading monitored files. This way, we avoid `fread()` to get blocked waiting for reading any content from kernel buffers and other files unable to be read.

- It has been added the file `/dev/core` (a symbolic link to `/proc/kcore`) and the whole `/proc` directory to the Syscheck ignore list. Despite the measures explained above, to monitor `/proc` hangs Syscheck for a while due to the number of files it contains.

### Log samples

Here we can see the logged messages when the timeout or the maximum reading filesize are reached:

```
2019/04/09 10:43:28 ossec-syscheckd: INFO: Starting syscheck scan.
2019/04/09 10:43:28 ossec-syscheckd: INFO: Starting syscheck database (pre-scan).
2019/04/09 10:43:34 ossec-syscheckd: WARNING: Timeout when scanning file '/proc/kmsg'. File skipped.
2019/04/09 10:43:39 ossec-syscheckd: WARNING: Filesize of '/proc/kcore' is higher than the maximum allowed (1024 MB). File skipped.
2019/04/09 10:44:11 ossec-syscheckd: WARNING: Timeout when scanning file '/proc/733/task/733/fd/5'. File skipped.
2019/04/09 10:44:16 ossec-syscheckd: WARNING: Timeout when scanning file '/proc/733/task/791/fd/5'. File skipped.
2019/04/09 10:44:21 ossec-syscheckd: WARNING: Timeout when scanning file '/proc/733/task/792/fd/5'. File skipped.
2019/04/09 10:44:26 ossec-syscheckd: WARNING: Timeout when scanning file '/proc/733/task/793/fd/5'. File skipped.
...
```

Those files are skipped and are not stored in the FIM database. So they won't be monitored until their integrity hashes can be calculated.

```
sqlite> select * from fim_entry where file="/proc/kmsg";
sqlite> select * from fim_entry where file="/proc/kcore";
```

Here we can see a Windows log when the filesize is reached:

```
2019/04/09 14:23:24 ossec-agent: INFO: Starting syscheck scan.
2019/04/09 14:23:24 ossec-agent: INFO: Starting syscheck database (pre-scan).
2019/04/09 14:23:24 ossec-agent: ERROR: Filesize of 'c:\size\testing.txt' is higher than the maximum allowed (1024 MB). File skipped.
2019/04/09 14:23:24 ossec-agent: INFO: Finished creating syscheck database (pre-scan completed).
```

### Testing

This PR has been tested at:

- [x] Linux agent (Ubuntu 18)

- [x] macOS agent (Mojave)

- [x] Windows agent (Windows Server 2019)

- [x] Solaris 11 agent

And Valgrind report shows there are no memory leaks or file descriptor leaks:

```
==67758== LEAK SUMMARY:
==67758==    definitely lost: 0 bytes in 0 blocks
==67758==    indirectly lost: 0 bytes in 0 blocks
==67758==      possibly lost: 576 bytes in 2 blocks
==67758==    still reachable: 26,951,967 bytes in 480,601 blocks
==67758==         suppressed: 0 bytes in 0 blocks
==67758== Reachable blocks (those to which a pointer was found) are not shown.
==67758== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

Regards.




 