### PR TITLE
Fix invalid version check on remote upgrades

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1908,9 +1908,9 @@ class Agent:
         Generates a list of available versions for its distribution and version.
         """
         invalid_platforms = ["darwin", "solaris", "aix", "hpux", "bsd"]
-        not_valid_versions = [("sles", "11"), ("rhel", "5"), ("centos", "5")]
+        not_valid_versions = [("sles", 11), ("rhel", 5), ("centos", 5)]
 
-        if self.os['platform'] in invalid_platforms or (self.os['platform'], self.os['major']) in not_valid_versions:
+        if self.os['platform'] in invalid_platforms or (self.os['platform'], int(self.os['major'])) in not_valid_versions:
             error = "The WPK for this platform is not available."
             raise WazuhException(1713, error)
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1908,7 +1908,7 @@ class Agent:
         Generates a list of available versions for its distribution and version.
         """
         invalid_platforms = ["darwin", "solaris", "aix", "hpux", "bsd"]
-        not_valid_versions = [("sles", 11), ("rhel", 5), ("centos", 5)]
+        not_valid_versions = [("sles", "11"), ("rhel", "5"), ("centos", "5")]
 
         if self.os['platform'] in invalid_platforms or (self.os['platform'], self.os['major']) in not_valid_versions:
             error = "The WPK for this platform is not available."


### PR DESCRIPTION
|Related issue|
|---|
|#3387|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The WPK upgrades are not supported for agents on CentOS 5. When querying the list of available versions, it checks the invalid versions before doing nothing.

This check: https://github.com/wazuh/wazuh/blob/12484f02f419294962809fbacd58c161129eaf61/framework/wazuh/agent.py#L1913 was not working properly because the major doesn't match.

## Logs/Alerts example

```
# agent_control -i 001

Wazuh agent_control. Agent information:
   Agent ID:   001
   Agent Name: centos5
   IP address: 192.168.0.55
   Status:     Active

   Operating system:    Linux |localhost.localdomain |2.6.18-419.el5.centos.plus |#1 SMP Sat Feb 25 15:50:12 UTC 2017 |x86_64 [CentOS Linux|centos: 5.11]
   Client version:      Wazuh v3.9.1 / ab73af41699f13fdd81903b5f23d8d00
   Shared file hash:    c6309ff81a74781f6b55b68129a76738
   Last keep alive:     Fri May 24 06:58:00 2019

   Syscheck last started at:  Fri May 24 03:08:35 2019
   Syscheck last ended at:    Fri May 24 03:09:07 2019

   Rootcheck last started at: Fri May 24 03:08:34 2019
```

### Before the change

```
# agent_upgrade -a 001 -d
Manager version: v3.9.1
Error 1749: Downgrading an agent requires the force flag. Use -F to force the downgrade: Agent: v3.9.1 -> v3.9.1
Traceback (most recent call last):
  File "/var/ossec/framework/scripts/agent_upgrade.py", line 170, in <module>
    main()
  File "/var/ossec/framework/scripts/agent_upgrade.py", line 124, in main
    rl_timeout=-1 if args.timeout == None else args.timeout, use_http=use_http)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.1-py3.7.egg/wazuh/agent.py", line 2189, in upgrade
    show_progress=show_progress, chunk_size=chunk_size, rl_timeout=rl_timeout, use_http=use_http)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.1-py3.7.egg/wazuh/agent.py", line 2055, in _send_wpk_file
    _get_wpk = self._get_wpk_file(wpk_repo=wpk_repo, debug=debug, version=version, force=force, use_http=use_http)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.1-py3.7.egg/wazuh/agent.py", line 1978, in _get_wpk_file
    raise WazuhException(1749, "Agent: {0} -> {1}".format(agent_ver.split(" ")[1], agent_new_ver))
wazuh.exception.WazuhException: Error 1749 - Downgrading an agent requires the force flag. Use -F to force the downgrade: Agent: v3.9.1 -> v3.9.1
```

### After the change

```
# agent_upgrade -a 001 -d
Manager version: v3.9.1
Error 1713: Error accessing repository: The WPK for this platform is not available.
Traceback (most recent call last):
  File "/var/ossec/framework/scripts/agent_upgrade.py", line 170, in <module>
    main()
  File "/var/ossec/framework/scripts/agent_upgrade.py", line 124, in main
    rl_timeout=-1 if args.timeout == None else args.timeout, use_http=use_http)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.1-py3.7.egg/wazuh/agent.py", line 2189, in upgrade
    show_progress=show_progress, chunk_size=chunk_size, rl_timeout=rl_timeout, use_http=use_http)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.1-py3.7.egg/wazuh/agent.py", line 2055, in _send_wpk_file
    _get_wpk = self._get_wpk_file(wpk_repo=wpk_repo, debug=debug, version=version, force=force, use_http=use_http)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.1-py3.7.egg/wazuh/agent.py", line 1955, in _get_wpk_file
    versions = self._get_versions(wpk_repo=wpk_repo, version=version, use_http=use_http)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.1-py3.7.egg/wazuh/agent.py", line 1915, in _get_versions
    raise WazuhException(1713, error)
wazuh.exception.WazuhException: Error 1713 - Error accessing repository: The WPK for this platform is not available.
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- [x] Upgrade a CentOS 5 agent by WPK