### PR TITLE
Show bucket type in `ossec.log` for AWS wodle

### DIFF
--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -72,10 +72,10 @@ void* wm_aws_main(wm_aws *aws_config) {
         time_start = time(NULL);
 
         for (cur_bucket = aws_config->buckets; cur_bucket; cur_bucket = cur_bucket->next) {
-            if (cur_bucket->aws_account_id && cur_bucket->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: %s (%s)", cur_bucket->aws_account_alias, cur_bucket->aws_account_id);
-            } else if (cur_bucket->aws_account_id) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: %s", cur_bucket->aws_account_id);
+            if (cur_bucket->aws_account_id && cur_bucket->type && cur_bucket->aws_account_alias) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: [%s] %s (%s)", cur_bucket->type, cur_bucket->aws_account_alias, cur_bucket->aws_account_id);
+            } else if (cur_bucket->aws_account_id && cur_bucket->type) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: [%s] %s", cur_bucket->type, cur_bucket->aws_account_id);
             } else {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: %s", cur_bucket->bucket);
             }
@@ -83,10 +83,10 @@ void* wm_aws_main(wm_aws *aws_config) {
         }
 
         for (cur_service = aws_config->services; cur_service; cur_service = cur_service->next) {
-            if (cur_service->aws_account_id && cur_service->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: %s (%s)", cur_service->aws_account_alias, cur_service->aws_account_id);
-            } else if (cur_service->aws_account_id) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: %s", cur_service->aws_account_id);
+            if (cur_service->aws_account_id && && cur_service->type && cur_service->aws_account_alias) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] %s (%s)", cur_service->type, cur_service->aws_account_alias, cur_service->aws_account_id);
+            } else if (cur_service->aws_account_id && cur_service->type) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] %s", cur_service->type, cur_service->aws_account_id);
             } else {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: %s", cur_service->type);
             }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -41,6 +41,8 @@ void* wm_aws_main(wm_aws *aws_config) {
     wm_aws_service *cur_service;
     time_t time_start;
     time_t time_sleep = 0;
+    char *log_info;
+
 
     wm_aws_setup(aws_config);
     mtinfo(WM_AWS_LOGTAG, "Module AWS started");
@@ -73,7 +75,7 @@ void* wm_aws_main(wm_aws *aws_config) {
 
         for (cur_bucket = aws_config->buckets; cur_bucket; cur_bucket = cur_bucket->next) {
 
-            char *log_info = NULL;
+            log_info = NULL;
 
             wm_strcat(&log_info, "Executing Bucket Analysis: (Bucket:", '\0');
             wm_strcat(&log_info, cur_bucket->bucket, ' ');
@@ -117,7 +119,7 @@ void* wm_aws_main(wm_aws *aws_config) {
 
         for (cur_service = aws_config->services; cur_service; cur_service = cur_service->next) {
 
-            char *log_info = NULL;
+            log_info = NULL;
 
             wm_strcat(&log_info, "Executing Service Analysis: (Service:", '\0');
             wm_strcat(&log_info, cur_service->type, ' ');

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -83,7 +83,7 @@ void* wm_aws_main(wm_aws *aws_config) {
         }
 
         for (cur_service = aws_config->services; cur_service; cur_service = cur_service->next) {
-            if (cur_service->aws_account_id && && cur_service->type && cur_service->aws_account_alias) {
+            if (cur_service->aws_account_id && cur_service->type && cur_service->aws_account_alias) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] %s (%s)", cur_service->type, cur_service->aws_account_alias, cur_service->aws_account_id);
             } else if (cur_service->aws_account_id && cur_service->type) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] %s", cur_service->type, cur_service->aws_account_id);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -72,62 +72,74 @@ void* wm_aws_main(wm_aws *aws_config) {
         time_start = time(NULL);
 
         for (cur_bucket = aws_config->buckets; cur_bucket; cur_bucket = cur_bucket->next) {
-            if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->aws_account_id && cur_bucket->type &&
-                cur_bucket->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account ID: %s, Account Alias: %s)",
-                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_id,
-                    cur_bucket->aws_account_alias);
-            } else if (cur_bucket->bucket && cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type &&
-                cur_bucket->aws_account_id) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account ID: %s)",
-                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_id);
-            } else if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type && cur_bucket->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account Alias: %s)",
-                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_alias);
-            } else if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type && cur_bucket->aws_profile) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Profile: %s)",
-                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_profile);
-            } else if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type && cur_bucket->aws_organization_id) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Organization ID: %s)",
-                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_organization_id);
-            } else if (cur_bucket->bucket && cur_bucket->type && cur_bucket->aws_account_id) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Account ID: %s)",
-                    cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_account_id);
-            } else if (cur_bucket->bucket && cur_bucket->type && cur_bucket->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Account Alias: %s)",
-                    cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_account_alias);
-            } else if (cur_bucket->bucket && cur_bucket->type && cur_bucket->aws_profile) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Profile: %s)",
-                    cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_profile);
-            } else if (cur_bucket->bucket && cur_bucket->type && cur_bucket->aws_organization_id) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Organization ID: %s)",
-                    cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_organization_id);
-            } else if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s)",
-                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type);
-            } else if (cur_bucket->bucket && cur_bucket->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s)", cur_bucket->bucket, cur_bucket->type);
+
+            char *log_info = NULL;
+
+            wm_strcat(&log_info, "Executing Bucket Analysis: (Bucket:", '\0');
+            wm_strcat(&log_info, cur_bucket->bucket, ' ');
+
+            if (cur_bucket->trail_prefix) {
+                wm_strcat(&log_info, ", Path:", '\0');
+                wm_strcat(&log_info, cur_bucket->trail_prefix, ' ');
             }
+
+            if (cur_bucket->type) {
+                wm_strcat(&log_info, ", Type:", '\0');
+                wm_strcat(&log_info, cur_bucket->type, ' ');
+            }
+
+            if (cur_bucket->aws_account_id) {
+                wm_strcat(&log_info, ", Account ID:", '\0');
+                wm_strcat(&log_info, cur_bucket->aws_account_id, ' ');
+            }
+
+            if (cur_bucket->aws_account_alias) {
+                wm_strcat(&log_info, ", Account Alias:", '\0');
+                wm_strcat(&log_info, cur_bucket->aws_account_alias, ' ');
+            }
+
+            if (cur_bucket->aws_organization_id) {
+                wm_strcat(&log_info, ", Organization ID:", '\0');
+                wm_strcat(&log_info, cur_bucket->aws_organization_id, ' ');
+            }
+
+            if (cur_bucket->aws_profile) {
+                wm_strcat(&log_info, ", Profile:", '\0');
+                wm_strcat(&log_info, cur_bucket->aws_profile, ' ');
+            }
+
+            wm_strcat(&log_info, ")", '\0');
+            mtinfo(WM_AWS_LOGTAG, log_info);
             wm_aws_run_s3(cur_bucket);
+            free(log_info);
         }
 
         for (cur_service = aws_config->services; cur_service; cur_service = cur_service->next) {
-            if (cur_service->type && cur_service->aws_account_id && cur_service->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account ID: %s, Account Alias: %s)",
-                    cur_service->type, cur_service->aws_account_id, cur_service->aws_account_alias);
-            } else if (cur_service->type && cur_service->aws_account_id) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account ID: %s)",
-                    cur_service->type, cur_service->aws_account_id);
-            } else if (cur_service->type && cur_service->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account Alias: %s)",
-                    cur_service->type, cur_service->aws_account_alias);
-            } else if (cur_service->type && cur_service->aws_profile) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Profile: %s)",
-                    cur_service->type, cur_service->aws_profile);
-            } else if (cur_service->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s)", cur_service->type);
+
+            char *log_info = NULL;
+
+            wm_strcat(&log_info, "Executing Service Analysis: (Service:", '\0');
+            wm_strcat(&log_info, cur_service->type, ' ');
+
+            if (cur_service->aws_account_id) {
+                wm_strcat(&log_info, ", Account ID:", '\0');
+                wm_strcat(&log_info, cur_service->aws_account_id, ' ');
             }
+
+            if (cur_service->aws_account_alias) {
+                wm_strcat(&log_info, ", Account Alias:", '\0');
+                wm_strcat(&log_info, cur_service->aws_account_alias, ' ');
+            }
+
+            if (cur_service->aws_account_id) {
+                wm_strcat(&log_info, ", Profile:", '\0');
+                wm_strcat(&log_info, cur_service->aws_profile, ' ');
+            }
+
+            wm_strcat(&log_info, ")", '\0');
+            mtinfo(WM_AWS_LOGTAG, log_info);
             wm_aws_run_service(cur_service);
+            free(log_info);
         }
 
         mtinfo(WM_AWS_LOGTAG, "Fetching logs finished.");

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -109,6 +109,7 @@ void* wm_aws_main(wm_aws *aws_config) {
             }
 
             wm_strcat(&log_info, ")", '\0');
+
             mtinfo(WM_AWS_LOGTAG, log_info);
             wm_aws_run_s3(cur_bucket);
             free(log_info);
@@ -137,6 +138,7 @@ void* wm_aws_main(wm_aws *aws_config) {
             }
 
             wm_strcat(&log_info, ")", '\0');
+
             mtinfo(WM_AWS_LOGTAG, log_info);
             wm_aws_run_service(cur_service);
             free(log_info);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -72,31 +72,58 @@ void* wm_aws_main(wm_aws *aws_config) {
         time_start = time(NULL);
 
         for (cur_bucket = aws_config->buckets; cur_bucket; cur_bucket = cur_bucket->next) {
-            if (cur_bucket->aws_account_id && cur_bucket->type && cur_bucket->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket %s Analysis: [%s] %s (%s)", cur_bucket->bucket, cur_bucket->type,
-                    cur_bucket->aws_account_alias, cur_bucket->aws_account_id);
-            } else if (cur_bucket->aws_account_id && cur_bucket->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket %s Analysis: [%s] %s", cur_bucket->bucket, cur_bucket->type,
-                    cur_bucket->aws_account_id);
-            } else if (cur_bucket->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket %s Analysis: [%s]", cur_bucket->bucket, cur_bucket->type);
+            if (cur_bucket->trail_prefix && cur_bucket->aws_account_id && cur_bucket->aws_account_alias) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account ID: %s, Account Alias: %s)",
+                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_id,
+                    cur_bucket->aws_account_alias);
+            } else if (cur_bucket->trail_prefix && cur_bucket->aws_account_id) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account ID: %s)",
+                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_id);
+            } else if (cur_bucket->trail_prefix && cur_bucket->aws_account_alias) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account Alias: %s)",
+                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_alias);
+            } else if (cur_bucket->trail_prefix && cur_bucket->aws_profile) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Profile: %s)",
+                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_profile);
+            } else if (cur_bucket->trail_prefix && cur_bucket->aws_organization_id) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Organization ID: %s)",
+                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_organization_id);
+            } else if (cur_bucket->aws_account_id) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Account ID: %s)",
+                    cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_account_id);
+            } else if (cur_bucket->aws_account_alias) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Account Alias: %s)",
+                    cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_account_alias);
+            } else if (cur_bucket->aws_profile) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Profile: %s)",
+                    cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_profile);
+            } else if (cur_bucket->aws_organization_id) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Organization ID: %s)",
+                    cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_organization_id);
+            } else if (cur_bucket->trail_prefix) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s)",
+                    cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type);
             } else {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket %s Analysis", cur_bucket->bucket);
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s)", cur_bucket->bucket, cur_bucket->type);
             }
             wm_aws_run_s3(cur_bucket);
         }
 
         for (cur_service = aws_config->services; cur_service; cur_service = cur_service->next) {
-            if (cur_service->aws_account_id && cur_service->type && cur_service->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service %s Analysis: [%s] %s (%s)", cur_service->type, cur_service->type,
-                    cur_service->aws_account_alias, cur_service->aws_account_id);
-            } else if (cur_service->aws_account_id && cur_service->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service %s Analysis: [%s] %s", cur_service->type, cur_service->type,
-                    cur_service->aws_account_id);
-            } else if (cur_service->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service %s Analysis: [%s] ", cur_service->type, cur_service->type);
+            if (cur_service->aws_account_id && cur_service->aws_account_alias) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account ID: %s, Account Alias: %s)",
+                    cur_service->type, cur_service->aws_account_id, cur_service->aws_account_alias);
+            } else if (cur_service->aws_account_id) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account ID: %s)",
+                    cur_service->type, cur_service->aws_account_id);
+            } else if (cur_service->aws_account_alias) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account Alias: %s)",
+                    cur_service->type, cur_service->aws_account_alias);
+            } else if (cur_service->aws_profile) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Profile: %s)",
+                    cur_service->type, cur_service->aws_profile);
             } else {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service %s Analysis", cur_service->type);
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s)", cur_service->type);
             }
             wm_aws_run_service(cur_service);
         }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -72,57 +72,59 @@ void* wm_aws_main(wm_aws *aws_config) {
         time_start = time(NULL);
 
         for (cur_bucket = aws_config->buckets; cur_bucket; cur_bucket = cur_bucket->next) {
-            if (cur_bucket->trail_prefix && cur_bucket->aws_account_id && cur_bucket->aws_account_alias) {
+            if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->aws_account_id && cur_bucket->type &&
+                cur_bucket->aws_account_alias) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account ID: %s, Account Alias: %s)",
                     cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_id,
                     cur_bucket->aws_account_alias);
-            } else if (cur_bucket->trail_prefix && cur_bucket->aws_account_id) {
+            } else if (cur_bucket->bucket && cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type &&
+                cur_bucket->aws_account_id) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account ID: %s)",
                     cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_id);
-            } else if (cur_bucket->trail_prefix && cur_bucket->aws_account_alias) {
+            } else if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type && cur_bucket->aws_account_alias) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Account Alias: %s)",
                     cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_account_alias);
-            } else if (cur_bucket->trail_prefix && cur_bucket->aws_profile) {
+            } else if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type && cur_bucket->aws_profile) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Profile: %s)",
                     cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_profile);
-            } else if (cur_bucket->trail_prefix && cur_bucket->aws_organization_id) {
+            } else if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type && cur_bucket->aws_organization_id) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s, Organization ID: %s)",
                     cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type, cur_bucket->aws_organization_id);
-            } else if (cur_bucket->aws_account_id) {
+            } else if (cur_bucket->bucket && cur_bucket->type && cur_bucket->aws_account_id) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Account ID: %s)",
                     cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_account_id);
-            } else if (cur_bucket->aws_account_alias) {
+            } else if (cur_bucket->bucket && cur_bucket->type && cur_bucket->aws_account_alias) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Account Alias: %s)",
                     cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_account_alias);
-            } else if (cur_bucket->aws_profile) {
+            } else if (cur_bucket->bucket && cur_bucket->type && cur_bucket->aws_profile) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Profile: %s)",
                     cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_profile);
-            } else if (cur_bucket->aws_organization_id) {
+            } else if (cur_bucket->bucket && cur_bucket->type && cur_bucket->aws_organization_id) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s, Organization ID: %s)",
                     cur_bucket->bucket, cur_bucket->type, cur_bucket->aws_organization_id);
-            } else if (cur_bucket->trail_prefix) {
+            } else if (cur_bucket->bucket && cur_bucket->trail_prefix && cur_bucket->type) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Path: %s, Type: %s)",
                     cur_bucket->bucket, cur_bucket->trail_prefix, cur_bucket->type);
-            } else {
+            } else if (cur_bucket->bucket && cur_bucket->type) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: (Bucket: %s, Type: %s)", cur_bucket->bucket, cur_bucket->type);
             }
             wm_aws_run_s3(cur_bucket);
         }
 
         for (cur_service = aws_config->services; cur_service; cur_service = cur_service->next) {
-            if (cur_service->aws_account_id && cur_service->aws_account_alias) {
+            if (cur_service->type && cur_service->aws_account_id && cur_service->aws_account_alias) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account ID: %s, Account Alias: %s)",
                     cur_service->type, cur_service->aws_account_id, cur_service->aws_account_alias);
-            } else if (cur_service->aws_account_id) {
+            } else if (cur_service->type && cur_service->aws_account_id) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account ID: %s)",
                     cur_service->type, cur_service->aws_account_id);
-            } else if (cur_service->aws_account_alias) {
+            } else if (cur_service->type && cur_service->aws_account_alias) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Account Alias: %s)",
                     cur_service->type, cur_service->aws_account_alias);
-            } else if (cur_service->aws_profile) {
+            } else if (cur_service->type && cur_service->aws_profile) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s, Profile: %s)",
                     cur_service->type, cur_service->aws_profile);
-            } else {
+            } else if (cur_service->type) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: (Service: %s)", cur_service->type);
             }
             wm_aws_run_service(cur_service);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -76,6 +76,8 @@ void* wm_aws_main(wm_aws *aws_config) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: [%s] %s (%s)", cur_bucket->type, cur_bucket->aws_account_alias, cur_bucket->aws_account_id);
             } else if (cur_bucket->aws_account_id && cur_bucket->type) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: [%s] %s", cur_bucket->type, cur_bucket->aws_account_id);
+            } else if (cur_bucket->type) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: [%s]", cur_bucket->type);
             } else {
                 mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: %s", cur_bucket->bucket);
             }
@@ -87,6 +89,8 @@ void* wm_aws_main(wm_aws *aws_config) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] %s (%s)", cur_service->type, cur_service->aws_account_alias, cur_service->aws_account_id);
             } else if (cur_service->aws_account_id && cur_service->type) {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] %s", cur_service->type, cur_service->aws_account_id);
+            } else if (cur_service->type) {
+                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] ", cur_service->type);
             } else {
                 mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: %s", cur_service->type);
             }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -132,7 +132,7 @@ void* wm_aws_main(wm_aws *aws_config) {
                 wm_strcat(&log_info, cur_service->aws_account_alias, ' ');
             }
 
-            if (cur_service->aws_account_id) {
+            if (cur_service->aws_profile) {
                 wm_strcat(&log_info, ", Profile:", '\0');
                 wm_strcat(&log_info, cur_service->aws_profile, ' ');
             }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -78,7 +78,13 @@ void* wm_aws_main(wm_aws *aws_config) {
             log_info = NULL;
 
             wm_strcat(&log_info, "Executing Bucket Analysis: (Bucket:", '\0');
-            wm_strcat(&log_info, cur_bucket->bucket, ' ');
+            if (cur_bucket->bucket) {
+                wm_strcat(&log_info, cur_bucket->bucket, ' ');
+            }
+            else {
+                wm_strcat(&log_info, "unknown_bucket", ' ');
+            }
+
 
             if (cur_bucket->trail_prefix) {
                 wm_strcat(&log_info, ", Path:", '\0');
@@ -122,7 +128,13 @@ void* wm_aws_main(wm_aws *aws_config) {
             log_info = NULL;
 
             wm_strcat(&log_info, "Executing Service Analysis: (Service:", '\0');
-            wm_strcat(&log_info, cur_service->type, ' ');
+            if (cur_service->type) {
+                wm_strcat(&log_info, cur_service->type, ' ');
+            }
+            else {
+                wm_strcat(&log_info, "unknown_type", ' ');
+            }
+
 
             if (cur_service->aws_account_id) {
                 wm_strcat(&log_info, ", Account ID:", '\0');

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -73,26 +73,30 @@ void* wm_aws_main(wm_aws *aws_config) {
 
         for (cur_bucket = aws_config->buckets; cur_bucket; cur_bucket = cur_bucket->next) {
             if (cur_bucket->aws_account_id && cur_bucket->type && cur_bucket->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: [%s] %s (%s)", cur_bucket->type, cur_bucket->aws_account_alias, cur_bucket->aws_account_id);
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket %s Analysis: [%s] %s (%s)", cur_bucket->bucket, cur_bucket->type,
+                    cur_bucket->aws_account_alias, cur_bucket->aws_account_id);
             } else if (cur_bucket->aws_account_id && cur_bucket->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: [%s] %s", cur_bucket->type, cur_bucket->aws_account_id);
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket %s Analysis: [%s] %s", cur_bucket->bucket, cur_bucket->type,
+                    cur_bucket->aws_account_id);
             } else if (cur_bucket->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: [%s]", cur_bucket->type);
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket %s Analysis: [%s]", cur_bucket->bucket, cur_bucket->type);
             } else {
-                mtinfo(WM_AWS_LOGTAG, "Executing Bucket Analysis: %s", cur_bucket->bucket);
+                mtinfo(WM_AWS_LOGTAG, "Executing Bucket %s Analysis", cur_bucket->bucket);
             }
             wm_aws_run_s3(cur_bucket);
         }
 
         for (cur_service = aws_config->services; cur_service; cur_service = cur_service->next) {
             if (cur_service->aws_account_id && cur_service->type && cur_service->aws_account_alias) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] %s (%s)", cur_service->type, cur_service->aws_account_alias, cur_service->aws_account_id);
+                mtinfo(WM_AWS_LOGTAG, "Executing Service %s Analysis: [%s] %s (%s)", cur_service->type, cur_service->type,
+                    cur_service->aws_account_alias, cur_service->aws_account_id);
             } else if (cur_service->aws_account_id && cur_service->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] %s", cur_service->type, cur_service->aws_account_id);
+                mtinfo(WM_AWS_LOGTAG, "Executing Service %s Analysis: [%s] %s", cur_service->type, cur_service->type,
+                    cur_service->aws_account_id);
             } else if (cur_service->type) {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: [%s] ", cur_service->type);
+                mtinfo(WM_AWS_LOGTAG, "Executing Service %s Analysis: [%s] ", cur_service->type, cur_service->type);
             } else {
-                mtinfo(WM_AWS_LOGTAG, "Executing Service Analysis: %s", cur_service->type);
+                mtinfo(WM_AWS_LOGTAG, "Executing Service %s Analysis", cur_service->type);
             }
             wm_aws_run_service(cur_service);
         }


### PR DESCRIPTION
Hi team,

This PR closes #3095. I made a change for showing the type of the bucket which is being analysed in `ossec.log`:

```bash
2019/04/16 11:11:56 wazuh-modulesd:aws-s3: INFO: Module AWS started
2019/04/16 11:11:56 wazuh-modulesd:aws-s3: INFO: Starting fetching of logs.
2019/04/16 11:11:56 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: (Bucket: wazuh-cloudtrail, Type: cloudtrail, Profile: default)
2019/04/16 11:12:03 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: (Bucket: wazuh-aws-wodle, Path: config, Type: config)
2019/04/16 11:12:04 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: (Bucket: wazuh-aws-wodle, Path: vpc, Type: vpcflow)
2019/04/16 11:12:08 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: (Bucket: wazuh-aws-wodle, Path: kms_compress_encrypted, Type: custom)
2019/04/16 11:12:10 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: (Bucket: wazuh-aws-wodle, Path: macie, Type: custom)
2019/04/16 11:12:13 wazuh-modulesd:aws-s3: INFO: Executing Service Analysis: (Service: inspector)
2019/04/16 11:12:17 wazuh-modulesd:aws-s3: INFO: Fetching logs finished.

```

Best regards,

Demetrio.