### PR TITLE
Fix aborting loop while reading agent info files

### DIFF
--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -393,7 +393,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                 # check if the date is older than the manager's date
                                 if local_mtime > mtime:
                                     logger.debug2("Receiving an old file ({})".format(file_path))
-                                    return
+                                    continue
 
                             with open(tmp_unmerged_path, 'wb') as f:
                                 f.write(file_data)


### PR DESCRIPTION
This PR fixes #3271.

As explained in the issue, I confirm the problem is an early termination of the for loop in this line https://github.com/wazuh/wazuh/blob/69729679efce4aed0029ae37f80610aef574f5e8/framework/wazuh/cluster/master.py#L359.

Furthermore, there is another issue regarding the lock in https://github.com/wazuh/wazuh/blob/69729679efce4aed0029ae37f80610aef574f5e8/framework/wazuh/cluster/master.py#L349 which is not released if loop is aborted.
