### PR TITLE
Fix permissions after copying agent-groups to workers in cluster

### DIFF
--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -332,6 +332,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     with open(tmp_unmerged_path, 'wb') as f:
                         f.write(content)
                     os.chown(tmp_unmerged_path, common.ossec_uid, common.ossec_gid)
+                    os.chmod(tmp_unmerged_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
                     os.rename(tmp_unmerged_path, full_unmerged_name)
             else:
                 if not os.path.exists(os.path.dirname(full_filename_path)):
@@ -345,7 +346,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         for filetype, files in ko_files.items():
             if filetype == 'shared' or filetype == 'missing':
                 logger.debug("Received {} {} files to update from master.".format(len(ko_files[filetype]),
-                                                                                       filetype))
+                                                                                  filetype))
                 for filename, data in files.items():
                     try:
                         logger.debug2("Processing file {}".format(filename))


### PR DESCRIPTION
|Related issue|
|---|
|#3438|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The fix is the one proposed in the issue description. A new call to `os.chmod` sets the correct permissions when the worker processes the files received from the master.

## Tests

I have replicated the same steps described in the issue, this time with the expected result:

- Create a group
```
root@7a1e2bc9708a:/wazuh-api# curl -u foo:bar "http://localhost:55000/agents/groups/test" -XPUT
{"error":0,"data":"Group 'test' created."}
```
- Add an agent to the group
```
root@7a1e2bc9708a:/wazuh-api# curl -u foo:bar "http://localhost:55000/agents/001/group/test" -XPUT
{"error":0,"data":"Group 'test' added to agent '001'."}
```
- Check permissions on the rest of workers:
```
root@1fd2b8a8f564:/var/ossec/queue/agent-groups# ls -lrth
total 4.0K
-rw-rw---- 1 ossec ossec 8 May 31 13:19 001
```

<!--
At least, the following checks should be marked to accept the PR.
-->

- [x] Working on cluster environments
- [x] Check errors or warnings in cluster and ossec logs
