### PR TITLE
Parse HIPAA and NIST 800 53 as rule groups.

### DIFF
--- a/extensions/elasticsearch/6.x/wazuh-template.json
+++ b/extensions/elasticsearch/6.x/wazuh-template.json
@@ -290,6 +290,14 @@
             "gpg13": {
               "type": "keyword",
               "doc_values": "true"
+            },
+            "hipaa": {
+              "type": "keyword",
+              "doc_values": "true"
+            },
+            "nist_800_53": {
+              "type": "keyword",
+              "doc_values": "true"
             }
           }
         },

--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -292,6 +292,14 @@
           "gpg13": {
             "type": "keyword",
             "doc_values": "true"
+          },
+          "hipaa": {
+            "type": "keyword",
+            "doc_values": "true"
+          },
+          "nist_800_53": {
+            "type": "keyword",
+            "doc_values": "true"
           }
         }
       },

--- a/src/analysisd/format/json_extended.h
+++ b/src/analysisd/format/json_extended.h
@@ -42,6 +42,10 @@ int add_groupCIS(cJSON *rule, char * group, int firstCIS);
 int add_groupGDPR(cJSON* rule, char* group, int firstGDPR);
 // Parsing GPG13 Compliance groups
 int add_groupGPG13(cJSON* rule, char* group, int firstGPG13);
+//Parsing HIPAA Compliance groups
+int add_groupHIPAA(cJSON* rule, char* group, int firstHIPAA);
+//Parsing NIST_500_83 Compliance groups
+int add_groupNIST(cJSON* rule, char* group, int firstNIST);
 // Aux functions
 int str_cut(char *str, int begin, int len);
 regex_t * compile_regex (const char * regex_text);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3326|

## Description

The groups `HIPAA` and `NIST 800 53` were added to the parser of compliance groups. Also the fields were added to the ELK template.

## Logs/Alerts example

![image](https://user-images.githubusercontent.com/9034923/58473348-abb67280-8148-11e9-9465-f59bc4c13d8f.png)

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster enviroments
- [x] Configuration on demand reports new parameters
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities