### PR TITLE
Let the sources installer support NetBSD

### DIFF
--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -51,6 +51,10 @@ else
         GROUPADD="/usr/bin/mkgroup"
         USERADD="/usr/sbin/useradd"
         OSMYSHELL="/bin/false"
+    elif [ "$UNAME" = "NetBSD" ]; then
+        GROUPADD="/usr/sbin/groupadd"
+        USERADD="/usr/sbin/useradd"
+        OSMYSHELL="/sbin/nologin"
     else
     # All current linux distributions should support system accounts for
     # users/groups. If not, leave the GROUPADD/USERADD as it was before
@@ -88,7 +92,7 @@ else
 
     for U in ${NEWUSERS}; do
         if ! grep "^${U}" /etc/passwd > /dev/null 2>&1; then
-            if [ "$UNAME" = "OpenBSD" -o "$UNAME" = "SunOS" -o "$UNAME" = "HP-UX" ]; then
+            if [ "$UNAME" = "OpenBSD" -o "$UNAME" = "SunOS" -o "$UNAME" = "HP-UX" -o "$UNAME" = "NetBSD" ]; then
                 ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
             elif [ "$UNAME" = "AIX" ]; then
                 GID=$(cat /etc/group | grep ossec| cut -d':' -f 3)

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -207,7 +207,7 @@ InstallOpenSCAPFiles()
         OPENSCAP_FILES=$(cat .$OPENSCAP_FILES_PATH)
         for file in $OPENSCAP_FILES; do
             if [ -f "../wodles/oscap/content/$file" ]; then
-                ${INSTALL} -v -m 0640 -o root -g ${OSSEC_GROUP} ../wodles/oscap/content/$file ${PREFIX}/wodles/oscap/content
+                ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../wodles/oscap/content/$file ${PREFIX}/wodles/oscap/content
             else
                 echo "ERROR: SCAP security policy not found: ./wodles/oscap/content/$file"
             fi
@@ -235,7 +235,7 @@ InstallSecurityConfigurationAssessmentFiles()
         CONFIGURATION_ASSESSMENT_FILES=$(cat .$CONFIGURATION_ASSESSMENT_FILES_PATH)
         for file in $CONFIGURATION_ASSESSMENT_FILES; do
             if [ -f "../etc/sca/$file" ]; then
-                ${INSTALL} -v -m 0640 -o root -g ${OSSEC_GROUP} ../etc/sca/$file ${PREFIX}/ruleset/sca
+                ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../etc/sca/$file ${PREFIX}/ruleset/sca
             else
                 echo "ERROR: SCA policy not found: ./etc/sca/$file"
             fi


### PR DESCRIPTION
|Related issue|
|---|
|#3443|

## Description

This PR aims to apply the sources installer the changes needed to support agents on NetBSD:

1. Let the installer use the BSD syntax of the `useradd` command.
2. Remove the verbose mode from the `install` command, applying to the SCA files.

## Logs

This PR will remove the errors reported in #3443 during the installation.

## Tests

- [X] Sources installation of an agent on Linux.
- [X] Sources installation of a manager on Linux.
- [X] Sources installation of an agent on NetBSD 8.0.

### Remarks

1. Since no code belonging to the core has been modified, performance tests don't apply.
2. The syntax for `useradd` for NetBSD should not impact other platforms.
3. Removing `-v` from `install` should not produce any issue in the installation procedure.