### PR TITLE
Fixed SCA command execution logic

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1535,8 +1535,8 @@ static int wm_sca_read_command(char *command, char *pattern,wm_sca_t * data, cha
 
         if (*reason == NULL) {
             os_malloc(OS_MAXSTR, *reason);
-            mdebug1("Internal error running command '%s'", command);
-            sprintf(*reason, "Internal error running command '%s'", command);
+            mdebug1("Failed to run command '%s'", command);
+            sprintf(*reason, "Failed to run command '%s'", command);
         }
         return 2;
     }


### PR DESCRIPTION
### Related issue
https://github.com/wazuh/wazuh/issues/3289

## Description

The logic has been fixed by changing the bad comparison against zero to this new one as shown below:

```C
switch( wm_exec(command,&cmd_output,&result_code,data->commands_timeout,NULL)) {
    case 0:
        if (result_code > 0) {
            mdebug1("Command (%s) returned code %d.", command, result_code);
            if (*reason == NULL){
                os_malloc(OS_MAXSTR, *reason);
                if (result_code == EXECVE_ERROR) {
                    mdebug1("Invalid path or permissions running command '%s'",command);
                    sprintf(*reason, "Invalid path or permissions running command '%s'",command);
                } else {
                    mdebug1("Internal error running command '%s'", command);
                    sprintf(*reason, "Internal error running command '%s'", command);
                }
            }
            os_free(cmd_output);
            return 2;
        }
        break;
    case 1:
        if (*reason == NULL) {
            os_malloc(OS_MAXSTR, *reason);
            mdebug1("Timeout overtaken running command '%s'", command);
            sprintf(*reason, "Timeout overtaken running command '%s'", command);
        }
        os_free(cmd_output);
        return 2;
    default:
        mdebug1("Command (%s) returned code %d.", command, result_code);

        if (*reason == NULL) {
            os_malloc(OS_MAXSTR, *reason);
            mdebug1("Internal error running command '%s'", command);
            sprintf(*reason, "Internal error running command '%s'", command);
        }
        return 2;
    }
```


## Logs/Alerts example

Test script:

```
#!/bin/bash

echo "Script output"
echo "This is a test"
echo "Ending test output"
```


- [x] Test scenarios

  - [x] Command timeout execution

Debug:
```
2019/05/10 10:27:34 sca[25541] wm_sca.c:1528 at wm_sca_read_command(): DEBUG: Timeout overtaken running command '/home/rafa/testscript.sh'
```
Alert generated
```
** Alert 1557476859.64501: - sca,gdpr_IV_35.7.d
2019 May 10 10:27:39 rafa-GS63-7RD->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Debian/Linux: Ensure /tmp is configured'
{"type":"check","id":1984028721,"policy":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","check":{"id":5000,"title":"Ensure /tmp is configured","description":"The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.","rationale":"Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.","remediation":"Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.","compliance":{"cis_csc":"5.1","cis":"1.1.2"},"rules":["c:/home/rafa/testscript.sh -> r:^This is a test;"],"references":"https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","command":"/home/rafa/testscript.sh","status":"Not applicable","reason":"Timeout overtaken running command '/home/rafa/testscript.sh'"}}
sca.type: check
sca.scan_id: 1984028721
sca.policy: CIS benchmark for Debian/Linux
sca.check.id: 5000
sca.check.title: Ensure /tmp is configured
sca.check.description: The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.
sca.check.rationale: Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.
sca.check.remediation: Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.
sca.check.compliance.cis_csc: 5.1
sca.check.compliance.cis: 1.1.2
sca.check.references: https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
sca.check.command: ["/home/rafa/testscript.sh"]
sca.check.status: Not applicable
sca.check.reason: Timeout overtaken running command '/home/rafa/testscript.sh'
```
  - [x] Valgrind

```
==25541== LEAK SUMMARY:
==25541==    definitely lost: 0 bytes in 0 blocks
==25541==    indirectly lost: 0 bytes in 0 blocks
==25541==      possibly lost: 6,696 bytes in 10 blocks
==25541==    still reachable: 458,784 bytes in 361 blocks
==25541==                       of which reachable via heuristic:
==25541==                         length64           : 223,896 bytes in 124 blocks
==25541==         suppressed: 0 bytes in 0 blocks
==25541== Reachable blocks (those to which a pointer was found) are not shown.
==25541== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==25541== 
==25541== For counts of detected and suppressed errors, rerun with: -v
==25541== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
```

  - [x] Bad script path

Debug:
```
2019/05/10 10:31:15 wazuh-modulesd[25631] wm_exec.c:427 at wm_exec(): DEBUG: Invalid command: '/home/rafa/testscript.sh_': (2) No such file or directory
2019/05/10 10:31:15 sca[25631] wm_sca.c:1534 at wm_sca_read_command(): DEBUG: Command (/home/rafa/testscript.sh_) returned code 127.
```

Alert generated
```
** Alert 1557477021.69994: - sca,gdpr_IV_35.7.d
2019 May 10 10:30:21 rafa-GS63-7RD->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Debian/Linux: Ensure /tmp is configured'
{"type":"check","id":1414633970,"policy":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","check":{"id":5000,"title":"Ensure /tmp is configured","description":"The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.","rationale":"Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.","remediation":"Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.","compliance":{"cis_csc":"5.1","cis":"1.1.2"},"rules":["c:/home/rafa/testscript.sh_ -> r:^This is a test;"],"references":"https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","command":"/home/rafa/testscript.sh_","status":"Not applicable","reason":"Internal error running command '/home/rafa/testscript.sh_'"}}
sca.type: check
sca.scan_id: 1414633970
sca.policy: CIS benchmark for Debian/Linux
sca.check.id: 5000
sca.check.title: Ensure /tmp is configured
sca.check.description: The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.
sca.check.rationale: Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.
sca.check.remediation: Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.
sca.check.compliance.cis_csc: 5.1
sca.check.compliance.cis: 1.1.2
sca.check.references: https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
sca.check.command: ["/home/rafa/testscript.sh_"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command '/home/rafa/testscript.sh_'
```
  - [x] Valgrind

```
==25631== LEAK SUMMARY:
==25631==    definitely lost: 0 bytes in 0 blocks
==25631==    indirectly lost: 0 bytes in 0 blocks
==25631==      possibly lost: 6,408 bytes in 9 blocks
==25631==    still reachable: 453,847 bytes in 276 blocks
==25631==                       of which reachable via heuristic:
==25631==                         length64           : 223,896 bytes in 124 blocks
==25631==         suppressed: 0 bytes in 0 blocks
==25631== Reachable blocks (those to which a pointer was found) are not shown.
==25631== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

  - [x] Bad script permissions

Debug:

```
2019/05/10 10:41:19 wazuh-modulesd[26065] wm_exec.c:427 at wm_exec(): DEBUG: Invalid command: '/home/rafa/testscript.sh': (0) Success
2019/05/10 10:41:19 sca[26065] wm_sca.c:1534 at wm_sca_read_command(): DEBUG: Command (/home/rafa/testscript.sh) returned code 127.
```

Alert generated
```
** Alert 1557477684.75486: - sca,gdpr_IV_35.7.d
2019 May 10 10:41:24 rafa-GS63-7RD->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Debian/Linux: Ensure /tmp is configured'
{"type":"check","id":2076556907,"policy":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","check":{"id":5000,"title":"Ensure /tmp is configured","description":"The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.","rationale":"Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.","remediation":"Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.","compliance":{"cis_csc":"5.1","cis":"1.1.2"},"rules":["c:/home/rafa/testscript.sh -> r:^This is a test;"],"references":"https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","command":"/home/rafa/testscript.sh","status":"Not applicable","reason":"Internal error running command '/home/rafa/testscript.sh'"}}
sca.type: check
sca.scan_id: 2076556907
sca.policy: CIS benchmark for Debian/Linux
sca.check.id: 5000
sca.check.title: Ensure /tmp is configured
sca.check.description: The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.
sca.check.rationale: Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.
sca.check.remediation: Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.
sca.check.compliance.cis_csc: 5.1
sca.check.compliance.cis: 1.1.2
sca.check.references: https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
sca.check.command: ["/home/rafa/testscript.sh"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command '/home/rafa/testscript.sh'
```

  - [x] Valgrind

```
==26065== LEAK SUMMARY:
==26065==    definitely lost: 0 bytes in 0 blocks
==26065==    indirectly lost: 0 bytes in 0 blocks
==26065==      possibly lost: 6,408 bytes in 9 blocks
==26065==    still reachable: 453,844 bytes in 276 blocks
==26065==                       of which reachable via heuristic:
==26065==                         length64           : 223,896 bytes in 124 blocks
==26065==         suppressed: 0 bytes in 0 blocks
==26065== Reachable blocks (those to which a pointer was found) are not shown.
==26065== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```


  - [x] Command failed execution

Debug:
```
2019/05/10 10:48:00 sca[26373] wm_sca.c:1669 at wm_sca_pt_matches(): DEBUG: Testing buf "Script output" with minterm "r:^This is a test" -> 0
2019/05/10 10:48:00 sca[26373] wm_sca.c:1672 at wm_sca_pt_matches(): DEBUG: Rule test result: 0
2019/05/10 10:48:00 sca[26373] wm_sca.c:1669 at wm_sca_pt_matches(): DEBUG: Testing buf "This is a test" with minterm "r:^This is a test" -> 1
2019/05/10 10:48:00 sca[26373] wm_sca.c:1672 at wm_sca_pt_matches(): DEBUG: Rule test result: 1
2019/05/10 10:48:00 sca[26373] wm_sca.c:1589 at wm_sca_read_command(): DEBUG: Result for r:^This is a test(/home/rafa/testscript.sh) -> 1
2019/05/10 10:48:00 sca[26373] wm_sca.c:1011 at wm_sca_do_scan(): DEBUG: Command returned found.
2019/05/10 10:48:00 sca[26373] wm_sca.c:1147 at wm_sca_do_scan(): DEBUG: Condition ANY.
```

Alert generated:
```
** Alert 1557478085.80973: - sca,gdpr_IV_35.7.d
2019 May 10 10:48:05 rafa-GS63-7RD->sca
Rule: 19014 (level 9) -> 'CIS benchmark for Debian/Linux: Ensure /tmp is configured: Status changed from 'not applicable' to failed'
{"type":"check","id":1364457649,"policy":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","check":{"id":5000,"title":"Ensure /tmp is configured","description":"The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.","rationale":"Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.","remediation":"Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.","compliance":{"cis_csc":"5.1","cis":"1.1.2"},"rules":["c:/home/rafa/testscript.sh -> r:^This is a test;"],"references":"https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","command":"/home/rafa/testscript.sh","result":"failed"}}
sca.type: check
sca.scan_id: 1364457649
sca.policy: CIS benchmark for Debian/Linux
sca.check.id: 5000
sca.check.title: Ensure /tmp is configured
sca.check.description: The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.
sca.check.rationale: Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.
sca.check.remediation: Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.
sca.check.compliance.cis_csc: 5.1
sca.check.compliance.cis: 1.1.2
sca.check.references: https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
sca.check.command: ["/home/rafa/testscript.sh"]
sca.check.result: failed
sca.check.previous_result: Not applicable
```

  - [x] Valgrind

```
==26373== LEAK SUMMARY:
==26373==    definitely lost: 0 bytes in 0 blocks
==26373==    indirectly lost: 0 bytes in 0 blocks
==26373==      possibly lost: 6,408 bytes in 9 blocks
==26373==    still reachable: 453,791 bytes in 276 blocks
==26373==                       of which reachable via heuristic:
==26373==                         length64           : 223,896 bytes in 124 blocks
==26373==         suppressed: 0 bytes in 0 blocks
==26373== Reachable blocks (those to which a pointer was found) are not shown.
==26373== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

  - [x] Command passed execution

Debug:
```
2019/05/10 10:50:34 sca[26547] wm_sca.c:1008 at wm_sca_do_scan(): DEBUG: Running command: '/home/rafa/testscript.sh'.
2019/05/10 10:50:34 sca[26547] wm_sca.c:1568 at wm_sca_read_command(): DEBUG: Rule without IN/NIN: !r:^This is a test
2019/05/10 10:50:34 sca[26547] wm_sca.c:1572 at wm_sca_read_command(): DEBUG: Negation found, is a NIN rule
2019/05/10 10:50:34 sca[26547] wm_sca.c:1669 at wm_sca_pt_matches(): DEBUG: Testing buf "Script output" with minterm "!r:^This is a test" -> 1
2019/05/10 10:50:34 sca[26547] wm_sca.c:1672 at wm_sca_pt_matches(): DEBUG: Rule test result: 1
2019/05/10 10:50:34 sca[26547] wm_sca.c:1589 at wm_sca_read_command(): DEBUG: Result for !r:^This is a test(/home/rafa/testscript.sh) -> 1
2019/05/10 10:50:34 sca[26547] wm_sca.c:1147 at wm_sca_do_scan(): DEBUG: Condition ANY.
```

Alert generated:

```
** Alert 1557478239.85721: - sca,gdpr_IV_35.7.d
2019 May 10 10:50:39 rafa-GS63-7RD->sca
Rule: 19008 (level 3) -> 'CIS benchmark for Debian/Linux: Ensure /tmp is configured'
{"type":"check","id":771398906,"policy":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","check":{"id":5000,"title":"Ensure /tmp is configured","description":"The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.","rationale":"Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.","remediation":"Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.","compliance":{"cis_csc":"5.1","cis":"1.1.2"},"rules":["c:/home/rafa/testscript.sh -> !r:^This is a test;"],"references":"https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","command":"/home/rafa/testscript.sh","result":"passed"}}
sca.type: check
sca.scan_id: 771398906
sca.policy: CIS benchmark for Debian/Linux
sca.check.id: 5000
sca.check.title: Ensure /tmp is configured
sca.check.description: The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.
sca.check.rationale: Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.
sca.check.remediation: Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.
sca.check.compliance.cis_csc: 5.1
sca.check.compliance.cis: 1.1.2
sca.check.references: https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
sca.check.command: ["/home/rafa/testscript.sh"]
sca.check.result: passed
```

  - [x] Valgrind

```
==26547== LEAK SUMMARY:
==26547==    definitely lost: 0 bytes in 0 blocks
==26547==    indirectly lost: 0 bytes in 0 blocks
==26547==      possibly lost: 6,408 bytes in 9 blocks
==26547==    still reachable: 453,792 bytes in 276 blocks
==26547==                       of which reachable via heuristic:
==26547==                         length64           : 223,896 bytes in 124 blocks
==26547==         suppressed: 0 bytes in 0 blocks
==26547== Reachable blocks (those to which a pointer was found) are not shown.
==26547== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```


  - [x] Test various commands (`ls -R /`, `netstat`,`df -h`)

Alerts generated:
```
** Alert 1557479677.91036: - sca,gdpr_IV_35.7.d
2019 May 10 11:14:37 rafa-GS63-7RD->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Debian/Linux: Ensure /tmp is configured'
{"type":"check","id":89793811,"policy":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","check":{"id":5000,"title":"Ensure /tmp is configured","description":"The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.","rationale":"Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.","remediation":"Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.","compliance":{"cis_csc":"5.1","cis":"1.1.2"},"rules":["c:ls -R / -> !r:^This is a test;"],"references":"https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","command":"ls -R /","status":"Not applicable","reason":"Timeout overtaken running command 'ls -R /'"}}
sca.type: check
sca.scan_id: 89793811
sca.policy: CIS benchmark for Debian/Linux
sca.check.id: 5000
sca.check.title: Ensure /tmp is configured
sca.check.description: The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.
sca.check.rationale: Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.
sca.check.remediation: Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.
sca.check.compliance.cis_csc: 5.1
sca.check.compliance.cis: 1.1.2
sca.check.references: https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
sca.check.command: ["ls -R /"]
sca.check.status: Not applicable
sca.check.reason: Timeout overtaken running command 'ls -R /'

** Alert 1557479677.94000: - sca,gdpr_IV_35.7.d
2019 May 10 11:14:37 rafa-GS63-7RD->sca
Rule: 19008 (level 3) -> 'CIS benchmark for Debian/Linux: Ensure /tmp is configured'
{"type":"check","id":89793811,"policy":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","check":{"id":5001,"title":"Ensure /tmp is configured","description":"The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.","rationale":"Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.","remediation":"Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.","compliance":{"cis_csc":"5.1","cis":"1.1.2"},"rules":["c:netstat -> !r:^This is a test;"],"references":"https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","command":"netstat","result":"passed"}}
sca.type: check
sca.scan_id: 89793811
sca.policy: CIS benchmark for Debian/Linux
sca.check.id: 5001
sca.check.title: Ensure /tmp is configured
sca.check.description: The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.
sca.check.rationale: Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.
sca.check.remediation: Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.
sca.check.compliance.cis_csc: 5.1
sca.check.compliance.cis: 1.1.2
sca.check.references: https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
sca.check.command: ["netstat"]
sca.check.result: passed

** Alert 1557479677.96831: - sca,gdpr_IV_35.7.d
2019 May 10 11:14:37 rafa-GS63-7RD->sca
Rule: 19008 (level 3) -> 'CIS benchmark for Debian/Linux: Ensure /tmp is configured'
{"type":"check","id":89793811,"policy":"CIS benchmark for Debian/Linux","policy_id":"cis_debian","check":{"id":5002,"title":"Ensure /tmp is configured","description":"The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.","rationale":"Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.","remediation":"Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.","compliance":{"cis_csc":"5.1","cis":"1.1.2"},"rules":["c:df -h -> !r:^This is a test;"],"references":"https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","command":"df -h","result":"passed"}}
sca.type: check
sca.scan_id: 89793811
sca.policy: CIS benchmark for Debian/Linux
sca.check.id: 5002
sca.check.title: Ensure /tmp is configured
sca.check.description: The /tmp directory is a world-writable directory used for temporary storage by all users and some applications.
sca.check.rationale: Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp.
sca.check.remediation: Configure /etc/fstab as appropiate or enable systemd /tmp mounting and edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount.
sca.check.compliance.cis_csc: 5.1
sca.check.compliance.cis: 1.1.2
sca.check.references: https://tldp.org/HOWTO/LVM-HOWTO/,https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
sca.check.command: ["df -h"]
sca.check.result: passed
```

  - [x] Valgrind

```
==9395== LEAK SUMMARY:
==9395==    definitely lost: 0 bytes in 0 blocks
==9395==    indirectly lost: 0 bytes in 0 blocks
==9395==      possibly lost: 6,408 bytes in 9 blocks
==9395==    still reachable: 458,921 bytes in 385 blocks
==9395==                       of which reachable via heuristic:
==9395==                         length64           : 223,896 bytes in 124 blocks
==9395==         suppressed: 0 bytes in 0 blocks
==9395== Reachable blocks (those to which a pointer was found) are not shown.
==9395== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Review logs syntax and correct language

