### PR TITLE
Fix bad performance in distributed API

### DIFF
--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -276,7 +276,7 @@ def compress_files(name, list_path, cluster_control_json=None):
     return zip_file_path
 
 
-def decompress_files(zip_path, ko_files_name="cluster_control.json"):
+async def decompress_files(zip_path, ko_files_name="cluster_control.json"):
     ko_files = ""
     zip_dir = zip_path + 'dir'
     mkdir_with_mode(zip_dir)

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -190,7 +190,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             logger = self.task_loggers['Integrity']
             logger.info("Analyzing received files: Start.")
 
-            ko_files, zip_path = cluster.decompress_files(received_filename)
+            ko_files, zip_path = await cluster.decompress_files(received_filename)
             logger.info("Analyzing received files: Missing: {}. Shared: {}. Extra: {}. ExtraValid: {}".format(
                 len(ko_files['missing']), len(ko_files['shared']), len(ko_files['extra']), len(ko_files['extra_valid'])))
 


### PR DESCRIPTION

|Related issue|
|---|
|#3469|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The problem was caused by function `process_files_from_worker` called in line: https://github.com/wazuh/wazuh/blob/5add9c8476fa7514ece1bd07077d6f089b704250/framework/wazuh/cluster/master.py#L343

The whole function has been reviewed to find the best approach to break the synchronous tasks into smaller asynchronous 'chunks'. This way, the event loop gets more fine-grained tasks and the distributed API requests can be interleaved better with the slow and heavy agent-info files synchronization. This effect is especially noticeable in environments with a high penalization on disk I/O.

The main changes are:
- Convert `process_files_from_worker` function in `master.py` into an async
- Convert `update_file` function in `master.py` into an async in order to use `asyncio.sleep` in the for loop to release the event loop and allow other asynchronous tasks to be executed.
- Convert `decompress_files` into an async.

In order to better understand why the fix works, one needs to keep in mind the single threaded model behind 'asyncio' and the event loop. This is a good resource to learn more about it: https://realpython.com/async-io-python/

## Logs example
<!--
Paste here related logs and alerts
-->

Now the `cluster.log` shows the DAPI request interleaving with agent-info synchronization:
```
# Agent info synchro from worker 1
2019/06/05 16:34:24 wazuh-clusterd: DEBUG2: [Worker worker1] [Agent info] Receiving an old file (queue/agent-info/a820-any)
#####
2019/06/05 16:34:25 wazuh-clusterd: DEBUG: [Worker worker2] [Main] Command received: b'file_end'
2019/06/05 16:34:25 wazuh-clusterd: DEBUG: [Worker worker1] [Main] Command received: b'sync_i_w_m'
2019/06/05 16:34:25 wazuh-clusterd: DEBUG: [Worker worker1] [Main] Command received: b'sync_a_w_m_p'
2019/06/05 16:34:25 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Waiting to receive zip file from worker
2019/06/05 16:34:25 wazuh-clusterd: DEBUG: [Worker worker2] [Main] Command received: b'sync_a_w_m_e'
2019/06/05 16:34:25 wazuh-clusterd: DEBUG: [Worker worker1] [Main] Command received: b'new_file'
2019/06/05 16:34:26 wazuh-clusterd: DEBUG: [Worker worker2] [Agent info] Received file from worker: '/var/ossec/queue/cluster/worker2/worker2-1559752462.8213613-9977092013834181.zip'
2019/06/05 16:34:26 wazuh-clusterd: INFO: [Worker worker2] [Agent info] Analyzing worker files: Received 0 files to check.
2019/06/05 16:34:26 wazuh-clusterd: DEBUG: [Worker worker1] [Main] Command received: b'file_upd'
2019/06/05 16:34:26 wazuh-clusterd: DEBUG: [Master] [File integrity] Calculating
2019/06/05 16:34:26 wazuh-clusterd: DEBUG: [Master] [File integrity] Calculated.
2019/06/05 16:34:27 wazuh-clusterd: DEBUG: [Worker worker1] [Main] Command received: b'file_end'
2019/06/05 16:34:27 wazuh-clusterd: DEBUG: [Worker worker1] [Main] Command received: b'sync_i_w_m_e'

# cluster_control -l call...
2019/06/05 16:34:28 wazuh-clusterd: INFO: [Local 381899] [Main] Connection received in local server.
############
2019/06/05 16:34:28 wazuh-clusterd: DEBUG: [Worker worker1] [Integrity] Received file from worker: '/var/ossec/queue/cluster/worker1/worker1-1559752464.44066-5426953714779785.zip'
2019/06/05 16:34:28 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Analyzing worker integrity: Received 12 files to check.
2019/06/05 16:34:28 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Analyzing worker integrity: Files checked. There are no KO files.
2019/06/05 16:34:28 wazuh-clusterd: INFO: [Local 381899] [Main] Disconnected.
2019/06/05 16:34:29 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Finished integrity synchronization.
2019/06/05 16:34:30 wazuh-clusterd: DEBUG2: [Worker worker1] [Agent info] Receiving an old file (queue/agent-info/a874-any)
2019/06/05 16:34:31 wazuh-clusterd: DEBUG: [Worker worker2] [Main] Command received: b'sync_i_w_m_p'
2019/06/05 16:34:32 wazuh-clusterd: DEBUG: [Worker worker2] [Main] Command received: b'sync_i_w_m'
2019/06/05 16:34:32 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Waiting to receive zip file from worker
2019/06/05 16:34:32 wazuh-clusterd: DEBUG: [Worker worker2] [Main] Command received: b'new_file'
2019/06/05 16:34:32 wazuh-clusterd: DEBUG: [Worker worker3] [Main] Command received: b'sync_i_w_m_p'
2019/06/05 16:34:33 wazuh-clusterd: DEBUG: [Worker worker2] [Main] Command received: b'file_upd'
2019/06/05 16:34:33 wazuh-clusterd: DEBUG: [Worker worker3] [Main] Command received: b'sync_i_w_m'
2019/06/05 16:34:33 wazuh-clusterd: INFO: [Worker worker3] [Integrity] Waiting to receive zip file from worker
2019/06/05 16:34:33 wazuh-clusterd: DEBUG: [Worker worker3] [Main] Command received: b'new_file'
2019/06/05 16:34:33 wazuh-clusterd: DEBUG: [Worker worker3] [Main] Command received: b'sync_a_w_m_p'
2019/06/05 16:34:33 wazuh-clusterd: DEBUG: [Worker worker2] [Main] Command received: b'file_end'
2019/06/05 16:34:34 wazuh-clusterd: DEBUG: [Worker worker3] [Main] Command received: b'file_upd'
2019/06/05 16:34:34 wazuh-clusterd: DEBUG: [Worker worker3] [Main] Command received: b'sync_a_w_m'
2019/06/05 16:34:34 wazuh-clusterd: DEBUG: [Worker worker2] [Main] Command received: b'sync_i_w_m_e'
2019/06/05 16:34:34 wazuh-clusterd: INFO: [Worker worker3] [Agent info] Waiting to receive zip file from worker
2019/06/05 16:34:34 wazuh-clusterd: DEBUG: [Worker worker3] [Main] Command received: b'file_end'
2019/06/05 16:34:34 wazuh-clusterd: DEBUG: [Worker worker3] [Main] Command received: b'new_file'
2019/06/05 16:34:34 wazuh-clusterd: DEBUG: [Worker worker2] [Integrity] Received file from worker: '/var/ossec/queue/cluster/worker2/worker2-1559752471.5954356-8446102307979.zip'
2019/06/05 16:34:34 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Analyzing worker integrity: Received 12 files to check.
```

## Tests

Demonstrating it works is challenging since it depends a lot on how fast the `process_files_from_worker` is executed according to the environment. 

It has been tested with a local environment with more than 3000 agents and a cluster of 4 nodes (1 master and 3 workers). To simulate slow disk I/O, I have used `sleep` function to slower the execution.
Without the fix the output of cluster_control was an API timeout error. After the fix:
```
root@1026be6bf8dd:/# /var/ossec/bin/cluster_control -l
NAME         TYPE    VERSION  ADDRESS       
master-node  master  3.9.2    wazuh-master  
worker2      worker  3.9.2    172.19.0.3    
worker1      worker  3.9.2    172.19.0.4    
worker3      worker  3.9.2    172.19.0.5    
root@1026be6bf8dd:/# time /var/ossec/bin/cluster_control -l
NAME         TYPE    VERSION  ADDRESS       
master-node  master  3.9.2    wazuh-master  
worker2      worker  3.9.2    172.19.0.3    
worker1      worker  3.9.2    172.19.0.4    
worker3      worker  3.9.2    172.19.0.5    

real	0m1.069s
user	0m0.286s
sys	0m0.044s
```

`cluster.log` have been reviewed in masters and workers without any errors.