### PR TITLE
Fix error when editing ossec.conf in docker

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -536,7 +536,7 @@ class Agent:
                         rename(agent_file, backup_file)
 
             # Overwrite client.keys
-            move(f_keys_temp, common.client_keys)
+            move(f_keys_temp, common.client_keys, copy_function=copyfile)
         except Exception as e:
             raise WazuhException(1748, str(e))
 
@@ -733,7 +733,7 @@ class Agent:
                     f_kt.write('{0} {1} {2} {3}\n'.format(agent_id, name, ip, agent_key))
 
                 # Overwrite client.keys
-                move(f_keys_temp, common.client_keys)
+                move(f_keys_temp, common.client_keys, copy_function=copyfile)
             except WazuhException as ex:
                 fcntl.lockf(lock_file, fcntl.LOCK_UN)
                 lock_file.close()
@@ -773,7 +773,7 @@ class Agent:
         group_path = "{0}/{1}".format(common.shared_path, group_id)
         group_backup = "{0}/groups/{1}_{2}".format(common.backup_path, group_id, int(time()))
         if path.exists(group_path):
-            move(group_path, group_backup)
+            move(group_path, group_backup, copy_function=copyfile)
 
         msg = "Group '{0}' removed.".format(group_id)
 

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -8,7 +8,7 @@ import random
 import time
 from os import remove, path as os_path
 import re
-from shutil import move
+from shutil import move, copyfile
 from xml.dom.minidom import parseString
 from wazuh.exception import WazuhException
 from wazuh import common
@@ -673,7 +673,7 @@ def upload_group_configuration(group_id, file_content):
         # move temporary file to group folder
         try:
             new_conf_path = "{}/{}/agent.conf".format(common.shared_path, group_id)
-            move(tmp_file_path, new_conf_path)
+            move(tmp_file_path, new_conf_path, copy_function=copyfile)
         except Exception as e:
             raise WazuhException(1017, str(e))
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from glob import glob
 from os import remove, chmod
 from os.path import exists, join
-from shutil import move, Error
+from shutil import move, Error, copyfile
 from xml.dom.minidom import parseString
 from xml.parsers.expat import ExpatError
 from typing import Dict
@@ -265,7 +265,7 @@ def upload_xml(xml_file, path):
         # move temporary file to group folder
         try:
             new_conf_path = join(common.ossec_path, path)
-            move(tmp_file_path, new_conf_path)
+            move(tmp_file_path, new_conf_path, copy_function=copyfile)
         except Error:
             raise WazuhException(1016)
         except Exception:
@@ -307,7 +307,7 @@ def upload_list(list_file, path):
     # move temporary file to group folder
     try:
         new_conf_path = join(common.ossec_path, path)
-        move(tmp_file_path, new_conf_path)
+        move(tmp_file_path, new_conf_path, copy_function=copyfile)
     except Error:
         raise WazuhException(1016)
     except Exception:

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -3,15 +3,17 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from freezegun import freeze_time
-from unittest.mock import patch, mock_open
 import sqlite3
+
 import os
 import pytest
-from wazuh.exception import WazuhException
+from freezegun import freeze_time
+from shutil import copyfile
+from unittest.mock import patch, mock_open
 
-from wazuh.agent import Agent
 from wazuh import common
+from wazuh.agent import Agent
+from wazuh.exception import WazuhException
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
@@ -239,7 +241,7 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
         assert len((rename_mock if backup else rmtree_mock).mock_calls) == 5
         # make sure the mock is called with a string according to a non-backup path
         exists_mock.assert_any_call('/var/ossec/queue/agent-info/agent-1-any')
-        move_mock.assert_called_once_with(common.client_keys + '.tmp', common.client_keys)
+        move_mock.assert_called_once_with(common.client_keys + '.tmp', common.client_keys, copy_function=copyfile)
         if backup:
             backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any')
             makedirs_mock.assert_called_once_with(backup_path)

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -5,11 +5,11 @@
 import json
 import os
 import pytest
+from shutil import copyfile
 from unittest.mock import patch, mock_open
 
 from wazuh.exception import WazuhException
 from wazuh.manager import upload_file, get_file, restart, validation, status, delete_file, ossec_log
-
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
@@ -83,7 +83,7 @@ def test_restart_ok(test_manager):
     """
     Tests restarting a manager
     """
-    assert restart() == 'Restarting manager'
+    assert restart() == 'Restart request sent'
 
 
 @pytest.mark.parametrize('input_file, output_file', [
@@ -113,7 +113,8 @@ def test_upload_file(remove_mock, move_mock, chmod_mock, mock_rand, mock_time, t
     m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 'w')
     m.assert_any_call(os.path.join(test_data_path, input_file))
     move_mock.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'),
-                                      os.path.join(test_data_path, output_file))
+                                      os.path.join(test_data_path, output_file),
+                                      copy_function=copyfile)
     remove_mock.assert_called_once_with(os.path.join(test_data_path, input_file))
 
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3335|

## Description

Accordingly to what has been explained in the comments inside the related issue, the quickest and safest fix is using a different copy function for the `shutil.move` function. This is the way to avoid changing permissions to a non owned file.

## Tests

### Unit tests
```
root@b9bf086153d4:/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.10.0-py3.7.egg# /var/ossec/framework/python/bin/pytest wazuh/
================================================ test session starts =================================================
platform linux -- Python 3.7.2, pytest-4.5.0, py-1.8.0, pluggy-0.11.0
rootdir: /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.10.0-py3.7.egg
collected 217 items                                                                                                  
wazuh/cluster/tests/test_cluster.py ..................                                                         [  8%]
wazuh/cluster/tests/test_worker.py ...........                                                                 [ 13%]
wazuh/tests/test_active_response.py ......                                                                     [ 16%]
wazuh/tests/test_agent.py ..........................................                                           [ 35%]
wazuh/tests/test_cdb_list.py ...........                                                                       [ 40%]
wazuh/tests/test_decoders.py ........................................                                          [ 58%]
wazuh/tests/test_group.py ........                                                                             [ 62%]
wazuh/tests/test_manager.py .............................                                                      [ 76%]
wazuh/tests/test_rules.py ........................................                                             [ 94%]
wazuh/tests/test_security_configuration_assessment.py .....                                                    [ 96%]
wazuh/tests/test_wdb.py .......                                                                                [100%]
============================================= 217 passed in 2.08 seconds =============================================
```
### Mocha tests

```javascript
# mocha test/test_manager.js --timeout=10000
  Manager
    GET/manager/status
      ✓ Request (409ms)
    GET/manager/info
      ✓ Request (237ms)
    GET/manager/configuration
      ✓ Request (232ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (267ms)
      ✓ Errors: Invalid Section (225ms)
      ✓ Filters: Section - field (233ms)
      ✓ Errors: Invalid field (232ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (213ms)
      ✓ Filters: date (243ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field (41ms)
    GET/manager/stats/hourly
      ✓ Request (198ms)
    GET/manager/stats/weekly
      ✓ Request (233ms)
    GET/manager/stats/analysisd
      ✓ Request (250ms)
    GET/manager/stats/remoted
      ✓ Request (223ms)
    GET/manager/logs
      ✓ Request (261ms)
      ✓ Pagination (260ms)
      ✓ Retrieve all elements with limit=0 (248ms)
      ✓ Sort (263ms)
      ✓ SortField (257ms)
      ✓ Search (283ms)
      ✓ Filters: type_log (257ms)
      ✓ Filters: category (257ms)
      ✓ Filters: type_log and category (256ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (259ms)
    POST/manager/files
      ✓ Upload ossec.conf (220ms)
      ✓ Upload ossec.conf (overwrite=false) (219ms)
      ✓ Upload rules (new rule) (212ms)
      ✓ Upload rules (overwrite=true) (210ms)
      ✓ Upload rules (overwrite=false) (240ms)
      ✓ Upload decoder (overwrite=true) (223ms)
      ✓ Upload decoder (without overwrite parameter) (229ms)
      ✓ Upload list (overwrite=true) (215ms)
      ✓ Upload list (without overwrite parameter) (224ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/manager/files
      ✓ Request ossec.conf (238ms)
      ✓ Request rules (local) (241ms)
      ✓ Request rules (global) (305ms)
      ✓ Request decoders (local) (302ms)
      ✓ Request decoders (global) (298ms)
      ✓ Request lists (375ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (1441ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (949ms)
    DELETE/manager/files
      ✓ Delete rules (398ms)
      ✓ Delete decoders (349ms)
      ✓ Delete CDB list (407ms)
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (1891ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (626ms)
    GET/manager/config/:component/:configuration
      ✓ Request-Agentless-Agentless (335ms)
      ✓ Request-Analysis-Global (352ms)
      ✓ Request-Analysis-Active-response (306ms)
      ✓ Request-Analysis-Alerts (295ms)
      ✓ Request-Analysis-Command (293ms)
      ✓ Request-Analysis-Internal (335ms)
      ✓ Request-Auth-Auth (276ms)
      ✓ Request-Com-Active-response (295ms)
      ✓ Request-Com-Internal (534ms)
      ✓ Request-Csyslog-Csyslog (339ms)
      ✓ Request-Integrator-Integration (298ms)
      ✓ Request-Logcollector-Localfile (322ms)
      ✓ Request-Logcollector-Socket (306ms)
      ✓ Request-Logcollector-Internal (277ms)
      ✓ Request-Mail-Global (268ms)
      ✓ Request-Mail-Alerts (294ms)
      ✓ Request-Mail-Internal (332ms)
      ✓ Request-Monitor-Internal (336ms)
      ✓ Request-Request-Remote (316ms)
      ✓ Request-Request-Internal (316ms)
      ✓ Request-Syscheck-Syscheck (381ms)
      ✓ Request-Syscheck-Rootcheck (269ms)
      ✓ Request-Syscheck-Internal (265ms)
      ✓ Request-Wmodules-Wmodules (336ms)
    PUT/manager/restart
      ✓ Request (310ms)
  88 passing (26s)
```
```javascript
# mocha test/test_cluster.js --timeout=10000
  Cluster
    GET/cluster/nodes
      ✓ Request (1217ms)
      ✓ Pagination (404ms)
      ✓ Retrieve all elements with limit=0 (406ms)
      ✓ Sort (336ms)
      ✓ Search (435ms)
      ✓ Filters: type (413ms)
      ✓ Filters: invalid type (400ms)
      ✓ Select (403ms)
      ✓ Select 2 (365ms)
      ✓ Wrong select (347ms)
    GET/cluster/:node_id/stats
      ✓ Cluster stats (493ms)
      ✓ Unexisting node stats (332ms)
      ✓ Analysisd stats (492ms)
      ✓ Remoted stats (402ms)
    GET/cluster/nodes/:node_name
      ✓ Request (321ms)
      ✓ Request wrong name (353ms)
    GET/cluster/status
      ✓ Request (380ms)
    GET/cluster/config
      ✓ Request (392ms)
    GET/cluster/healthcheck
      ✓ Request (369ms)
      ✓ Filter: node name (322ms)
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (456ms)
      ✓ Upload ossec.conf (worker) (442ms)
      ✓ Upload new rules (343ms)
      ✓ Upload rules (overwrite=true) (466ms)
      ✓ Upload rules (overwrite=false) (443ms)
      ✓ Upload new decoder (681ms)
      ✓ Upload decoder (overwrite=true) (387ms)
      ✓ Upload decoder (without overwrite parameter) (331ms)
      ✓ Upload new list (344ms)
      ✓ Upload list (overwrite=true) (351ms)
      ✓ Upload list (overwrite=false) (416ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (420ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (412ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (339ms)
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/cluster/:node_id/files
      ✓ Request ossec.conf (master) (290ms)
      ✓ Request ossec.conf (worker) (304ms)
      ✓ Request rules (local) (471ms)
      ✓ Request rules (global) (383ms)
      ✓ Request decoders (local) (301ms)
      ✓ Request decoders (global) (301ms)
      ✓ Request lists (332ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (284ms)
      ✓ Request file from unexisting node (296ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (363ms)
    GET/cluster/:node_id/configuration/validation (manager and worker OK)
      ✓ Request validation (master) (1560ms)
      ✓ Request validation (worker) (2344ms)
      ✓ Request validation (all nodes) (1495ms)
    GET/cluster/:node_id/configuration/validation (manager KO, worker OK)
      ✓ Request validation (master) (321ms)
      ✓ Request validation (worker) (1751ms)
      ✓ Request validation (all nodes) (1204ms)
    GET/cluster/:node_id/configuration/validation (manager OK, worker KO)
      ✓ Request validation (master) (1108ms)
      ✓ Request validation (worker) (321ms)
      ✓ Request validation (all nodes) (1478ms)
    GET/cluster/:node_id/configuration/validation (manager and worker KO)
      ✓ Request validation (master) (506ms)
      ✓ Request validation (worker)
      ✓ Request validation (all nodes) (405ms)
    DELETE/cluster/:node_id/files
      ✓ Delete rules (master) (364ms)
      ✓ Delete decoders (master) (262ms)
      ✓ Delete CDB list (master) (278ms)
      ✓ Delete file with empty path
    GET/cluster/master/config/:component/:configuration
      ✓ Request-Agentless-Agentless (262ms)
      ✓ Request-Analysis-Global (288ms)
      ✓ Request-Analysis-Active-response (260ms)
      ✓ Request-Analysis-Alerts (335ms)
      ✓ Request-Analysis-Command (441ms)
      ✓ Request-Analysis-Internal (313ms)
      ✓ Request-Auth-Auth (326ms)
      ✓ Request-Com-Active-response (379ms)
      ✓ Request-Com-Internal (357ms)
      ✓ Request-Csyslog-Csyslog (341ms)
      ✓ Request-Integrator-Integration (291ms)
      ✓ Request-Logcollector-Localfile (327ms)
      ✓ Request-Logcollector-Socket (307ms)
      ✓ Request-Logcollector-Internal (304ms)
      ✓ Request-Mail-Global (273ms)
      ✓ Request-Mail-Alerts (318ms)
      ✓ Request-Mail-Internal (298ms)
      ✓ Request-Monitor-Internal (353ms)
      ✓ Request-Request-Remote (307ms)
      ✓ Request-Request-Internal (338ms)
      ✓ Request-Syscheck-Syscheck (286ms)
      ✓ Request-Syscheck-Rootcheck (301ms)
      ✓ Request-Syscheck-Internal (296ms)
      ✓ Request-Wmodules-Wmodules (311ms)
    PUT/cluster/:node_id/restart
      ✓ Request (worker) (312ms)
      ✓ Request (master) (353ms)
  97 passing (44s)
```
```javascript
 Agents
    GET/agents
      ✓ Request (201ms)
      ✓ Pagination (215ms)
      ✓ Retrieve all elements with limit=0 (269ms)
      ✓ Sort (242ms)
      ✓ Wrong Sort (233ms)
      ✓ Search (232ms)
      ✓ Selector (233ms)
      ✓ Not allowed selector (210ms)
      ✓ Version (235ms)
      ✓ Os.platform (209ms)
      ✓ Os.version (209ms)
      ✓ ManagerHost (225ms)
      ✓ Filters: status (215ms)
      ✓ Filters: status 2 (212ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: older_than (211ms)
      ✓ Filters: group (219ms)
      ✓ Select: single field (222ms)
      ✓ Select: multiple fields (216ms)
      ✓ Select: wrong field (213ms)
      ✓ Select: invalid character
      ✓ Filters: query (234ms)
    GET/agents/summary
      ✓ Request (222ms)
    GET/agents/summary/os
      ✓ Request (220ms)
    GET/agents/outdated
      1) Request
    GET/agents/:agent_id
      ✓ Request (manager) (212ms)
      ✓ Request (agent) (202ms)
      ✓ Selector (213ms)
      ✓ Not allowed selector (220ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (209ms)
      ✓ Select (213ms)
      ✓ Select: wrong field (219ms)
    GET/agents/name/:agent_name
      ✓ Request (189ms)
      ✓ Wrong name (226ms)
      ✓ Selector (234ms)
      ✓ Not allowed selector (212ms)
    GET/agents/:agent_id/key
      ✓ Request (220ms)
      ✓ Params: Bad agent id
      ✓ Errors: No key (219ms)
    PUT/agents/groups/:group_id
      ✓ Request (228ms)
      ✓ Params: Bad group name
      ✓ Params: Group already exists (206ms)
    PUT/agents/:agent_id/group/:group_id
      ✓ Request (203ms)
      ✓ Params: Bad agent name
      ✓ Params: Agent does not exist (209ms)
      ✓ Params: Replace parameter (214ms)
    POST/agents/groups/:group_id/files/:file_name
      ✓ Request (238ms)
      ✓ ErrorOnBadGroup (208ms)
      ✓ ErrorOnEmptyConf
      ✓ OnlyAgentConfAllowed (224ms)
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (243ms)
      2) TooBigXML
    GET/agents/no_group
      ✓ Request (197ms)
      ✓ Pagination (208ms)
      ✓ Retrieve all elements with limit=0 (222ms)
      ✓ Sort (208ms)
      ✓ Search (215ms)
      ✓ Select (223ms)
      ✓ Wrong select (208ms)
      ✓ Filter: status (213ms)
    GET/agents/groups
      ✓ Request (211ms)
      ✓ Retrieve all elements with limit=0 (212ms)
      ✓ Hash algorithm (231ms)
      ✓ Wrong Hash algorithm (215ms)
    GET/agents/groups/:group_id
      ✓ Request (226ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (209ms)
      ✓ Select (211ms)
      ✓ Filter: status (232ms)
    GET/agents/groups/:group_id/configuration
      ✓ Request (257ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (404ms)
    GET/agents/groups/:group_id/files
      ✓ Request (336ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (233ms)
      ✓ Hash algorithm (247ms)
      ✓ Wrong Hash algorithm (227ms)
    GET/agents/groups/:group_id/files/:filename
      ✓ Request (274ms)
      ✓ UsingFormatAgentConfXML (252ms)
      ✓ UsingFormatAgentConfJSON (224ms)
      ✓ UsingFormatRootcheckXML (292ms)
      ✓ UsingFormatRootcheckJSON (829ms)
      ✓ Params: Bad group name
    POST/agents/groups/:group_id/configuration
      ✓ Request (293ms)
      ✓ ErrorOnBadGroup (250ms)
      ✓ ErrorOnEmptyConf
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (280ms)
      3) TooBigXML
    DELETE/agents/:agent_id/group
      ✓ Request (293ms)
      ✓ Errors: ID is not present (302ms)
      ✓ Params: Bad agent id
    DELETE/agents/:agent_id/group/:group_id
      ✓ Request (272ms)
      ✓ Errors: ID is not present (241ms)
      ✓ Errors: Group is not present (255ms)
      ✓ Params: Bad agent id
      ✓ Params: Bad group id (227ms)
    DELETE/agents/groups/:group_id
      ✓ Request (248ms)
      ✓ Params: Bad group id
    PUT/agents/restart
      ✓ Request (284ms)
    PUT/agents/:agent_id/restart
      ✓ Request (389ms)
      ✓ Params: Bad agent id
      ✓ Request (314ms)
    POST/agents/restart
      ✓ Request (229ms)
      ✓ Params: A good id and a bad one (210ms)
      ✓ Params: Bad agent id
      ✓ Request (241ms)
    DELETE/agents
      ✓ Request
      ✓ Filter: older_than, status and ids (3812ms)
      ✓ Errors: Get deleted agent (377ms)
      ✓ Filter: older_than (319ms)
    GET/agents/stats/distinct
      ✓ Request (251ms)
      ✓ Pagination (253ms)
      ✓ Retrieve all elements with limit=0 (240ms)
      ✓ Sort (258ms)
      ✓ Search (255ms)
      ✓ Select (222ms)
      ✓ Wrong select (231ms)
    GET/agents/:agent/config/:component/:configuration
      ✓ Request-Agent-Client (251ms)
      ✓ Request-Agent-Buffer (249ms)
      ✓ Request-Agent-Labels (439ms)
      ✓ Request-Agent-Internal (295ms)
      ✓ Request-Agentless-Agentless (255ms)
      ✓ Request-Analysis-Global (243ms)
      ✓ Request-Analysis-Active-response (314ms)
      ✓ Request-Analysis-Alerts (263ms)
      ✓ Request-Analysis-Command (264ms)
      ✓ Request-Analysis-Internal (236ms)
      ✓ Request-Auth-Auth (244ms)
      ✓ Request-Com-Active-response (261ms)
      ✓ Request-Com-Internal (268ms)
      ✓ Request-Csyslog-Csyslog (259ms)
      ✓ Request-Integrator-Integration (280ms)
      ✓ Request-Logcollector-Localfile (315ms)
      ✓ Request-Logcollector-Socket (294ms)
      ✓ Request-Logcollector-Internal (298ms)
      ✓ Request-Mail-Global (271ms)
      ✓ Request-Mail-Alerts (287ms)
      ✓ Request-Mail-Internal (260ms)
      ✓ Request-Monitor-Internal (304ms)
      ✓ Request-Request-Remote (255ms)
      ✓ Request-Request-Internal (260ms)
      ✓ Request-Syscheck-Syscheck (253ms)
      ✓ Request-Syscheck-Rootcheck (284ms)
      ✓ Request-Syscheck-Internal (263ms)
      ✓ Request-Wmodules-Wmodules (254ms)
  146 passing (39s)
  3 failing
```

### App test
![image (1)](https://user-images.githubusercontent.com/17462947/58018652-aa12fc00-7b03-11e9-8097-cf6aa9001999.png)


<!--
At least, the following checks should be marked to accept the PR.
-->

- [x] Working on cluster enviroments