### PR TITLE
Enable keepalive in TCP connections

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -212,6 +212,14 @@ remoted.receive_chunk=4096
 # 2. Full memory deallocation.
 remoted.buffer_relax=1
 
+# Keepalive options
+# Time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes
+remoted.tcp_keepidle=30
+# The time (in seconds) between individual keepalive probes
+remoted.tcp_keepintvl=10
+# Maximum number of keepalive probes TCP should send before dropping the connection
+remoted.tcp_keepcnt=3
+
 # Timeout to execute remote requests [1..3600]
 execd.request_timeout=60
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -213,11 +213,11 @@ remoted.receive_chunk=4096
 remoted.buffer_relax=1
 
 # Keepalive options
-# Time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes
+# Time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes [1..7200]
 remoted.tcp_keepidle=30
-# The time (in seconds) between individual keepalive probes
+# The time (in seconds) between individual keepalive probes [1..100]
 remoted.tcp_keepintvl=10
-# Maximum number of keepalive probes TCP should send before dropping the connection
+# Maximum number of keepalive probes TCP should send before dropping the connection [1..50]
 remoted.tcp_keepcnt=3
 
 # Timeout to execute remote requests [1..3600]

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -80,6 +80,7 @@
 #ifndef WIN32
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -57,7 +57,7 @@ static int OS_Bindport(u_int16_t _port, unsigned int _proto, const char *_ip, in
     if (_proto == IPPROTO_UDP) {
 #ifndef WIN32
         if ((ossock = socket(ipv6 == 1 ? PF_INET6 : PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
-#else 
+#else
         if ((ossock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
 #endif
             return OS_SOCKTERR;
@@ -258,7 +258,7 @@ static int OS_Connect(u_int16_t _port, unsigned int protocol, const char *_ip, i
     } else if (protocol == IPPROTO_UDP) {
 #ifndef WIN32
         if ((ossock = socket(ipv6 == 1 ? PF_INET6 : PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
-#else 
+#else
         if ((ossock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
 #endif
             return (OS_SOCKTERR);
@@ -542,7 +542,20 @@ int OS_CloseSocket(int socket)
 int OS_SetKeepalive(int socket)
 {
     int keepalive = 1;
-    return setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
+    return setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, (void *)&keepalive, sizeof(keepalive));
+}
+
+void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
+{
+    if (setsockopt(socket, SOL_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {
+        merror("OS_SetKeepalive_Options(TCP_KEEPCNT) failed with error '%s'", strerror(errno));
+    }
+    if (setsockopt(socket, SOL_TCP, TCP_KEEPIDLE, (void *)&idle, sizeof(idle)) < 0) {
+        merror("OS_SetKeepalive_Options(SO_KEEPIDLE) failed with error '%s'", strerror(errno));
+    }
+    if (setsockopt(socket, SOL_TCP, TCP_KEEPINTVL, (void *)&intvl, sizeof(intvl)) < 0) {
+        merror("OS_SetKeepalive_Options(TCP_KEEPINTVL) failed with error '%s'", strerror(errno));
+    }
 }
 
 int OS_SetRecvTimeout(int socket, long seconds, long useconds)

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -539,6 +539,12 @@ int OS_CloseSocket(int socket)
 #endif /* WIN32 */
 }
 
+int OS_SetKeepalive(int socket)
+{
+    int keepalive = 1;
+    return setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
+}
+
 int OS_SetRecvTimeout(int socket, long seconds, long useconds)
 {
 #ifdef WIN32

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -81,6 +81,11 @@ int OS_CloseSocket(int socket);
  */
 int OS_SetRecvTimeout(int socket, long seconds, long useconds);
 
+/*
+ * Enable SO_KEEPALIVE for TCP
+ */
+int OS_SetKeepalive(int socket);
+
 /* Set the delivery timeout for a socket
  * Returns 0 on success, else -1
  */

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -86,6 +86,11 @@ int OS_SetRecvTimeout(int socket, long seconds, long useconds);
  */
 int OS_SetKeepalive(int socket);
 
+/*
+ * Enable SO_KEEPALIVE options for TCP
+ */
+void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt);
+
 /* Set the delivery timeout for a socket
  * Returns 0 on success, else -1
  */

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -31,6 +31,9 @@ int guess_agent_group;
 int group_data_flush;
 unsigned receive_chunk;
 int buffer_relax;
+int tcp_keepidle;
+int tcp_keepintvl;
+int tcp_keepcnt;
 
 /* Read the config file (the remote access) */
 int RemotedConfig(const char *cfgfile, remoted *cfg)
@@ -151,6 +154,9 @@ cJSON *getRemoteInternalConfig(void) {
     cJSON_AddNumberToObject(remoted,"group_data_flush",group_data_flush);
     cJSON_AddNumberToObject(remoted,"receive_chunk",receive_chunk);
     cJSON_AddNumberToObject(remoted,"buffer_relax",buffer_relax);
+    cJSON_AddNumberToObject(remoted,"tcp_keepidle",tcp_keepidle);
+    cJSON_AddNumberToObject(remoted,"tcp_keepintvl",tcp_keepintvl);
+    cJSON_AddNumberToObject(remoted,"tcp_keepcnt",tcp_keepcnt);
 
     cJSON_AddItemToObject(internals,"remoted",remoted);
     cJSON_AddItemToObject(root,"internal",internals);

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -21,6 +21,9 @@ keystore keys;
 remoted logr;
 char* node_name;
 rlim_t nofile;
+int tcp_keepidle;
+int tcp_keepintvl;
+int tcp_keepcnt;
 
 /* Handle remote connections */
 void HandleRemote(int uid)
@@ -31,6 +34,10 @@ void HandleRemote(int uid)
 
     recv_timeout = getDefine_Int("remoted", "recv_timeout", 1, 60);
     send_timeout = getDefine_Int("remoted", "send_timeout", 1, 60);
+
+    tcp_keepidle = getDefine_Int("remoted", "tcp_keepidle", 1, 7200);
+    tcp_keepintvl = getDefine_Int("remoted", "tcp_keepintvl", 1, 100);
+    tcp_keepcnt = getDefine_Int("remoted", "tcp_keepcnt", 1, 50);
 
     /* If syslog connection and allowips is not defined, exit */
     if (logr.conn[position] == SYSLOG_CONN) {
@@ -67,6 +74,8 @@ void HandleRemote(int uid)
 
             if (OS_SetKeepalive(logr.sock) < 0){
                 merror("OS_SetKeepalive failed with error '%s'", strerror(errno));
+            } else {
+                OS_SetKeepalive_Options(logr.sock, tcp_keepidle, tcp_keepintvl, tcp_keepcnt);
             }
             if (OS_SetRecvTimeout(logr.sock, recv_timeout, 0) < 0){
                 merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -64,6 +64,10 @@ void HandleRemote(int uid)
         if ((logr.sock = OS_Bindporttcp(logr.port[position], logr.lip[position], logr.ipv6[position])) < 0) {
             merror_exit(BIND_ERROR, logr.port[position], errno, strerror(errno));
         } else if (logr.conn[position] == SECURE_CONN) {
+
+            if (OS_SetKeepalive(logr.sock) < 0){
+                merror("OS_SetKeepalive failed with error '%s'", strerror(errno));
+            }
             if (OS_SetRecvTimeout(logr.sock, recv_timeout, 0) < 0){
                 merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
             }

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -179,5 +179,8 @@ extern int guess_agent_group;
 extern int group_data_flush;
 extern unsigned receive_chunk;
 extern int buffer_relax;
+extern int tcp_keepidle;
+extern int tcp_keepintvl;
+extern int tcp_keepcnt;
 
 #endif /* __LOGREMOTE_H */


### PR DESCRIPTION
| Related issue    | 
|-----|
|https://github.com/wazuh/wazuh/pull/3078 |

This PR enables the keepalive flag in the TCP socket. 
The keepalive options are also defined by default to decrease the number of broken connections in the manager side (ossec-remoted).
These new options can be modified in the `internal_options.conf` file.