### PR TITLE
Fix agent mismatch in database when selecting agents with a mask

### DIFF
--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -37,7 +37,7 @@ static const char *SQL_UPDATE_REG_OFFSET = "UPDATE agent SET reg_offset = ? WHER
 static const char *SQL_DELETE_AGENT = "DELETE FROM agent WHERE id = ?;";
 static const char *SQL_SELECT_AGENT = "SELECT name FROM agent WHERE id = ?;";
 static const char *SQL_SELECT_AGENTS = "SELECT id FROM agent WHERE id != 0;";
-static const char *SQL_FIND_AGENT = "SELECT id FROM agent WHERE name = ? AND register_ip = ?;";
+static const char *SQL_FIND_AGENT = "SELECT id FROM agent WHERE name = ? AND (register_ip = ? OR register_ip LIKE ?2 || '/_%');";
 static const char *SQL_FIND_GROUP = "SELECT id FROM `group` WHERE name = ?;";
 static const char *SQL_SELECT_GROUPS = "SELECT name FROM `group`;";
 static const char *SQL_DELETE_GROUP = "DELETE FROM `group` WHERE name = ?;";


### PR DESCRIPTION
|Related issue|
|---|
|#2443|

## Description

The _agent-info_ files follow this pattern:

```
queue/agent-info/$name-$ip
```

The database module splits the name of the file into two strings: the _name_ and the _IP_. Then, it finds the agent in the DB using both parameters. This does not work if the agent was registered with an IP including a netmask:

- The `registered_ip` field includes the netmask.
- The file path will never include that, because the slask `/` is not permitted in file paths.

That prevents the module from finding the agent.

## Solution

Make the BD query match either the exact IP parameter or that IP plus `/_%`. That means the regex `/.+`. This should not produce a name conflict since the name of the agent does not allow slashes (`/`).

## Output

This fix just prevents the database module from producing debug logs.

`agent_control` should produce an output like this with this patch applied:
```
$ agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: stretch64 (server), IP: 127.0.0.1, Active/Local
   ID: 001, Name: centos, IP: 192.168.33.0/24, Active
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X. It fails [#3338]
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [x] Package upgrade
- [X] Review logs syntax and correct language