### PR TITLE
Change error message to debug in Whodata for Windows

### DIFF
--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1320,7 +1320,7 @@ int whodata_hash_add(OSHash *table, char *id, void *data, char *tag) {
         if (!result) {
             merror(FIM_ERROR_WHODATA_EVENTADD, tag, id);
         } else if (result == 1) {
-            merror(FIM_ERROR_WHODATA_EVENTADD_DUP, tag, id);
+            mdebug2(FIM_ERROR_WHODATA_EVENTADD_DUP, tag, id);
         }
     }
 


### PR DESCRIPTION
This PR restores the change added by https://github.com/wazuh/wazuh/pull/2995, which was lost due to a merge.

The reason is explained in https://github.com/wazuh/wazuh/issues/2904#issuecomment-478615279.