### PR TITLE
Delete timeout checking when reading files

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -145,7 +145,4 @@ int checkBinaryFile(const char *f_name);
 
 int64_t w_ftell (FILE *x);
 
-#ifndef WIN32
-size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, int timeout);
-#endif
 #endif /* __FILE_H */

--- a/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
+++ b/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
@@ -62,20 +62,7 @@ int OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5
     SHA256_Init(&sha256_ctx);
 
     /* Update for each one */
-#ifdef WIN32
     while ((n = fread(buf, 1, OS_BUFFER_SIZE, fp)) > 0) {
-#else
-    while ((n = w_fread_timeout(buf, 1, OS_BUFFER_SIZE, fp, 5)) > 0) {
-#endif
-        if (n == OS_BUFFER_SIZE + 1) {    // Timeout error
-            mwarn("Timeout when scanning file '%s'. File skipped.", fname);
-            if (prefilter_cmd == NULL) {
-                fclose(fp);
-            } else {
-                pclose(fp);
-            }
-            return (-1);
-        }
 
         if (max_size > 0) {
             read = read + n;

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -22,18 +22,6 @@
 #include <aclapi.h>
 #endif
 
-#ifndef WIN32
-#include <setjmp.h>
-
-static __thread sigjmp_buf env_alrm;
-static void sigalrm_handler(int signo)
-{
-    (void)signo;
-    /* restore env */
-    siglongjmp(env_alrm, 5);
-}
-#endif
-
 /* Vista product information */
 #ifdef WIN32
 
@@ -2941,42 +2929,6 @@ DWORD FileSizeWin(const char * file) {
     }
 
     return -1;
-}
-#endif
-
-#ifndef WIN32
-size_t w_fread_timeout(void *ptr, size_t size, size_t nitems, FILE *stream, int timeout){
-
-    size_t read_count = 0;
-
-    /* set long jump */
-    int val = sigsetjmp(env_alrm, 1);
-
-    if (!val) {
-        
-        /* setup signal handler */
-        if (signal(SIGALRM, &sigalrm_handler) == SIG_ERR)
-            return (0);
-
-        /* setup alarm */
-        alarm(timeout);
-
-        /* read */
-        read_count = fread(ptr, size, nitems, stream);
-
-    } else {
-        errno = EINTR;
-        /* To escalate the timeout error to the calling function, we set read_count to
-        the first value which fread cannot return ever */
-        read_count = (size * nitems) + 1;
-    }
-
-    /* unset signal handler and alarm */
-    signal(SIGALRM, NULL);
-    alarm(0);
-
-    return (read_count);
-
 }
 #endif
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR deletes the function `w_fread_timeout()` introduced at https://github.com/wazuh/wazuh/pull/3059 due to a bug in the signal handler when timing out the `fread()` function between the Syscheck daemon threads.

## Tests

- [x] Compilation without warnings (Linux/Windows)

- [x] Syscheck scan without issues