### PR TITLE
List label on rules stopped working after rule overwrite

### DIFF
--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -304,6 +304,17 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid)
             r_node->ruleinfo->ar = newrule->ar;
             r_node->ruleinfo->compiled_rule = newrule->compiled_rule;
 
+            r_node->ruleinfo->location = newrule->location;
+            r_node->ruleinfo->lists = newrule->lists;
+            r_node->ruleinfo->prev_rule = newrule->prev_rule;
+            r_node->ruleinfo->same_fields = newrule->same_fields;
+            r_node->ruleinfo->not_same_fields = newrule->not_same_fields;
+
+#ifdef LIBGEOIP_ENABLED
+            r_node->ruleinfo->srcgeoip = newrule->srcgeoip;
+            r_node->ruleinfo->dstgeoip = newrule->dstgeoip;
+#endif
+
             return (1);
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3381|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

https://github.com/wazuh/wazuh/blob/35fac3dc7fd52d1d7975e94617038202e941916e/src/analysisd/rules_list.c#L256

This function is responsible for rewriting the data of a rule that was triggered if there is another rule that overwrites it.

The label corresponding to the cdb lists was not being copied by this function. It has been added along with other attributes that may be useful after overwrite of a rule occurs.

```C
            r_node->ruleinfo->location = newrule->location;
            r_node->ruleinfo->lists = newrule->lists;
            r_node->ruleinfo->prev_rule = newrule->prev_rule;
            r_node->ruleinfo->same_fields = newrule->same_fields;
            r_node->ruleinfo->not_same_fields = newrule->not_same_fields;

#ifdef LIBGEOIP_ENABLED
            r_node->ruleinfo->srcgeoip = newrule->srcgeoip;
            r_node->ruleinfo->dstgeoip = newrule->dstgeoip;
#endif
```

<!--
Add a clear description of how the problem has been solved.
-->


## Logs/Alerts example

- Rule added on `/var/ossec/etc/rules/local_rules.xml`

```
  <rule id="5501" level="12" overwrite="yes">
    <if_sid>5500</if_sid>
    <match>session opened for user </match>
  <list field="program_name" lookup="match_key">etc/lists/my/oom_white_list</list>
    <description>System running out of memory. </description>

    <description>Availability of the MY system is in risk.</description>
    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
  </rule>
```
<br></br>
- Output when using as input of logcollector this sshd log line `May 23 13:10:58 centos sshd[7621]: pam_unix(sshd:session): session opened for user root by (uid=0)`
```
**Phase 1: Completed pre-decoding.
       full event: 'May 23 13:10:58 centos sshd[7621]: pam_unix(sshd:session): session opened for user root by (uid=0)'
       timestamp: 'May 23 13:10:58'
       hostname: 'centos'
       program_name: 'sshd'
       log: 'pam_unix(sshd:session): session opened for user root by (uid=0)'

**Phase 2: Completed decoding.
       decoder: 'pam'
       dstuser: 'root'
       uid: '0
```

- No rule matches with this log input and this is caused by the correct functioning of the label </list>.



<br></br>
## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
- [x] Linux
- [x] Source installation


The additional attributes that are now also copied do not represent a change in the way memory is allocated so they do not require a thorough memory test.

- [ ] QA templates contemplate the added capabilities