### PR TITLE
SSL output fix

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -346,12 +346,14 @@ int main(int argc, char **argv)
     ERR_clear_error();
     ret = SSL_connect(ssl);
     if (ret <= 0) {
-        merror("SSL error (%d). Connection refused by the manager. Maybe the port or certificate specified is incorrect. Exiting.", SSL_get_error(ssl, ret));
-    #ifdef DEBUG
-        ERR_print_errors_fp(stderr);  // This function empties the error queue
-    #endif
-        free(buf);
-        exit(1);
+
+#ifdef DEBUG
+    merror("SSL error (%d)",  SSL_get_error(ssl, ret))
+    ERR_print_errors_fp(stderr);  // This function empties the error queue
+#endif
+    merror("Connection refused by the manager. Maybe the port or certificate specified is incorrect. Exiting.");
+    free(buf);
+    exit(1);
     }
 
     minfo("Connected to %s:%d", ipaddress, port);
@@ -412,7 +414,9 @@ int main(int argc, char **argv)
     ret = SSL_write(ssl, buf, strlen(buf));
     if (ret < 0) {
         merror("SSL write error (unable to send message.)");
+#ifdef DEBUG
         ERR_print_errors_fp(stderr);
+#endif
         free(buf);
         exit(1);
     }

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -346,8 +346,10 @@ int main(int argc, char **argv)
     ERR_clear_error();
     ret = SSL_connect(ssl);
     if (ret <= 0) {
-        merror("SSL error (%d). Connection refused by the manager. Maybe the port specified is incorrect. Exiting.", SSL_get_error(ssl, ret));
+        merror("SSL error (%d). Connection refused by the manager. Maybe the port or certificate specified is incorrect. Exiting.", SSL_get_error(ssl, ret));
+    #ifdef DEBUG
         ERR_print_errors_fp(stderr);  // This function empties the error queue
+    #endif
         free(buf);
         exit(1);
     }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -137,7 +137,9 @@ static int ssl_error(const SSL *ssl, int ret)
                 usleep(100 * 1000);
                 return (0);
             default:
+#ifdef DEBUG
                 ERR_print_errors_fp(stderr);
+#endif
                 return (1);
         }
     }
@@ -1116,7 +1118,9 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             if (ret < 0) {
                 merror("SSL write error (%d)", ret);
                 merror("Agent key not saved for %s", agentname);
+#ifdef DEBUG
                 ERR_print_errors_fp(stderr);
+#endif
                 OS_DeleteKey(&keys, keys.keyentries[keys.keysize - 1]->id, 1);
             } else {
                 /* Add pending key to write */

--- a/src/os_auth/ssl-test.c
+++ b/src/os_auth/ssl-test.c
@@ -134,7 +134,9 @@ int main(int argc, char **argv)
     ret = SSL_connect(ssl);
     if (ret <= 0) {
         printf("SSL connect error\n");
+#ifdef DEBUG
         ERR_print_errors_fp(stderr);
+#endif
         exit(1);
     }
 
@@ -143,7 +145,9 @@ int main(int argc, char **argv)
     ret = SSL_write(ssl, TEST, sizeof(TEST));
     if (ret < 0) {
         printf("SSL write error\n");
+#ifdef DEBUG
         ERR_print_errors_fp(stderr);
+#endif
         exit(1);
     }
 

--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -137,19 +137,25 @@ int load_cert_and_key(SSL_CTX *ctx, const char *cert, const char *key)
 
     if (!(SSL_CTX_use_certificate_chain_file(ctx, cert))) {
         merror("Unable to read certificate file: %s", cert);
+#ifdef DEBUG
         ERR_print_errors_fp(stderr);
+#endif
         return 0;
     }
 
     if (!(SSL_CTX_use_PrivateKey_file(ctx, key, SSL_FILETYPE_PEM))) {
         merror("Unable to read private key file: %s", key);
+#ifdef DEBUG
         ERR_print_errors_fp(stderr);
+#endif
         return 0;
     }
 
     if (!SSL_CTX_check_private_key(ctx)) {
         merror("Unable to verify private key file");
+#ifdef DEBUG
         ERR_print_errors_fp(stderr);
+#endif
         return 0;
     }
 
@@ -193,7 +199,7 @@ int verify_callback(int ok, X509_STORE_CTX *store)
         X509_NAME_oneline(X509_get_issuer_name(cert), issuer, 256);
         X509_NAME_oneline(X509_get_subject_name(cert), subject, 256);
 
-        merror("issuer =  %s, subject =  %s", issuer, subject);
+        merror("Manager cert - issuer: %s, subject: %s", issuer, subject);
 
         merror("%i:%s", err, X509_verify_cert_error_string(err));
     }

--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -181,7 +181,7 @@ int load_ca_cert(SSL_CTX *ctx, const char *ca_cert)
  */
 int verify_callback(int ok, X509_STORE_CTX *store)
 {
-    char data[256];
+    char issuer[256], subject[256];
 
     if (!ok) {
         X509 *cert = X509_STORE_CTX_get_current_cert(store);
@@ -190,11 +190,10 @@ int verify_callback(int ok, X509_STORE_CTX *store)
 
         merror("Problem with certificate at depth %i", depth);
 
-        X509_NAME_oneline(X509_get_issuer_name(cert), data, 256);
-        merror("issuer =  %s", data);
+        X509_NAME_oneline(X509_get_issuer_name(cert), issuer, 256);
+        X509_NAME_oneline(X509_get_subject_name(cert), subject, 256);
 
-        X509_NAME_oneline(X509_get_subject_name(cert), data, 256);
-        merror("subject =  %s", data);
+        merror("issuer =  %s, subject =  %s", issuer, subject);
 
         merror("%i:%s", err, X509_verify_cert_error_string(err));
     }


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh/issues/2994.

-Verbose SSL error output has been placed under a debug definition.
-Wrong certificate is reported as a source of error: `SSL error. Connection refused by the manager. Maybe the port or certificate specified is incorrect. Exiting."`

