### PR TITLE
Add directory existence checking to SCA

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1574,6 +1574,7 @@ static int wm_sca_read_command(char *command, char *pattern,wm_sca_t * data, cha
            pattern_ref++;
            mdebug2("Negation found, is a NIN rule");
         } else {
+            in_operation = 1;
             mdebug2("Negation not found, is an IN rule");
         }
     } else {

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1487,7 +1487,7 @@ static int wm_sca_check_file(char * const file, char * const pattern, char **rea
         }
     }
 
-    mdebug2("Result for %s(%s) -> %d", pattern, file, result_accumulator);
+    mdebug2("Result for %s(%s) -> %d", pattern ? pattern : "EXISTS", file, result_accumulator);
     mdebug2("%s %d", in_operation ? "IN":"NIN", result_accumulator);
     os_free(file_list);
     return in_operation ? result_accumulator : !result_accumulator;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1044,11 +1044,9 @@ static int wm_sca_do_scan(cJSON *profile_check, OSStore *vars, wm_sca_t * data, 
                         if (reason == NULL) {
                             os_malloc(OS_MAXSTR, reason);
                             sprintf(reason,"Ignoring check for running command '%s'. The internal option 'sca.remote_commands' is disabled", f_value);
-                            found = 2;
                         }
-                    }
-
-                    if (found != 2) {
+                        found = 2;
+                    } else {
                         /* Get any variable */
                         if (value[0] == '$') {
                             f_value = (char *) OSStore_Get(vars, value);
@@ -1067,11 +1065,12 @@ static int wm_sca_do_scan(cJSON *profile_check, OSStore *vars, wm_sca_t * data, 
                             mdebug2("Command returned not found.");
                             found = 2;
                         }
-                        char _b_msg[OS_SIZE_1024 + 1];
-                        _b_msg[OS_SIZE_1024] = '\0';
-                        snprintf(_b_msg, OS_SIZE_1024, " Command: %s", f_value);
-                        append_msg_to_vm_scat(data, _b_msg);
                     }
+
+                    char _b_msg[OS_SIZE_1024 + 1];
+                    _b_msg[OS_SIZE_1024] = '\0';
+                    snprintf(_b_msg, OS_SIZE_1024, " Command: %s", f_value);
+                    append_msg_to_vm_scat(data, _b_msg);
                 }
 
     #ifdef WIN32


### PR DESCRIPTION
This PR addresses issue #3234 and is based on PR #3235

It comprises:
- Directory-check code refactoring.
- Add specialized function for rules of the form `'d:/dir_1.../dir_n;'` (existence checking)
- Fix a bug on negation handling in rules of type `command`.
- Fix a bug in rules of type `command` that could make possible to run a command regardless of having command execution disallowed.
- Fix a bug in rules of type `command` that would skip the addition of the information about the check if the check was not applicable.

# Tests
## Functional
- rules `d:/dir_1.../dir_n;` with and without existing directories.
- full featured rules  `d:/dir_1.../dir_n -> file -> pattern;` with and without existing directories (same as in #3235)
- Tested with https://github.com/wazuh/wazuh-qa/blob/591830be670b2828493a055bf1852e1c93bbfc0f/sca-tests/sca_directories_test_suite.yml#L16
## Compilation & memory
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

### Valgrind report
```
==15897== LEAK SUMMARY:
==15897==    definitely lost: 0 bytes in 0 blocks
==15897==    indirectly lost: 0 bytes in 0 blocks
==15897==      possibly lost: 6,408 bytes in 9 blocks
==15897==    still reachable: 469,856 bytes in 811 blocks
==15897==                       of which reachable via heuristic:
==15897==                         length64           : 223,896 bytes in 124 blocks
==15897==         suppressed: 0 bytes in 0 blocks
==15897== Reachable blocks (those to which a pointer was found) are not shown.
```