### PR TITLE
Centos 5 i386 msgpack flag 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,7 @@ Install()
     OS_VERSION_FOR_SYSC="${DIST_NAME}"
     if ([ "X${OS_VERSION_FOR_SYSC}" = "Xrhel" ] || [ "X${OS_VERSION_FOR_SYSC}" = "Xcentos" ]) && [ ${DIST_VER} -le 5 ]; then
         AUDIT_FLAG="USE_AUDIT=no"
+        MSGPACK_FLAG="USE_MSGPACK_OPT=no"
         if [ ${DIST_VER} -lt 5 ]; then
             SYSC_FLAG="DISABLE_SYSC=true"
         fi
@@ -128,7 +129,7 @@ Install()
 
         # Add DATABASE=pgsql or DATABASE=mysql to add support for database
         # alert entry
-        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} ${AUDIT_FLAG} ${LIB_FLAG} ${CPYTHON_FLAGS} -j${THREADS} build
+        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} ${MSGPACK_FLAG} ${AUDIT_FLAG} ${LIB_FLAG} ${CPYTHON_FLAGS} -j${THREADS} build
 
         if [ $? != 0 ]; then
             cd ../

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,6 +52,7 @@ USE_BIG_ENDIAN=no
 USE_AUDIT=no
 USE_FRAMEWORK_LIB=no
 MINGW_HOST=unknown
+USE_MSGPACK_OPT=yes
 
 ifneq ($(HAS_CHECKMODULE),)
 ifneq ($(HAS_SEMODULE_PACKAGE),)
@@ -215,6 +216,7 @@ endif
 ifneq (,$(filter ${USE_AUDIT},yes y Y 1))
         DEFINES+=-DENABLE_AUDIT
 endif
+
 
 OSSEC_CFLAGS+=${DEFINES}
 OSSEC_CFLAGS+=-pipe -Wall -Wextra
@@ -445,6 +447,7 @@ help: failtarget
 	@echo "   make USE_SELINUX=0           Build with SELinux policies"
 	@echo "   make USE_AUDIT=1             Build with audit service support"
 	@echo "   make USE_FRAMEWORK_LIB=0     Use external SQLite library for the framework"
+	@echo "   make USE_MSGPACK_OPT=yes     Use default architecture for building msgpack library"
 	@echo "   make OFLAGS=-Ox              Overrides optimization level"
 	@echo "   make DISABLE_SHARED=true	   Not to build the Wazuh shared library (for unsupported systems)"
 	@echo "   make DISABLE_SYSC=true       Not to build the Syscollector module (for unsupported systems)"
@@ -798,12 +801,16 @@ $(EXTERNAL_AUDIT)Makefile:
 
 #### msgpack #########
 
+ifeq (,$(filter ${USE_MSGPACK_OPT},yes y Y 1))
+        MSGPACK_ARCH=-march=i486
+endif
+
 ifneq (${TARGET},winagent)
 msgpack_c := $(wildcard ${EXTERNAL_MSGPACK}src/*.c)
 msgpack_o := $(msgpack_c:.c=.o)
 
 ${EXTERNAL_MSGPACK}src/%.o: ${EXTERNAL_MSGPACK}src/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -fPIC -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} ${MSGPACK_ARCH} -fPIC -c $^ -o $@
 
 $(MSGPACK_LIB): ${msgpack_o}
 	${OSSEC_LINK} $@ $^


### PR DESCRIPTION
### Set new flag for Centos 5 i386

As described on this issue: a new flag has been added to solved the compilation problem of `msgpack` for CentOS 5 i386 platform because of the missing function `__sync_sub_and_fetch_4`

### Resolution

For compiling on CentOS 5 i386 use: `USE_MSGPACK_OPT=no`