### PR TITLE
Fix compilation warnings on OpenBSD platform

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -142,7 +142,7 @@ ifeq (${uname_S},NetBSD)
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 else
 ifeq (${uname_S},OpenBSD)
-#		DEFINES+=-DOpenBSD
+		DEFINES+=-DOpenBSD
 		OSSEC_CFLAGS+=-pthread
 		OSSEC_LDFLAGS+=-pthread
 		OSSEC_LDFLAGS+=-L/usr/local/lib

--- a/src/Makefile
+++ b/src/Makefile
@@ -146,7 +146,7 @@ ifeq (${uname_S},OpenBSD)
 		OSSEC_CFLAGS+=-pthread
 		OSSEC_LDFLAGS+=-pthread
 		OSSEC_LDFLAGS+=-L/usr/local/lib
-		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
+		OSSEC_LDFLAGS+=-Wl,-zorigin '-Wl,-rpath,$$ORIGIN/../lib'
 else
 ifeq (${uname_S},HP-UX)
 		DEFINES+=-DHPUX
@@ -763,7 +763,11 @@ $(EXTERNAL_CURL)Makefile:
 	cd $(EXTERNAL_CURL) && ./configure --with-darwinssl --disable-ldap --without-libidn2
 else
 $(EXTERNAL_CURL)Makefile: $(OPENSSL_LIB)
+ifeq (${uname_S},Linux)
 	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-ldl -lpthread" ./configure --disable-ldap --without-libidn2
+else
+	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-lpthread" ./configure --disable-ldap --without-libidn2
+endif
 endif
 
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -16,8 +16,11 @@
 #define ARGV0 "ossec-analysisd"
 #endif
 
-#include <time.h>
 #include "shared.h"
+#include <time.h>
+#if defined(__MACH__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#include <sys/sysctl.h>
+#endif
 #include "alerts/alerts.h"
 #include "alerts/getloglocation.h"
 #include "os_execd/execd.h"

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -127,8 +127,10 @@ typedef uint8_t u_int8_t;
 
 #endif /* SOLARIS */
 
-#if defined HPUX
+#if defined(HPUX) || defined(DOpenBSD)
 #include <limits.h>
+typedef uint64_t u_int64_t;
+typedef int int32_t;
 typedef uint32_t u_int32_t;
 typedef uint16_t u_int16_t;
 typedef uint8_t u_int8_t;

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -71,6 +71,7 @@
 #include <ctype.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <pthread.h>
 
 /* The mingw32 builder used by travis.ci can't find glob.h
  * Yet glob must work on actual win32.

--- a/src/rootcheck/check_rc_if.c
+++ b/src/rootcheck/check_rc_if.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <pthread.h>
 
 #ifdef SOLARIS
 #include <stropts.h>


### PR DESCRIPTION
Hi team,

This PR closes #3104. Here you can see the changes:

- LibCURL does not compile because libdl does not exist on OpenBSD.
- Rootcheck can't compile due to a missing pthread library include.
- The system loader was ignoring the runpath.

Thanks to @vikman90 for the fix :)

Regards.