### PR TITLE
Better error handling

### DIFF
--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -10,7 +10,7 @@ from wazuh.cluster.dapi.dapi import DistributedAPI
 from ..util import remove_nones_to_dict, exception_handler
 
 loop = asyncio.get_event_loop()
-logger = logging.getLogger('wazuh.agents_controller')
+logger = logging.getLogger('wazuh')
 
 
 def delete_agents(pretty=False, wait_for_complete=False, ids=None, purge=None, status=None, older_than=None):  # noqa: E501
@@ -146,8 +146,8 @@ def restart_all_agents(pretty=True, wait_for_complete=False):  # noqa: E501
 
     :rtype: AgentRestarted
     """
-    import pydevd
-    pydevd.settrace('172.17.0.1', port=12345, stdoutToServer=True, stderrToServer=True)
+    #import pydevd
+    #pydevd.settrace('172.17.0.1', port=12345, stdoutToServer=True, stderrToServer=True)
     dapi = DistributedAPI(f=Agent.restart_agents,
                           f_kwargs={'restart_all': True},
                           request_type='distributed_master',

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -7,7 +7,7 @@ import logging
 
 from wazuh.agent import Agent
 from wazuh.cluster.dapi.dapi import DistributedAPI
-from ..util import remove_nones_to_dict
+from ..util import remove_nones_to_dict, exception_handler
 
 loop = asyncio.get_event_loop()
 logger = logging.getLogger('wazuh.agents_controller')
@@ -101,7 +101,6 @@ def get_all_agents(pretty=False, wait_for_complete=False, offset=0, limit=None, 
 
     :rtype: AllAgents
     """
-
     f_kwargs = {'offset': offset,
                 'limit': limit,
                 'sort': sort,
@@ -136,7 +135,8 @@ def get_all_agents(pretty=False, wait_for_complete=False, offset=0, limit=None, 
     return data, 200
 
 
-def restart_all_agents(wait_for_complete=False):  # noqa: E501
+@exception_handler
+def restart_all_agents(pretty=True, wait_for_complete=False):  # noqa: E501
     """Restarts all agents
 
      # noqa: E501
@@ -146,6 +146,8 @@ def restart_all_agents(wait_for_complete=False):  # noqa: E501
 
     :rtype: AgentRestarted
     """
+    import pydevd
+    pydevd.settrace('172.17.0.1', port=12345, stdoutToServer=True, stderrToServer=True)
     dapi = DistributedAPI(f=Agent.restart_agents,
                           f_kwargs={'restart_all': True},
                           request_type='distributed_master',
@@ -342,10 +344,6 @@ def get_agent_outdated():
 
 
 def restart_list_agents():
-    pass
-
-
-def restart_all_agents():
     pass
 
 

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -146,8 +146,7 @@ def restart_all_agents(pretty=True, wait_for_complete=False):  # noqa: E501
 
     :rtype: AgentRestarted
     """
-    #import pydevd
-    #pydevd.settrace('172.17.0.1', port=12345, stdoutToServer=True, stderrToServer=True)
+
     dapi = DistributedAPI(f=Agent.restart_agents,
                           f_kwargs={'restart_all': True},
                           request_type='distributed_master',

--- a/api/api/models/base_model_.py
+++ b/api/api/models/base_model_.py
@@ -20,6 +20,8 @@ class Model(object):
     @classmethod
     def from_dict(cls: typing.Type[T], dikt) -> T:
         """Returns the dict as a model"""
+        if isinstance(dikt, Exception):
+            raise dikt
         return util.deserialize_model(dikt, cls)
 
     def to_dict(self):

--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -4,11 +4,15 @@
 * Changed parameter **agent_id** type *integer* to *string* with minLength=3
 * Changed all return parameters **agent_id** type *integer* to *string*
 * Deleted all return parameters **path**, new API don't show any absolute path in responses.
+* `error` field has been removed. Now error status is shown in HTTP status code (400 for client error and 500 for server error)
+* `data` is never showing a human readable message. To be consistent, it will only contain an object or list of objects. In case
+a human readable message is shown, the new field `message` will be used instead.
 
 ## Active Response
 ### /active-response/:agent_id
 * Parameters **command**, **Custom** and **Arguments** must be in body.
 * **command** description changed.
+* In response, `data` key is now moved to new `message` key
 
 ## Agents
 
@@ -16,6 +20,7 @@
 ### DELETE /agents
 * Parameter **ids** must be in query, not in body because DELETE operations can't have a requestBody in OpenAPI 3
 * Parameter **status** renamed to **agent_status**
+* In response, `msg` key is now moved to new `message` key
 
 ### GET /agents
 * Parameter **status** renamed to **agent_status**
@@ -26,25 +31,71 @@
 ### GET /agents/groups/{group_id}
 * Parameter **status** renamed to **agent_status**
 
+### POST /agents/groups/{group_id}
+* In response, `msg` key is now moved to new `message` key
+
 ### POST /agents
 * Changed parameter **force** name to **force_time**
 
 ### DELETE /agents/:agent_id
 * Error: parameter **purge** type must be *boolean*, not *string*
+* In response, `msg` key is now moved to new `message` key
+
+### DELETE /agents/:agent_id/group
+* In response, `data` key is now moved to new `message` key
 
 ### DELETE /agents/group/:group_id
 * Parameter **agent_id** must be in query, not in body because DELETE operations can't have a requestBody in OpenAPI 3
 * Changed parameter **agent_id** name to **list_agents**
+* In response, `msg` key is now moved to new `message` key
+
+### DELETE /agents/{agent_id}/group/{group_id}
+* In response, `data` key is now moved to new `message` key
+
+### PUT /agents/{agent_id}/group/{group_id}
+* In response, `data` key is now moved to new `message` key
 
 ### DELETE /agents/groups
 * Changed parameter **ids** name to **list_groups**
 * Changed request parameters **ids** and **failed_ids** to **affected_groups** and **failed_groups**
+* In response, `msg` key is now moved to new `message` key
+
+### DELETE /agents/groups/:group_id
+* In response, `msg` key is now moved to new `message` key
+
+### PUT /agents/groups/:group_id
+* In response, `data` key is now moved to new `message` key
+
+### POST /agents/groups/:group_id/configuration
+* In response, `data` key is now moved to new `message` key
+
+### POST /agents/groups/{group_id}/files/{file_name}
+* In response, `data` key is now moved to new `message` key
 
 ### PUT /agents/{agent_id}/upgrade
 * Changed parameter type **force** from integer to boolean
+* In response, `data` key is now moved to new `message` key
+
+### PUT /agents/{agent_id}/upgrade_custom
+* In response, `data` key is now moved to new `message` key
+
+### GET /agents/{agent_id}/upgrade_result
+* In response, `data` key is now moved to new `message` key
+
+### PUT /agents/:agent_id/restart
+* In response, `msg` key is now moved to new `message` key
 
 ### POST/agents/insert
 * Parameter **force** renamed to **force_after**
+
+### GET/agents/:agent_id/key
+* Response structure changed from `{"data": "agent_key"}` to `{"data": {"key": "agent_key"}}`
+
+### POST/agents/restart
+* In response, `msg` key is now moved to new `message` key
+
+### PUT/agents/restart
+* In response, `data` key is now moved to new `message` key
 
 ## Cache
 ### DELETE /cache (Clear group cache)
@@ -56,6 +107,21 @@
 ## Cluster
 ### GET /cluster/{node_id}/stats
 * Changed date format from YYYYMMDD to YYYY-MM-DD
+
+### GET /cluster/{node_id}/files
+* Now file contents are return in a structure like `{"data": {"contents": "file contents"}}`
+
+### POST /cluster/{node_id}/files
+* In response, `data` key is now moved to new `message` key
+
+### DELETE /cluster/{node_id}/files
+* In response, `data` key is now moved to new `message` key
+
+### PUT /cluster/restart
+* In response, `data` key is now moved to new `message` key
+
+### PUT /cluster/{node_id}/restart
+* In response, `data` key is now moved to new `message` key
 
 
 ## Experimental

--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -123,11 +123,20 @@ a human readable message is shown, the new field `message` will be used instead.
 ### PUT /cluster/{node_id}/restart
 * In response, `data` key is now moved to new `message` key
 
+### GET /cluster/configuration/validation
+* Now errors are shown in a different schema with a HTTP status 400. See spec for more details.
+
+### GET /cluster/{node_id}/configuration/validation
+* Now errors are shown in a different schema with a HTTP status 400. See spec for more details.
+
 
 ## Experimental
 ### General
 * Changed **ram_free**, **ram_total**, **cpu_cores** type to integer and **cpu_mhz** type to number float
 * Deleded all parameters **agent_id** from all endpoints
+
+### DELETE/experimental/syscheck
+* In response, `data` key is now moved to new `message` key
 
 ### /experimental/syscollector/netiface
 * Changed **mtu**, **tx_packets**, **rx_packets**, **tx_bytes**, **rx_bytes**, **tx_errors**, **rx_errors**, **tx_dropped** and **rx_dropped** parameters to type integer.
@@ -138,14 +147,51 @@ a human readable message is shown, the new field `message` will be used instead.
 * Parameter **name** renamed to **process_name**
 
 ## Manager
+
+### GET /manager/files
+* Now file contents are return in a structure like `{"data": {"contents": "file contents"}}`
+
+### POST /manager/files
+* In response, `data` key is now moved to new `message` key
+
+### DELETE /manager/files
+* In response, `data` key is now moved to new `message` key
+
 ### GET /manager/stats
 * Changed date format from YYYYMMDD to YYYY-MM-DD
 
 ### GET/manager/info
 * Parameter `openssl_support` is now a boolean.
 
+### PUT/manager/restart
+* In response, `data` key is now moved to new `message` key
+
 ### GET/manager/stats/weekly
 * Parameter **hours** changed to **averages**.
+
+## Rootcheck
+### PUT/rootcheck
+* In response, `data` key is now moved to new `message` key
+
+### DELETE/rootcheck
+* In response, `data` key is now moved to new `message` key
+
+### PUT/rootcheck/:agent_id
+* In response, `data` key is now moved to new `message` key
+
+### DELETE/rootcheck/:agent_id
+* In response, `data` key is now moved to new `message` key
+
+
+## Syscheck
+### PUT/syscheck
+* In response, `data` key is now moved to new `message` key
+
+### PUT/syscheck/{agent_id}
+* In response, `data` key is now moved to new `message` key
+
+### DELETE/syscheck/{agent_id}
+* In response, `data` key is now moved to new `message` key
 
 ## Syscollectior
 ### /syscollector/:agent_id/netaddr

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2121,13 +2121,6 @@ components:
           - sha3_512
           - shake_128
           - shake_256
-    ip:
-      in: query
-      name: ip
-      description: Filters by agent IP
-      schema:
-        type: string
-        format: alphanumeric
     limit:
       in: query
       name: limit

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -34,6 +34,20 @@ components:
           minimum: 0
           description: Total elements available. It can be used to implement pagination over results.
 
+    ApiError:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri
+
     GenericResult:
       type: object
       properties:
@@ -3013,8 +3027,8 @@ tags:
   - name: syscollector
     description: 'Capability to collect interesting information for each agent'
 
-#security:
-#    - jwt: []
+security:
+    - jwt: []
 
 paths:
   /active-response/{agent_id}:
@@ -5942,24 +5956,29 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
         '200':
-          description: 'Confirmation message'
+          description: 'Configuration is OK'
+
+        '400':
+          description: 'Error in configuration'
           content:
             application/json:
               schema:
                 allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - type: object
-                  properties:
-                    data:
-                      allOf:
-                        - $ref: '#/components/schemas/ConfigurationValidation'
+                  - $ref: '#/components/schemas/ApiError'
+                  - type: object
+                    properties:
+                      errors:
+                        type: array
+                        items:
+                          type: string
               example:
-                error: 0
-                data:
-                  status: KO
-                  details:
-                    - "(1230): Invalid element in the configuration: 'hello'."
-                    - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
+                type: "about:blank"
+                title: "Bad configuration"
+                detail: "Wazuh configuration has not been properly set"
+                errors:
+                  - "(1230): Invalid element in the configuration: 'hello'."
+                  - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
+
 
   /cluster/{node_id}/configuration/validation:
     get:
@@ -5974,24 +5993,28 @@ paths:
         - $ref: '#/components/parameters/node_id'
       responses:
         '200':
-          description: 'Confirmation message'
+          description: 'Configuration is OK'
+
+        '400':
+          description: 'Error in configuration'
           content:
             application/json:
               schema:
                 allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - type: object
-                  properties:
-                    data:
-                      allOf:
-                        - $ref: '#/components/schemas/ConfigurationValidation'
+                  - $ref: '#/components/schemas/ApiError'
+                  - type: object
+                    properties:
+                      errors:
+                        type: array
+                        items:
+                          type: string
               example:
-                error: 0
-                data:
-                  status: KO
-                  details:
-                    - "(1230): Invalid element in the configuration: 'hello'."
-                    - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
+                type: "about:blank"
+                title: "Bad configuration"
+                detail: "Wazuh configuration has not been properly set"
+                errors:
+                  - "(1230): Invalid element in the configuration: 'hello'."
+                  - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
 
   /lists:
     get:
@@ -6028,25 +6051,24 @@ paths:
                               type: array
                               items:
                                 $ref: '#/components/schemas/CDBList'
-                example:
-                  error: 0
-                  data:
-                    totalItems: 2
-                    items:
-                      - path: etc/lists/amazon/aws-eventnames
-                        items:
-                        - key: AttachLoadBalancers
-                          value: Autoscaling
-                        - key: TerminateInstanceInAutoScalingGroup
-                          value: Autoscaling
-                        - key: CreateStack
-                          value: Cloudformation
-                      - path: etc/lists/audit-keys
-                        items:
-                        - key: audit-wazuh-w
-                          value: write
-                        - key: audit-wazuh-a
-                          value: attribute
+              example:
+                data:
+                  totalItems: 2
+                  items:
+                    - path: etc/lists/amazon/aws-eventnames
+                      items:
+                      - key: AttachLoadBalancers
+                        value: Autoscaling
+                      - key: TerminateInstanceInAutoScalingGroup
+                        value: Autoscaling
+                      - key: CreateStack
+                        value: Cloudformation
+                    - path: etc/lists/audit-keys
+                      items:
+                      - key: audit-wazuh-w
+                        value: write
+                      - key: audit-wazuh-a
+                        value: attribute
 
 
   /lists/files:
@@ -6086,7 +6108,6 @@ paths:
                                     description: Path where the CDB list file is stored. This path is relative to the Wazuh installation path.
                                     type: string
                 example:
-                  error: 0
                   data:
                     totalItems: 2
                     items:
@@ -6116,10 +6137,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhDaemonsStatus'
+                      $ref: '#/components/schemas/WazuhDaemonsStatus'
               example:
-                error: 0
                 data:
                   ossec-agentlessd: stopped
                   ossec-analysisd: running
@@ -6158,10 +6177,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhInfo'
+                      $ref: '#/components/schemas/WazuhInfo'
               example:
-                error: 0
                 data:
                   path: /var/ossec
                   version: v3.9.0
@@ -6196,10 +6213,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhConfiguration'
+                      $ref: '#/components/schemas/WazuhConfiguration'
               example:
-                error: 0
                 data:
                   global:
                     jsonout_output: yes
@@ -6257,10 +6272,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhStats'
+                      $ref: '#/components/schemas/WazuhStats'
               example:
-                error: 0
                 data:
                   - hour: 15
                     alerts:
@@ -6310,10 +6323,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhHourlyStats'
+                      $ref: '#/components/schemas/WazuhHourlyStats'
               example:
-                error: 0
                 data:
                   averages:
                     - 40
@@ -6363,10 +6374,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhWeeklyStats'
+                      $ref: '#/components/schemas/WazuhWeeklyStats'
               example:
-                error: 0
                 data:
                   Sun:
                     averages:
@@ -6579,10 +6588,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhAnalysisdStats'
+                      $ref: '#/components/schemas/WazuhAnalysisdStats'
               example:
-                error: 0
                 data:
                   total_events_decoded: 5
                   syscheck_events_decoded: 0
@@ -6652,10 +6659,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhRemotedStats'
+                      $ref: '#/components/schemas/WazuhRemotedStats'
               example:
-                error: 0
                 data:
                   queue_size: 0
                   total_queue_size: 131072
@@ -6702,7 +6707,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/WazuhLogs'
               example:
-                error: 0
                 data:
                   totalItems: 3
                   items:
@@ -6740,10 +6744,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhLogsSummary'
+                      $ref: '#/components/schemas/WazuhLogsSummary'
               example:
-                error: 0
                 data:
                   wazuh-modulesd:
                     info: 2
@@ -6785,15 +6787,18 @@ paths:
             application/json:
               schema:
                 allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - type: object
-                  properties:
-                    data:
-                      description: File contents.
-                      type: string
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          contents:
+                            description: File contents.
+                            type: string
               example:
-                error: 0
-                data: "<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n"
+                data:
+                  contents: "<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n"
     post:
       tags:
       - manager
@@ -6811,12 +6816,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: File updated successfully.
+                message: File updated successfully.
     delete:
       tags:
       - manager
@@ -6833,12 +6835,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: File was deleted.
+                message: File was deleted.
 
   /manager/restart:
     put:
@@ -6856,12 +6855,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: Restarting manager.
+                message: Restarting manager.
 
   /manager/configuration/validation:
     get:
@@ -6875,24 +6871,28 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
         '200':
-          description: 'Confirmation message'
+          description: 'Configuration is OK'
+
+        '400':
+          description: 'Error in configuration'
           content:
             application/json:
               schema:
                 allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - type: object
-                  properties:
-                    data:
-                      allOf:
-                        - $ref: '#/components/schemas/ConfigurationValidation'
+                  - $ref: '#/components/schemas/ApiError'
+                  - type: object
+                    properties:
+                      errors:
+                        type: array
+                        items:
+                          type: string
               example:
-                error: 0
-                data:
-                  status: KO
-                  details:
-                    - "(1230): Invalid element in the configuration: 'hello'."
-                    - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
+                type: "about:blank"
+                title: "Bad configuration"
+                detail: "Wazuh configuration has not been properly set"
+                errors:
+                  - "(1230): Invalid element in the configuration: 'hello'."
+                  - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
 
   /rootcheck:
     put:
@@ -6910,12 +6910,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Restarting Syscheck/Rootcheck on all agents"
+                message: "Restarting Syscheck/Rootcheck on all agents"
     delete:
       tags:
       - rootcheck
@@ -6931,12 +6928,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Rootcheck database deleted"
+                message: "Rootcheck database deleted"
 
   /rootcheck/{agent_id}:
     get:
@@ -6978,7 +6972,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/RootcheckDatabase'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -7007,12 +7000,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Restarting Syscheck/Rootcheck locally"
+                message: "Restarting Syscheck/Rootcheck locally"
     delete:
       tags:
       - rootcheck
@@ -7029,12 +7019,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Rootcheck database deleted"
+                message: "Rootcheck database deleted"
 
   /rootcheck/{agent_id}/pci:
     get:
@@ -7071,7 +7058,6 @@ paths:
                               items:
                                 type: string
               example:
-                error: 0
                 data:
                   totalItems: 1
                   items:
@@ -7112,7 +7098,6 @@ paths:
                               items:
                                 type: string
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -7141,10 +7126,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                      - $ref: '#/components/schemas/LastScan'
+                      $ref: '#/components/schemas/LastScan'
               example:
-                error: 0
                 data:
                   end: "2019-03-08T10:35:21Z"
                   start: "2019-03-08T10:34:56Z"
@@ -7190,7 +7173,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Rules'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -7263,7 +7245,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Rules'
               example:
-                error: 0
                 data:
                   totalItems: 1
                   items:
@@ -7318,7 +7299,6 @@ paths:
                               items:
                                 type: string
               example:
-                error: 0
                 data:
                   totalItems: 4
                   items:
@@ -7361,7 +7341,6 @@ paths:
                               items:
                                 type: string
               example:
-                error: 0
                 data:
                   totalItems: 4
                   items:
@@ -7404,7 +7383,6 @@ paths:
                               items:
                                 type: string
               example:
-                error: 0
                 data:
                   totalItems: 4
                   items:
@@ -7451,7 +7429,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/RulesFiles'
               example:
-                error: 0
                 data:
                   totalItems: 4
                   items:
@@ -7507,7 +7484,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SCADatabase'
               example:
-               error: 0
                data:
                 totalItems: 2
                 items:
@@ -7577,7 +7553,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SCAChecks'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -7627,12 +7602,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Restarting Syscheck/Rootcheck on all agents"
+                message: "Restarting Syscheck/Rootcheck on all agents"
 
   /syscheck/{agent_id}:
     get:
@@ -7677,7 +7649,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscheckDatabase'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -7725,12 +7696,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Restarting Syscheck/Rootcheck locally"
+                message: "Restarting Syscheck/Rootcheck locally"
     delete:
       tags:
       - syscheck
@@ -7747,12 +7715,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Syscheck database deleted"
+                message: "Syscheck database deleted"
 
   /syscheck/{agent_id}/last_scan:
     get:
@@ -7776,10 +7741,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                      - $ref: '#/components/schemas/LastScan'
+                      $ref: '#/components/schemas/LastScan'
               example:
-                error: 0
                 data:
                   end: "2019-03-08T10:35:21Z"
                   start: "2019-03-08T10:34:56Z"
@@ -7822,7 +7785,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Decoder'
               example:
-                error: 0
                 data:
                   totalItems: 571
                   items:
@@ -7877,7 +7839,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Decoder'
               example:
-                error: 0
                 data:
                   totalItems: 3
                   items:
@@ -7938,7 +7899,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/DecoderFile'
               example:
-                error: 0
                 data:
                   totalItems: 571
                   items:
@@ -7998,7 +7958,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Decoder'
               example:
-                error: 0
                 data:
                   totalItems: 153
                   items:
@@ -8033,12 +7992,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/GenericResult'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: Syscheck database deleted
+                message: Syscheck database deleted
 
   /experimental/ciscat/results:
     get:
@@ -8083,7 +8039,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/CiscatResults'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -8151,7 +8106,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorHardware'
               example:
-                error: 0
                 data:
                   totalItems: 4
                   items:
@@ -8221,7 +8175,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorNetwork'
               example:
-                error: 0
                 data:
                   totalItems: 16
                   items:
@@ -8286,7 +8239,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorInterface'
               example:
-                error: 0
                 data:
                   totalItems: 8
                   items:
@@ -8368,7 +8320,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorProtocol'
               example:
-                error: 0
                 data:
                   totalItems: 16
                   items:
@@ -8423,7 +8374,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorOS'
               example:
-                error: 0
                 data:
                   totalItems: 4
                   items:
@@ -8500,7 +8450,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorPackages'
               example:
-                error: 0
                 data:
                   totalItems: 2014
                   items:
@@ -8576,7 +8525,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorPorts'
               example:
-                error: 0
                 data:
                   totalItems: 18
                   items:
@@ -8658,7 +8606,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorProcess'
               example:
-                error: 0
                 data:
                   totalItems: 420
                   items:
@@ -8748,7 +8695,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/SyscollectorHardware'
               example:
-                error: 0
                 data:
                   cpu:
                     core: 2
@@ -8804,7 +8750,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorNetwork'
               example:
-                error: 0
                 data:
                   totalItems: 4
                   items:
@@ -8868,7 +8813,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorInterface'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -8949,7 +8893,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorProtocol'
               example:
-                error: 0
                 data:
                   totalItems: 4
                   items:
@@ -8987,7 +8930,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/SyscollectorOS'
               example:
-                error: 0
                 data:
                   os:
                     codename: "Bionic Beaver"
@@ -9046,7 +8988,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorPackages'
               example:
-                error: 0
                 data:
                   totalItems: 535
                   items:
@@ -9120,7 +9061,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorPorts'
               example:
-                error: 0
                 data:
                   totalItems: 18
                   items:
@@ -9203,7 +9143,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/SyscollectorProcess'
               example:
-                error: 0
                 data:
                   totalItems: 120
                   items:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -47,13 +47,9 @@ components:
         instance:
           type: string
           format: uri
-
-    GenericResult:
-      type: object
-      properties:
-        data:
-          type: string
-          description: Confirmation message.
+        code:
+          type: integer
+          format: int32
 
     ScanIdTime:
       type: object

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -14,6 +14,14 @@ info:
     url: 'https://github.com/wazuh/wazuh/blob/master/LICENSE'
 
 components:
+  responses:
+    ResponseError:
+      description: Response to report a result error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+
   schemas:
     ## Common models
     ApiResponse:
@@ -36,6 +44,10 @@ components:
 
     ApiError:
       type: object
+      required:
+        - type
+        - title
+        - detail
       properties:
         type:
           type: string
@@ -50,6 +62,18 @@ components:
         code:
           type: integer
           format: int32
+        remediation:
+          type: string
+        dapi_errors:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              error:
+                type: string
+              logfile:
+                type: string
+                format: path
 
     ScanIdTime:
       type: object
@@ -1757,6 +1781,7 @@ components:
       scheme: bearer
       bearerFormat: JWT
       x-bearerInfoFunc: api.authentication.decode_token
+
   parameters:
     agent_id:
       in: path
@@ -3023,8 +3048,8 @@ tags:
   - name: syscollector
     description: 'Capability to collect interesting information for each agent'
 
-#security:
-#   - jwt: []
+security:
+   - jwt: []
 
 paths:
   /active-response/{agent_id}:
@@ -3067,6 +3092,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Command sent."
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents:
     delete:
@@ -3110,6 +3137,8 @@ paths:
                   - '005'
                   older_than: 10s
                   total_affected_agents: 2
+        default:
+          $ref: '#/components/responses/ResponseError'
     get:
       tags:
       - agents
@@ -3237,6 +3266,8 @@ paths:
                     registerIP: any
                     id: '002'
                     node_name: unknown
+        default:
+          $ref: '#/components/responses/ResponseError'
     post:
       tags:
       - agents
@@ -3282,6 +3313,8 @@ paths:
                 data:
                   id: "007"
                   key: MDA3IE5ld0hvc3QgMTAuMC4wLjkgZTk5MDE2ZTkzMjMyZDBjZDYyMGIyZTZmMTM2ZjMzMDQxMjY3M2E0NGRmOTNmODk1NzFjMGQyYzczY2VlYzRhZQ==
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}:
     delete:
@@ -3312,6 +3345,8 @@ paths:
                 data:
                   affected_agents:
                   - '008'
+        default:
+          $ref: '#/components/responses/ResponseError'
     get:
       tags:
         - agents
@@ -3360,6 +3395,8 @@ paths:
                   registerIP: "172.18.0.6"
                   status: "Active"
                   version: "Wazuh v3.8.2"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/config/{component}/{configuration}:
     get:
@@ -3427,6 +3464,8 @@ paths:
                         logformat: syslog
                         target:
                           - agent
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/group:
     delete:
@@ -3448,6 +3487,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Group unset for agent '004'."
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/group/is_sync:
     get:
@@ -3477,6 +3518,8 @@ paths:
               example:
                 data:
                     synced: false
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/group/{group_id}:
     delete:
@@ -3499,6 +3542,9 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Group 'dmz' unset for agent '004'."
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     put:
       tags:
         - agents
@@ -3524,6 +3570,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Group '004' already belongs to group 'dmz'."
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/key:
     get:
@@ -3555,6 +3603,8 @@ paths:
               example:
                 data:
                   key: MDA0IG1haW5fZGF0YWJhc2UgMTAuMC4wLjE1IDIzNGM1Y2MzZjhhNzA2OWY2ZGRjN2I0NDc1MWZmNmE1Zjg3MjExMTJiZWJhNmFhMWUyMDIzNWI4MTBjYWNiM2I=
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/restart:
     put:
@@ -3584,6 +3634,8 @@ paths:
                   data:
                     affected_agents:
                       - "007"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/upgrade:
     put:
@@ -3624,6 +3676,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Upgrade procedure started"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/upgrade_custom:
     put:
@@ -3657,6 +3711,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Installation started"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_name}:
     put:
@@ -3685,6 +3741,8 @@ paths:
                 data:
                   id: "008"
                   key: MDA4IG15TmV3QWdlbnQgYW55IDIyNGVmNmI4NjYyMDk5OTc5NzdiZWJhNDRmZTAyNDI0NjU2ZDM1NjhjNWJiZWI4Njk0M2JkMzdjZjA5YjZlM2M=
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/{agent_id}/upgrade_result:
     get:
@@ -3703,7 +3761,6 @@ paths:
           schema:
             type: integer
             format: int32
-
       responses:
         '200':
           description: 'Get agent upgrade result'
@@ -3713,6 +3770,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: Agent upgraded successfully
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/group/{group_id}:
     delete:
@@ -3744,6 +3803,9 @@ paths:
                   affected_agents:
                   - '001'
                   - '002'
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     post:
       tags:
         - agents
@@ -3783,6 +3845,9 @@ paths:
                   affected_agents:
                   - '001'
                   - '002'
+        default:
+          $ref: '#/components/responses/ResponseError'
+
   /agents/groups:
     delete:
       tags:
@@ -3816,6 +3881,9 @@ paths:
                   - '002'
                   - '005'
                   - '003'
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     get:
       tags:
         - agents
@@ -3864,6 +3932,8 @@ paths:
                     name: pciserver
                     mergedSum: 220d6c5fc253f251827ee7487341c0fc
                     configSum: ab73af41699f13fdd81903b5f23d8d00
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/groups/{group_id}:
     delete:
@@ -3898,6 +3968,9 @@ paths:
                   affected_agents:
                   - '001'
                   - '002'
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     get:
       tags:
         - agents
@@ -3981,6 +4054,9 @@ paths:
                     registerIP: 10.0.0.15
                     node_name: unknown
                     id: '004'
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     put:
       tags:
         - agents
@@ -4000,6 +4076,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Group 'pciserver' created"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/groups/{group_id}/configuration:
     get:
@@ -4043,6 +4121,9 @@ paths:
                       localfile:
                       - location: /var/log/linux.log
                       - log_format: syslog
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     post:
       tags:
         - agents
@@ -4072,6 +4153,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: Agent configuration was updated successfully
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/groups/{group_id}/files:
     get:
@@ -4164,6 +4247,8 @@ paths:
                       hash: 92d8011facc8b921ece301ea4ce6a616
                     - filename: win_malware_rcl.txt
                       hash: 6a8d3c63a0e77dea35aaed3ee2cca3a1
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/groups/{group_id}/files/{file_name}:
     get:
@@ -4208,6 +4293,9 @@ paths:
                       reference: "https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf"
                       checks:
                         - "f:/etc/fstab -> !r:/tmp;"
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     post:
       tags:
         - agents
@@ -4237,6 +4325,9 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: Agent configuration was updated successfully
+        default:
+          $ref: '#/components/responses/ResponseError'
+
   /agents/insert:
     post:
       tags:
@@ -4294,6 +4385,8 @@ paths:
                 data:
                   id: 123
                   key: MTIzIE5ld0hvc3RfMiAxMC4wLjEwLjEwIDFhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpNjQ=
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/name/{agent_name}:
     get:
@@ -4328,6 +4421,8 @@ paths:
                   registerIP: 10.0.0.9
                   node_name: unknown
                   id: "007"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/no_group:
     get:
@@ -4389,6 +4484,8 @@ paths:
                       registerIP: 10.0.10.10
                       node_name: unknown
                       id: "123"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/outdated:
     get:
@@ -4433,6 +4530,8 @@ paths:
                     - version: Wazuh v3.0.0
                       id: "004"
                       name: dmz002
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/restart:
     post:
@@ -4473,6 +4572,9 @@ paths:
                     affected_agents:
                     - '002'
                     - '004'
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     put:
       tags:
       - agents
@@ -4490,6 +4592,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Restarting all agents"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/stats/distinct:
     get:
@@ -4548,6 +4652,8 @@ paths:
                         platform: ubuntu
                       count: 2
                     - count: 5
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/summary:
     get:
@@ -4588,6 +4694,8 @@ paths:
                   Disconnected: 0
                   Never connected: 5
                   Pending: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /agents/summary/os:
     get:
@@ -4629,6 +4737,8 @@ paths:
                   totalItems: 1
                   items:
                     - ubuntu
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cache/:
     delete:
@@ -4683,6 +4793,8 @@ paths:
                   all:
                     -
                   groups:
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cache/{group}:
     delete:
@@ -4714,6 +4826,8 @@ paths:
                   groups:
                     agents:
                       - /agents/stats/distinct?pretty&fields=os.platform
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cache/config:
     get:
@@ -4746,6 +4860,8 @@ paths:
                     -
                   jsonp: false
                   redisClient: false
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /ciscat/{agent_id}/results:
     get:
@@ -4817,6 +4933,8 @@ paths:
                     pass: 96
                     notchecked: 71
                     unknown: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/node:
     get:
@@ -4854,6 +4972,8 @@ paths:
                   node: "node02"
                   cluster: "wazuh"
                   type: "worker"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/nodes:
     get:
@@ -4902,6 +5022,8 @@ paths:
                       type: "master"
                       version: "3.9.0"
                       ip: "172.17.0.100"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/nodes/{node_id}:
     get:
@@ -4933,6 +5055,8 @@ paths:
                   type: "worker"
                   version: "3.9.0"
                   ip: "172.17.0.101"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/healthcheck:
     get:
@@ -5002,6 +5126,8 @@ paths:
                         - type: "Last keep alive"
                           date_start: "2019-01-11T18:52:57.72Z"
                           date_end: "2019-01-11T18:52:57.73Z"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/healthcheck/{node_id}:
     get:
@@ -5056,6 +5182,8 @@ paths:
                     - type: "Last keep alive"
                       date_start: "2019-01-11 18:52:57.72"
                       date_end: "2019-01-11 18:52:57.73"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/status:
     get:
@@ -5095,6 +5223,8 @@ paths:
                 data:
                   enabled: yes
                   running: yes
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/config:
     get:
@@ -5162,6 +5292,8 @@ paths:
                     - 172.17.0.100
                   hidden: no
                   disabled: false
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/status:
     get:
@@ -5203,6 +5335,8 @@ paths:
                   ossec-syscheckd: running
                   wazuh-clusterd: running
                   wazuh-modulesd: running
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/info:
     get:
@@ -5238,6 +5372,8 @@ paths:
                   ruleset_version: 3905
                   tz_offset: +0000
                   tz_name: UTC
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/configuration:
     get:
@@ -5299,6 +5435,8 @@ paths:
                       timeout_allowed: yes
                     - name: restart-ossec
                       executable: restart-ossec.sh
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/stats:
     get:
@@ -5352,6 +5490,8 @@ paths:
                     events: 4379
                     syscheck: 0
                     firewall: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/stats/hourly:
     get:
@@ -5404,6 +5544,8 @@ paths:
                     - 65
                     - 23
                   interactions: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/stats/weekly:
     get:
@@ -5619,6 +5761,8 @@ paths:
                     - 65
                     - 23
                     interactions: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/stats/analysisd:
     get:
@@ -5691,6 +5835,8 @@ paths:
                   statistical_queue_size: 16384
                   archives_queue_usage: 0
                   archives_queue_size: 16384
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/stats/remoted:
     get:
@@ -5725,6 +5871,8 @@ paths:
                   discarded_count: 0
                   msg_sent: 0
                   recv_bytes: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/logs:
     get:
@@ -5778,6 +5926,8 @@ paths:
                       tag: ossec-rootcheck
                       level: info
                       description: Starting rootcheck scan.
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/logs/summary:
     get:
@@ -5825,6 +5975,8 @@ paths:
                     debug: 0
                     error: 0
                     warning: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/files:
     get:
@@ -5857,6 +6009,9 @@ paths:
               example:
                 data:
                   contents: "<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n"
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     post:
       tags:
       - cluster
@@ -5878,6 +6033,9 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: File updated successfully.
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     delete:
       tags:
       - cluster
@@ -5898,6 +6056,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: File was deleted.
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/restart:
     put:
@@ -5918,6 +6078,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: Restarting cluster.
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/{node_id}/restart:
     put:
@@ -5939,6 +6101,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: Restarting manager.
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /cluster/configuration/validation:
     get:
@@ -5974,6 +6138,8 @@ paths:
                 errors:
                   - "(1230): Invalid element in the configuration: 'hello'."
                   - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
+        default:
+          $ref: '#/components/responses/ResponseError'
 
 
   /cluster/{node_id}/configuration/validation:
@@ -6011,6 +6177,8 @@ paths:
                 errors:
                   - "(1230): Invalid element in the configuration: 'hello'."
                   - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /lists:
     get:
@@ -6065,6 +6233,8 @@ paths:
                         value: write
                       - key: audit-wazuh-a
                         value: attribute
+        default:
+          $ref: '#/components/responses/ResponseError'
 
 
   /lists/files:
@@ -6111,6 +6281,8 @@ paths:
                         path: etc/lists
                       - name: aws-sources
                         path: etc/lists/amazon
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/status:
     get:
@@ -6151,6 +6323,8 @@ paths:
                   ossec-syscheckd: running
                   wazuh-clusterd: running
                   wazuh-modulesd: running
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/info:
     get:
@@ -6185,6 +6359,8 @@ paths:
                   ruleset_version: 3905
                   tz_offset: +0000
                   tz_name: UTC
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/configuration:
     get:
@@ -6245,6 +6421,8 @@ paths:
                       timeout_allowed: yes
                     - name: restart-ossec
                       executable: restart-ossec.sh
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/stats:
     get:
@@ -6297,6 +6475,8 @@ paths:
                     events: 4379
                     syscheck: 0
                     firewall: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/stats/hourly:
     get:
@@ -6348,6 +6528,8 @@ paths:
                     - 65
                     - 23
                   interactions: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/stats/weekly:
     get:
@@ -6562,6 +6744,8 @@ paths:
                     - 65
                     - 23
                     interactions: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/stats/analysisd:
     get:
@@ -6633,6 +6817,8 @@ paths:
                   statistical_queue_size: 16384
                   archives_queue_usage: 0
                   archives_queue_size: 16384
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/stats/remoted:
     get:
@@ -6666,6 +6852,8 @@ paths:
                   discarded_count: 0
                   msg_sent: 0
                   recv_bytes: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/logs:
     get:
@@ -6718,6 +6906,8 @@ paths:
                       tag: ossec-rootcheck
                       level: info
                       description: Starting rootcheck scan.
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/logs/summary:
     get:
@@ -6764,6 +6954,8 @@ paths:
                     debug: 0
                     error: 0
                     warning: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/files:
     get:
@@ -6795,6 +6987,9 @@ paths:
               example:
                 data:
                   contents: "<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n"
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     post:
       tags:
       - manager
@@ -6815,6 +7010,9 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: File updated successfully.
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     delete:
       tags:
       - manager
@@ -6834,6 +7032,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: File was deleted.
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/restart:
     put:
@@ -6854,6 +7054,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: Restarting manager.
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /manager/configuration/validation:
     get:
@@ -6889,6 +7091,8 @@ paths:
                 errors:
                   - "(1230): Invalid element in the configuration: 'hello'."
                   - "(1202): Configuration error at '/var/ossec/etc/ossec.conf'."
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rootcheck:
     put:
@@ -6909,6 +7113,9 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Restarting Syscheck/Rootcheck on all agents"
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     delete:
       tags:
       - rootcheck
@@ -6927,6 +7134,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Rootcheck database deleted"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rootcheck/{agent_id}:
     get:
@@ -6980,6 +7189,9 @@ paths:
                       oldDay: "2019-03-08T09:20:05Z"
                       pci: 2.2.4
                       event: "System Audit: SSH Hardening - 4: No Public Key authentication {PCI_DSS: 2.2.4}. File: /etc/ssh/sshd_config. Reference: 4 ."
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     put:
       tags:
       - rootcheck
@@ -6999,6 +7211,9 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Restarting Syscheck/Rootcheck locally"
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     delete:
       tags:
       - rootcheck
@@ -7018,6 +7233,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Rootcheck database deleted"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rootcheck/{agent_id}/pci:
     get:
@@ -7058,6 +7275,8 @@ paths:
                   totalItems: 1
                   items:
                   - 2.2.4
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rootcheck/{agent_id}/cis:
     get:
@@ -7099,6 +7318,8 @@ paths:
                   items:
                   - "2.3 Debian Linux"
                   - "1.4 Debian Linux"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rootcheck/{agent_id}/last_scan:
     get:
@@ -7127,6 +7348,8 @@ paths:
                 data:
                   end: "2019-03-08T10:35:21Z"
                   start: "2019-03-08T10:34:56Z"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rules:
     get:
@@ -7205,6 +7428,8 @@ paths:
                       details:
                         if_sid: "510"
                         match: "^Windows Malware"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rules/{rule_id}:
     get:
@@ -7260,6 +7485,8 @@ paths:
                         if_sid: "7505"
                         match: contains the EICAR test file
                         options: alert_by_email
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rules/groups:
     get:
@@ -7302,6 +7529,8 @@ paths:
                     - access_denied
                     - accesslog
                     - account_changed
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rules/pci:
     get:
@@ -7344,6 +7573,8 @@ paths:
                     - "1.3.4"
                     - "1.4"
                     - "10.1"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rules/gdpr:
     get:
@@ -7386,6 +7617,8 @@ paths:
                     - "IV_30.1.g"
                     - "IV_32.2"
                     - "IV_35.7.d"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /rules/files:
     get:
@@ -7440,6 +7673,8 @@ paths:
                     - file: 0020-syslog_rules.xml
                       path: ruleset/rules
                       status: enabled
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /sca/{agent_id}:
     get:
@@ -7501,6 +7736,8 @@ paths:
                   policy_id: "cis_debian"
                   end_scan: "2019-03-06T10:11:53Z"
                   start_scan: "2019-03-06T10:11:53Z"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /sca/{agent_id}/checks/{policy_id}:
     get:
@@ -7581,6 +7818,8 @@ paths:
                       value: "9"
                     - key: pci_dss
                       value: "2.2.2"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscheck:
     put:
@@ -7601,6 +7840,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Restarting Syscheck/Rootcheck on all agents"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscheck/{agent_id}:
     get:
@@ -7676,6 +7917,9 @@ paths:
                       gid: "0"
                       mtime: "2018-11-05T11:51:29Z"
                       sha256: a39fbc57dc2ef8a473f078d1f6a35f725809400df67070b8852e8ed725047df2
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     put:
       tags:
       - syscheck
@@ -7695,6 +7939,9 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Restarting Syscheck/Rootcheck locally"
+        default:
+          $ref: '#/components/responses/ResponseError'
+
     delete:
       tags:
       - syscheck
@@ -7714,6 +7961,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: "Syscheck database deleted"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscheck/{agent_id}/last_scan:
     get:
@@ -7742,6 +7991,8 @@ paths:
                 data:
                   end: "2019-03-08T10:35:21Z"
                   start: "2019-03-08T10:34:56Z"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /decoders:
     get:
@@ -7799,6 +8050,8 @@ paths:
                       prematch: "^Agent buffer:"
                       regex: "^ '(\\S+)'."
                       order: level
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /decoders/{decoder_name}:
     get:
@@ -7856,6 +8109,8 @@ paths:
                     status: enabled
                     details:
                       prematch: "^[\\w+ \\w+ \\d+ \\d+:\\d+:\\d+.\\d+ \\d+] [\\S+:warn] |^[\\w+ \\w+ \\d+ \\d+:\\d+:\\d+.\\d+ \\d+] [\\S+:notice] |^[\\w+ \\w+ \\d+ \\d+:\\d+:\\d+.\\d+ \\d+] [\\S*:error] |^[\\w+ \\w+ \\d+ \\d+:\\d+:\\d+.\\d+ \\d+] [\\S+:info] "
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /decoders/files:
     get:
@@ -7919,6 +8174,8 @@ paths:
                     status: enabled
                   - file: 0345-unbound_decoders.xml
                     status: enabled
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /decoders/parents:
     get:
@@ -7971,6 +8228,8 @@ paths:
                       prematch: "^azure_tag: azure-storage. "
                       regex: "^azure_storage_tag: (\\S+)"
                       order: tag
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscheck:
     delete:
@@ -7991,6 +8250,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               example:
                 message: Syscheck database deleted
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/ciscat/results:
     get:
@@ -8060,6 +8321,8 @@ paths:
                     pass: 104
                     notchecked: 36
                     unknown: 1
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscollector/hardware:
     get:
@@ -8131,6 +8394,8 @@ paths:
                       time: "2019-02-19T10:26:20Z"
                     board_serial: "0"
                     agent_id: "001"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscollector/netaddr:
     get:
@@ -8186,6 +8451,8 @@ paths:
                     address: "fe80::a00:27ff:fefc:51f5"
                     netmask: "ffff:ffff:ffff:ffff::"
                     agent_id: "000"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscollector/netiface:
     get:
@@ -8276,6 +8543,8 @@ paths:
                     mtu: 1500
                     state: "up"
                     agent_id: "000"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscollector/netproto:
     get:
@@ -8329,6 +8598,8 @@ paths:
                     type: "ipv6"
                     dhcp: "enabled"
                     agent_id: "000"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscollector/os:
     get:
@@ -8405,6 +8676,8 @@ paths:
                     sysname: "Linux"
                     hostname: "agent-1"
                     agent_id: "001"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscollector/packages:
     get:
@@ -8477,6 +8750,8 @@ paths:
                     version: "0.6.45-1ubuntu1"
                     format: "deb"
                     agent_id: "000"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscollector/ports:
     get:
@@ -8552,6 +8827,8 @@ paths:
                     rx_queue: 0
                     inode: 18153
                     tx_queue: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /experimental/syscollector/processes:
     get:
@@ -8665,6 +8942,8 @@ paths:
                     start_time: 22
                     tty: 0
                     agent_id: "000"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscollector/{agent_id}/hardware:
     get:
@@ -8704,6 +8983,8 @@ paths:
                     id: 599386135
                     time: "2019-03-08T08:30:53Z"
                   board_serial: "0"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscollector/{agent_id}/netaddr:
     get:
@@ -8759,6 +9040,8 @@ paths:
                     iface: "enp0s8"
                     netmask: "ffff:ffff:ffff:ffff::"
                     scan_id: 1478544824
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscollector/{agent_id}/netiface:
     get:
@@ -8848,6 +9131,8 @@ paths:
                     type: "ethernet"
                     mtu: 1500
                     mac: "08:00:27:78:05:d4"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscollector/{agent_id}/netproto:
     get:
@@ -8900,6 +9185,8 @@ paths:
                     iface: "enp0s8"
                     dhcp: "enabled"
                     scan_id: 1478544824
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscollector/{agent_id}/os:
     get:
@@ -8942,6 +9229,8 @@ paths:
                   version: "#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018"
                   sysname: "Linux"
                   hostname: "master"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscollector/{agent_id}/packages:
     get:
@@ -9013,6 +9302,8 @@ paths:
                     version: "3.5.44"
                     section: "admin"
                     multiarch: "foreign"
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscollector/{agent_id}/ports:
     get:
@@ -9088,6 +9379,8 @@ paths:
                     rx_queue: 0
                     inode: 18153
                     tx_queue: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /syscollector/{agent_id}/processes:
     get:
@@ -9202,6 +9495,8 @@ paths:
                     tgid: 121
                     start_time: 1009
                     tty: 0
+        default:
+          $ref: '#/components/responses/ResponseError'
 
   /security/user/authenticate:
     get:
@@ -9224,6 +9519,8 @@ paths:
                     type: string
         '401':
           description: 'Access unauthorized'
+        default:
+          $ref: '#/components/responses/ResponseError'
 
 externalDocs:
   description: Find more about Wazuh API usage

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3027,8 +3027,8 @@ tags:
   - name: syscollector
     description: 'Capability to collect interesting information for each agent'
 
-security:
-    - jwt: []
+#security:
+#   - jwt: []
 
 paths:
   /active-response/{agent_id}:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -18,17 +18,10 @@ components:
     ## Common models
     ApiResponse:
       type: object
-      required:
-      - error
       properties:
-        error:
-          type: integer
-          format: int32
-          minimum: 0
-          description: Result 0 (No error), other value (error).
         message:
           type: string
-          description: Error message. Only returned when error field is higher than 0.
+          description: Human readable description to explain the result of the request
 
     ListMetadata:
       type: object
@@ -41,7 +34,7 @@ components:
           minimum: 0
           description: Total elements available. It can be used to implement pagination over results.
 
-    ConfirmationMessage:
+    GenericResult:
       type: object
       properties:
         data:
@@ -63,12 +56,8 @@ components:
     ItemAffected:
       type: object
       required:
-      - msg
       - affected_items
       properties:
-        msg:
-          type: string
-          description: Confirmation message.
         affected_items:
           type: array
           description: Items that successfully applied the API call action.
@@ -3024,8 +3013,8 @@ tags:
   - name: syscollector
     description: 'Capability to collect interesting information for each agent'
 
-security:
-    - jwt: []
+#security:
+#    - jwt: []
 
 paths:
   /active-response/{agent_id}:
@@ -3065,12 +3054,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
-                example:
-                  data: "Command sent."
-                  error: 0
+                $ref: '#/components/schemas/ApiResponse'
+              example:
+                message: "Command sent."
 
   /agents:
     delete:
@@ -3107,9 +3093,8 @@ paths:
                     data:
                       $ref: '#/components/schemas/AllItemsAffected'
               example:
-                error: 0
+                message: All selected agents were removed
                 data:
-                  msg: All selected agents were removed
                   affected_agents:
                   - '003'
                   - '005'
@@ -3172,7 +3157,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Agent'
               example:
-                error: 0
                 data:
                   totalItems: 7
                   items:
@@ -3285,7 +3269,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/AgentIdKey'
               example:
-                error: 0
                 data:
                   id: "007"
                   key: MDA3IE5ld0hvc3QgMTAuMC4wLjkgZTk5MDE2ZTkzMjMyZDBjZDYyMGIyZTZmMTM2ZjMzMDQxMjY3M2E0NGRmOTNmODk1NzFjMGQyYzczY2VlYzRhZQ==
@@ -3315,9 +3298,8 @@ paths:
                     data:
                       $ref: '#/components/schemas/ItemAffected'
               example:
-                error: 0
+                message: All selected agents were removed
                 data:
-                  msg: All selected agents were removed
                   affected_agents:
                   - '008'
     get:
@@ -3342,10 +3324,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/Agent'
+                      $ref: '#/components/schemas/Agent'
               example:
-                error: 0
                 data:
                   configSum: "ab73af41699f13fdd81903b5f23d8d00"
                   dateAdd: '2018-10-11T09:37:23Z'
@@ -3395,10 +3375,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/AgentConfiguration'
+                      $ref: '#/components/schemas/AgentConfiguration'
               example:
-                error: 0
                 data:
                     localfile:
                       - logformat: command
@@ -3457,12 +3435,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Group unset for agent '004'."
+                message: "Group unset for agent '004'."
 
   /agents/{agent_id}/group/is_sync:
     get:
@@ -3490,7 +3465,6 @@ paths:
                           syncef:
                             type: boolean
               example:
-                error: 0
                 data:
                     synced: false
 
@@ -3512,12 +3486,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Group 'dmz' unset for agent '004'."
+                message: "Group 'dmz' unset for agent '004'."
     put:
       tags:
         - agents
@@ -3540,12 +3511,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Group '004' already belongs to group 'dmz'."
+                message: "Group '004' already belongs to group 'dmz'."
 
   /agents/{agent_id}/key:
     get:
@@ -3569,11 +3537,14 @@ paths:
                   - type: object
                     properties:
                       data:
-                        type: string
-                        description: Agent key.
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: Agent key.
               example:
-                error: 0
-                data: MDA0IG1haW5fZGF0YWJhc2UgMTAuMC4wLjE1IDIzNGM1Y2MzZjhhNzA2OWY2ZGRjN2I0NDc1MWZmNmE1Zjg3MjExMTJiZWJhNmFhMWUyMDIzNWI4MTBjYWNiM2I=
+                data:
+                  key: MDA0IG1haW5fZGF0YWJhc2UgMTAuMC4wLjE1IDIzNGM1Y2MzZjhhNzA2OWY2ZGRjN2I0NDc1MWZmNmE1Zjg3MjExMTJiZWJhNmFhMWUyMDIzNWI4MTBjYWNiM2I=
 
   /agents/{agent_id}/restart:
     put:
@@ -3599,9 +3570,8 @@ paths:
                     data:
                       $ref: '#/components/schemas/ItemAffected'
                 example:
-                  error: 0
+                  message: All selected agents were restarted
                   data:
-                    msg: All selected agents were restarted
                     affected_agents:
                       - "007"
 
@@ -3641,12 +3611,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Upgrade procedure started"
+                message: "Upgrade procedure started"
 
   /agents/{agent_id}/upgrade_custom:
     put:
@@ -3677,12 +3644,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Installation started"
+                message: "Installation started"
 
   /agents/{agent_name}:
     put:
@@ -3708,7 +3672,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/AgentIdKey'
               example:
-                error: 0
                 data:
                   id: "008"
                   key: MDA4IG15TmV3QWdlbnQgYW55IDIyNGVmNmI4NjYyMDk5OTc5NzdiZWJhNDRmZTAyNDI0NjU2ZDM1NjhjNWJiZWI4Njk0M2JkMzdjZjA5YjZlM2M=
@@ -3737,12 +3700,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: Agent upgraded successfully
+                message: Agent upgraded successfully
 
   /agents/group/{group_id}:
     delete:
@@ -3769,9 +3729,8 @@ paths:
                     data:
                       $ref: '#/components/schemas/ItemAffected'
               example:
-                error: 0
+                message: All selected agents were removed to group dmz
                 data:
-                  msg: All selected agents were removed to group dmz
                   affected_agents:
                   - '001'
                   - '002'
@@ -3809,9 +3768,8 @@ paths:
                     data:
                       $ref: '#/components/schemas/ItemAffected'
               example:
-                error: 0
+                message: All selected agents assigned to group dmz
                 data:
-                  msg: All selected agents assigned to group dmz
                   affected_agents:
                   - '001'
                   - '002'
@@ -3839,9 +3797,8 @@ paths:
                     data:
                       $ref: '#/components/schemas/AllItemsAffected'
               example:
-                error: 0
+                message: All selected groups were removed
                 data:
-                  msg: All selected groups were removed
                   affected_groups:
                   - 'webserver'
                   - 'dataserver'
@@ -3883,7 +3840,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/AgentGroup'
               example:
-                error: 0
                 data:
                   item:
                   - count: 2
@@ -3925,9 +3881,8 @@ paths:
                         - $ref: '#/components/schemas/ItemAffected'
                         - $ref: '#/components/schemas/AgentGroupDeleted'
               example:
-                error: 0
+                message: All selected groups were removed
                 data:
-                  msg: All selected groups were removed
                   affected_groups:
                   - 'dmz'
                   affected_agents:
@@ -3970,7 +3925,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Agent'
               example:
-                error: 0
                 data:
                   totalItems: 3
                   items:
@@ -4033,12 +3987,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Group 'pciserver' created"
+                message: "Group 'pciserver' created"
 
   /agents/groups/{group_id}/configuration:
     get:
@@ -4073,7 +4024,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/GroupConfiguration'
               example:
-                error: 0
                 data:
                   totalItems: 1
                   items:
@@ -4109,12 +4059,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: Agent configuration was updated successfully
+                message: Agent configuration was updated successfully
 
   /agents/groups/{group_id}/files:
     get:
@@ -4156,7 +4103,6 @@ paths:
                                   hash:
                                     type: string
               example:
-                error: 0
                 data:
                   totalItems: 24
                   items:
@@ -4239,7 +4185,6 @@ paths:
                         - type: object
                           description: "The output format depends on the type of file that has been requested: rootkit file, rootkit trojans or rcl."
               example:
-                error: 0
                 data:
                   vars:
                   controls:
@@ -4279,12 +4224,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: Agent configuration was updated successfully
+                message: Agent configuration was updated successfully
   /agents/insert:
     post:
       tags:
@@ -4339,7 +4281,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/AgentIdKey'
               example:
-                error: 0
                 data:
                   id: 123
                   key: MTIzIE5ld0hvc3RfMiAxMC4wLjEwLjEwIDFhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpNjQ=
@@ -4367,10 +4308,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/Agent'
+                      $ref: '#/components/schemas/Agent'
               example:
-                error: 0
                 data:
                   ip: 10.0.0.9
                   status: Never connected
@@ -4416,7 +4355,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Agent'
               example:
-                error: 0
                 data:
                   totalItems: 3
                   items:
@@ -4476,7 +4414,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/AgentSimple'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -4521,9 +4458,8 @@ paths:
                     data:
                       $ref: '#/components/schemas/ItemAffected'
                 example:
-                  error: 0
+                  message: All selected agents were restarted
                   data:
-                    msg: All selected agents were restarted
                     affected_agents:
                     - '002'
                     - '004'
@@ -4541,12 +4477,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: "Restarting all agents"
+                message: "Restarting all agents"
 
   /agents/stats/distinct:
     get:
@@ -4598,7 +4531,6 @@ paths:
                                   count:
                                     type: integer
               example:
-                error: 0
                 data:
                   totalItems: 7
                   items:
@@ -4640,7 +4572,6 @@ paths:
                         Pending:
                           type: integer
               example:
-                error: 0
                 data:
                   Total: 7
                   Active: 2
@@ -4684,7 +4615,6 @@ paths:
                               items:
                                 type: string
               example:
-                error: 0
                 data:
                   totalItems: 1
                   items:
@@ -4713,7 +4643,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/GroupCache'
               example:
-                error: 0
                 data:
                   all:
                     -
@@ -4740,7 +4669,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/GroupCache'
               example:
-                error: 0
                 data:
                   all:
                     -
@@ -4770,7 +4698,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/GroupCache'
               example:
-                error: 0
                 data:
                   all:
                     - /agents/stats/distinct?pretty&fields=os.platform
@@ -4801,7 +4728,6 @@ paths:
                     data:
                       $ref: '#/components/schemas/CacheConfig'
               example:
-                error: 0
                 data:
                   debug: false
                   defaultDuration: 750
@@ -4856,7 +4782,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/CiscatResults'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -4915,7 +4840,6 @@ paths:
                           description: Node type.
                           type: string
               example:
-                error: 0
                 data:
                   node: "node02"
                   cluster: "wazuh"
@@ -4957,7 +4881,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/ClusterNode'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -4993,10 +4916,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/ClusterNode'
+                      $ref: '#/components/schemas/ClusterNode'
               example:
-                error: 0
                 data:
                   name: "node02"
                   type: "worker"
@@ -5033,7 +4954,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/Healthcheck'
               example:
-                error: 0
                 data:
                   totalItems: 2
                   items:
@@ -5095,10 +5015,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/Healthcheck'
+                      $ref: '#/components/schemas/Healthcheck'
               example:
-                error: 0
                 data:
                   info:
                     ip: "172.17.0.101"
@@ -5164,7 +5082,6 @@ paths:
                           - yes
                           - no
               example:
-                error: 0
                 data:
                   enabled: yes
                   running: yes
@@ -5224,7 +5141,6 @@ paths:
                           description: Whether the cluster is enabled or not.
                           type: boolean
               example:
-                error: 0
                 data:
                   name: wazuh
                   node_name: node02
@@ -5259,10 +5175,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhDaemonsStatus'
+                      $ref: '#/components/schemas/WazuhDaemonsStatus'
               example:
-                error: 0
                 data:
                   ossec-agentlessd: stopped
                   ossec-analysisd: running
@@ -5302,10 +5216,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhInfo'
+                      $ref: '#/components/schemas/WazuhInfo'
               example:
-                error: 0
                 data:
                   path: /var/ossec
                   version: v3.9.0
@@ -5341,10 +5253,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhConfiguration'
+                      $ref: '#/components/schemas/WazuhConfiguration'
               example:
-                error: 0
                 data:
                   global:
                     jsonout_output: yes
@@ -5403,10 +5313,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhStats'
+                      $ref: '#/components/schemas/WazuhStats'
               example:
-                error: 0
                 data:
                   - hour: 15
                     alerts:
@@ -5457,10 +5365,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhHourlyStats'
+                      $ref: '#/components/schemas/WazuhHourlyStats'
               example:
-                error: 0
                 data:
                   averages:
                     - 40
@@ -5511,10 +5417,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhWeeklyStats'
+                      $ref: '#/components/schemas/WazuhWeeklyStats'
               example:
-                error: 0
                 data:
                   Sun:
                     averages:
@@ -5728,10 +5632,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhAnalysisdStats'
+                      $ref: '#/components/schemas/WazuhAnalysisdStats'
               example:
-                error: 0
                 data:
                   total_events_decoded: 5
                   syscheck_events_decoded: 0
@@ -5802,10 +5704,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhRemotedStats'
+                      $ref: '#/components/schemas/WazuhRemotedStats'
               example:
-                error: 0
                 data:
                   queue_size: 0
                   total_queue_size: 131072
@@ -5853,7 +5753,6 @@ paths:
                               items:
                                 $ref: '#/components/schemas/WazuhLogs'
               example:
-                error: 0
                 data:
                   totalItems: 3
                   items:
@@ -5892,10 +5791,8 @@ paths:
                 - type: object
                   properties:
                     data:
-                      allOf:
-                        - $ref: '#/components/schemas/WazuhLogsSummary'
+                      $ref: '#/components/schemas/WazuhLogsSummary'
               example:
-                error: 0
                 data:
                   wazuh-modulesd:
                     info: 2
@@ -5942,11 +5839,14 @@ paths:
                 - type: object
                   properties:
                     data:
-                      description: File contents.
-                      type: string
+                      type: object
+                      properties:
+                        contents:
+                          description: File contents.
+                          type: string
               example:
-                error: 0
-                data: "<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n"
+                data:
+                  contents: "<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n"
     post:
       tags:
       - cluster
@@ -5965,12 +5865,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: File updated successfully.
+                message: File updated successfully.
     delete:
       tags:
       - cluster
@@ -5988,12 +5885,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: File was deleted.
+                message: File was deleted.
 
   /cluster/restart:
     put:
@@ -6011,12 +5905,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: Restarting cluster.
+                message: Restarting cluster.
 
   /cluster/{node_id}/restart:
     put:
@@ -6035,12 +5926,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                $ref: '#/components/schemas/ApiResponse'
               example:
-                error: 0
-                data: Restarting manager.
+                message: Restarting manager.
 
   /cluster/configuration/validation:
     get:
@@ -6925,7 +6813,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: File updated successfully.
@@ -6947,7 +6835,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: File was deleted.
@@ -6970,7 +6858,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: Restarting manager.
@@ -7024,7 +6912,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: "Restarting Syscheck/Rootcheck on all agents"
@@ -7045,7 +6933,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: "Rootcheck database deleted"
@@ -7121,7 +7009,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: "Restarting Syscheck/Rootcheck locally"
@@ -7143,7 +7031,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: "Rootcheck database deleted"
@@ -7741,7 +7629,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: "Restarting Syscheck/Rootcheck on all agents"
@@ -7839,7 +7727,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: "Restarting Syscheck/Rootcheck locally"
@@ -7861,7 +7749,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: "Syscheck database deleted"
@@ -8147,7 +8035,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'
-                - $ref: '#/components/schemas/ConfirmationMessage'
+                - $ref: '#/components/schemas/GenericResult'
               example:
                 error: 0
                 data: Syscheck database deleted

--- a/api/api/util.py
+++ b/api/api/util.py
@@ -186,6 +186,7 @@ def exception_handler(f):
                 if len(result) > 0:
                     if isinstance(result[0], Exception):
                         raise result[0]
+            return result
         except Exception as e:
             return _create_problem(e)
 

--- a/api/api/util.py
+++ b/api/api/util.py
@@ -169,15 +169,37 @@ def to_relative_path(full_path):
 
 
 def _create_problem(exc):
+    """
+    Builds an HTTP response to show a WazuhException information
+    :param exc: WazuhException to be rendered
+    :return: HTTP response to be return by an API controller
+    """
+    if isinstance(exc, WazuhException):
+        ext = remove_nones_to_dict({'remediation': exc.remediation,
+                                    'code': exc.code,
+                                    'dapi_errors': exc.dapi_errors
+                                    })
+    else:
+        ext = None
     if isinstance(exc, (WazuhInternalError, WazuhException)):
-        return problem(500, 'Wazuh Internal Error', exc.message, ext={'remediation': exc.remediation})
+        return problem(500,
+                       'Wazuh Internal Error',
+                       exc.message,
+                       ext=ext)
     elif isinstance(exc, WazuhError):
-        return problem(400, 'Wazuh Error', exc.message, ext={'remediation': exc.remediation})
+        return problem(400,
+                       'Wazuh Error',
+                       exc.message,
+                       ext=ext)
     raise exc
 
 
 def exception_handler(f):
+    """
+    Enables a controller to handle a WazuhException return by a framework function
 
+    Intended to be used as a decorator
+    """
     @wraps(f)
     def handle_exception(*args, **kwargs):
         try:

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -51,6 +51,8 @@ def main(cors, port, host, ssl_context, main_logger):
 # Main
 #
 if __name__ == '__main__':
+    my_wazuh = Wazuh(get_init=True)
+
     parser = argparse.ArgumentParser()
     ####################################################################################################################
     parser.add_argument('-f', help="Run in foreground", action='store_true', dest='foreground')
@@ -59,8 +61,6 @@ if __name__ == '__main__':
     parser.add_argument('-c', help="Configuration file to use", type=str, metavar='config', dest='config_file',
                         default=common.ossec_conf)
     args = parser.parse_args()
-
-    my_wazuh = Wazuh(get_init=True)
 
     configuration = configuration.read_config()
     if args.test_config:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -912,7 +912,6 @@ class Agent:
 
         if restart_all:
             oq = OssecQueue(common.ARQUEUE)
-            raise WazuhInternalError(1000, extra_message="Fake error")
             ret_msg = oq.send_msg_to_agent(OssecQueue.RESTART_AGENTS)
             oq.close()
             return ret_msg

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -5,10 +5,11 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import operator
+from wazuh.results import WazuhResult
 from wazuh.utils import cut_array, sort_array, search_array, chmod_r, chown_r, WazuhVersion, plain_dict_to_nested_dict, \
                         get_fields_to_nest, get_hash, WazuhDBQuery, WazuhDBQueryDistinct, WazuhDBQueryGroupBy, mkdir_with_mode, \
                         md5
-from wazuh.exception import WazuhException
+from wazuh.exception import WazuhException, WazuhInternalError
 from wazuh.ossec_queue import OssecQueue
 from wazuh.ossec_socket import OssecSocket, OssecSocketJSON
 from wazuh.database import Connection
@@ -898,7 +899,6 @@ class Agent:
                                               default_sort_field='os_platform', query=q, min_select_fields=set())
         return db_query.run()
 
-
     @staticmethod
     def restart_agents(agent_id=None, restart_all=False):
         """
@@ -912,6 +912,7 @@ class Agent:
 
         if restart_all:
             oq = OssecQueue(common.ARQUEUE)
+            raise WazuhInternalError(1000, extra_message="Fake error")
             ret_msg = oq.send_msg_to_agent(OssecQueue.RESTART_AGENTS)
             oq.close()
             return ret_msg
@@ -938,14 +939,20 @@ class Agent:
             else:
                 message = 'Some agents were not restarted'
 
-            final_dict = {}
             if failed_ids:
-                final_dict = {'msg': message, 'affected_agents': affected_agents, 'failed_ids': failed_ids}
+                final_dict = {'message': message,
+                              'data': {'affected_agents': affected_agents,
+                                       'failed_ids': failed_ids}
+                              }
             else:
-                final_dict = {'msg': message, 'affected_agents': affected_agents}
+                final_dict = {'message': message,
+                              'data': {'affected_agents': affected_agents}
+                              }
 
-            return final_dict
+            result = WazuhResult(final_dict, str_priority=['Some agents were not restarted',
+                                                           'All selected agents were restarted'])
 
+            return result
 
     @staticmethod
     def get_agent_by_name(agent_name, select=None):

--- a/framework/wazuh/cluster/control.py
+++ b/framework/wazuh/cluster/control.py
@@ -2,7 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 from wazuh.cluster import local_client
-from wazuh import common, exception
+from wazuh import common
 from wazuh.agent import Agent
 from wazuh.cluster.dapi.dapi import WazuhJSONEncoder
 import json

--- a/framework/wazuh/cluster/control.py
+++ b/framework/wazuh/cluster/control.py
@@ -4,7 +4,7 @@
 from wazuh.cluster import local_client
 from wazuh import common, exception
 from wazuh.agent import Agent
-from wazuh.cluster.dapi.dapi import CallableEncoder
+from wazuh.cluster.dapi.dapi import WazuhJSONEncoder
 import json
 
 
@@ -51,7 +51,7 @@ async def get_agents(filter_node=None, filter_status=None):
                   }
 
     result = json.loads(await local_client.execute(command=b'dapi',
-                                                   data=json.dumps(input_json, cls=CallableEncoder).encode(),
+                                                   data=json.dumps(input_json, cls=WazuhJSONEncoder).encode(),
                                                    wait_for_complete=False))
     if result['error'] > 0:
         raise Exception(result['message'])

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -209,7 +209,7 @@ class DistributedAPI:
                                                   wait_for_complete=self.wait_for_complete),
                           object_hook=as_wazuh_object)
 
-    async def forward_request(self) -> str:
+    async def forward_request(self) -> [wresults.WazuhResult, exception.WazuhException]:
         """
         Forwards a request to the node who has all available information to answer it. This function is called when a
         distributed_master function is used. Only the master node calls this function. An API request will only be

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -59,6 +59,8 @@ class DistributedAPI:
 
         :return: Dictionary with API response
         """
+        import pydevd_pycharm
+        pydevd_pycharm.settrace('172.17.0.1', port=12345, stdoutToServer=True, stderrToServer=True)
         try:
             is_dapi_enabled = self.cluster_items['distributed_api']['enabled']
             is_cluster_disabled = self.node == local_client and cluster.check_cluster_status()
@@ -108,7 +110,7 @@ class DistributedAPI:
             if self.debug:
                 raise
             self.logger.error(f'Unhandled exception: {str(e)}', exc_info=True)
-            return exception.WazuhInternalError(extra_message=str(e))
+            return exception.WazuhInternalError(1000, extra_message=str(e))
 
     async def execute_local_request(self) -> Dict:
         """

--- a/framework/wazuh/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/cluster/dapi/tests/test_dapi.py
@@ -1,76 +1,48 @@
 import json
+import pytest
 
 from wazuh import Wazuh
 from wazuh.agent import Agent
+from wazuh.exception import WazuhError, WazuhInternalError
 from wazuh.manager import status
+from wazuh.results import WazuhResult, WazuhQueryResult
 from wazuh.cluster.dapi.dapi import WazuhJSONEncoder, as_wazuh_object
 
-obj_to_encode_1 = {'foo': 'bar',
-                   'foo2': 3,
-                   'mycallable': Wazuh(ossec_path='/var/ossec').get_ossec_init
-                   }
+objects_to_encode = [
+    {'foo': 'bar',
+     'foo2': 3,
+     'mycallable': Wazuh(ossec_path='/var/ossec').get_ossec_init},
+    {'foo': 'bar',
+     'foo2': 3,
+     'mycallable': Agent.get_agents_summary},
+    {'foo': 'bar',
+     'foo2': 3,
+     'mycallable': status},
+    {'foo': 'bar',
+     'foo2': 3,
+     'exception': WazuhError(1500,
+                             extra_message="test message",
+                             extra_remediation="test remediation")},
+    {'foo': 'bar',
+     'foo2': 3,
+     'exception': WazuhInternalError(1000,
+                                     extra_message="test message",
+                                     extra_remediation="test remediation")},
+    {'foo': 'bar',
+     'foo2': 3,
+     'result': WazuhResult({'field1': 'value1', 'field2': 3}, str_priority=['KO', 'OK'])},
+    {'foo': 'bar',
+     'foo2': 3,
+     'result': WazuhQueryResult({'field1': 'value1', 'field2': 3}, str_priority=['KO', 'OK'])}
+]
 
-obj_to_encode_2 = {'foo': 'bar',
-                   'foo2': 3,
-                   'mycallable': Agent.get_agents_summary
-                   }
 
-obj_to_encode_3 = {'foo': 'bar',
-                   'foo2': 3,
-                   'mycallable': status
-                   }
-
-
-def test_encoder_decoder():
+@pytest.mark.parametrize('obj', objects_to_encode)
+def test_encoder_decoder(obj):
 
     # Encoding first object
-    encoded = json.dumps(obj_to_encode_1, cls=WazuhJSONEncoder)
-    encoded_dict = json.loads(encoded)
-    assert(isinstance(encoded_dict, dict))
-    assert('mycallable' in encoded_dict)
-    mycallable_dict = encoded_dict['mycallable']
-    assert('__callable__' in mycallable_dict)
-    callable = mycallable_dict['__callable__']
-    assert('__wazuh__' in callable)
-    assert ('__name__' in callable)
-    assert ('__qualname__' in callable)
-    assert ('__module__' in callable)
+    encoded = json.dumps(obj, cls=WazuhJSONEncoder)
 
     # Decoding first object
-    obj_1_again = json.loads(encoded, object_hook=as_wazuh_object)
-    assert(obj_1_again == obj_to_encode_1)
-
-    # Encoding second object
-    encoded = json.dumps(obj_to_encode_2, cls=WazuhJSONEncoder)
-    encoded_dict = json.loads(encoded)
-    assert (isinstance(encoded_dict, dict))
-    assert ('mycallable' in encoded_dict)
-    mycallable_dict = encoded_dict['mycallable']
-    assert ('__callable__' in mycallable_dict)
-    callable = mycallable_dict['__callable__']
-    assert ('__name__' in callable)
-    assert ('__qualname__' in callable)
-    assert ('__module__' in callable)
-
-    # Decoding second object
-    obj_2_again = json.loads(encoded, object_hook=as_wazuh_object)
-    assert(obj_2_again == obj_to_encode_2)
-
-    # Encoding third object
-    encoded = json.dumps(obj_to_encode_3, cls=WazuhJSONEncoder)
-    encoded_dict = json.loads(encoded)
-    assert (isinstance(encoded_dict, dict))
-    assert ('mycallable' in encoded_dict)
-    mycallable_dict = encoded_dict['mycallable']
-    assert ('__callable__' in mycallable_dict)
-    callable = mycallable_dict['__callable__']
-    assert ('__name__' in callable)
-    assert ('__qualname__' in callable)
-    assert ('__module__' in callable)
-
-    # Decoding third object
-    obj_3_again = json.loads(encoded, object_hook=as_wazuh_object)
-    assert(obj_3_again == obj_to_encode_3)
-
-
-
+    obj_again = json.loads(encoded, object_hook=as_wazuh_object)
+    assert(obj_again == obj)

--- a/framework/wazuh/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/cluster/dapi/tests/test_dapi.py
@@ -3,7 +3,7 @@ import json
 from wazuh import Wazuh
 from wazuh.agent import Agent
 from wazuh.manager import status
-from wazuh.cluster.dapi.dapi import CallableEncoder, as_callable
+from wazuh.cluster.dapi.dapi import WazuhJSONEncoder, as_wazuh_object
 
 obj_to_encode_1 = {'foo': 'bar',
                    'foo2': 3,
@@ -24,7 +24,7 @@ obj_to_encode_3 = {'foo': 'bar',
 def test_encoder_decoder():
 
     # Encoding first object
-    encoded = json.dumps(obj_to_encode_1, cls=CallableEncoder)
+    encoded = json.dumps(obj_to_encode_1, cls=WazuhJSONEncoder)
     encoded_dict = json.loads(encoded)
     assert(isinstance(encoded_dict, dict))
     assert('mycallable' in encoded_dict)
@@ -37,11 +37,11 @@ def test_encoder_decoder():
     assert ('__module__' in callable)
 
     # Decoding first object
-    obj_1_again = json.loads(encoded, object_hook=as_callable)
+    obj_1_again = json.loads(encoded, object_hook=as_wazuh_object)
     assert(obj_1_again == obj_to_encode_1)
 
     # Encoding second object
-    encoded = json.dumps(obj_to_encode_2, cls=CallableEncoder)
+    encoded = json.dumps(obj_to_encode_2, cls=WazuhJSONEncoder)
     encoded_dict = json.loads(encoded)
     assert (isinstance(encoded_dict, dict))
     assert ('mycallable' in encoded_dict)
@@ -53,11 +53,11 @@ def test_encoder_decoder():
     assert ('__module__' in callable)
 
     # Decoding second object
-    obj_2_again = json.loads(encoded, object_hook=as_callable)
+    obj_2_again = json.loads(encoded, object_hook=as_wazuh_object)
     assert(obj_2_again == obj_to_encode_2)
 
     # Encoding third object
-    encoded = json.dumps(obj_to_encode_3, cls=CallableEncoder)
+    encoded = json.dumps(obj_to_encode_3, cls=WazuhJSONEncoder)
     encoded_dict = json.loads(encoded)
     assert (isinstance(encoded_dict, dict))
     assert ('mycallable' in encoded_dict)
@@ -69,7 +69,7 @@ def test_encoder_decoder():
     assert ('__module__' in callable)
 
     # Decoding third object
-    obj_3_again = json.loads(encoded, object_hook=as_callable)
+    obj_3_again = json.loads(encoded, object_hook=as_wazuh_object)
     assert(obj_3_again == obj_to_encode_3)
 
 

--- a/framework/wazuh/cluster/local_client.py
+++ b/framework/wazuh/cluster/local_client.py
@@ -114,7 +114,7 @@ class LocalClient(client.AbstractClientManager):
                     raise exception.WazuhException(3020)
             else:
                 request_result = result
-        return json.loads(request_result)
+        return request_result
 
 
 async def execute(command: bytes, data: bytes, wait_for_complete: bool) -> Dict:

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -195,7 +195,7 @@ class WazuhException(Exception):
         # > 9000: Authd
     }
 
-    def __init__(self, code, extra_message=None, extra_remediation=None, cmd_error=False):
+    def __init__(self, code, extra_message=None, extra_remediation=None, cmd_error=False, node_name=None):
         """
         Creates a Wazuh Exception.
 
@@ -207,6 +207,7 @@ class WazuhException(Exception):
         self._extra_message = extra_message
         self._extra_remediation = extra_remediation
         self._cmd_error = cmd_error
+        self._node_name = node_name
 
         error_details = self.ERRORS[self._code]
         if isinstance(error_details, dict):
@@ -233,6 +234,11 @@ class WazuhException(Exception):
     def __repr__(self):
         return repr(self.to_dict())
 
+    def __eq__(self, other):
+        if not isinstance(other, WazuhException):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
     def __or__(self, other):
         return self
 
@@ -241,7 +247,7 @@ class WazuhException(Exception):
                 'extra_message': self._extra_message,
                 'extra_remediation': self._extra_remediation,
                 'cmd_error': self._cmd_error,
-                'exception_type': self.__class__
+                'node_name': self._node_name
                 }
 
     @property
@@ -252,11 +258,13 @@ class WazuhException(Exception):
     def remediation(self):
         return self._remediation
 
-    @staticmethod
-    def from_dict(dct):
-        local_dct = deepcopy(dct)
-        exception_type = local_dct.pop('exception_type')
-        return globals()[exception_type](**local_dct)
+    @property
+    def node_name(self):
+        return self._node_name
+
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(**dct)
 
 
 class WazuhInternalError(WazuhException):

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -1,8 +1,9 @@
-
-
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+
+from copy import deepcopy
 
 
 class WazuhException(Exception):
@@ -177,7 +178,10 @@ class WazuhException(Exception):
         3010: 'Received the status/group of an unexisting agent',
         3011: 'Agent info file received in a worker node',
         3012: 'Cluster is not running',
-        3013: 'Cluster is disabled',
+        3013: {'message': 'Cluster is disabled in `WAZUH_HOME/etc/ossec.conf`',
+               'remediation': 'Please, visit [official documentation](https://documentation.wazuh.com/current/user-manual/manager/wazuh-cluster.html)'
+                              ' to get more information about how to configure a cluster'
+               },
         3015: 'Cannot access directory',
         3016: 'Received an error response',
         3017: 'The agent is not reporting to any manager',
@@ -191,7 +195,7 @@ class WazuhException(Exception):
         # > 9000: Authd
     }
 
-    def __init__(self, code, extra_message=None, cmd_error=False):
+    def __init__(self, code, extra_message=None, extra_remediation=None, cmd_error=False):
         """
         Creates a Wazuh Exception.
 
@@ -199,20 +203,73 @@ class WazuhException(Exception):
         :param extra_message: Adds an extra message to the error description.
         :param cmd_error: If it is a custom error code (i.e. ossec commands), the error description will be the message.
         """
-        self.code = code
+        self._code = code
+        self._extra_message = extra_message
+        self._extra_remediation = extra_remediation
+        self._cmd_error = cmd_error
+
+        error_details = self.ERRORS[self._code]
+        if isinstance(error_details, dict):
+            code_message, code_remediation = error_details.get('message', ''), error_details.get('remediation', None)
+        else:
+            code_message, code_remediation = error_details, None
+
         if not cmd_error:
             if extra_message:
                 if isinstance(extra_message, dict):
-                    self.message = self.ERRORS[code].format(**extra_message)
+                    self._message = code_message.format(**extra_message)
                 else:
-                    self.message = "{0}: {1}".format(self.ERRORS[code], extra_message)
+                    self._message = "{0}: {1}".format(code_message, extra_message)
             else:
-                self.message = self.ERRORS[code]
+                self._message = code_message
         else:
-            self.message = extra_message
+            self._message = extra_message
+
+        self._remediation = code_remediation if extra_remediation is None else f"{code_remediation}. {extra_remediation}"
 
     def __str__(self):
-        return "Error {0} - {1}".format(self.code, self.message)
+        return "Error {0} - {1}".format(self._code, self._message)
+
+    def __repr__(self):
+        return repr(self.to_dict())
+
+    def __or__(self, other):
+        return self
 
     def to_dict(self):
-        return {'error': self.code, 'message': self.message}
+        return {'code': self._code,
+                'extra_message': self._extra_message,
+                'extra_remediation': self._extra_remediation,
+                'cmd_error': self._cmd_error,
+                'exception_type': self.__class__
+                }
+
+    @property
+    def message(self):
+        return self._message
+
+    @property
+    def remediation(self):
+        return self._remediation
+
+    @staticmethod
+    def from_dict(dct):
+        local_dct = deepcopy(dct)
+        exception_type = local_dct.pop('exception_type')
+        return globals()[exception_type](**local_dct)
+
+
+class WazuhInternalError(WazuhException):
+    """
+    This type of exception is raised when an unexpected error in framework code occurs,
+    which means an internal error could not be handled
+    """
+    pass
+
+
+class WazuhError(WazuhException):
+    """
+    This type of exception is raised as a controlled response to a bad request from user
+    that cannot be performed properly
+    """
+    pass

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -237,12 +237,11 @@ def upload_xml(xml_file, path):
             # beauty xml file
             xml = parseString('<root>' + xml_file + '</root>')
             # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
-            indent = '  '
-            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent=indent).split('\n')[2:-2])) + '\n'
+            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent='  ').split('\n')[2:-2])) + '\n'
             # revert xml.dom replacings
             # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
             pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
-                .replace("&gt;", ">").replace('&apos', "'").replace(fr"^{indent}", "")
+                .replace("&gt;", ">").replace('&apos', "'")
             tmp_file.write(pretty_xml)
         chmod(tmp_file_path, 0o640)
     except IOError:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -237,11 +237,12 @@ def upload_xml(xml_file, path):
             # beauty xml file
             xml = parseString('<root>' + xml_file + '</root>')
             # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
-            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent='  ').split('\n')[2:-2])) + '\n'
+            indent = '  '
+            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent=indent).split('\n')[2:-2])) + '\n'
             # revert xml.dom replacings
             # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
             pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
-                .replace("&gt;", ">").replace('&apos', "'")
+                .replace("&gt;", ">").replace('&apos', "'").replace(fr"^{indent}", "")
             tmp_file.write(pretty_xml)
         chmod(tmp_file_path, 0o640)
     except IOError:

--- a/framework/wazuh/results.py
+++ b/framework/wazuh/results.py
@@ -11,13 +11,30 @@ from wazuh.exception import WazuhException, WazuhInternalError
 
 
 class WazuhResult(dict):
+    """
+    Models a result returned by any framework function. This should be the class of object that every
+    framework function returns.
+    """
 
     def __init__(self, dct, str_priority=None):
+        """
+        Initializes an instance
+
+        :param dct: map to take key-values from
+        :param str_priority: list of strings. If not None, conflicts when merging str values in the result
+         are solved taking the first value found in str_priority. I.e.: {'foo': 'KO'} and {'foo': 'OK'} results in
+         {'foo': 'KO'} if str_priority is set to ['KO', 'OK'] because 'KO' takes a higher priority level than 'OK'
+        """
         super().__init__(dct)
         self._str_priority = str_priority
 
     def __or__(self, other):
-        
+        """
+        | operator used to merge two WazuhResult objects. When merged with a WazuhException, the result is always a
+        WazuhException
+        :param other: WazuhResult or WazuhException
+        :return: a new WazuhResult or WazuhException
+        """
         if isinstance(other, WazuhException):
             return other
         elif not isinstance(other, dict):
@@ -45,25 +62,57 @@ class WazuhResult(dict):
         return result
 
     def to_dict(self):
+        """
+        Translates the result into a dict
+        :return: dict
+        """
         return {
             'str_priority': self._str_priority,
             'result': deepcopy(self)
         }
 
     def limit(self, limit=database_limit, offset=0):
+        """
+        Should take the first `limit` results starting from `offset`
+
+        To be redefined in WazuhResult subclasses.
+
+        :param limit: integer. Default the value specified in wazuh.common.database_limit
+        :param offset: integer. Default 0.
+        :return: filtered WazuhResult
+        """
         return deepcopy(self)
 
-    def sort(self, fields=[], order='asc'):
+    def sort(self, fields=None, order='asc'):
+        """
+        Sorts according to `fields` in order `order`
+
+        To be redefined in WazuhResult subclasses.
+
+        :param fields: criteria for sorting the results
+        :param order: string. Must be 'asc' or 'desc'
+        :return: sorted WazuhResult
+        """
         return deepcopy(self)
 
     @classmethod
     def from_dict(cls, dct):
+        """
+        Builds an instance from a dict
+        :param dct: dict
+        :return: instance of cls
+        """
         result = cls(dct['result'], str_priority=dct['str_priority'])
         result.update(dct['result'])
         return result
 
 
 class WazuhQueryResult(WazuhResult):
+    """
+    Result that implements limit and sort methods.
+
+    Should be used for results with a data.items structure
+    """
 
     def limit(self, limit=database_limit, offset=0):
         result = deepcopy(self)
@@ -71,7 +120,8 @@ class WazuhQueryResult(WazuhResult):
             result['data']['items'] = result['data']['items'][offset:offset+limit]
         return result
 
-    def sort(self, fields=[], order='asc'):
+    def sort(self, fields=None, order='asc'):
+        fields = [] if fields is None else fields
         result = deepcopy(self)
         if 'data' in result and 'items' in result['data'] and isinstance(result['data']['items'], list):
             result['data']['items'] = utils.sort_array(result['data']['items'], fields, order)

--- a/framework/wazuh/results.py
+++ b/framework/wazuh/results.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from copy import deepcopy
+from numbers import Number
+
+from wazuh import utils
+from wazuh.common import database_limit
+from wazuh.exception import WazuhException, WazuhInternalError
+
+
+class WazuhResult(dict):
+
+    def __or__(self, other):
+        
+        if isinstance(other, WazuhException):
+            return other
+        elif not isinstance(dict):
+            raise WazuhInternalError(1000, extra_message=f"WazuhResult cannot be merged with {type(other)} object")
+
+        result = deepcopy(self)
+
+        for key, field in other.items():
+            if key not in result:
+                result[key] = field
+            elif isinstance(field, dict):
+                result[key] = WazuhResult(result[key]) | WazuhResult(field)
+            elif isinstance(field, list):
+                self_field = result[key]
+                result[key] = [*self_field, *[elem for elem in field if elem not in self_field]]
+            elif isinstance(field, Number):
+                result[key] = result[key] + field
+            elif isinstance(field, str):  # str
+                result[key] = "|".join([result[key], field])
+
+        return result
+
+    def limit(self, limit=database_limit, offset=0):
+        return deepcopy(self)
+
+    def sort(self, fields=[], order='asc'):
+        return deepcopy(self)
+
+
+class WazuhQueryResult(WazuhResult):
+
+    def limit(self, limit=database_limit, offset=0):
+        result = deepcopy(self)
+        if 'data' in result and 'items' in result['data'] and isinstance(result['data']['items'], list):
+            result['data']['items'] = result['data']['items'][offset:offset+limit]
+        return result
+
+    def sort(self, fields=[], order='asc'):
+        result = deepcopy(self)
+        if 'data' in result and 'items' in result['data'] and isinstance(result['data']['items'], list):
+            result['data']['items'] = utils.sort_array(result['data']['items'], fields, order)
+        return result

--- a/framework/wazuh/results.py
+++ b/framework/wazuh/results.py
@@ -16,7 +16,7 @@ class WazuhResult(dict):
         
         if isinstance(other, WazuhException):
             return other
-        elif not isinstance(dict):
+        elif not isinstance(other, dict):
             raise WazuhInternalError(1000, extra_message=f"WazuhResult cannot be merged with {type(other)} object")
 
         result = deepcopy(self)

--- a/framework/wazuh/wlogging.py
+++ b/framework/wazuh/wlogging.py
@@ -104,7 +104,8 @@ class WazuhLogger:
 
         def error(self, msg, *args, **kws):
             if self.isEnabledFor(logging.ERROR):
-                kws['exc_info'] = self.isEnabledFor(logging.DEBUG2)
+                if 'exc_info' not in kws:
+                    kws['exc_info'] = self.isEnabledFor(logging.DEBUG2)
                 self._log(logging.ERROR, msg, args, **kws)
 
         logging.addLevelName(logging.DEBUG2, "DEBUG2")


### PR DESCRIPTION
This PR closes #2843. It will add the following features:
* Changes HTTP status codes to differentiate success responses (200), client errors (400) and internal server errors (500)
* Unifies response error formats
* Enables logging for internal server errors (500). Now the traceback will be shown in /var/ossec/logs/api.log or /var/ossec/logs/cluster.log depending on the node where the exception were raised
* Adds more fields to better understand errors:
   * `remediation`: message to help users to fix their problem
   * `dapi_errors`: summary of nodes in error and the path to log file
* Refactor distributed api code and removed some dangerous hardcodes
* Create a new WazuhResult class which will be in charge of encapsulating any result from framework package
* Improve WazuhException class

A minimal example of error response:
```
root@e9f9af01b337:/# curl -XPUT "http://localhost:55000/agents/restart"
{
  "code": 1000,
  "dapi_errors": {
    "master-node": {
      "error": "Wazuh Internal Error: Fake error",
      "logfile": "WAZUH_HOME/logs/api.log"
    },
    "worker1": {
      "error": "Wazuh Internal Error: Fake error",
      "logfile": "WAZUH_HOME/logs/cluster.log"
    }
  },
  "detail": "Wazuh Internal Error: Fake error",
  "status": 500,
  "title": "Wazuh Internal Error",
  "type": "about:blank"
}
```
Now the error can be diagnosed in the log:
```
2019/04/09 14:41:06 INFO:  127.0.0.1 - -  "PUT /agents/restart HTTP/1.1" 500 -
2019/04/09 14:52:52 INFO: Running on http://0.0.0.0:55000/ (Press CTRL+C to quit)
2019/04/09 14:53:02 INFO:  127.0.0.1 - -  "PUT /agents/restart HTTP/1.1" 200 -
2019/04/09 14:53:21 INFO: Running on http://0.0.0.0:55000/ (Press CTRL+C to quit)
2019/04/09 14:53:39 ERROR:  Wazuh Internal Error: Fake error
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh/cluster/dapi/dapi.py", line 147, in execute_local_request
    data = await asyncio.wait_for(task, timeout=timeout)
  File "/var/ossec/framework/python/lib/python3.7/asyncio/tasks.py", line 416, in wait_for
    return fut.result()
  File "/var/ossec/framework/python/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh/cluster/dapi/dapi.py", line 131, in run_local
    data = self.f(**self.f_kwargs)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh/agent.py", line 917, in restart_agents
    raise WazuhInternalError(1000, extra_message="Fake error")
wazuh.exception.WazuhInternalError: Error 1000 - Wazuh Internal Error: Fake error
2019/04/09 14:53:39 INFO:  127.0.0.1 - -  "PUT /agents/restart HTTP/1.1" 500 -
```

Unit tests:
```
root@e9f9af01b337:/# /var/ossec/framework/python/bin/pytest /var/ossec/framework/python/lib/python3.7/site-packages/wazuh/cluster/dapi/tests/test_dapi.py 
================================================ test session starts =================================================
platform linux -- Python 3.7.2, pytest-4.4.0, py-1.8.0, pluggy-0.9.0
rootdir: /var/ossec/framework/python/lib/python3.7/site-packages/wazuh/cluster/dapi/tests
collected 7 items                                                                                                    

var/ossec/framework/python/lib/python3.7/site-packages/wazuh/cluster/dapi/tests/test_dapi.py .......           [100%]

============================================== 7 passed in 0.11 seconds ==============================================
```