### PR TITLE
Delegate database deletion to wazuh-db

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -525,14 +525,15 @@ class Agent:
                 ('{}/queue/diff/{}'.format(common.ossec_path, self.name), '{}/diff'.format(agent_backup_dir))
             ]
 
-            for agent_file, backup_file in filter(path.exists, agent_files):
-                if not backup:
-                    if path.isdir(agent_file):
-                        rmtree(agent_file)
-                    else:
-                        remove(agent_file)
-                elif not path.exists(backup_file):
-                    rename(agent_file, backup_file)
+            for agent_file, backup_file in agent_files:
+                if path.exists(agent_file):
+                    if not backup:
+                        if path.isdir(agent_file):
+                            rmtree(agent_file)
+                        else:
+                            remove(agent_file)
+                    elif not path.exists(backup_file):
+                        rename(agent_file, backup_file)
 
             # Overwrite client.keys
             move(f_keys_temp, common.client_keys)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -434,7 +434,6 @@ class Agent:
 
         return data
 
-
     def _remove_manual(self, backup=False, purge=False):
         """
         Deletes the agent.
@@ -473,6 +472,10 @@ class Agent:
                 chmod(f_keys_temp, f_keys_st.st_mode)
         except Exception as e:
             raise WazuhException(1746, str(e))
+
+        # Tell wazuhbd to delete agent database
+        wdb_conn = WazuhDBConnection()
+        wdb_conn.delete_agents_db([self.id])
 
         try:
             # remove agent from groups
@@ -518,9 +521,6 @@ class Agent:
                 ('{0}/queue/agent-info/{1}-{2}'.format(common.ossec_path, self.name, self.registerIP), '{0}/agent-info'.format(agent_backup_dir)),
                 ('{0}/queue/rootcheck/({1}) {2}->rootcheck'.format(common.ossec_path, self.name, self.registerIP), '{0}/rootcheck'.format(agent_backup_dir)),
                 ('{0}/queue/agent-groups/{1}'.format(common.ossec_path, self.id), '{0}/agent-group'.format(agent_backup_dir)),
-                ('{}/queue/db/{}.db'.format(common.ossec_path, self.id), '{}/queue_db'.format(agent_backup_dir)),
-                ('{}/queue/db/{}.db-wal'.format(common.ossec_path, self.id), '{}/queue_db_wal'.format(agent_backup_dir)),
-                ('{}/queue/db/{}.db-shm'.format(common.ossec_path, self.id), '{}/queue_db_shm'.format(agent_backup_dir)),
                 ('{}/var/db/agents/{}-{}.db'.format(common.ossec_path, self.name, self.id), '{}/var_db'.format(agent_backup_dir)),
                 ('{}/queue/diff/{}'.format(common.ossec_path, self.name), '{}/diff'.format(agent_backup_dir))
             ]

--- a/framework/wazuh/cluster/tests/test_worker.py
+++ b/framework/wazuh/cluster/tests/test_worker.py
@@ -73,13 +73,14 @@ def test_check_removed_agents(remove_agents_patch, old_ck, new_ck, agents_to_rem
     {'001'},
     [str(x).zfill(3) for x in range(1, 15)]
 ])
+@patch('wazuh.cluster.worker.WazuhDBConnection')
 @patch('shutil.rmtree')
 @patch('os.remove')
 @patch('glob.iglob')
 @patch('wazuh.agent.Agent.get_agents_overview')
 @patch('wazuh.cluster.worker.Connection')
 @patch('os.path.isdir')
-def test_remove_bulk_agents(isdir_mock, connection_mock, agents_mock, glob_mock, remove_mock, rmtree_mock, agents_to_remove):
+def test_remove_bulk_agents(isdir_mock, connection_mock, agents_mock, glob_mock, remove_mock, rmtree_mock, wdb_mock, agents_to_remove):
     """
     Tests WorkerHandler.remove_bulk_agents function.
     """
@@ -87,8 +88,7 @@ def test_remove_bulk_agents(isdir_mock, connection_mock, agents_mock, glob_mock,
                                 'items': [{'id': a_id, 'ip': '0.0.0.0', 'name': 'test'} for a_id in agents_to_remove]}
     files_to_remove = ['/var/ossec/queue/agent-info/{name}-{ip}', '/var/ossec/queue/rootcheck/({name}) {ip}->rootcheck',
                        '/var/ossec/queue/diff/{name}', '/var/ossec/queue/agent-groups/{id}',
-                       '/var/ossec/queue/rids/{id}', '/var/ossec/queue/db/{id}.db', '/var/ossec/queue/db/{id}.db-wal',
-                       '/var/ossec/queue/db/{id}.db-shm', '/var/ossec/var/db/agents/{name}-{id}.db', 'global.db']
+                       '/var/ossec/queue/rids/{id}', '/var/ossec/var/db/agents/{name}-{id}.db', 'global.db']
     glob_mock.side_effect = [[f.format(id=a, ip='0.0.0.0', name='test') for a in agents_to_remove] for f in files_to_remove]
     root_logger = logging.getLogger()
     root_logger.debug2 = root_logger.debug

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -17,6 +17,7 @@ from wazuh.exception import WazuhException
 from wazuh.agent import Agent
 from wazuh.database import Connection
 from wazuh.cluster.dapi import dapi
+from wazuh.wdb import WazuhDBConnection
 
 
 class ReceiveIntegrityTask(c_common.ReceiveFileTask):
@@ -245,8 +246,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             files_to_remove = ['{ossec_path}/queue/agent-info/{name}-{ip}',
                                '{ossec_path}/queue/rootcheck/({name}) {ip}->rootcheck',
                                '{ossec_path}/queue/diff/{name}', '{ossec_path}/queue/agent-groups/{id}',
-                               '{ossec_path}/queue/rids/{id}', '{ossec_path}/queue/db/{id}.db',
-                               '{ossec_path}/queue/db/{id}.db-wal', '{ossec_path}/queue/db/{id}.db-shm',
+                               '{ossec_path}/queue/rids/{id}',
                                '{ossec_path}/var/db/agents/{name}-{id}.db']
             remove_agent_file_type(files_to_remove)
 
@@ -261,6 +261,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             conn.execute('delete from belongs where {}'.format(
                 ' or '.join(['id_agent = :{}'.format(i) for i in agent_ids_db.keys()])), agent_ids_db)
             conn.commit()
+
+            # Tell wazuhbd to delete agent database
+            wdb_conn = WazuhDBConnection()
+            wdb_conn.delete_agents_db(agents_ids_sublist)
+
         logger.info("Agent files removed")
 
     @staticmethod

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -168,7 +168,7 @@ class WazuhException(Exception):
         2000: 'No such database file',
         2001: 'Incompatible version of SQLite',
         2002: 'Maximum attempts exceeded for sqlite3 execute',
-        2003: 'Error in database request',
+        2003: 'Error in wazuhdb request',
         2004: 'Database query not valid',
         2005: 'Could not connect to wdb socket',
         2006: 'Received JSON from Wazuh DB is not correctly formatted',

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -201,6 +201,7 @@ def test_get_config_error(ossec_socket_mock, test_data, agent_id, component, con
     False,
     True
 ])
+@patch('wazuh.agent.WazuhDBConnection')
 @patch('wazuh.agent.remove')
 @patch('wazuh.agent.rmtree')
 @patch('wazuh.agent.move')
@@ -216,7 +217,8 @@ def test_get_config_error(ossec_socket_mock, test_data, agent_id, component, con
 @patch('wazuh.agent.chmod_r')
 @freeze_time('1975-01-01')
 def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isfile_mock, exists_mock, glob_mock,
-                       stat_mock, chmod_mock, chown_mock, move_mock, rmtree_mock, remove_mock, test_data, backup):
+                       stat_mock, chmod_mock, chown_mock, move_mock, rmtree_mock, remove_mock, wdb_mock, test_data,
+                       backup):
     """
     Test the _remove_manual function
     """
@@ -234,7 +236,7 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
         stat_mock.assert_called_once_with(common.client_keys)
         chown_mock.assert_called_once_with(common.client_keys + '.tmp', common.ossec_uid, common.ossec_gid)
         remove_mock.assert_any_call(os.path.join(common.ossec_path, 'queue/rids/001'))
-        assert len((rename_mock if backup else rmtree_mock).mock_calls) == 8
+        assert len((rename_mock if backup else rmtree_mock).mock_calls) == 5
         move_mock.assert_called_once_with(common.client_keys + '.tmp', common.client_keys)
         if backup:
             backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any')
@@ -249,6 +251,7 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
     ('001', 1748),
     ('001', 1747)
 ])
+@patch('wazuh.agent.WazuhDBConnection')
 @patch('wazuh.agent.remove')
 @patch('wazuh.agent.rmtree')
 @patch('wazuh.agent.move')
@@ -264,8 +267,8 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
 @patch('wazuh.agent.chmod_r')
 @freeze_time('1975-01-01')
 def test_remove_manual_error(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isfile_mock, exists_mock, glob_mock,
-                             stat_mock, chmod_mock, chown_mock, move_mock, rmtree_mock, remove_mock, test_data,
-                             agent_id, expected_exception):
+                             stat_mock, chmod_mock, chown_mock, move_mock, rmtree_mock, remove_mock, wdb_mock,
+                             test_data, agent_id, expected_exception):
     """
     Test the _remove_manual function error cases
     """

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -237,6 +237,8 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
         chown_mock.assert_called_once_with(common.client_keys + '.tmp', common.ossec_uid, common.ossec_gid)
         remove_mock.assert_any_call(os.path.join(common.ossec_path, 'queue/rids/001'))
         assert len((rename_mock if backup else rmtree_mock).mock_calls) == 5
+        # make sure the mock is called with a string according to a non-backup path
+        exists_mock.assert_any_call('/var/ossec/queue/agent-info/agent-1-any')
         move_mock.assert_called_once_with(common.client_keys + '.tmp', common.client_keys)
         if backup:
             backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any')

--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -10,6 +10,7 @@ import socket
 import re
 import json
 import struct
+from typing import List
 
 
 class WazuhDBConnection:
@@ -33,6 +34,10 @@ class WazuhDBConnection:
     def __query_input_validation(self, query):
         """
         Checks input queries have the correct format
+
+        Accepted query formats:
+        - agent 000 sql sql_sentence
+        - global sql sql_sentence
         """
         query_elements = query.split(" ")
         sql_first_index = 2 if query_elements[0] == 'agent' else 1
@@ -89,6 +94,20 @@ class WazuhDBConnection:
                 to_lower = True
 
         return new_query
+
+    def delete_agents_db(self, agents_id: List[str]):
+        """
+        Delete agents db through wazuh-db service
+
+        :param agents_id: strings of agents
+        :return: dict received from wazuh db in the form: {"agents": {"ID": "MESSAGE"}}, where MESSAGE may be one
+        of the following:
+        - Ok
+        - Invalid agent ID
+        - DB waiting for deletion
+        - DB not found
+        """
+        return self._send(f"wazuhdb remove {' '.join(agents_id)}")
 
     def execute(self, query, count=False, delete=False, update=False):
         """


### PR DESCRIPTION
This PR fixes #3152 .

A new method has been added to `WazuhDBConnection` class in order to give another method to communicate with socket to send the new `wazuhdb remove` command. In consequence, the `_remove_manual` and `remove_bulk_agents` functions have been modified to call `WazuhDBConnection` instead of removing sqlite db files manually.

Furthermore, during testing a bug was found and fixed. It caused a Python exception when removing an agent with a disabled authd service.

Tests performed:
* Unit tests
```
root@91b9343baaee:/var/ossec/etc# /var/ossec/framework/python/bin/pytest /var/ossec/framework/python/lib/python3.7/site-packages/wazuh
================================================ test session starts =================================================
platform linux -- Python 3.7.2, pytest-4.4.1, py-1.8.0, pluggy-0.9.0
rootdir: /var/ossec
collected 217 items                                                                                                  

../framework/python/lib/python3.7/site-packages/wazuh/cluster/tests/test_cluster.py ..................         [  8%]
../framework/python/lib/python3.7/site-packages/wazuh/cluster/tests/test_worker.py ...........                 [ 13%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_active_response.py ......                     [ 16%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_agent.py .................................... [ 32%]
......                                                                                                         [ 35%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_cdb_list.py ...........                       [ 40%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_decoders.py ................................. [ 55%]
.......                                                                                                        [ 58%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_group.py ........                             [ 62%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_manager.py .............................      [ 76%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_rules.py .................................... [ 92%]
....                                                                                                           [ 94%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_security_configuration_assessment.py .....    [ 96%]
../framework/python/lib/python3.7/site-packages/wazuh/tests/test_wdb.py .......                                [100%]

============================================= 217 passed in 0.86 seconds =============================================
```
* Integration tests (in a cluster with 3 manager nodes and 3 agents, authd disabled)
```
root@91b9343baaee:/var/ossec/queue/db# curl -u foo:bar -XDELETE "http://localhost:55000/agents/001?pretty"
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "001"
      ]
   }
}
```
After a few seconds, sqlite databases were deleted:
```
root@91b9343baaee:/var/ossec/queue/db# ls -lrth
total 1.3M
-rw-r----- 1 ossec ossec 668K Apr 23 15:07 000.db
srw-rw---- 1 ossec ossec    0 Apr 23 15:07 wdb
-rw-r----- 1 ossec ossec 552K Apr 23 15:08 000.db-wal
-rw-r----- 1 ossec ossec  32K Apr 23 15:08 000.db-shm
```

It also works deleting agents in other workers:
```
root@91b9343baaee:/var/ossec/queue/db# curl -u foo:bar -XDELETE "http://localhost:55000/agents/002?pretty"
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "002"
      ]
   }
}
root@91b9343baaee:/var/ossec/queue/db# curl -u foo:bar "http://localhost:55000/agents?pretty"
{
   "error": 0,
   "data": {
      "items": [
         {
            "os": {
               "arch": "x86_64",
               "codename": "Bionic Beaver",
               "major": "18",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "uname": "Linux |91b9343baaee |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64",
               "version": "18.04.1 LTS"
            },
            "lastKeepAlive": "9999-12-31 23:59:59",
            "ip": "127.0.0.1",
            "dateAdd": "2019-04-23 14:59:04",
            "name": "91b9343baaee",
            "node_name": "master-node",
            "id": "000",
            "version": "Wazuh v3.9.0",
            "registerIP": "127.0.0.1",
            "status": "Active",
            "manager": "91b9343baaee"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Bionic Beaver",
               "major": "18",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "uname": "Linux |d8892d39fbc2 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64",
               "version": "18.04.1 LTS"
            },
            "lastKeepAlive": "2019-04-23 16:05:58",
            "group": [
               "default"
            ],
            "ip": "172.19.0.7",
            "dateAdd": "2019-04-23 15:00:26",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "name": "d8892d39fbc2",
            "node_name": "worker1",
            "id": "003",
            "version": "Wazuh v3.8.2",
            "registerIP": "172.19.0.7",
            "mergedSum": "c6309ff81a74781f6b55b68129a76738",
            "status": "Active",
            "manager": "b58a00122183"
         }
      ],
      "totalItems": 2
   }
}
```
