### PR TITLE
Give a single warning when more than one deprecated configuration is indicated in vulnerability-detector

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -134,8 +134,11 @@ int set_oval_version(char *feed, const char *version, update_node **upd_list, up
         }
         upd->dist_ref = DIS_DEBIAN;
     } else if (!strcmp(feed, vu_dist_tag[DIS_REDHAT])) {
-        if (version) {
+        static char rh_dep_adv = 0;
+
+        if (version && !rh_dep_adv) {
             mwarn("The specific definition of the Red Hat feeds is deprecated. Use only redhat instead.");
+            rh_dep_adv = 1;
         }
         os_index = CVE_REDHAT;
         upd->dist_tag = vu_dist_tag[DIS_REDHAT];


### PR DESCRIPTION
In 3.8.0 the granular Red Hat configuration for this module was deprecated by a unitary configuration: `<feed name="redhat">`. 

From that version, we get a warning message for each deprecated block of this type:

``` XML
    <feed name="redhat-7">
      <disabled>yes</disabled>
      <update_interval>1h</update_interval>
    </feed>
```

> 2019/04/30 11:08:25 wazuh-modulesd: WARNING: The specific definition of the Red Hat feeds is deprecated. Use only redhat instead.

From this PR, that warning is only shown once.