### PR TITLE
Force formatting of data.aws.tags field as an object

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -634,6 +634,9 @@ class AWSBucket(WazuhIntegration):
         if 'sourceIPAddress' in event['aws'] and re.match(r'\d+\.\d+.\d+.\d+', event['aws']['sourceIPAddress']):
             event['aws']['source_ip_address'] = event['aws']['sourceIPAddress']
 
+        if 'tags' in event['aws'] and not isinstance(event['aws']['tags'], dict):
+            event['aws']['tags'] = {'value': event['aws']['tags']}
+
         return event
 
     def decompress_file(self, log_key):


### PR DESCRIPTION
Hello team,

This PR fixes #3125.

This was the index pattern before doing the fix:
![image](https://user-images.githubusercontent.com/8604906/56279172-ed92d880-6107-11e9-80f0-1e2aec15c640.png)

This is the index pattern now:
![imagen](https://user-images.githubusercontent.com/8604906/56279206-fbe0f480-6107-11e9-8e5c-3ee082bd7737.png)

No more errors have been seen on the logstash log file.

Best regards,
Marta