### PR TITLE
Fix leaks on SCA

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -878,11 +878,12 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
     char *hash_scan_info = NULL;
     os_sha256 hash_sha256 = {0};
     os_calloc(OS_MAXSTR,sizeof(char),hash_scan_info);
-    
+
     int result_db = FindScanInfo(lf,policy_id->valuestring,socket,hash_scan_info);
 
     int scan_id_old = 0;
     sscanf(hash_scan_info, "%s %d", hash_sha256, &scan_id_old);
+    os_free(hash_scan_info);
 
     switch (result_db)
     {
@@ -954,7 +955,6 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             if(references) {
                 if(!references->valuestring) {
                     merror("Malformed JSON: field 'references' must be a string");
-                    os_free(hash_scan_info);
                     return;
                 }
                 references_db = references->valuestring;
@@ -963,7 +963,6 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             if(description) {
                 if(!description->valuestring) {
                     merror("Malformed JSON: field 'description' must be a string");
-                    os_free(hash_scan_info);
                     return;
                 }
                 description_db = description->valuestring;
@@ -996,8 +995,6 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             os_free(old_hash);
             break;
     }
-
-    os_free(hash_scan_info);
 
     char *wdb_response = NULL;
     os_calloc(OS_MAXSTR,sizeof(char),wdb_response);

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -954,6 +954,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             if(references) {
                 if(!references->valuestring) {
                     merror("Malformed JSON: field 'references' must be a string");
+                    os_free(hash_scan_info);
                     return;
                 }
                 references_db = references->valuestring;
@@ -962,6 +963,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             if(description) {
                 if(!description->valuestring) {
                     merror("Malformed JSON: field 'description' must be a string");
+                    os_free(hash_scan_info);
                     return;
                 }
                 description_db = description->valuestring;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -531,9 +531,10 @@ static void wm_sca_read_files(wm_sca_t * data) {
                     wm_delay(1000 * data->summary_delay);
                     wm_sca_send_summary(data,id,summary_passed,summary_failed,policy,time_start,time_end,integrity_hash, integrity_hash_file, first_scan,cis_db_index);
                     snprintf(last_sha256[cis_db_index] ,sizeof(os_sha256),"%s",integrity_hash);
-                    os_free(integrity_hash);
-                    os_free(integrity_hash_file);
                 }
+
+                os_free(integrity_hash);
+                os_free(integrity_hash_file);
 
                 minfo("Evaluation finished for policy '%s'.",data->profile[i]->profile);
                 wm_sca_reset_summary();


### PR DESCRIPTION
This PR:

* Fixes leak on SCA decoder. Memory allocated at 880 is only released within the happy-path, at line 1000, but there are two early returns that do not release so. Solved by releasing the memory ASAP.

* Fixes potential leak on SCA module. Memory reserved at 523 and 525 is then released within the happy-path that requires both being NOT-NULL. The problem would arise if one of them is NULL but the other is not, leading to a memory leak caused by the later. 
 ```c
char * integrity_hash = wm_sca_hash_integrity(cis_db_index);
char * integrity_hash_file = wm_sca_hash_integrity_file(path);
[...]
if(integrity_hash && integrity_hash_file) {
   [...]
    os_free(integrity_hash);	
    os_free(integrity_hash_file);
}
```
