### PR TITLE
Restore bookmark storage in Windows Eventchannel collector

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -78,6 +78,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     //os_calloc(1, sizeof(wlabel_t), logf[pl].labels);
     logf[pl].ign = 360;
     logf[pl].exists = 1;
+    logf[pl].future = 1;
 
     /* Search for entries related to files */
     i = 0;

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -91,6 +91,10 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         } else if (strcmp(node[i]->element, xml_localfile_future) == 0) {
             if (strcmp(node[i]->content, "yes") == 0) {
                 logf[pl].future = 1;
+            } else if (strcmp(node[i]->content, "no") == 0) {
+                logf[pl].future = 0;
+            } else {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             }
         } else if (strcmp(node[i]->element, xml_localfile_query) == 0) {
             os_strdup(node[i]->content, logf[pl].query);

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -262,6 +262,116 @@ EVT_HANDLE read_bookmark(os_channel *channel)
     return (bookmark);
 }
 
+/* Update the log position of a bookmark */
+int update_bookmark(EVT_HANDLE evt, os_channel *channel)
+{
+    DWORD size = 0;
+    DWORD count = 0;
+    wchar_t *buffer = NULL;
+    int result = 0;
+    int status = 0;
+    EVT_HANDLE bookmark = NULL;
+    FILE *fp = NULL;
+
+    if ((bookmark = EvtCreateBookmark(NULL)) == NULL) {
+        mferror(
+            "Could not EvtCreateBookmark() bookmark (%s) for (%s) which returned (%lu)",
+            channel->bookmark_filename,
+            channel->evt_log,
+            GetLastError());
+        goto cleanup;
+    }
+
+    if (!EvtUpdateBookmark(bookmark, evt)) {
+        mferror(
+            "Could not EvtUpdateBookmark() bookmark (%s) for (%s) which returned (%lu)",
+            channel->bookmark_filename,
+            channel->evt_log,
+            GetLastError());
+        goto cleanup;
+    }
+
+    /* Make initial call to determine buffer size */
+    result = EvtRender(NULL,
+                       bookmark,
+                       EvtRenderBookmark,
+                       0,
+                       NULL,
+                       &size,
+                       &count);
+    if (result != FALSE || GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+        mferror(
+            "Could not EvtRender() to get buffer size to update bookmark (%s) for (%s) which returned (%lu)",
+            channel->bookmark_filename,
+            channel->evt_log,
+            GetLastError());
+        goto cleanup;
+    }
+
+    if ((buffer = calloc(size, sizeof(char))) == NULL) {
+        mferror(
+            "Could not calloc() memory to save bookmark (%s) for (%s) which returned [(%d)-(%s)]",
+            channel->bookmark_filename,
+            channel->evt_log,
+            errno,
+            strerror(errno));
+        goto cleanup;
+    }
+
+    if (!EvtRender(NULL,
+                   bookmark,
+                   EvtRenderBookmark,
+                   size,
+                   buffer,
+                   &size,
+                   &count)) {
+        mferror(
+            "Could not EvtRender() bookmark (%s) for (%s) which returned (%lu)",
+            channel->bookmark_filename, channel->evt_log,
+            GetLastError());
+        goto cleanup;
+    }
+
+    if ((fp = fopen(channel->bookmark_filename, "w")) == NULL) {
+        mwarn(
+            "Could not fopen() bookmark (%s) for (%s) which returned [(%d)-(%s)]",
+            channel->bookmark_filename,
+            channel->evt_log,
+            errno,
+            strerror(errno));
+        goto cleanup;
+    }
+
+    if ((fwrite(buffer, 1, size, fp)) < size) {
+        mferror(
+            "Could not fwrite() to bookmark (%s) for (%s) which returned [(%d)-(%s)]",
+            channel->bookmark_filename,
+            channel->evt_log,
+            errno,
+            strerror(errno));
+        goto cleanup;
+    }
+
+    fclose(fp);
+
+    /* Success */
+    status = 1;
+
+cleanup:
+    free(buffer);
+
+    if (bookmark != NULL) {
+        EvtClose(bookmark);
+    }
+
+    if (fp) {
+        fclose(fp);
+    }
+
+    return (status);
+}
+
+
 void send_channel_event(EVT_HANDLE evt, os_channel *channel)
 {
     DWORD buffer_length = 0;
@@ -323,7 +433,7 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
         goto cleanup;
     }
     xml_event = convert_windows_string((LPCWSTR) properties_values);
-    
+
     if (!xml_event) {
         goto cleanup;
     }
@@ -389,6 +499,10 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
 
     if (SendMSG(logr_queue, msg_sent, "EventChannel", WIN_EVT_MQ) < 0) {
         merror(QUEUE_SEND);
+    }
+
+    if (channel->bookmark_enabled) {
+        update_bookmark(evt, channel);
     }
 
 cleanup:


### PR DESCRIPTION
|Related issue|
|---|
|#3475|

## Description

### Fix

Since that function was removed accidentally in Wazuh 3.8.0, the solution is copying that function and its call exactly from v3.7.2:

1. Restore the definition of function `update_bookmark()`: https://github.com/wazuh/wazuh/blob/v3.7.2/src/logcollector/read_win_event_channel.c#L361-L468
2. Put back the call to that function at `send_channel_event()`: https://github.com/wazuh/wazuh/blob/v3.7.2/src/logcollector/read_win_event_channel.c#L669-L671

## Tests

### Functional requirement test

- [X] Windows Server 2019.
- [x] Windows Server 2012.

#### Settings

```xml
<localfile>
 <log_format>eventchannel</log_format>
 <location>Security</location>
  <only-future-events>yes</only-future-events>
```

#### Steps

1. Stop the agent.
2. Log off.
3. Log in.
4. Start the agent.

#### Expected result

The result of those actions depend on the option `<only-future-events>`: the log-off and log-in alerts must appear in the manager if and only if `<only-future-events>` is `no`.

```
** Alert 1559832886.172620: - windows, windows_security,pci_dss_10.2.5,gdpr_IV_32.2,
2019 Jun 06 16:54:46 (WIN-21GEGK6RAC3) 192.168.33.1->EventChannel
Rule: 60137 (level 3) -> 'Windows User Logoff'
{"win":{"system":{"providerName":"Microsoft-Windows-Security-Auditing","providerGuid":"{54849625-5478-4994-a5ba-3e3b0328c30d}","eventID":"4647","version":"0","level":"0","task":"12545","opcode":"0","keywords":"0x8020000000000000","systemTime":"2019-06-06T14:55:09.215790400Z","eventRecordID":"1628","processID":"604","threadID":"340","channel":"Security","computer":"WIN-21GEGK6RAC3","severityValue":"AUDIT_SUCCESS","message":"User initiated logoff:"},"eventdata":{"targetUserSid":"S-1-5-21-1645777427-241849594-3390699525-500","targetUserName":"Administrator","targetDomainName":"WIN-21GEGK6RAC3","targetLogonId":"0x24b00"}}}
win.system.providerName: Microsoft-Windows-Security-Auditing
win.system.providerGuid: {54849625-5478-4994-a5ba-3e3b0328c30d}
win.system.eventID: 4647
win.system.version: 0
win.system.level: 0
win.system.task: 12545
win.system.opcode: 0
win.system.keywords: 0x8020000000000000
win.system.systemTime: 2019-06-06T14:55:09.215790400Z
win.system.eventRecordID: 1628
win.system.processID: 604
win.system.threadID: 340
win.system.channel: Security
win.system.computer: WIN-21GEGK6RAC3
win.system.severityValue: AUDIT_SUCCESS
win.system.message: User initiated logoff:
win.eventdata.targetUserSid: S-1-5-21-1645777427-241849594-3390699525-500
win.eventdata.targetUserName: Administrator
win.eventdata.targetDomainName: WIN-21GEGK6RAC3
win.eventdata.targetLogonId: 0x24b00
```

#### Notes

Since we have only copied the lost code back into the Eventchannel collector, the bookmarking feature shall work wherever it worked until v3.7.2.

### Standard tests

- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [x] MAC OS X
- [X] Package installation
- [X] Package upgrade
- [X] DrMemory report for affected components
- [X] QA templates contemplate the added capabilities: https://github.com/wazuh/wazuh-qa/commit/edc6e5bc1fa093e4c6b720e8b4c92629fabc304e