### PR TITLE
Fix SCA dir. exploration for dir. checking

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1412,6 +1412,8 @@ static int wm_sca_check_file(char * const file, char * const pattern, char **rea
         return 0;
     }
 
+    mdebug2("Checking file '%s'", file);
+
     if (pattern && !w_is_file(file)) {
         if (*reason == NULL){
             os_malloc(OS_MAXSTR, *reason);
@@ -1657,27 +1659,23 @@ int wm_sca_pt_matches(const char * const str, const char * const pattern)
 
 static int wm_sca_check_dir(const char *dir, const char *file, char *pattern, char **reason)
 {
-    int ret_code = 0;
-    int result_dir;
-    int result_file;
-    char f_name[PATH_MAX + 2];
+    int result_accumulator = 0;
     struct dirent *entry;
-    struct stat statbuf_local;
-    DIR *dp = NULL;
 
-    f_name[PATH_MAX + 1] = '\0';
+    mdebug2("Checking directory %s", dir);
 
-    dp = opendir(dir);
+    DIR *dp = opendir(dir);
 
     if (!dp && file != NULL){
         if (*reason == NULL){
             os_malloc(OS_MAXSTR, *reason);
             sprintf(*reason, "Directory %s not found", dir);
         }
-        return (2);
+        return 2;
     }
+
     if (!dp) {
-        return (0);
+        return 0;
     }
 
     while ((entry = readdir(dp)) != NULL) {
@@ -1687,53 +1685,51 @@ static int wm_sca_check_dir(const char *dir, const char *file, char *pattern, ch
             continue;
         }
 
+        int result;
+        char f_name[PATH_MAX + 2];
+        f_name[PATH_MAX + 1] = '\0';
+
         /* Create new file + path string */
         snprintf(f_name, PATH_MAX + 1, "%s/%s", dir, entry->d_name);
 
-        mdebug2("Testing pattern '%s' with path '%s'", pattern, f_name);
-        /* Check if the read entry matches the provided file name */
-        if (strncasecmp(file, "r:", 2) == 0) {
-            if (OS_Regex(file + 2, entry->d_name)) {
-                result_file = wm_sca_check_file(f_name, pattern, reason);
-                if (result_file == 1) {
-                    ret_code = 1;
-                    break;
-                } else if (result_file == 2) {
-                    ret_code = 2;
-                }
+        mdebug2("Considering entry '%s'", f_name);
+
+        struct stat statbuf_local;
+        if (lstat(f_name, &statbuf_local) != 0) {
+            mdebug2("Cannot lstat dir entry '%s'", f_name);
+            if (*reason == NULL){
+                os_malloc(OS_MAXSTR, *reason);
+                sprintf(*reason, "Cannot lstat dir entry '%s", f_name);
             }
-        } else {
-            /* ... otherwise try without regex */
-            if (OS_Match2(file, entry->d_name)) {
-                result_file = wm_sca_check_file(f_name, pattern, reason);
-                if (result_file == 1) {
-                    ret_code = 1;
-                    break;
-                } else if (result_file == 2) {
-                    ret_code = 2;
-                }
-            }
+            result_accumulator = 2;
+            continue;
         }
 
-        /* Check if file is a directory */
-        if (lstat(f_name, &statbuf_local) == 0) {
-            if (S_ISDIR(statbuf_local.st_mode)) {
-                mdebug2("Entering directory %s", f_name);
-                result_dir = wm_sca_check_dir(f_name, file, pattern, reason);
-                if (result_dir == 1) {
-                    ret_code = 1;
-                    break;
-                } else if (result_dir == 2) {
-                    ret_code = 2;
-                }
-            }
+        if (S_ISDIR(statbuf_local.st_mode)) {
+            result = wm_sca_check_dir(f_name, file, pattern, reason);
+        } else if (((strncasecmp(file, "r:", 2) == 0) && OS_Regex(file + 2, entry->d_name))
+                || OS_Match2(file, entry->d_name))
+        {
+            result = wm_sca_check_file(f_name, pattern, reason);
+        } else {
+            mdebug2("Skipping entry '%s'", f_name);
+            continue;
         }
-        mdebug2("Test result: %d", ret_code);
+
+        mdebug2("Result for entry '%s': %d", f_name, result);
+
+        if (result == 1) {
+            mdebug2("Match found in '%s', skipping the rest.", f_name);
+            result_accumulator = 1;
+            break;
+        } else if (result == 2) {
+            result_accumulator = 2;
+        }
     }
 
     closedir(dp);
-    return (ret_code);
-
+    mdebug2("Check result for dir '%s': %d", dir, result_accumulator);
+    return result_accumulator;
 }
 
 /* Check if a process is running */


### PR DESCRIPTION
Currently wm_sca_check_dir tries to open directories as if they were files.
This PR fixes such behaviour, reported on #3215.

## Test cases
#### Test rule:
`'d:/fstest -> r:fstab -> r:123;'`

#### Test File tree:
```
/fstest/
├── [drwxr-xr-x]  fstab2
│   ├── [drwxr-xr-x]  fstab3
│   └── [-rw-r--r--]  fstab-file (contains '/tmp')
└── [-rw-r--r--]  fstab3 (contains '123')
```

### Execution of the Happy-Path
- No directories are explored by `wm_sca_check_file()`.
- Match found for file `/fstest/fstab3`.


#### Test log
```
[...]
wm_sca.c:901  at wm_sca_do_scan(): DEBUG: Checking entry: 'Test rule'.
wm_sca.c:912  at wm_sca_do_scan(): DEBUG: Rule is: d:/fstest -> r:fstab -> r:123;
wm_sca.c:1069 at wm_sca_do_scan(): DEBUG: Checking dir: /fstest
wm_sca.c:1080 at wm_sca_do_scan(): DEBUG: /fstest => is_nfs=0, skip_nfs=-1
wm_sca.c:1671 at wm_sca_check_dir(): DEBUG: Checking directory /fstest
wm_sca.c:1697 at wm_sca_check_dir(): DEBUG: Considering entry '/fstest/fstab2'
wm_sca.c:1671 at wm_sca_check_dir(): DEBUG: Checking directory /fstest/fstab2
wm_sca.c:1697 at wm_sca_check_dir(): DEBUG: Considering entry '/fstest/fstab2/fstab3'
wm_sca.c:1671 at wm_sca_check_dir(): DEBUG: Checking directory /fstest/fstab2/fstab3
wm_sca.c:1732 at wm_sca_check_dir(): DEBUG: Check result for dir '/fstest/fstab2/fstab3': 0
wm_sca.c:1720 at wm_sca_check_dir(): DEBUG: Result for entry '/fstest/fstab2/fstab3': 0
wm_sca.c:1697 at wm_sca_check_dir(): DEBUG: Considering entry '/fstest/fstab2/fstab-file'
wm_sca.c:1415 at wm_sca_check_file(): DEBUG: Checking file '/fstest/fstab2/fstab-file'
[File contents checking: no match]
wm_sca.c:1488 at wm_sca_check_file(): DEBUG: Result for r:123(/fstest/fstab2/fstab-file) -> 0
wm_sca.c:1720 at wm_sca_check_dir(): DEBUG: Result for entry '/fstest/fstab2/fstab-file': 0
wm_sca.c:1732 at wm_sca_check_dir(): DEBUG: Check result for dir '/fstest/fstab2': 0
wm_sca.c:1720 at wm_sca_check_dir(): DEBUG: Result for entry '/fstest/fstab2': 0
wm_sca.c:1697 at wm_sca_check_dir(): DEBUG: Considering entry '/fstest/fstab3'
wm_sca.c:1415 at wm_sca_check_file(): DEBUG: Checking file '/fstest/fstab3'
[File contents checking: match]
wm_sca.c:1473 at wm_sca_check_file(): DEBUG: Result for r:123(/fstest/fstab3) -> 1
wm_sca.c:1720 at wm_sca_check_dir(): DEBUG: Result for entry '/fstest/fstab3': 1
wm_sca.c:1723 at wm_sca_check_dir(): DEBUG: Match found in '/fstest/fstab3', skipping the rest.
wm_sca.c:1732 at wm_sca_check_dir(): DEBUG: Check result for dir '/fstest': 1
[...]
```
### Execution of a path with errors
Created by inducing a 'Not Found error" prior to exploring the matching fil, by renaming the `fstab2` folder right before it is going to be explored.
- /fstest/fstab2 checking is reported as an error.
- No directories are explored by `wm_sca_check_file()`.
- Match found for file `/fstest/fstab3`.

#### Test log
```
[...]
wm_sca.c:901 at wm_sca_do_scan(): DEBUG: Checking entry: 'Test rule'.
wm_sca.c:912 at wm_sca_do_scan(): DEBUG: Rule is: d:/fstest -> r:fstab -> r:123;
wm_sca.c:1069 at wm_sca_do_scan(): DEBUG: Checking dir: /fstest
wm_sca.c:1080 at wm_sca_do_scan(): DEBUG: /fstest => is_nfs=0, skip_nfs=-1
wm_sca.c:1671 at wm_sca_check_dir(): DEBUG: Checking directory /fstest
wm_sca.c:1697 at wm_sca_check_dir(): DEBUG: Considering entry '/fstest/fstab2'
[/fstest/fstab2 ceases to exist]
wm_sca.c:1700 at wm_sca_check_dir(): DEBUG: Cannot lstat dir entry '/fstest/fstab2'
wm_sca.c:1697 at wm_sca_check_dir(): DEBUG: Considering entry '/fstest/fstab3
wm_sca.c:1415 at wm_sca_check_file(): DEBUG: Checking file '/fstest/fstab3'
[File contents checking: match]
wm_sca.c:1470 at wm_sca_check_file(): DEBUG: r:123(123) -> 1
wm_sca.c:1472 at wm_sca_check_file(): DEBUG: Match found. Skipping the rest.
wm_sca.c:1473 at wm_sca_check_file(): DEBUG: Result for r:123(/fstest/fstab3) -> 1
wm_sca.c:1720 at wm_sca_check_dir(): DEBUG: Result for entry '/fstest/fstab3': 1
wm_sca.c:1723 at wm_sca_check_dir(): DEBUG: Match found in '/fstest/fstab3', skipping the rest.
wm_sca.c:1732 at wm_sca_check_dir(): DEBUG: Check result for dir '/fstest': 1

```
