### PR TITLE
Fix manager compilation in MacosX

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -545,7 +545,7 @@ int OS_SetKeepalive(int socket)
     return setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, (void *)&keepalive, sizeof(keepalive));
 }
 
-#ifndef CLIENT
+#ifdef _REMOTED_KEEPALIVE_
 void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
 {
     if (setsockopt(socket, SOL_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -16,6 +16,10 @@
 #ifndef __OS_NET_H
 #define __OS_NET_H
 
+#if !defined(CLIENT) && !defined(Darwin)
+#define _REMOTED_KEEPALIVE_ 1
+#endif
+
 /* OS_Bindport*
  * Bind a specific port (protocol and a ip).
  * If the IP is not set, it is going to use ADDR_ANY
@@ -89,7 +93,7 @@ int OS_SetKeepalive(int socket);
 /*
  * Enable SO_KEEPALIVE options for TCP
  */
-#ifndef CLIENT
+#ifdef _REMOTED_KEEPALIVE_
 void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt);
 #endif
 /* Set the delivery timeout for a socket

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -75,7 +75,7 @@ void HandleRemote(int uid)
             if (OS_SetKeepalive(logr.sock) < 0){
                 merror("OS_SetKeepalive failed with error '%s'", strerror(errno));
             }
-#ifndef CLIENT
+#ifdef _REMOTED_KEEPALIVE_
             else {
                 OS_SetKeepalive_Options(logr.sock, tcp_keepidle, tcp_keepintvl, tcp_keepcnt);
             }


### PR DESCRIPTION
This PR fixes the manager compilation bug on MacOS X systems that affected `3.9.x`.

The sockets in this system cannot be configured with keepalive options: `TCP_KEEPCNT`, `TCP_KEEPIDLE` and `TCP_KEEPINTVL`, as they are of Linux.

Related PR: https://github.com/wazuh/wazuh/pull/3069.