### PR TITLE
Increased email_maxperhour upper limit

### DIFF
--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -530,7 +530,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                 }
                 Mail->maxperhour = atoi(node[i]->content);
 
-                if ((Mail->maxperhour <= 0) || (Mail->maxperhour > 9999)) {
+                if ((Mail->maxperhour <= 0) || (Mail->maxperhour > 99999)) {
                     merror(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 }

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -530,7 +530,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                 }
                 Mail->maxperhour = atoi(node[i]->content);
 
-                if ((Mail->maxperhour <= 0) || (Mail->maxperhour > 99999)) {
+                if ((Mail->maxperhour <= 0) || (Mail->maxperhour > 1000000)) {
                     merror(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3021|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR increases the upper limit on `<email_maxperhour>` value: the old value was 9999 and the current value is 1000000
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
Example of valid config with the new upper limit:
`<email_maxperhour>70000</email_maxperhour>`

<!--
When proceed, this section should include new configuration parameters.
-->
## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
 - [x] Linux
- [x] Source installation