### PR TITLE
Fix descriptor leak appearing in Modulesd on subprocess execution error

### DIFF
--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -301,7 +301,13 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
 
         // Error
 
-        merror("fork()");
+        merror("Cannot run a subprocess: %s (%d)", strerror(errno), errno);
+
+        if (output) {
+            close(pipe_fd[0]);
+            close(pipe_fd[1]);
+        }
+
         return -1;
 
     case 0:
@@ -381,6 +387,12 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             if (pthread_create(&thread, NULL, reader, &tinfo)) {
                 merror("Couldn't create reading thread.");
                 w_mutex_unlock(&tinfo.mutex);
+
+                if (output) {
+                    close(pipe_fd[0]);
+                    close(pipe_fd[1]);
+                }
+
                 return -1;
             }
 
@@ -397,12 +409,10 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             case ETIMEDOUT:
                 retval = WM_ERROR_TIMEOUT;
                 kill(-pid, SIGTERM);
-                pthread_cancel(thread);
                 break;
 
             default:
                 kill(-pid, SIGTERM);
-                pthread_cancel(thread);
             }
             // Wait for thread
 


### PR DESCRIPTION
@BraulioV and @wazuh/cicd discovered a memory leak in _wazuh-modulesd_:

![slack-imgs](https://user-images.githubusercontent.com/10536251/58972610-3d178b80-87be-11e9-88d5-62646db32db2.png)

This issue may be due to three conditions:

1. If the fork operation failed.
2. If the thread creation failed.
3. On timeout, the thread that should close the descriptor was killed.

### Modules affected by this issue

- OpenSCAP
- CIS-CAT
- Command
- Azure
- SCA
- AWS
- Docker

## How to reproduce

1. Set up a module with a short timeout. For instance, a command:
```xml
<wodle name="command">
  <tag>sleep_test</tag>
  <timeout>1</timeout>
  <command>sleep 10</command>
  <interval>1</interval>
</wodle>
```

This log appears in _ossec.log_:
> 2019/06/05 16:38:49 wazuh-modulesd:command: ERROR: sleep_test: Timeout overtaken. You can modify your command timeout at ossec.conf. Exiting...

This is the output of `lsof` for _wazuh-modulesd_:
```
COMMAND    PID USER   FD   TYPE             DEVICE SIZE/OFF   NODE NAME
wazuh-mod 8305 root  cwd    DIR                8,1     4096 257130 /var/ossec
wazuh-mod 8305 root  rtd    DIR                8,1     4096      2 /
wazuh-mod 8305 root  txt    REG                8,1  1689416 257145 /var/ossec/bin/wazuh-modulesd
wazuh-mod 8305 root  mem    REG                8,1   100736  71206 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
wazuh-mod 8305 root  mem    REG                8,1    51672   3281 /usr/lib/x86_64-linux-gnu/libnss_files-2.29.so
wazuh-mod 8305 root  mem    REG                8,1    18656   3274 /usr/lib/x86_64-linux-gnu/libdl-2.29.so
wazuh-mod 8305 root  mem    REG                8,1  2000480   3272 /usr/lib/x86_64-linux-gnu/libc-2.29.so
wazuh-mod 8305 root  mem    REG                8,1   149840   4798 /usr/lib/x86_64-linux-gnu/libpthread-2.29.so
wazuh-mod 8305 root  mem    REG                8,1    39880   4800 /usr/lib/x86_64-linux-gnu/librt-2.29.so
wazuh-mod 8305 root  mem    REG                8,1  7121744 257138 /var/ossec/lib/libwazuhext.so
wazuh-mod 8305 root  mem    REG                8,1   179032   3268 /usr/lib/x86_64-linux-gnu/ld-2.29.so
wazuh-mod 8305 root    0u   CHR              136,1      0t0      4 /dev/pts/1
wazuh-mod 8305 root    1u   CHR              136,1      0t0      4 /dev/pts/1
wazuh-mod 8305 root    2u   CHR              136,1      0t0      4 /dev/pts/1
wazuh-mod 8305 root    3u  unix 0xffff951f232af000      0t0 548265 type=DGRAM
wazuh-mod 8305 root    4u  unix 0xffff951f61afa800      0t0 547570 type=DGRAM
wazuh-mod 8305 root    5r  FIFO               0,12      0t0 548264 pipe
wazuh-mod 8305 root    6r   CHR                1,9      0t0     11 /dev/urandom
wazuh-mod 8305 root    7r  FIFO               0,12      0t0 547571 pipe
wazuh-mod 8305 root    8u  unix 0xffff951f61afbc00      0t0 547572 type=DGRAM
wazuh-mod 8305 root    9u  unix 0xffff951f232ad000      0t0 548266 type=DGRAM
wazuh-mod 8305 root   10r  FIFO               0,12      0t0 549814 pipe
wazuh-mod 8305 root   11u  unix 0xffff951f61af8c00      0t0 547573 /var/ossec/queue/ossec/wmodules type=STREAM
wazuh-mod 8305 root   12r  FIFO               0,12      0t0 549407 pipe
wazuh-mod 8305 root   13u  unix 0xffff951f61afb000      0t0 547574 /var/ossec/queue/ossec/control type=STREAM
wazuh-mod 8305 root   14u  unix 0xffff951f61af9c00      0t0 547575 /var/ossec/queue/alerts/cfgaq type=DGRAM
wazuh-mod 8305 root   15r  FIFO               0,12      0t0 549089 pipe
wazuh-mod 8305 root   16r   REG                8,1      354 100973 /var/log/osquery/osqueryd.results.log
wazuh-mod 8305 root   17r  FIFO               0,12      0t0 549773 pipe
wazuh-mod 8305 root   18r  FIFO               0,12      0t0 549410 pipe
wazuh-mod 8305 root   19r  FIFO               0,12      0t0 549412 pipe
wazuh-mod 8305 root   20r  FIFO               0,12      0t0 549413 pipe
wazuh-mod 8305 root   21r  FIFO               0,12      0t0 549414 pipe
wazuh-mod 8305 root   22r  FIFO               0,12      0t0 549467 pipe
wazuh-mod 8305 root   23r  FIFO               0,12      0t0 549509 pipe
wazuh-mod 8305 root   24r  FIFO               0,12      0t0 549571 pipe
wazuh-mod 8305 root   25r  FIFO               0,12      0t0 549647 pipe
wazuh-mod 8305 root   26r  FIFO               0,12      0t0 549732 pipe
wazuh-mod 8305 root   27r  FIFO               0,12      0t0 549812 pipe
wazuh-mod 8305 root   28r  FIFO               0,12      0t0 549815 pipe
wazuh-mod 8305 root   29r  FIFO               0,12      0t0 549816 pipe
wazuh-mod 8305 root   30r  FIFO               0,12      0t0 549817 pipe
wazuh-mod 8305 root   31r  FIFO               0,12      0t0 549820 pipe
wazuh-mod 8305 root   32r  FIFO               0,12      0t0 549822 pipe
wazuh-mod 8305 root   33r  FIFO               0,12      0t0 549828 pipe
wazuh-mod 8305 root   34r  FIFO               0,12      0t0 549829 pipe
wazuh-mod 8305 root   35r  FIFO               0,12      0t0 549830 pipe
wazuh-mod 8305 root   36r  FIFO               0,12      0t0 549831 pipe
wazuh-mod 8305 root   37r  FIFO               0,12      0t0 549833 pipe
wazuh-mod 8305 root   38r  FIFO               0,12      0t0 549834 pipe
wazuh-mod 8305 root   39r  FIFO               0,12      0t0 549835 pipe
wazuh-mod 8305 root   40r  FIFO               0,12      0t0 549836 pipe
wazuh-mod 8305 root   41r  FIFO               0,12      0t0 549837 pipe
wazuh-mod 8305 root   42r  FIFO               0,12      0t0 549839 pipe
wazuh-mod 8305 root   43r  FIFO               0,12      0t0 549845 pipe
wazuh-mod 8305 root   44r  FIFO               0,12      0t0 549846 pipe
wazuh-mod 8305 root   45r  FIFO               0,12      0t0 549847 pipe
wazuh-mod 8305 root   46r  FIFO               0,12      0t0 549848 pipe
wazuh-mod 8305 root   47r  FIFO               0,12      0t0 549850 pipe
wazuh-mod 8305 root   48r  FIFO               0,12      0t0 549851 pipe
wazuh-mod 8305 root   49r  FIFO               0,12      0t0 549852 pipe
wazuh-mod 8305 root   50r  FIFO               0,12      0t0 549853 pipe
wazuh-mod 8305 root   51r  FIFO               0,12      0t0 549854 pipe
wazuh-mod 8305 root   52r  FIFO               0,12      0t0 549861 pipe
wazuh-mod 8305 root   53r  FIFO               0,12      0t0 549862 pipe
wazuh-mod 8305 root   54r  FIFO               0,12      0t0 549863 pipe
wazuh-mod 8305 root   55r  FIFO               0,12      0t0 549864 pipe
wazuh-mod 8305 root   56r  FIFO               0,12      0t0 549865 pipe
wazuh-mod 8305 root   57r  FIFO               0,12      0t0 549867 pipe
wazuh-mod 8305 root   58r  FIFO               0,12      0t0 549868 pipe
wazuh-mod 8305 root   59r  FIFO               0,12      0t0 549869 pipe
```

### Impact

This issue and the corresponding fix affect to the mentioned components running on UNIX. 

## Tests

- [X] Compilation on Linux
- Memory tests
  - [X] Valgrind report for affected components
```
==11107== HEAP SUMMARY:
==11107==     in use at exit: 268,985 bytes in 3,897 blocks
==11107==   total heap usage: 127,393 allocs, 123,496 frees, 11,123,946 bytes allocated
==11107==
==11107== 272 bytes in 1 blocks are possibly lost in loss record 49 of 100
==11107==    at 0x483AB35: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11107==    by 0x4013706: allocate_dtv (dl-tls.c:286)
==11107==    by 0x4013706: _dl_allocate_tls (dl-tls.c:532)
==11107==    by 0x4E78DA9: allocate_stack (allocatestack.c:621)
==11107==    by 0x4E78DA9: pthread_create@@GLIBC_2.2.5 (pthread_create.c:669)
==11107==    by 0x117C3C: CreateThreadJoinable (pthreads_op.c:47)
==11107==    by 0x117CE3: CreateThread (pthreads_op.c:62)
==11107==    by 0x10F49D: main (main.c:102)
==11107==
==11107== 272 bytes in 1 blocks are possibly lost in loss record 50 of 100
==11107==    at 0x483AB35: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11107==    by 0x4013706: allocate_dtv (dl-tls.c:286)
==11107==    by 0x4013706: _dl_allocate_tls (dl-tls.c:532)
==11107==    by 0x4E78DA9: allocate_stack (allocatestack.c:621)
==11107==    by 0x4E78DA9: pthread_create@@GLIBC_2.2.5 (pthread_create.c:669)
==11107==    by 0x14AF07: wm_osquery_monitor_main (wm_osquery_monitor.c:610)
==11107==    by 0x4E78181: start_thread (pthread_create.c:486)
==11107==    by 0x4FADB1E: clone (clone.S:95)
==11107==
==11107== 272 bytes in 1 blocks are possibly lost in loss record 51 of 100
==11107==    at 0x483AB35: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11107==    by 0x4013706: allocate_dtv (dl-tls.c:286)
==11107==    by 0x4013706: _dl_allocate_tls (dl-tls.c:532)
==11107==    by 0x4E78DA9: allocate_stack (allocatestack.c:621)
==11107==    by 0x4E78DA9: pthread_create@@GLIBC_2.2.5 (pthread_create.c:669)
==11107==    by 0x117C3C: CreateThreadJoinable (pthreads_op.c:47)
==11107==    by 0x117CE3: CreateThread (pthreads_op.c:62)
==11107==    by 0x14E2D0: wm_sca_main (wm_sca.c:209)
==11107==    by 0x4E78181: start_thread (pthread_create.c:486)
==11107==    by 0x4FADB1E: clone (clone.S:95)
==11107==
==11107== 272 bytes in 1 blocks are possibly lost in loss record 52 of 100
==11107==    at 0x483AB35: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11107==    by 0x4013706: allocate_dtv (dl-tls.c:286)
==11107==    by 0x4013706: _dl_allocate_tls (dl-tls.c:532)
==11107==    by 0x4E78DA9: allocate_stack (allocatestack.c:621)
==11107==    by 0x4E78DA9: pthread_create@@GLIBC_2.2.5 (pthread_create.c:669)
==11107==    by 0x117C3C: CreateThreadJoinable (pthreads_op.c:47)
==11107==    by 0x117CE3: CreateThread (pthreads_op.c:62)
==11107==    by 0x14E2F1: wm_sca_main (wm_sca.c:210)
==11107==    by 0x4E78181: start_thread (pthread_create.c:486)
==11107==    by 0x4FADB1E: clone (clone.S:95)
==11107==
==11107== 2,176 bytes in 8 blocks are possibly lost in loss record 82 of 100
==11107==    at 0x483AB35: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11107==    by 0x4013706: allocate_dtv (dl-tls.c:286)
==11107==    by 0x4013706: _dl_allocate_tls (dl-tls.c:532)
==11107==    by 0x4E78DA9: allocate_stack (allocatestack.c:621)
==11107==    by 0x4E78DA9: pthread_create@@GLIBC_2.2.5 (pthread_create.c:669)
==11107==    by 0x117C3C: CreateThreadJoinable (pthreads_op.c:47)
==11107==    by 0x10F3FC: main (main.c:95)
==11107==
==11107== LEAK SUMMARY:
==11107==    definitely lost: 0 bytes in 0 blocks
==11107==    indirectly lost: 0 bytes in 0 blocks
==11107==      possibly lost: 3,264 bytes in 12 blocks
==11107==    still reachable: 265,721 bytes in 3,885 blocks
==11107==         suppressed: 0 bytes in 0 blocks
==11107== Reachable blocks (those to which a pointer was found) are not shown.
==11107== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==11107==
==11107== For counts of detected and suppressed errors, rerun with: -v
==11107== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
```
- [X] Review logs syntax and correct language