### PR TITLE
Clarified usage of NOPASS for agentless

### DIFF
--- a/src/agentlessd/scripts/register_host.sh
+++ b/src/agentlessd/scripts/register_host.sh
@@ -59,7 +59,7 @@ elif [ "x$1" = "xadd" ]; then
 
     # Check if the password was supplied
     if [ "x$3" = "x" ]; then
-        echo "Please provide password for host $2."
+        echo "Please provide password for host $2 ('NOPASS' for no password)."
         echo -n "Password: ";
         stty -echo
         read INPASS


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Agentless to a device without password (i.e. using ssh keys) is not documented. 
As can be seen in `ssh.exp` it tries to match `NOPASS` in the registered hosts in order to log in without passwords.
Since there may devices that prompt for a blank password it is best to keep that check but instruct the users to specify this password.
(Assuming no devices use the exact password `NOPASS`)
This PR improves a prompt to the host registration tool when entering the password.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [ ] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
