### PR TITLE
Add ports scan to syscollector capabilities in Mac OS agents

### DIFF
--- a/etc/templates/config/darwin/wodle-syscollector.template
+++ b/etc/templates/config/darwin/wodle-syscollector.template
@@ -7,6 +7,6 @@
     <os>yes</os>
     <network>yes</network>
     <packages>yes</packages>
-    <ports all="no">no</ports>
+    <ports all="no">yes</ports>
     <processes>yes</processes>
   </wodle>

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -154,6 +154,11 @@ void sys_ports_linux(int queue_fd, const char* WM_SYS_LOCATION, int check_all);
 // Opened ports inventory for Windows
 void sys_ports_windows(const char* LOCATION, int check_all);
 
+// Opened ports inventory for MAC OS X
+#ifdef __MACH__
+    void sys_ports_mac(int queue_fd, const char* WM_SYS_LOCATION, int check_all);
+#endif
+
 // Installed packages inventory for Linux
 void sys_packages_linux(int queue_fd, const char* WM_SYS_LOCATION);
 char * sys_deb_packages(int queue_fd, const char* WM_SYS_LOCATION, int random_id);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -28,7 +28,6 @@
 
 
 #ifdef __MACH__
-<<<<<<< HEAD
 
 #include <ctype.h>
 #include <libproc.h>
@@ -36,11 +35,8 @@
 #include <grp.h>
 #include <sys/resource.h>
 #include <sys/proc.h>
-=======
 #include <sys/proc_info.h>
-#include <libproc.h>
 #include <netdb.h>
->>>>>>> 611d96aaa... Add port inventory to syscollector MAC agents
 
 #if !HAVE_SOCKADDR_SA_LEN
 #define SA_LEN(sa)      af_to_len(sa->sa_family)
@@ -56,11 +52,9 @@
 
 hw_info *get_system_bsd();    // Get system information
 
-#ifdef __MACH__
-    OSHash *gateways;
-#endif
 
 #if defined(__MACH__)
+OSHash *gateways;
 
 char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_id);
 
@@ -1507,7 +1501,7 @@ void sys_ports_mac(int queue_fd, const char* WM_SYS_LOCATION, int check_all) {
                 snprintf(protocol, 5, "%s%c",
                     socketInfo.psi.soi_kind == SOCKINFO_TCP ? "tcp" : "udp",
                     socketInfo.psi.soi_family == AF_INET6 ? '6' : '\0');
- 
+
 
                 int localPort = (int)ntohs(socketInfo.psi.soi_proto.pri_in.insi_lport);
                 int remotePort = (int)ntohs(socketInfo.psi.soi_proto.pri_in.insi_fport);
@@ -1567,10 +1561,8 @@ void sys_ports_mac(int queue_fd, const char* WM_SYS_LOCATION, int check_all) {
 }
 
 void sys_proc_mac(int queue_fd, const char* LOCATION){
-    char *timestamp;
-    struct tm localtm;
-    int random_id = os_random();
 
+    int random_id = os_random();
     if(random_id < 0) {
         random_id = -random_id;
     }
@@ -1579,8 +1571,10 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
     int usec = 1000000 / wm_max_eps;
 
     time_t now = time(NULL);
+    struct tm localtm;
     localtime_r(&now, &localtm);
 
+    char *timestamp;
     os_calloc(TIME_LENGTH, sizeof(char), timestamp);
 
     snprintf(timestamp, TIME_LENGTH-1, "%d/%02d/%02d %02d:%02d:%02d",
@@ -1590,19 +1584,19 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
     mtdebug1(WM_SYS_LOGTAG, "Starting running processes inventory.");
 
 
-    pid_t * pids = NULL;
     int32_t maxproc;
     size_t len = sizeof(maxproc);
     sysctlbyname("kern.maxproc", &maxproc, &len, NULL, 0);
 
+    pid_t *pids = NULL;
     os_calloc(maxproc, 1, pids);
     int count = proc_listallpids(pids, maxproc);
 
     mtdebug2(WM_SYS_LOGTAG, "Number of processes retrieved: %d", count);
 
-    int index;
     cJSON *proc_array = cJSON_CreateArray();
 
+    int index;
     for(index=0; index < count; ++index) {
 
         struct proc_taskallinfo task_info;

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -1448,10 +1448,6 @@ void sys_ports_mac(int queue_fd, const char* WM_SYS_LOCATION, int check_all) {
         // Get the list of open FDs
         struct proc_fdinfo *procFDInfo;
         os_malloc(bufferSize, procFDInfo);
-        if (!procFDInfo) {
-            mterror(WM_SYS_LOGTAG, "Out of memory. Unable to allocate buffer with %d bytes", bufferSize);
-            continue;
-        }
         proc_pidinfo(pid, PROC_PIDLISTFDS, 0, procFDInfo, bufferSize);
         int numberOfProcFDs = bufferSize / PROC_PIDLISTFD_SIZE;
 

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -14,21 +14,21 @@
 #if defined(__MACH__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 
 #include <sys/types.h>
-#include <sys/sysctl.h>
 #include <sys/vmmeter.h>
 #include <sys/sysctl.h>
 #include <sys/socket.h>
 #include <net/if.h>
 #include <net/if_dl.h>
+#include <net/if_types.h>
+#include <net/route.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <net/if_types.h>
 #include <ifaddrs.h>
 #include <string.h>
-#include <net/route.h>
 
 
 #ifdef __MACH__
+<<<<<<< HEAD
 
 #include <ctype.h>
 #include <libproc.h>
@@ -36,6 +36,11 @@
 #include <grp.h>
 #include <sys/resource.h>
 #include <sys/proc.h>
+=======
+#include <sys/proc_info.h>
+#include <libproc.h>
+#include <netdb.h>
+>>>>>>> 611d96aaa... Add port inventory to syscollector MAC agents
 
 #if !HAVE_SOCKADDR_SA_LEN
 #define SA_LEN(sa)      af_to_len(sa->sa_family)
@@ -1361,7 +1366,205 @@ int getGatewayList(OSHash *gateway_list){
     return 0;
 }
 
-#ifdef __MACH__
+char *get_port_state(int state) {
+    char *port_state;
+    os_calloc(STATE_LENGTH, sizeof(char), port_state);
+
+    switch(state){
+        case TSI_S_ESTABLISHED:
+            snprintf(port_state, STATE_LENGTH, "%s", "established");
+            break;
+        case TSI_S_SYN_SENT:
+            snprintf(port_state, STATE_LENGTH, "%s", "syn_sent");
+            break;
+        case TSI_S_SYN_RECEIVED:
+            snprintf(port_state, STATE_LENGTH, "%s", "syn_recv");
+            break;
+        case TSI_S_FIN_WAIT_1:
+            snprintf(port_state, STATE_LENGTH, "%s", "fin_wait1");
+            break;
+        case TSI_S_FIN_WAIT_2:
+            snprintf(port_state, STATE_LENGTH, "%s", "fin_wait2");
+            break;
+        case TSI_S_TIME_WAIT:
+            snprintf(port_state, STATE_LENGTH, "%s", "time_wait");
+            break;
+        case TSI_S_CLOSED:
+            snprintf(port_state, STATE_LENGTH, "%s", "close");
+            break;
+        case TSI_S__CLOSE_WAIT:
+            snprintf(port_state, STATE_LENGTH, "%s", "close_wait");
+            break;
+        case TSI_S_LAST_ACK:
+            snprintf(port_state, STATE_LENGTH, "%s", "last_ack");
+            break;
+        case TSI_S_LISTEN:
+            snprintf(port_state, STATE_LENGTH, "%s", "listening");
+            break;
+        case TSI_S_CLOSING:
+            snprintf(port_state, STATE_LENGTH, "%s", "closing");
+            break;
+        default:
+            snprintf(port_state, STATE_LENGTH, "%s", "unknown");
+            break;
+    }
+    return port_state;
+}
+
+void sys_ports_mac(int queue_fd, const char* WM_SYS_LOCATION, int check_all) {
+
+    time_t now = time(NULL);
+    struct tm localtm;
+    localtime_r(&now, &localtm);
+
+    char *timestamp;
+    os_calloc(TIME_LENGTH, sizeof(char), timestamp);
+    snprintf(timestamp, TIME_LENGTH - 1, "%d/%02d/%02d %02d:%02d:%02d",
+            localtm.tm_year + 1900, localtm.tm_mon + 1,
+            localtm.tm_mday, localtm.tm_hour, localtm.tm_min, localtm.tm_sec);
+
+    int random_id = os_random();
+    if (random_id < 0) {
+        random_id = -random_id;
+    }
+
+    // Define time to sleep between messages sent
+    const int usec = 1000000 / wm_max_eps;
+
+    mtdebug1(WM_SYS_LOGTAG, "Starting ports inventory.");
+
+    pid_t * pids = NULL;
+    int32_t maxproc;
+    size_t len = sizeof(maxproc);
+    sysctlbyname("kern.maxproc", &maxproc, &len, NULL, 0);
+
+    os_calloc(maxproc, 1, pids);
+    int count = proc_listallpids(pids, maxproc);
+
+    int index;
+    for(index = 0; index < count; ++index) {
+        pid_t pid = pids[index];
+        // Figure out the size of the buffer needed to hold the list of open FDs
+        int bufferSize = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, 0, 0);
+        if (bufferSize == -1) {
+            mterror(WM_SYS_LOGTAG, "Unable to get open file handles for %d", pid);
+            continue;
+        }
+
+        // Get the list of open FDs
+        struct proc_fdinfo *procFDInfo;
+        os_malloc(bufferSize, procFDInfo);
+        if (!procFDInfo) {
+            mterror(WM_SYS_LOGTAG, "Out of memory. Unable to allocate buffer with %d bytes", bufferSize);
+            continue;
+        }
+        proc_pidinfo(pid, PROC_PIDLISTFDS, 0, procFDInfo, bufferSize);
+        int numberOfProcFDs = bufferSize / PROC_PIDLISTFD_SIZE;
+
+        int i;
+        for(i = 0; i < numberOfProcFDs; i++) {
+            if(procFDInfo[i].proc_fdtype == PROX_FDTYPE_SOCKET) {
+                struct  proc_bsdinfo pbsd;
+                proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &pbsd, PROC_PIDTBSDINFO_SIZE);
+                struct socket_fdinfo socketInfo;
+                int bytesUsed = proc_pidfdinfo(pid, procFDInfo[i].proc_fd, PROC_PIDFDSOCKETINFO, &socketInfo, PROC_PIDFDSOCKETINFO_SIZE);
+
+                if (bytesUsed != PROC_PIDFDSOCKETINFO_SIZE) {
+                    continue;
+                }
+
+                if (socketInfo.psi.soi_kind != SOCKINFO_TCP && socketInfo.psi.soi_kind != SOCKINFO_IN) {
+                    continue;
+                }
+
+                char laddr[NI_MAXHOST];
+                char faddr[NI_MAXHOST];
+
+                switch(socketInfo.psi.soi_family) {
+                    case AF_INET6: {
+                        struct sockaddr_in6 lsin6 = {0};
+                        lsin6.sin6_family = AF_INET6;
+                        lsin6.sin6_addr  = (struct in6_addr)socketInfo.psi.soi_proto.pri_in.insi_laddr.ina_6;
+                        getnameinfo((struct sockaddr *)&lsin6, sizeof(lsin6), laddr, sizeof(laddr), NULL, 0, NI_NUMERICHOST);
+                        lsin6.sin6_addr  = (struct in6_addr)socketInfo.psi.soi_proto.pri_in.insi_faddr.ina_6;
+                        getnameinfo((struct sockaddr *)&lsin6, sizeof(lsin6), faddr, sizeof(faddr), NULL, 0, NI_NUMERICHOST);
+                        break;
+                    }
+                    case AF_INET: {
+                        struct sockaddr_in lsin = {0};
+                        lsin.sin_family = AF_INET;
+                        lsin.sin_addr = (struct in_addr)socketInfo.psi.soi_proto.pri_in.insi_laddr.ina_46.i46a_addr4;
+                        getnameinfo((struct sockaddr *)&lsin, sizeof(lsin), laddr, sizeof(laddr), NULL, 0, NI_NUMERICHOST);
+                        lsin.sin_addr = (struct in_addr)socketInfo.psi.soi_proto.pri_in.insi_faddr.ina_46.i46a_addr4;
+                        getnameinfo((struct sockaddr *)&lsin, sizeof(lsin), faddr, sizeof(faddr), NULL, 0, NI_NUMERICHOST);
+                        break;
+                    }
+                    default:
+                        continue;
+                }
+
+                char protocol[5];
+                snprintf(protocol, 5, "%s%c",
+                    socketInfo.psi.soi_kind == SOCKINFO_TCP ? "tcp" : "udp",
+                    socketInfo.psi.soi_family == AF_INET6 ? '6' : '\0');
+ 
+
+                int localPort = (int)ntohs(socketInfo.psi.soi_proto.pri_in.insi_lport);
+                int remotePort = (int)ntohs(socketInfo.psi.soi_proto.pri_in.insi_fport);
+
+                cJSON *object = cJSON_CreateObject();
+                cJSON_AddStringToObject(object, "type", "port");
+                cJSON_AddNumberToObject(object, "ID", random_id);
+                cJSON_AddStringToObject(object, "timestamp", timestamp);
+
+                cJSON *port = cJSON_CreateObject();
+                cJSON_AddItemToObject(object, "port", port);
+                cJSON_AddStringToObject(port, "protocol", protocol);
+                cJSON_AddStringToObject(port, "local_ip", laddr);
+                cJSON_AddNumberToObject(port, "local_port", localPort);
+                cJSON_AddStringToObject(port, "remote_ip", faddr);
+                cJSON_AddNumberToObject(port, "remote_port", remotePort);
+
+                int listening = 0;
+                if (!strncmp(protocol, "tcp", 3)) {
+                    char *port_state = get_port_state((int)socketInfo.psi.soi_proto.pri_tcp.tcpsi_state);
+                    cJSON_AddStringToObject(port, "state", port_state);
+                    if (!strcmp(port_state, "listening")) {
+                        listening = 1;
+                    }
+                    os_free(port_state);
+                }
+
+                cJSON_AddNumberToObject(port, "PID", pid);
+                cJSON_AddStringToObject(port, "process", pbsd.pbi_name);
+
+                if (check_all || listening) {
+                    char *string = cJSON_PrintUnformatted(object);
+                    mtdebug2(WM_SYS_LOGTAG, "sys_ports_mac() sending '%s'", string);
+                    wm_sendmsg(usec, queue_fd, string, WM_SYS_LOCATION, SYSCOLLECTOR_MQ);
+                    os_free(string);
+                }
+
+                cJSON_Delete(object);
+
+            }
+        }
+        os_free(procFDInfo);
+    }
+
+    os_free(pids);
+    cJSON *object = cJSON_CreateObject();
+    cJSON_AddStringToObject(object, "type", "port_end");
+    cJSON_AddNumberToObject(object, "ID", random_id);
+    cJSON_AddStringToObject(object, "timestamp", timestamp);
+    os_free(timestamp);
+
+    char *string = cJSON_PrintUnformatted(object);
+    cJSON_Delete(object);
+    mtdebug2(WM_SYS_LOGTAG, "sys_ports_mac() sending '%s'", string);
+    SendMSG(queue_fd, string, WM_SYS_LOCATION, SYSCOLLECTOR_MQ);
+    os_free(string);
+}
 
 void sys_proc_mac(int queue_fd, const char* LOCATION){
     char *timestamp;
@@ -1500,8 +1703,6 @@ void sys_proc_mac(int queue_fd, const char* LOCATION){
     cJSON_Delete(object);
     os_free(end_msg);
 }
-
-#endif
 
 #endif
 

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -135,6 +135,8 @@ void* wm_sys_main(wm_sys_t *sys) {
                 sys_ports_windows(WM_SYS_LOCATION, sys->flags.allports);
             #elif defined(__linux__)
                 sys_ports_linux(queue_fd, WM_SYS_LOCATION, sys->flags.allports);
+            #elif defined(__MACH__)
+                sys_ports_mac(queue_fd, WM_SYS_LOCATION, sys->flags.allports);
             #else
                 sys->flags.portsinfo = 0;
                 mtwarn(WM_SYS_LOGTAG, "Opened ports inventory is not available for this OS version.");


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3296|

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds the ports scan of syscollector to Mac OS X agents. It also changes the template for Darwin agents to include the ports scan in the default syscollector configuration.

The algorithm for the scan is:

 · Retrieve the list of the process IDs with the function: `proc_listallpids()`
 · Obtain the information of opened files for each process with the function: `proc_pidfdinfo()`
 · Check if the file opened is an internet socket. In case it is, extract the information.
 · Send the information to the Wazuh manager

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->
Now, the ossec.conf of the MAC agents has the process scan activated in the default configuration

```
 <!-- System inventory -->
  <wodle name="syscollector">
    <disabled>no</disabled>
    <interval>1h</interval>
    <scan_on_start>yes</scan_on_start>
    <hardware>yes</hardware>
    <os>yes</os>
    <network>yes</network>
    <packages>yes</packages>
    <ports all="no">yes</ports>
    <processes>no</processes>
  </wodle>
```
## Logs/Alerts example

<!--
Paste here related logs and alerts
-->
Information stored in the DB of the agent.
```
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |49194|192.168.0.74  |1514||||established||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |22|192.168.0.74  |59728||||established||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |22|192.168.0.74  |59728||||established||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |22|192.168.0.74  |59728||||established||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |22|192.168.0.74  |59728||||established||
698580644|2019/05/17 17:40:21|udp|0.0.0.0  |35072|0.0.0.0  |0||||||
698580644|2019/05/17 17:40:21|udp|0.0.0.0  |35328|0.0.0.0  |0||||||
698580644|2019/05/17 17:40:21|tcp|127.0.0.1  |49152|127.0.0.1  |5951||||established||
698580644|2019/05/17 17:40:21|tcp6|::|80|::|0||||listening||
698580644|2019/05/17 17:40:21|udp|0.0.0.0  |59668|0.0.0.0  |0||||||
698580644|2019/05/17 17:40:21|udp6|::|5353|::|0||||||
698580644|2019/05/17 17:40:21|udp6|::|88|::|0||||||
698580644|2019/05/17 17:40:21|tcp6|::|88|::|0||||listening||
698580644|2019/05/17 17:40:21|udp|0.0.0.0  |22528|0.0.0.0  |0||||||
698580644|2019/05/17 17:40:21|tcp|0.0.0.0  |88|0.0.0.0  |0||||listening||
698580644|2019/05/17 17:40:21|tcp6|::|80|::|0||||listening||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |49153|17.252.76.99  |5223||||established||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |49153|17.252.76.99  |5223||||established||
698580644|2019/05/17 17:40:21|tcp|127.0.0.1  |5951|0.0.0.0  |0||||listening||
698580644|2019/05/17 17:40:21|tcp|127.0.0.1  |5951|127.0.0.1  |49152||||established||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |49158|37.252.246.105  |5938||||established||
698580644|2019/05/17 17:40:21|udp|0.0.0.0  |28127|0.0.0.0  |0||||||
698580644|2019/05/17 17:40:21|tcp6|::|5900|::|0||||listening||
698580644|2019/05/17 17:40:21|tcp|0.0.0.0  |5900|0.0.0.0  |0||||listening||
698580644|2019/05/17 17:40:21|tcp6|::|22|::|0||||listening||
698580644|2019/05/17 17:40:21|tcp|0.0.0.0  |22|0.0.0.0  |0||||listening||
698580644|2019/05/17 17:40:21|tcp6|::|22|::|0||||listening||
698580644|2019/05/17 17:40:21|tcp|0.0.0.0  |22|0.0.0.0  |0||||listening||
698580644|2019/05/17 17:40:21|udp|0.0.0.0  |35328|0.0.0.0  |0||||||
698580644|2019/05/17 17:40:21|tcp6|::|5900|::|0||||listening||
698580644|2019/05/17 17:40:21|tcp|0.0.0.0  |5900|0.0.0.0  |0||||listening||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |22|192.168.0.74  |59728||||established||
698580644|2019/05/17 17:40:21|udp|0.0.0.0  |35072|0.0.0.0  |0||||||
698580644|2019/05/17 17:40:21|tcp|192.168.0.253  |22|192.168.0.74  |59728||||established||
```
This is how the information is displayed in Kibana

![image](https://user-images.githubusercontent.com/9034923/58017753-4b4c8300-7b01-11e9-955a-b0f7f356b3a7.png)

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities