### PR TITLE
Add process scan to syscollector capabilities in Mac OS agents

### DIFF
--- a/etc/templates/config/darwin/wodle-syscollector.template
+++ b/etc/templates/config/darwin/wodle-syscollector.template
@@ -8,5 +8,5 @@
     <network>yes</network>
     <packages>yes</packages>
     <ports all="no">no</ports>
-    <processes>no</processes>
+    <processes>yes</processes>
   </wodle>

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -214,6 +214,9 @@ void sys_network_windows(const char* LOCATION);
 // Running processes inventory
 void sys_proc_linux(int queue_fd, const char* LOCATION);
 void sys_proc_windows(const char* LOCATION);
+#ifdef __MACH__
+void sys_proc_mac(int queue_fd, const char* LOCATION);
+#endif
 
 // Read string from a byte array until find a NULL byte
 char* read_string(u_int8_t* bytes);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -1441,7 +1441,7 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
                 status = "Z";   //ZOMBIE
                 break;
             default:
-                mterror(WM_SYS_LOGTAG, "Error getting the status of the process %d", pid);
+                mtdebug1(WM_SYS_LOGTAG, "Error getting the status of the process %d", pid);
                 status = "E";     //Error getting the status
         }
 
@@ -1463,7 +1463,7 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
 
         cJSON_AddNumberToObject(process, "priority", task_info.ptinfo.pti_priority);
         cJSON_AddNumberToObject(process, "nice", task_info.pbsd.pbi_nice);
-        cJSON_AddNumberToObject(process, "vm_size", task_info.ptinfo.pti_virtual_size);
+        cJSON_AddNumberToObject(process, "vm_size", task_info.ptinfo.pti_virtual_size / 1024);
 
         cJSON_AddItemToArray(proc_array, object);
     }

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -1388,9 +1388,14 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
 
     mtdebug1(WM_SYS_LOGTAG, "Starting running processes inventory.");
 
+
     pid_t * pids = NULL;
-    os_calloc(0x1000, 1, pids);
-    int count = proc_listallpids(pids, 0x1000);
+    int32_t maxproc;
+    size_t len = sizeof(maxproc);
+    sysctlbyname("kern.maxproc", &maxproc, &len, NULL, 0);
+
+    os_calloc(maxproc, 1, pids);
+    int count = proc_listallpids(pids, maxproc);
 
     mtdebug2(WM_SYS_LOGTAG, "Number of processes retrieved: %d", count);
 

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -1420,22 +1420,19 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
         char *status;
 		switch(task_info.pbsd.pbi_status){
 			case 1:
-				status = "S"; //SLEEP
+				status = "I"; //IDLE
 				break;
 			case 2:
-				status = "W";  //WAIT
-				break;
-			case 3:
 				status = "R"; //RUNNING
 				break;
+			case 3:
+				status = "S";  //SLEEP
+				break;
 			case 4:
-				status = "I";  //IDLE
+				status = "T";    //STOPPED
 				break;
 			case 5:
-				status = "Z";    //ZOMBIE
-				break;
-			case 6:
-				status = "T";   //STOPPED
+				status = "Z";   //ZOMBIE
 				break;
 			default:
                 mterror(WM_SYS_LOGTAG," Error getting the status of the process %d", pid);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -26,6 +26,10 @@
 #include <ifaddrs.h>
 #include <string.h>
 #include <net/route.h>
+
+
+#ifdef __MACH__
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -35,8 +39,6 @@
 #include <sys/resource.h>
 #include <sys/proc.h>
 
-
-#ifdef __MACH__
 #if !HAVE_SOCKADDR_SA_LEN
 #define SA_LEN(sa)      af_to_len(sa->sa_family)
 #if HAVE_SIOCGLIFNUM
@@ -1384,7 +1386,10 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
             localtm.tm_year + 1900, localtm.tm_mon + 1,
             localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
 
-    pid_t * pids = calloc(0x1000, 1);
+    mtdebug1(WM_SYS_LOGTAG, "Starting running processes inventory.");
+
+    pid_t * pids = NULL;
+    os_calloc(0x1000, 1, pids);
     int count = proc_listallpids(pids, 0x1000);
 
     mtdebug2(WM_SYS_LOGTAG, "Number of processes retrieved: %d", count);
@@ -1393,11 +1398,9 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
     cJSON *item;
     cJSON *proc_array = cJSON_CreateArray();
 
-    mtdebug1(WM_SYS_LOGTAG, "Starting running processes inventory.");
-
     for(index=0; index < count; ++index) {
 
-       	struct proc_taskallinfo task_info;
+        struct proc_taskallinfo task_info;
 
         cJSON *object = cJSON_CreateObject();
         cJSON *process = cJSON_CreateObject();
@@ -1406,37 +1409,38 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
         cJSON_AddStringToObject(object, "timestamp", timestamp);
         cJSON_AddItemToObject(object, "process", process);
 
-		pid_t pid = pids[ index ] ;
+        pid_t pid = pids[ index ] ;
         cJSON_AddNumberToObject(process,"pid",pid);
 
-		int st = proc_pidinfo(pid, PROC_PIDTASKALLINFO, 0,
-							&task_info, PROC_PIDTASKALLINFO_SIZE);
+        int st = proc_pidinfo(pid, PROC_PIDTASKALLINFO, 0,
+                            &task_info, PROC_PIDTASKALLINFO_SIZE);
 
-		if (st != PROC_PIDTASKALLINFO_SIZE) {
-			mterror(WM_SYS_LOGTAG, "Cannot get process info for PID %d", pid);
-			continue;
-		}
+        if (st != PROC_PIDTASKALLINFO_SIZE) {
+            mterror(WM_SYS_LOGTAG, "Cannot get process info for PID %d", pid);
+            cJSON_Delete(object);
+            continue;
+        }
 
         char *status;
-		switch(task_info.pbsd.pbi_status){
-			case 1:
-				status = "I"; //IDLE
-				break;
-			case 2:
-				status = "R"; //RUNNING
-				break;
-			case 3:
-				status = "S";  //SLEEP
-				break;
-			case 4:
-				status = "T";    //STOPPED
-				break;
-			case 5:
-				status = "Z";   //ZOMBIE
-				break;
-			default:
-                mterror(WM_SYS_LOGTAG," Error getting the status of the process %d", pid);
-				status = "E";     //Error getting the status
+        switch(task_info.pbsd.pbi_status){
+            case 1:
+                status = "I"; //IDLE
+                break;
+            case 2:
+                status = "R"; //RUNNING
+                break;
+            case 3:
+                status = "S";  //SLEEP
+                break;
+            case 4:
+                status = "T";    //STOPPED
+                break;
+            case 5:
+                status = "Z";   //ZOMBIE
+                break;
+            default:
+                mterror(WM_SYS_LOGTAG,"Error getting the status of the process %d", pid);
+                status = "E";     //Error getting the status
         }
 
         cJSON_AddStringToObject(process,"name",task_info.pbsd.pbi_name);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -1446,20 +1446,23 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
         struct passwd *euser = getpwuid((int)task_info.pbsd.pbi_uid);
         if(euser)
             cJSON_AddStringToObject(process,"euser",euser->pw_name);
-        
+
         struct passwd *ruser = getpwuid((int)task_info.pbsd.pbi_ruid);
         if(ruser)
             cJSON_AddStringToObject(process,"ruser",ruser->pw_name);
-            
+
         struct group *rgroup = getgrgid((int)task_info.pbsd.pbi_rgid);
         if(rgroup)
             cJSON_AddStringToObject(process,"rgroup",rgroup->gr_name);
+
         cJSON_AddNumberToObject(process,"priority",task_info.ptinfo.pti_priority);
         cJSON_AddNumberToObject(process,"nice",task_info.pbsd.pbi_nice);
         cJSON_AddNumberToObject(process,"vm_size",task_info.ptinfo.pti_virtual_size);
 
         cJSON_AddItemToArray(proc_array, object);
     }
+
+    free(pids);
 
     cJSON_ArrayForEach(item, proc_array) {
         char *string = cJSON_PrintUnformatted(item);

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -147,6 +147,8 @@ void* wm_sys_main(wm_sys_t *sys) {
                 sys_proc_linux(queue_fd, WM_SYS_LOCATION);
             #elif defined(WIN32)
                 sys_proc_windows(WM_SYS_LOCATION);
+            #elif defined(__MACH__)
+                sys_proc_mac(queue_fd, WM_SYS_LOCATION);
             #else
                 sys->flags.procinfo = 0;
                 mtwarn(WM_SYS_LOGTAG, "Running processes inventory is not available for this OS version.");


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3295|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds the process scan of syscollector to Mac OS X agents. It also changes the template for Darwin agents to include the process scan in the default syscollector configuration.
<!--
Add a clear description of how the problem has been solved.
-->
The algorithm for the scan is:
 - Retrieve the list of the process IDs with the function: `proc_listallpids()`
 - Obtain the information of each process with the function: `proc_pidinfo()`
 - Send the information to the Wazuh manager

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

Now, the `ossec.conf` of the MAC agents has the process scan activated in the default configuration
```
 <!-- System inventory -->
  <wodle name="syscollector">
    <disabled>no</disabled>
    <interval>1h</interval>
    <scan_on_start>yes</scan_on_start>
    <hardware>yes</hardware>
    <os>yes</os>
    <network>yes</network>
    <packages>yes</packages>
    <ports all="no">no</ports>
    <processes>yes</processes>
  </wodle>
```

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

Sample of information stored in the database:
![image](https://user-images.githubusercontent.com/9034923/57709183-e3aeb780-766a-11e9-869a-ef3324aaf207.png)

This is how the information is displayed in Kibana
![image](https://user-images.githubusercontent.com/9034923/57709511-7c453780-766b-11e9-8b9e-34d278ec90af.png)


## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- Memory tests
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities