### PR TITLE
Fix deleting of temporary files in worker nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - A configuration request to Analysisd made it crash if the option `<white_list>` is empty. ([#3383](https://github.com/wazuh/wazuh/pull/3383))
 - Fixed error when uploading some configuration files through API in wazuh-docker environments. ([#3335](https://github.com/wazuh/wazuh/issues/3335))
+- Fixed error deleting temporary files during cluster synchronization. ([#3379](https://github.com/wazuh/wazuh/issues/3379))
 
 ## [v3.9.1] 2019-05-21
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3379|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
The problem has been fixed by wrapping the block of code inside a `try-finally`, so the temporary files or folders gets deleted always, even when an exception is raised or a return statement is executed before the deletion command.

This fix has been applied in every point where compressed or decompressed temporary files are being used.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

- Done similar steps in https://github.com/wazuh/wazuh/issues/3379#issuecomment-495109363, and checked directory manually and cluster.log. No more temporary folders remain after the fix.

- [x] Working on cluster enviroments
