### PR TITLE
Store the rules of SCA checks in the Wazuh database

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -679,37 +679,39 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
                     //Save rules
                     cJSON *rule;
                     cJSON_ArrayForEach(rule, rules){
+                        if(rule->valuestring){
+                            char flag = rule->valuestring[0];
+                            char *type = NULL;
+                            switch (flag) {
+                                case 'f':
+                                    os_calloc(5, sizeof(char), type);
+                                    strncpy(type, "file", 5);
+                                    break;
+                                case 'd':
+                                    os_calloc(10, sizeof(char), type);
+                                    strncpy(type, "directory", 10);
+                                    break;
+                                case 'r':
+                                    os_calloc(9, sizeof(char), type);
+                                    strncpy(type, "registry", 9);
+                                    break;
+                                case 'c':
+                                    os_calloc(8, sizeof(char), type);
+                                    strncpy(type, "command", 8);
+                                    break;
+                                case 'p':
+                                    os_calloc(8, sizeof(char), type);
+                                    strncpy(type, "process", 8);
+                                    break;
+                                default:
+                                    merror("Invalid type: %c", flag);
+                                    continue;
+                            }
 
-                        char flag = rule->valuestring[0];
-                        char *type = NULL;
-                        switch (flag) {
-                            case 'f':
-                                os_calloc(5, sizeof(char), type);
-                                strncpy(type, "file", 5);
-                                break;
-                            case 'd':
-                                os_calloc(10, sizeof(char), type);
-                                strncpy(type, "directory", 10);
-                                break;
-                            case 'r':
-                                os_calloc(9, sizeof(char), type);
-                                strncpy(type, "register", 9);
-                                break;
-                            case 'c':
-                                os_calloc(8, sizeof(char), type);
-                                strncpy(type, "command", 8);
-                                break;
-                            case 'p':
-                                os_calloc(8, sizeof(char), type);
-                                strncpy(type, "process", 8);
-                                break;
-                            default:
-                                merror("Invalid type: %c", flag);
-                                break;
+                            SaveRules(lf, socket, id->valueint, type, rule->valuestring);
+
+                            os_free(type);
                         }
-                        SaveRules(lf, socket, id->valueint, type, rule->valuestring);
-
-                        os_free(type);
                     }
                 }
                 break;

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -34,12 +34,13 @@ static int DeletePolicyCheckDistinct(Eventinfo *lf, char *policy_id,int scan_id,
 static int SaveEventcheck(Eventinfo *lf, int exists, int *socket, __attribute__((unused)) int id , __attribute__((unused)) int scan_id,__attribute__((unused)) char * title,__attribute__((unused)) char *description, __attribute__((unused)) char *rationale, __attribute__((unused)) char *remediation,__attribute__((unused)) char * file, __attribute__((unused))char * directory,__attribute__((unused)) char * process, __attribute__((unused)) char * registry,__attribute__((unused)) char * reference,__attribute__((unused))char * result,__attribute__((unused))char * policy_id,cJSON *event);
 static int SaveScanInfo(Eventinfo *lf,int *socket, char * policy_id,int scan_id, int pm_start_scan, int pm_end_scan, int pass,int failed, int score,char * hash,int update);
 static int SaveCompliance(Eventinfo *lf,int *socket, int id_check, char *key, char *value);
+static int SaveRules(Eventinfo *lf,int *socket, int id_check, char *type, char *rule);
 static int SavePolicyInfo(Eventinfo *lf,int *socket, char *name,char *file, char * id,char *description,char * references);
 static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event);
 static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event);
 static void HandlePoliciesInfo(Eventinfo *lf,int *socket,cJSON *event);
 static void HandleDumpEvent(Eventinfo *lf,int *socket,cJSON *event);
-static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,cJSON **title,cJSON **description,cJSON **rationale,cJSON **remediation,cJSON **compliance,cJSON **check,cJSON **reference,cJSON **file,cJSON **directory,cJSON **process,cJSON **registry,cJSON **result,cJSON **policy_id,cJSON **command);
+static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,cJSON **title,cJSON **description,cJSON **rationale,cJSON **remediation,cJSON **compliance,cJSON **check,cJSON **reference,cJSON **file,cJSON **directory,cJSON **process,cJSON **registry,cJSON **result,cJSON **policy_id,cJSON **command, cJSON **rules);
 static int CheckPoliciesJSON(cJSON *event,cJSON **policies);
 static int CheckDumpJSON(cJSON *event,cJSON **elements_sent,cJSON **policy_id,cJSON **scan_id);
 static void FillCheckEventInfo(Eventinfo *lf,cJSON *scan_id,cJSON *id,cJSON *name,cJSON *title,cJSON *description,cJSON *rationale,cJSON *remediation,cJSON *compliance,cJSON *reference,cJSON *file,cJSON *directory,cJSON *process,cJSON *registry,cJSON *result,char *old_result,cJSON *command);
@@ -569,6 +570,27 @@ static int SaveCompliance(Eventinfo *lf,int *socket, int id_check, char *key, ch
     }
 }
 
+static int SaveRules(Eventinfo *lf,int *socket, int id_check, char *type, char *rule) {
+    char *msg = NULL;
+    char *response = NULL;
+
+    os_calloc(OS_MAXSTR, sizeof(char), msg);
+    os_calloc(OS_MAXSTR, sizeof(char), response);
+
+    snprintf(msg, OS_MAXSTR - 1, "agent %s sca insert_rules %d|%s|%s",lf->agent_id, id_check, type, rule);
+   
+    if (pm_send_db(msg, response, socket) == 0)
+    {
+        os_free(response);
+        return 0;
+    }
+    else
+    {
+        os_free(response);
+        return -1;
+    }
+}
+
 static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
 
     cJSON *scan_id = NULL;
@@ -588,8 +610,9 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
     cJSON *command = NULL;
     cJSON *result = NULL;
     cJSON *policy_id = NULL;
+    cJSON *rules = NULL;
 
-    if(!CheckEventJSON(event,&scan_id,&id,&name,&title,&description,&rationale,&remediation,&compliance,&check,&reference,&file,&directory,&process,&registry,&result,&policy_id,&command)) {
+    if(!CheckEventJSON(event,&scan_id,&id,&name,&title,&description,&rationale,&remediation,&compliance,&check,&reference,&file,&directory,&process,&registry,&result,&policy_id,&command,&rules)) {
        
         int result_event = 0;
         char *wdb_response = NULL;
@@ -651,6 +674,42 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
                         if(free_value) {
                             os_free(value);
                         }
+                    }
+
+                    //Save rules
+                    cJSON *rule;
+                    cJSON_ArrayForEach(rule, rules){
+
+                        char flag = rule->valuestring[0];
+                        char *type = NULL;
+                        switch (flag) {
+                            case 'f':
+                                os_calloc(5, sizeof(char), type);
+                                strncpy(type, "file", 5);
+                                break;
+                            case 'd':
+                                os_calloc(10, sizeof(char), type);
+                                strncpy(type, "directory", 10);
+                                break;
+                            case 'r':
+                                os_calloc(9, sizeof(char), type);
+                                strncpy(type, "register", 9);
+                                break;
+                            case 'c':
+                                os_calloc(8, sizeof(char), type);
+                                strncpy(type, "command", 8);
+                                break;
+                            case 'p':
+                                os_calloc(8, sizeof(char), type);
+                                strncpy(type, "process", 8);
+                                break;
+                            default:
+                                merror("Invalid type: %c", flag);
+                                break;
+                        }
+                        SaveRules(lf, socket, id->valueint, type, rule->valuestring);
+
+                        os_free(type);
                     }
                 }
                 break;
@@ -963,7 +1022,7 @@ static int CheckDumpJSON(cJSON *event,cJSON **elements_sent,cJSON **policy_id,cJ
     return retval;
 }
 
-static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,cJSON **title,cJSON **description,cJSON **rationale,cJSON **remediation,cJSON **compliance,cJSON **check,cJSON **reference,cJSON **file,cJSON **directory,cJSON **process,cJSON **registry,cJSON **result,cJSON **policy_id,cJSON **command) {
+static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,cJSON **title,cJSON **description,cJSON **rationale,cJSON **remediation,cJSON **compliance,cJSON **check,cJSON **reference,cJSON **file,cJSON **directory,cJSON **process,cJSON **registry,cJSON **result,cJSON **policy_id,cJSON **command, cJSON **rules) {
     int retval = 1;
     cJSON *obj;
 
@@ -1096,6 +1155,8 @@ static int CheckEventJSON(cJSON *event,cJSON **scan_id,cJSON **id,cJSON **name,c
             merror("Malformed JSON: field 'command' must be a string");
             return retval;
         }
+
+        *rules = cJSON_GetObjectItem(*check, "rules");
         
         if( *result = cJSON_GetObjectItem(*check, "result"), !*result) {
             merror("Malformed JSON: field 'result' not found");

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -260,6 +260,13 @@ CREATE TABLE IF NOT EXISTS sca_check (
 
 CREATE INDEX IF NOT EXISTS policy_id_index ON sca_check (policy_id);
 
+CREATE TABLE IF NOT EXISTS sca_check_rules (
+  id_check INTEGER REFERENCES sca_check (id),
+  `type` TEXT,
+  rule TEXT,
+  PRIMARY KEY (id_check, `type`, rule)
+);
+
 CREATE TABLE IF NOT EXISTS sca_check_compliance (
    id_check INTEGER REFERENCES sca_check (id),
   `key` TEXT,

--- a/src/wazuh_db/schema_upgrade_v2.sql
+++ b/src/wazuh_db/schema_upgrade_v2.sql
@@ -46,6 +46,13 @@ CREATE TABLE IF NOT EXISTS sca_check (
 
 CREATE INDEX IF NOT EXISTS policy_id_index ON sca_check (policy_id);
 
+CREATE TABLE IF NOT EXISTS sca_check_rules (
+  id_check INTEGER REFERENCES sca_check (id),
+  `type` TEXT,
+  rule TEXT,
+  PRIMARY KEY (id_check, `type`, rule)
+);
+
 CREATE TABLE IF NOT EXISTS sca_check_compliance (
    id_check INTEGER REFERENCES sca_check (id),
   `key` TEXT,

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -87,6 +87,7 @@ static const char *SQL_STMT[] = {
     "DELETE FROM sca_check WHERE policy_id = ?;",
     "DELETE FROM sca_scan_info WHERE policy_id = ?;",
     "DELETE FROM sca_check_compliance WHERE id_check NOT IN ( SELECT id FROM sca_check);",
+    "DELETE FROM sca_check_rules WHERE id_check NOT IN ( SELECT id FROM sca_check);",
     "SELECT id FROM sca_check WHERE policy_id = ?;",
     "DELETE FROM sca_check WHERE scan_id != ? AND policy_id = ?;"
 };

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -75,6 +75,7 @@ static const char *SQL_STMT[] = {
     "UPDATE sca_global SET scan_id = ?, name = ?, description = ?, `references` = ?, pass = ?, failed = ?, score = ? WHERE name = ?;",
     "SELECT name FROM sca_global WHERE name = ?;",
     "INSERT INTO sca_check_compliance (id_check,`key`,`value`) VALUES(?,?,?);",
+    "INSERT INTO sca_check_rules (id_check,`type`, rule) VALUES(?,?,?);",
     "SELECT policy_id,hash,id FROM sca_scan_info WHERE policy_id = ?;",
     "UPDATE sca_scan_info SET start_scan = ?, end_scan = ?, id = ?, pass = ?, fail = ? , score = ?, hash = ? WHERE policy_id = ?;",
     "SELECT id FROM sca_policy WHERE id = ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -95,6 +95,7 @@ typedef enum wdb_stmt {
     WDB_STMT_SCA_GLOBAL_UPDATE,
     WDB_STMT_SCA_GLOBAL_FIND,
     WDB_STMT_SCA_INSERT_COMPLIANCE,
+    WDB_STMT_SCA_INSERT_RULES,
     WDB_STMT_SCA_FIND_SCAN,
     WDB_STMT_SCA_SCAN_INFO_UPDATE_START,
     WDB_STMT_SCA_POLICY_FIND,
@@ -221,6 +222,9 @@ int wdb_sca_global_find(wdb_t * wdb, char *name, char * output);
 
 /* Insert global configuration assessment compliance entry. Returns number of affected rows or -1 on error.  */
 int wdb_sca_compliance_save(wdb_t * wdb, int id_check, char *key, char *value);
+
+/* Insert the rules of the policy checks,. Returns number of affected rows or -1 on error.  */
+int wdb_sca_rules_save(wdb_t * wdb, int id_check, char *type, char *rule);
 
 /* Update global configuration assessment entry. Returns number of affected rows or -1 on error.  */
 int wdb_sca_global_update(wdb_t * wdb, int scan_id, char *name,char *description,char *references,int pass,int failed,int score);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -107,6 +107,7 @@ typedef enum wdb_stmt {
     WDB_STMT_SCA_CHECK_DELETE,
     WDB_STMT_SCA_SCAN_INFO_DELETE,
     WDB_STMT_SCA_CHECK_COMPLIANCE_DELETE,
+    WDB_STMT_SCA_CHECK_RULES_DELETE,
     WDB_STMT_SCA_CHECK_FIND,
     WDB_STMT_SCA_CHECK_DELETE_DISTINCT,
     WDB_STMT_SIZE
@@ -261,6 +262,9 @@ int wdb_sca_scan_info_delete(wdb_t * wdb,char * policy_id);
 
 /* Delete a configuration assessment check compliances. Returns 0 on success or -1 on error (new) */
 int wdb_sca_check_compliances_delete(wdb_t * wdb);
+
+/* Delete a configuration assessment check rules. Returns 0 on success or -1 on error (new) */
+int wdb_sca_check_rules_delete(wdb_t * wdb);
 
 /* Delete distinct configuration assessment check. Returns 0 on success or -1 on error (new) */
 int wdb_sca_check_delete_distinct(wdb_t * wdb,char * policy_id,int scan_id);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -997,6 +997,46 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         }
 
         return result;
+    } else if (strcmp(curr, "insert_rules") == 0){
+
+
+         int id_check;
+        char *type;
+        char *rule;
+
+         curr = next;
+
+         if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid Security Configuration Assessment query syntax.");
+            mdebug2("Security Configuration Assessment query: %s", curr);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+         id_check = strtol(curr,NULL,10);
+        *next++ = '\0';
+
+         curr = next;
+        if (next = strchr(curr, '|'), !next) {
+            mdebug1("Invalid Security Configuration Assessment query syntax.");
+            mdebug2("Security Configuration Assessment query: %s", curr);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid configuration assessment query syntax, near '%.32s'", curr);
+            return -1;
+        }
+
+         type = curr;
+        *next++ = '\0';
+
+         rule = next;
+        if (result = wdb_sca_rules_save(wdb,id_check,type,rule), result < 0) {
+            mdebug1("Cannot save configuration assessment information.");
+            snprintf(output, OS_MAXSTR + 1, "err Cannot save configuration assessment global information.");
+        } else {
+            snprintf(output, OS_MAXSTR + 1, "ok");
+        }
+
+         return result;
+         
     } else if (strcmp(curr, "insert_compliance") == 0) {
 
         int id_check;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -728,6 +728,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
             wdb_sca_check_compliances_delete(wdb);
+            wdb_sca_check_rules_delete(wdb);
         }
 
         return result;
@@ -745,6 +746,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         } else {
             snprintf(output, OS_MAXSTR + 1, "ok");
             wdb_sca_check_compliances_delete(wdb);
+            wdb_sca_check_rules_delete(wdb);
         }
 
         return result;
@@ -1036,7 +1038,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         }
 
          return result;
-         
+
     } else if (strcmp(curr, "insert_compliance") == 0) {
 
         int id_check;

--- a/src/wazuh_db/wdb_sca.c
+++ b/src/wazuh_db/wdb_sca.c
@@ -505,6 +505,34 @@ int wdb_sca_compliance_save(wdb_t * wdb, int id_check, char *key, char *value) {
     }
 }
 
+int wdb_sca_rules_save(wdb_t * wdb, int id_check, char *type, char *rule){
+    if (!wdb->transaction && wdb_begin2(wdb) < 0){
+        mdebug1("at wdb_rootcheck_save(): cannot begin transaction");
+        return -1;
+    }
+
+     sqlite3_stmt *stmt = NULL;
+
+     if (wdb_stmt_cache(wdb, WDB_STMT_SCA_INSERT_RULES) < 0) {
+        mdebug1("at wdb_rootcheck_save(): cannot cache statement");
+        return -1;
+    }
+
+     stmt = wdb->stmt[WDB_STMT_SCA_INSERT_RULES];
+
+     sqlite3_bind_int(stmt, 1, id_check);
+    sqlite3_bind_text(stmt, 2, type, -1, NULL);
+    sqlite3_bind_text(stmt, 3, rule, -1, NULL);
+
+     if (sqlite3_step(stmt) == SQLITE_DONE) {
+        return 0;
+    } else {
+        merror("sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        return -1;
+    }
+}
+
+
 /* Insert policy entry. Returns 0 on success or -1 on error (new) */
 int wdb_sca_policy_info_save(wdb_t * wdb,char *name,char * file,char * id,char * description,char *references ) {
 

--- a/src/wazuh_db/wdb_sca.c
+++ b/src/wazuh_db/wdb_sca.c
@@ -134,14 +134,14 @@ int wdb_sca_find(wdb_t * wdb, int pm_id, char * output) {
 int wdb_sca_save(wdb_t * wdb, int id,int scan_id,char * title,char *description,char *rationale,char *remediation, char * file,char * directory,char * process,char * registry,char * reference,char * result,char * policy_id,char * command) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        mdebug1("at wdb_rootcheck_save(): cannot begin transaction");
+        mdebug1("at wdb_sca_save(): cannot begin transaction");
         return -1;
     }
 
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_SCA_INSERT) < 0) {
-        mdebug1("at wdb_rootcheck_save(): cannot cache statement");
+        mdebug1("at wdb_sca_save(): cannot cache statement");
         return -1;
     }
 
@@ -624,14 +624,14 @@ int wdb_sca_scan_info_save(wdb_t * wdb, int start_scan, int end_scan, int scan_i
 
 int wdb_sca_scan_info_update(wdb_t * wdb, char * module, int end_scan){
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        mdebug1("at wdb_rootcheck_update(): cannot begin transaction");
+        mdebug1("at wdb_sca_scan_info_update(): cannot begin transaction");
         return -1;
     }
 
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_SCA_SCAN_INFO_UPDATE) < 0) {
-        mdebug1("at wdb_rootcheck_update(): cannot cache statement");
+        mdebug1("at wdb_sca_scan_info_update(): cannot cache statement");
         return -1;
     }
 
@@ -643,21 +643,21 @@ int wdb_sca_scan_info_update(wdb_t * wdb, char * module, int end_scan){
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return sqlite3_changes(wdb->db);
     } else {
-        merror("at wdb_rootcheck_update(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        merror("at wdb_sca_scan_info_update(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 }
 
 int wdb_sca_check_update_scan_id(wdb_t * wdb, __attribute__((unused))int scan_id_old,int scan_id_new,char * policy_id){
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        mdebug1("at wdb_rootcheck_update(): cannot begin transaction");
+        mdebug1("at wdb_sca_check_update_scan_id(): cannot begin transaction");
         return -1;
     }
 
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_SCA_CHECK_UPDATE_SCAN_ID) < 0) {
-        mdebug1("at wdb_rootcheck_update(): cannot cache statement");
+        mdebug1("at wdb_sca_check_update_scan_id(): cannot cache statement");
         return -1;
     }
 
@@ -669,21 +669,21 @@ int wdb_sca_check_update_scan_id(wdb_t * wdb, __attribute__((unused))int scan_id
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return sqlite3_changes(wdb->db);
     } else {
-        merror("at wdb_rootcheck_update(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        merror("at wdb_sca_check_update_scan_id(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 }
 
 int wdb_sca_scan_info_update_start(wdb_t * wdb, char * policy_id, int start_scan,int end_scan,int scan_id,int pass,int fail,int score,char * hash) {
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        mdebug1("at wdb_rootcheck_update(): cannot begin transaction");
+        mdebug1("at wdb_sca_scan_info_update_start(): cannot begin transaction");
         return -1;
     }
 
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_SCA_SCAN_INFO_UPDATE_START) < 0) {
-        mdebug1("at wdb_rootcheck_update(): cannot cache statement");
+        mdebug1("at wdb_sca_scan_info_update_start(): cannot cache statement");
         return -1;
     }
 
@@ -701,7 +701,7 @@ int wdb_sca_scan_info_update_start(wdb_t * wdb, char * policy_id, int start_scan
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return sqlite3_changes(wdb->db);
     } else {
-        merror("at wdb_rootcheck_update(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        merror("at wdb_sca_scan_info_update_start(): sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
         return -1;
     }
 }
@@ -761,14 +761,14 @@ end:
 int wdb_sca_update(wdb_t * wdb, char * result, int id,int scan_id) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        mdebug1("at wdb_rootcheck_update(): cannot begin transaction");
+        mdebug1("at wdb_sca_update(): cannot begin transaction");
         return -1;
     }
 
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_SCA_UPDATE) < 0) {
-        mdebug1("at wdb_rootcheck_update(): cannot cache statement");
+        mdebug1("at wdb_sca_update(): cannot cache statement");
         return -1;
     }
 

--- a/src/wazuh_db/wdb_sca.c
+++ b/src/wazuh_db/wdb_sca.c
@@ -413,6 +413,30 @@ int wdb_sca_check_compliances_delete(wdb_t * wdb) {
     }
 }
 
+int wdb_sca_check_rules_delete(wdb_t * wdb) {
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0){
+        mdebug1("at wdb_sca_check_rules_delete(): cannot begin transaction");
+        return -1;
+    }
+
+    sqlite3_stmt *stmt = NULL;
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_SCA_CHECK_RULES_DELETE) < 0) {
+        mdebug1("at wdb_sca_check_rules_delete(): cannot cache statement");
+        return -1;
+    }
+
+    stmt = wdb->stmt[WDB_STMT_SCA_CHECK_RULES_DELETE];
+    
+    if (sqlite3_step(stmt) == SQLITE_DONE) {
+        return 0;
+    } else {
+        merror("sqlite3_step(): %s", sqlite3_errmsg(wdb->db));
+        return -1;
+    }
+}
+
 /* Look for a scan configuration assessment entry in Wazuh DB. Returns 1 if found, 0 if not, or -1 on error. (new) */
 int wdb_sca_scan_find(wdb_t * wdb, char *policy_id, char * output) {
 
@@ -480,14 +504,14 @@ int wdb_sca_policy_find(wdb_t * wdb, char *id, char * output) {
 
 int wdb_sca_compliance_save(wdb_t * wdb, int id_check, char *key, char *value) {
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        mdebug1("at wdb_rootcheck_save(): cannot begin transaction");
+        mdebug1("at wdb_sca_compliance_save(): cannot begin transaction");
         return -1;
     }
 
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_SCA_INSERT_COMPLIANCE) < 0) {
-        mdebug1("at wdb_rootcheck_save(): cannot cache statement");
+        mdebug1("at wdb_sca_compliance_save(): cannot cache statement");
         return -1;
     }
 
@@ -507,20 +531,20 @@ int wdb_sca_compliance_save(wdb_t * wdb, int id_check, char *key, char *value) {
 
 int wdb_sca_rules_save(wdb_t * wdb, int id_check, char *type, char *rule){
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        mdebug1("at wdb_rootcheck_save(): cannot begin transaction");
+        mdebug1("at wdb_sca_rules_save(): cannot begin transaction");
         return -1;
     }
 
      sqlite3_stmt *stmt = NULL;
 
      if (wdb_stmt_cache(wdb, WDB_STMT_SCA_INSERT_RULES) < 0) {
-        mdebug1("at wdb_rootcheck_save(): cannot cache statement");
+        mdebug1("at wdb_sca_rules_save(): cannot cache statement");
         return -1;
     }
 
      stmt = wdb->stmt[WDB_STMT_SCA_INSERT_RULES];
 
-     sqlite3_bind_int(stmt, 1, id_check);
+    sqlite3_bind_int(stmt, 1, id_check);
     sqlite3_bind_text(stmt, 2, type, -1, NULL);
     sqlite3_bind_text(stmt, 3, rule, -1, NULL);
 
@@ -537,14 +561,14 @@ int wdb_sca_rules_save(wdb_t * wdb, int id_check, char *type, char *rule){
 int wdb_sca_policy_info_save(wdb_t * wdb,char *name,char * file,char * id,char * description,char *references ) {
 
      if (!wdb->transaction && wdb_begin2(wdb) < 0){
-        mdebug1("cannot begin transaction");
+        mdebug1("at wdb_sca_policy_info_save(): cannot begin transaction");
         return -1;
     }
 
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, WDB_STMT_SCA_POLICY_INSERT) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("at wdb_sca_policy_info_save(): cannot cache statement");
         return -1;
     }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -824,8 +824,13 @@ static int wm_sca_do_scan(OSList *p_list,cJSON *profile_check,OSStore *vars,wm_s
                 nbuf = p_check->valuestring;
                 mdebug2("Rule is: %s",nbuf);
 
+                /* Make a copy of the rule */
+                char *rule_cp;
+                os_strdup(nbuf, rule_cp);
+
                 /* Get value to look for */
-                value = wm_sca_get_value(nbuf, &type);
+                value = wm_sca_get_value(rule_cp, &type);
+
                 if (value == NULL) {
                     mdebug1(WM_SCA_INVALID_RKCL_VALUE, nbuf);
                     goto clean_return;
@@ -2206,6 +2211,7 @@ static cJSON *wm_sca_build_event(cJSON *profile,cJSON *policy,char **p_alert_msg
     cJSON *description = cJSON_GetObjectItem(profile, "description");
     cJSON *rationale = cJSON_GetObjectItem(profile, "rationale");
     cJSON *remediation = cJSON_GetObjectItem(profile, "remediation");
+    cJSON *rules = cJSON_GetObjectItem(profile, "rules");
 
     if(!pm_id) {
         mdebug1("No 'id' field found on check.");
@@ -2281,6 +2287,8 @@ static cJSON *wm_sca_build_event(cJSON *profile,cJSON *policy,char **p_alert_msg
 
         cJSON_AddItemToObject(check,"compliance",add_compliances);
     }
+
+    cJSON_AddItemToObject(check,"rules", cJSON_Duplicate(rules,1));
 
     cJSON *references = cJSON_GetObjectItem(profile, "references");
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -416,12 +416,12 @@ static void wm_sca_read_files(wm_sca_t * data) {
             yaml_document_t document;
 
             if (yaml_parse_file(path, &document)) {
-                merror("Policy file could not be parsed: '%s'. Skipping it.",path);
+                mwarn("Policy file could not be parsed: '%s'. Skipping it.",path);
                 goto next;
             }
 
             if (object = yaml2json(&document,1), !object) {
-                merror("Transforming yaml to json: '%s'. Skipping it.",path);
+                mwarn("Transforming yaml to json: '%s'. Skipping it.",path);
                 goto next;
             }
 
@@ -436,12 +436,12 @@ static void wm_sca_read_files(wm_sca_t * data) {
             cJSON_AddItemReferenceToArray(requirements_array, requirements);
 
             if(wm_sca_check_policy(policy, profiles)) {
-                merror("Validating policy file: '%s'. Skipping it.", path);
+                mwarn("Validating policy file: '%s'. Skipping it.", path);
                 goto next;
             }
 
             if(requirements && wm_sca_check_requirements(requirements)) {
-                merror("Reading 'requirements' section of file: '%s'. Skipping it.", path);
+                mwarn("Reading 'requirements' section of file: '%s'. Skipping it.", path);
                 goto next;
             }
 
@@ -451,14 +451,14 @@ static void wm_sca_read_files(wm_sca_t * data) {
             }
 
             if(!profiles){
-                merror("Reading 'checks' section of file: '%s'. Skipping it.", path);
+                mwarn("Reading 'checks' section of file: '%s'. Skipping it.", path);
                 goto next;
             }
 
             vars = OSStore_Create();
 
             if( wm_sca_get_vars(variables,vars) != 0 ){
-                merror("Reading 'variables' section of file: '%s'. Skipping it.", path);
+                mwarn("Reading 'variables' section of file: '%s'. Skipping it.", path);
                 goto next;
             }
 
@@ -568,51 +568,51 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
 
     id = cJSON_GetObjectItem(policy, "id");
     if(!id) {
-        merror("Field 'id' not found in policy header.");
+        mwarn("Field 'id' not found in policy header.");
         return retval;
     }
 
     if(!id->valuestring){
-        merror("Invalid format for field 'id'.");
+        mwarn("Invalid format for field 'id'.");
         return retval;
     }
 
     name = cJSON_GetObjectItem(policy, "name");
     if(!name) {
-        merror("Field 'name' not found in policy header.");
+        mwarn("Field 'name' not found in policy header.");
         return retval;
     }
 
     if(!name->valuestring){
-        merror("Invalid format for field 'name'.");
+        mwarn("Invalid format for field 'name'.");
         return retval;
     }
 
     file = cJSON_GetObjectItem(policy, "file");
     if(!file) {
-        merror("Field 'file' not found in policy header.");
+        mwarn("Field 'file' not found in policy header.");
         return retval;
     }
 
     if(!file->valuestring){
-        merror("Invalid format for field 'file'.");
+        mwarn("Invalid format for field 'file'.");
         return retval;
     }
 
     description = cJSON_GetObjectItem(policy, "description");
     if(!description) {
-        merror("Field 'description' not found in policy header.");
+        mwarn("Field 'description' not found in policy header.");
         return retval;
     }
 
     if(!description->valuestring) {
-        merror("Invalid format for field 'description'.");
+        mwarn("Invalid format for field 'description'.");
         return retval;
     }
 
     // Check for policy rules with duplicated IDs */
     if (!profiles) {
-        merror("Section 'checks' not found.");
+        mwarn("Section 'checks' not found.");
         return retval;
     } else {
         os_calloc(1, sizeof(int), read_id);
@@ -624,12 +624,12 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
             check_id = cJSON_GetObjectItem(check, "id");
 
             if (check_id == NULL) {
-                merror("Check ID not found.");
+                mwarn("Check ID not found.");
                 free(read_id);
                 return retval;
             } else if (check_id->valueint <= 0) {
                 // Invalid ID
-                merror("Invalid check ID: %d", check_id->valueint);
+                mwarn("Invalid check ID: %d", check_id->valueint);
                 free(read_id);
                 return retval;
             }
@@ -637,7 +637,7 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
             for (i = 0; read_id[i] != 0; i++) {
                 if (check_id->valueint == read_id[i]) {
                     // Duplicated ID
-                    merror("Duplicated check ID: %d", check_id->valueint);
+                    mwarn("Duplicated check ID: %d", check_id->valueint);
                     free(read_id);
                     return retval;
                 }
@@ -649,23 +649,51 @@ static int wm_sca_check_policy(cJSON *policy, cJSON *profiles) {
             rules_id = cJSON_GetObjectItem(check, "rules");
 
             if (rules_id == NULL) {
-                merror("Invalid check %d: no rules found.", check_id->valueint);
+                mwarn("Invalid check %d: no rules found.", check_id->valueint);
                 free(read_id);
                 return retval;
             }
 
             cJSON_ArrayForEach(rule, rules_id){
+
+                if (!rule->valuestring) {
+                    mwarn("Invalid check %d: Empty rule.", check_id->valueint);
+                    free(read_id);
+                    return retval;
+                } else {
+                    switch (rule->valuestring[0]) {
+                        case 'f':
+                            break;
+                        case 'd':
+                            break;
+                        case 'p':
+                            break;
+                        case 'r':
+                            break;
+                        case 'c':
+                            break;
+                        case '\0':
+                            mwarn("Invalid check %d: Empty rule.", check_id->valueint);
+                            free(read_id);
+                            return retval;
+                        default:
+                            mwarn("Invalid check %d: Invalid rule format.", check_id->valueint);
+                            free(read_id);
+                            return retval;
+                    }
+                }
+
                 rules_n++;
 
                 if (rules_n > 255) {
                     free(read_id);
-                    merror("Invalid check %d: Maximum number of rules is 255.", check_id->valueint);
+                    mwarn("Invalid check %d: Maximum number of rules is 255.", check_id->valueint);
                     return retval;
                 }
             }
 
             if (rules_n == 0) {
-                merror("Invalid check %d: no rules found.", check_id->valueint);
+                mwarn("Invalid check %d: no rules found.", check_id->valueint);
                 free(read_id);
                 return retval;
             }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1123,6 +1123,8 @@ static int wm_sca_do_scan(OSList *p_list,cJSON *profile_check,OSStore *vars,wm_s
                         g_found = -1;
                     }
                 }
+
+                os_free(rule_cp);
             }
 
             if (condition & WM_SCA_COND_NON) {


### PR DESCRIPTION
This PR is the development for the issue: https://github.com/wazuh/wazuh/issues/2960

The commit https://github.com/wazuh/wazuh/commit/423e85a39de2c6ec2d549c6f87d3b0b9e720d426 adds the table `sca_check_rules` to the agent database. This table contains the id of the check, the type of rule and the rule itself. If a check has multiple rules each one  will be stored in a different row.

The commit https://github.com/wazuh/wazuh/commit/4901c55ed3c747da76d4c4df8729803393118834 adds the rules of the SCA check to the SCA event sent to the manager. This way we can use the rules in the `analysisd` decoder and send it to the Wazuh DB. Also it adds the funcionality to fill the `sca_check_rules` table.

The commit https://github.com/wazuh/wazuh/commit/6f335883dd544164af6480d5e18443697c0e5b25 adds to Wazuh DB the capability to delete an entry of `sca_check_rules` when it is deleted from `sca_check` as it is done with the table `sca_check_compliances`

This PR must:
- [x] Fill the table `sca_check_rules` of the agent database
- [x] Delete the entries of a check that has been removed from a policy file

Testing process:
- [x] Test agents with differents OS 
  - [x] Windows
  - [x] MAC
  - [x] Centos 7
  - [x] Ubuntu 18
- [x] Run the modified modules with Valgrind
  - [x] `wazuh-modulesd`
  - [x] `ossec-analysisd`
  - [x] `wazuh-db`
- [x] Integrity checks
  - [x] New check in the policy
  - [x] Delete a check from a policy