### PR TITLE
Fix return value when using convert_windows_string

### DIFF
--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -129,15 +129,6 @@ wchar_t *convert_unix_string(char *string)
     return (dest);
 }
 
-char *get_property_value(PEVT_VARIANT value)
-{
-    if (value->Type == EvtVarTypeNull) {
-        return (NULL);
-    }
-
-    return (convert_windows_string(value->StringVal));
-}
-
 int get_username_and_domain(os_event *event)
 {
     int result = 0;
@@ -496,65 +487,67 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
     }
     xml_event = convert_windows_string((LPCWSTR) properties_values);
     
-    if (xml_event) {
-        find_prov = strstr(xml_event, "Provider Name=");
+    if (!xml_event) {
+        goto cleanup;
+    }
 
-        if(find_prov){
-            beg_prov = strchr(find_prov, '\'');
-            if(beg_prov){
-                end_prov = strchr(beg_prov+1, '\'');
+    find_prov = strstr(xml_event, "Provider Name=");
 
-                if (end_prov){
-                    num = end_prov - beg_prov - 1;
+    if(find_prov){
+        beg_prov = strchr(find_prov, '\'');
+        if(beg_prov){
+            end_prov = strchr(beg_prov+1, '\'');
 
-                    if(num > OS_MAXSTR - 1){
-                        mwarn("The event message has exceeded the maximum size.");
-                        goto cleanup;
-                    }
+            if (end_prov){
+                num = end_prov - beg_prov - 1;
 
-                    memcpy(provider_name, beg_prov+1, num);
-                    provider_name[num] = '\0';
-                    find_prov = '\0';
-                    beg_prov = '\0';
-                    end_prov = '\0';
+                if(num > OS_MAXSTR - 1){
+                    mwarn("The event message has exceeded the maximum size.");
+                    goto cleanup;
                 }
+
+                memcpy(provider_name, beg_prov+1, num);
+                provider_name[num] = '\0';
+                find_prov = '\0';
+                beg_prov = '\0';
+                end_prov = '\0';
             }
         }
+    }
 
-        if (provider_name) {
-            wprovider_name = convert_unix_string(provider_name);
+    if (provider_name) {
+        wprovider_name = convert_unix_string(provider_name);
 
-            if (wprovider_name == NULL || (msg_from_prov = get_message(evt, wprovider_name, EvtFormatMessageEvent)) == NULL) {
-                mferror(
-                    "Could not get message for (%s), provider (%s)",
-                    channel->evt_log, provider_name);
-            }
-            else {
-                avoid_dup = strchr(msg_from_prov, '\r');
-
-                if (avoid_dup){
-                    num = avoid_dup - msg_from_prov;
-                    memcpy(filtered_msg, msg_from_prov, num);
-                    filtered_msg[num] = '\0';
-                    cJSON_AddStringToObject(event_json, "Message", filtered_msg);
-                } else {
-                    win_format_event_string(msg_from_prov);
-                    cJSON_AddStringToObject(event_json, "Message", msg_from_prov);
-                }
-                avoid_dup = '\0';
-            }
-        } else {
-            cJSON_AddStringToObject(event_json, "Message", "No message");
+        if (wprovider_name == NULL || (msg_from_prov = get_message(evt, wprovider_name, EvtFormatMessageEvent)) == NULL) {
+            mferror(
+                "Could not get message for (%s), provider (%s)",
+                channel->evt_log, provider_name);
         }
+        else {
+            avoid_dup = strchr(msg_from_prov, '\r');
 
-        win_format_event_string(xml_event);
-
-        cJSON_AddStringToObject(event_json, "Event", xml_event);
-        msg_sent = cJSON_PrintUnformatted(event_json);
-
-        if (SendMSG(logr_queue, msg_sent, "EventChannel", WIN_EVT_MQ) < 0) {
-            merror(QUEUE_SEND);
+            if (avoid_dup){
+                num = avoid_dup - msg_from_prov;
+                memcpy(filtered_msg, msg_from_prov, num);
+                filtered_msg[num] = '\0';
+                cJSON_AddStringToObject(event_json, "Message", filtered_msg);
+            } else {
+                win_format_event_string(msg_from_prov);
+                cJSON_AddStringToObject(event_json, "Message", msg_from_prov);
+            }
+            avoid_dup = '\0';
         }
+    } else {
+        cJSON_AddStringToObject(event_json, "Message", "No message");
+    }
+
+    win_format_event_string(xml_event);
+
+    cJSON_AddStringToObject(event_json, "Event", xml_event);
+    msg_sent = cJSON_PrintUnformatted(event_json);
+
+    if (SendMSG(logr_queue, msg_sent, "EventChannel", WIN_EVT_MQ) < 0) {
+        merror(QUEUE_SEND);
     }
 
 cleanup:

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -846,9 +846,9 @@ add_whodata_evt:
     }
     retval = 0;
 clean:
-    free(user_name);
+    os_free(user_name);
     free(path);
-    free(process_name);
+    os_free(process_name);
     if (user_id) {
         LocalFree(user_id);
     }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3341|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
To fix this bug it was necessary to check if the returned value was NULL.
I have added few more changes to the code:
- Removed some functions that were not being called in the project.
- Added the specific check to avoid the bug.
- Added some additional information to error messages.
    · The `get_message` function returns the error code converted to string and the provider name from which the message could not be accessed.
- Changed the `if` statement that checks the `get_message` function. Now it checks either if the provider name is NULL or the `get_message` has succeeded. This has been made to make the statement more clear as the fact that the provider name is not null comes inherent in the `get_message` call, where this field is used to retrieve the event's message.

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- Memory tests
  - [x] Valgrind report for affected components