### PR TITLE
Fix os_trimcrlf out of bounds access

### DIFF
--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -34,6 +34,11 @@ void os_trimcrlf(char *str)
 
     while (str[len] == '\n' || str[len] == '\r') {
         str[len] = '\0';
+
+        if (len == 0) {
+            break;
+        }
+
         len--;
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3314|


## Description
In order to prevent the out of bound access, the while loop will break after processing the `str[0]` position.

## Tests
Using the same POC code from #3314

```C
#include <stdio.h>
#include <string.h>
#include <stdlib.h>

void os_trimcrlf(char *str)
{
    if (str == NULL) {
        return;
    }

    if (*str == '\0') {
        return;
    }

    size_t len = strlen(str);
    len--;
    while (str[len] == '\n' || str[len] == '\r') {
        str[len] = '\0';

        if (len == 0) {
            break;
        }

        len--;
        printf("LEN: %ld\n", len);
    }
}

int main(void)
{
    char *str = calloc(1000, 1);
    memset(str, '\n', 10);
    os_trimcrlf(str + 5);
}
```
### Output: 
```
LEN: 3
LEN: 2
LEN: 1
LEN: 0
```

**_Q.E.D._**