### PR TITLE
Fix more complete message on minimal Wazuh stopped daemons

### DIFF
--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -108,9 +108,12 @@ class DistributedAPI:
             return
         basic_services = ('wazuh-modulesd', 'ossec-remoted', 'ossec-analysisd', 'ossec-execd', 'wazuh-db')
         status = operator.itemgetter(*basic_services)(manager.status())
+        status_dict = {}
+        for i in range(0,len(basic_services)):
+            status_dict[basic_services[i]] = status[i]
         for status_name, exc_code in [('failed', 1019), ('restarting', 1017), ('stopped', 1018)]:
             if status_name in status:
-                raise exception.WazuhException(exc_code, status)
+                raise exception.WazuhException(exc_code, str(status_dict))
 
     def print_json(self, data: Union[Dict, str], error: int = 0) -> str:
         def encode_json(o):

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -17,9 +17,6 @@ import os
 import time
 import copy
 
-import pydevd_pycharm
-pydevd_pycharm.settrace('172.17.0.1', port=12345, stdoutToServer=True, stderrToServer=True)
-
 class DistributedAPI:
     """
     Represents a distributed API request
@@ -116,7 +113,7 @@ class DistributedAPI:
 
         for status_name, exc_code in [('failed', 1019), ('restarting', 1017), ('stopped', 1018)]:
             if status_name in basic_status:
-                raise exception.WazuhException(exc_code, str(required_status))
+                raise exception.WazuhException(exc_code, extra_message=str(required_status))
 
     def print_json(self, data: Union[Dict, str], error: int = 0) -> str:
         def encode_json(o):

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -113,7 +113,7 @@ class DistributedAPI:
 
         for status_name, exc_code in [('failed', 1019), ('restarting', 1017), ('stopped', 1018)]:
             if status_name in basic_status:
-                raise exception.WazuhException(exc_code, extra_message=str(required_status))
+                raise exception.WazuhException(exc_code, extra_message=required_status)
 
     def print_json(self, data: Union[Dict, str], error: int = 0) -> str:
         def encode_json(o):

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -29,9 +29,15 @@ class WazuhException(Exception):
         1014: 'Error communicating with socket',
         1015: 'Error agent version is null. Was the agent ever connected?',
         1016: 'Error moving file',
-        1017: 'Wazuh is restarting',
-        1018: 'Wazuh is stopped. Start Wazuh before using the API.',
-        1019: 'There is a failed process. Review that before using the API.',
+        1017: 'Wazuh is restarting. Current status is wazuh-modulesd->{wazuh-modulesd}, '
+              'ossec-remoted->{ossec-remoted}, ossec-analysisd->{ossec-analysisd}, ossec-execd->{ossec-execd}, '
+              'wazuh-db->{wazuh-db}',
+        1018: 'Wazuh is stopped. Start Wazuh before using the API. Current status is wazuh-modulesd->{wazuh-modulesd}, '
+              'ossec-remoted->{ossec-remoted}, ossec-analysisd->{ossec-analysisd}, ossec-execd->{ossec-execd},'
+              'wazuh-db->{wazuh-db}',
+        1019: 'There is a failed process. Review that before using the API. Current status is '
+              'wazuh-modulesd->{wazuh-modulesd}, ossec-remoted->{ossec-remoted}, ossec-analysisd->{ossec-analysisd}, '
+              'ossec-execd->{ossec-execd}, wazuh-db->{wazuh-db}',
 
         # Configuration: 1100 - 1199
         1100: 'Error checking configuration',


### PR DESCRIPTION
Hi team, this PR closes https://github.com/wazuh/wazuh/issues/3346

## Description

When one of the minimal Wazuh daemons is down, a message was shown that only indicated if it was running or stopped but without indicating which minimal Wazuh daemon it refers to.

To solve this, a dictionary has been generated that will store the key-value pair of each daemon and will be the one returned in case of error.

## Tests
```json
{"message": "Wazuh is stopped. Start Wazuh before using the API.: {'wazuh-modulesd': 'stopped', 'ossec-remoted': 'running', 'ossec-analysisd': 'running', 'ossec-execd': 'running', 'wazuh-db': 'running'}",
 "error": 1018
}
```

Best regards, 

Jesús.