### PR TITLE
 Disable hostname resolution in agent start up

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -27,6 +27,17 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     /* Initial random numbers must happen before chroot */
     srandom_init();
 
+    // Resolve hostnames
+    rc = 0;
+    while (rc < agt->rip_id) {
+        if (OS_IsValidIP(agt->server[rc].rip, NULL) != 1) {
+            mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
+            resolveHostname(&agt->server[rc].rip, 5);
+            mdebug2("Server hostname resolved: %s", agt->server[rc].rip);
+        }
+        rc++;
+    }
+
     /* Going Daemon */
     if (!run_foreground) {
         nowDaemon();

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -33,7 +33,8 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
         if (OS_IsValidIP(agt->server[rc].rip, NULL) != 1) {
             mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
             resolveHostname(&agt->server[rc].rip, 5);
-            mdebug2("Server hostname resolved: %s", agt->server[rc].rip);
+            int rip_l = strlen(agt->server[rc].rip);
+            mdebug2("Server hostname resolved: %.*s", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
         }
         rc++;
     }
@@ -141,7 +142,8 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     /* Connect remote */
     rc = 0;
     while (rc < agt->rip_id) {
-        minfo("Server IP Address: %s", agt->server[rc].rip);
+        int rip_l = strlen(agt->server[rc].rip);
+        minfo("Server IP Address: %.*s", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
         rc++;
     }
 

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -41,6 +41,9 @@ typedef struct agent_state_t {
     unsigned int msg_sent;
 } agent_state_t;
 
+/* Resolve hostname */
+void resolveHostname(char **hostname, int attemps);
+
 /* Client configuration */
 int ClientConf(const char *cfgfile);
 

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -42,7 +42,7 @@ typedef struct agent_state_t {
 } agent_state_t;
 
 /* Resolve hostname */
-void resolveHostname(char **hostname, int attemps);
+void resolveHostname(char **hostname, int attempts);
 
 /* Client configuration */
 int ClientConf(const char *cfgfile);

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -195,7 +195,7 @@ cJSON *getAgentInternalOptions(void) {
 }
 
 
-void resolveHostname(char **hostname, int attemps) {
+void resolveHostname(char **hostname, int attempts) {
 
     char *tmp_str;
     char *f_ip;
@@ -209,7 +209,7 @@ void resolveHostname(char **hostname, int attemps) {
         *tmp_str = '\0';
     }
 
-    f_ip = OS_GetHost(*hostname, attemps);
+    f_ip = OS_GetHost(*hostname, attempts);
     if (f_ip) {
         char ip_str[128] = {0};
         snprintf(ip_str, 127, "%s/%s", *hostname, f_ip);

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -193,3 +193,33 @@ cJSON *getAgentInternalOptions(void) {
 
     return root;
 }
+
+
+void resolveHostname(char **hostname, int attemps) {
+
+    char *tmp_str;
+    char *f_ip;
+
+    if (OS_IsValidIP(*hostname, NULL) == 1) {
+        return;
+    }
+
+    tmp_str = strchr(*hostname, '/');
+    if (tmp_str) {
+        *tmp_str = '\0';
+    }
+
+    f_ip = OS_GetHost(*hostname, attemps);
+    if (f_ip) {
+        char ip_str[128] = {0};
+        snprintf(ip_str, 127, "%s/%s", *hostname, f_ip);
+        free(f_ip);
+        free(*hostname);
+        os_strdup(ip_str, *hostname);
+    } else {
+        char ip_str[128] = {0};
+        snprintf(ip_str, 127, "%s/", *hostname);
+        free(*hostname);
+        os_strdup(ip_str, *hostname);
+    }
+}

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -82,6 +82,7 @@ int connect_server(int initial_id)
 
         // The hostname was not resolved correctly
         if (strlen(tmp_str) == 0) {
+            rc++;
             continue;
         }
 

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -61,7 +61,7 @@ int connect_server(int initial_id)
         // The hostname was not resolved correctly
         if (strlen(tmp_str) == 0) {
             int rip_l = strlen(agt->server[rc].rip);
-            mdebug2("Discarding connection to '%.*s'. Could not resolve hostname.", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
+            mdebug2("Could not resolve hostname '%.*s'", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
             rc++;
             if (agt->server[rc].rip == NULL) {
                 attempts += 10;

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -71,13 +71,18 @@ int connect_server(int initial_id)
 
                 tmp_str++;
             } else {
-                mwarn("Unable to reload hostname for '%s'. Using previous address.",
+                mdebug1("Unable to resolve hostname for '%s'.",
                        agt->server[rc].rip);
                 *tmp_str = '/';
                 tmp_str++;
             }
         } else {
             tmp_str = agt->server[rc].rip;
+        }
+
+        // The hostname was not resolved correctly
+        if (strlen(tmp_str) == 0) {
+            continue;
         }
 
         minfo("Trying to connect to server (%s:%d/%s).",

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -60,7 +60,8 @@ int connect_server(int initial_id)
 
         // The hostname was not resolved correctly
         if (strlen(tmp_str) == 0) {
-            mdebug2("Discarding connection to '%s'. Could not resolve hostname.", agt->server[rc].rip);
+            int rip_l = strlen(agt->server[rc].rip);
+            mdebug2("Discarding connection to '%.*s'. Could not resolve hostname.", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
             rc++;
             if (agt->server[rc].rip == NULL) {
                 attempts += 10;

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -49,40 +49,27 @@ int connect_server(int initial_id)
         /* Check if we have a hostname */
         tmp_str = strchr(agt->server[rc].rip, '/');
         if (tmp_str) {
-            char *f_ip;
-            *tmp_str = '\0';
-
-            f_ip = OS_GetHost(agt->server[rc].rip, 5);
-            if (f_ip) {
-                char ip_str[128];
-                ip_str[127] = '\0';
-
-                snprintf(ip_str, 127, "%s/%s", agt->server[rc].rip, f_ip);
-
-                free(f_ip);
-                free(agt->server[rc].rip);
-
-                os_strdup(ip_str, agt->server[rc].rip);
-                tmp_str = strchr(agt->server[rc].rip, '/');
-                if (!tmp_str) {
-                    mwarn("Invalid hostname format: '%s'.", agt->server[rc].rip);
-                    return 0;
-                }
-
-                tmp_str++;
-            } else {
-                mdebug1("Unable to resolve hostname for '%s'.",
-                       agt->server[rc].rip);
-                *tmp_str = '/';
-                tmp_str++;
+            // Resolve hostname
+            if (!isChroot()) {
+                resolveHostname(&agt->server[rc].rip, 5);
             }
+            tmp_str++;
         } else {
             tmp_str = agt->server[rc].rip;
         }
 
         // The hostname was not resolved correctly
         if (strlen(tmp_str) == 0) {
+            mdebug2("Discarding connection to '%s'. Could not resolve hostname.", agt->server[rc].rip);
             rc++;
+            if (agt->server[rc].rip == NULL) {
+                attempts += 10;
+                if (agt->server[1].rip) {
+                    merror("Unable to connect to any server.");
+                }
+                sleep(attempts < agt->notify_time ? attempts : agt->notify_time);
+                rc = 0;
+            }
             continue;
         }
 

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -19,7 +19,9 @@ int Read_Client_Server(XML_NODE node, agent *logr);
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
     int i = 0;
+    char f_ip[128];
     char * rip = NULL;
+    char * s_ip;
     int port = DEFAULT_SECURE;
     int protocol = UDP_PROTO;
 
@@ -74,12 +76,23 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             rip = node[i]->content;
         } else if (strcmp(node[i]->element, xml_client_hostname) == 0) {
             mwarn("The <%s> tag is deprecated, please use <server><address> instead.", xml_client_hostname);
-            if (strchr(node[i]->content, '/') ==  NULL) {
-                snprintf(rip, 127, "%s/", node[i]->content);
+            // Check for hostname resolution
+            if (s_ip = OS_GetHost(node[i]->content, 5), !s_ip) {
+                // Hostname could not be resolved
+                if (strchr(node[i]->content, '/') ==  NULL) {
+                    snprintf(f_ip, 127, "%s/", node[i]->content);
+                    rip = f_ip;
+                    free(s_ip);
+                } else {
+                    merror(AG_INV_HOST, node[i]->content);
+                    return (OS_INVALID);
+                }
             } else {
-                merror(AG_INV_HOST, node[i]->content);
-                return (OS_INVALID);
+                snprintf(f_ip, 127, "%s/%s", node[i]->content, s_ip);
+                rip = f_ip;
+                free(s_ip);
             }
+
         } else if (strcmp(node[i]->element, xml_client_port) == 0) {
             mwarn("The <%s> tag is deprecated, please use <server><port> instead.", xml_client_port);
 
@@ -224,15 +237,27 @@ int Read_Client_Server(XML_NODE node, agent * logr)
         }
         /* Get server address (IP or hostname) */
         else if (strcmp(node[j]->element, xml_client_addr) == 0) {
+            char * s_ip;
+
             if (OS_IsValidIP(node[j]->content, NULL) == 1) { // IP
                 rip = node[j]->content;
-            } else if (strchr(node[j]->content, '/') ==  NULL) { // Hostname
-                snprintf(f_ip, sizeof(f_ip), "%s/", node[j]->content);
-                rip = f_ip;
+
+            } else if (s_ip = OS_GetHost(node[j]->content, 5), !s_ip) {
+                // Hostname could not be resolved
+                if (strchr(node[j]->content, '/') ==  NULL) {
+                    snprintf(f_ip, 127, "%s/", node[j]->content);
+                    rip = f_ip;
+                    free(s_ip);
+                } else {
+                    merror(AG_INV_HOST, node[j]->content);
+                    return (OS_INVALID);
+                }
             } else {
-                merror(AG_INV_HOST, node[j]->content);
-                return (OS_INVALID);
+                snprintf(f_ip, 127, "%s/%s", node[j]->content, s_ip);
+                rip = f_ip;
+                free(s_ip);
             }
+
         } else if (strcmp(node[j]->element, xml_client_port) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -19,9 +19,7 @@ int Read_Client_Server(XML_NODE node, agent *logr);
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
     int i = 0;
-    char f_ip[128];
     char * rip = NULL;
-    char * s_ip;
     int port = DEFAULT_SECURE;
     int protocol = UDP_PROTO;
 
@@ -76,15 +74,12 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             rip = node[i]->content;
         } else if (strcmp(node[i]->element, xml_client_hostname) == 0) {
             mwarn("The <%s> tag is deprecated, please use <server><address> instead.", xml_client_hostname);
-
-            if (s_ip = OS_GetHost(node[i]->content, 5), !s_ip) {
+            if (strchr(node[i]->content, '/') ==  NULL) {
+                snprintf(rip, 127, "%s/", node[i]->content);
+            } else {
                 merror(AG_INV_HOST, node[i]->content);
                 return (OS_INVALID);
             }
-
-            snprintf(f_ip, 127, "%s/%s", node[i]->content, s_ip);
-            rip = f_ip;
-            free(s_ip);
         } else if (strcmp(node[i]->element, xml_client_port) == 0) {
             mwarn("The <%s> tag is deprecated, please use <server><port> instead.", xml_client_port);
 
@@ -229,14 +224,11 @@ int Read_Client_Server(XML_NODE node, agent * logr)
         }
         /* Get server address (IP or hostname) */
         else if (strcmp(node[j]->element, xml_client_addr) == 0) {
-            char * s_ip;
-
-            if (OS_IsValidIP(node[j]->content, NULL) == 1) {
+            if (OS_IsValidIP(node[j]->content, NULL) == 1) { // IP
                 rip = node[j]->content;
-            } else if (s_ip = OS_GetHost(node[j]->content, 5), s_ip) {
-                snprintf(f_ip, sizeof(f_ip), "%s/%s", node[j]->content, s_ip);
+            } else if (strchr(node[j]->content, '/') ==  NULL) { // Hostname
+                snprintf(f_ip, sizeof(f_ip), "%s/", node[j]->content);
                 rip = f_ip;
-                free(s_ip);
             } else {
                 merror(AG_INV_HOST, node[j]->content);
                 return (OS_INVALID);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -19,9 +19,8 @@ int Read_Client_Server(XML_NODE node, agent *logr);
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
     int i = 0;
-    char f_ip[128];
+    char f_ip[128] = {'\0'};
     char * rip = NULL;
-    char * s_ip;
     int port = DEFAULT_SECURE;
     int protocol = UDP_PROTO;
 
@@ -76,21 +75,12 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             rip = node[i]->content;
         } else if (strcmp(node[i]->element, xml_client_hostname) == 0) {
             mwarn("The <%s> tag is deprecated, please use <server><address> instead.", xml_client_hostname);
-            // Check for hostname resolution
-            if (s_ip = OS_GetHost(node[i]->content, 5), !s_ip) {
-                // Hostname could not be resolved
-                if (strchr(node[i]->content, '/') ==  NULL) {
-                    snprintf(f_ip, 127, "%s/", node[i]->content);
-                    rip = f_ip;
-                    free(s_ip);
-                } else {
-                    merror(AG_INV_HOST, node[i]->content);
-                    return (OS_INVALID);
-                }
-            } else {
-                snprintf(f_ip, 127, "%s/%s", node[i]->content, s_ip);
+            if (strchr(node[i]->content, '/') ==  NULL) {
+                snprintf(f_ip, 127, "%s/", node[i]->content);
                 rip = f_ip;
-                free(s_ip);
+            } else {
+                merror(AG_INV_HOST, node[i]->content);
+                return (OS_INVALID);
             }
 
         } else if (strcmp(node[i]->element, xml_client_port) == 0) {
@@ -237,27 +227,15 @@ int Read_Client_Server(XML_NODE node, agent * logr)
         }
         /* Get server address (IP or hostname) */
         else if (strcmp(node[j]->element, xml_client_addr) == 0) {
-            char * s_ip;
-
-            if (OS_IsValidIP(node[j]->content, NULL) == 1) { // IP
+            if (OS_IsValidIP(node[j]->content, NULL) == 1) {
                 rip = node[j]->content;
-
-            } else if (s_ip = OS_GetHost(node[j]->content, 5), !s_ip) {
-                // Hostname could not be resolved
-                if (strchr(node[j]->content, '/') ==  NULL) {
-                    snprintf(f_ip, 127, "%s/", node[j]->content);
-                    rip = f_ip;
-                    free(s_ip);
-                } else {
-                    merror(AG_INV_HOST, node[j]->content);
-                    return (OS_INVALID);
-                }
-            } else {
-                snprintf(f_ip, 127, "%s/%s", node[j]->content, s_ip);
+            } else if (strchr(node[j]->content, '/') ==  NULL) {
+                snprintf(f_ip, 127, "%s", node[j]->content);
                 rip = f_ip;
-                free(s_ip);
+            } else {
+                merror(AG_INV_HOST, node[j]->content);
+                return (OS_INVALID);
             }
-
         } else if (strcmp(node[j]->element, xml_client_port) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -513,7 +513,8 @@ char *OS_GetHost(const char *host, unsigned int attempts)
 
     while (i <= attempts) {
         if ((h = gethostbyname(host)) == NULL) {
-            sleep(i++);
+            sleep(1);
+            i++;
             continue;
         }
 

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -323,19 +323,11 @@ int get_ossec_server()
             success = 1;
             goto ret;
         } else {
-            /* If we don't find the IP, try the server hostname */
-            char *s_ip;
-            s_ip = OS_GetHost(str, 0);
-            if (s_ip) {
-                /* Clear the host memory */
-                free(s_ip);
-
-                /* Assign the hostname to the server info */
-                config_inst.server_type = SERVER_HOST_USED;
-                config_inst.server = str;
-                success = 1;
-                goto ret;
-            }
+            /* If we don't find the IP, get the server hostname */
+            config_inst.server_type = SERVER_HOST_USED;
+            config_inst.server = str;
+            success = 1;
+            goto ret;
         }
     }
     if (str = OS_GetOneContentforElement(&xml, xml_serverip), str) {
@@ -347,15 +339,10 @@ int get_ossec_server()
         }
     }
     if (str = OS_GetOneContentforElement(&xml, xml_serverhost), str) {
-        char *s_ip;
-        s_ip = OS_GetHost(str, 0);
-        if (s_ip) {
-            free(s_ip);
-            config_inst.server_type = SERVER_HOST_USED;
-            config_inst.server = str;
-            success = 1;
-            goto ret;
-        }
+        config_inst.server_type = SERVER_HOST_USED;
+        config_inst.server = str;
+        success = 1;
+        goto ret;
     }
 
     /* Set up final server name when not available */
@@ -432,13 +419,13 @@ int set_ossec_server(char *ip, HWND hwnd)
         s_ip = OS_GetHost(ip, 0);
 
         if (!s_ip) {
-            MessageBox(hwnd, "Invalid Server IP Address.\r\n"
-                       "It must be the valid IPv4 address of the "
-                       "OSSEC server or the resolvable hostname.",
-                       "Error -- Failure Setting IP", MB_OK);
-            return (0);
+            MessageBox(hwnd,
+                       "The hostname provided could not be resolved.\r\n"
+                       "Make sure you entered a valid address.",
+                       "Hostname saved", MB_OK | MB_ICONINFORMATION);
+        } else {
+            free(s_ip);
         }
-        free(s_ip);
         config_inst.server_type = SERVER_HOST_USED;
         xml_pt = xml_serveraddr;
     } else {

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -415,16 +415,12 @@ int set_ossec_server(char *ip, HWND hwnd)
 
     /* Verify IP Address */
     if (OS_IsValidIP(ip, NULL) != 1) {
-        char *s_ip;
-        s_ip = OS_GetHost(ip, 0);
 
-        if (!s_ip) {
+        if (strchr(ip, '/')) {
             MessageBox(hwnd,
-                       "The hostname provided could not be resolved.\r\n"
-                       "Make sure you entered a valid address.",
-                       "Hostname saved", MB_OK | MB_ICONINFORMATION);
-        } else {
-            free(s_ip);
+                       "A valid hostname cannot contain the following character: /",
+                       "Cannot save hostname", MB_OK | MB_ICONERROR);
+            return (0);
         }
         config_inst.server_type = SERVER_HOST_USED;
         xml_pt = xml_serveraddr;

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -126,6 +126,7 @@ int main(int argc, char **argv)
 int local_start()
 {
     int debug_level;
+    int rc;
     char *cfg = DEFAULTCPATH;
     WSADATA wsaData;
     DWORD  threadID;
@@ -171,6 +172,17 @@ int local_start()
         minfo("Max time to reconnect can't be less than notify_time(%d), using notify_time*3 (%d)", agt->notify_time, agt->max_time_reconnect_try);
     }
     minfo("Using notify time: %d and max time to reconnect: %d", agt->notify_time, agt->max_time_reconnect_try);
+
+    // Resolve hostnames
+    rc = 0;
+    while (rc < agt->rip_id) {
+        if (OS_IsValidIP(agt->server[rc].rip, NULL) != 1) {
+            mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
+            resolveHostname(&agt->server[rc].rip, 5);
+            mdebug2("Server hostname resolved: %s", agt->server[rc].rip);
+        }
+        rc++;
+    }
 
     /* Read logcollector config file */
     mdebug1("Reading logcollector configuration.");


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/2770|

## Description

This PR removes the hostname resolution during the configuration reading in the agent start up.
If the DNS is not reachable when the agent is starting, the config validation aborts the starting.
Removing this validation, the agent is now able to resolve the hostname once it has started.

This PR also improves some messages related with the agent connection.


## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
  - [x] Solaris 10
- [x] Source installation
- [x] Source upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster enviroments
