### PR TITLE
Fixed the reading and usage of "attempts" setting

### DIFF
--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -103,11 +103,7 @@ cJSON *wm_docker_dump(const wm_docker_t *docker_conf) {
     if (docker_conf->flags.enabled) cJSON_AddStringToObject(wm_docker,"disabled","no"); else cJSON_AddStringToObject(wm_docker,"disabled","yes");
     if (docker_conf->flags.run_on_start) cJSON_AddStringToObject(wm_docker,"run_on_start","yes"); else cJSON_AddStringToObject(wm_docker,"run_on_start","no");
     cJSON_AddNumberToObject(wm_docker,"interval",docker_conf->interval);
-    if (docker_conf->attempts) {
-        cJSON_AddNumberToObject(wm_docker, "attempts", docker_conf->attempts);
-    } else {
-        cJSON_AddNumberToObject(wm_docker, "attempts", 5);
-    }
+    cJSON_AddNumberToObject(wm_docker, "attempts", docker_conf->attempts);
     cJSON_AddItemToObject(root,"docker-listener",wm_docker);
 
     return root;

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -80,7 +80,7 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
         os_free(output);
 
-        if (attempts > docker_conf->attempts) {
+        if (attempts >= docker_conf->attempts) {
             mterror(WM_DOCKER_LOGTAG, "Maximum attempts reached to run the listener. Exiting...");
             pthread_exit(NULL);
         }
@@ -103,7 +103,11 @@ cJSON *wm_docker_dump(const wm_docker_t *docker_conf) {
     if (docker_conf->flags.enabled) cJSON_AddStringToObject(wm_docker,"disabled","no"); else cJSON_AddStringToObject(wm_docker,"disabled","yes");
     if (docker_conf->flags.run_on_start) cJSON_AddStringToObject(wm_docker,"run_on_start","yes"); else cJSON_AddStringToObject(wm_docker,"run_on_start","no");
     cJSON_AddNumberToObject(wm_docker,"interval",docker_conf->interval);
-
+    if (docker_conf->attempts) {
+        cJSON_AddNumberToObject(wm_docker, "attempts", docker_conf->attempts);
+    } else {
+        cJSON_AddNumberToObject(wm_docker, "attempts", 5);
+    }
     cJSON_AddItemToObject(root,"docker-listener",wm_docker);
 
     return root;


### PR DESCRIPTION
Hi team,

Playing around with the Docker _wodle_, I've noticed the Wazuh API is not giving us the `attempts` field from the _wodle_ configuration using `GET /agents/:agentid/config/wmodules/wmodules`. Looking at https://github.com/wazuh/wazuh/blob/3.9/src/wazuh_modules/wm_docker.c I've concluded it wasn't using `attempts` properly and its value wasn't being dumped.

This PR tries to solve this issue modifying the next two blocks:

Here `>` has been replaced with `>=`, so the otherwise you may fall into `1 > 1` that is false.
```c
if (attempts >= docker_conf->attempts) {
```

The second modification was load attempts value in `wm_docker_dump` function:

```c
cJSON_AddNumberToObject(wm_docker, "attempts", docker_conf->attempts);
```

Regards