### PR TITLE
Change SCA db check from md5 to sha256

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -954,7 +954,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             /* Integrity check */
             if(strcmp(wdb_response,hash->valuestring)) {
 
-                mdebug2("MD5 from DB: %s MD5 from summary: %s",wdb_response,hash->valuestring);
+                mdebug2("SHA256 from DB: %s SHA256 from summary: %s",wdb_response,hash->valuestring);
                 mdebug2("Requesting DB dump");
 
                 if (!first_scan) {
@@ -991,7 +991,7 @@ static void HandleDumpEvent(Eventinfo *lf,int *socket,cJSON *event) {
                 break;
         }
 
-        /* Check the new md5 */
+        /* Check the new sha256 */
         char *wdb_response = NULL;
         os_calloc(OS_MAXSTR,sizeof(char),wdb_response);
 
@@ -1011,7 +1011,7 @@ static void HandleDumpEvent(Eventinfo *lf,int *socket,cJSON *event) {
                 /* Integrity check */
                 if(strcmp(wdb_response, hash_sha256)) {
 
-                    mdebug2("MD5 from DB: %s MD5 from summary: %s", wdb_response, hash_sha256);
+                    mdebug2("SHA256 from DB: %s SHA256 from summary: %s", wdb_response, hash_sha256);
                     mdebug2("Requesting DB dump");
                     PushDumpRequest(lf->agent_id,policy_id->valuestring,0);
                 }

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -18,7 +18,7 @@
 #include "plugin_decoders.h"
 #include "wazuh_modules/wmodules.h"
 #include "os_net/os_net.h"
-#include "os_crypto/md5/md5_op.h"
+#include "os_crypto/sha256/sha256_op.h"
 #include "string_op.h"
 #include "../../remoted/remoted.h"
 #include <time.h>
@@ -836,13 +836,13 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
 
     int result_event = 0;
     char *hash_scan_info = NULL;
-    os_md5 hash_md5 = {0};
+    os_sha256 hash_sha256 = {0};
     os_calloc(OS_MAXSTR,sizeof(char),hash_scan_info);
     
     int result_db = FindScanInfo(lf,policy_id->valuestring,socket,hash_scan_info);
 
     int scan_id_old = 0;
-    sscanf(hash_scan_info,"%s %d",hash_md5,&scan_id_old);
+    sscanf(hash_scan_info, "%s %d", hash_sha256, &scan_id_old);
 
     switch (result_db)
     {
@@ -858,7 +858,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             } else {
 
                 /* Compare hash with previous hash */
-                if(strcmp(hash_md5,hash->valuestring)) {
+                if(strcmp(hash_sha256, hash->valuestring)) {
                     if (!first_scan) {
                         FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,score,file,policy_id);
                     }
@@ -878,7 +878,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             } else {
 
                 /* Compare hash with previous hash */
-                if(strcmp(hash_md5,hash->valuestring)) {
+                if(strcmp(hash_sha256, hash->valuestring)) {
                     if (!first_scan) {
                         FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,score,file,policy_id);
                        
@@ -1000,18 +1000,18 @@ static void HandleDumpEvent(Eventinfo *lf,int *socket,cJSON *event) {
         if (!result_db)
         {   
             char *hash_scan_info = NULL;
-            os_md5 hash_md5 = {0};
+            os_sha256 hash_sha256 = {0};
             os_calloc(OS_MAXSTR,sizeof(char),hash_scan_info);
             
             int result_db_hash = FindScanInfo(lf,policy_id->valuestring,socket,hash_scan_info);
-            sscanf(hash_scan_info,"%s",hash_md5);
+            sscanf(hash_scan_info, "%s", hash_sha256);
 
             if(!result_db_hash) {
             
                 /* Integrity check */
-                if(strcmp(wdb_response,hash_md5)) {
+                if(strcmp(wdb_response, hash_sha256)) {
 
-                    mdebug2("MD5 from DB: %s MD5 from summary: %s",wdb_response,hash_md5);
+                    mdebug2("MD5 from DB: %s MD5 from summary: %s", wdb_response, hash_sha256);
                     mdebug2("Requesting DB dump");
                     PushDumpRequest(lf->agent_id,policy_id->valuestring,0);
                 }

--- a/src/wazuh_db/wdb_sca.c
+++ b/src/wazuh_db/wdb_sca.c
@@ -10,7 +10,7 @@
  */
 
 #include "wdb.h"
-#include "os_crypto/md5/md5_op.h"
+#include "os_crypto/sha256/sha256_op.h"
 
 static const char *SQL_INSERT_PM = "INSERT INTO pm_event (date_first, date_last, log, pci_dss, cis) VALUES (datetime(?, 'unixepoch', 'localtime'), datetime(?, 'unixepoch', 'localtime'), ?, ?, ?);";
 static const char *SQL_UPDATE_PM = "UPDATE pm_event SET date_last = datetime(?, 'unixepoch', 'localtime') WHERE log = ?;";
@@ -747,9 +747,9 @@ int wdb_sca_checks_get_result(wdb_t * wdb, char * policy_id, char * output) {
 end:
     if(has_result) {
         if(str) {
-            os_md5 md5_hash;
-            OS_MD5_Str(str,-1,md5_hash);
-            snprintf(output,OS_MAXSTR,"%s",md5_hash);
+            os_sha256 hash;
+            OS_SHA256_String(str,hash);
+            snprintf(output,OS_MAXSTR,"%s",hash);
             os_free(str);
         }
         return 1;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -11,7 +11,7 @@
 
 #include "wmodules.h"
 #include <os_net/os_net.h>
-#include "os_crypto/md5/md5_op.h"
+#include "os_crypto/sha256/sha256_op.h"
 #include "shared.h"
 
 
@@ -99,7 +99,7 @@ static unsigned int summary_passed = 0;
 static unsigned int summary_failed = 0;
 
 OSHash **cis_db;
-char **last_md5;
+char **last_sha256;
 cis_db_hash_info_t *cis_db_for_hash;
 
 static w_queue_t * request_queue;
@@ -175,8 +175,8 @@ void * wm_sca_main(wm_sca_t * data) {
     /* Create summary hash for each policy file */
     if(data->profile){
         for(i = 0; data->profile[i]; i++) {
-            os_realloc(last_md5, (i + 2) * sizeof(char *), last_md5);
-            os_calloc(1,sizeof(os_md5),last_md5[i]);
+            os_realloc(last_sha256, (i + 2) * sizeof(char *), last_sha256);
+            os_calloc(1,sizeof(os_sha256),last_sha256[i]);
         }
     }
 
@@ -525,7 +525,7 @@ static void wm_sca_read_files(wm_sca_t * data) {
                 if(integrity_hash) {
                     wm_delay(1000 * data->summary_delay);
                     wm_sca_send_summary(data,id,summary_passed,summary_failed,policy,time_start,time_end,integrity_hash,first_scan,cis_db_index);
-                    snprintf(last_md5[cis_db_index] ,sizeof(os_md5),"%s",integrity_hash);
+                    snprintf(last_sha256[cis_db_index] ,sizeof(os_sha256),"%s",integrity_hash);
                     os_free(integrity_hash);
                 }
 
@@ -2555,7 +2555,6 @@ static void wm_sca_free_hash_data(cis_db_info_t *event) {
 }
 
 static char *wm_sca_hash_integrity(int policy_index) {
-    os_md5 md5_hash;
     char *str = NULL;
 
     int i;
@@ -2569,9 +2568,10 @@ static char *wm_sca_hash_integrity(int policy_index) {
     }
 
     if(str) {
-        OS_MD5_Str(str,-1,md5_hash);
+        os_sha256 hash;
+        OS_SHA256_String(str, hash);
         os_free(str);
-        return strdup(md5_hash);
+        return strdup(hash);
     }
 
     return NULL;


### PR DESCRIPTION
This PR changes the hash function used to check for changes in the SCA DB, solving issue #3110.