### PR TITLE
Covering ignore rootcheck case of use

### DIFF
--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -310,8 +310,11 @@ static int read_sys_dir(const char *dir_name, int do_read, int depth)
                 _sys_errors++;
             }
 #else
-            notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
-            _sys_errors++;
+            if (!check_ignore(dir_name)) {
+                notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+                _sys_errors++;
+            }
+
 #endif
         }
 #endif /* WIN32 */


### PR DESCRIPTION
This PR solves a problem about `ignore` found in this issue: https://github.com/wazuh/wazuh-qa/issues/79

- **check_rc_sys** module was **not checking** if paths/files were in the **ignore list**. An alert was thrown even if the path was included in the ignore list.
- Now its checked before it outputs the alerts and before accounting for it.

<br></br>
Creating hidden files in `/dev` plus using `<ignore type="sregex">^/dev</ignore>` now gives no alerts about files on `/dev`.