### PR TITLE
Change aws vpc start and end timestamps

### DIFF
--- a/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
+++ b/extensions/elasticsearch/wazuh-elastic6-template-alerts.json
@@ -631,10 +631,12 @@
                 },
                 "end": {
                   "type": "date",
+                  "format": "epoch_second",
                   "doc_values": "true"
                 },
                 "start": {
                   "type": "date",
+                  "format": "epoch_second",
                   "doc_values": "true"
                 },
                 "source_ip_address": {


### PR DESCRIPTION
AWS vpcflow timestamps are in epoch second.  Elasticsearch defaults to epoch milli.  As a result, all of the vpcflow start and end times are incorrect.

This doesn't update existing indexes.  I had to reindex all the old indexes after I updated the template.