### PR TITLE
Cluster: Fix typings error in client.py and worker.py inside cluster

### DIFF
--- a/framework/wazuh/cluster/client.py
+++ b/framework/wazuh/cluster/client.py
@@ -44,7 +44,7 @@ class AbstractClientManager:
         self.extra_args = {}
         self.loop = asyncio.get_running_loop()
 
-    def add_tasks(self) -> List[Tuple[asyncio.coroutine,Tuple]]:
+    def add_tasks(self) -> List[Tuple[asyncio.coroutine, Tuple]]:
         """
         Adds client tasks to the task list. The client tasks are just test function that were made to test
         the protocol.

--- a/framework/wazuh/cluster/client.py
+++ b/framework/wazuh/cluster/client.py
@@ -44,7 +44,7 @@ class AbstractClientManager:
         self.extra_args = {}
         self.loop = asyncio.get_running_loop()
 
-    def add_tasks(self) -> List[asyncio.coroutine, Tuple]:
+    def add_tasks(self) -> List[Tuple[asyncio.coroutine,Tuple]]:
         """
         Adds client tasks to the task list. The client tasks are just test function that were made to test
         the protocol.

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -521,7 +521,7 @@ class Worker(client.AbstractClientManager):
         self.extra_args = {'cluster_name': self.cluster_name, 'version': self.version, 'node_type': self.node_type}
         self.dapi = dapi.APIRequestQueue(server=self)
 
-    def add_tasks(self) -> List[Tuple[asyncio.coroutine,Tuple]]:
+    def add_tasks(self) -> List[Tuple[asyncio.coroutine, Tuple]]:
         """
         Defines the tasks the worker will always run in a infinite loop.
         :return: A list of tuples: The first item is the coroutine to run and the second is the arguments it needs.

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -521,7 +521,7 @@ class Worker(client.AbstractClientManager):
         self.extra_args = {'cluster_name': self.cluster_name, 'version': self.version, 'node_type': self.node_type}
         self.dapi = dapi.APIRequestQueue(server=self)
 
-    def add_tasks(self) -> List[asyncio.coroutine, Tuple]:
+    def add_tasks(self) -> List[Tuple[asyncio.coroutine,Tuple]]:
         """
         Defines the tasks the worker will always run in a infinite loop.
         :return: A list of tuples: The first item is the coroutine to run and the second is the arguments it needs.


### PR DESCRIPTION
Hi team,

This issue closes #3264

**Run Wazuh-Manager after fixes:**
```
root@655a4a453514:/# service wazuh-manager restart
Killing wazuh-clusterd...
Killing wazuh-modulesd...
Killing ossec-monitord...
Killing ossec-logcollector...
Killing ossec-remoted...
Killing ossec-syscheckd...
Killing ossec-analysisd...
ossec-maild not running...
Killing ossec-execd...
Killing wazuh-db...
Killing ossec-authd...
ossec-agentlessd not running...
ossec-integratord not running...
ossec-dbd not running...
ossec-csyslogd not running...
Wazuh v3.10.0 Stopped
Starting Wazuh v3.10.0...
Started ossec-csyslogd...
Started ossec-dbd...
2019/05/07 15:33:01 ossec-integratord: INFO: Remote integrations not configured. Clean exit.
Started ossec-integratord...
Started ossec-agentlessd...
Started ossec-authd...
Started wazuh-db...
Started ossec-execd...
Started ossec-analysisd...
Started ossec-syscheckd...
Started ossec-remoted...
Started ossec-logcollector...
Started ossec-monitord...
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.
```