### PR TITLE
Added hash_field

### DIFF
--- a/framework/wazuh/security_configuration_assessment.py
+++ b/framework/wazuh/security_configuration_assessment.py
@@ -23,6 +23,7 @@ fields_translation_sca = {'policy_id': 'policy_id',
                           'pass': 'pass',
                           'fail': 'fail',
                           'score': 'score',
+                          'hash_file': 'hash_file',
                           'end_scan': "strftime('%Y-%m-%d %H:%M:%S', datetime(end_scan, 'unixepoch'))",
                           'start_scan': "strftime('%Y-%m-%d %H:%M:%S', datetime(start_scan, 'unixepoch'))"
                           }

--- a/framework/wazuh/tests/data/schema_sca_test.sql
+++ b/framework/wazuh/tests/data/schema_sca_test.sql
@@ -6,7 +6,7 @@
  * and/or modify it under the terms of GPLv2.
  */
 
-CREATE TABLE sca_policy (name TEXT, file TEXT, id TEXT, description TEXT, `references` TEXT);
+CREATE TABLE sca_policy (name TEXT, file TEXT, id TEXT, description TEXT, `references` TEXT, hash_file TEXT);
 
 CREATE TABLE sca_scan_info (id INTEGER PRIMARY KEY, start_scan INTEGER, end_scan INTEGER,
                             policy_id TEXT REFERENCES sca_policy (id), pass INTEGER, fail INTEGER, score INTEGER,
@@ -27,9 +27,9 @@ CREATE TABLE sca_check_rules (id_check INTEGER REFERENCES sca_check (id), type T
 CREATE INDEX id_check_rules_index ON sca_check_rules (id_check);
 
 
-INSERT INTO sca_policy VALUES('CIS benchmark for Debian/Linux','cis_debian_linux_rcl.yml','cis_debian','This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.','https://www.cisecurity.org/cis-benchmarks/');
-INSERT INTO sca_policy VALUES('System audit for web-related vulnerabilities','system_audit_rcl.yml','system_audit','Guidance for establishing a secure configuration for web-related vulnerabilities.','(null)');
-INSERT INTO sca_policy VALUES('System audit for SSH hardening','system_audit_ssh.yml','system_audit_ssh','Guidance for establishing a secure configuration for SSH service vulnerabilities.','https://www.ssh.com/ssh/');
+INSERT INTO sca_policy VALUES('CIS benchmark for Debian/Linux','cis_debian_linux_rcl.yml','cis_debian','This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.','https://www.cisecurity.org/cis-benchmarks/', 'asdfasdfasdfasdfasdfasdfasdfasdfas');
+INSERT INTO sca_policy VALUES('System audit for web-related vulnerabilities','system_audit_rcl.yml','system_audit','Guidance for establishing a secure configuration for web-related vulnerabilities.','(null)', 'asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfas');
+INSERT INTO sca_policy VALUES('System audit for SSH hardening','system_audit_ssh.yml','system_audit_ssh','Guidance for establishing a secure configuration for SSH service vulnerabilities.','https://www.ssh.com/ssh/', 'asdfasdfasdfasdfasdfasdfasdfasdfasdfaasdfasdfasasdfas');
 
 
 INSERT INTO sca_scan_info VALUES(4261713,1554818833,1554818833,'system_audit',76,0,100,'9cb618b94a97c1ed9e9eebfa0e24ba3c');


### PR DESCRIPTION
This PR is part of https://github.com/wazuh/wazuh/issues/3154 
The hash_file field has been added to the security_configuration_assessment.py file, taking advantage of the functionality added in https://github.com/wazuh/wazuh/issues/3099 , the tests carried out are the following: 
```bash
root@b2225824f222:/wazuh/framework/wazuh/tests# /var/ossec/framework/python/bin/pytest test_security_configuration_assessment.py 
============================================================= test session starts ==============================================================
platform linux -- Python 3.7.2, pytest-4.4.1, py-1.8.0, pluggy-0.9.0
rootdir: /wazuh/framework
collected 5 items                                                                                                                              

test_security_configuration_assessment.py .....                                                                                          [100%]

=========================================================== 5 passed in 0.25 seconds ===========================================================
```
```bash
curl -u foo:bar -X GET "http://localhost:55000/sca/000?pretty"
...
{
            "score": 100,
            "policy_id": "system_audit",
            "fail": 0,
            "pass": 16,
            "end_scan": "2019-04-23 08:27:43",
            "start_scan": "2019-04-23 08:27:43",
            "description": "Guidance for establishing a secure configuration for web-related vulnerabilities.",
            "name": "System audit for web-related vulnerabilities",
            "hash_file": "f2323962b52c2cc1aa0c53a34871aabe242d571af423a33f831bd77336822f58"
}
...
```