### PR TITLE
Fix sca condition handling

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -814,7 +814,7 @@ static int wm_sca_check_requirements(cJSON *requirements) {
 
 static int wm_sca_do_scan(cJSON *profile_check,OSStore *vars,wm_sca_t * data,int id,cJSON *policy,int requirements_scan,int cis_db_index,unsigned int remote_policy,int first_scan,int *checks_number) {
 
-    int type = 0, condition = 0;
+    int type = 0;
     char *nbuf = NULL;
     char buf[OS_SIZE_1024 + 2];
     char root_dir[OS_SIZE_1024 + 2];
@@ -870,6 +870,7 @@ static int wm_sca_do_scan(cJSON *profile_check,OSStore *vars,wm_sca_t * data,int
         }
 
         /* Get condition */
+        int condition = 0;
         if(c_condition) {
             if(!c_condition->valuestring) {
                 mdebug1("Field 'condition' must be a string.");

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -30,7 +30,7 @@
 #define WM_SCA_COND_ANY       0x002
 #define WM_SCA_COND_REQ       0x004
 #define WM_SCA_COND_NON       0x008
-#define WM_SCA_COND_INV       0x016
+#define WM_SCA_COND_INV       0x010
 #define WM_SCA_STAMP          "sca"
 #define WM_CONFIGURATION_ASSESSMENT_DB_DUMP                   "sca-dump"
 


### PR DESCRIPTION
## Changes performed on this PR
Bugs reported on #3288

### Evaluation condition for rules is aggregated between checks
#### Testing scenario
Execution of a check aggregated by `ANY` followed by a `NONE`
#### Before
```
Thread 6 "wazuh-modulesd" hit Breakpoint 1, wm_sca_do_scan (profile_check=0x7fffe801ac40, vars=0x7fffe8017520, data=0x5555556941a0, id=1448770363, policy=0x7fffe8018080, requirements_scan=0, cis_db_index=0, 
    remote_policy=0, first_scan=0, checks_number=0x7ffff56a2c78) at wazuh_modules/wm_sca.c:890
890	rn;
(gdb) p condition
$21 = 2
(gdb) c

[....]

Thread 6 "wazuh-modulesd" hit Breakpoint 1, wm_sca_do_scan (profile_check=0x7fffe801ac40, vars=0x7fffe8017520, data=0x5555556941a0, id=1448770363, policy=0x7fffe8018080, requirements_scan=0, cis_db_index=0, 
    remote_policy=0, first_scan=0, checks_number=0x7ffff56a2c78) at wazuh_modules/wm_sca.c:890
890	rn;
(gdb) p c_condition->valuestring
$22 = 0x7fffe8005ea0 "none"
(gdb) p condition
$23 = 10 -> should be 8
```
#### After
```
Thread 6 "wazuh-modulesd" hit Breakpoint 1, wm_sca_do_scan (profile_check=0x7fffec0169d0, vars=0x7fffec017c70, data=0x5555556941a0, id=763370574, policy=0x7fffec001900, requirements_scan=0, cis_db_index=0, 
    remote_policy=0, first_scan=1, checks_number=0x7ffff56a2c78) at wazuh_modules/wm_sca.c:891
891	        if(p_checks){
(gdb) p condition
$3 = 2
(gdb) p c_condition->valuestring
$4 = 0x7fffec017130 "any"
(gdb) c

[...]

Thread 6 "wazuh-modulesd" hit Breakpoint 1, wm_sca_do_scan (profile_check=0x7fffec0169d0, vars=0x7fffec017c70, data=0x5555556941a0, id=763370574, policy=0x7fffec001900, requirements_scan=0, cis_db_index=0, 
    remote_policy=0, first_scan=1, checks_number=0x7ffff56a2c78) at wazuh_modules/wm_sca.c:891
891	        if(p_checks){
(gdb) p c_condition->valuestring
$5 = 0x7fffec0061a0 "none"
(gdb) p condition
$6 = 8 -> correct
```

### Bug in condition flags
#### Before
```
(gdb) p /t 0x2
$8 = 10
(gdb) p /t 0x16
$9 = 10110
```

bit_1 is 1 for both

#### After
```
(gdb) p /t 0x1
$11 = 1
(gdb) p /t 0x2
$12 = 10
(gdb) p /t 0x4
$13 = 100
(gdb) p /t 0x8
$14 = 1000
(gdb) p /t 0x10
$15 = 10000
```
No 1-bits in common.
