### PR TITLE
Ensure internal_options.conf file is overwriten upon install

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -190,7 +190,7 @@
                         <Condition>VersionNT &gt;= 600</Condition>
                     </Component>
                     <Component Id="INTERNAL_OPTIONS.CONF" DiskId="1" Guid="D2F2A5B9-1A98-4BB8-8AC4-D948CA97DD0E">
-                        <File Id="INTERNAL_OPTIONS.CONF" Name="internal_options.conf" Source="internal_options.conf" />
+                        <File Id="INTERNAL_OPTIONS.CONF" Name="internal_options.conf" Source="internal_options.conf" DefaultVersion="1.0"/>
                     </Component>
                     <Component Id="LICENSE.TXT" DiskId="1" Guid="556F08A0-D372-4BB5-BC44-73CE45957084">
                         <File Id="LICENSE.TXT" Name="LICENSE.txt" Source="LICENSE.txt" />


### PR DESCRIPTION
This PR addresses issue #3088 by adding fake versioning to the internal_options.conf file.
As the actual file is not versioned, it will always be overwrriten by the _default-versioned_ file present on the installer.