### PR TITLE
Fix invalid access to OSMatch array in remote config request

### DIFF
--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -153,7 +153,7 @@ cJSON *getGlobalConfig(void) {
         }
         OSMatch **wl;
         wl = Config.hostname_white_list;
-        while (*wl) {
+        while (wl && *wl) {
             char **tmp_pts = (*wl)->patterns;
             while (*tmp_pts) {
                 cJSON_AddItemToArray(ip_list,cJSON_CreateString(*tmp_pts));


### PR DESCRIPTION
## Description

Executing the API query for getting the `<global>` configuration in `analysisd` causes a segmentation fault in `ossec-analysisd` when tries to read the addresses array with regex (`<white_list>^localhost.localdomain$</white_list>`) and it is empty.

https://github.com/wazuh/wazuh/blob/b3dc8c2fd5f0c9c554bc24537d23a84307d5f3da/src/analysisd/config.c#L156

In this PR I've added a check to ensure the array is not null before accessing.

## API output example [Fixed]

```
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/000/config/analysis/global?pretty"
{
   "error": 0,
   "data": {
      "global": {
         "email_notification": "no",
         "logall": "no",
         "logall_json": "no",
         "integrity_checking": 8,
         "rootkit_detection": 8,
         "host_information": 8,
         "prelude_output": "no",
         "zeromq_output": "no",
         "jsonout_output": "yes",
         "alerts_log": "yes",
         "stats": 4,
         "memory_size": 8192,
         "white_list": [
            "127.0.0.1",
            "127.0.0.53"
         ],
         "rotate_interval": 0,
         "max_output_size": 0
      }
   }
}
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [ ] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster enviroments
- [ ] Configuration on demand reports new parameters
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities