### PR TITLE
Fix FIM check_inode option

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -405,7 +405,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
                     user ? user : "",
                     opts & CHECK_GROUP ? get_group(statbuf.st_gid) : "",
                     str_mtime,
-                    str_inode,
+                    opts & CHECK_INODE ? str_inode : "",
                     opts & CHECK_SHA256SUM ? sf256_sum : "",
                     opts & CHECK_ATTRS ? w_get_file_attrs(file_name) : 0);
 
@@ -522,7 +522,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
                 user ? user : "",
                 opts & CHECK_GROUP ? get_group(statbuf.st_gid) : "",
                 str_mtime,
-                str_inode,
+                opts & CHECK_INODE ? str_inode : "",
                 opts & CHECK_SHA256SUM ? sf256_sum : "",
                 opts & CHECK_ATTRS ? w_get_file_attrs(file_name) : 0,
                 wd_sum,
@@ -545,7 +545,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
                 opts & CHECK_OWNER ? get_user(file_name, S_ISLNK(statbuf.st_mode) ? statbuf_lnk.st_uid : statbuf.st_uid, NULL) : "",
                 opts & CHECK_GROUP ? get_group(S_ISLNK(statbuf.st_mode) ? statbuf_lnk.st_gid : statbuf.st_gid) : "",
                 str_mtime,
-                str_inode,
+                opts & CHECK_INODE ? str_inode : "",
                 opts & CHECK_SHA256SUM ? sf256_sum : "",
                 0,
                 wd_sum,

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -440,9 +440,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
                 *str_mtime = '\0';
             }
 
-            if (opts & CHECK_INODE) {
-                sprintf(str_inode, "%ld", (long)statbuf.st_ino);
-            }
+            sprintf(str_inode, "%ld", (long)statbuf.st_ino);
 
             snprintf(alert_msg, OS_MAXSTR, "%c%c%c%c%c%c%c%c%c%c%c%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%u",
                     opts & CHECK_SIZE ? '+' : '-',

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -556,7 +556,7 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
         owner == 0 ? "" : get_user(file_name, statbuf.st_uid, NULL),
         group == 0 ? "" : get_group(statbuf.st_gid),
         str_mtime,
-        str_inode,
+        inode == 0 ? "" : str_inode,
         sha256sum  == 0 ? "" : sf256_sum,
         0);
 #else
@@ -599,7 +599,7 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
         owner == 0 ? "" : user,
         group == 0 ? "" : get_group(statbuf.st_gid),
         str_mtime,
-        str_inode,
+        inode == 0 ? "" : str_inode,
         sha256sum  == 0 ? "" : sf256_sum,
         attributes);
 


### PR DESCRIPTION
Hi team,

This PR solves the following issue #3208 

Example
-----
Recursive folder deletion:  `rm -rf dir1` that wasn't working previously.
```
** Alert 1556618013.673751: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 30 11:53:33 workstation->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/root/dir1/f1' was deleted.
(Audit) User: 'root (0)'
(Audit) Login user: 'cervi (1000)'
(Audit) Effective user: 'root (0)'
(Audit) Group: 'root (0)'
(Audit) Process id: '21833'
(Audit) Process name: '/bin/rm'


** Alert 1556618013.674160: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 30 11:53:33 workstation->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/root/dir1/dir2/dir3/f3' was deleted.
(Audit) User: 'root (0)'
(Audit) Login user: 'cervi (1000)'
(Audit) Effective user: 'root (0)'
(Audit) Group: 'root (0)'
(Audit) Process id: '21833'
(Audit) Process name: '/bin/rm'


** Alert 1556618013.674579: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 30 11:53:33 workstation->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/root/dir1/dir2/dir3/dir4/dir5/f5' was deleted.
(Audit) User: 'root (0)'
(Audit) Login user: 'cervi (1000)'
(Audit) Effective user: 'root (0)'
(Audit) Group: 'root (0)'
(Audit) Process id: '21833'
(Audit) Process name: '/bin/rm'


** Alert 1556618013.675008: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 30 11:53:33 workstation->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/root/dir1/dir2/dir3/dir4/f4' was deleted.
(Audit) User: 'root (0)'
(Audit) Login user: 'cervi (1000)'
(Audit) Effective user: 'root (0)'
(Audit) Group: 'root (0)'
(Audit) Process id: '21833'
(Audit) Process name: '/bin/rm'


** Alert 1556618013.675432: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 30 11:53:33 workstation->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/root/dir1/dir2/dir3/f4' was deleted.
(Audit) User: 'root (0)'
(Audit) Login user: 'cervi (1000)'
(Audit) Effective user: 'root (0)'
(Audit) Group: 'root (0)'
(Audit) Process id: '21833'
(Audit) Process name: '/bin/rm'


** Alert 1556618013.675851: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
2019 Apr 30 11:53:33 workstation->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/root/dir1/dir2/f2' was deleted.
(Audit) User: 'root (0)'
(Audit) Login user: 'cervi (1000)'
(Audit) Effective user: 'root (0)'
(Audit) Group: 'root (0)'
(Audit) Process id: '21833'
(Audit) Process name: '/bin/rm'
```
Best regards,
Cerv1.