### PR TITLE
Delete database from Wazuh-DB for removed agents

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -369,7 +369,7 @@ wazuh_db.sock_queue_size=128
 # Number of worker threads (1..32)
 wazuh_db.worker_pool_size=8
 
-# Time margin before committing (1..3600)
+# Time margin before committing (10..3600)
 wazuh_db.commit_time=60
 
 # Number of allowed open databases before closing (1..4096)

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -17,7 +17,7 @@
 #include "external/cJSON/cJSON.h"
 #include <stdlib.h>
 
-#if defined(__MINGW32__) || defined(__hppa__)
+#if defined(__hppa__)
 static int setenv(const char *name, const char *val, __attribute__((unused)) int overwrite)
 {
     int len = strlen(name) + strlen(val) + 2;
@@ -71,6 +71,8 @@ char *chomp(char *str)
 
     return (str);
 }
+
+#ifndef CLIENT
 
 int add_agent(int json_output, int no_limit)
 {
@@ -562,6 +564,8 @@ cleanup:
     auth_close(sock);
     return 0;
 }
+
+#endif
 
 int list_agents(int cmdlist)
 {

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -166,7 +166,7 @@ int OS_RemoveAgent(const char *u_id) {
     wdb_send_query(wdbquery, &wdboutput);
 
     if (wdboutput) {
-        minfo("Wazuh-db output delete: '%s'", wdboutput);
+        mdebug1("DB from agent %s was deleted '%s'", u_id, wdboutput);
         os_free(wdboutput);
     }
 

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -162,7 +162,6 @@ int OS_RemoveAgent(const char *u_id) {
     }
 
     // Remove DB from wazuh-db
-
     snprintf(wdbquery, OS_SIZE_128, "agent %s remove", u_id);
     wdb_send_query(wdbquery, &wdboutput);
 

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -11,9 +11,9 @@
 #include "manage_agents.h"
 #include "os_crypto/md5/md5_op.h"
 #include "os_crypto/sha256/sha256_op.h"
-#include "wazuhdb_op.h"
 #ifndef CLIENT
 #include "wazuh_db/wdb.h"
+#include "wazuhdb_op.h"
 #endif
 
 #define str_startwith(x, y) strncmp(x, y, strlen(y))
@@ -60,6 +60,8 @@ int OS_AddNewAgent(keystore *keys, const char *id, const char *name, const char 
 
     return OS_AddKey(keys, id, name, ip ? ip : "any", key);
 }
+
+#ifndef CLIENT
 
 int OS_RemoveAgent(const char *u_id) {
     FILE *fp;
@@ -177,6 +179,9 @@ int OS_RemoveAgent(const char *u_id) {
     OS_RemoveAgentGroup(u_id);
     return 1;
 }
+
+#endif
+
 
 int OS_IsValidID(const char *id)
 {

--- a/src/headers/wazuhdb_op.h
+++ b/src/headers/wazuhdb_op.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2015-2019, Wazuh Inc.
+ * April 15, 2019.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "shared.h"
+#include "os_net/os_net.h"
+
+
+int wdb_send_query(char *wazuhdb_query, char **output);

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -996,7 +996,6 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                         minfo("Duplicated IP '%s' (%s). Saving backup.", srcip, id_exist);
 
                         snprintf(wdbquery, OS_SIZE_128, "agent %s remove", id_exist);
-                        minfo("fixwdb: %s", wdbquery);
                         wdb_send_query(wdbquery, &wdboutput);
 
                         if (wdboutput) {

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -28,6 +28,7 @@
 #include <sys/wait.h>
 #include "check_cert.h"
 #include "os_crypto/md5/md5_op.h"
+#include "wazuhdb_op.h"
 
 /* Prototypes */
 static void help_authd(void) __attribute((noreturn));
@@ -612,6 +613,8 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
     char *id_exist = NULL;
     char * buf = NULL;
     int index;
+    char wdbquery[OS_SIZE_128];
+    char *wdboutput;
 
     authd_sigblock();
 
@@ -991,6 +994,15 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                     if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
                         id_exist = keys.keyentries[index]->id;
                         minfo("Duplicated IP '%s' (%s). Saving backup.", srcip, id_exist);
+
+                        snprintf(wdbquery, OS_SIZE_128, "agent %s remove", id_exist);
+                        minfo("fixwdb: %s", wdbquery);
+                        wdb_send_query(wdbquery, &wdboutput);
+
+                        if (wdboutput) {
+                            os_free(wdboutput);
+                        }
+
                         OS_RemoveAgentGroup(id_exist);
                         add_backup(keys.keyentries[index]);
                         OS_DeleteKey(&keys, id_exist, 0);
@@ -1030,6 +1042,14 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                 if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
                     id_exist = keys.keyentries[index]->id;
                     minfo("Duplicated name '%s' (%s). Saving backup.", agentname, id_exist);
+
+                    snprintf(wdbquery, OS_SIZE_128, "agent %s remove", id_exist);
+                    wdb_send_query(wdbquery, &wdboutput);
+
+                    if (wdboutput) {
+                        os_free(wdboutput);
+                    }
+
                     add_backup(keys.keyentries[index]);
                     OS_DeleteKey(&keys, id_exist, 0);
                 } else {

--- a/src/shared/auth_client.c
+++ b/src/shared/auth_client.c
@@ -12,11 +12,14 @@
 #include "shared.h"
 #include <os_net/os_net.h>
 #include <external/cJSON/cJSON.h>
+#include "wazuhdb_op.h"
 
 // Remove agent. Returns 0 on success or -1 on error.
 int auth_remove_agent(int sock, const char *id, int json_format) {
     char buffer[OS_MAXSTR + 1];
     char *output;
+    char wdbquery[OS_SIZE_128 + 1];
+    char *wdboutput;
     int result;
     ssize_t length;
     cJSON *response;
@@ -28,6 +31,14 @@ int auth_remove_agent(int sock, const char *id, int json_format) {
     cJSON_AddItemToObject(request, "arguments", arguments);
     cJSON_AddStringToObject(request, "function", "remove");
     cJSON_AddStringToObject(arguments, "id", id);
+
+    snprintf(wdbquery, OS_SIZE_128, "agent %s remove", id);
+    wdb_send_query(wdbquery, &wdboutput);
+
+    if (wdboutput) {
+        minfo("Wazuh-db output delete: '%s'", wdboutput);
+        os_free(wdboutput);
+    }
 
     output = cJSON_PrintUnformatted(request);
 

--- a/src/shared/auth_client.c
+++ b/src/shared/auth_client.c
@@ -18,7 +18,7 @@
 int auth_remove_agent(int sock, const char *id, int json_format) {
     char buffer[OS_MAXSTR + 1];
     char *output;
-    char wdbquery[OS_SIZE_128 + 1];
+    char wdbquery[OS_SIZE_128];
     char *wdboutput;
     int result;
     ssize_t length;
@@ -74,7 +74,6 @@ int auth_remove_agent(int sock, const char *id, int json_format) {
             wdb_send_query(wdbquery, &wdboutput);
 
             if (wdboutput) {
-                minfo("Wazuh-db output delete: '%s'", wdboutput);
                 os_free(wdboutput);
             }
         }

--- a/src/shared/auth_client.c
+++ b/src/shared/auth_client.c
@@ -9,6 +9,8 @@
  * Foundation.
  */
 
+#ifndef CLIENT
+
 #include "shared.h"
 #include <os_net/os_net.h>
 #include <external/cJSON/cJSON.h>
@@ -83,3 +85,5 @@ int auth_remove_agent(int sock, const char *id, int json_format) {
 
     return result;
 }
+
+#endif

--- a/src/shared/auth_client.c
+++ b/src/shared/auth_client.c
@@ -32,14 +32,6 @@ int auth_remove_agent(int sock, const char *id, int json_format) {
     cJSON_AddStringToObject(request, "function", "remove");
     cJSON_AddStringToObject(arguments, "id", id);
 
-    snprintf(wdbquery, OS_SIZE_128, "agent %s remove", id);
-    wdb_send_query(wdbquery, &wdboutput);
-
-    if (wdboutput) {
-        minfo("Wazuh-db output delete: '%s'", wdboutput);
-        os_free(wdboutput);
-    }
-
     output = cJSON_PrintUnformatted(request);
 
     if (OS_SendSecureTCP(sock, strlen(output), output) < 0) {
@@ -77,6 +69,14 @@ int auth_remove_agent(int sock, const char *id, int json_format) {
             result = -1;
         } else {
             result = 0;
+
+            snprintf(wdbquery, OS_SIZE_128, "agent %s remove", id);
+            wdb_send_query(wdbquery, &wdboutput);
+
+            if (wdboutput) {
+                minfo("Wazuh-db output delete: '%s'", wdboutput);
+                os_free(wdboutput);
+            }
         }
 
         cJSON_Delete(response);

--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015-2019, Wazuh Inc.
+ * April 15, 2019.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wazuhdb_op.h"
+
+
+int wdb_send_query(char *wazuhdb_query, char **output) {
+    struct timeval timeout = {0, 1000};
+    fd_set fdset;
+    char response[OS_SIZE_6144];
+    int wdb_socket = -1;
+    int size = strlen(wazuhdb_query);
+    int retval = -2;
+    int attempts;
+
+    // Connect to socket if disconnected
+    if (wdb_socket < 0) {
+        for (attempts = 1; attempts <= 3 && (wdb_socket = OS_ConnectUnixDomain(WDB_LOCAL_SOCK, SOCK_STREAM, OS_SIZE_6144)) < 0; attempts++) {
+            switch (errno) {
+            case ENOENT:
+                mtinfo(ARGV0, "Cannot find '%s'. Waiting %d seconds to reconnect.", WDB_LOCAL_SOCK, attempts);
+                break;
+            default:
+                mtinfo(ARGV0, "Cannot connect to '%s': %s (%d). Waiting %d seconds to reconnect.", WDB_LOCAL_SOCK, strerror(errno), errno, attempts);
+            }
+            sleep(attempts);
+        }
+
+        if (wdb_socket < 0) {
+            mterror(ARGV0, "Unable to connect to socket '%s'.", WDB_LOCAL_SOCK);
+            return retval;
+        }
+    }
+
+    // Send query to Wazuh DB
+    if (OS_SendSecureTCP(wdb_socket, size + 1, wazuhdb_query) != 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            mterror(ARGV0, "database socket is full");
+        } else if (errno == EPIPE) {
+            // Retry to connect
+            mterror(ARGV0, "Connection with wazuh-db lost. Reconnecting.");
+            close(wdb_socket);
+
+            if (wdb_socket = OS_ConnectUnixDomain(WDB_LOCAL_SOCK, SOCK_STREAM, OS_SIZE_6144), wdb_socket < 0) {
+                switch (errno) {
+                case ENOENT:
+                    mterror(ARGV0, "Cannot find '%s'. Please check that Wazuh DB is running.", WDB_LOCAL_SOCK);
+                    break;
+                default:
+                    mterror(ARGV0, "Cannot connect to '%s': %s (%d)", WDB_LOCAL_SOCK, strerror(errno), errno);
+                }
+                return retval;
+            }
+
+            if (OS_SendSecureTCP(wdb_socket, size + 1, wazuhdb_query)) {
+                mterror(ARGV0, "in send reattempt (%d) '%s'.", errno, strerror(errno));
+                return retval;
+            }
+        } else {
+            mterror(ARGV0, "in send (%d) '%s'.", errno, strerror(errno));
+            return retval;
+        }
+    }
+
+    // Wait for socket
+    FD_ZERO(&fdset);
+    FD_SET(wdb_socket, &fdset);
+
+    if (select(wdb_socket + 1, &fdset, NULL, NULL, &timeout) < 0) {
+        mterror(ARGV0, "in select (%d) '%s'.", errno, strerror(errno));
+        return retval;
+    }
+    retval = -1;
+
+    // Receive response from socket
+    if (OS_RecvSecureTCP(wdb_socket, response, OS_SIZE_6144 - 1) > 0) {
+        os_strdup(response, *output);
+
+        if (response[0] == 'o' && response[1] == 'k') {
+            retval = 0;
+        } else {
+            mterror(ARGV0, "Bad response '%s'.", response);
+        }
+    } else {
+        mterror(ARGV0, "no response from wazuh-db.");
+    }
+
+    return retval;
+}

--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -8,6 +8,8 @@
  * Foundation.
  */
 
+#ifndef CLIENT
+
 #include "wazuhdb_op.h"
 
 
@@ -94,3 +96,5 @@ int wdb_send_query(char *wazuhdb_query, char **output) {
 
     return retval;
 }
+
+#endif

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -78,7 +78,7 @@ int main(int argc, char ** argv) {
 
     config.sock_queue_size = getDefine_Int("wazuh_db", "sock_queue_size", 1, 1024);
     config.worker_pool_size = getDefine_Int("wazuh_db", "worker_pool_size", 1, 32);
-    config.commit_time = getDefine_Int("wazuh_db", "commit_time", 1, 3600);
+    config.commit_time = getDefine_Int("wazuh_db", "commit_time", 10, 3600);
     config.open_db_limit = getDefine_Int("wazuh_db", "open_db_limit", 1, 4096);
     nofile = getDefine_Int("wazuh_db", "rlimit_nofile", 1024, 1048576);
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -189,6 +189,9 @@ wdb_t * wdb_open_agent2(int agent_id) {
     if (wdb = (wdb_t *)OSHash_Get(open_dbs, sagent_id), wdb) {
         // Checking if database was removed to avoid create it again
         if (wdb->remove) {
+            w_mutex_lock(&wdb->mutex);
+            wdb->last = time(NULL);
+            w_mutex_unlock(&wdb->mutex);
             w_mutex_unlock(&pool_mutex);
             return wdb;
         }

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -654,6 +654,8 @@ void wdb_commit_old() {
             mdebug2("Committing database for agent %s", node->agent_id);
             if (node->remove) {
                 wdb_close(node);
+                w_mutex_unlock(&pool_mutex);
+                return;
             } else {
                 wdb_commit2(node);
             }

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -122,6 +122,7 @@ typedef struct wdb_t {
     time_t last;
     pthread_mutex_t mutex;
     struct wdb_t * next;
+    int removed;
 } wdb_t;
 
 typedef struct wdb_config {
@@ -487,6 +488,8 @@ void wdb_close_all();
 void wdb_commit_old();
 
 void wdb_close_old();
+
+int wdb_remove_database(wdb_t *wdb);
 
 cJSON * wdb_exec(sqlite3 * db, const char * sql);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -294,8 +294,8 @@ int wdb_update_groups(const char *dirname);
 /* Delete agent. It opens and closes the DB. Returns 0 on success or -1 on error. */
 int wdb_remove_agent(int id);
 
-/* Remove agents databases from id's list. */ 
-int wdb_remove_multiple_agents(char *agent_list);
+/* Remove agents databases from id's list. */
+cJSON *wdb_remove_multiple_agents(char *agent_list);
 
 /* Delete group. It opens and closes the DB. Returns 0 on success or -1 on error. */
 int wdb_remove_group_db(const char *name);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -122,7 +122,7 @@ typedef struct wdb_t {
     time_t last;
     pthread_mutex_t mutex;
     struct wdb_t * next;
-    int removed;
+    int remove;
 } wdb_t;
 
 typedef struct wdb_config {
@@ -489,7 +489,7 @@ void wdb_commit_old();
 
 void wdb_close_old();
 
-int wdb_remove_database(wdb_t *wdb);
+void wdb_remove_database(wdb_t *wdb);
 
 cJSON * wdb_exec(sqlite3 * db, const char * sql);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -294,6 +294,9 @@ int wdb_update_groups(const char *dirname);
 /* Delete agent. It opens and closes the DB. Returns 0 on success or -1 on error. */
 int wdb_remove_agent(int id);
 
+/* Remove agents databases from id's list. */ 
+int wdb_remove_multiple_agents(char *agent_list);
+
 /* Delete group. It opens and closes the DB. Returns 0 on success or -1 on error. */
 int wdb_remove_group_db(const char *name);
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -72,6 +72,11 @@ int wdb_parse(char * input, char * output) {
             return -1;
         }
 
+        if (wdb->removed) {
+            minfo("Message received from an deleted agent('%s'), ignoring", wdb->agent_id);
+            return 0;
+        }
+
         mdebug2("Agent %s query: %s", sagent_id, query);
 
         if (next = wstr_chr(query, ' '), next) {
@@ -239,6 +244,16 @@ int wdb_parse(char * input, char * output) {
                     result = -1;
                 }
             }
+        } else if (strcmp(query, "remove") == 0) {
+            if (wdb_remove_database(wdb) < 0) {
+                mdebug1("DB(%s) Cannot begin transaction.", sagent_id);
+                snprintf(output, OS_MAXSTR + 1, "err Cannot begin transaction");
+                result = -1;
+            } else {
+                snprintf(output, OS_MAXSTR + 1, "ok");
+                result = -1;
+            }
+            return result;
         } else if (strcmp(query, "begin") == 0) {
             if (wdb_begin2(wdb) < 0) {
                 mdebug1("DB(%s) Cannot begin transaction.", sagent_id);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -288,6 +288,26 @@ int wdb_parse(char * input, char * output) {
         }
         wdb_leave(wdb);
         return result;
+    } else if (strcmp(actor, "wazuhdb") == 0) {
+        query = next;
+
+        if (next = wstr_chr(query, ' '), !next) {
+            mdebug1("Invalid DB query syntax.");
+            mdebug2("DB query error near: %s", query);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+            return -1;
+        }
+        *next++ = '\0';
+
+        if(strcmp(query, "remove") == 0) {
+            wdb_remove_multiple_agents(next);
+        } else {
+            mdebug1("Invalid DB query syntax.");
+            mdebug2("DB query error near: %s", query);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+            return -1;
+        }
+        return result;
     } else {
         mdebug1("DB(%s) Invalid DB query actor: %s", sagent_id, actor);
         snprintf(output, OS_MAXSTR + 1, "err Invalid DB query actor: '%.32s'", actor);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -308,7 +308,7 @@ int wdb_parse(char * input, char * output) {
         } else {
             mdebug1("Invalid DB query syntax.");
             mdebug2("DB query error near: %s", query);
-            snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+            snprintf(output, OS_MAXSTR + 1, "err No agents id provided");
             return -1;
         }
         return result;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -251,7 +251,7 @@ int wdb_parse(char * input, char * output) {
                 result = -1;
             } else {
                 snprintf(output, OS_MAXSTR + 1, "ok");
-                result = -1;
+                result = 0;
             }
             return result;
         } else if (strcmp(query, "begin") == 0) {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -300,7 +300,11 @@ int wdb_parse(char * input, char * output) {
         *next++ = '\0';
 
         if(strcmp(query, "remove") == 0) {
-            wdb_remove_multiple_agents(next);
+            data = wdb_remove_multiple_agents(next);
+            out = cJSON_PrintUnformatted(data);
+            snprintf(output, OS_MAXSTR + 1, "ok %s", out);
+            os_free(out);
+            cJSON_Delete(data);
         } else {
             mdebug1("Invalid DB query syntax.");
             mdebug2("DB query error near: %s", query);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -72,8 +72,8 @@ int wdb_parse(char * input, char * output) {
             return -1;
         }
 
-        if (wdb->removed) {
-            minfo("Message received from an deleted agent('%s'), ignoring", wdb->agent_id);
+        if (wdb->remove) {
+            mdebug1("Message received from an deleted agent('%s'), ignoring", wdb->agent_id);
             return 0;
         }
 
@@ -245,14 +245,9 @@ int wdb_parse(char * input, char * output) {
                 }
             }
         } else if (strcmp(query, "remove") == 0) {
-            if (wdb_remove_database(wdb) < 0) {
-                mdebug1("DB(%s) Cannot begin transaction.", sagent_id);
-                snprintf(output, OS_MAXSTR + 1, "err Cannot begin transaction");
-                result = -1;
-            } else {
-                snprintf(output, OS_MAXSTR + 1, "ok");
-                result = 0;
-            }
+            wdb_remove_database(wdb);
+            snprintf(output, OS_MAXSTR + 1, "ok");
+
             return result;
         } else if (strcmp(query, "begin") == 0) {
             if (wdb_begin2(wdb) < 0) {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -14,6 +14,7 @@
 #include "wazuh_db/wdb.h"
 #include "addagent/manage_agents.h" // FILE_SIZE
 #include "external/cJSON/cJSON.h"
+#include "wazuhdb_op.h"
 
 #ifndef WIN32
 
@@ -414,11 +415,12 @@ void wm_sync_agents() {
         for (i = 0; agents[i] != -1; i++) {
             snprintf(id, 9, "%03d", agents[i]);
 
-            if (OS_IsAllowedID(&keys, id) == -1)
+            if (OS_IsAllowedID(&keys, id) == -1) {
                 if (wdb_remove_agent(agents[i]) < 0) {
                     mtdebug1(WM_DATABASE_LOGTAG, "Couldn't remove agent %s", id);
                 }
             }
+        }
 
         free(agents);
     }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -14,7 +14,6 @@
 #include "wazuh_db/wdb.h"
 #include "addagent/manage_agents.h" // FILE_SIZE
 #include "external/cJSON/cJSON.h"
-#include "wazuhdb_op.h"
 
 #ifndef WIN32
 


### PR DESCRIPTION
## Related issue:
- https://github.com/wazuh/wazuh/issues/2985

Added the functionality that allows Wazuh-DB to remove the databases of agents that have been removed.

Proven cases:
- Run `manage_agent -r <agent_id>` with `ossec-authd` started
- Run `manage_agent -r <agent_id>` with `ossec-authd` stopped
- Register an already registered agent matching IP
- Register an already registered agent matching the name

In the last two cases, a new record is created that changes the agent id, therefore new databases are generated in Wazuh-DB.

The deletion of the databases occurs when Wazuh-DB checks that the database has not been modified in a number of seconds defined in `internal_options.conf` the value `wazuh_db.commit_time` (by default set to 60 sec.). We have modified the minimum value that can be configured in this option to 10 seconds to prevent Wazuh-DB from regenerating a database that has just been deleted because it has received a message in a short space of time.