### PR TITLE
3309 fix rhel 8

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -33,7 +33,7 @@ runInit()
         # RHEL 8 services must to be installed in /usr/lib/systemd/system/
         if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
             cp -p ./src/systemd/wazuh-$type.service /usr/lib/systemd/system/
-            chown root:ossec /etc/systemd/system/"wazuh-"$type.service
+            chown root:ossec /usr/lib/systemd/system/"wazuh-"$type.service
             systemctl daemon-reload
         else
             cp -p ./src/systemd/wazuh-$type.service /etc/systemd/system/

--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -6,7 +6,7 @@
 
 UN=${NUNAME};
 service="wazuh";
-. ./dist-detect.sh
+./dist-detect.sh
 
 runInit()
 {

--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -6,6 +6,7 @@
 
 UN=${NUNAME};
 service="wazuh";
+. ./dist-detect.sh
 
 runInit()
 {
@@ -29,9 +30,16 @@ runInit()
         else
             type=agent
         fi
-        cp -p ./src/systemd/wazuh-$type.service /etc/systemd/system/
-        chown root:ossec /etc/systemd/system/"wazuh-"$type.service
-        systemctl daemon-reload
+        # RHEL 8 services must to be installed in /usr/lib/systemd/system/
+        if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
+            cp -p ./src/systemd/wazuh-$type.service /usr/lib/systemd/system/
+            chown root:ossec /etc/systemd/system/"wazuh-"$type.service
+            systemctl daemon-reload
+        else
+            cp -p ./src/systemd/wazuh-$type.service /etc/systemd/system/
+            chown root:ossec /etc/systemd/system/"wazuh-"$type.service
+            systemctl daemon-reload
+        fi
 
         if [ "X${update_only}" = "X" ]
         then


### PR DESCRIPTION
|Related issue|
|----|
|https://github.com/wazuh/wazuh/issues/3309|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hello team 

 This PR solves https://github.com/wazuh/wazuh/issues/3309 by adding an if in "init.sh" script. This code will detect if the target OS is Red Hat Enterprise Linux 8 and it will add the service in the correct path. If not, all as usual. 

## Logs/Alerts example

- Oracle Linux 8 Beta compilation warnings, ping @wazuh/core 
[output_ol8.txt](https://github.com/wazuh/wazuh/files/3239957/output_ol8.txt)
## Tests

- [x] Centos 7 sources compilation and installation
```
[root@manager wazuh-3309-fix-rhel-8]# systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
   Loaded: loaded (/etc/systemd/system/wazuh-agent.service; enabled; vendor preset: disabled)
   Active: inactive (dead)
[root@manager wazuh-3309-fix-rhel-8]# 
```
- [x] Centos 7 sources compilation and Red Hat 8 installation
```
[root@managerrhel8 wazuh-3309-fix-rhel-8]# systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
   Loaded: loaded (/usr/lib/systemd/system/wazuh-agent.service; enabled; vendor preset: disabled)
   Active: inactive (dead)
```
- [x] Centos 7 sources compilation and Oracle Linux 7 installation
```
[root@oraclelinux7 wazuh-3309-fix-rhel-8]# systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
   Loaded: loaded (/etc/systemd/system/wazuh-agent.service; enabled; vendor preset: disabled)
   Active: inactive (dead)
```
- [x] Oracle Linux 8  sources compilation and Oracle Linux 8 installation
```
[root@localhost ~]# systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
   Loaded: loaded (/etc/systemd/system/wazuh-agent.service; enabled; vendor preset: disabled)
   Active: active (running) since Fri 2019-05-31 05:58:24 EDT; 23min ago
  Process: 736 ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-control start (code=exited, status=0/SUCCESS)
    Tasks: 23 (limit: 24003)
   Memory: 16.4M
   CGroup: /system.slice/wazuh-agent.service
           ├─794 /var/ossec/bin/ossec-execd
           ├─799 /var/ossec/bin/ossec-agentd
           ├─808 /var/ossec/bin/ossec-syscheckd
           ├─814 /var/ossec/bin/ossec-logcollector
           └─817 /var/ossec/bin/wazuh-modulesd

May 31 05:58:22 localhost.localdomain env[736]: Deleting PID file '/var/ossec/var/run/ossec-logcollector-31688.pid' not used...
May 31 05:58:22 localhost.localdomain env[736]: Deleting PID file '/var/ossec/var/run/ossec-syscheckd-31683.pid' not used...
May 31 05:58:22 localhost.localdomain env[736]: Deleting PID file '/var/ossec/var/run/ossec-agentd-31677.pid' not used...
May 31 05:58:22 localhost.localdomain env[736]: Deleting PID file '/var/ossec/var/run/ossec-execd-31671.pid' not used...
May 31 05:58:22 localhost.localdomain env[736]: Started ossec-execd...
May 31 05:58:22 localhost.localdomain env[736]: Started ossec-agentd...
May 31 05:58:22 localhost.localdomain env[736]: Started ossec-syscheckd...
May 31 05:58:22 localhost.localdomain env[736]: Started ossec-logcollector...
May 31 05:58:22 localhost.localdomain env[736]: Started wazuh-modulesd...
May 31 05:58:24 localhost.localdomain systemd[1]: Started Wazuh agent.
```
- [x] Upgrade from RHEL 7 to RHEL 8
I installed a wazuh-agent 3.9.2 with this modification in RHEL 7. I upgraded to RHEL 8 and the service still working: 
```
[root@localhost vagrant]# systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
   Loaded: loaded (/etc/systemd/system/wazuh-agent.service; enabled; vendor preset: disabled)
   Active: active (running) since Fri 2019-05-31 13:46:11 UTC; 2min 12s ago
    Tasks: 25 (limit: 5079)
   Memory: 506.0M
   CGroup: /system.slice/wazuh-agent.service
           ├─820 /var/ossec/bin/ossec-execd
           ├─834 /var/ossec/bin/ossec-agentd
           ├─840 /var/ossec/bin/ossec-syscheckd
           ├─844 /var/ossec/bin/ossec-logcollector
           └─854 /var/ossec/bin/wazuh-modulesd

May 31 13:46:08 localhost.localdomain systemd[1]: Starting Wazuh agent...
May 31 13:46:09 localhost.localdomain env[713]: Starting Wazuh v3.9.2...
May 31 13:46:09 localhost.localdomain env[713]: Started ossec-execd...
May 31 13:46:09 localhost.localdomain env[713]: Started ossec-agentd...
May 31 13:46:09 localhost.localdomain env[713]: Started ossec-syscheckd...
May 31 13:46:09 localhost.localdomain env[713]: Started ossec-logcollector...
May 31 13:46:09 localhost.localdomain env[713]: Started wazuh-modulesd...
May 31 13:46:11 localhost.localdomain env[713]: Completed.
May 31 13:46:11 localhost.localdomain systemd[1]: Started Wazuh agent.

```
The RHEL upgrades preserves the Wazuh services. After check it, I uninstalled wazuh-agent and tried to install it again (3.9.1 version without fix): 
```
[root@localhost vagrant]# rpm -ivh https://packages.wazuh.com/3.x/yum/wazuh-agent-3.9.1-1.x86_64.rpm
Retrieving https://packages.wazuh.com/3.x/yum/wazuh-agent-3.9.1-1.x86_64.rpm
warning: /var/tmp/rpm-tmp.jUdW6a: Header V4 RSA/SHA1 Signature, key ID 29111145: NOKEY
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-3.9.1-1              ################################# [100%]
[root@localhost vagrant]# vi /var/ossec/etc/ossec.conf
[root@localhost vagrant]# /var/ossec/bin/agent-auth -m 172.16.1.2
2019/05/31 13:53:05 agent-auth: INFO: Started (pid: 9769).
2019/05/31 13:53:05 agent-auth: INFO: No authentication password provided.
2019/05/31 13:53:05 agent-auth: INFO: Connected to 172.16.1.2:1515
2019/05/31 13:53:05 agent-auth: INFO: Using agent name as: localhost.localdomain
2019/05/31 13:53:05 agent-auth: INFO: Send request to manager. Waiting for reply.
2019/05/31 13:53:05 agent-auth: INFO: Received response with agent key
2019/05/31 13:53:05 agent-auth: INFO: Valid key created. Finished.
2019/05/31 13:53:05 agent-auth: INFO: Connection closed.
[root@localhost vagrant]# systemctl restart wazuh-agent
[root@localhost vagrant]# systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
   Loaded: loaded (/etc/systemd/system/wazuh-agent.service; enabled; vendor preset: disabled)
   Active: active (running) since Fri 2019-05-31 13:53:10 UTC; 15s ago
  Process: 9772 ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-control start (code=exited, status=0/SUCCESS)
    Tasks: 24 (limit: 5079)
   Memory: 8.6M
   CGroup: /system.slice/wazuh-agent.service
           ├─9800 /var/ossec/bin/ossec-execd
           ├─9805 /var/ossec/bin/ossec-agentd
           ├─9813 /var/ossec/bin/ossec-syscheckd
           ├─9818 /var/ossec/bin/ossec-logcollector
           └─9821 /var/ossec/bin/wazuh-modulesd

May 31 13:53:07 localhost.localdomain systemd[1]: Starting Wazuh agent...
May 31 13:53:07 localhost.localdomain env[9772]: Starting Wazuh v3.9.1...
May 31 13:53:07 localhost.localdomain env[9772]: Started ossec-execd...
May 31 13:53:08 localhost.localdomain env[9772]: Started ossec-agentd...
May 31 13:53:08 localhost.localdomain env[9772]: Started ossec-syscheckd...
May 31 13:53:08 localhost.localdomain env[9772]: Started ossec-logcollector...
May 31 13:53:08 localhost.localdomain env[9772]: Started wazuh-modulesd...
May 31 13:53:10 localhost.localdomain env[9772]: Completed.
May 31 13:53:10 localhost.localdomain systemd[1]: Started Wazuh agent.
[root@localhost vagrant]# cat /etc/redhat-release 
Red Hat Enterprise Linux release 8.0 (Ootpa)
```
- [X] Linux Wazuh Agent compilation
- [X] Linux Wazuh Manager compilation
- [X] Windows Wazuh Agent compilation
- [X] Source installation
- [X] Package installation
- [ ] Source upgrade - Not available
- [X] Package upgrade
- [X] Retrocompatibility with older Wazuh versions
- [X] Working on cluster environments
 