### PR TITLE
Change the alert message when a SACL is invalidated in Whodata

### DIFF
--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -37,7 +37,7 @@
 #define FIM_WHODATA_STARTING                "(6018): Starting file integrity monitoring real-time Whodata engine."
 #define FIM_WHODATA_STARTED                 "(6019): File integrity monitoring real-time Whodata engine started."
 #define FIM_WHODATA_READDED                 "(6020): '%s' has been re-added. It will be monitored in real-time Whodata mode."
-#define FIM_WHODATA_SACL_CHANGED            "(6021): The SACL of '%s' has been modified and it is not valid for the real-time Whodata mode. Whodata will not be available for this file."
+#define FIM_WHODATA_SACL_CHANGED            "(6021): The SACL of '%s' has been modified and its alerts will no longer include whodata information."
 #define FIM_WHODATA_DELETE                  "(6022): '%s' has been deleted. It will not be monitored in real-time Whodata mode."
 
 #define FIM_AUDIT_NOSOCKET                  "(6023): No socket found at '%s'. Restarting Auditd service."

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1329,7 +1329,7 @@ int whodata_hash_add(OSHash *table, char *id, void *data, char *tag) {
 
 void notify_SACL_change(char *dir) {
     char msg_alert[OS_SIZE_1024 + 1];
-    snprintf(msg_alert, OS_SIZE_1024, "ossec: Audit: The SACL of '%s' has been modified and can no longer be scanned in whodata mode.", dir);
+    snprintf(msg_alert, OS_SIZE_1024, "ossec: Audit: The SACL of '%s' has been modified and its alerts will no longer include whodata information.", dir);
     SendMSG(syscheck.queue, msg_alert, "syscheck", LOCALFILE_MQ);
 }
 


### PR DESCRIPTION
When a directory monitored in Whodata mode is modified and its SACL invalidated, it stops being monitored with audit options. After this, when the next scan arrives this directory is monitored in realtime, but seeing the alert, it seemed like it wouldn't be monitored.

### Before

```
** Alert 1557752450.44086: - ossec,syscheck,gdpr_II_5.1.f,gdpr_IV_35.7.d,
2019 May 13 13:00:50 (agwin) any->syscheck
Rule: 517 (level 7) -> 'Syscheck Audit: The SACL of 'c:\folder' has been modified and can no longer be scanned in whodata mode.'
ossec: Audit: The SACL of 'c:\folder' has been modified and can no longer be scanned in whodata mode.
```

### Now

```
** Alert 1557754134.62229: - ossec,syscheck,gdpr_II_5.1.f,gdpr_IV_35.7.d,
2019 May 13 13:28:54 (agwin) any->syscheck
Rule: 517 (level 7) -> 'Syscheck Audit: The SACL of 'c:\folder' has been modified and its alerts will no longer include whodata information.'
ossec: Audit: The SACL of 'c:\folder' has been modified and its alerts will no longer include whodata information.
```

Tested in Windows Server 2016.