### PR TITLE
Fixed wrong counting of files of logcollector 3.8 - 3.9

### DIFF
--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -47,6 +47,10 @@ int LogCollectorConfig(const char *cfgfile)
     reload_interval = getDefine_Int("logcollector", "reload_interval", 1, 86400);
     reload_delay = getDefine_Int("logcollector", "reload_delay", 0, 30000);
 
+    /* Current and total files counter */
+    total_files = 0;
+    current_files = 0;
+
     if (force_reload && reload_interval < vcheck_files) {
         mwarn("Reload interval (%d) must be greater or equal than the checking interval (%d).", reload_interval, vcheck_files);
     }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -255,7 +255,7 @@ void LogCollectorStart()
 
     /* Start up message */
     minfo(STARTUP_MSG, (int)getpid());
-    mdebug2(CURRENT_FILES, current_files, maximum_files);
+    mdebug1(CURRENT_FILES, current_files, maximum_files);
 
 #ifndef WIN32
     // Start com request thread
@@ -324,7 +324,7 @@ void LogCollectorStart()
                                 if (Remove_Localfile(&(globs[j].gfiles), i, 1, 0)) {
                                     merror(REM_ERROR, current->file);
                                 } else {
-                                    mdebug2(CURRENT_FILES, current_files, maximum_files);
+                                    mdebug1(CURRENT_FILES, current_files, maximum_files);
                                     i--;
                                     continue;
                                 }
@@ -399,7 +399,7 @@ void LogCollectorStart()
                                 if (Remove_Localfile(&(globs[j].gfiles), i, 1, 0)) {
                                     merror(REM_ERROR, current->file);
                                 } else {
-                                    mdebug2(CURRENT_FILES, current_files, maximum_files);
+                                    mdebug1(CURRENT_FILES, current_files, maximum_files);
                                     i--;
                                     continue;
                                 }
@@ -985,7 +985,7 @@ int check_pattern_expand(int do_seek) {
                     globs[j].gfiles[i + 1].file = NULL;
                     globs[j].gfiles[i + 1].target = NULL;
                     current_files++;
-                    mdebug2(CURRENT_FILES, current_files, maximum_files);
+                    mdebug1(CURRENT_FILES, current_files, maximum_files);
                     if  (!i && !globs[j].gfiles[i].read) {
                         set_read(&globs[j].gfiles[i], i, j);
                     } else {
@@ -1031,7 +1031,7 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
                 if (result) {
                     merror_exit(REM_ERROR, current->file);
                 } else {
-                    mdebug2(CURRENT_FILES, current_files, maximum_files);
+                    mdebug1(CURRENT_FILES, current_files, maximum_files);
                 }
                 d_control = NEXT_IT;
                 break;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -83,9 +83,6 @@ void LogCollectorStart()
     char keepalive[1024];
     logreader *current;
 
-    total_files = 0;
-    current_files = 0;
-
     set_sockets();
     files_lock_init();
 


### PR DESCRIPTION
### Wrong counting of files

Before logcollector starts, all `<localfiles>` are read and the `current_files` counter is incremented for each file encountered. Then it is set to zero as explained in the related issue https://github.com/wazuh/wazuh/issues/3090 causing a wrong value when duplicates files are removed.

### Solution

Set the `current_files` counter to zero before reading all the `<localfiles>`