### PR TITLE
Fix parser of the CIS-CAT XML report

### DIFF
--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -952,7 +952,7 @@ void wm_ciscat_preparser(){
 
         fprintf(out_fp, "%s", readbuff);
 
-        while (fgets(readbuff, OS_MAXSTR, in_fp) && (strstr(readbuff, WM_CISCAT_RESULT_START) == NULL)) {
+        while (fgets(readbuff, OS_MAXSTR, in_fp) && (strstr(readbuff, WM_CISCAT_RESULT_START) == NULL && strstr(readbuff, WM_CISCAT_RESULT_START2) == NULL)) {
 
             if (strstr(readbuff, WM_CISCAT_RULE_START) || strstr(readbuff, WM_CISCAT_RULE_START2)) {
                 inside_rule = 1;

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -24,6 +24,7 @@
 #define WM_CISCAT_PROFILE2      "<xccdf:Profile id="
 #define WM_CISCAT_GROUP_START   "<Group id="
 #define WM_CISCAT_RESULT_START  "<TestResult"
+#define WM_CISCAT_RESULT_START2 "<xccdf:TestResult"
 #define WM_CISCAT_RULE_START    "<Rule id="
 #define WM_CISCAT_RULE_END      "</Rule>"
 #define WM_CISCAT_DESC_START    "<description"


### PR DESCRIPTION
As the issue #3256 reports, the XML parser for the CIS-CAT module was failing when the tag `xccdf:TestResult` is found in the report file instead of `TestResult`.

This PR adds this case and solves the mentioned issue.

Regards.