### PR TITLE
GET/manager/logs: fix bugs when parsing multiline logs and using filters

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -125,7 +125,7 @@ def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.d
             else:
                 continue
         else:
-            if logs and line:
+            if logs and line and log_category == logs[-1]['tag'] and level == logs[-1]['level']:
                 logs[-1]['description'] += "\n" + line
 
     if search:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -125,7 +125,7 @@ def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.d
             else:
                 continue
         else:
-            if logs:
+            if logs and line:
                 logs[-1]['description'] += "\n" + line
 
     if search:

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -186,21 +186,27 @@ ossec_log_file = """2019/03/26 20:14:37 wazuh-modulesd:database[27799] wm_databa
 2019/03/27 10:42:06 wazuh-modulesd:syscollector: INFO: Starting evaluation.
 2019/03/26 13:03:11 ossec-csyslogd: INFO: Remote syslog server not configured. Clean exit.
 2019/03/26 19:49:15 ossec-execd: ERROR: (1210): Queue '/var/ossec/queue/alerts/execa' not accessible: 'No such file or directory'.
-2019/03/26 17:07:32 wazuh-modulesd:aws-s3[13155] wmodules-aws.c:186 at wm_aws_read(): ERROR: Invalid bucket type 'inspector'. Valid ones are 'cloudtrail', 'config', 'custom', 'guardduty' or 'vpcflow'"""
+2019/03/26 17:07:32 wazuh-modulesd:aws-s3[13155] wmodules-aws.c:186 at wm_aws_read(): ERROR: Invalid bucket type 'inspector'. Valid ones are 'cloudtrail', 'config', 'custom', 'guardduty' or 'vpcflow'
+2019/04/11 12:51:40 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: wazuh-aws-wodle
+2019/04/11 12:53:37 wazuh-modulesd:aws-s3: WARNING: Bucket:  -  Returned exit code 7
+2019/04/11 12:53:37 wazuh-modulesd:aws-s3: WARNING: Bucket:  -  Unexpected error querying/working with objects in S3: db_maintenance() got an unexpected keyword argument 'aws_account_id'
+
+2019/04/11 12:53:37 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: wazuh-aws-wodle"""
 
 
 @pytest.mark.parametrize('category, type_log, totalItems', [
-    ('all', 'all', 6),
+    ('all', 'all', 10),
     ('wazuh-modulesd:database', 'all', 2),
     ('wazuh-modulesd:syscollector', 'all', 1),
-    ('wazuh-modulesd:aws-s3', 'all', 1),
+    ('wazuh-modulesd:aws-s3', 'all', 5),
     ('ossec-execd', 'all', 1),
     ('ossec-csyslogd', 'all', 1),
     ('random', 'all', 0),
-    ('all', 'info', 2),
+    ('all', 'info', 4),
     ('all', 'error', 2),
     ('all', 'debug', 2),
-    ('all', 'random', 0)
+    ('all', 'random', 0),
+    ('all', 'warning', 2)
 ])
 def test_ossec_log(test_manager, category, type_log, totalItems):
     """
@@ -210,3 +216,4 @@ def test_ossec_log(test_manager, category, type_log, totalItems):
         tail_patch.return_value = ossec_log_file.splitlines()
         logs = ossec_log(category=category, type_log=type_log)
         assert logs['totalItems'] == totalItems
+        assert all(log['description'][-1] != '\n' for log in logs['items'])

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -191,18 +191,21 @@ ossec_log_file = """2019/03/26 20:14:37 wazuh-modulesd:database[27799] wm_databa
 2019/04/11 12:53:37 wazuh-modulesd:aws-s3: WARNING: Bucket:  -  Returned exit code 7
 2019/04/11 12:53:37 wazuh-modulesd:aws-s3: WARNING: Bucket:  -  Unexpected error querying/working with objects in S3: db_maintenance() got an unexpected keyword argument 'aws_account_id'
 
-2019/04/11 12:53:37 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: wazuh-aws-wodle"""
+2019/04/11 12:53:37 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: wazuh-aws-wodle
+2019/03/27 10:42:06 wazuh-modulesd:syscollector: INFO: This is a 
+multiline log
+2019/03/26 13:03:11 ossec-csyslogd: INFO: Remote syslog server not configured. Clean exit."""
 
 
 @pytest.mark.parametrize('category, type_log, totalItems', [
-    ('all', 'all', 10),
+    ('all', 'all', 12),
     ('wazuh-modulesd:database', 'all', 2),
-    ('wazuh-modulesd:syscollector', 'all', 1),
+    ('wazuh-modulesd:syscollector', 'all', 2),
     ('wazuh-modulesd:aws-s3', 'all', 5),
     ('ossec-execd', 'all', 1),
-    ('ossec-csyslogd', 'all', 1),
+    ('ossec-csyslogd', 'all', 2),
     ('random', 'all', 0),
-    ('all', 'info', 4),
+    ('all', 'info', 6),
     ('all', 'error', 2),
     ('all', 'debug', 2),
     ('all', 'random', 0),
@@ -217,3 +220,5 @@ def test_ossec_log(test_manager, category, type_log, totalItems):
         logs = ossec_log(category=category, type_log=type_log)
         assert logs['totalItems'] == totalItems
         assert all(log['description'][-1] != '\n' for log in logs['items'])
+        if category != 'all' and category != 'wazuh-modulesd:syscollector':
+            assert all('\n' not in log['description'] for log in logs['items'])


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh/issues/3086.

Before:
```javascript
root@master:/home/vagrant# curl -u foo:bar "localhost:55000/manager/logs?pretty&category=ossec-analysisd&type_log=error"
{
   "error": 0,
   "data": {
      "items": [
         {
            "timestamp": "2019-04-11 13:33:00",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         },
         {
            "timestamp": "2019-04-11 13:33:00",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         },
         {
            "timestamp": "2019-04-11 12:11:43",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)].\n\n\n\n\n\n\n\n\n\n\n\n"
         },
         {
            "timestamp": "2019-04-11 11:54:52",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         },
         {
            "timestamp": "2019-04-11 11:54:51",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         }
      ],
      "totalItems": 5
   }
}
```

After
```javascript
root@master:/home/vagrant/GitHub/wazuh/framework# curl -u foo:bar "localhost:55000/manager/logs?pretty&category=ossec-analysisd&type_log=error"
{
   "error": 0,
   "data": {
      "items": [
         {
            "timestamp": "2019-04-11 13:33:00",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         },
         {
            "timestamp": "2019-04-11 13:33:00",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         },
         {
            "timestamp": "2019-04-11 12:11:43",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         },
         {
            "timestamp": "2019-04-11 11:54:52",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         },
         {
            "timestamp": "2019-04-11 11:54:51",
            "tag": "ossec-analysisd",
            "level": "error",
            "description": " (1126): Unable to open file 'etc/lists/blacklist-alienvault.cdb' due to [(2)-(No such file or directory)]."
         }
      ],
      "totalItems": 5
   }
}
```

Best regards,
Marta