### PR TITLE
Fix compilation issue for local installation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -626,7 +626,7 @@ DB_LIB      = $(EXTERNAL_LIBDB).libs/libdb-6.2.a
 LIBYAML_LIB = $(EXTERNAL_LIBYAML)src/.libs/libyaml.a
 LIBCURL_LIB = $(EXTERNAL_CURL)lib/.libs/libcurl.a
 AUDIT_LIB = $(EXTERNAL_AUDIT)lib/.libs/libaudit.a
-LIBFFI_LIB = $(EXTERNAL_LIBFFI)server/.libs/libffi.a
+LIBFFI_LIB = $(EXTERNAL_LIBFFI)$(TARGET)/.libs/libffi.a
 MSGPACK_LIB = $(EXTERNAL_MSGPACK)libmsgpack.a
 
 EXTERNAL_LIBS := $(JSON_LIB) $(ZLIB_LIB) $(OPENSSL_LIB) $(CRYPTO_LIB) $(SQLITE_LIB) $(LIBYAML_LIB)


### PR DESCRIPTION
|Related issue|
|---|
|#3336|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The `TARGET=local` definition conflicts with a parameter in the _libffi_'s Makefile. That makes _libffi_ compile the sources into _src/external/libffi/server_. However, in _local_ mode, it tries to compile into _src/external/libffi/local_, this prevents the Wazuh's Makefile from finding the library while assembling _libwazuhext.so_.

## Solution

The most simple fix is let the Wazuh's Makefile find _libffi.a_ in a location that depends on the `TARGET` variable.

If we undefined `TARGET`, we would need to find the default target directory for _libffi_, that depends on the architecture.

## Output

```
make TARGET=local
```
```
General settings:
    TARGET:             local
    V:
    DEBUG:              yes
    DEBUGAD
    PREFIX:             /var/ossec
    MAXAGENTS:          14000
    DATABASE:
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/3.9
User settings:
    OSSEC_GROUP:        ossec
    OSSEC_USER:         ossec
    OSSEC_USER_MAIL:    ossecm
    OSSEC_USER_REM:     ossecr
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    USE_FRAMEWORK_LIB:  no
Mysql settings:
    includes:
    libs:
Pgsql settings:
    includes:
    libs:
Defines:
    -DMAX_AGENTS=14000 -DOSSECHIDS -DDEFAULTDIR="/var/ossec" -DUSER="ossec" -DREMUSER="ossecr" -DGROUPGLOBAL="ossec" -DMAILUSER="ossecm" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_SHARED -DENABLE_AUDIT -DLOCAL
Compiler:
    CFLAGS            -Wl,--start-group -Iexternal/audit-userspace/lib -pthread -Iexternal/libdb/build_unix/ -g  -DMAX_AGENTS=14000 -DOSSECHIDS -DDEFAULTDIR="/var/ossec" -DUSER="ossec" -DREMUSER="ossecr" -DGROUPGLOBAL="ossec" -DMAILUSER="ossecm" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_SHARED -DENABLE_AUDIT -DLOCAL -pipe -Wall -Wextra -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include
    LDFLAGS            '-Wl,-rpath,/../lib' -pthread -lrt -ldl
    CC                cc
    MAKE              make
make[1]: Leaving directory `/root/wazuh/src'

Done building local
```

- Compilation without warnings in every supported platform.
  - [X] Linux (local installation)
  - [ ] MAC OS X (local installation). The compilation fails (#3338).
- [X] Source installation.
- [ ] Package installation. It applies neither to manager nor agents.