### PR TITLE
Revert changes introduced in #3279

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1157,7 +1157,7 @@ class Agent:
 
 
     @staticmethod
-    def insert_agent(name, id, key, ip='any', force=0):
+    def insert_agent(name, id, key, ip='any', force=-1):
         """
         Create a new agent providing the id, name, ip and key to the Manager.
 


### PR DESCRIPTION
Hi team,

This issue reverts changes made in #3279. Issue [#318](https://github.com/wazuh/wazuh-api/issues/318) solves the described error but has secondary effects which causes new errors in `mocha` tests because the fix made in this PR enables `force` parameter in all requests.

Before applying PR #3279, this was the output of executing `test_agent_2.js` (it is the same in this PR):

```javascript
mocha test/test_agents_2.js


  Agents
    PUT/agents/:agent_name
      ✓ Request (310ms)
      ✓ Errors: Name already present (280ms)
      ✓ Params: Bad agent name
    DELETE/agents/:agent_id
      ✓ Request (260ms)
      ✓ Errors: ID is not present (295ms)
      ✓ Params: Bad agent id
    POST/agents
      Any
        ✓ Request (355ms)
        ✓ Check key (281ms)
        ✓ Errors: Name already present (258ms)
        ✓ Filters: Missing field name
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (290ms)
        ✓ Errors: Duplicated IP (266ms)
      IP
        ✓ Request (295ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2
    POST/agents/insert
      Any
        ✓ Request (295ms)
        ✓ Errors: Name already present (266ms)
        1) Errors: ID already present
        ✓ Errors: Invalid key (293ms)
        ✓ Filters: Missing fields
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (274ms)
        ✓ Errors: Duplicated IP (256ms)
      IP
        ✓ Request (262ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2


  26 passing (8s)
  1 failing

```
After applying PR #3279:
```javascript
mocha test/test_agents_2.js


  Agents
    PUT/agents/:agent_name
      ✓ Request (363ms)
      ✓ Errors: Name already present (287ms)
      ✓ Params: Bad agent name
    DELETE/agents/:agent_id
      ✓ Request (256ms)
      ✓ Errors: ID is not present (284ms)
      ✓ Params: Bad agent id
    POST/agents
      Any
        ✓ Request (286ms)
        ✓ Check key (284ms)
        ✓ Errors: Name already present (255ms)
        ✓ Filters: Missing field name
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (298ms)
        ✓ Errors: Duplicated IP (280ms)
      IP
        ✓ Request (304ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2
    POST/agents/insert
      Any
        ✓ Request (289ms)
        1) Errors: Name already present
        2) Errors: ID already present
        ✓ Errors: Invalid key (259ms)
        ✓ Filters: Missing fields
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (285ms)
        3) Errors: Duplicated IP
      IP
        ✓ Request (277ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2


  24 passing (8s)
  3 failing

  1) Agents
       POST/agents/insert
         Any
           Errors: Name already present:
     Uncaught AssertionError: expected Object {
  error: 0,
  data: Object {
    id: '751',
    key: 'NzUxIE5ld0FnZW50UG9zdEluc2VydCBhbnkgMWFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGk2NA=='
  }
} to have property message
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:484:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /shared/wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /shared/wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)

  2) Agents
       POST/agents/insert
         Any
           Errors: ID already present:
     Uncaught AssertionError: expected Object {
  error: 0,
  data: Object {
    id: '750',
    key: 'NzUwIE5ld0FnZW50UG9zdEluc2VydCBhbnkgMWFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGk2NA=='
  }
} to have property message
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:503:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /shared/wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /shared/wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)

  3) Agents
       POST/agents/insert
         IP Automatic
           Errors: Duplicated IP:
     Uncaught AssertionError: expected Object {
  error: 0,
  data: Object {
    id: '756',
    key: 'NzU2IE5ld0FnZW50UG9zdEluc2VydDMgMTI3LjAuMC4xIDFhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpNjQ='
  }
} to have property message
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:615:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /shared/wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /shared/wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)
```

Issue #3431 includes more details about errors inserting agents.

Best regards,

Demetrio.

