### PR TITLE
Updated multiple regular expressions in decoders and rules to remove IPv4 dependencies or handle more general IPv6 representations.

### DIFF
--- a/etc/decoders/0125-hp_decoders.xml
+++ b/etc/decoders/0125-hp_decoders.xml
@@ -41,6 +41,6 @@ Jun  8 11:54:52 HP-5500EI-HO %%10SHELL/4/LOGINAUTHFAIL(t): Trap 1.1.1.1.1.1.2550
 
 <decoder name="hp_5500_fields">
     <parent>hp_5500</parent>
-    <regex offset="after_regex">from (\d+.\d+.\d+.\d+)</regex>
+    <regex offset="after_regex">from (\S+)</regex>
     <order>srcip</order>
 </decoder>

--- a/etc/decoders/0275-sendmail_decoders.xml
+++ b/etc/decoders/0275-sendmail_decoders.xml
@@ -45,14 +45,14 @@
 <decoder name="sendmail-reject-nodns">
   <parent>sendmail-reject</parent>
   <prematch>relay=[</prematch>
-  <regex offset="after_prematch">^(\d+.\d+.\d+.\d+)]|^(\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*:\w*)]</regex>
+  <regex offset="after_prematch">^(\S+)]</regex>
   <order>srcip</order>
 </decoder>
 
 <decoder name="sendmail-reject-dns">
   <parent>sendmail-reject</parent>
   <prematch>relay=\S+ [</prematch>
-  <regex offset="after_prematch">^(\d+.\d+.\d+.\d+)]|^(\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*:\w*)]</regex>
+  <regex offset="after_prematch">^(\S+)]</regex>
   <order>srcip</order>
 </decoder>
 

--- a/etc/decoders/0360-vmware_decoders.xml
+++ b/etc/decoders/0360-vmware_decoders.xml
@@ -30,8 +30,8 @@
 
 <decoder name="vmware-extra">
   <parent>vmware</parent>
-  <regex offset="after_regex">^: User (\w+)@(\d+.\d+.\d+.\d+)</regex>
-  <regex> logged |^: Failed login \w+ for (\w+)@(\d+.\d+.\d+.\d+)</regex>
+  <regex offset="after_regex">^: User (\w+)@(\S+)</regex>
+  <regex> logged |^: Failed login \w+ for (\w+)@(\S+)</regex>
   <order>user, srcip</order>
 </decoder>
 

--- a/etc/decoders/0370-vsftpd_decoders.xml
+++ b/etc/decoders/0370-vsftpd_decoders.xml
@@ -22,13 +22,13 @@
   - Sun Aug 16 16:26:21 2015 [pid 4976] [ftpuser] OK RENAME: Client "172.28.5.129", "/index.php /4444index.php"
 <decoder name="vsftpd">
   <prematch>^\w\w\w \w\w\w\s+\d+ \S+ \d+ [pid \d+] </prematch>
-  <regex offset="after_prematch">Client "(\d+.\d+.\d+.\d+)"$</regex>
+  <regex offset="after_prematch">Client "(\S+)"$</regex>
   <order>srcip</order>
 </decoder>
 <decoder name="vsftpd">
   <program_name>^vsftpd</program_name>
   <prematch>^\w\w\w \w\w\w\s+\d+ \S+ \d+ [pid \d+] </prematch>
-  <regex offset="after_prematch">Client "(\d+.\d+.\d+.\d+)"$</regex>
+  <regex offset="after_prematch">Client "(\S+)"$</regex>
   <order>srcip</order>
 </decoder>
 -->

--- a/etc/decoders/0395-sqlserver_decoders.xml
+++ b/etc/decoders/0395-sqlserver_decoders.xml
@@ -50,7 +50,7 @@
 <decoder name="sqlserver-loginsuccess">
     <parent>sqlserver</parent>
     <prematch offset="after_parent">Login succeeded for user </prematch>
-    <regex offset="after_prematch">'(\.*)'\.+[CLIENT: (\d+.\d+.\d+.\d+)]|'(\.*)'\.+[CLIENT: (\S+)]</regex>
+    <regex offset="after_prematch">'(\.*)'\.+[CLIENT: (\S+)]|'(\.*)'\.+[CLIENT: (\S+)]</regex>
     <order>srcuser,srcip</order>
 </decoder>
 
@@ -61,7 +61,7 @@
 <decoder name="sqlserver-loginfailed">
     <parent>sqlserver</parent>
     <prematch offset="after_parent">Login failed for user </prematch>
-    <regex offset="after_prematch">'(\.*)'\.+[CLIENT: (\d+.\d+.\d+.\d+)]|'(\.*)'\.+[CLIENT: (\S+)]</regex>
+    <regex offset="after_prematch">'(\.*)'\.+[CLIENT: (\S+)]|'(\.*)'\.+[CLIENT: (\S+)]</regex>
     <order>srcuser,srcip</order>
 </decoder>
 

--- a/etc/decoders/0395-sqlserver_decoders.xml
+++ b/etc/decoders/0395-sqlserver_decoders.xml
@@ -50,7 +50,7 @@
 <decoder name="sqlserver-loginsuccess">
     <parent>sqlserver</parent>
     <prematch offset="after_parent">Login succeeded for user </prematch>
-    <regex offset="after_prematch">'(\.*)'\.+[CLIENT: (\S+)]|'(\.*)'\.+[CLIENT: (\S+)]</regex>
+    <regex offset="after_prematch">'(\.*)'\.+[CLIENT: (\S+)]</regex>
     <order>srcuser,srcip</order>
 </decoder>
 
@@ -61,7 +61,7 @@
 <decoder name="sqlserver-loginfailed">
     <parent>sqlserver</parent>
     <prematch offset="after_parent">Login failed for user </prematch>
-    <regex offset="after_prematch">'(\.*)'\.+[CLIENT: (\S+)]|'(\.*)'\.+[CLIENT: (\S+)]</regex>
+    <regex offset="after_prematch">'(\.*)'\.+[CLIENT: (\S+)]</regex>
     <order>srcuser,srcip</order>
 </decoder>
 

--- a/etc/decoders/0400-identity_guard_decoders.xml
+++ b/etc/decoders/0400-identity_guard_decoders.xml
@@ -16,7 +16,7 @@
 <decoder name="identity_guard-aud6001">
     <parent>identity_guard</parent>
     <prematch offset="after_parent">[AUD6001]</prematch>
-    <regex offset="after_parent">^[(\.+)] [\.+] [(\.+)] [\.+] User (\S+) failed authentication. Authentication Type: (\S+), Default Password: (\S+), Remote Address: (\d+.\d+.\d+.\d+)</regex>
+    <regex offset="after_parent">^[(\.+)] [\.+] [(\.+)] [\.+] User (\S+) failed authentication. Authentication Type: (\S+), Default Password: (\S+), Remote Address: (\S+)</regex>
     <order>identity_guard.type,identity_guard.id,srcuser,identity_guard.authenticationtype,identity_guard.defaultpassword,srcip</order>
 </decoder>
 

--- a/etc/decoders/0420-vshell_decoders.xml
+++ b/etc/decoders/0420-vshell_decoders.xml
@@ -23,7 +23,7 @@
 <decoder name="vshell-rejected">
   <parent>windows-date-format</parent>
   <prematch>VShellSSH2 dbg </prematch>
-  <regex offset="after_prematch">(\d+.\d+.\d+.\d+) rejected by Deny Hosts file </regex>
+  <regex offset="after_prematch">(\S+) rejected by Deny Hosts file </regex>
   <order>srcip</order>
 </decoder>
 

--- a/etc/decoders/0425-qualysguard_decoders.xml
+++ b/etc/decoders/0425-qualysguard_decoders.xml
@@ -7,7 +7,7 @@
 
 
 <decoder name="qualysguard">
-	<prematch>^"\d\d\d\d\d\d,""\w+"",""\d\d/\d\d/\d\d\d\d \(Overdue\)"",""\d+.\d+.\d+.\d+""</prematch>
+	<prematch>^"\d\d\d\d\d\d,""\w+"",""\d\d/\d\d/\d\d\d\d \(Overdue\)"",""\S+""</prematch>
 </decoder>
 
 <!--
@@ -24,7 +24,7 @@ EXAMPLE WITHOUT NETBIOS_HOSTNAME
 
 <decoder name="qualys_fields">
 	<parent>qualysguard</parent>
-	<regex>"(\d\d\d\d\d\d),""(\w+)"",""(\d\d/\d\d/\d\d\d\d \(Overdue\))"",""(\d+.\d+.\d+.\d+)"",</regex>
+	<regex>"(\d\d\d\d\d\d),""(\w+)"",""(\d\d/\d\d/\d\d\d\d \(Overdue\))"",""(\S+)"",</regex>
 	<order>qualysguard.ticket, qualysguard.state, qualysguard.due_date, qualysguard.ip</order>
 </decoder>
 

--- a/etc/decoders/0435-owncloud_decoders.xml
+++ b/etc/decoders/0435-owncloud_decoders.xml
@@ -53,21 +53,21 @@
 <decoder name="owncloud-failed1">
   <parent>owncloud</parent>
   <prematch>Login failed: user </prematch>
-  <regex offset="after_prematch">^'(\w+)' , wrong password, IP:(\d+.\d+.\d+.\d+)</regex>
+  <regex offset="after_prematch">^'(\w+)' , wrong password, IP:(\S+)</regex>
   <order>user, srcip</order>
 </decoder>
 
 <decoder name="owncloud-failed2">
   <parent>owncloud</parent>
   <prematch>Login failed: </prematch>
-  <regex offset="after_prematch">^'(\w+)' \(Remote IP: '(\d+.\d+.\d+.\d+)</regex>
+  <regex offset="after_prematch">^'(\w+)' \(Remote IP: '(\S+)</regex>
   <order>user, srcip</order>
 </decoder>
 
 <decoder name="owncloud-malicious">
   <parent>owncloud</parent>
   <prematch>Passed filename is not valid, might be malicious </prematch>
-  <regex offset="after_prematch">;ip:"(\d+.\d+.\d+.\d+)|;ip:\\"(\d+.\d+.\d+.\d+)</regex>
+  <regex offset="after_prematch">;ip:"(\S+)|;ip:\\"(\S+)</regex>
   <order>srcip</order>
 </decoder>
 

--- a/etc/rules/0470-vshell_rules.xml
+++ b/etc/rules/0470-vshell_rules.xml
@@ -36,7 +36,7 @@
 
   <rule id="86804" level="10">
     <if_sid>86800</if_sid>
-    <regex>Connection from (\d+.\d+.\d+.\d+) rejected by Deny Hosts file</regex>
+    <regex>Connection from (\S+) rejected by Deny Hosts file</regex>
     <description>Host is trying to connect to VShell server but exists in the deny file.</description>
     <group>gdpr_IV_35.7.d,</group>
   </rule>


### PR DESCRIPTION
This replaces the \d+.\d+.\d+.\d+ regexp with the more general \S+.
