### PR TITLE
Fixed execd crash when timeout list is not initialized

### DIFF
--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -57,18 +57,21 @@ static void execd_shutdown(int sig)
     /* Remove pending active responses */
     minfo(EXEC_SHUTDOWN);
 
-    timeout_node = OSList_GetFirstNode(timeout_list);
-    while (timeout_node) {
-        timeout_data *list_entry;
+    if (timeout_list) {
+        
+        timeout_node = OSList_GetFirstNode(timeout_list);
+        while (timeout_node) {
+            timeout_data *list_entry;
 
-        list_entry = (timeout_data *)timeout_node->data;
+            list_entry = (timeout_data *)timeout_node->data;
 
-        mdebug2("Delete pending AR: %s", list_entry->command[0]);
-        ExecCmd(list_entry->command);
+            mdebug2("Delete pending AR: %s", list_entry->command[0]);
+            ExecCmd(list_entry->command);
 
-        /* Delete current node - already sets the pointer to next */
-        OSList_DeleteCurrentlyNode(timeout_list);
-        timeout_node = OSList_GetCurrentlyNode(timeout_list);
+            /* Delete current node - already sets the pointer to next */
+            OSList_DeleteCurrentlyNode(timeout_list);
+            timeout_node = OSList_GetCurrentlyNode(timeout_list);
+        }
     }
 
     HandleSIG(sig);

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -56,22 +56,19 @@ static void execd_shutdown(int sig)
 {
     /* Remove pending active responses */
     minfo(EXEC_SHUTDOWN);
+ 
+    timeout_node = timeout_list ? OSList_GetFirstNode(timeout_list) : NULL;
+    while (timeout_node) {
+        timeout_data *list_entry;
 
-    if (timeout_list) {
-        
-        timeout_node = OSList_GetFirstNode(timeout_list);
-        while (timeout_node) {
-            timeout_data *list_entry;
+        list_entry = (timeout_data *)timeout_node->data;
 
-            list_entry = (timeout_data *)timeout_node->data;
+        mdebug2("Delete pending AR: %s", list_entry->command[0]);
+        ExecCmd(list_entry->command);
 
-            mdebug2("Delete pending AR: %s", list_entry->command[0]);
-            ExecCmd(list_entry->command);
-
-            /* Delete current node - already sets the pointer to next */
-            OSList_DeleteCurrentlyNode(timeout_list);
-            timeout_node = OSList_GetCurrentlyNode(timeout_list);
-        }
+        /* Delete current node - already sets the pointer to next */
+        OSList_DeleteCurrentlyNode(timeout_list);
+        timeout_node = OSList_GetCurrentlyNode(timeout_list);
     }
 
     HandleSIG(sig);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3312|

## Description

Check that `timeout_list` is not null when the `execd_shutdown` is called through the signal handler.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Retrocompatibility with older Wazuh versions

- [x] No segfault with active response enabled
- [x] No segafult with active response disabled