### PR TITLE
Fix for getting agent version in syscheck

### DIFF
--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -12,6 +12,7 @@ from wazuh.ossec_queue import OssecQueue
 from wazuh import common, Connection
 from datetime import datetime
 from wazuh.wdb import WazuhDBConnection
+from wazuh.utils import WazuhVersion
 
 
 def run(agent_id=None, all_agents=False):
@@ -92,7 +93,7 @@ def last_scan(agent_id):
         # if the agent is never connected, it won't have either version (key error) or last scan information.
         return {'start': 'ND', 'end': 'ND'}
 
-    if agent_version < 'Wazuh v3.7.0':
+    if WazuhVersion(agent_version) < WazuhVersion('Wazuh v3.7.0'):
         db_agent = glob('{0}/{1}-*.db'.format(common.database_path_agents, agent_id))
         if not db_agent:
             raise WazuhException(1600)

--- a/framework/wazuh/tests/data/schema_syscheck_test.sql
+++ b/framework/wazuh/tests/data/schema_syscheck_test.sql
@@ -1,0 +1,19 @@
+/*
+ * SQL Schema syscheck tests
+ * Copyright (C) 2015-2019, Wazuh Inc.
+ * February 13, 2019.
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+ */
+
+CREATE TABLE pm_event (id INTEGER PRIMARY KEY AUTOINCREMENT, date_first TEXT, date_last TEXT, log TEXT, pci_dss TEXT, cis TEXT);
+CREATE INDEX pm_event_log ON pm_event (log);
+CREATE INDEX pm_event_date ON pm_event (date_last);
+
+INSERT INTO pm_event(id, date_first, date_last, log) VALUES (1, '2019-05-29 12:20:11', '2019-05-29 12:21:02', 'Starting syscheck scan.');
+INSERT INTO pm_event(id, date_first, date_last, log) VALUES (2, '2019-05-29 12:20:26', '2019-05-29 12:21:16', 'Ending syscheck scan.');
+INSERT INTO pm_event(id, date_first, date_last, log) VALUES (3, '2019-05-29 12:21:26', '2019-05-29 12:21:26', 'Starting rootcheck scan.');
+INSERT INTO pm_event(id, date_first, date_last, log) VALUES (4, '2019-05-29 12:21:35', '2019-05-29 12:21:35', 'Ending rootcheck scan.');
+
+CREATE TABLE scan_info (module TEXT PRIMARY KEY, first_start INTEGER, first_end INTEGER, start_scan INTEGER, end_scan INTEGER, fim_first_check INTEGER, fim_second_check INTEGER, fim_third_check INTEGER);
+INSERT INTO scan_info(module, first_start, first_end, start_scan, end_scan, fim_first_check, fim_second_check, fim_third_check) VALUES ('fim', 1559134512, 1559134532, 1559134512, 1559134532, 1559134512, 1559132445, 1559132394);

--- a/framework/wazuh/tests/data/schema_syscheck_test.sql
+++ b/framework/wazuh/tests/data/schema_syscheck_test.sql
@@ -7,8 +7,6 @@
  */
 
 CREATE TABLE pm_event (id INTEGER PRIMARY KEY AUTOINCREMENT, date_first TEXT, date_last TEXT, log TEXT, pci_dss TEXT, cis TEXT);
-CREATE INDEX pm_event_log ON pm_event (log);
-CREATE INDEX pm_event_date ON pm_event (date_last);
 
 INSERT INTO pm_event(id, date_first, date_last, log) VALUES (1, '2019-05-29 12:20:11', '2019-05-29 12:21:02', 'Starting syscheck scan.');
 INSERT INTO pm_event(id, date_first, date_last, log) VALUES (2, '2019-05-29 12:20:26', '2019-05-29 12:21:16', 'Ending syscheck scan.');

--- a/framework/wazuh/tests/test_syscheck.py
+++ b/framework/wazuh/tests/test_syscheck.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from sqlite3 import connect
+from unittest.mock import patch, mock_open
+import os
+import pytest
+
+from wazuh.syscheck import last_scan
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+
+
+def get_fake_syscheck_db(sql_file):
+
+    def create_memory_db(*args, **kwargs):
+        syscheck_db = connect(':memory:')
+        cur = syscheck_db.cursor()
+        with open(os.path.join(test_data_path, sql_file)) as f:
+            cur.executescript(f.read())
+
+        return syscheck_db
+
+    return create_memory_db
+
+
+@pytest.mark.parametrize('agent_id, version', [
+    ('001', {'version': 'Wazuh v3.5.0'}),
+    ('002', {'version': 'Wazuh v3.6.2'}),
+    ('003', {'version': 'Wazuh v3.7.1'}),
+    ('004', {'version': 'Wazuh v3.8.2'}),
+    ('005', {'version': 'Wazuh v3.9.1'}),
+    ('006', {'version': 'Wazuh v3.10.0'})
+])
+@patch('sqlite3.connect', side_effect=get_fake_syscheck_db('schema_syscheck_test.sql'))
+def test_last_scan(db_mock, version, agent_id):
+    """
+    Test last_scan function
+    """
+    with patch('wazuh.syscheck.Agent.get_basic_information', return_value=version):
+        result = last_scan(agent_id)
+        
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {'start', 'end'}


### PR DESCRIPTION
Hi team,

A lexicographical comparison is made on this line:

https://github.com/wazuh/wazuh/blob/f9a870f8414d3a6fd889484f120b296a93e04783/framework/wazuh/syscheck.py#L95

This will not work in `3.10` version or higher, so that made a fix for using `WazuhVersion` class for comparing versions properly.

Furthermore, I added a unit test for testing this function.

Best regards,

Demetrio.