### PR TITLE
Replace local protocol definitions with Socket API definitions.

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -91,7 +91,7 @@ cJSON *getClientConfig(void) {
             cJSON *server = cJSON_CreateObject();
             cJSON_AddStringToObject(server,"address",agt->server[i].rip);
             cJSON_AddNumberToObject(server,"port",agt->server[i].port);
-            if (agt->server[i].protocol == UDP_PROTO) cJSON_AddStringToObject(server,"protocol","udp"); else cJSON_AddStringToObject(server,"protocol","tcp");
+            if (agt->server[i].protocol == IPPROTO_UDP) cJSON_AddStringToObject(server,"protocol","udp"); else cJSON_AddStringToObject(server,"protocol","tcp");
             cJSON_AddItemToArray(servers,server);
         }
         cJSON_AddItemToObject(client,"server",servers);

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -82,7 +82,7 @@ void *receiver_thread(__attribute__((unused)) void *none)
 
         /* Read until no more messages are available */
         while (1) {
-            if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
+            if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
                 /* Only one read per call */
                 if (reads++) {
                     break;

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -42,7 +42,7 @@ int receive_msg()
 
     /* Read until no more messages are available */
     while (1) {
-        if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
+        if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
             /* Only one read per call */
             if (reads++) {
                 break;

--- a/src/client-agent/request.c
+++ b/src/client-agent/request.c
@@ -168,7 +168,7 @@ int req_push(char * buffer, size_t length) {
 
         // Send ACK, only in UDP mode
 
-        if (agt->server[agt->rip_id].protocol == UDP_PROTO) {
+        if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
             mdebug2("req_push(): Sending ack (%s).", counter);
             // Example: #!-req 16 ack
             snprintf(response, REQ_RESPONSE_LENGTH, CONTROL_HEADER HC_REQUEST "%s ack", counter);
@@ -339,7 +339,7 @@ void * req_receiver(__attribute__((unused)) void * arg) {
 
             // Wait for ACK, only in UDP mode
 
-            if (agt->server[agt->rip_id].protocol == UDP_PROTO) {
+            if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
                 gettimeofday(&now, NULL);
                 nsec = now.tv_usec * 1000 + rto_msec * 1000000;
                 timeout.tv_sec = now.tv_sec + rto_sec + nsec / 1000000000;

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -29,7 +29,7 @@ int send_msg(const char *msg, ssize_t msg_length)
     }
 
     /* Send msg_size of crypt_msg */
-    if (agt->server[agt->rip_id].protocol == UDP_PROTO) {
+    if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
         retval = OS_SendUDPbySize(agt->sock, msg_size, crypt_msg);
 #ifndef WIN32
         error = errno;

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -39,7 +39,7 @@ int connect_server(int initial_id)
             minfo("Closing connection to server (%s:%d/%s).",
                     agt->server[rc].rip,
                     agt->server[rc].port,
-                    agt->server[rc].protocol == UDP_PROTO ? "udp" : "tcp");
+                    agt->server[rc].protocol == IPPROTO_UDP ? "udp" : "tcp");
         }
     }
 
@@ -83,9 +83,9 @@ int connect_server(int initial_id)
         minfo("Trying to connect to server (%s:%d/%s).",
                 agt->server[rc].rip,
                 agt->server[rc].port,
-                agt->server[rc].protocol == UDP_PROTO ? "udp" : "tcp");
+                agt->server[rc].protocol == IPPROTO_UDP ? "udp" : "tcp");
 
-        if (agt->server[rc].protocol == UDP_PROTO) {
+        if (agt->server[rc].protocol == IPPROTO_UDP) {
             agt->sock = OS_ConnectUDP(agt->server[rc].port, tmp_str, strchr(tmp_str, ':') != NULL);
         } else {
             if (agt->sock >= 0) {
@@ -117,7 +117,7 @@ int connect_server(int initial_id)
                 rc = 0;
             }
         } else {
-            if (agt->server[rc].protocol == TCP_PROTO) {
+            if (agt->server[rc].protocol == IPPROTO_TCP) {
                 if (OS_SetRecvTimeout(agt->sock, timeout, 0) < 0){
                     switch (errno) {
                     case ENOPROTOOPT:
@@ -131,7 +131,7 @@ int connect_server(int initial_id)
             }
 
 #ifdef WIN32
-            if (agt->server[rc].protocol == UDP_PROTO) {
+            if (agt->server[rc].protocol == IPPROTO_UDP) {
                 int bmode = 1;
 
                 /* Set socket to non-blocking */
@@ -177,7 +177,7 @@ void start_agent(int is_startup)
 
         /* Read until our reply comes back */
         while (attempts <= 5) {
-            if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
+            if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
 
                 switch (wnet_select(agt->sock, timeout)) {
                 case -1:
@@ -217,7 +217,7 @@ void start_agent(int is_startup)
 
                 /* Send message again (after three attempts) */
                 if (attempts >= 3 || recv_b == OS_SOCKTERR) {
-                    if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
+                    if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
                         if (!connect_server(agt->rip_id)) {
                             continue;
                         }
@@ -226,7 +226,7 @@ void start_agent(int is_startup)
                     }
                 }
 
-                if (agt->server[agt->rip_id].protocol == TCP_PROTO) {
+                if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
                     send_msg(msg, -1);
                 }
 
@@ -246,7 +246,7 @@ void start_agent(int is_startup)
                     available_server = time(0);
 
                     minfo(AG_CONNECTED, agt->server[agt->rip_id].rip,
-                            agt->server[agt->rip_id].port, agt->server[agt->rip_id].protocol == UDP_PROTO ? "udp" : "tcp");
+                            agt->server[agt->rip_id].port, agt->server[agt->rip_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
 
                     if (is_startup) {
                         /* Send log message about start up */

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -23,7 +23,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     char * rip = NULL;
     char * s_ip;
     int port = DEFAULT_SECURE;
-    int protocol = UDP_PROTO;
+    int protocol = IPPROTO_UDP;
 
     /* XML definitions */
     const char *xml_client_server = "server";
@@ -156,9 +156,9 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             mwarn("The <%s> tag is deprecated, please use <server><protocol> instead.", xml_protocol);
 
             if (strcmp(node[i]->content, "tcp") == 0) {
-                protocol = TCP_PROTO;
+                protocol = IPPROTO_TCP;
             } else if (strcmp(node[i]->content, "udp") == 0) {
-                protocol = UDP_PROTO;
+                protocol = IPPROTO_UDP;
             } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
@@ -215,7 +215,7 @@ int Read_Client_Server(XML_NODE node, agent * logr)
     char f_ip[128];
     char * rip = NULL;
     int port = DEFAULT_SECURE;
-    int protocol = UDP_PROTO;
+    int protocol = IPPROTO_UDP;
 
     /* Get parameters for each configurated server*/
 
@@ -253,9 +253,9 @@ int Read_Client_Server(XML_NODE node, agent * logr)
             }
         } else if (strcmp(node[j]->element, xml_protocol) == 0) {
             if (strcmp(node[j]->content, "tcp") == 0) {
-                protocol = TCP_PROTO;
+                protocol = IPPROTO_TCP;
             } else if (strcmp(node[j]->content, "udp") == 0) {
-                protocol = UDP_PROTO;
+                protocol = IPPROTO_UDP;
             } else {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -34,9 +34,6 @@
 #define CCLUSTER      004000000
 #define CSOCKET       010000000
 
-#define UDP_PROTO   6
-#define TCP_PROTO   17
-
 #define MAX_NEEDED_TAGS 4
 
 typedef enum needed_tags {

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -143,13 +143,13 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         } else if (strcasecmp(node[i]->element, xml_remote_proto) == 0) {
             if (strcasecmp(node[i]->content, "tcp") == 0) {
 #if defined(__linux__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-                logr->proto[pl] = TCP_PROTO;
+                logr->proto[pl] = IPPROTO_TCP;
 #else
                 merror(TCP_NOT_SUPPORT);
                 return (OS_INVALID);
 #endif
             } else if (strcasecmp(node[i]->content, "udp") == 0) {
-                logr->proto[pl] = UDP_PROTO;
+                logr->proto[pl] = IPPROTO_UDP;
             } else {
                 merror(XML_VALUEERR, node[i]->element,
                        node[i]->content);
@@ -233,7 +233,7 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 
     /* Set default protocol */
     if (logr->proto[pl] == 0) {
-        logr->proto[pl] = UDP_PROTO;
+        logr->proto[pl] = IPPROTO_UDP;
     }
 
     /* Queue_size is only for secure connections */

--- a/src/config/socket-config.c
+++ b/src/config/socket-config.c
@@ -47,7 +47,7 @@ int Read_Socket(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     }
     logf[pl].name = NULL;
     logf[pl].location = NULL;
-    logf[pl].mode = UDP_PROTO;
+    logf[pl].mode = IPPROTO_UDP;
     logf[pl].prefix = NULL;
     logf[pl].socket = -1;
 
@@ -72,9 +72,9 @@ int Read_Socket(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             os_strdup(node[i]->content, logf[pl].location);
         } else if (!strcmp(node[i]->element, socket_mode)) {
             if (strcasecmp(node[i]->content, "tcp") == 0) {
-                logf[pl].mode = TCP_PROTO;
+                logf[pl].mode = IPPROTO_TCP;
             } else if (strcasecmp(node[i]->content, "udp") == 0) {
-                logf[pl].mode = UDP_PROTO;
+                logf[pl].mode = IPPROTO_UDP;
             } else {
                 merror("Socket type '%s' is not valid at <%s>. Should be 'udp' or 'tcp'.", node[i]->content, node[i]->element);
                 return OS_INVALID;

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -194,7 +194,7 @@ cJSON *getSocketConfig(void) {
 
         cJSON_AddStringToObject(target,"name",logsk[i].name);
         cJSON_AddStringToObject(target,"location",logsk[i].location);
-        if (logsk[i].mode == UDP_PROTO) {
+        if (logsk[i].mode == IPPROTO_UDP) {
             cJSON_AddStringToObject(target,"mode","udp");
         } else {
             cJSON_AddStringToObject(target,"mode","tcp");

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1460,7 +1460,7 @@ static void set_sockets() {
     // List readed sockets
     unsigned int sk;
     for (sk=0; logsk && logsk[sk].name; sk++) {
-        mdebug1("Socket '%s' (%s) added. Location: %s", logsk[sk].name, logsk[sk].mode == UDP_PROTO ? "udp" : "tcp", logsk[sk].location);
+        mdebug1("Socket '%s' (%s) added. Location: %s", logsk[sk].name, logsk[sk].mode == IPPROTO_UDP ? "udp" : "tcp", logsk[sk].location);
     }
 
     for (i = 0, t = -1;; i++) {

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -96,8 +96,8 @@ cJSON *getRemoteConfig(void) {
             else if (logr.conn[i] == SECURE_CONN) cJSON_AddStringToObject(conn,"connection","secure");
             if (logr.ipv6 && logr.ipv6[i]) cJSON_AddStringToObject(conn,"ipv6","yes"); else cJSON_AddStringToObject(conn,"ipv6","no");
             if (logr.lip && logr.lip[i]) cJSON_AddStringToObject(conn,"local_ip",logr.lip[i]);
-            if (logr.proto && logr.proto[i] == UDP_PROTO) cJSON_AddStringToObject(conn,"protocol","udp");
-            else if (logr.proto && logr.proto[i] == TCP_PROTO) cJSON_AddStringToObject(conn,"protocol","tcp");
+            if (logr.proto && logr.proto[i] == IPPROTO_UDP) cJSON_AddStringToObject(conn,"protocol","udp");
+            else if (logr.proto && logr.proto[i] == IPPROTO_TCP) cJSON_AddStringToObject(conn,"protocol","tcp");
             if (logr.port && logr.port[i]){
                 sprintf(port,"%d",logr.port[i]);
                 cJSON_AddStringToObject(conn,"port",port);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -926,7 +926,7 @@ int send_file_toagent(const char *agent_id, const char *group, const char *name,
             return (-1);
         }
 
-        if (logr.proto[logr.position] == UDP_PROTO) {
+        if (logr.proto[logr.position] == IPPROTO_UDP) {
             /* Sleep 1 every 30 messages -- no flood */
             if (i > 30) {
                 sleep(1);

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -67,7 +67,7 @@ void HandleRemote(int uid)
     }
 
     /* Bind TCP */
-    if (logr.proto[position] == TCP_PROTO) {
+    if (logr.proto[position] == IPPROTO_TCP) {
         if ((logr.sock = OS_Bindporttcp(logr.port[position], logr.lip[position], logr.ipv6[position])) < 0) {
             merror_exit(BIND_ERROR, logr.port[position], errno, strerror(errno));
         } else if (logr.conn[position] == SECURE_CONN) {
@@ -109,7 +109,7 @@ void HandleRemote(int uid)
     minfo(STARTUP_MSG " Listening on port %d/%s (%s).",
     (int)getpid(),
     logr.port[position],
-    logr.proto[position] == TCP_PROTO ? "TCP" : "UDP",
+    logr.proto[position] == IPPROTO_TCP ? "TCP" : "UDP",
     logr.conn[position] == SECURE_CONN ? "secure" : "syslog");
 
     /* If secure connection, deal with it */
@@ -117,7 +117,7 @@ void HandleRemote(int uid)
         HandleSecure();
     }
 
-    else if (logr.proto[position] == TCP_PROTO) {
+    else if (logr.proto[position] == IPPROTO_TCP) {
         HandleSyslogTCP();
     }
 

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -253,7 +253,7 @@ void * req_dispatch(req_node_t * node) {
 
             // Wait for ACK or response, only in UDP mode
 
-            if (logr.proto[logr.position] == UDP_PROTO) {
+            if (logr.proto[logr.position] == IPPROTO_UDP) {
                 gettimeofday(&now, NULL);
                 nsec = now.tv_usec * 1000 + rto_msec * 1000000;
                 timeout.tv_sec = now.tv_sec + rto_sec + nsec / 1000000000;
@@ -304,7 +304,7 @@ void * req_dispatch(req_node_t * node) {
 
         // Send ACK, only in UDP mode
 
-        if (logr.proto[logr.position] == UDP_PROTO) {
+        if (logr.proto[logr.position] == IPPROTO_UDP) {
             // Example: #!-req 16 ack
             mdebug2("req_dispatch(): Sending ack (%s).", node->counter);
             snprintf(response, REQ_RESPONSE_LENGTH, CONTROL_HEADER HC_REQUEST "%s ack", node->counter);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -133,7 +133,7 @@ void HandleSecure()
     /* Initialize some variables */
     memset(buffer, '\0', OS_MAXSTR + 1);
 
-    if (protocol == TCP_PROTO) {
+    if (protocol == IPPROTO_TCP) {
         if (notify = wnotify_init(MAX_EVENTS), !notify) {
             merror_exit("wnotify_init(): %s (%d)", strerror(errno), errno);
         }
@@ -145,7 +145,7 @@ void HandleSecure()
 
     while (1) {
         /* Receive message  */
-        if (protocol == TCP_PROTO) {
+        if (protocol == IPPROTO_TCP) {
             if (n_events = wnotify_wait(notify, EPOLL_MILLIS), n_events < 0) {
                 if (errno != EINTR) {
                     merror("Waiting for connection: %s (%d)", strerror(errno), errno);
@@ -371,7 +371,7 @@ static void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
 
         memcpy(&keys.keyentries[agentid]->peer_info, peer_info, logr.peer_size);
         keyentry * key = OS_DupKeyEntry(keys.keyentries[agentid]);
-        r = (protocol == TCP_PROTO) ? OS_AddSocket(&keys, agentid, sock_client) : 2;
+        r = (protocol == IPPROTO_TCP) ? OS_AddSocket(&keys, agentid, sock_client) : 2;
         keys.keyentries[agentid]->rcvd = time(0);
 
         switch (r) {

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -99,7 +99,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
     }
 
     /* Send initial message */
-    if (logr.proto[logr.position] == UDP_PROTO) {
+    if (logr.proto[logr.position] == IPPROTO_UDP) {
         retval = sendto(logr.sock, crypt_msg, msg_size, 0, (struct sockaddr *)&keys.keyentries[key_id]->peer_info, logr.peer_size) == msg_size ? 0 : -1;
         error = errno;
     } else if (keys.keyentries[key_id]->sock >= 0) {

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -125,11 +125,11 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
         const char * strmode;
 
         switch (target->log_socket->mode) {
-        case UDP_PROTO:
+        case IPPROTO_UDP:
             sock_type = SOCK_DGRAM;
             strmode = "udp";
             break;
-        case TCP_PROTO:
+        case IPPROTO_TCP:
             sock_type = SOCK_STREAM;
             strmode = "tcp";
             break;

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -469,7 +469,7 @@ int SendMSG(__attribute__((unused)) int queue, const char *message, const char *
                     }
                 }
 
-                minfo(AG_CONNECTED, agt->server[agt->rip_id].rip, agt->server[agt->rip_id].port, agt->server[agt->rip_id].protocol == UDP_PROTO ? "udp" : "tcp");
+                minfo(AG_CONNECTED, agt->server[agt->rip_id].rip, agt->server[agt->rip_id].port, agt->server[agt->rip_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
                 minfo(SERVER_UP);
                 update_status(GA_STATUS_ACTIVE);
             }


### PR DESCRIPTION
Not only are the local definitions of TCP_PROTO and UDP_PROTO unnecessary since the Socket API already defines IPPROTO_TCP and IPPROTO_UDP, the local definitions also swap the protocol numbers between TCP and UDP creating unnecessary confusion.
