### PR TITLE
Fix invalid read in logcollector

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -614,7 +614,7 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *gl
 
             (*logf)[size - 1].file = NULL;
             (*logf)[size - 1].fp = NULL;
-            
+
             if(!gl) {
                 (*logf)[size - 1].target = NULL;
                 (*logf)[size - 1].ffile = NULL;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1598,6 +1598,7 @@ int w_msg_hash_queues_add_entry(const char *key){
 int w_msg_hash_queues_push(const char *str, char *file, unsigned long size, logtarget * targets, char queue_mq) {
     w_msg_queue_t *msg;
     int i;
+    char *file_cpy;
 
     for (i = 0; targets[i].log_socket; i++)
     {
@@ -1608,7 +1609,8 @@ int w_msg_hash_queues_push(const char *str, char *file, unsigned long size, logt
         w_mutex_unlock(&mutex);
 
         if (msg) {
-            w_msg_queue_push(msg, str, file, size, &targets[i], queue_mq);
+            os_strdup(file, file_cpy);
+            w_msg_queue_push(msg, str, file_cpy, size, &targets[i], queue_mq);
         }
     }
 
@@ -1655,6 +1657,7 @@ int w_msg_queue_push(w_msg_queue_t * msg, const char * buffer, char *file, unsig
     w_mutex_unlock(&msg->mutex);
 
     if (result < 0) {
+        free(message->file);
         free(message->buffer);
         free(message);
         mdebug2("Discarding log line for target '%s'", log_target->log_socket->name);
@@ -1707,6 +1710,7 @@ void * w_output_thread(void * args){
             }
         }
 
+        free(message->file);
         free(message->buffer);
         free(message);
     }


### PR DESCRIPTION
This PR fixes an invalid read in the Logcollector output thread that forwards events to Analysisd. 

The way to replicate it is to remove a localfile that had been queued to be sent to Analysisd.

> ==20271== 166701 errors in context 5 of 8:
> ==20271== Invalid read of size 1
> ==20271==    at 0x5C98EF9: vfprintf (in /usr/lib64/libc-2.17.so)
> ==20271==    by 0x5CC3F38: vsnprintf (in /usr/lib64/libc-2.17.so)
> ==20271==    by 0x5C9F3C1: snprintf (in /usr/lib64/libc-2.17.so)
> ==20271==    by 0x47FF36: SendMSG (mq_op.c:80)
> ==20271==    by 0x4800AC: SendMSGtoSCK (mq_op.c:119)
> ==20271==    by 0x41047E: w_output_thread (logcollector.c:1702)
> ==20271==    by 0x5A37DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==20271==    by 0x5D49EAC: clone (in /usr/lib64/libc-2.17.so)
> ==20271==  Address 0x612e0e0 is 0 bytes inside a block of size 49 free'd
> ==20271==    at 0x4C2ACBD: free (vg_replace_malloc.c:530)
> ==20271==    by 0x415957: Remove_Localfile (localfile-config.c:601)
> ==20271==    by 0x40CFF1: LogCollectorStart (logcollector.c:462)
> ==20271==    by 0x40B1A1: main (main.c:187)
> ==20271==  Block was alloc'd at
> ==20271==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
> ==20271==    by 0x5CD80C9: strdup (in /usr/lib64/libc-2.17.so)
> ==20271==    by 0x40E6F9: check_pattern_expand (logcollector.c:1159)
> ==20271==    by 0x40CDDF: LogCollectorStart (logcollector.c:692)
> ==20271==    by 0x40B1A1: main (main.c:187)

Replicated in Wazuh 3.9.0-rc9.