### PR TITLE
Avoid processing null elements of an array in Vulnerability Detector

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -320,7 +320,7 @@
 #define VU_NO_SYSC_SCANS            "(5434): No package inventory found for agent %s, so their vulnerabilities will not be checked."
 #define VU_GLOBALDB_OPEN_ERROR      "(5435): Could not open global_db."
 #define VU_REPORT_ERROR             "(5436): The agent %s vulnerabilities could not be reported."
-#define VU_UPDATE_RETRY             "(5437): Failed when updating '%s %s' database. Retrying in %lu seconds..."
+#define VU_UPDATE_RETRY             "(5437): Failed when updating %s %s database. Retrying in %lu seconds..."
 #define VU_API_REQ_INV              "(5489): There was no valid response to '%s' after %d attempts."
 #define VU_PARSED_FEED_ERROR        "(5491): The %s feed couldn't be parsed."
 #define VU_VER_EXTRACT_ERROR        "(5493): The version of '%s' could not be extracted."
@@ -329,6 +329,7 @@
 #define VU_NULL_AGENT_IP            "(5498): The agent database returned a null registration IP address. Skipping agent %s."
 #define VU_API_REQ_INV_NEW          "(5499): There was no valid response to '%s' after %d attempts. Trying the next page..."
 #define VU_UNC_SEVERITY             "(5500): Uncontrolled severity has been found: '%s'."
+#define VU_FEED_NODE_NULL_ELM       "(5506): Null elements needing value have been found in a node of the feed. The update will not continue."
 
 
 /* File integrity monitoring error messages*/

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -1231,7 +1231,7 @@ char *wm_vuldet_extract_advisories(cJSON *advisories) {
     size_t size;
 
     if (advisories) {
-        for (; advisories; advisories = advisories->next) {
+        for (; advisories && advisories->valuestring; advisories = advisories->next) {
             if (!advisories_str) {
                 if (w_strdup(advisories->valuestring, advisories_str)) {
                     return NULL;
@@ -2154,7 +2154,7 @@ int wm_vuldet_json_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities
                 w_strdup(tmp_cwe, parsed_vulnerabilities->info_cves->cwe);
 
                 // Set the vulnerability - package relationship
-                for (; tmp_affected_packages; tmp_affected_packages = tmp_affected_packages->next) {
+                for (; tmp_affected_packages && tmp_affected_packages->valuestring; tmp_affected_packages = tmp_affected_packages->next) {
                     wm_vuldet_add_rvulnerability(parsed_vulnerabilities);
                     w_strdup(tmp_cve, parsed_vulnerabilities->rh_vulnerabilities->cve_id);
                     if (!wm_vuldet_decode_package_version(tmp_affected_packages->valuestring,

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -2009,11 +2009,11 @@ int wm_vuldet_run_update(update_node *upd, const char *dist_tag, const char *dis
             if (!upd->attempted) {
                 upd->last_update = time(NULL) - upd->interval + WM_VULNDETECTOR_RETRY_UPDATE;
                 upd->attempted = 1;
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version, (long unsigned)WM_VULNDETECTOR_RETRY_UPDATE);
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version ? upd->version : "feed", (long unsigned)WM_VULNDETECTOR_RETRY_UPDATE);
             } else {
                 upd->last_update = time(NULL);
                 upd->attempted = 0;
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version, upd->interval);
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version ? upd->version : "feed", upd->interval);
             }
             return OS_INVALID;
         } else {
@@ -2133,6 +2133,7 @@ int wm_vuldet_json_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities
             }
 
             if(!tmp_bugzilla_description || !tmp_cve) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FEED_NODE_NULL_ELM);
                 return 1;
             }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3456|

## Description

This PR prevents the bug described in the issue, and also protects it from happening in the other string array that we can find in a vulnerability node: `affected_packages`. 

However, a null element in `affected_packages` does not produce a segmentation fault as it does if this element is found in `advisories`.

The fix consists of adding a null check on the elements of the array.

## Configuration options

Considering that this error is not replicable with the currently hosted feed, the configuration must involve an offline update. We can use `url` or `path` for this.

``` XML
    <feed name="redhat">
      <disabled>no</disabled>
      <path>/local_path/feed.json</path>
      <update_from_year>2010</update_from_year>
      <update_interval>1m</update_interval>
    </feed>
```
To replicate it, we have to download a feed and modify one of its vulnerabilities by adding `null` value to an array of strings like:

``` JSON
    "advisories": [
      "RHSA-2014:0429",
      "RHSA-2014:0452",
      "RHSA-2014:0401",
      "RHSA-2014:0253",
      "RHSA-2014:0252",
      "RHSA-2015:1009",
      "RHSA-2014:0525",
      "RHSA-2014:0526",
      "RHSA-2014:0527",
      "RHSA-2014:0528",
      "RHSA-2014:0400",
      null
    ]
```

## Tests

- [x] Configuration of null elements in the rest of the vulnerability variables (previously controlled).
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
