### PR TITLE
Fix restart script for restarting Wazuh in Docker containers

### DIFF
--- a/active-response/restart.sh
+++ b/active-response/restart.sh
@@ -42,7 +42,7 @@ if [ "$TYPE" = "manager" ]; then
 fi
 
 # Restart Wazuh
-if command -v systemctl > /dev/null 2>&1; then
+if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
     touch ${PWD}/var/run/.restart     
     systemctl restart wazuh-$TYPE
     rm -f ${PWD}/var/run/.restart

--- a/active-response/restart.sh
+++ b/active-response/restart.sh
@@ -11,7 +11,7 @@ help()
 }
 
 # Usage
-if [ "$1" == "-h" ]; then
+if [ "$1" = "-h" ]; then
     help
     exit 0;
 fi

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -378,7 +378,7 @@ def restart_all_nodes():
     :return: Confirmation message.
     """
     restart()
-    return "Restarting cluster"
+    return "Restart request sent"
 
 
 #

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -434,7 +434,7 @@ def restart():
         fcntl.lockf(lock_file, fcntl.LOCK_UN)
         lock_file.close()
 
-    return "Restarting manager"
+    return "Restart request sent"
 
 
 def _check_wazuh_xml(files):


### PR DESCRIPTION
Hi team,

This PR closes #3273. I made a fix for restarting Wazuh in Docker containers.

This happens when we try use `restart.sh` without this fix:
```bash
# /var/ossec/active-response/bin/restart.sh agent  
System has not been booted with systemd as init system (PID 1). Can't operate.
```

After apply this fix:
```bash
# /var/ossec/active-response/bin/restart.sh manager
Killing wazuh-clusterd...
Killing wazuh-modulesd...
Killing ossec-monitord...
Killing ossec-logcollector...
Killing ossec-remoted...
Killing ossec-syscheckd...
Killing ossec-analysisd...
ossec-maild not running...
Killing ossec-execd...
Killing wazuh-db...
Killing ossec-authd...
ossec-agentlessd not running...
ossec-integratord not running...
ossec-dbd not running...
ossec-csyslogd not running...
Wazuh v3.9.0 Stopped
Starting Wazuh v3.9.0...
Started ossec-csyslogd...
Started ossec-dbd...
2019/05/08 10:47:18 ossec-integratord: INFO: Remote integrations not configured. Clean exit.
Started ossec-integratord...
Started ossec-agentlessd...
Started ossec-authd...
Started wazuh-db...
Started ossec-execd...
Started ossec-analysisd...
Started ossec-syscheckd...
Started ossec-remoted...
Started ossec-logcollector...
Started ossec-monitord...
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.
```

Using API call in a Docker container:

```bash
# curl -u foo:bar -k -X PUT http://127.0.0.1:55000/manager/restart?pretty
{
   "error": 0,
   "data": "Restart request sent"
}
```

Best regards,

Demetrio.