### PR TITLE
Remove socket deletion from epoll

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -202,10 +202,6 @@ void HandleSecure()
                         // Fallthrough
 
                     case 0:
-                        if (wnotify_delete(notify, sock_client) < 0) {
-                            merror("wnotify_delete(%d): %s (%d)", sock_client, strerror(errno), errno);
-                        }
-
                         _close_sock(&keys, sock_client);
                         continue;
 


### PR DESCRIPTION
## Description

The file descriptor deletion from the `epoll` has been removed from the `HandleSecure()` function.

https://github.com/wazuh/wazuh/blob/090986e4bebbfc737c551d6b4d9485acfb9d1a5c/src/remoted/secure.c#L198-L200

This deletion is not necessary because the file descriptor is removed from it after all the file descriptors referring to the socket have been closed. It is described here:
- [`epoll` documentation](http://man7.org/linux/man-pages/man7/epoll.7.html):
> Will closing a file descriptor cause it to be removed from all epoll interest lists?
>
> Yes, but be aware of the following point.  A file descriptor is a reference to an open file description (see open(2)).  Whenever a file descriptor is duplicated via dup(2), dup2(2), fcntl(2) F_DUPFD, or fork(2), a new file descriptor referring to the same open file description is created.  An open file description con‐ tinues to exist until all file descriptors referring to it have been closed.

- [`kqueue` manual](https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2):
> Calling close() on a file descriptor will remove any kevents that reference the descriptor.

In high load environments, this deletion might cause a race condition and the following error could appear: 
```
2019/05/20 05:33:12 ossec-remoted: ERROR: wnotify_delete(130): Bad file descriptor (9)
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
