### PR TITLE
Fix SIGABORTED and SEGFAULT at execd upgrading an agent by WPK while auto-restarting

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2069,6 +2069,20 @@ class Agent:
         wpk_file_size = stat("{0}/var/upgrade/{1}".format(common.ossec_path, wpk_file)).st_size
         if debug:
             print("Upgrade PKG: {0} ({1} KB)".format(wpk_file, wpk_file_size/1024))
+
+        # Sending reset lock timeout
+        s = OssecSocket(common.REQUEST_SOCKET)
+        msg = "{0} com lock_restart {1}".format(str(self.id).zfill(3), str(rl_timeout))
+        s.send(msg.encode())
+        if debug:
+            print("MSG SENT: {0}".format(str(msg)))
+        data = s.receive().decode()
+        s.close()
+        if debug:
+            print("RESPONSE: {0}".format(data))
+        if not data.startswith('ok'):
+            raise WazuhException(1715, data.replace("err ",""))
+
         # Open file on agent
         s = OssecSocket(common.REQUEST_SOCKET)
         msg = "{0} com open wb {1}".format(str(self.id).zfill(3), wpk_file)
@@ -2309,6 +2323,19 @@ class Agent:
         if debug:
             print("Custom WPK file: {0} ({1} KB)".format(wpk_file, wpk_file_size/1024))
 
+        # Sending reset lock timeout
+        s = OssecSocket(common.REQUEST_SOCKET)
+        msg = "{0} com lock_restart {1}".format(str(self.id).zfill(3), str(rl_timeout))
+        s.send(msg.encode())
+        if debug:
+            print("MSG SENT: {0}".format(str(msg)))
+        data = s.receive().decode()
+        s.close()
+        if debug:
+            print("RESPONSE: {0}".format(data))
+        if not data.startswith('ok'):
+            raise WazuhException(1715, data.replace("err ",""))
+
         # Open file on agent
         s = OssecSocket(common.REQUEST_SOCKET)
         msg = "{0} com open wb {1}".format(str(self.id).zfill(3), wpk_file)
@@ -2335,19 +2362,6 @@ class Agent:
         if not data.startswith('ok'):
             raise WazuhException(1715, data.replace("err ",""))
 
-        # Sending reset lock timeout
-        s = OssecSocket(common.REQUEST_SOCKET)
-        msg = "{0} com lock_restart {1}".format(str(self.id).zfill(3), str(rl_timeout))
-        s.send(msg.encode())
-        if debug:
-            print("MSG SENT: {0}".format(str(msg)))
-        data = s.receive().decode()
-        s.close()
-        if debug:
-            print("RESPONSE: {0}".format(data))
-        if not data.startswith('ok'):
-            raise WazuhException(1715, data.replace("err ",""))
-
         # Sending file to agent
         if debug:
             print("Chunk size: {0} bytes".format(chunk_size))
@@ -2365,6 +2379,8 @@ class Agent:
                 s.send(msg.encode() + bytes_read)
                 data = s.receive().decode()
                 s.close()
+                if not data.startswith('ok'):
+                    raise WazuhException(1715, data.replace("err ",""))
                 bytes_read = file.read(chunk_size)
                 file_sha1.update(bytes_read)
                 if show_progress:

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -538,7 +538,8 @@ size_t wcom_restart(char ** output) {
 
         switch (fork()) {
             case -1:
-                merror("At WCOM upgrade_result: Cannot fork");
+                merror("At WCOM restart: Cannot fork");
+                os_strdup("err Cannot fork", *output);
             break;
             case 0:
                 sleep(1);

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -549,13 +549,12 @@ size_t wcom_restart(char ** output) {
 #else
         char exec_cm[] = {"\"" AR_BINDIR "/restart-ossec.cmd\" add \"-\" \"null\" \"(from_the_server) (no_rule_id)\""};
         ExecCmd_Win32(exec_cm);
-        if (!*output) os_strdup("ok ", *output);
 #endif
     } else {
         minfo(LOCK_RES, (int)lock);
-        os_strdup("not ok ", *output);
     }
 
+    if (!*output) os_strdup("ok ", *output);
     return strlen(*output);
 }
 

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -254,6 +254,11 @@ size_t wcom_write(const char *file_path, char *buffer, size_t length, char ** ou
     char final_path[PATH_MAX + 1];
 
     if (!*file.path) {
+        if (file_path) {
+            merror("At WCOM write: File not opened. Agent might have been auto-restarted during upgrade.");
+            os_strdup("err File not opened. Agent might have been auto-restarted during upgrade", *output);
+            return strlen(*output);
+        }
         merror("At WCOM write: No file is opened.");
         os_strdup("err No file opened", *output);
         return strlen(*output);

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -553,6 +553,7 @@ size_t wcom_restart(char ** output) {
 #endif
     } else {
         minfo(LOCK_RES, (int)lock);
+        os_strdup("not ok ", *output);
     }
 
     return strlen(*output);
@@ -702,10 +703,10 @@ void * wcom_main(__attribute__((unused)) void * arg) {
         default:
             length = wcom_dispatch(buffer, length, &response);
             OS_SendSecureTCP(peer, length, response);
-            free(response);
+            os_free(response);
             close(peer);
         }
-        free(buffer);
+        os_free(buffer);
     }
 
     mdebug1("Local server thread finished.");


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3227|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes a double free and a segmentation fault generated at OpenSUSE 42.3. The steps to reproduce it are explained at the issue; additionally, mention that this occurs when the lock is higher than 0, at this [function](https://github.com/wazuh/wazuh/blob/80b09587120ab673e3f7982c8aac8e5aac412359/src/os_execd/wcom.c#L523), to make this happen, try sending the WPK twice before auto-restarting.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

```
** Alert 1559293710.1677719: - wazuh,upgrade,
2019 May 31 11:08:30 misi->wazuh-upgrade
Rule: 217 (level 3) -> 'Custom installation started.'
wazuh: Custom installation on agent 004 (suse): started.
agent.id: 004
agent.name: suse
** Alert 1559293722.1677949: mail  - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,
2019 May 31 11:08:42 (suse) any->ossec
Rule: 503 (level 3) -> 'Ossec agent started.'
ossec: Agent started: 'suse->any'.
** Alert 1559293727.1679286: - wazuh,upgrade,upgrade_success,
2019 May 31 11:08:47 misi->wazuh-upgrade
Rule: 214 (level 3) -> 'Remote upgrade finished successfully.'
wazuh: Upgrade procedure on agent 004 (suse): succeeded. New version: Wazuh v3.8.3
agent.id: 004
agent.name: suse
agent.new_version: v3.8.3
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- Memory tests
  - [x] Valgrind report for affected components (`execd`)
```
==1338== HEAP SUMMARY:
==1338==     in use at exit: 1,052 bytes in 6 blocks
==1338==   total heap usage: 46,938 allocs, 46,932 frees, 886,609,794 bytes allocated
==1338== 
==1338== LEAK SUMMARY:
==1338==    definitely lost: 0 bytes in 0 blocks
==1338==    indirectly lost: 0 bytes in 0 blocks
==1338==      possibly lost: 272 bytes in 1 blocks
==1338==    still reachable: 780 bytes in 5 blocks
==1338==         suppressed: 0 bytes in 0 blocks
==1338== Rerun with --leak-check=full to see details of leaked memory
==1338== 
==1338== For counts of detected and suppressed errors, rerun with: -v
==1338== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
- Custom tests
  - [x] Sending WPK package while agent auto-restart works.
  - [x] Check that the WPK is correctly installed.
  - [x] Check the correct version of the agent.

Before upgrading:
```
# cat /etc/ossec-init.conf 
DIRECTORY="/var/ossec"
NAME="Wazuh"
VERSION="v3.8.3"
REVISION="3815"
DATE="Fri May 31 11:04:18 CEST 2019"
TYPE="agent"
```
After sending the WPK package.
```
# cat /etc/ossec-init.conf 
DIRECTORY="/var/ossec"
NAME="Wazuh"
VERSION="v3.9.1"
REVISION="3921"
DATE="Fri May 31 11:04:43 CEST 2019"
TYPE="agent"
```
  - [x] No `Broken pipe` error messages on the manager. If there are, they are due to stop sending the WPK package before it is finished.
  - [x] No `Could not auto-restart agent` error messages on the agent.
  - [x] No `Target 'com' refused connection` error messages on the agent.
  - [x] No `No file opened` messages on the agent.

This is the `agent_upgrade` output:
```
# /var/ossec/bin/agent_upgrade -a 004 -f wazuh_agent_v3.9.1_linux_x86_64.wpk -x upgrade.sh -d
Custom WPK file: wazuh_agent_v3.9.1_linux_x86_64.wpk (4496.46484375 KB)
MSG SENT: 004 com lock_restart 300
RESPONSE: ok 
MSG SENT: 004 com open wb wazuh_agent_v3.9.1_linux_x86_64.wpk
RESPONSE: ok 
Chunk size: 512 bytes
Error 1715: Error sending WPK file: File not opened. Agent might have been auto-restarted during upgrade
Traceback (most recent call last):
  File "/var/ossec/framework/scripts/agent_upgrade.py", line 170, in <module>
    main()
  File "/var/ossec/framework/scripts/agent_upgrade.py", line 95, in main
    rl_timeout=-1 if args.timeout == None else args.timeout)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.2-py3.7.egg/wazuh/agent.py", line 2413, in upgrade_custom
    sending_result = self._send_custom_wpk_file(file_path, debug, show_progress, chunk_size, rl_timeout)
  File "/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.9.2-py3.7.egg/wazuh/agent.py", line 2357, in _send_custom_wpk_file
    raise WazuhException(1715, data.replace("err ",""))
wazuh.exception.WazuhException: Error 1715 - Error sending WPK file: File not opened. Agent might have been auto-restarted during upgrade.
```
And the output at the agent side:
`2019/06/03 12:57:16 ossec-execd: ERROR: At WCOM write: File not opened. Agent might have been auto-restarted during upgrade.`
  - [x] Same tests for Ubuntu.
