### PR TITLE
Remove the Windows syscollector library from being freed

### DIFF
--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -661,9 +661,6 @@ char *get_win_agent_ip(){
     }
 
 end:
-    if (sys_library) {
-        FreeLibrary(sys_library);
-    }
 
     if (pAddresses) {
         win_free((HLOCAL)pAddresses);


### PR DESCRIPTION
The Windows agent stopped working during the syscollector scan due to an unnecessary free of the Windows syscollector library.

This free was unnecessary because the load of the library is just called once and there is no memory leak.

I've tracked the memory used by the agent with the Windows Powershell executing:
`Get-Process -Name ossec-agent | Select-Object Name,@{Name='WorkingSet';Expression={($_.WorkingSet)}}`

And using Dr.memory where I didn't get any message regarding syscollector issues.