### PR TITLE
Changed type for sca.scan: score, failed, passed

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -1130,15 +1130,15 @@
                   "doc_values": "true"
                 },
                 "passed": {
-                  "type": "keyword",
+                  "type": "integer",
                   "doc_values": "true"
                 },
                 "failed": {
-                  "type": "keyword",
+                  "type": "integer",
                   "doc_values": "true"
                 },
                 "score": {
-                  "type": "keyword",
+                  "type": "long",
                   "doc_values": "true"
                 },
                 "check": {


### PR DESCRIPTION
Hi team, from the @wazuh/frontend team we need to change some types from SCA fields.

- `sca.scan.passed`: from `keyword` to `integer` because it will be always an integer and we can use it with some math functions in Kibana.
- `sca.scan.failed`: from `keyword` to `integer`, same as `sca.scan.passed`.
- `sca.scan.score`: from `keyword` to `long` because it will be always a percentage like value and making it `long` allows us to apply some math functions in Kibana too.

Regards