### PR TITLE
SCA: Fix leaks, prints of NULL strs & minor mistakes

### DIFF
--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -178,10 +178,11 @@ void W_JSON_AddField(cJSON *root, const char *key, const char *value) {
 
         free(current);
     } else if (!cJSON_GetObjectItem(root, key)) {
-        int value_len = 0;
-        if (value[0] == '['
-            && (value_len = strnlen(value, OS_MAXSTR))
-            && value[value_len - 1] == ']') 
+        char *string_end =  NULL;
+        if (*value == '[' && 
+           (string_end = memchr(value, '\0', OS_MAXSTR)) &&
+           (string_end != NULL) &&
+           (']' == *(string_end - 1)))
         {
             cJSON_AddItemToObject(root, key, cJSON_Parse(value));
         } else {

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -14,7 +14,7 @@
 
 #define WM_SCA_LOGTAG SCA_WM_NAME
 #define WM_SCA_INVALID_RKCL_NAME  "(1251): Invalid configuration name: '%s'."
-#define WM_SCA_INVALID_RKCL_VALUE "(1252): Invalid configuration value: '%s'."
+#define WM_SCA_INVALID_RKCL_VALUE "(1252): Invalid rule: '%s'."
 #define WM_SCA_INVALID_ROOTDIR    "(1253): Invalid rootdir (unable to retrieve)."
 #define WM_SCA_INVALID_RKCL_VAR   "(1254): Invalid variable: '%s'."
 


### PR DESCRIPTION
This PR fixes some leaking scenarios on wm_sca.c and some other minor issues.

* wm_sca:343 status = 0;
        -> Value was never read before being rewritten
                -> Line deleted.
* wm_sca:841 merror("... %s", name);
        -> name might be null and still be used in the debug message
                -> "NULL!" message printed in such cases.
* wm_sca:1436 os_free(cmd_output);
        -> Possible use after free at 1439
                -> Moved down to 1442  & added another at 1438.

* possible leaks produced @ wm_sca:875 os_strdup(nbuf, rule_cp);
    * Leaks are caused by jumps inside the loop
                -> Moved rule_cp declaration to 852, before the loop.
    * wm_sca:943 goto clean_return; (found by **coverity**)
        -> Jumping leads to rule_cp not being released
                -> Added os_free(rule_cp) just before the goto.
    * wm_sca:943 break;
        -> Breaking leads to rule_cp not being released
                -> Added os_free after loop block.
    * wm_sca:905 continue (and many other continues)
        -> Loop restarted without releasing rule_cp
                -> Added os_free at the begining of the loop.
