### PR TITLE
Fix memory leak when updating a Vulnerability Detector feed

### DIFF
--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -943,6 +943,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval) {
         free(rvul_aux->cve_id);
         free(rvul_aux->package_name);
         free(rvul_aux->package_version);
+        free(rvul_aux->OS_minor);
         free(rvul_aux);
     }
 


### PR DESCRIPTION
This PR fixes a memory leak when updating a Vulnerability Detector feed with the new queuing system.

### How to replicate it

This is Valgrind's report that uncovered the memory leak:

> ==14286== LEAK SUMMARY:
> ==14286==    definitely lost: 1,175 bytes in 273 blocks
> ==14286==    indirectly lost: 0 bytes in 0 blocks
> ==14286==      possibly lost: 6,696 bytes in 10 blocks
> ==14286==    still reachable: 620,596 bytes in 3,581 blocks
> ==14286==                       of which reachable via heuristic:
> ==14286==                         length64           : 223,872 bytes in 122 blocks
> ==14286==         suppressed: 0 bytes in 0 blocks
> ==14286== Reachable blocks (those to which a pointer was found) are not shown.
> ==14286== To see them, rerun with: --leak-check=full --show-leak-kinds=all
> ==14286== 
> ==14286== For counts of detected and suppressed errors, rerun with: -v
> ==14286== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
> ==20976== Memcheck, a memory error detector
> ==20976== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
> ==20976== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
> ==20976== Command: /var/ossec/bin/wazuh-modulesd -f

To replicate it, run Vulnerability Detector updating any feed with valgrind as follows:

``` BASH
pkill -f modulesd; valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --num-callers=20 /var/ossec/bin/wazuh-modulesd -f 2> /tmp/valgrind.report
```

Replicated in Ubuntu 16 with Valgrind 3.11. The use of Valgrind in another system and with other parameters can hide the memory leak.

- Compilation without warnings in every supported platform
 - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
 - [x] Valgrind report for affected components
 - [x] CPU impact
 - [x] RAM usage impact