### PR TITLE
Fix invalid read CIS-CAT

### DIFF
--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -103,6 +103,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
         }
 
         if (!skip_java) {
+            os_free(ciscat->java_path);
             os_strdup(java_fullpath, ciscat->java_path);
         } else {
             if (ciscat->java_path) {
@@ -236,6 +237,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                         #else
                             snprintf(bench_fullpath, OS_MAXSTR - 1, "%s/%s", cis_path, eval->path);
                         #endif
+                            os_free(eval->path);
                             os_strdup(bench_fullpath, eval->path);
                             break;
                         default:

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -967,17 +967,21 @@ void wm_ciscat_preparser(){
                     if (strstr(readbuff, WM_CISCAT_DESC_END) || strstr(readbuff, WM_CISCAT_DESC_END2)) {
                         string = wm_ciscat_remove_tags(readbuff);
                         size = strlen(string);
-                        if (string[size - 1] == '\n') {
-                            string[size - 1] = '\0';
+                        if (size > 0) {
+                            if (string[size - 1] == '\n') {
+                                string[size - 1] = '\0';
+                            }
+                            snprintf(result, OS_MAXSTR - 1, "<description>%s</description>", string);
                         }
-                        snprintf(result, OS_MAXSTR - 1, "<description>%s</description>", string);
                         free(string);
                     } else {
                         size = strlen(readbuff);
-                        if (readbuff[size - 1] == '\n') {
-                            readbuff[size - 1] = '\0';
+                        if (size > 0) {
+                            if (readbuff[size - 1] == '\n') {
+                                readbuff[size - 1] = '\0';
+                            }
+                            snprintf(result, OS_MAXSTR - 1, "%s", readbuff);
                         }
-                        snprintf(result, OS_MAXSTR - 1, "%s", readbuff);
                         inside = 1;
                         continue;
                     }
@@ -986,17 +990,21 @@ void wm_ciscat_preparser(){
                     if (strstr(readbuff, WM_CISCAT_RATIO_END) || strstr(readbuff, WM_CISCAT_RATIO_END2)) {
                         string = wm_ciscat_remove_tags(readbuff);
                         size = strlen(string);
-                        if (string[size - 1] == '\n') {
-                            string[size - 1] = '\0';
+                        if (size > 0) {
+                            if (string[size - 1] == '\n') {
+                                string[size - 1] = '\0';
+                            }
+                            snprintf(result, OS_MAXSTR - 1, "<rationale>%s</rationale>", string);
                         }
-                        snprintf(result, OS_MAXSTR - 1, "<rationale>%s</rationale>", string);
                         free(string);
                     } else {
                         size = strlen(readbuff);
-                        if (readbuff[size - 1] == '\n') {
-                            readbuff[size - 1] = '\0';
+                        if (size > 0) {
+                            if (readbuff[size - 1] == '\n') {
+                                readbuff[size - 1] = '\0';
+                            }
+                            snprintf(result, OS_MAXSTR - 1, "%s", readbuff);
                         }
-                        snprintf(result, OS_MAXSTR - 1, "%s", readbuff);
                         inside = 1;
                         continue;
                     }
@@ -1005,17 +1013,21 @@ void wm_ciscat_preparser(){
                     if (strstr(readbuff, WM_CISCAT_FIXTEXT_END) || strstr(readbuff, WM_CISCAT_FIXTEXT_END2)) {
                         string = wm_ciscat_remove_tags(readbuff);
                         size = strlen(string);
-                        if (string[size - 1] == '\n') {
-                            string[size - 1] = '\0';
+                        if (size > 0) {
+                            if (string[size - 1] == '\n') {
+                                string[size - 1] = '\0';
+                            }
+                            snprintf(result, OS_MAXSTR - 1, "<fixtext>%s</fixtext>", string);
                         }
-                        snprintf(result, OS_MAXSTR - 1, "<fixtext>%s</fixtext>", string);
                         free(string);
                     } else {
                         size = strlen(readbuff);
-                        if (readbuff[size - 1] == '\n') {
-                            readbuff[size - 1] = '\0';
+                        if (size > 0) {
+                            if (readbuff[size - 1] == '\n') {
+                                readbuff[size - 1] = '\0';
+                            }
+                            snprintf(result, OS_MAXSTR - 1, "%s", readbuff);
                         }
-                        snprintf(result, OS_MAXSTR - 1, "%s", readbuff);
                         inside = 1;
                         continue;
                     }
@@ -1032,10 +1044,12 @@ void wm_ciscat_preparser(){
                     } else {
                         string = wm_ciscat_remove_tags(aux_str);
                         size = strlen(string);
-                        if (string[size - 1] == '\n') {
-                            string[size - 1] = ' ';
+                        if (size > 0) {
+                            if (string[size - 1] == '\n') {
+                                string[size - 1] = ' ';
+                            }
+                            wm_strcat(&result, string, '\0');
                         }
-                        wm_strcat(&result, string, '\0');
                         free(string);
                         continue;
                     }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3399|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes the invalid read reported at the mentioned issue for CIS-CAT.

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- Memory tests
  - [x] Valgrind report for affected components
```
==11869== HEAP SUMMARY:
==11869==     in use at exit: 69,941 bytes in 52 blocks
==11869==   total heap usage: 5,563 allocs, 5,511 frees, 2,448,861 bytes allocated
==11869== 
==11869== 12 bytes in 1 blocks are definitely lost in loss record 9 of 42
==11869==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11869==    by 0x5B249B9: strdup (strdup.c:42)
==11869==    by 0x1B84A4: wm_ciscat_read (wmodules-ciscat.c:238)
==11869==    by 0x15E563: Read_WModule (wmodules-config.c:106)
==11869==    by 0x14A008: read_main_elements (config.c:142)
==11869==    by 0x14A731: ReadConfig (config.c:245)
==11869==    by 0x112404: wm_config (wmodules.c:37)
==11869==    by 0x111FBB: wm_setup (main.c:138)
==11869==    by 0x111D78: main (main.c:85)
==11869== 
==11869== 51 bytes in 1 blocks are definitely lost in loss record 26 of 42
==11869==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11869==    by 0x5B249B9: strdup (strdup.c:42)
==11869==    by 0x1B778D: wm_ciscat_read (wmodules-ciscat.c:86)
==11869==    by 0x15E563: Read_WModule (wmodules-config.c:106)
==11869==    by 0x14A008: read_main_elements (config.c:142)
==11869==    by 0x14A731: ReadConfig (config.c:245)
==11869==    by 0x112404: wm_config (wmodules.c:37)
==11869==    by 0x111FBB: wm_setup (main.c:138)
==11869==    by 0x111D78: main (main.c:85)
==11869== 
==11869== 272 bytes in 1 blocks are possibly lost in loss record 40 of 42
==11869==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11869==    by 0x40134A6: allocate_dtv (dl-tls.c:286)
==11869==    by 0x40134A6: _dl_allocate_tls (dl-tls.c:530)
==11869==    by 0x5870227: allocate_stack (allocatestack.c:627)
==11869==    by 0x5870227: pthread_create@@GLIBC_2.2.5 (pthread_create.c:644)
==11869==    by 0x13C49F: CreateThreadJoinable (pthreads_op.c:47)
==11869==    by 0x111DDF: main (main.c:95)
==11869== 
==11869== LEAK SUMMARY:
==11869==    definitely lost: 63 bytes in 2 blocks
==11869==    indirectly lost: 0 bytes in 0 blocks
==11869==      possibly lost: 272 bytes in 1 blocks
==11869==    still reachable: 69,606 bytes in 49 blocks
==11869==         suppressed: 0 bytes in 0 blocks
==11869== Reachable blocks (those to which a pointer was found) are not shown.
==11869== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==11869== 
==11869== For counts of detected and suppressed errors, rerun with: -v
==11869== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```

```
2019/05/28 08:42:30 wazuh-modulesd:ciscat: INFO: Starting evaluation.
2019/05/28 08:42:30 wazuh-modulesd:database: INFO: Module started.
2019/05/28 08:42:31 wazuh-modulesd:download: INFO: Module started
2019/05/28 08:42:45 wazuh-modulesd:ciscat: INFO: Scan finished successfully. File: /media/cristina/MISI/Descargas/ciscat_java/ciscat/cis-cat-full/benchmarks/CIS_Debian_Linux_3_Benchmark_v1.0.0.xml
```