### PR TITLE
Fixed AIX msgpack compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -96,7 +96,7 @@ ifneq (,$(filter ${USE_AUDIT},yes y Y 1))
 endif
 else
 ifeq (${uname_S},AIX)
-		DEFINES+=-DAIX
+		DEFINES+=-DAIX -D__unix
 		DEFINES+=-DHIGHFIRST
 		OSSEC_CFLAGS+=-pthread
 		OSSEC_LDFLAGS+=-pthread


### PR DESCRIPTION
### Compilation failed

Compilation failed due to structure redefinition caused by `msgpack` https://github.com/wazuh/wazuh/issues/3182:

```
In file included from external/msgpack/include/msgpack.h:22:0,
                 from wazuh_modules/wm_fluent.c:20:
external/msgpack/include/msgpack/vrefbuffer.h:19:8: error: redefinition of 'struct iovec'
 struct iovec {
        ^
In file included from /usr/include/sys/socket.h:74:0,
                 from ./headers/shared.h:85,
                 from wazuh_modules/wmodules.h:19,
                 from wazuh_modules/wm_fluent.c:13:
/usr/include/sys/uio.h:59:8: note: originally defined here
 struct iovec {
```

### Remediation

Added the flag `-D__unix` for AIX in Makefile