### PR TITLE
Fix string truncation warnings in GCC 8

### DIFF
--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -131,7 +131,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
     }
 
     /* Create alert */
-    snprintf(diff_alert, BUFFER_SIZE - 1, "ossec: agentless: Change detected:\n%s", buf);
+    snprintf(diff_alert, sizeof(diff_alert), "ossec: agentless: Change detected:\n%s", buf);
     snprintf(buf, 1024, "(%s) %s->agentless", script, host);
 
     if (SendMSG(lessdc.queue, diff_alert, buf, LOCALFILE_MQ) < 0) {

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -332,7 +332,7 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
 // Parse timestamp
 void W_JSON_AddTimestamp(cJSON* root, const Eventinfo* lf)
 {
-    char timestamp[64];
+    char timestamp[160];
     char datetime[64];
     char timezone[64];
     struct tm tm;
@@ -375,7 +375,7 @@ void W_JSON_ParseAgentIP(cJSON* root, const Eventinfo* lf)
     }
 
     os_free(string);
-    
+
 }
 
 // The file location usually comes with more information about the alert (like hostname or ip) we will extract just the

--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -34,7 +34,7 @@ int Lists_OP_LoadList(char *listfile)
         merror_exit(MEM_ERROR, errno, strerror(errno));
     }
 
-    snprintf(a_filename, OS_MAXSTR - 1, "%s", listfile);
+    snprintf(a_filename, OS_MAXSTR, "%s", listfile);
     if ((strchr(a_filename, '/') == NULL)) {
         /* default to ruleset/rules/ if a path is not given */
         snprintf(b_filename, OS_MAXSTR, "ruleset/rules/%.65516s", a_filename);

--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -21,7 +21,6 @@ void Lists_OP_CreateLists()
 
 int Lists_OP_LoadList(char *listfile)
 {
-    /* XXX Jeremy: I hate this.  I think I'm missing something dumb here */
     char *holder;
     char a_filename[OS_MAXSTR];
     char b_filename[OS_MAXSTR];
@@ -38,16 +37,16 @@ int Lists_OP_LoadList(char *listfile)
     snprintf(a_filename, OS_MAXSTR - 1, "%s", listfile);
     if ((strchr(a_filename, '/') == NULL)) {
         /* default to ruleset/rules/ if a path is not given */
-        snprintf(b_filename, OS_MAXSTR - 1, "ruleset/rules/%s", a_filename);
-        snprintf(a_filename, OS_MAXSTR - 1, "%s", b_filename);
+        snprintf(b_filename, OS_MAXSTR, "ruleset/rules/%.65516s", a_filename);
+        snprintf(a_filename, OS_MAXSTR, "%s", b_filename);
     }
     if ((holder = strstr(a_filename, ".cdb"))) {
         snprintf(b_filename, (size_t)(holder - a_filename) + 1, "%s", a_filename);
-        snprintf(a_filename, OS_MAXSTR - 1, "%s", b_filename);
+        snprintf(a_filename, OS_MAXSTR, "%s", b_filename);
     }
 
-    snprintf(b_filename, OS_MAXSTR - 1, "%s.cdb", a_filename);
-    
+    snprintf(b_filename, OS_MAXSTR, "%.65531s.cdb", a_filename);
+
     /* Check if the CDB list file is actually available */
     FILE *txt_fd = fopen(a_filename, "r");
     if (!txt_fd)

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -22,7 +22,7 @@ unsigned int s_events_decoded = 0;
 unsigned int s_events_processed = 0;
 unsigned int s_events_dropped = 0 ;
 volatile unsigned int s_events_received = 0;
-unsigned int s_alerts_written  = 0; 
+unsigned int s_alerts_written  = 0;
 unsigned int s_firewall_written = 0;
 unsigned int s_fts_written = 0;
 
@@ -89,7 +89,7 @@ void * w_analysisd_state_main(){
 
 int w_analysisd_write_state(){
     FILE * fp;
-    char path[PATH_MAX + 1];
+    char path[PATH_MAX - 8];
     char path_temp[PATH_MAX + 1];
 
     if (!strcmp(__local_name, "unset")) {
@@ -234,7 +234,7 @@ int w_analysisd_write_state(){
         "# Archives log queue size\n"
         "archives_queue_size='%u'\n"
         "\n",
-        __local_name, 
+        __local_name,
         s_events_decoded + s_events_syscheck_decoded + s_events_syscollector_decoded + s_events_rootcheck_decoded + s_events_hostinfo_decoded + s_events_winevt_decoded ,
         s_events_syscheck_decoded,
         s_events_syscheck_decoded / interval ,

--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -127,7 +127,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
     char warn_msg[OS_MAXSTR];
     char normal_msg[OS_MAXSTR];
 
-    char warn_str[OS_MAXSTR];
+    char warn_str[OS_SIZE_2048];
     int wait_ms = 1000 / agt->events_persec;
 
     while(1){
@@ -179,7 +179,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
 
             buff.warn = 0;
             mwarn(WARN_BUFFER, warn_level);
-            snprintf(warn_str, OS_MAXSTR, OS_WARN_BUFFER, warn_level);
+            snprintf(warn_str, OS_SIZE_2048, OS_WARN_BUFFER, warn_level);
             snprintf(warn_msg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "ossec-agent", warn_str);
             delay(wait_ms);
             send_msg(warn_msg, -1);

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -54,7 +54,7 @@ int write_state() {
     FILE * fp;
     struct tm tm;
     const char * status;
-    char path[PATH_MAX + 1];
+    char path[PATH_MAX - 8];
     char last_keepalive[1024] = "";
     char last_ack[1024] = "";
 

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -354,7 +354,7 @@
 #define FIM_ERROR_REALTIME_INITIALIZE               "(6618): Unable to initialize real time file monitoring."
 
 #define FIM_ERROR_WHODATA_ADD_DIRECTORY             "(6619): Unable to add directory to whodata real time monitoring: '%s'."
-#define FIM_ERROR_WHODATA_AUDIT_SUPPORT             "(6620): Error creating the whodata context. Error %lu."
+#define FIM_ERROR_WHODATA_AUDIT_SUPPORT             "(6620): Audit support not built. Whodata is not available."
 #define FIM_ERROR_WHODATA_EVENTCHANNEL              "(6621): Event Channel subscription could not be made. Whodata scan is disabled."
 #define FIM_ERROR_WHODATA_RESTORE_POLICIES          "(6622): There is no backup of audit policies. Policies will not be restored."
 #define FIM_ERROR_WHODATA_RENDER_EVENT              "(6623): Error rendering the event. Error %lu."

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -112,7 +112,7 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
         OS_MD5_Str(id, -1, filesum2);
 
         /* Generate new filesum1 */
-        snprintf(_finalstr, sizeof(_finalstr) - 1, "%s%s", filesum1, filesum2);
+        snprintf(_finalstr, sizeof(_finalstr), "%s%s", filesum1, filesum2);
 
         /* Use just half of the first MD5 (name/id) */
         OS_MD5_Str(_finalstr, -1, filesum1);
@@ -123,7 +123,7 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
         OS_MD5_Str(key, -1, filesum2);
 
         /* Generate final key */
-        snprintf(_finalstr, 49, "%s%s", filesum2, filesum1);
+        snprintf(_finalstr, sizeof(_finalstr), "%s%s", filesum2, filesum1);
 
         /* Final key is 48 * 4 = 192bits */
         os_strdup(_finalstr, keys->keyentries[keys->keysize]->key);

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -298,7 +298,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     int socket = -1;
     unsigned int i = 0;
     char *msg;
-    char snd_msg[128];
+    char snd_msg[256];
 
     MailNode *mailmsg;
 
@@ -340,11 +340,11 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         free(msg);
 
         /* Send HELO message */
-        memset(snd_msg, '\0', 128);
+        memset(snd_msg, '\0', 256);
         if (mail->heloserver) {
-            snprintf(snd_msg, 127, "Helo %s\r\n", mail->heloserver);
+            snprintf(snd_msg, 256, "Helo %s\r\n", mail->heloserver);
         } else {
-            snprintf(snd_msg, 127, "Helo %s\r\n", "notify.ossec.net");
+            snprintf(snd_msg, 256, "Helo %s\r\n", "notify.ossec.net");
         }
         OS_SendTCP(socket, snd_msg);
         msg = OS_RecvTCP(socket, OS_SIZE_1024);
@@ -383,8 +383,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         free(msg);
 
         /* Build "Mail from" msg */
-        memset(snd_msg, '\0', 128);
-        snprintf(snd_msg, 127, MAILFROM, mail->from);
+        memset(snd_msg, '\0', 256);
+        snprintf(snd_msg, 256, MAILFROM, mail->from);
         OS_SendTCP(socket, snd_msg);
         msg = OS_RecvTCP(socket, OS_SIZE_1024);
         if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
@@ -409,8 +409,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
                 }
                 break;
             }
-            memset(snd_msg, '\0', 128);
-            snprintf(snd_msg, 127, RCPTTO, mail->to[i++]);
+            memset(snd_msg, '\0', 256);
+            snprintf(snd_msg, 256, RCPTTO, mail->to[i++]);
             OS_SendTCP(socket, snd_msg);
             msg = OS_RecvTCP(socket, OS_SIZE_1024);
             if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
@@ -434,8 +434,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
                     continue;
                 }
 
-                memset(snd_msg, '\0', 128);
-                snprintf(snd_msg, 127, RCPTTO, mail->gran_to[i]);
+                memset(snd_msg, '\0', 256);
+                snprintf(snd_msg, 256, RCPTTO, mail->gran_to[i]);
                 OS_SendTCP(socket, snd_msg);
                 msg = OS_RecvTCP(socket, OS_SIZE_1024);
                 if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
@@ -472,8 +472,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 
     if (mail->to) {
         /* Building "From" and "To" in the e-mail header */
-        memset(snd_msg, '\0', 128);
-        snprintf(snd_msg, 127, TO, mail->to[0]);
+        memset(snd_msg, '\0', 256);
+        snprintf(snd_msg, 256, TO, mail->to[0]);
 
         if (sendmail) {
             fprintf(sendmail, "%s", snd_msg);
@@ -482,8 +482,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         }
     }
 
-    memset(snd_msg, '\0', 128);
-    snprintf(snd_msg, 127, FROM, mail->from);
+    memset(snd_msg, '\0', 256);
+    snprintf(snd_msg, 255, FROM, mail->from);
 
     if (sendmail) {
         fprintf(sendmail, "%s", snd_msg);
@@ -493,8 +493,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 
     /* Send reply-to if set */
     if (mail->reply_to){
-        memset(snd_msg, '\0', 128);
-        snprintf(snd_msg, 127, REPLYTO, mail->reply_to);
+        memset(snd_msg, '\0', 256);
+        snprintf(snd_msg, 256, REPLYTO, mail->reply_to);
         if (sendmail) {
             fprintf(sendmail, "%s", snd_msg);
         } else {
@@ -511,8 +511,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
                     break;
                 }
 
-                memset(snd_msg, '\0', 128);
-                snprintf(snd_msg, 127, TO, mail->to[i]);
+                memset(snd_msg, '\0', 256);
+                snprintf(snd_msg, 256, TO, mail->to[i]);
 
                 if (sendmail) {
                     fprintf(sendmail, "%s", snd_msg);
@@ -534,8 +534,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
                 continue;
             }
 
-            memset(snd_msg, '\0', 128);
-            snprintf(snd_msg, 127, TO, mail->gran_to[i]);
+            memset(snd_msg, '\0', 256);
+            snprintf(snd_msg, 256, TO, mail->gran_to[i]);
 
             if (sendmail) {
                 fprintf(sendmail, "%s", snd_msg);
@@ -549,13 +549,13 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     }
 
     /* Send date */
-    memset(snd_msg, '\0', 128);
+    memset(snd_msg, '\0', 256);
 
     /* Solaris doesn't have the "%z", so we set the timezone to 0 */
 #ifdef SOLARIS
-    strftime(snd_msg, 127, "Date: %a, %d %b %Y %T -0000\r\n", p);
+    strftime(snd_msg, 255, "Date: %a, %d %b %Y %T -0000\r\n", p);
 #else
-    strftime(snd_msg, 127, "Date: %a, %d %b %Y %T %z\r\n", p);
+    strftime(snd_msg, 255, "Date: %a, %d %b %Y %T %z\r\n", p);
 #endif
 
     if (sendmail) {
@@ -566,8 +566,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 
     if (mail->idsname) {
         /* Send server name header */
-        memset(snd_msg, '\0', 128);
-        snprintf(snd_msg, 127, XHEADER, mail->idsname);
+        memset(snd_msg, '\0', 256);
+        snprintf(snd_msg, 256, XHEADER, mail->idsname);
 
         if (sendmail) {
             fprintf(sendmail, "%s", snd_msg);
@@ -577,17 +577,17 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     }
 
     /* Send subject */
-    memset(snd_msg, '\0', 128);
+    memset(snd_msg, '\0', 256);
 
     /* Check if global subject is available */
     if ((_g_subject_level != 0) && (_g_subject[0] != '\0')) {
-        snprintf(snd_msg, 127, SUBJECT, _g_subject);
+        snprintf(snd_msg, 256, SUBJECT, _g_subject);
 
         /* Clear global values */
         _g_subject[0] = '\0';
         _g_subject_level = 0;
     } else {
-        snprintf(snd_msg, 127, SUBJECT, mailmsg->mail->subject);
+        snprintf(snd_msg, 256, SUBJECT, mailmsg->mail->subject);
     }
 
     if (sendmail) {
@@ -643,6 +643,6 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         close(socket);
     }
 
-    memset_secure(snd_msg, '\0', 128);
+    memset_secure(snd_msg, '\0', 256);
     return (0);
 }

--- a/src/os_xml/os_xml_variables.c
+++ b/src/os_xml/os_xml_variables.c
@@ -181,7 +181,7 @@ int OS_ApplyVariables(OS_XML *_lxml)
                             if ((j == s) && (strlen(lvar) >= 1)) {
                                 snprintf(_lxml->err, XML_ERR_LENGTH,
                                          "XMLERR: Unknown variable"
-                                         ": '%s'.", lvar);
+                                         ": '%.95s'.", lvar);
                                 _lxml->err_line = _lxml->ln[i];
                                 goto fail;
                             } else if (j == s) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -341,7 +341,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
     else{
         // Merge ar.conf always
         if (!logr.nocmerged) {
-            snprintf(merged_tmp, PATH_MAX + 1, "%s.tmp", merged);
+            snprintf(merged_tmp, PATH_MAX + 1, "%s/%s/%s.tmp", sharedcfg_dir, group, SHAREDCFG_FILENAME);
             // First call, truncate merged file
             MergeAppendFile(merged_tmp, NULL, group, -1);
         }
@@ -755,7 +755,7 @@ static void c_files()
             OS_SHA256_String(groups_info,multi_group_hash);
 
             os_calloc(9, sizeof(char), _hash);
-            snprintf(_hash, 8, "%s", multi_group_hash);
+            snprintf(_hash, 9, "%.8s", multi_group_hash);
 
             if(OSHash_Add_ex(m_hash, groups_info, _hash) != 2){
                 os_free(_hash);

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -26,13 +26,13 @@ void * rem_state_main() {
         return NULL;
     }
 
-    os_calloc(30, sizeof(char), refresh_time);
+    os_calloc(48, sizeof(char), refresh_time);
     if (interval < 60) {
-        snprintf(refresh_time, 30, "Updated every %i seconds.", interval);
+        snprintf(refresh_time, 48, "Updated every %i seconds.", interval);
     } else if (interval < 3600) {
-        snprintf(refresh_time, 30, "Updated every %i minutes.", interval/60);
+        snprintf(refresh_time, 48, "Updated every %i minutes.", interval/60);
     } else {
-        snprintf(refresh_time, 30, "Updated every %i hours.", interval/3600);
+        snprintf(refresh_time, 48, "Updated every %i hours.", interval/3600);
     }
 
     mdebug1("State file updating thread started.");
@@ -47,7 +47,7 @@ void * rem_state_main() {
 
 int rem_write_state() {
     FILE * fp;
-    char path[PATH_MAX + 1];
+    char path[PATH_MAX - 8];
     char path_temp[PATH_MAX + 1];
     remoted_state_t state_cpy;
 

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -182,10 +182,10 @@ void check_rc_files(const char *basedir, FILE *fp)
         }
 
         if (is_file(file_path)) {
-            char op_msg[OS_SIZE_1024 + 1];
+            char op_msg[OS_SIZE_2048];
 
             _errors = 1;
-            snprintf(op_msg, OS_SIZE_1024, "Rootkit '%s' detected "
+            snprintf(op_msg, OS_SIZE_2048, "Rootkit '%s' detected "
                      "by the presence of file '%s'.", name, file_path);
 
             notify_rk(ALERT_ROOTKIT_FOUND, op_msg);

--- a/src/rootcheck/check_rc_pids.c
+++ b/src/rootcheck/check_rc_pids.c
@@ -103,7 +103,7 @@ static void loop_all_pids(const char *ps, pid_t max_pid, int *_errors, int *_tot
     pid_t i = 1;
     pid_t my_pid;
 
-    char command[OS_SIZE_1024 + 1];
+    char command[OS_SIZE_1024 + 64];
 
     my_pid = getpid();
 
@@ -165,7 +165,7 @@ static void loop_all_pids(const char *ps, pid_t max_pid, int *_errors, int *_tot
 
         /* Check if the process appears in ps(1) output */
         if (*ps) {
-            snprintf(command, OS_SIZE_1024, "%s -p %d > /dev/null 2>&1", ps, (int)i);
+            snprintf(command, sizeof(command), "%s -p %d > /dev/null 2>&1", ps, (int)i);
             _ps0 = 0;
             if (system(command) == 0) {
                 _ps0 = 1;
@@ -315,8 +315,8 @@ void check_rc_pids()
     loop_all_pids(ps, max_pid, &_errors, &_total);
 
     if (_errors == 0) {
-        char op_msg[OS_SIZE_1024 + 1];
-        snprintf(op_msg, OS_SIZE_1024, "No hidden process by Kernel-level "
+        char op_msg[OS_SIZE_2048];
+        snprintf(op_msg, OS_SIZE_2048, "No hidden process by Kernel-level "
                  "rootkits.\n      %s is not trojaned. "
                  "Analyzed %d processes.", ps, _total);
         notify_rk(ALERT_OK, op_msg);

--- a/src/rootcheck/check_rc_trojans.c
+++ b/src/rootcheck/check_rc_trojans.c
@@ -89,10 +89,10 @@ void check_rc_trojans(const char *basedir, FILE *fp)
 
             /* Check if entry is found */
             if (is_file(file_path) && os_string(file_path, string_to_look)) {
-                char op_msg[OS_SIZE_1024 + 1];
+                char op_msg[OS_SIZE_2048];
                 _errors = 1;
 
-                snprintf(op_msg, OS_SIZE_1024, "Trojaned version of file "
+                snprintf(op_msg, OS_SIZE_2048, "Trojaned version of file "
                          "'%s' detected. Signature used: '%s' (%s).",
                          file_path,
                          string_to_look,

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -94,11 +94,11 @@ static char *_read_file(const char *high_name, const char *low_name, const char 
             merror(FGETS_ERROR, def_file, buf);
             continue;
         }
-        
+
         /* Prepare buf_pt to access the value for this option */
         *buf_pt = '\0';
         buf_pt++;
-        
+
         /* Remove possible whitespaces between the low name and the equal sign */
         i = (strlen(tmp_buffer) - 1);
         while(tmp_buffer[i] == ' ')
@@ -106,15 +106,15 @@ static char *_read_file(const char *high_name, const char *low_name, const char 
             tmp_buffer[i] = '\0';
             i--;
         }
-        
+
         /* Check for the low name */
         if (strcmp(tmp_buffer, low_name) != 0) {
             continue;
         }
-        
+
         /* Ignore possible whitespaces between the equal sign and the value for this option */
         while(*buf_pt == ' ') buf_pt++;
-        
+
         /* Remove newlines or anything that will cause errors */
         tmp_buffer = strrchr(buf_pt, '\n');
         if (tmp_buffer) {
@@ -605,16 +605,16 @@ char *OS_IsValidTime(const char *time_str)
         return (NULL);
     }
 
-    os_calloc(13, sizeof(char), ret);
+    os_calloc(16, sizeof(char), ret);
 
     /* Fix dump hours */
     if (strcmp(first_hour, second_hour) > 0) {
-        snprintf(ret, 12, "!%s%s", second_hour, first_hour);
+        snprintf(ret, 16, "!%s%s", second_hour, first_hour);
         return (ret);
     }
 
     /* For the normal times */
-    snprintf(ret, 12, "%c%s%s", ng == 0 ? '.' : '!', first_hour, second_hour);
+    snprintf(ret, 16, "%c%s%s", ng == 0 ? '.' : '!', first_hour, second_hour);
 
     return (ret);
 }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -366,7 +366,7 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
     if (lstat(file_name, &statbuf) < 0)
 #endif
     {
-        char alert_msg[OS_SIZE_6144 + 1];
+        char alert_msg[OS_SIZE_6144 + OS_SIZE_2048];
         char wd_sum[OS_SIZE_6144 + 1];
         int pos;
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -72,12 +72,12 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
     }
 
     if (s_node = (syscheck_node *) OSHash_Get_ex(syscheck.fp, path), s_node) {
-        char c_sum[OS_MAXSTR + 1];
+        char c_sum[OS_SIZE_4096 + 1];
         size_t c_sum_size;
 
         buf = s_node->checksum;
         c_sum[0] = '\0';
-        c_sum[OS_MAXSTR] = '\0';
+        c_sum[OS_SIZE_4096] = '\0';
 
         // If it returns < 0, we've already alerted the deleted file
         if (c_read_file(path, *file_link ? file_link : NULL, buf, c_sum, evt) < 0) {

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -106,7 +106,7 @@ int init_auditd_socket(void);
 int audit_add_rule(const char *path, const char *key);
 int audit_delete_rule(const char *path, const char *key);
 void *audit_main(int *audit_sock);
-void *audit_reload_thread(void);
+void *audit_reload_thread();
 void *audit_healthcheck_thread(int *audit_sock);
 void audit_reload_rules(void);
 int audit_health_check(int audit_socket);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -911,7 +911,7 @@ void audit_reload_rules(void) {
 }
 
 
-void *audit_reload_thread(void) {
+void *audit_reload_thread() {
 
     sleep(RELOAD_RULES_INTERVAL);
     while (audit_thread_active) {

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -392,7 +392,7 @@ int main(int argc, char **argv)
 
             /* Get netmask from IP */
             getNetmask(keys.keyentries[agt_id]->ip->netmask, final_mask, 128);
-            snprintf(final_ip, 128, "%s%s", keys.keyentries[agt_id]->ip->ip,
+            snprintf(final_ip, sizeof(final_ip), "%s%s", keys.keyentries[agt_id]->ip->ip,
                      final_mask);
 
             if (!csv_output && !json_output) {

--- a/src/util/clear_stats.c
+++ b/src/util/clear_stats.c
@@ -123,11 +123,11 @@ int main(int argc, char **argv)
         int i = 0;
         while (i <= 6) {
             const char *daily_dir = STATWQUEUE;
-            char dir_path[OS_MAXSTR + 1];
+            char dir_path[PATH_MAX + 1];
             DIR *daily;
             struct dirent *entry;
 
-            snprintf(dir_path, OS_MAXSTR, "%s/%d", daily_dir, i);
+            snprintf(dir_path, PATH_MAX, "%s/%d", daily_dir, i);
             daily = opendir(dir_path);
             if (!daily) {
                 merror_exit("Unable to open: '%s' (no stats)", dir_path);

--- a/src/util/rootcheck_control.c
+++ b/src/util/rootcheck_control.c
@@ -347,7 +347,7 @@ int main(int argc, char **argv)
             final_mask[128] = '\0';
             getNetmask(keys.keyentries[i]->ip->netmask,
                        final_mask, 128);
-            snprintf(final_ip, 128, "%s%s", keys.keyentries[i]->ip->ip,
+            snprintf(final_ip, sizeof(final_ip), "%s%s", keys.keyentries[i]->ip->ip,
                      final_mask);
 
             if (!(csv_output || json_output))

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -369,17 +369,17 @@ int wdb_create_agent_db(int id, const char *name) {
 
 /* Create database for agent from profile. Returns 0 on success or -1 on error. */
 int wdb_remove_agent_db(int id, const char * name) {
-    char path[OS_FLSIZE + 1];
-    char path_aux[OS_FLSIZE + 1];
+    char path[PATH_MAX];
+    char path_aux[PATH_MAX];
 
-    snprintf(path, OS_FLSIZE, "%s%s/agents/%03d-%s.db", isChroot() ? "/" : "", WDB_DIR, id, name);
+    snprintf(path, PATH_MAX, "%s%s/agents/%03d-%s.db", isChroot() ? "/" : "", WDB_DIR, id, name);
 
     if (!remove(path)) {
-        snprintf(path_aux, OS_FLSIZE, "%s-shm", path);
+        snprintf(path, PATH_MAX, "%s%s/agents/%03d-%s.db-shm", isChroot() ? "/" : "", WDB_DIR, id, name);
         if (remove(path_aux) < 0) {
             mdebug2(DELETE_ERROR, path_aux, errno, strerror(errno));
         }
-        snprintf(path_aux, OS_FLSIZE, "%s-wal", path);
+        snprintf(path, PATH_MAX, "%s%s/agents/%03d-%s.db-wal", isChroot() ? "/" : "", WDB_DIR, id, name);
         if (remove(path_aux) < 0) {
             mdebug2(DELETE_ERROR, path_aux, errno, strerror(errno));
         }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -12,6 +12,8 @@
 #include "wdb.h"
 #include "external/cJSON/cJSON.h"
 
+#define WDB_RESPONSE_BEGIN_SIZE 16
+
 int wdb_parse(char * input, char * output) {
     char * actor;
     char * id;
@@ -289,7 +291,7 @@ int wdb_parse_syscheck(wdb_t * wdb, char * input, char * output) {
     char * curr;
     char * next;
     char * checksum;
-    char buffer[OS_MAXSTR + 1];
+    char buffer[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE];
     int ftype;
     int result;
     long ts;
@@ -445,11 +447,11 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
     if (strcmp(curr, "query") == 0) {
 
         int pm_id;
-        char result_found[OS_MAXSTR + 1] = {0};
+        char result_found[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE] = {0};
 
         curr = next;
         pm_id = strtol(curr,NULL,10);
-        
+
         result = wdb_sca_find(wdb, pm_id, result_found);
 
         switch (result) {
@@ -664,7 +666,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
     } else if (strcmp(curr, "query_global") == 0) {
 
         char *name;
-        char result_found[OS_MAXSTR + 1] = {0};
+        char result_found[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE] = {0};
 
         curr = next;
         name = curr;
@@ -676,7 +678,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
                 snprintf(output, OS_MAXSTR + 1, "ok not found");
                 break;
             case 1:
-                snprintf(output, OS_MAXSTR + 1, "ok found %s",result_found);
+                snprintf(output, OS_MAXSTR + 1, "ok found %s", result_found);
                 break;
             default:
                 mdebug1("Cannot query Security Configuration Assessment.");
@@ -752,7 +754,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
     } else if (strcmp(curr, "query_results") == 0) {
 
         char * policy_id;
-        char result_found[OS_MAXSTR + 1] = {0};
+        char result_found[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE] = {0};
 
         curr = next;
         policy_id = curr;
@@ -775,7 +777,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
     } else if (strcmp(curr, "query_scan") == 0) {
 
         char *policy_id;
-        char result_found[OS_MAXSTR + 1] = {0};
+        char result_found[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE] = {0};
 
         curr = next;
         policy_id = curr;
@@ -797,7 +799,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         return result;
     } else if (strcmp(curr, "query_policies") == 0) {
 
-        char result_found[OS_MAXSTR + 1] = {0};
+        char result_found[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE] = {0};
 
         curr = next;
 
@@ -819,7 +821,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
     } else if (strcmp(curr, "query_policy") == 0) {
 
         char *policy;
-        char result_found[OS_MAXSTR + 1] = {0};
+        char result_found[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE] = {0};
 
         curr = next;
         policy = curr;
@@ -842,7 +844,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
     } else if (strcmp(curr, "query_policy_sha256") == 0) {
 
         char *policy;
-        char result_found[OS_MAXSTR + 1] = {0};
+        char result_found[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE] = {0};
 
         curr = next;
         policy = curr;

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -49,7 +49,7 @@
 #define STATE_LENGTH 20
 #define MTU_LENGTH 20
 #define DHCP_LENGTH 10
-#define V_LENGTH    128
+#define V_LENGTH    256
 #define COMMAND_LENGTH  512
 #define PATH_LENGTH     512
 #define TIME_LENGTH     64

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -24,7 +24,7 @@ cJSON *wm_sys_dump(const wm_sys_t *sys);
 const wm_context WM_SYS_CONTEXT = {
     "syscollector",
     (wm_routine)wm_sys_main,
-    (wm_routine)wm_sys_destroy,
+    (wm_routine)(void *)wm_sys_destroy,
     (cJSON * (*)(const void *))wm_sys_dump
 };
 

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -556,9 +556,9 @@ char * sys_rpm_packages(int queue_fd, const char* LOCATION, int random_id){
         }
 
         if (epoch) {
-            snprintf(final_version, V_LENGTH - 1, "%d:%s-%s", epoch, version, release);
+            snprintf(final_version, V_LENGTH, "%d:%s-%s", epoch, version, release);
         } else {
-            snprintf(final_version, V_LENGTH - 1, "%s-%s", version, release);
+            snprintf(final_version, V_LENGTH, "%s-%s", version, release);
         }
         cJSON_AddStringToObject(package, "version", final_version);
 

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -30,7 +30,7 @@ cJSON *wm_aws_dump(const wm_aws *aws_config);
 const wm_context WM_AWS_CONTEXT = {
     "aws-s3",
     (wm_routine)wm_aws_main,
-    (wm_routine)wm_aws_destroy,
+    (wm_routine)(void *)wm_aws_destroy,
     (cJSON * (*)(const void *))wm_aws_dump
 };
 

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -35,7 +35,7 @@ cJSON *wm_azure_dump(const wm_azure_t *azure);                          // Dump 
 const wm_context WM_AZURE_CONTEXT = {
     AZ_WM_NAME,
     (wm_routine)wm_azure_main,
-    (wm_routine)wm_azure_destroy,
+    (wm_routine)(void *)wm_azure_destroy,
     (cJSON * (*)(const void *))wm_azure_dump
 };
 

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -44,7 +44,7 @@ const char *WM_CISCAT_LOCATION = "wodle_cis-cat";  // Location field for event s
 const wm_context WM_CISCAT_CONTEXT = {
     "cis-cat",
     (wm_routine)wm_ciscat_main,
-    (wm_routine)wm_ciscat_destroy,
+    (wm_routine)(void *)wm_ciscat_destroy,
     (cJSON * (*)(const void *))wm_ciscat_dump
 };
 

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -20,7 +20,7 @@ cJSON *wm_command_dump(const wm_command_t * command);
 const wm_context WM_COMMAND_CONTEXT = {
     "command",
     (wm_routine)wm_command_main,
-    (wm_routine)wm_command_destroy,
+    (wm_routine)(void *)wm_command_destroy,
     (cJSON * (*)(const void *))wm_command_dump
 };
 

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -27,7 +27,7 @@ cJSON *wm_docker_dump(const wm_docker_t *docker_conf);         // Dump docker co
 const wm_context WM_DOCKER_CONTEXT = {
     "docker-listener",
     (wm_routine)wm_docker_main,
-    (wm_routine)wm_docker_destroy,
+    (wm_routine)(void *)wm_docker_destroy,
     (cJSON * (*)(const void *))wm_docker_dump
 };
 

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -26,7 +26,7 @@
 
 static void * wm_download_main(wm_download_t * data);   // Module main function. It won't return
 static void wm_download_destroy(wm_download_t * data);  // Destroy data
-cJSON *wm_download_dump(void);     // Read config
+cJSON *wm_download_dump();     // Read config
 
 // Dispatch request. Write the output into the same input buffer.
 static void wm_download_dispatch(char * buffer);
@@ -34,7 +34,7 @@ static void wm_download_dispatch(char * buffer);
 const wm_context WM_DOWNLOAD_CONTEXT = {
     "download",
     (wm_routine)wm_download_main,
-    (wm_routine)wm_download_destroy,
+    (wm_routine)(void *)wm_download_destroy,
     (cJSON * (*)(const void *))wm_download_dump
 };
 
@@ -208,7 +208,7 @@ wmodule * wm_download_read() {
 #endif
 }
 
-cJSON *wm_download_dump(void) {
+cJSON *wm_download_dump() {
     cJSON *root = cJSON_CreateObject();
     cJSON *wm_wd = cJSON_CreateObject();
     cJSON_AddStringToObject(wm_wd,"enabled","yes");

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -61,7 +61,7 @@ static int wm_fluent_check_config(wm_fluent_t * fluent);
 const wm_context WM_FLUENT_CONTEXT = {
     FLUENT_WM_NAME,
     (wm_routine)wm_fluent_main,
-    (wm_routine)wm_fluent_destroy,
+    (wm_routine)(void *)wm_fluent_destroy,
     (cJSON * (*)(const void *))wm_fluent_dump
 };
 

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -51,7 +51,7 @@ const char *exec_params[2] = { "id", "ip" };
 const wm_context WM_KEY_REQUEST_CONTEXT = {
     KEY_WM_NAME,
     (wm_routine)wm_key_request_main,
-    (wm_routine)wm_key_request_destroy,
+    (wm_routine)(void *)wm_key_request_destroy,
     (cJSON * (*)(const void *))wm_key_request_dump
 };
 

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -20,7 +20,7 @@ cJSON *wm_oscap_dump(const wm_oscap *oscap);
 const wm_context WM_OSCAP_CONTEXT = {
     "open-scap",
     (wm_routine)wm_oscap_main,
-    (wm_routine)wm_oscap_destroy,
+    (wm_routine)(void *)wm_oscap_destroy,
     (cJSON * (*)(const void *))wm_oscap_dump
 };
 

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -49,7 +49,7 @@ static volatile int active = 1;
 const wm_context WM_OSQUERYMONITOR_CONTEXT = {
     "osquery",
     (wm_routine)wm_osquery_monitor_main,
-    (wm_routine)wm_osquery_monitor_destroy,
+    (wm_routine)(void *)wm_osquery_monitor_destroy,
     (cJSON * (*)(const void *))wm_osquery_dump
 };
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -94,7 +94,7 @@ cJSON *wm_sca_dump(const wm_sca_t * data);     // Read config
 const wm_context WM_SCA_CONTEXT = {
     SCA_WM_NAME,
     (wm_routine)wm_sca_main,
-    (wm_routine)wm_sca_destroy,
+    (wm_routine)(void *)wm_sca_destroy,
     (cJSON * (*)(const void *))wm_sca_dump
 };
 
@@ -123,7 +123,7 @@ void * wm_sca_main(wm_sca_t * data) {
     if (!data->profile || data->profile[0] == NULL) {
         minfo("No policies defined. Exiting.");
         pthread_exit(NULL);
-    }     
+    }
 
     data->msg_delay = 1000000 / wm_max_eps;
     data->summary_delay = 3; /* Seconds to wait for summary sending */
@@ -1472,7 +1472,7 @@ static int wm_sca_read_command(char *command, char *pattern,wm_sca_t * data)
                 full_negate = 0;
                 break;
             }
-         
+
         }
 
         if (full_negate == 1) {
@@ -1742,7 +1742,7 @@ static int wm_sca_is_registry(char *entry_name, char *reg_option, char *reg_valu
     int test_results_64 = 0;
 
     // most likely to find it in the 64bit registry nowadays. Comes first to leverage short-circuit evaluation.
-    
+
     const int found = wm_sca_test_key(rk, entry_name, KEY_WOW64_64KEY, reg_option, reg_value, &test_results_64)
                    || wm_sca_test_key(rk, entry_name, KEY_WOW64_32KEY, reg_option, reg_value, &test_results_32);
     const int test_results = test_results_32 || test_results_64;
@@ -1819,10 +1819,10 @@ static int wm_sca_test_key(char *subkey, char *full_key_name, unsigned long arch
         *test_result = 0;
         return 0;
     }
-    
+
     /* If the key does exists, a test for existance succeeds  */
     *test_result = 1;
-    
+
     /* If option is set, set test_result as the value of query key */
     if (reg_option) {
         *test_result = wm_sca_winreg_querykey(oshkey, subkey, full_key_name, reg_option, reg_value);
@@ -2438,7 +2438,7 @@ static void *wm_sca_dump_db_thread(wm_sca_t * data) {
                 wm_delay(1000 * time);
                 mdebug1("Dumping results to SCA DB for policy index '%u'",request->policy_index);
             }
-          
+
             int scan_id = -1;
 
             for(i = 0; cis_db_for_hash[request->policy_index].elem[i]; i++) {
@@ -2463,7 +2463,7 @@ static void *wm_sca_dump_db_thread(wm_sca_t * data) {
             }
 
             wm_delay(5000);
-           
+
             int elements_sent = i - 1;
             mdebug1("Sending end of dump control event");
 
@@ -2544,7 +2544,7 @@ void wm_sca_push_request_win(char * msg){
                     if(strcmp(data_win->profile[i]->policy_id,db) == 0){
                         request_dump_t *request;
                         os_calloc(1, sizeof(request_dump_t),request);
-                         
+
                         request->policy_index = i;
                         request->first_scan = atoi(first_scan);
 
@@ -2614,7 +2614,7 @@ static void * wm_sca_request_thread(wm_sca_t * data) {
                         if(strcmp(data->profile[i]->policy_id,db) == 0){
                             request_dump_t *request;
                             os_calloc(1, sizeof(request_dump_t),request);
-                         
+
                             request->policy_index = i;
                             request->first_scan = atoi(first_scan);
 

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -1828,7 +1828,7 @@ const char *wm_vuldet_decode_package_version(char *raw, const char **OS, char **
 
 int check_timestamp(const char *OS, char *timst, char *ret_timst) {
     int retval = VU_TIMESTAMP_FAIL;
-    char stored_timestamp[KEY_SIZE];
+    char stored_timestamp[OS_SIZE_256];
     int i;
     sqlite3_stmt *stmt = NULL;
     sqlite3 *db = NULL;
@@ -1841,7 +1841,7 @@ int check_timestamp(const char *OS, char *timst, char *ret_timst) {
         }
         sqlite3_bind_text(stmt, 1, OS, -1, NULL);
         if (wm_vuldet_step(stmt) == SQLITE_ROW) {
-            snprintf(stored_timestamp, KEY_SIZE, "%s", sqlite3_column_text(stmt, 0));
+            snprintf(stored_timestamp, OS_SIZE_256, "%s", sqlite3_column_text(stmt, 0));
             for (i = 0; stored_timestamp[i] != '\0'; i++) {
                  if (stored_timestamp[i] == '-' ||
                  stored_timestamp[i] == ' ' ||

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -73,7 +73,7 @@ int usec;
 const wm_context WM_VULNDETECTOR_CONTEXT = {
     "vulnerability-detector",
     (wm_routine)wm_vuldet_main,
-    (wm_routine)wm_vuldet_destroy,
+    (wm_routine)(void *)wm_vuldet_destroy,
     (cJSON * (*)(const void *))wm_vuldet_dump
 };
 


### PR DESCRIPTION
This PR solves some warnings caused by a possible string truncation using the `snprintf` function.