### PR TITLE
Scripts using command instead of which

### DIFF
--- a/active-response/firewalls/npf.sh
+++ b/active-response/firewalls/npf.sh
@@ -8,6 +8,7 @@ find_path () {
     for PART in $PATH; do
         if test -x "$PART/$1"; then
             echo $PART/$1
+			break
         fi
     done
 }

--- a/active-response/firewalls/npf.sh
+++ b/active-response/firewalls/npf.sh
@@ -8,7 +8,7 @@ find_path () {
     for PART in $PATH; do
         if test -x "$PART/$1"; then
             echo $PART/$1
-			break
+	    break
         fi
     done
 }

--- a/active-response/firewalls/npf.sh
+++ b/active-response/firewalls/npf.sh
@@ -2,7 +2,17 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Author: Gianni D'Aprile
 
-GREP=`which grep`
+# Aux function to replace which command.
+find_path () {
+    IFS=":"
+    for PART in $PATH; do
+        if test -x "$PART/$1"; then
+            echo $PART/$1
+        fi
+    done
+}
+
+GREP=$(find_path grep)
 
 ACTION=$1
 USER=$2

--- a/active-response/ossec-slack.sh
+++ b/active-response/ossec-slack.sh
@@ -37,9 +37,9 @@ ALERTFULL=`grep -A 10 "$ALERTTIME" ${PWD}/../logs/alerts/alerts.log | grep -v "\
 
 PAYLOAD='{"channel": "'"$CHANNEL"'", "username": "'"$SLACKUSER"'", "text": "'"${ALERTFULL}"'"}'
 
-ls "`which curl`" > /dev/null 2>&1
+ls "`command -v curl`" > /dev/null 2>&1
 if [ ! $? = 0 ]; then
-    ls "`which wget`" > /dev/null 2>&1
+    ls "`command -v wget`" > /dev/null 2>&1
     if [ $? = 0 ]; then
         wget --keep-session-cookies --post-data="${PAYLOAD}" ${SITE} 2>>${PWD}/../logs/active-responses.log
         exit 0;

--- a/active-response/ossec-tweeter.sh
+++ b/active-response/ossec-tweeter.sh
@@ -45,9 +45,9 @@ else
 fi    
 
 
-ls "`which curl`" > /dev/null 2>&1
+ls "`command -v curl`" > /dev/null 2>&1
 if [ ! $? = 0 ]; then
-    ls "`which wget`" > /dev/null 2>&1
+    ls "`command -v wget`" > /dev/null 2>&1
     if [ $? = 0 ]; then
         wget --keep-session-cookies --http-user=$TWITTERUSER --http-password=$TWITTERPASS --post-data="source=$SOURCE&$REQUESTUSER$REQUESTMSG" $SITE 2>>${PWD}/../logs/active-responses.log
         exit 0;

--- a/contrib/ossec2snorby/ossec2snorby_ubuntu.sh
+++ b/contrib/ossec2snorby/ossec2snorby_ubuntu.sh
@@ -12,7 +12,7 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/bin/ossec2snorby/ossec2snorby.pl
-PERLPATH=`which perl` || { echo "  [ERROR]:perl not found."; exit 1; }
+PERLPATH=`command -v perl` || { echo "  [ERROR]:perl not found."; exit 1; }
 NAME="ossec2snorby.pl"
 DESC="Ossec2Snorby Output Processor"
 PIDFILE="/var/run/ossec2snorby.pid"

--- a/extensions/elasticsearch/restore_alerts/restore_alerts.sh
+++ b/extensions/elasticsearch/restore_alerts/restore_alerts.sh
@@ -65,8 +65,8 @@ exec_cmd_bash() {
 
 install_logstash () {
     # Check package manager
-    YUM_CMD=$(which yum)
-    APT_GET_CMD=$(which apt-get)
+    YUM_CMD=$(command -v yum)
+    APT_GET_CMD=$(command -v apt-get)
 
     # Add Elastic Stack repository
     if [[ ! -z $YUM_CMD ]]; then

--- a/src/init/fw-check.sh
+++ b/src/init/fw-check.sh
@@ -27,7 +27,7 @@ if [ "X${UNAME}" = "XFreeBSD" ]; then
 # Darwin
 elif [ "X${UNAME}" = "XDarwin" ]; then
     # Is pfctl present?
-    if which pfctl > /dev/null; then
+    if command -v pfctl > /dev/null; then
         echo "Firewall detected: PF";
         FILE="pf.sh";
     else

--- a/src/init/shared.sh
+++ b/src/init/shared.sh
@@ -14,7 +14,7 @@ UNAME=`uname -snr`
 NUNAME=`uname`
 
 # If whoami does not exist, try id
-ls "`which whoami`" > /dev/null 2>&1
+ls "`command -v whoami`" > /dev/null 2>&1
 if [ ! $? = 0 ]; then
     ME=`id | cut -d " " -f 1`
     if [ "X${ME}" = "Xuid=0(root)" ]; then
@@ -28,7 +28,7 @@ OSSEC_INIT="/etc/ossec-init.conf"
 HOST=`hostname`
 NAMESERVERS=`cat /etc/resolv.conf | grep "^nameserver" | cut -d " " -sf 2`
 NAMESERVERS2=`cat /etc/resolv.conf | grep "^nameserver" | cut -sf 2`
-HOST_CMD=`which host 2>/dev/null`
+HOST_CMD=`command -v host 2>/dev/null`
 NAME="Wazuh"
 INSTYPE="server"
 DEFAULT_DIR=`grep DIR ${LOCATION} | cut -f2 -d\"`

--- a/src/os_dbd/dbmake.sh
+++ b/src/os_dbd/dbmake.sh
@@ -8,7 +8,7 @@ PI=""
 PL=""
 
 # Look for MySQL
-ls "`which mysql 2>/dev/null`" > /dev/null 2>&1
+ls "`command -v mysql 2>/dev/null`" > /dev/null 2>&1
 if [ $? = 0 ]; then
     # Check if mysql_config is installed to use it
     mysql_config --port > /dev/null 2>&1
@@ -45,7 +45,7 @@ if [ $? = 0 ]; then
 fi
 
 # Look for PostgreSQL
-ls "`which psql 2>/dev/null`" > /dev/null 2>&1
+ls "`command -v psql 2>/dev/null`" > /dev/null 2>&1
 if [ $? = 0 ]; then
     # Check if pg_config is installed to use it
     pg_config --version > /dev/null 2>&1


### PR DESCRIPTION
This pull request gives a solution to issue https://github.com/wazuh/wazuh/issues/3106

- The **following list of scripts used `which`** command:

    - `wazuh/active-response/ossec-slack.sh`
    - `wazuh/active-response/ossec-tweeter.sh` 
    - `wazuh/active-response/firewalls/npf.sh` 
    - `wazuh/contrib/ossec2snorby/ossec2snorby_ubuntu.sh`
    - `wazuh/extensions/elasticsearch/restore_alerts/restore_alerts.sh`
    - `wazuh/src/init/fw-check.sh`
    - `wazuh/src/init/shared.sh`
    - `wazuh/src/os_dbd/dbmake.sh`
<br><br/>

- `which` command was replaced **succesfully in all but `npf.sh`**. In this, `which` **was used on an alias**, specifically on `grep`. 

```
~$ command -v grep
alias grep='grep --color=auto
```
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_As seen in the example, command is not able to output the grep path._

<br><br/>

- This **particular case**(`npf.sh`) required a **bash function** going through $PATH folders to **get the specified executable path**. It can also be used to check if the executable exists.

```bash
find_path () {
    IFS=":"
    for PART in $PATH; do
        if test -x "$PART/$1"; then
            echo $PART/$1
        fi
    done
}
```
