### PR TITLE
Reduced message level for FIM_LINKCHECK_START

### DIFF
--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -683,11 +683,11 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
     char *conv_link;
 
     syscheck.sym_checker_interval = checker_sleep;
-    minfo(FIM_LINKCHECK_START, checker_sleep);
+    mdebug1(FIM_LINKCHECK_START, checker_sleep);
 
     while (1) {
         sleep(checker_sleep);
-        minfo(FIM_LINKCHECK_START, checker_sleep);
+        mdebug1(FIM_LINKCHECK_START, checker_sleep);
 
         for (i = 0; syscheck.dir[i]; i++) {
             if (syscheck.converted_links[i]) {


### PR DESCRIPTION
Hi team,

```
ossec-syscheckd INFO:  (6233): Starting symbolic link updater. Interval '600'.
```

This message should be a _debug_ message instead of an _info_ message.