### PR TITLE
Fixed SCA request DB interval

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -141,7 +141,7 @@ void * wm_sca_main(wm_sca_t * data) {
     data->remote_commands = 0;
     data->commands_timeout = 30;
 
-    data->request_db_interval = getDefine_Int("sca","request_db_interval", 0, 60) * 60;
+    data->request_db_interval = getDefine_Int("sca","request_db_interval", 1, 60) * 60;
     data->commands_timeout = getDefine_Int("sca", "commands_timeout", 1, 300);
 #ifdef CLIENT
     data->remote_commands = getDefine_Int("sca", "remote_commands", 0, 1);


### PR DESCRIPTION
### Request DB Interval

As explained on this issue https://github.com/wazuh/wazuh/issues/3233, setting the internal option `sca.request_db_interval` to 0 caused a division by zero leading to a crash.

### Resolution

Fix the `request_db_interval` to allow the minimum value be greater than zero. 

https://github.com/wazuh/wazuh/blob/3.9/src/wazuh_modules/wm_sca.c#L144