### PR TITLE
Fixed check without ; then

### DIFF
--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -153,7 +153,7 @@ main () {
         else
             # Single address
             edit_value_tag "address" ${WAZUH_MANAGER_IP}
-            if [ -z ${WAZUH_AUTHD_SERVER} ];
+            if [ -z ${WAZUH_AUTHD_SERVER} ]; then
                 WAZUH_AUTHD_SERVER=${WAZUH_MANAGER_IP}
             fi
         fi

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -147,13 +147,13 @@ main () {
             # Get uniques values
             ADDRESSES=($(echo "${ADDRESSES[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
             add_adress_block "${ADDRESSES[@]}"
-            if -z ${WAZUH_AUTHD_SERVER}
+            if [ -z ${WAZUH_AUTHD_SERVER} ]; then
                 WAZUH_AUTHD_SERVER=${ADDRESSES[0]}
             fi
         else
             # Single address
             edit_value_tag "address" ${WAZUH_MANAGER_IP}
-            if -z ${WAZUH_AUTHD_SERVER}
+            if [ -z ${WAZUH_AUTHD_SERVER} ];
                 WAZUH_AUTHD_SERVER=${WAZUH_MANAGER_IP}
             fi
         fi


### PR DESCRIPTION
Hello team

 This PR fixes the error in which the if doesn't have "; then". 

Best regards, 