### PR TITLE
Added line number on error while parsing files.yml

### DIFF
--- a/src/remoted/shared_download.c
+++ b/src/remoted/shared_download.c
@@ -63,7 +63,7 @@ const char *w_read_scalar_value(yaml_event_t * event){
 
 int w_move_next(yaml_parser_t * parser, yaml_event_t * event){
     if (!yaml_parser_parse(parser, event)) {
-        merror("Parser error %d", parser->error);
+        merror("Parser error %d on line %d", parser->error, (unsigned int)parser->problem_mark.line);
         return W_PARSER_ERROR;
     }
     return 0;
@@ -109,17 +109,16 @@ agent_group * w_read_agents(yaml_parser_t * parser) {
                 break;
 
             default:
-                merror("Parsing error: unexpected token %d", event.type);
+                merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
                 goto error;
             }
-
         } while (event.type != YAML_MAPPING_END_EVENT);
 
         yaml_event_delete(&event);
         return agents;
 
     default:
-        merror("Parsing error: unexpected token %d", event.type);
+        merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
     }
 
 error:
@@ -201,7 +200,7 @@ int w_read_group(yaml_parser_t * parser, remote_files_group * group) {
                 break;
 
             default:
-                merror("Parsing error: unexpected token %d", event.type);
+                merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
                 goto error;
             }
         } while (event.type != YAML_MAPPING_END_EVENT);
@@ -210,7 +209,7 @@ int w_read_group(yaml_parser_t * parser, remote_files_group * group) {
         return 0;
 
     default:
-        merror("Parsing error: unexpected token %d", event.type);
+        merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
     }
 
 error:
@@ -255,17 +254,16 @@ remote_files_group * w_read_groups(yaml_parser_t * parser) {
                 break;
 
             default:
-                merror("Parsing error: unexpected token %d", event.type);
+                merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
                 goto error;
             }
-
         } while (event.type != YAML_MAPPING_END_EVENT);
 
         yaml_event_delete(&event);
         return groups;
 
     default:
-        merror("Parsing error: unexpected token %d", event.type);
+        merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
     }
 
 error:
@@ -318,17 +316,16 @@ file * w_read_group_files(yaml_parser_t * parser) {
                 break;
 
             default:
-                merror("Parsing error: unexpected token %d", event.type);
+                merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
                 goto error;
             }
-
         } while (event.type != YAML_MAPPING_END_EVENT);
 
         yaml_event_delete(&event);
         return files;
 
     default:
-        merror("Parsing error: unexpected token %d", event.type);
+        merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
         goto error;
     }
 
@@ -380,7 +377,7 @@ int w_do_parsing(const char * yaml_file, remote_files_group ** agent_remote_grou
     yaml_event_delete(&event);
 
     if (!yaml_parser_parse(&parser, &event)) {
-        merror("Parser error %d", parser.error);
+        merror("Parser error %d on line %d", parser.error, (unsigned int)parser.problem_mark.line);
         goto end;
     }
 
@@ -423,7 +420,7 @@ int w_do_parsing(const char * yaml_file, remote_files_group ** agent_remote_grou
                             }
                         }
                     } else {
-                        merror("Parsing file '%s': unexpected identifier: '%s'", yaml_file, w_read_scalar_value(&event));
+                        merror("Parsing file '%s': unexpected identifier: '%s' on line %d", yaml_file, w_read_scalar_value(&event), (unsigned int)event.start_mark.line);
                     }
 
                     break;
@@ -431,15 +428,14 @@ int w_do_parsing(const char * yaml_file, remote_files_group ** agent_remote_grou
                     break;
 
                 default:
-                    merror("Parsing '%s': unexpected token %d", yaml_file, event.type);
+                    merror("Parsing '%s': unexpected token %d on line %d", yaml_file, event.type, (unsigned int)event.start_mark.line);
                     goto end;
                 }
-
             } while (event.type != YAML_MAPPING_END_EVENT);
             break;
 
         default:
-            merror("Parsing '%s': unexpected token %d", yaml_file, event.type);
+            merror("Parsing '%s': unexpected token %d on line %d", yaml_file, event.type, (unsigned int)event.start_mark.line);
             goto end;
         }
 
@@ -452,14 +448,14 @@ int w_do_parsing(const char * yaml_file, remote_files_group ** agent_remote_grou
     yaml_event_delete(&event);
 
     if (!(yaml_parser_parse(&parser, &event) && event.type == YAML_DOCUMENT_END_EVENT)) {
-        merror("Parser error %d: expecting document end", parser.error);
+        merror("Parser error %d: expecting document end on line %d", parser.error, (unsigned int)parser.problem_mark.line);
         goto end;
     }
 
     yaml_event_delete(&event);
 
     if (!(yaml_parser_parse(&parser, &event) && event.type == YAML_STREAM_END_EVENT)) {
-        merror("Parser error %d: expecting file end", parser.error);
+        merror("Parser error %d: expecting file end on line %d", parser.error, (unsigned int)parser.problem_mark.line);
         goto end;
     }
 

--- a/src/remoted/shared_download.c
+++ b/src/remoted/shared_download.c
@@ -63,7 +63,7 @@ const char *w_read_scalar_value(yaml_event_t * event){
 
 int w_move_next(yaml_parser_t * parser, yaml_event_t * event){
     if (!yaml_parser_parse(parser, event)) {
-        merror("Parser error %d on line %d", parser->error, (unsigned int)parser->problem_mark.line);
+        merror("Parser error on line %d: [(%d)-(%s)]", (unsigned int)parser->problem_mark.line, parser->error, parser->problem);
         return W_PARSER_ERROR;
     }
     return 0;
@@ -109,7 +109,7 @@ agent_group * w_read_agents(yaml_parser_t * parser) {
                 break;
 
             default:
-                merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
+                merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
                 goto error;
             }
         } while (event.type != YAML_MAPPING_END_EVENT);
@@ -118,7 +118,7 @@ agent_group * w_read_agents(yaml_parser_t * parser) {
         return agents;
 
     default:
-        merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
+        merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
     }
 
 error:
@@ -200,7 +200,7 @@ int w_read_group(yaml_parser_t * parser, remote_files_group * group) {
                 break;
 
             default:
-                merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
+                merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
                 goto error;
             }
         } while (event.type != YAML_MAPPING_END_EVENT);
@@ -209,7 +209,7 @@ int w_read_group(yaml_parser_t * parser, remote_files_group * group) {
         return 0;
 
     default:
-        merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
+        merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
     }
 
 error:
@@ -254,7 +254,7 @@ remote_files_group * w_read_groups(yaml_parser_t * parser) {
                 break;
 
             default:
-                merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
+                merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
                 goto error;
             }
         } while (event.type != YAML_MAPPING_END_EVENT);
@@ -263,7 +263,7 @@ remote_files_group * w_read_groups(yaml_parser_t * parser) {
         return groups;
 
     default:
-        merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
+        merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
     }
 
 error:
@@ -316,7 +316,7 @@ file * w_read_group_files(yaml_parser_t * parser) {
                 break;
 
             default:
-                merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
+                merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
                 goto error;
             }
         } while (event.type != YAML_MAPPING_END_EVENT);
@@ -325,7 +325,7 @@ file * w_read_group_files(yaml_parser_t * parser) {
         return files;
 
     default:
-        merror("Parsing error: unexpected token %d on line %d", event.type, (unsigned int)event.start_mark.line);
+        merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
         goto error;
     }
 
@@ -377,7 +377,7 @@ int w_do_parsing(const char * yaml_file, remote_files_group ** agent_remote_grou
     yaml_event_delete(&event);
 
     if (!yaml_parser_parse(&parser, &event)) {
-        merror("Parser error %d on line %d", parser.error, (unsigned int)parser.problem_mark.line);
+        merror("Parser error on line %d: [(%d)-(%s)]", (unsigned int)parser.problem_mark.line, parser.error, parser.problem);
         goto end;
     }
 
@@ -428,14 +428,14 @@ int w_do_parsing(const char * yaml_file, remote_files_group ** agent_remote_grou
                     break;
 
                 default:
-                    merror("Parsing '%s': unexpected token %d on line %d", yaml_file, event.type, (unsigned int)event.start_mark.line);
+                    merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
                     goto end;
                 }
             } while (event.type != YAML_MAPPING_END_EVENT);
             break;
 
         default:
-            merror("Parsing '%s': unexpected token %d on line %d", yaml_file, event.type, (unsigned int)event.start_mark.line);
+            merror("Parsing error on line %d: unexpected token", (unsigned int)event.start_mark.line);
             goto end;
         }
 
@@ -448,14 +448,14 @@ int w_do_parsing(const char * yaml_file, remote_files_group ** agent_remote_grou
     yaml_event_delete(&event);
 
     if (!(yaml_parser_parse(&parser, &event) && event.type == YAML_DOCUMENT_END_EVENT)) {
-        merror("Parser error %d: expecting document end on line %d", parser.error, (unsigned int)parser.problem_mark.line);
+        merror("Parser error on line %d: [(%d)-(expecting document end)]", (unsigned int)parser.problem_mark.line, parser.error);
         goto end;
     }
 
     yaml_event_delete(&event);
 
     if (!(yaml_parser_parse(&parser, &event) && event.type == YAML_STREAM_END_EVENT)) {
-        merror("Parser error %d: expecting file end on line %d", parser.error, (unsigned int)parser.problem_mark.line);
+        merror("Parser error on line %d: [(%d)-(expecting file end on line)]",(unsigned int)parser.problem_mark.line, parser.error);
         goto end;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3324|

## Description

Added the line number causing the problem by using the yaml parser structs that provide the information:

- `parser->problem_mark.line` when calling the function `yaml_parser_parse`
- `event.start_mark.line` when extracting a event

## Logs/Alerts example

```
2019/05/15 12:27:10 ossec-remoted[25579] shared_download.c:368 at w_do_parsing(): DEBUG: Started yaml parsing of file: /etc/shared/files.yml
2019/05/15 12:27:10 ossec-remoted[25579] shared_download.c:266 at w_read_groups(): ERROR: Parsing error: unexpected token 6 on line 2
```

```
2019/05/15 12:33:48 ossec-remoted[26333] shared_download.c:368 at w_do_parsing(): DEBUG: Started yaml parsing of file: /etc/shared/files.yml
2019/05/15 12:33:48 ossec-remoted[26333] shared_download.c:66 at w_move_next(): ERROR: Parser error 4 on line 13
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- Memory tests
  - [x] Valgrind report for affected components
- [x] Retrocompatibility with older Wazuh versions

- [x] Bad indentation 

```yaml
    groups:
        my_group_1:
            files:
                agent.conf: https://example.com/agent.conf
                rootcheck.txt: https://example.com/rootcheck.txt
                merged.mg: https://example.com/merged.mg
            poll: 15

        my_group_2:
            files:
                agent.conf: https://example.com/agent.conf
            poll: 200

      agents:
          001: my_group_1
          002: my_group_2
          003: another_group
```

```
2019/05/15 12:38:34 ossec-remoted[26549] shared_download.c:368 at w_do_parsing(): DEBUG: Started yaml parsing of file: /etc/shared/files.yml
2019/05/15 12:38:34 ossec-remoted[26549] shared_download.c:66 at w_move_next(): ERROR: Parser error 4 on line 13
```

- [x] Bad token 

```yaml
    groups:
        my_group_1:
            files:
                agent.conf: https://example.com/agent.conf
                rootcheck.txt: https://example.com/rootcheck.txt
                merged.mg: https://example.com/merged.mg
            poll: 15

        my_group_2:
            files:
                bad_token
                agent.conf: https://example.com/agent.conf
            poll: 200

      agents:
          001: my_group_1
          002: my_group_2
          003: another_group
```

```
2019/05/15 12:40:54 ossec-remoted[26675] shared_download.c:368 at w_do_parsing(): DEBUG: Started yaml parsing of file: /etc/shared/files.yml
2019/05/15 12:40:54 ossec-remoted[26675] shared_download.c:328 at w_read_group_files(): ERROR: Parsing error: unexpected token 6 on line 10
```

- [x] Bad token 

```yaml
    groups:
        my_group_1
            files:
                agent.conf: https://example.com/agent.conf
                rootcheck.txt: https://example.com/rootcheck.txt
                merged.mg: https://example.com/merged.mg
            poll: 15

        my_group_2:
            files:
                bad_token
                agent.conf: https://example.com/agent.conf
            poll: 200

      agents:
          001: my_group_1
          002: my_group_2
          003: another_group
```

```
2019/05/15 12:42:31 ossec-remoted[26783] shared_download.c:368 at w_do_parsing(): DEBUG: Started yaml parsing of file: /etc/shared/files.yml
2019/05/15 12:42:31 ossec-remoted[26783] shared_download.c:266 at w_read_groups(): ERROR: Parsing error: unexpected token 6 on line 1
```

- [x] Bad yaml

```yaml
    groups:
        my_group_1
            files:
                agent.conf: https://example.com/agent.conf
                rootcheck.txt: https://example.com/rootcheck.txt
                merged.mg: https://example.com/merged.mg
            poll: 15

        my_group_2:
            files:
                bad_token
                agent.conf: https://example.com/agent.conf
            poll: 200

      agents: bad_yaml
          001: my_group_1
          002: my_group_2
          003: another_group
```

```
2019/05/15 12:44:05 ossec-remoted[26839] shared_download.c:368 at w_do_parsing(): DEBUG: Started yaml parsing of file: /etc/shared/files.yml
2019/05/15 12:44:05 ossec-remoted[26839] shared_download.c:66 at w_move_next(): ERROR: Parser error 4 on line 13
```

-  [x] Valgrind report

```
==26894== LEAK SUMMARY:
==26894==    definitely lost: 0 bytes in 0 blocks
==26894==    indirectly lost: 0 bytes in 0 blocks
==26894==      possibly lost: 5,184 bytes in 18 blocks
==26894==    still reachable: 1,102,125 bytes in 109 blocks
==26894==         suppressed: 0 bytes in 0 blocks
==26894== Reachable blocks (those to which a pointer was found) are not shown.
==26894== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```


