### PR TITLE
Add SCA compliance groups to rule groups

### DIFF
--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -236,8 +236,13 @@ void add_SCA_groups(cJSON *rule, char* compliance, char* value){
         cJSON_AddItemToArray(group, cJSON_CreateString(token));
     }
 
-    if(new_group && cJSON_GetArraySize(group) > 0)
-        cJSON_AddItemToObject(rule, compliance, group);
+    if(new_group){
+        if(cJSON_GetArraySize(group) > 0){
+            cJSON_AddItemToObject(rule, compliance, group);
+        } else {
+            cJSON_Delete(group);
+        }
+    }
 
     free(aux);
 }
@@ -616,7 +621,7 @@ void trim(char* s)
     char* p = s;
     int l = strlen(p);
 
-    while(isspace(p[l - 1]))
+    while( l > 0 && isspace(p[l - 1]))
         p[--l] = 0;
     while(*p && isspace(*p))
         ++p, --l;

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -215,7 +215,7 @@ void W_JSON_ParseGroups(cJSON* root, const Eventinfo* lf)
     }
 }
 
-int add_SCA_groups(cJSON *rule, char* compliance, char* version){
+void add_SCA_groups(cJSON *rule, char* compliance, char* version){
     cJSON *group = cJSON_GetObjectItem(rule, compliance);
     
     if(!group){
@@ -224,7 +224,6 @@ int add_SCA_groups(cJSON *rule, char* compliance, char* version){
     }
 
     cJSON_AddItemToArray(group, cJSON_CreateString(version));
-    return 0;
 }
 // Parse groups PCI
 int add_groupPCI(cJSON* rule, char* group, int firstPCI)

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -216,28 +216,29 @@ void W_JSON_ParseGroups(cJSON* root, const Eventinfo* lf)
 }
 
 void add_SCA_groups(cJSON *rule, char* compliance, char* value){
-    if(value){
-        char *aux;
-        os_strdup(value, aux);
-        cJSON *group = cJSON_GetObjectItem(rule, compliance);
-        if(!group){
-            group = cJSON_CreateArray();
-            cJSON_AddItemToObject(rule, compliance, group);
-        }
-        char *token;
-        char *state;
-        token = strtok_r(aux, ",", &state);
-        trim(token);
-        cJSON_AddItemToArray(group, cJSON_CreateString(token));
-        if(strlen(state) > 0){
-            while ((token = strtok_r(NULL,",", &state))){
-                trim(token);
-                if(strlen(token) > 0)
-                    cJSON_AddItemToArray(group, cJSON_CreateString(token));
-            }
-        }
-        free(aux);
+
+    if(!value) return;
+
+    char *aux;
+    os_strdup(value, aux);
+    cJSON *group = cJSON_GetObjectItem(rule, compliance);
+    if(!group){
+        group = cJSON_CreateArray();
+        cJSON_AddItemToObject(rule, compliance, group);
     }
+    char *token;
+    char *state;
+    token = strtok_r(aux, ",", &state);
+    trim(token);
+    cJSON_AddItemToArray(group, cJSON_CreateString(token));
+    if(strlen(state) > 0){
+        while ((token = strtok_r(NULL,",", &state))){
+            trim(token);
+            if(strlen(token) > 0)
+                cJSON_AddItemToArray(group, cJSON_CreateString(token));
+        }
+    }
+    free(aux);
 }
 // Parse groups PCI
 int add_groupPCI(cJSON* rule, char* group, int firstPCI)
@@ -609,6 +610,8 @@ int str_cut(char* str, int begin, int len)
 }
 void trim(char* s)
 {
+    if(!s) return;
+
     char* p = s;
     int l = strlen(p);
 

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -215,15 +215,29 @@ void W_JSON_ParseGroups(cJSON* root, const Eventinfo* lf)
     }
 }
 
-void add_SCA_groups(cJSON *rule, char* compliance, char* version){
+void add_SCA_groups(cJSON *rule, char* compliance, char* value){
+    char *aux;
+    os_strdup(value, aux);
     cJSON *group = cJSON_GetObjectItem(rule, compliance);
-    
     if(!group){
         group = cJSON_CreateArray();
         cJSON_AddItemToObject(rule, compliance, group);
     }
+    char *token;
+    char *state;
+    token = strtok_r(aux, ",", &state);
+    cJSON_AddItemToArray(group, cJSON_CreateString(token));
+    if(strlen(state) > 0){
+        if(state[0] == ' ')
+            ++state;
+        while ((token = strtok_r(NULL,",", &state))){
+            cJSON_AddItemToArray(group, cJSON_CreateString(token));
+            if(strlen(state) > 0 && state[0] == ' ')
+                ++state;
+        }
+    }
+    free(aux);
 
-    cJSON_AddItemToArray(group, cJSON_CreateString(version));
 }
 // Parse groups PCI
 int add_groupPCI(cJSON* rule, char* group, int firstPCI)

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -226,14 +226,13 @@ void add_SCA_groups(cJSON *rule, char* compliance, char* value){
     char *token;
     char *state;
     token = strtok_r(aux, ",", &state);
+    trim(token);
     cJSON_AddItemToArray(group, cJSON_CreateString(token));
     if(strlen(state) > 0){
-        if(state[0] == ' ')
-            ++state;
         while ((token = strtok_r(NULL,",", &state))){
-            cJSON_AddItemToArray(group, cJSON_CreateString(token));
-            if(strlen(state) > 0 && state[0] == ' ')
-                ++state;
+            trim(token);
+            if(strlen(token) > 0)
+                cJSON_AddItemToArray(group, cJSON_CreateString(token));
         }
     }
     free(aux);

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -220,24 +220,25 @@ void add_SCA_groups(cJSON *rule, char* compliance, char* value){
     if(!value) return;
 
     char *aux;
+    int new_group = 0;
     os_strdup(value, aux);
     cJSON *group = cJSON_GetObjectItem(rule, compliance);
     if(!group){
         group = cJSON_CreateArray();
-        cJSON_AddItemToObject(rule, compliance, group);
+        new_group = 1;
     }
     char *token;
     char *state;
-    token = strtok_r(aux, ",", &state);
-    trim(token);
-    cJSON_AddItemToArray(group, cJSON_CreateString(token));
-    if(strlen(state) > 0){
-        while ((token = strtok_r(NULL,",", &state))){
-            trim(token);
-            if(strlen(token) > 0)
-                cJSON_AddItemToArray(group, cJSON_CreateString(token));
-        }
+    for(token = strtok_r(aux, ",", &state); token; token = strtok_r(NULL, ",", &state)){
+        trim(token);
+        if(strlen(token) == 0)
+            continue;
+        cJSON_AddItemToArray(group, cJSON_CreateString(token));
     }
+
+    if(new_group && cJSON_GetArraySize(group) > 0)
+        cJSON_AddItemToObject(rule, compliance, group);
+
     free(aux);
 }
 // Parse groups PCI

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -197,6 +197,34 @@ void W_JSON_ParseGroups(cJSON* root, const Eventinfo* lf)
         }
         token = strtok_r(0, delim, &saveptr);
     }
+
+    //Add SCA compliance groups
+    cJSON *data = cJSON_GetObjectItem(root,"data");
+    if(data){
+        cJSON *sca = cJSON_GetObjectItem(data,"sca");
+        if(sca){
+            cJSON *check = cJSON_GetObjectItem(sca,"check");
+            if(check){
+                cJSON *compliances = cJSON_GetObjectItem(check,"compliance");
+                cJSON *compliance;
+                cJSON_ArrayForEach(compliance,compliances){
+                    add_SCA_groups(rule, compliance->string, compliance->valuestring);
+                }
+            }
+        }
+    }
+}
+
+int add_SCA_groups(cJSON *rule, char* compliance, char* version){
+    cJSON *group = cJSON_GetObjectItem(rule, compliance);
+    
+    if(!group){
+        group = cJSON_CreateArray();
+        cJSON_AddItemToObject(rule, compliance, group);
+    }
+
+    cJSON_AddItemToArray(group, cJSON_CreateString(version));
+    return 0;
 }
 // Parse groups PCI
 int add_groupPCI(cJSON* rule, char* group, int firstPCI)

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -216,27 +216,28 @@ void W_JSON_ParseGroups(cJSON* root, const Eventinfo* lf)
 }
 
 void add_SCA_groups(cJSON *rule, char* compliance, char* value){
-    char *aux;
-    os_strdup(value, aux);
-    cJSON *group = cJSON_GetObjectItem(rule, compliance);
-    if(!group){
-        group = cJSON_CreateArray();
-        cJSON_AddItemToObject(rule, compliance, group);
-    }
-    char *token;
-    char *state;
-    token = strtok_r(aux, ",", &state);
-    trim(token);
-    cJSON_AddItemToArray(group, cJSON_CreateString(token));
-    if(strlen(state) > 0){
-        while ((token = strtok_r(NULL,",", &state))){
-            trim(token);
-            if(strlen(token) > 0)
-                cJSON_AddItemToArray(group, cJSON_CreateString(token));
+    if(value){
+        char *aux;
+        os_strdup(value, aux);
+        cJSON *group = cJSON_GetObjectItem(rule, compliance);
+        if(!group){
+            group = cJSON_CreateArray();
+            cJSON_AddItemToObject(rule, compliance, group);
         }
+        char *token;
+        char *state;
+        token = strtok_r(aux, ",", &state);
+        trim(token);
+        cJSON_AddItemToArray(group, cJSON_CreateString(token));
+        if(strlen(state) > 0){
+            while ((token = strtok_r(NULL,",", &state))){
+                trim(token);
+                if(strlen(token) > 0)
+                    cJSON_AddItemToArray(group, cJSON_CreateString(token));
+            }
+        }
+        free(aux);
     }
-    free(aux);
-
 }
 // Parse groups PCI
 int add_groupPCI(cJSON* rule, char* group, int firstPCI)

--- a/src/analysisd/format/json_extended.h
+++ b/src/analysisd/format/json_extended.h
@@ -42,10 +42,12 @@ int add_groupCIS(cJSON *rule, char * group, int firstCIS);
 int add_groupGDPR(cJSON* rule, char* group, int firstGDPR);
 // Parsing GPG13 Compliance groups
 int add_groupGPG13(cJSON* rule, char* group, int firstGPG13);
-//Parsing HIPAA Compliance groups
+// Parsing HIPAA Compliance groups
 int add_groupHIPAA(cJSON* rule, char* group, int firstHIPAA);
-//Parsing NIST_500_83 Compliance groups
+// Parsing NIST_500_83 Compliance groups
 int add_groupNIST(cJSON* rule, char* group, int firstNIST);
+// Add SCA compliance groups to rule groups
+int add_SCA_groups(cJSON *rule, char* compliance, char* version);
 // Aux functions
 int str_cut(char *str, int begin, int len);
 regex_t * compile_regex (const char * regex_text);

--- a/src/analysisd/format/json_extended.h
+++ b/src/analysisd/format/json_extended.h
@@ -47,7 +47,7 @@ int add_groupHIPAA(cJSON* rule, char* group, int firstHIPAA);
 // Parsing NIST_500_83 Compliance groups
 int add_groupNIST(cJSON* rule, char* group, int firstNIST);
 // Add SCA compliance groups to rule groups
-int add_SCA_groups(cJSON *rule, char* compliance, char* version);
+void add_SCA_groups(cJSON *rule, char* compliance, char* version);
 // Aux functions
 int str_cut(char *str, int begin, int len);
 regex_t * compile_regex (const char * regex_text);

--- a/src/analysisd/format/json_extended.h
+++ b/src/analysisd/format/json_extended.h
@@ -47,7 +47,7 @@ int add_groupHIPAA(cJSON* rule, char* group, int firstHIPAA);
 // Parsing NIST_500_83 Compliance groups
 int add_groupNIST(cJSON* rule, char* group, int firstNIST);
 // Add SCA compliance groups to rule groups
-void add_SCA_groups(cJSON *rule, char* compliance, char* version);
+void add_SCA_groups(cJSON *rule, char* compliance, char* value);
 // Aux functions
 int str_cut(char *str, int begin, int len);
 regex_t * compile_regex (const char * regex_text);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3326|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds de SCA groups to the rule JSON object. It merges the coincident groups and creates a new object for new groups.

## Examples
The screenshots of the rule information showed in Kibana are in the issue: https://github.com/wazuh/wazuh/issues/3326#issuecomment-497290143

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster enviroments
- [x] Review logs syntax and correct language

Valgrind report
-------------------
![image](https://user-images.githubusercontent.com/9034923/58629566-1ac4d000-82dd-11e9-8fbf-0861ad0998b0.png)
Those 100 bytes reported are a known issue and happen when `analysisd` reads the configuration.