### PR TITLE
Manage timeout error in TCP connections

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -186,6 +186,13 @@ void HandleSecure()
                         switch (errno) {
                         case ECONNRESET:
                         case ENOTCONN:
+                        case EAGAIN:
+#if EAGAIN != EWOULDBLOCK
+                        case EWOULDBLOCK:
+#endif
+#if ETIMEDOUT
+                        case ETIMEDOUT:
+#endif
                             mdebug2("TCP peer [%d] at %s: %s (%d)", sock_client, inet_ntoa(peer_info.sin_addr), strerror(errno), errno);
                             break;
                         default:


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3376|


## Description

This PR solves the issue https://github.com/wazuh/wazuh/issues/3376.
The timeout error is managed and now this error is logged only in debug.
Error codes `EAGAIN`, `EWOULDBLOCK` and `ETIMEDOUT` were added to ensure compatibility.


## Logs/Alerts example

```
2019/05/30 11:44:17 ossec-remoted[12184] secure.c:196 at HandleSecure(): DEBUG: TCP peer [12] at 192.168.99.77: Connection timed out (110)
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform:
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Retrocompatibility with older Wazuh versions
