### PR TITLE
Increase IPSIZE for IPv6 compatibility.

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -133,9 +133,9 @@ void run_notify()
 #if defined (__linux__) || defined (__MACH__)
     char *agent_ip;
     int sock;
-    char label_ip[50];
+    char label_ip[60];
     int i;
-    os_calloc(16,sizeof(char),agent_ip);
+    os_calloc(IPSIZE,sizeof(char),agent_ip);
 
     for (i = SOCK_ATTEMPTS; i > 0; --i) {
         if (sock = control_check_connection(), sock >= 0) {
@@ -147,7 +147,7 @@ void run_notify()
                     merror("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
                 }
                 else{
-                    snprintf(label_ip,50,"#\"_agent_ip\":%s", agent_ip);
+                    snprintf(label_ip,sizeof label_ip,"#\"_agent_ip\":%s", agent_ip);
                 }
             }
 

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -48,7 +48,7 @@
 #define OS_HEADER_SIZE  OS_SIZE_128     /* Maximum header size          */
 #define OS_LOG_HEADER   OS_SIZE_256     /* Maximum log header size      */
 #define OS_SK_HEADER    OS_SIZE_6144    /* Maximum syscheck header size */
-#define IPSIZE          16              /* IP Address size              */
+#define IPSIZE          INET6_ADDRSTRLEN /* IP Address size             */
 #define AUTH_POOL       1000            /* Max number of connections    */
 #define BACKLOG         128             /* Socket input queue length    */
 #define MAX_EVENTS      1024            /* Max number of epoll events   */

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -675,7 +675,7 @@ void send_win32_info(time_t curr_time)
     char tmp_msg[OS_MAXSTR - OS_HEADER_SIZE + 2];
     char tmp_labels[OS_MAXSTR - OS_HEADER_SIZE] = { '\0' };
     char *agent_ip;
-    char label_ip[30];
+    char label_ip[60];
 
     agent_ip = get_win_agent_ip();
 
@@ -726,7 +726,7 @@ void send_win32_info(time_t curr_time)
 
     /* Create message */
     if(agent_ip){
-        snprintf(label_ip,30,"#\"_agent_ip\":%s",agent_ip);
+        snprintf(label_ip,sizeof label_ip,"#\"_agent_ip\":%s",agent_ip);
         /* In case there is an agent IP the message has a new line at the end to emulate the random string generated in Linux agents
            to avoid the delete of the agent IP */
         if (File_DateofChange(AGENTCONFIGINT) > 0) {


### PR DESCRIPTION
Increase IPSIZE to the larger Socket API (RFC 3493) length for IPv6 compatibility.