### PR TITLE
Fixing granular mails group tag

### DIFF
--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -576,7 +576,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
             }
 
             /* Look for the group */
-            if (json_object = cJSON_GetObjectItem(rule,"group"), json_object) {
+            if (json_object = cJSON_GetObjectItem(rule,"groups"), json_object) {
                 int found = 0;
 
                 if (Mail->gran_group[i]) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/75|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
When using `JSON` as a `<email_log_source>` and an email granular config with a `<group>` tag like the one on the further example configuration, the email specified received unwanted emails from all alerts, with or without that group.
```
<email_alerts>
    <email_to>tsts.mail2.tsts@gmail.com</email_to>
    <level>3</level>
<group>sshd</group>
    <do_not_group/>
  </email_alerts>
```
<br> </br>
The further line was trying to get the field "group" from alerts stored on `alerts.json` when the field is called "groups". This minor fix corrects the way it works so that now, emails included in granular configurations that make use of the groups tag, only receive emails with alerts from those groups.
https://github.com/wazuh/wazuh/blob/15fcb8786770a2f0951d621dd878452d81a7a475/src/os_maild/os_maild_client.c#L579


<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [ ] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster enviroments
- [ ] Configuration on demand reports new parameters
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities