### PR TITLE
Improve error messages in active configuration API endpoint

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -751,4 +751,5 @@ def get_active_configuration(agent_id, component, configuration):
         msg = json.loads(rec_msg)
         return msg
     else:
-        raise WazuhException(1117 if "No such file or directory" in rec_msg else 1116, rec_msg.replace("err ", ""))
+        raise WazuhException(1117 if "No such file or directory" in rec_msg or "Cannot send request" in rec_msg
+                                  else 1116, rec_msg.replace("err ", ""))

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -35,7 +35,7 @@ class WazuhException(Exception):
 
         # Configuration: 1100 - 1199
         1100: 'Error checking configuration',
-        1101: 'Error getting configuration',
+        1101: 'Requested component does not exist',
         1102: 'Invalid section',
         1103: 'Invalid field in section',
         1104: 'Invalid type',
@@ -50,6 +50,9 @@ class WazuhException(Exception):
         1113: "XML syntax error",
         1114: "Wazuh syntax error",
         1115: "Error executing verify-agent-conf",
+        1116: "Requested component configuration does not exist",
+        1117: "Unable to connect with component. The component might be disabled.",
+        1118: "Could not request component configuration",
 
         # Rule: 1200 - 1299
         1200: 'Error reading rules from ossec.conf',

--- a/framework/wazuh/ossec_socket.py
+++ b/framework/wazuh/ossec_socket.py
@@ -22,8 +22,8 @@ class OssecSocket:
         try:
             self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.s.connect(self.path)
-        except:
-            raise WazuhException(1013, self.path)
+        except Exception as e:
+            raise WazuhException(1013, str(e))
 
     def close(self):
         self.s.close()
@@ -35,22 +35,19 @@ class OssecSocket:
         try:
             sent = self.s.send(pack("<I", len(msg_bytes)) + msg_bytes)
             if sent == 0:
-                raise WazuhException(1014, self.path)
+                raise WazuhException(1014, "Number of sent bytes is 0")
             return sent
-        except:
-            raise WazuhException(1014, self.path)
+        except Exception as e:
+            raise WazuhException(1014, str(e))
 
     def receive(self):
 
         try:
             size = unpack("<I", self.s.recv(4, socket.MSG_WAITALL))[0]
-
-            if size > OssecSocket.MAX_SIZE:
-                raise WazuhException(1014, self.path)
-
             return self.s.recv(size, socket.MSG_WAITALL)
-        except:
-            raise WazuhException(1014, self.path)
+        except Exception as e:
+            raise WazuhException(1014, str(e))
+
 
 class OssecSocketJSON(OssecSocket):
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -171,10 +171,9 @@ def test_get_agents_overview_status_olderthan(test_data, status, older_than, tot
     ('002', 'logcollector', 'internal', 1735),
     ('000', None, None, 1307),
     ('000', 'random', 'random', 1101),
-    ('000', 'analysis', 'rules', 1101),
-    ('000', 'analysis', 'internal', 1013),
-    ('000', 'analysis', 'internal', 1014),
-    ('000', 'analysis', 'internal', 1101),
+    ('000', 'analysis', 'internal', 1117),
+    ('000', 'analysis', 'internal', 1118),
+    ('000', 'analysis', 'random', 1116),
     ('000', 'analysis', 'internal', None)
 ])
 @patch('wazuh.configuration.OssecSocket')
@@ -182,10 +181,10 @@ def test_get_config_error(ossec_socket_mock, test_data, agent_id, component, con
     """
     Tests get_config function error cases.
     """
-    if expected_exception == 1013:
+    if expected_exception == 1117:
         ossec_socket_mock.side_effect = Exception('Boom!')
 
-    ossec_socket_mock.return_value.receive.return_value = b'string_without_spaces' if expected_exception == 1014 \
+    ossec_socket_mock.return_value.receive.return_value = b'string_without_spaces' if expected_exception == 1118 \
         else (b'random random' if expected_exception is not None else b'ok {"message":"value"}')
 
     with patch('sqlite3.connect') as mock_db:


### PR DESCRIPTION
Hello team,

This PR closes #3083.

The same error examples which were shown in the PR:
```javascript
# curl -u foo:bar "localhost:55000/agents/000/config/integrator/integration?pretty"
{
   "error": 1117,
   "message": "Unable to connect with component. The component might be disabled."
}
# curl -u foo:bar "localhost:55000/agents/000/config/random/random?pretty"
{
   "error": 1101,
   "message": "Requested component does not exist"
}
# curl -u foo:bar "localhost:55000/agents/000/config/wmodules/random?pretty"
{
   "error": 1116,
   "message": "Requested component configuration does not exist"
}
```

This PR also fixes the bug that made `GET/agent/:agent_id/config/analysis/{rules, decoders}` request to fail. 

Best regards,
Marta