### PR TITLE
Fixed summary double filling on SCA

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -766,6 +766,8 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
 
 static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
 
+    int alert_data_fill = 0;
+
     cJSON *pm_scan_id = NULL;
     cJSON *pm_scan_start = NULL;
     cJSON *pm_scan_end = NULL;
@@ -929,10 +931,11 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
                 if(strcmp(hash_sha256, hash->valuestring)) {
                     if (!first_scan) {
                         FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,invalid,total_checks,score,file,policy_id);
+                        alert_data_fill = 1;
                     }
                 }
 
-                if (force_alert) {
+                if (force_alert && !alert_data_fill) {
                     FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,invalid,total_checks,score,file,policy_id);
                 }
             }
@@ -948,7 +951,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
                 if(strcmp(hash_sha256, hash->valuestring)) {
                     if (!first_scan) {
                         FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,invalid,total_checks,score,file,policy_id);
-                       
+                        alert_data_fill = 1;
                     } else {
                         /* Request dump */
                         mdebug1("Requesting dump first scan for policy: %s",policy_id->valuestring);
@@ -956,7 +959,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
                     }
                 }
 
-                if (force_alert) {
+                if (force_alert && !alert_data_fill) {
                     FillScanInfo(lf,pm_scan_id,policy,description,passed,failed,invalid,total_checks,score,file,policy_id);
                 }
             }


### PR DESCRIPTION
### Summary fields repeated

As explained on this issue https://github.com/wazuh/wazuh/issues/3263 when a policy integrity fails and force alert is set, the summary fields are repeated.

```
** Alert 1557240720.1808442: - sca,gdpr_IV_35.7.d
2019 May 07 16:52:00 (macos) any->sca
Rule: 19004 (level 7) -> 'SCA summary: CIS Apple macOS 10.13 Benchmark: Score less than 50% (43)'
{"type":"summary","scan_id":1273154325,"name":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","file":"cis_apple_macOS_10.13.yml","description":"This document, CIS Apple macOS 10.13 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.13. This guide was tested against Apple macOS 10.13. To obtain the latest version of this guide, please visit http://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org","references":"https://www.cisecurity.org/cis-benchmarks/","passed":13,"failed":17,"invalid":0,"total_checks":30,"score":43.333332061767578,"start_time":1557240672,"end_time":1557240708,"hash":"eed29f398a966b8f26916e94111328f782272e4793f4c7bc5a2edd733a5a6ec5","hash_file":"dbbc8635241ed48b27f9187aba21ab2452c7afbfa621c8c6ee6c06ca2360c9b0","force_alert":"1"}
sca.type: summary
sca.scan_id: 1273154325
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.description: This document, CIS Apple macOS 10.13 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.13. This guide was tested against Apple macOS 10.13. To obtain the latest version of this guide, please visit http://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org
sca.policy_id: cis_apple_macos_10_13
sca.passed: 13
sca.failed: 17
sca.invalid: 0
sca.total_checks: 30
sca.score: 43
sca.file: cis_apple_macOS_10.13.yml
sca.type: summary
sca.scan_id: 1273154325
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.description: This document, CIS Apple macOS 10.13 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.13. This guide was tested against Apple macOS 10.13. To obtain the latest version of this guide, please visit http://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org
sca.policy_id: cis_apple_macos_10_13
sca.passed: 13
sca.failed: 17
sca.invalid: 0
sca.total_checks: 30
sca.score: 43
sca.file: cis_apple_macOS_10.13.yml
```

### Remediation

Set a new `alert_data_fill` variable to check if we have already filled the fields.

### Tests made

- [x] Start and send first scan

```
** Alert 1557322979.754998: - sca,gdpr_IV_35.7.d
2019 May 08 15:42:59 rafa-GS63-7RD->sca
Rule: 19004 (level 7) -> 'SCA summary: CIS benchmark for Debian/Linux: Score less than 50% (48)'
{"type":"summary","scan_id":1144711465,"name":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","file":"cis_debian_linux_rcl.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":15,"failed":16,"invalid":11,"total_checks":42,"score":48.3870964050293,"start_time":1557322950,"end_time":1557322966,"hash":"955d00be997975db766368b3babfb9da0a2722d76caea891a8559629a84ffc84","hash_file":"8db06ce8c56fb7ed50255b5191e3835632b649aeb642c7948c4ac020f1311141","force_alert":"1"}
sca.type: summary
sca.scan_id: 1144711465
sca.policy: CIS benchmark for Debian/Linux
sca.description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.
sca.policy_id: cis_debian
sca.passed: 15
sca.failed: 16
sca.invalid: 11
sca.total_checks: 42
sca.score: 48
sca.file: cis_debian_linux_rcl.yml
```
- [x] At runtime change policy file, wait for the new scan to arrive

```
** Alert 1557323096.855387: - sca,gdpr_IV_35.7.d
2019 May 08 15:44:56 rafa-GS63-7RD->sca
Rule: 19004 (level 7) -> 'SCA summary: CIS benchmark for Debian/Linux: Score less than 50% (48)'
{"type":"summary","scan_id":214870006,"name":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","file":"cis_debian_linux_rcl.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":15,"failed":16,"invalid":11,"total_checks":42,"score":48.3870964050293,"start_time":1557323070,"end_time":1557323083,"hash":"955d00be997975db766368b3babfb9da0a2722d76caea891a8559629a84ffc84","hash_file":"c6431d7e170b9f6aca163334ce231fa9e27f160f951b80e9504b60c2764f48c5","force_alert":"1"}
sca.type: summary
sca.scan_id: 214870006
sca.policy: CIS benchmark for Debian/Linux
sca.description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.
sca.policy_id: cis_debian
sca.passed: 15
sca.failed: 16
sca.invalid: 11
sca.total_checks: 42
sca.score: 48
sca.file: cis_debian_linux_rcl.yml
```

- [x] Change the policy file and restart, wait for the scan to arrive

```
** Alert 1557323197.942392: - sca,gdpr_IV_35.7.d
2019 May 08 15:46:37 rafa-GS63-7RD->sca
Rule: 19004 (level 7) -> 'SCA summary: CIS benchmark for Debian/Linux: Score less than 50% (48)'
{"type":"summary","scan_id":661962000,"name":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","file":"cis_debian_linux_rcl.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":15,"failed":16,"invalid":11,"total_checks":42,"score":48.3870964050293,"start_time":1557323170,"end_time":1557323185,"hash":"955d00be997975db766368b3babfb9da0a2722d76caea891a8559629a84ffc84","hash_file":"d38ed941ee41d03329a92447e209bc12e6010c2d3afa17667ee3662a9fb89cc4","force_alert":"1"}
sca.type: summary
sca.scan_id: 661962000
sca.policy: CIS benchmark for Debian/Linux
sca.description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.
sca.policy_id: cis_debian
sca.passed: 15
sca.failed: 16
sca.invalid: 11
sca.total_checks: 42
sca.score: 48
sca.file: cis_debian_linux_rcl.yml
```

- [x] Make a check change from passed to failed, wait for the scan to arrive

```
** Alert 1557323489.959650: - sca,gdpr_IV_35.7.d
2019 May 08 15:51:29 rafa-GS63-7RD->sca
Rule: 19003 (level 5) -> 'SCA summary: CIS benchmark for Debian/Linux: Score less than 80% (51)'
{"type":"summary","scan_id":950489061,"name":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","file":"cis_debian_linux_rcl.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":16,"failed":15,"invalid":11,"total_checks":42,"score":51.612899780273438,"start_time":1557323470,"end_time":1557323486,"hash":"94b261a80d9c1dea29673e138f0d2698fa17e3acb73d5f96637090f8b66a2b14","hash_file":"d38ed941ee41d03329a92447e209bc12e6010c2d3afa17667ee3662a9fb89cc4"}
sca.type: summary
sca.scan_id: 950489061
sca.policy: CIS benchmark for Debian/Linux
sca.description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.
sca.policy_id: cis_debian
sca.passed: 16
sca.failed: 15
sca.invalid: 11
sca.total_checks: 42
sca.score: 51
sca.file: cis_debian_linux_rcl.yml
```

- [x] Make integrity fail, wait for new scan to arrive

```
** Alert 1557323693.963560: - sca,gdpr_IV_35.7.d
2019 May 08 15:54:53 rafa-GS63-7RD->sca
Rule: 19004 (level 7) -> 'SCA summary: CIS benchmark for Debian/Linux: Score less than 50% (48)'
{"type":"summary","scan_id":1872884377,"name":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","file":"cis_debian_linux_rcl.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":15,"failed":16,"invalid":11,"total_checks":42,"score":48.3870964050293,"start_time":1557323665,"end_time":1557323681,"hash":"955d00be997975db766368b3babfb9da0a2722d76caea891a8559629a84ffc84","hash_file":"d38ed941ee41d03329a92447e209bc12e6010c2d3afa17667ee3662a9fb89cc4","force_alert":"1"}
sca.type: summary
sca.scan_id: 1872884377
sca.policy: CIS benchmark for Debian/Linux
sca.description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux systems running on x86 and x64 platforms. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist which should be considered in addition to those explicitly mentioned.
sca.policy_id: cis_debian
sca.passed: 15
sca.failed: 16
sca.invalid: 11
sca.total_checks: 42
sca.score: 48
sca.file: cis_debian_linux_rcl.yml
```
