### PR TITLE
Overwrite rules label fix and rules features tests

### DIFF
--- a/contrib/ossec-testing/ruleset/test_decoders.xml
+++ b/contrib/ossec-testing/ruleset/test_decoders.xml
@@ -1,0 +1,9 @@
+<decoder name="ow_test">
+  <program_name>^ow_test$</program_name>
+</decoder>
+
+<decoder name="test_same">
+  <program_name>^test_same_fields$</program_name>
+  <regex>User '(\w+)' logged from '(\d+.\d+.\d+.\d+)' (\d+) this is</regex>
+  <order>user, srcip, number</order>
+</decoder>

--- a/contrib/ossec-testing/ruleset/test_rules.xml
+++ b/contrib/ossec-testing/ruleset/test_rules.xml
@@ -1,0 +1,50 @@
+<group name="qa,test">
+
+<!-- May 27 14:49:04 testUser ow_test[13244]: overwrite and list test -->
+<!-- testing overwrite and list -->
+  <rule id="99900" level="5">
+    <match>overwrite and list test</match>
+    <description>Testing ow&list</description>
+  </rule>
+
+  <rule id="99900" level="7" overwrite="yes">
+    <match>overwrite and list test</match>
+    <list field="program_name" lookup="not_match_key">etc/lists/black_list</list>
+    <description>Successfully</description>
+  </rule>
+
+
+<!-- Trigger alerts which depend on same_fields . Also it tests if_matched_sid -->
+<!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test -->
+<!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test -->
+<!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test -->
+
+<rule id="999205" level="3">
+  <match>this is the same_fields test</match>
+  <description>Testing same_fields</description>
+</rule>
+
+<rule id="999206" level="7" frequency="3" timeframe="300">
+  <if_matched_sid>999205</if_matched_sid>
+  <same_field>number</same_field>
+  <description>Same fields works!</description>
+</rule>
+
+
+<!-- Trigger alerts which depend on not_same_fields . Also it tests if_matched_sid. -->
+<!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the not_same_fields test -->
+<!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 6 this is the not_same_fields test -->
+<!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 7 this is the not_same_fields test -->
+  <rule id="999207" level="3">
+  <match>this is the not_same_fields test</match>
+  <description>Testing not_same_fields</description>
+</rule>
+
+<rule id="999208" level="7" frequency="3" timeframe="300">
+ <if_matched_sid>999207</if_matched_sid>
+  <not_same_field>number</not_same_field>
+  <description>Not Same fields works!</description>
+</rule>
+
+
+</group>

--- a/contrib/ossec-testing/tests/features.ini
+++ b/contrib/ossec-testing/tests/features.ini
@@ -1,0 +1,38 @@
+[overwrite & list]
+log 1 pass =  May 27 14:49:04 testUser ow_test[13244]: overwrite and list test
+
+rule = 99900
+alert = 7
+decoder = ow_test
+
+[same fields]
+log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test
+log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test
+log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test
+
+rule = 999206
+alert = 7
+decoder = test_same
+
+[not same fields]
+log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the not_same_fields test
+log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 6 this is the not_same_fields test
+log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 7 this is the not_same_fields test
+
+rule = 999208
+alert = 7
+decoder = test_same
+
+[sshd brute force rule]
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+
+rule = 5712
+alert = 10
+decoder = sshd

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -304,6 +304,17 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid)
             r_node->ruleinfo->ar = newrule->ar;
             r_node->ruleinfo->compiled_rule = newrule->compiled_rule;
 
+            r_node->ruleinfo->location = newrule->location;
+            r_node->ruleinfo->lists = newrule->lists;
+            r_node->ruleinfo->prev_rule = newrule->prev_rule;
+            r_node->ruleinfo->same_fields = newrule->same_fields;
+            r_node->ruleinfo->not_same_fields = newrule->not_same_fields;
+
+#ifdef LIBGEOIP_ENABLED
+            r_node->ruleinfo->srcgeoip = newrule->srcgeoip;
+            r_node->ruleinfo->dstgeoip = newrule->dstgeoip;
+#endif
+
             return (1);
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3381|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

- ### Overwrite & list fix
https://github.com/wazuh/wazuh/blob/35fac3dc7fd52d1d7975e94617038202e941916e/src/analysisd/rules_list.c#L256

This function is responsible for rewriting the data of a rule that was triggered if there is another rule that overwrites it.

The label corresponding to the cdb lists was not being copied by this function. It has been added along with other attributes that may be useful after overwrite of a rule occurs.


```C
            r_node->ruleinfo->location = newrule->location;
            r_node->ruleinfo->lists = newrule->lists;
            r_node->ruleinfo->prev_rule = newrule->prev_rule;
            r_node->ruleinfo->same_fields = newrule->same_fields;
            r_node->ruleinfo->not_same_fields = newrule->not_same_fields;

#ifdef LIBGEOIP_ENABLED
            r_node->ruleinfo->srcgeoip = newrule->srcgeoip;
            r_node->ruleinfo->dstgeoip = newrule->dstgeoip;
#endif
```


- ### Rules features test

    - in `contrib/ossec-testing` has been added a test file(features.ini) that checks that this new feature works.
    - The script that performs the tests has been modified so that it admits inputs with more than one event. This way checks that require multiple events as input can be performed.


<br></br>

## Logs/Alerts example

- Rule added on `/var/ossec/etc/rules/local_rules.xml`

```
  <rule id="5501" level="12" overwrite="yes">
    <if_sid>5500</if_sid>
    <match>session opened for user </match>
  <list field="program_name" lookup="match_key">etc/lists/my/oom_white_list</list>
    <description>System running out of memory. </description>

    <description>Availability of the MY system is in risk.</description>
    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
  </rule>
```
<br></br>
- Output when using as input of logcollector this sshd log line `May 23 13:10:58 centos sshd[7621]: pam_unix(sshd:session): session opened for user root by (uid=0)`
```
**Phase 1: Completed pre-decoding.
       full event: 'May 23 13:10:58 centos sshd[7621]: pam_unix(sshd:session): session opened for user root by (uid=0)'
       timestamp: 'May 23 13:10:58'
       hostname: 'centos'
       program_name: 'sshd'
       log: 'pam_unix(sshd:session): session opened for user root by (uid=0)'

**Phase 2: Completed decoding.
       decoder: 'pam'
       dstuser: 'root'
       uid: '0
```

- No rule matches with this log input and this is caused by the correct functioning of the label </list>.



<br></br>
## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

Compilation without warnings in every supported platform:
- [x] Linux
- [x] Source installation


The additional attributes that are now also copied do not represent a change in the way memory is allocated so they do not require a thorough memory test.
<br></br>
- [x] QA templates contemplate the added capabilities

QA template for ruleset has been extended to include testing this new functionality. A test file has also been added to `contrib/ossec-testing` for automatic testing.