### PR TITLE
Fix alert email sending when no_full_log option is set in a rule

### DIFF
--- a/src/os_maild/maild.h
+++ b/src/os_maild/maild.h
@@ -47,7 +47,7 @@
                             "Received From: %s\r\n" \
                             "Rule: %d fired (level %d) -> \"%s\"\r\n" \
                             "%s" \
-                            "Portion of the log(s):\r\n\r\n%s\r\n" \
+                            "Alert(s):\r\n\r\n%s\r\n" \
                             "\r\n\r\n --END OF NOTIFICATION\r\n\r\n\r\n"
 #endif
 

--- a/src/os_maild/maild.h
+++ b/src/os_maild/maild.h
@@ -47,7 +47,7 @@
                             "Received From: %s\r\n" \
                             "Rule: %d fired (level %d) -> \"%s\"\r\n" \
                             "%s" \
-                            "Alert(s):\r\n\r\n%s\r\n" \
+                            "Portion of the log(s):\r\n\r\n%s\r\n" \
                             "\r\n\r\n --END OF NOTIFICATION\r\n\r\n\r\n"
 #endif
 

--- a/src/os_maild/maild.h
+++ b/src/os_maild/maild.h
@@ -77,6 +77,16 @@ size_t mailcom_getconfig(const char * section, char ** output);
 MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *mail, MailMsg **msg_sms) __attribute__((nonnull));
 MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *mail, MailMsg **msg_sms) __attribute__((nonnull));
 
+/**
+ * @brief Read cJSON and save in printed with email format
+ * @param item Pointer to the cJSON to read
+ * @param printed Body email
+ * @param body_size Maximun body message size
+ * @param tab Determine the number of tabs on each line
+ * @param counter Count the number of times that is tabulated in a line
+ */
+void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int counter);
+
 /* Send an email */
 int OS_Sendmail(MailConfig *mail, struct tm *p) __attribute__((nonnull));
 int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg) __attribute__((nonnull));

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -823,6 +823,10 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
         PrintTable(item->next, printed, body_size, tab, counter);
     }
 
+    /* Clear memory */
     free(tab_child);
+    free(delimitator);
+    free(endline);
+    free(space);
 }
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -419,10 +419,12 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         goto end;
     }
     alert_level = json_field->valueint;
+
     if (json_field = cJSON_GetObjectItem(rule,"description"), !json_field) {
         goto end;
     }
     alert_desc = strdup(json_field->valuestring);
+
     if (json_field = cJSON_GetObjectItem(rule,"id"), !json_field) {
         goto end;
     }

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -386,21 +386,18 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
 
     // Get full_log field content
     json_field = cJSON_GetObjectItem(al_json,"full_log");
-    if (!json_field) {
-        goto end;
+    if (json_field) {
+        log_size = strlen(json_field->valuestring) + 4;
+
+        /* If size left is small than the size of the log, stop it */
+        if (body_size <= log_size) {
+            goto end;
+        }
+
+        strncpy(logs, json_field->valuestring, body_size);
+        strncpy(logs + log_size, "\r\n", body_size - log_size);
+        body_size -= log_size;
     }
-
-    log_size = strlen(json_field->valuestring) + 4;
-
-    /* If size left is small than the size of the log, stop it */
-    if (body_size <= log_size) {
-        goto end;
-    }
-
-    strncpy(logs, json_field->valuestring, body_size);
-    strncpy(logs + log_size, "\r\n", body_size - log_size);
-    body_size -= log_size;
-
 
     json_object = cJSON_GetObjectItem(al_json,"syscheck");
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -744,20 +744,54 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
     os_malloc(256*sizeof(char), t);
     strncpy(t, tab, 256*sizeof(char));
 
+
     /* If final node, it print */
     if ((item->type & 0xFF) == cJSON_Number || (item->type & 0xFF) == cJSON_String ||
-        (item->type & 0xFF) == cJSON_False || (item->type & 0xFF) == cJSON_True ||
-        (item->type & 0xFF) == cJSON_Array) {
+        (item->type & 0xFF) == cJSON_False || (item->type & 0xFF) == cJSON_True ){
 
         item->string[0] = toupper(item->string[0]);
         val2 = cJSON_PrintUnformatted(item);
-        log_size = strlen(val2) + strlen(item->string) + 8;
+        log_size = strlen(val2) + strlen(tab) + strlen(item->string) + 6;
 
         if (body_size > log_size) {
             strncat(printed, tab, strlen(tab));
             strncat(printed, item->string, strlen(item->string));
             strncat(printed, ": ", 2);
             strncat(printed, val2, body_size);
+            strncat(printed, "\r\n", 4);
+            body_size -= log_size;
+        }
+
+        free(val2);
+    }
+    else if ((item->type & 0xFF) == cJSON_Array){
+
+        cJSON *json_array;
+        int i = 0;
+        log_size = strlen(item->string) + strlen(tab) + 2;
+
+        if(body_size > log_size){
+            item->string[0] = toupper(item->string[0]);
+            strncat(printed, tab, strlen(tab));
+            strncat(printed, item->string, strlen(item->string));
+            strncat(printed, ": ", 2);
+            body_size -= log_size;
+        }
+
+        while(json_array = cJSON_GetArrayItem(item, i)){
+            val2 = cJSON_PrintUnformatted(json_array);
+            log_size = strlen(val2) + 1;
+
+            if(body_size > log_size){
+                strncat(printed, json_array->valuestring, body_size);
+                strncat(printed, " ", 1);
+                body_size -= log_size;
+            }
+
+            i++;
+        }
+
+        if(body_size > 4){
             strncat(printed, "\r\n", 4);
             body_size -= log_size;
         }
@@ -789,6 +823,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
             }
         }
     }
+
 
     /* If there are more items in the array the function is called with the same number of tabs */
     if(item->next && body_size > 2){

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -722,15 +722,7 @@ end:
     return NULL;
 }
 
-
-/**
- * @brief Read cJSON and save in printed with email format
- * @param item Pointer to the cJSON to read
- * @param printed Body email
- * @param body_size Maximun body message size
- * @param tab Determine the number of tabs on each line
- * @param counter Count the number of times that is tabulated in a line
- */
+/* Read cJSON and save in printed with email format */
 void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int counter)
 {
     char *val2;
@@ -795,7 +787,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
         }
 
     }
-    /* If you have a child, the PrintTable function is called with one more tabulation.*/
+    /* If it have a child, the PrintTable function is called with one more tabulation.*/
     else {
         if (item->child){
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -348,7 +348,6 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
 {
     int i = 0, sms_set = 0, donotgroup = 0;
     size_t *body_size, log_size;
-    body_size = OS_MAXSTR - 3;
     char logs[OS_MAXSTR + 1] = "";
     char *subject_host = NULL;
     char *json_str;
@@ -384,6 +383,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
     os_calloc(BODY_SIZE, sizeof(char), mail->body);
     os_calloc(SUBJECT_SIZE, sizeof(char), mail->subject);
     os_malloc(sizeof(size_t), body_size);
+    body_size = OS_MAXSTR - 3;
 
     // Add alert to logs
     char *tab;

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -347,7 +347,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
 MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sms)
 {
     int i = 0, sms_set = 0, donotgroup = 0;
-    size_t *body_size, log_size;
+    size_t body_size, log_size;
     char logs[OS_MAXSTR + 1] = "";
     char *subject_host = NULL;
     char *json_str;
@@ -385,12 +385,11 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
     os_calloc(SUBJECT_SIZE, sizeof(char), mail->subject);
 
     /* To create body mail*/
-    os_malloc(sizeof(size_t), body_size);
     body_size = OS_MAXSTR - 3;
     os_malloc(14*sizeof(char), tab);
     strncpy(tab, "\t", 2);
 
-    /* Add alert to logs */
+    /* Remove full log from alert */
     if(cJSON_GetObjectItem(al_json, "full_log")){
         cJSON_DeleteItemFromObject(al_json, "full_log");
     }
@@ -399,7 +398,6 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
     PrintTable(al_json, logs, body_size, tab, 2);
 
     free(tab);
-    free(body_size);
 
     /* Subject */
 
@@ -626,7 +624,7 @@ end:
 
 
 
-void PrintTable(cJSON *item, char *printed, size_t *body_size, char *tab, int counter)
+void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int counter)
 {
     char *val2;
     int log_size;

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -490,8 +490,10 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         }
     }
     else {
+        /* The full alert is printed */
+        /* tab is used to determine the number of tabs on each line */
         char *tab;
-        os_malloc(14*sizeof(char), tab);
+        os_malloc(256*sizeof(char), tab);
         strncpy(tab, "\t", 2);
 
         PrintTable(al_json, logs, body_size, tab, 2);
@@ -724,16 +726,25 @@ end:
 }
 
 
-
+/**
+ * @brief Read cJSON and save in printed with email format
+ * @param item Pointer to the cJSON to read
+ * @param printed Body email
+ * @param body_size Maximun body message size
+ * @param tab Determine the number of tabs on each line
+ * @param counter Count the number of times that is tabulated in a line
+ */
 void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int counter)
 {
     char *val2;
     int log_size;
     char *t;
 
-    os_malloc(14*sizeof(char), t);
-    strncpy(t, tab, 14*sizeof(char));
+    /* Like tab, t is used to derterminate the number of times a line must be tabbed. */
+    os_malloc(256*sizeof(char), t);
+    strncpy(t, tab, 256*sizeof(char));
 
+    /* If final node, it print */
     if ((item->type & 0xFF) == cJSON_Number || (item->type & 0xFF) == cJSON_String ||
         (item->type & 0xFF) == cJSON_False || (item->type & 0xFF) == cJSON_True ||
         (item->type & 0xFF) == cJSON_Array) {
@@ -753,6 +764,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
         free(val2);
     }
+    /* If you have a child, the PrintTable function is called with one more tabulation.*/
     else {
         if (item->child){
 
@@ -767,7 +779,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
                     body_size -= log_size;
                 }
             }
-
+            /* 12/2 is max number of times that it can be tabulated */
             if(counter < 12){
                 strncat(t, "\t", 2);
                 PrintTable(item->child, printed, body_size, t, (counter + 2));
@@ -778,6 +790,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
         }
     }
 
+    /* If there are more items in the array the function is called with the same number of tabs */
     if(item->next && body_size > 2){
         PrintTable(item->next, printed, body_size, tab, counter);
     }

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -397,6 +397,20 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         strncpy(logs, json_field->valuestring, body_size);
         strncpy(logs + log_size, "\r\n", body_size - log_size);
         body_size -= log_size;
+    } else {
+        char *string = cJSON_Print(al_json);
+        log_size = strlen(string) + 4;
+
+        /* If size left is small than the size of the log, stop it */
+        if (body_size <= log_size) {
+            os_free(string);
+            goto end;
+        }
+
+        strncpy(logs, string, body_size);
+        strncpy(logs + log_size, "\r\n", body_size - log_size);
+        body_size -= log_size;
+        os_free(string);
     }
 
     json_object = cJSON_GetObjectItem(al_json,"syscheck");

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -825,8 +825,5 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
     /* Clear memory */
     free(tab_child);
-    free(delimitator);
-    free(endline);
-    free(space);
 }
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -386,7 +386,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
 
     /* Add alert to logs */
 
-    if(json_field = cJSON_GetObjectItem(al_json,"full_log")){
+    if(json_field = cJSON_GetObjectItem(al_json,"full_log"), json_field){
 
         log_size = strlen(json_field->valuestring) + 4;
 
@@ -398,7 +398,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         strncpy(logs + log_size, "\r\n", body_size - log_size);
 
     }
-    else if (json_object = cJSON_GetObjectItem(al_json,"syscheck")){
+    else if (json_object = cJSON_GetObjectItem(al_json,"syscheck"), json_field){
 
         json_field = cJSON_GetObjectItem(json_object,"path");
         if (json_field) {
@@ -734,7 +734,7 @@ end:
 void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int counter)
 {
     char *val2;
-    int log_size;
+    size_t log_size;
     char *t;
 
     /* Like tab, t is used to derterminate the number of times a line must be tabbed. */
@@ -775,7 +775,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
             body_size -= log_size;
         }
 
-        while(json_array = cJSON_GetArrayItem(item, i)){
+        while(json_array = cJSON_GetArrayItem(item, i), json_array){
             val2 = cJSON_PrintUnformatted(json_array);
             log_size = strlen(val2) + 1;
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -386,9 +386,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
 
     /* Add alert to logs */
 
-    json_field = cJSON_GetObjectItem(al_json,"full_log");
-
-    if(json_field){
+    if(json_field = cJSON_GetObjectItem(al_json,"full_log")){
 
         log_size = strlen(json_field->valuestring) + 4;
 
@@ -400,55 +398,96 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         strncpy(logs + log_size, "\r\n", body_size - log_size);
         body_size -= log_size;
 
-        json_object = cJSON_GetObjectItem(al_json,"syscheck");
 
-        if (json_object) {
+    }
+    else if (json_object = cJSON_GetObjectItem(al_json,"syscheck")){
 
-            json_field = cJSON_GetObjectItem(json_object,"md5_before");
-            if (json_field) {
-                log_size = strlen(json_field->valuestring) + 16 + 4;
-                if (body_size > log_size) {
-                    strncat(logs, "Old md5sum was: ", 16);
-                    strncat(logs, json_field->valuestring, body_size);
-                    strncat(logs, "\r\n", 4);
-                    body_size -= log_size;
-                }
-            }
-
-            json_field = cJSON_GetObjectItem(json_object,"md5_after");
-            if (json_field) {
-                log_size = strlen(json_field->valuestring) + 15 + 4;
-                if (body_size > log_size) {
-                    strncat(logs, "New md5sum is: ", 15);
-                    strncat(logs, json_field->valuestring, body_size);
-                    strncat(logs, "\r\n", 4);
-                    body_size -= log_size;
-                }
-            }
-
-            json_field = cJSON_GetObjectItem(json_object,"sha1_before");
-            if (json_field) {
-                log_size = strlen(json_field->valuestring) + 16 + 4;
-                if (body_size > log_size) {
-                    strncat(logs, "Old sh1sum was: ", 16);
-                    strncat(logs, json_field->valuestring, body_size);
-                    strncat(logs, "\r\n", 4);
-                    body_size -= log_size;
-                }
-            }
-
-            json_field = cJSON_GetObjectItem(json_object,"sha1_after");
-            if (json_field) {
-                log_size = strlen(json_field->valuestring) + 15 + 4;
-                if (body_size > log_size) {
-                    strncat(logs, "New sh1sum is: ", 15);
-                    strncat(logs, json_field->valuestring, body_size);
-                    strncat(logs, "\r\n", 4);
-                    body_size -= log_size;
-                }
+        json_field = cJSON_GetObjectItem(json_object,"path");
+        if (json_field) {
+            log_size = strlen(json_field->valuestring) + 6;
+            if (body_size > log_size) {
+                strncat(logs, "File: ", 6);
+                strncat(logs, json_field->valuestring, body_size);
+                body_size -= log_size;
             }
         }
 
+        json_field = cJSON_GetObjectItem(json_object,"event");
+        if (json_field) {
+            log_size = strlen(json_field->valuestring) + 1 + 4;
+            if (body_size > log_size) {
+                strncat(logs, " ", 1);
+                strncat(logs, json_field->valuestring, body_size);
+                strncat(logs, "\r\n", 4);
+                body_size -= log_size;
+            }
+        }
+
+        json_field = cJSON_GetObjectItem(json_object,"md5_before");
+        if (json_field) {
+            log_size = strlen(json_field->valuestring) + 16 + 4;
+            if (body_size > log_size) {
+                strncat(logs, "Old md5sum was: ", 16);
+                strncat(logs, json_field->valuestring, body_size);
+                strncat(logs, "\r\n", 4);
+                body_size -= log_size;
+            }
+        }
+
+        json_field = cJSON_GetObjectItem(json_object,"md5_after");
+        if (json_field) {
+            log_size = strlen(json_field->valuestring) + 15 + 4;
+            if (body_size > log_size) {
+                strncat(logs, "New md5sum is: ", 15);
+                strncat(logs, json_field->valuestring, body_size);
+                strncat(logs, "\r\n", 4);
+                body_size -= log_size;
+            }
+        }
+
+        json_field = cJSON_GetObjectItem(json_object,"sha1_before");
+        if (json_field) {
+            log_size = strlen(json_field->valuestring) + 17 + 4;
+            if (body_size > log_size) {
+                strncat(logs, "Old sha1sum was: ", 17);
+                strncat(logs, json_field->valuestring, body_size);
+                strncat(logs, "\r\n", 4);
+                body_size -= log_size;
+            }
+        }
+
+        json_field = cJSON_GetObjectItem(json_object,"sha1_after");
+        if (json_field) {
+            log_size = strlen(json_field->valuestring) + 16 + 4;
+            if (body_size > log_size) {
+                strncat(logs, "New sha1sum is: ", 16);
+                strncat(logs, json_field->valuestring, body_size);
+                strncat(logs, "\r\n", 4);
+                body_size -= log_size;
+            }
+        }
+
+        json_field = cJSON_GetObjectItem(json_object,"sha256_before");
+        if (json_field) {
+            log_size = strlen(json_field->valuestring) + 19 + 4;
+            if (body_size > log_size) {
+                strncat(logs, "Old sha256sum was: ", 19);
+                strncat(logs, json_field->valuestring, body_size);
+                strncat(logs, "\r\n", 4);
+                body_size -= log_size;
+            }
+        }
+
+        json_field = cJSON_GetObjectItem(json_object,"sha256_after");
+        if (json_field) {
+            log_size = strlen(json_field->valuestring) + 18 + 4;
+            if (body_size > log_size) {
+                strncat(logs, "New sha256sum is: ", 18);
+                strncat(logs, json_field->valuestring, body_size);
+                strncat(logs, "\r\n", 4);
+                body_size -= log_size;
+            }
+        }
     }
     else {
         char *tab;

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -396,8 +396,6 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
 
         strncpy(logs, json_field->valuestring, body_size);
         strncpy(logs + log_size, "\r\n", body_size - log_size);
-        body_size -= log_size;
-
 
     }
     else if (json_object = cJSON_GetObjectItem(al_json,"syscheck")){
@@ -485,7 +483,6 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
                 strncat(logs, "New sha256sum is: ", 18);
                 strncat(logs, json_field->valuestring, body_size);
                 strncat(logs, "\r\n", 4);
-                body_size -= log_size;
             }
         }
     }
@@ -788,6 +785,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
                 body_size -= log_size;
             }
 
+            free(val2);
             i++;
         }
 
@@ -796,7 +794,6 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
             body_size -= log_size;
         }
 
-        free(val2);
     }
     /* If you have a child, the PrintTable function is called with one more tabulation.*/
     else {

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -356,7 +356,6 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
     char *alert_desc = NULL;
     char *timestamp = NULL;
     unsigned int rule_id = 0;
-    char *tab;
 
     MailMsg *mail = NULL;
     cJSON *al_json;
@@ -451,8 +450,8 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         }
 
     }
-    else
-    {
+    else {
+        char *tab;
         os_malloc(14*sizeof(char), tab);
         strncpy(tab, "\t", 2);
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -810,14 +810,9 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
                     body_size -= log_size;
                 }
             }
-            /* 12/2 is max number of times that it can be tabulated */
-            if(counter < 12){
-                strncat(t, "\t", 2);
-                PrintTable(item->child, printed, body_size, t, (counter + 2));
-            }
-            else {
-                PrintTable(item->child, printed, body_size, t, counter);
-            }
+
+            strncat(t, "\t", 2);
+            PrintTable(item->child, printed, body_size, t, (counter + 2));
         }
     }
 


### PR DESCRIPTION
This fixes #3163 and #3762 

Fix
---
- The email alerts that were triggered by rules that have the `no_full_log` option weren't working.

Testing
---
### Rule configuration
This rule has been included in `/var/ossec/etc/rules/local_rules.xml`:
```
<group name="SSHLoginFailed">
  <rule id="100150" level="14">
    <decoded_as>json</decoded_as>
    <field name="eventid">\.*login.failed</field>
    <description> Username $(username) : attempted to login</description>
    <options>no_full_log</options>
  </rule>
</group>
```

To trigger the alert that matches this rule the following log has been concatenated to `/var/log/syslog` (Ubuntu):
```
{"eventid":"cowrie.login.failed","username":"twalton","timestamp":"2019-04-17T16:24:33.510587Z","message":"login attempt [twalton/test] failed","system":"SSHService 'ssh-userauth'","src_ip":"10.160.60.27","session":"f05271d202b6","password":"test","sensor":"1ca11427d473"}
```

### Valgrind report
```
==27856== HEAP SUMMARY:
==27856==     in use at exit: 68,585 bytes in 49 blocks
==27856==   total heap usage: 9,581 allocs, 9,532 frees, 3,596,032 bytes allocated
==27856==
==27856== 75 (24 direct, 51 indirect) bytes in 1 blocks are definitely lost in loss record 23 of 30
==27856==    at 0x4C2FD5F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27856==    by 0x41E1F7: Read_Global (global-config.c:426)
==27856==    by 0x40E12B: read_main_elements (config.c:71)
==27856==    by 0x40F0BF: ReadConfig (config.c:245)
==27856==    by 0x40BAFD: MailConf (config.c:54)
==27856==    by 0x40C68F: main (maild.c:123)
==27856==
==27856== 159 (16 direct, 143 indirect) bytes in 1 blocks are definitely lost in loss record 25 of 30
==27856==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27856==    by 0x4C2FDEF: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27856==    by 0x41E3B7: Read_Global (global-config.c:446)
==27856==    by 0x40E12B: read_main_elements (config.c:71)
==27856==    by 0x40F0BF: ReadConfig (config.c:245)
==27856==    by 0x40BAFD: MailConf (config.c:54)
==27856==    by 0x40C68F: main (maild.c:123)
==27856==
==27856== 393 (144 direct, 249 indirect) bytes in 1 blocks are definitely lost in loss record 27 of 30
==27856==    at 0x4C2FD5F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27856==    by 0x41C9E9: Read_GlobalSK (global-config.c:105)
==27856==    by 0x40E4DA: read_main_elements (config.c:102)
==27856==    by 0x40F0BF: ReadConfig (config.c:245)
==27856==    by 0x40BAFD: MailConf (config.c:54)
==27856==    by 0x40C68F: main (maild.c:123)
==27856==
==27856== LEAK SUMMARY:
==27856==    definitely lost: 184 bytes in 3 blocks
==27856==    indirectly lost: 443 bytes in 27 blocks
==27856==      possibly lost: 0 bytes in 0 blocks
==27856==    still reachable: 67,958 bytes in 19 blocks
==27856==         suppressed: 0 bytes in 0 blocks
==27856== Reachable blocks (those to which a pointer was found) are not shown.
```

Result
---
An alert mail that's been triggered by a rule that has the `no_full_log` option, now look like this:
```
Wazuh Notification.
2019-04-25T10:23:15.118+0000

Received From: vm-ubuntu4->/var/log/syslog
Rule: 100150 fired (level 14) -> " Username twalton : attempted to login"
Portion of the log(s):




 --END OF NOTIFICATION

```