### PR TITLE
Fix wm_exec usages

### DIFF
--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -666,13 +666,12 @@ static int CheckManagerConfiguration(char ** output) {
         snprintf(command_in, PATH_MAX, "%s/%s %s", DEFAULTDIR, daemons[i], "-t");
 
         if (wm_exec(command_in, &output_msg, &result_code, timeout, NULL) < 0) {
-            if (result_code == 0x7F) {
+            if (result_code == EXECVE_ERROR) {
                 mwarn("Path is invalid or file has insufficient permissions. %s", command_in);
             } else {
                 mwarn("Error executing [%s]", command_in);
             }
 
-            os_free(output_msg);
             goto error;
         }
 

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -480,14 +480,14 @@ size_t wcom_upgrade(const char * package, const char * installer, char ** output
     if (wm_exec(installer_j, &out, &status, req_timeout, NULL) < 0) {
         merror("At WCOM upgrade: Error executing command [%s]", installer_j);
         os_strdup("err Cannot execute installer", *output);
-        return strlen(*output);
     } else {
         os_malloc(OS_MAXSTR + 1, *output);
         int offset = snprintf(*output, OS_MAXSTR, "ok %d ", status);
         strncpy(*output + offset, out, OS_MAXSTR - offset + 1);
-        free(out);
-        return strlen(*output);
     }
+
+    os_free(out);
+    return strlen(*output);
 }
 
 size_t wcom_upgrade_result(char ** output){

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -484,9 +484,8 @@ size_t wcom_upgrade(const char * package, const char * installer, char ** output
         os_malloc(OS_MAXSTR + 1, *output);
         int offset = snprintf(*output, OS_MAXSTR, "ok %d ", status);
         strncpy(*output + offset, out, OS_MAXSTR - offset + 1);
+        os_free(out);
     }
-
-    os_free(out);
     return strlen(*output);
 }
 

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1184,7 +1184,6 @@ int set_policies() {
     retval = 0;
     restore_policies = 1;
 end:
-
     if (f_backup) {
         fclose(f_backup);
     }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -450,7 +450,7 @@ int restore_audit_policies() {
         return 1;
     }
 
-    if (wm_exec_ret_code == WM_ERROR_TIMEOUT) {
+    if (wm_exec_ret_code == 1) {
         merror(FIM_ERROR_WHODATA_AUDITPOL, "time overtaken while running the command");
         return 1;
     }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -446,9 +446,11 @@ int restore_audit_policies() {
     // Get the current policies
     if (wm_exec(command, &output, &result_code, 5, NULL), result_code) {
         merror(FIM_ERROR_WHODATA_AUDITPOL, output);
+        os_free(output);
         return 1;
     }
 
+    os_free(output);
     return 0;
 }
 
@@ -1141,7 +1143,7 @@ int set_policies() {
         goto end;
     }
 
-    free(output);
+    os_free(output);
     output = NULL;
 
     if (f_backup = fopen (WPOL_BACKUP_FILE, "r"), !f_backup) {
@@ -1175,7 +1177,7 @@ int set_policies() {
     retval = 0;
     restore_policies = 1;
 end:
-    free(output);
+    os_free(output);
     if (f_backup) {
         fclose(f_backup);
     }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -443,7 +443,8 @@ int restore_audit_policies() {
         return 1;
     }
     // Get the current policies
-    const int wm_exec_ret_code = wm_exec(command, NULL, &result_code, 5, NULL);
+    char *cmd_output = NULL;
+    const int wm_exec_ret_code = wm_exec(command, &cmd_output, &result_code, 5, NULL);
 
     if (wm_exec_ret_code < 0) {
         merror(FIM_ERROR_WHODATA_AUDITPOL, "failed to execute command");
@@ -452,11 +453,13 @@ int restore_audit_policies() {
 
     if (wm_exec_ret_code == 1) {
         merror(FIM_ERROR_WHODATA_AUDITPOL, "time overtaken while running the command");
+        os_free(cmd_output);
         return 1;
     }
 
-    if (result_code) {
-        merror(FIM_ERROR_WHODATA_AUDITPOL, "command returned failure");
+    if (!wm_exec_ret_code && result_code) {
+        mterror(FIM_ERROR_WHODATA_AUDITPOL, "command returned failure. Output: %s", cmd_output);
+        os_free(cmd_output);
         return 1;
     }
 

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -407,49 +407,47 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     wm_strcat(&trail_title, " - ", ' ');
 
     mtdebug1(WM_AWS_LOGTAG, "Launching S3 Command: %s", command);
-    switch (wm_exec(command, &output, &status, 0, NULL)) {
-    case 0:
-        if (status > 0) {
-            mtwarn(WM_AWS_LOGTAG, "%s Returned exit code %d", trail_title, status);
-            if(status == 1) {
-                char * unknown_error_msg = strstr(output,"Unknown error");
-                if (unknown_error_msg == NULL)
-                    mtwarn(WM_AWS_LOGTAG, "%s Unknown error.", trail_title);
-                else
-                    mtwarn(WM_AWS_LOGTAG, "%s %s", trail_title, unknown_error_msg);
-            }
-            else if(status == 2) {
-                char * ptr;
-                if (ptr = strstr(output, "aws.py: error:"), ptr) {
-                    ptr += 14;
-                    mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments: %s", trail_title, ptr);
-                } else {
-                    mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments.", trail_title);
-                }
-            }
-            else {
-                char * ptr;
-                if (ptr = strstr(output, "ERROR: "), ptr) {
-                    ptr += 7;
-                    mtwarn(WM_AWS_LOGTAG, "%s %s", trail_title, ptr);
-                } else {
-                    mtwarn(WM_AWS_LOGTAG, "%s %s", trail_title, output);
-                }
-            }
 
+    const int wm_exec_ret_code = wm_exec(command, &output, &status, 0, NULL);
 
-            mtdebug1(WM_AWS_LOGTAG, "%s OUTPUT: %s", trail_title, output);
-        } else {
-            mtdebug2(WM_AWS_LOGTAG, "%s OUTPUT: %s", trail_title, output);
-        }
-        break;
-
-    default:
-        mterror(WM_AWS_LOGTAG, "Internal calling. Exiting...");
+    if (wm_exec_ret_code != 0){
+        mterror(WM_AWS_LOGTAG, "Internal error. Exiting...");
         os_free(trail_title);
-        os_free(output);
         os_free(command);
+        if (wm_exec_ret_code > 0) {
+            os_free(output);
+        }
         pthread_exit(NULL);
+    }
+
+    if (status > 0) {
+        mtwarn(WM_AWS_LOGTAG, "%s Returned exit code %d", trail_title, status);
+        if(status == 1) {
+            char * unknown_error_msg = strstr(output,"Unknown error");
+            if (unknown_error_msg == NULL)
+                mtwarn(WM_AWS_LOGTAG, "%s Unknown error.", trail_title);
+            else
+                mtwarn(WM_AWS_LOGTAG, "%s %s", trail_title, unknown_error_msg);
+        } else if(status == 2) {
+            char * ptr;
+            if (ptr = strstr(output, "aws.py: error:"), ptr) {
+                ptr += 14;
+                mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments: %s", trail_title, ptr);
+            } else {
+                mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments.", trail_title);
+            }
+        } else {
+            char * ptr;
+            if (ptr = strstr(output, "ERROR: "), ptr) {
+                ptr += 7;
+                mtwarn(WM_AWS_LOGTAG, "%s %s", trail_title, ptr);
+            } else {
+                mtwarn(WM_AWS_LOGTAG, "%s %s", trail_title, output);
+            }
+        }
+        mtdebug1(WM_AWS_LOGTAG, "%s OUTPUT: %s", trail_title, output);
+    } else {
+        mtdebug2(WM_AWS_LOGTAG, "%s OUTPUT: %s", trail_title, output);
     }
 
     char *line;
@@ -542,50 +540,52 @@ void wm_aws_run_service(wm_aws_service *exec_service) {
     wm_strcat(&service_title, " - ", ' ');
 
     mtdebug1(WM_AWS_LOGTAG, "Launching S3 Command: %s", command);
-    switch (wm_exec(command, &output, &status, 0, NULL)) {
-    case 0:
-        if (status > 0) {
-            mtwarn(WM_AWS_LOGTAG, "%s Returned exit code %d", service_title, status);
-            if(status == 1) {
-                char * unknown_error_msg = strstr(output,"Unknown error");
-                if (unknown_error_msg == NULL)
-                    mtwarn(WM_AWS_LOGTAG, "%s Unknown error.", service_title);
-                else
-                    mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, unknown_error_msg);
-            }
-            else if(status == 2) {
-                char * ptr;
-                if (ptr = strstr(output, "aws.py: error:"), ptr) {
-                    ptr += 14;
-                    mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments: %s", service_title, ptr);
-                } else {
-                    mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments.", service_title);
-                }
-            }
-            else {
-                char * ptr;
-                if (ptr = strstr(output, "ERROR: "), ptr) {
-                    ptr += 7;
-                    mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, ptr);
-                } else {
-                    mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, output);
-                }
-            }
 
+    const int wm_exec_ret_code = wm_exec(command, &output, &status, 0, NULL);
 
-            mtdebug1(WM_AWS_LOGTAG, "%s OUTPUT: %s", service_title, output);
-        } else {
-            mtdebug2(WM_AWS_LOGTAG, "%s OUTPUT: %s", service_title, output);
-        }
-        break;
+    os_free(command);
 
-    default:
-        mterror(WM_AWS_LOGTAG, "Internal calling. Exiting...");
+    if (wm_exec_ret_code) {
+        mterror(WM_AWS_LOGTAG, "Internal error. Exiting...");
         os_free(service_title);
-        os_free(output);
-        os_free(command);
+
+        if (wm_exec_ret_code > 0) {
+            os_free(output);
+        }
         pthread_exit(NULL);
     }
+
+    if (status > 0) {
+        mtwarn(WM_AWS_LOGTAG, "%s Returned exit code %d", service_title, status);
+        if(status == 1) {
+            char * unknown_error_msg = strstr(output,"Unknown error");
+            if (unknown_error_msg == NULL)
+                mtwarn(WM_AWS_LOGTAG, "%s Unknown error.", service_title);
+            else
+                mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, unknown_error_msg);
+        } else if(status == 2) {
+            char * ptr;
+            if (ptr = strstr(output, "aws.py: error:"), ptr) {
+                ptr += 14;
+                mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments: %s", service_title, ptr);
+            } else {
+                mtwarn(WM_AWS_LOGTAG, "%s Error parsing arguments.", service_title);
+            }
+        } else {
+            char * ptr;
+            if (ptr = strstr(output, "ERROR: "), ptr) {
+                ptr += 7;
+                mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, ptr);
+            } else {
+                mtwarn(WM_AWS_LOGTAG, "%s %s", service_title, output);
+            }
+        }
+        mtdebug1(WM_AWS_LOGTAG, "%s OUTPUT: %s", service_title, output);
+    } else {
+        mtdebug2(WM_AWS_LOGTAG, "%s OUTPUT: %s", service_title, output);
+    }
+
+    os_free(service_title);
 
     char *line;
     char *save_ptr;
@@ -593,7 +593,5 @@ void wm_aws_run_service(wm_aws_service *exec_service) {
         wm_sendmsg(usec, queue_fd, line, WM_AWS_CONTEXT.name, LOCALFILE_MQ);
     }
 
-    os_free(service_title);
     os_free(output);
-    os_free(command);
 }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -410,10 +410,11 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
 
     const int wm_exec_ret_code = wm_exec(command, &output, &status, 0, NULL);
 
+    os_free(command);
+
     if (wm_exec_ret_code != 0){
         mterror(WM_AWS_LOGTAG, "Internal error. Exiting...");
         os_free(trail_title);
-        os_free(command);
         if (wm_exec_ret_code > 0) {
             os_free(output);
         }
@@ -458,7 +459,6 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
 
     os_free(trail_title);
     os_free(output);
-    os_free(command);
 }
 
 // Run a service parsing

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -446,17 +446,21 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
 
     default:
         mterror(WM_AWS_LOGTAG, "Internal calling. Exiting...");
+        os_free(trail_title);
+        os_free(output);
+        os_free(command);
         pthread_exit(NULL);
     }
-    char * line;
 
-    for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
+    char *line;
+    char *save_ptr;
+    for (line = strtok_r(output, "\n", &save_ptr); line; line = strtok_r(NULL, "\n", &save_ptr)) {
         wm_sendmsg(usec, queue_fd, line, WM_AWS_CONTEXT.name, LOCALFILE_MQ);
     }
-    free(line);
-    free(trail_title);
-    free(output);
-    free(command);
+
+    os_free(trail_title);
+    os_free(output);
+    os_free(command);
 }
 
 // Run a service parsing
@@ -577,15 +581,19 @@ void wm_aws_run_service(wm_aws_service *exec_service) {
 
     default:
         mterror(WM_AWS_LOGTAG, "Internal calling. Exiting...");
+        os_free(service_title);
+        os_free(output);
+        os_free(command);
         pthread_exit(NULL);
     }
-    char * line;
 
-    for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
+    char *line;
+    char *save_ptr;
+    for (line = strtok_r(output, "\n", &save_ptr); line; line = strtok_r(NULL, "\n", &save_ptr)) {
         wm_sendmsg(usec, queue_fd, line, WM_AWS_CONTEXT.name, LOCALFILE_MQ);
     }
-    free(line);
-    free(service_title);
-    free(output);
-    free(command);
+
+    os_free(service_title);
+    os_free(output);
+    os_free(command);
 }

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -251,9 +251,8 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
                 mterror(WM_AZURE_LOGTAG, "Timeout expired at request '%s'.", curr_request->tag);
                 break;
             default:
-                mterror(WM_AZURE_LOGTAG, "Internal calling. Exiting...");
+                mterror(WM_AZURE_LOGTAG, "Internal error. Exiting...");
                 os_free(command);
-                os_free(output);
                 pthread_exit(NULL);
         }
 
@@ -324,9 +323,8 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
                 mterror(WM_AZURE_LOGTAG, "Timeout expired at request '%s'.", curr_request->tag);
                 break;
             default:
-                mterror(WM_AZURE_LOGTAG, "Internal calling. Exiting...");
+                mterror(WM_AZURE_LOGTAG, "Internal error. Exiting...");
                 os_free(command);
-                os_free(output);
                 pthread_exit(NULL);
         }
 
@@ -405,9 +403,8 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
                 mterror(WM_AZURE_LOGTAG, "Timeout expired at request '%s'.", curr_container->name);
                 break;
             default:
-                mterror(WM_AZURE_LOGTAG, "Internal calling. Exiting...");
+                mterror(WM_AZURE_LOGTAG, "Internal error. Exiting...");
                 os_free(command);
-                os_free(output);
                 pthread_exit(NULL);
         }
 

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -250,16 +250,17 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
             case WM_ERROR_TIMEOUT:
                 mterror(WM_AZURE_LOGTAG, "Timeout expired at request '%s'.", curr_request->tag);
                 break;
-
             default:
                 mterror(WM_AZURE_LOGTAG, "Internal calling. Exiting...");
+                os_free(command);
+                os_free(output);
                 pthread_exit(NULL);
         }
 
         mtinfo(WM_AZURE_LOGTAG, "Finished Log Analytics collection for request '%s'.", curr_request->tag);
 
-        free(command);
-        free(output);
+        os_free(command);
+        os_free(output);
     }
 }
 
@@ -322,16 +323,17 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
             case WM_ERROR_TIMEOUT:
                 mterror(WM_AZURE_LOGTAG, "Timeout expired at request '%s'.", curr_request->tag);
                 break;
-
             default:
                 mterror(WM_AZURE_LOGTAG, "Internal calling. Exiting...");
+                os_free(command);
+                os_free(output);
                 pthread_exit(NULL);
         }
 
         mtinfo(WM_AZURE_LOGTAG, "Finished Graphs log collection for request '%s'.", curr_request->tag);
 
-        free(command);
-        free(output);
+        os_free(command);
+        os_free(output);
     }
 }
 
@@ -402,16 +404,17 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
             case WM_ERROR_TIMEOUT:
                 mterror(WM_AZURE_LOGTAG, "Timeout expired at request '%s'.", curr_container->name);
                 break;
-
             default:
                 mterror(WM_AZURE_LOGTAG, "Internal calling. Exiting...");
+                os_free(command);
+                os_free(output);
                 pthread_exit(NULL);
         }
 
         mtinfo(WM_AZURE_LOGTAG, "Finished Storage log collection for container '%s'.", curr_container->name);
 
-        free(command);
-        free(output);
+        os_free(command);
+        os_free(output);
     }
 }
 

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -582,7 +582,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
                 mterror(WM_CISCAT_LOGTAG, "Unable to change working directory: %s", strerror(errno));
                 os_free(command);
                 _exit(EXIT_FAILURE);
-            } 
+            }
 
             mtdebug2(WM_CISCAT_LOGTAG, "Changing working directory to %s", path);
             mtdebug1(WM_CISCAT_LOGTAG, "Launching command: %s", command);

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -173,14 +173,12 @@ void * wm_command_main(wm_command_t * command) {
     }
 
     while (1) {
-        int status = 0;
-        char * output = NULL;
-
         mtdebug1(WM_COMMAND_LOGTAG, "Starting command '%s'.", command->tag);
-
         // Get time and execute
         time_start = time(NULL);
 
+        int status = 0;
+        char *output = NULL;
         switch (wm_exec(command->full_command, command->ignore_output ? NULL : &output, &status, command->timeout, NULL)) {
         case 0:
             if (status > 0) {
@@ -201,9 +199,9 @@ void * wm_command_main(wm_command_t * command) {
         }
 
         if (!command->ignore_output && output != NULL) {
-            char * line;
-
-            for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
+            char *line;
+            char *save_ptr;
+            for (line = strtok_r(output, "\n", &save_ptr); line; line = strtok_r(NULL, "\n", &save_ptr)){
             #ifdef WIN32
                 wm_sendmsg(usec, 0, line, extag, LOCALFILE_MQ);
             #else
@@ -211,7 +209,7 @@ void * wm_command_main(wm_command_t * command) {
             #endif
             }
 
-            free(output);
+            os_free(output);
         }
 
 

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -189,7 +189,7 @@ void * wm_command_main(wm_command_t * command) {
                 }
             }
             break;
-        case 1:
+        case WM_ERROR_TIMEOUT:
             mterror(WM_COMMAND_LOGTAG, "%s: Timeout overtaken. You can modify your command timeout at ossec.conf. Exiting...", command->tag);
             break;
 

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -65,16 +65,14 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
                 if (status > 0) {
                     mtwarn(WM_DOCKER_LOGTAG, "Returned exit code %d", status);
                     mterror(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
-                } else {
-                    if (output) {
-                        mtdebug2(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
-                    }
+                } else if (output) {
+                    mtdebug2(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
                 }
                 attempts++;
                 break;
             default:
                 mterror(WM_DOCKER_LOGTAG, "Internal calling. Exiting...");
-                free(output);
+                os_free(output);
                 pthread_exit(NULL);
         }
 

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -72,7 +72,6 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
                 break;
             default:
                 mterror(WM_DOCKER_LOGTAG, "Internal calling. Exiting...");
-                os_free(output);
                 pthread_exit(NULL);
         }
 

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -60,27 +60,26 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
         mtdebug1(WM_DOCKER_LOGTAG, "Launching command '%s'.", command);
 
-        switch (wm_exec(command, &output, &status, 0, NULL)) {
-            case 0:
-                if (status > 0) {
-                    mtwarn(WM_DOCKER_LOGTAG, "Returned exit code %d", status);
-                    mterror(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
-                } else if (output) {
-                    mtdebug2(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
-                }
-                attempts++;
-                break;
-            default:
-                mterror(WM_DOCKER_LOGTAG, "Internal calling. Exiting...");
-                pthread_exit(NULL);
-        }
-
-        os_free(output);
-
         if (attempts >= docker_conf->attempts) {
             mterror(WM_DOCKER_LOGTAG, "Maximum attempts reached to run the listener. Exiting...");
             pthread_exit(NULL);
         }
+
+        attempts++;
+
+        if (wm_exec(command, &output, &status, 0, NULL) < 0) {
+            mterror(WM_DOCKER_LOGTAG, "Internal error. Retrying");
+            continue;
+        }
+
+        if (status == 0) {
+            mtdebug2(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
+        } else {
+            mtwarn(WM_DOCKER_LOGTAG, "Returned exit code %d", status);
+            mterror(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
+        }
+
+        os_free(output);
 
         mtwarn(WM_DOCKER_LOGTAG, "Docker-listener finished unexpectedly (code %d). Retrying to run it in %u seconds...", status, docker_conf->interval);
         sleep(docker_conf->interval);

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -158,10 +158,7 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
             WaitForSingleObject(hThread, INFINITE);
         }
 
-        if (retval >= 0)
-            *output = tinfo.output ? tinfo.output : strdup("");
-        else
-            free(tinfo.output);
+        *output = tinfo.output ? tinfo.output : strdup("");
 
         CloseHandle(hThread);
         CloseHandle(tinfo.pipe);
@@ -513,13 +510,7 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
         wm_remove_sid(pid);
 
         if (output) {
-            // Setup output
-
-            if (retval >= 0) {
-                *output = tinfo.output ? tinfo.output : strdup("");
-            } else {
-                free(tinfo.output);
-            }
+            *output = tinfo.output ? tinfo.output : strdup("");
         }
     }
 

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -159,10 +159,9 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
         }
 
         if (retval >= 0) {
-                *output = tinfo.output ? tinfo.output : strdup("");
-            } else {
-                free(tinfo.output);
-            }
+            *output = tinfo.output ? tinfo.output : strdup("");
+        } else {
+            free(tinfo.output);
         }
 
         CloseHandle(hThread);

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -158,7 +158,12 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
             WaitForSingleObject(hThread, INFINITE);
         }
 
-        *output = tinfo.output ? tinfo.output : strdup("");
+        if (retval >= 0) {
+                *output = tinfo.output ? tinfo.output : strdup("");
+            } else {
+                free(tinfo.output);
+            }
+        }
 
         CloseHandle(hThread);
         CloseHandle(tinfo.pipe);
@@ -510,7 +515,13 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
         wm_remove_sid(pid);
 
         if (output) {
-            *output = tinfo.output ? tinfo.output : strdup("");
+            // Setup output
+
+            if (retval >= 0) {
+                *output = tinfo.output ? tinfo.output : strdup("");
+            } else {
+                free(tinfo.output);
+            }
         }
     }
 

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -295,12 +295,14 @@ int wm_key_request_dispatch(char * buffer, const wm_krequest_t * data) {
         }
     }
 
-    agent_infoJSON = cJSON_Parse(output);
-    os_free(output);
+    const char *cjson_parse_end = NULL;
+    agent_infoJSON = cJSON_ParseWithOpts(output, &cjson_parse_end, 0);
 
     if (!agent_infoJSON) {
-        mdebug1("Error parsing JSON event. %s", cJSON_GetErrorPtr());
+        mdebug1("Error parsing JSON event. %s", cjson_parse_end ? cjson_parse_end : "");
+        os_free(output);
     } else {
+        os_free(output);
         int error = 0;
         cJSON *error_message = NULL;
         cJSON *data_json = NULL;

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -271,7 +271,6 @@ int wm_key_request_dispatch(char * buffer, const wm_krequest_t * data) {
             } else {
                 mwarn("Error executing [%s]", data->exec_path);
             }
-            os_free(output);
             os_free(command);
             OSHash_Delete_ex(request_hash,buffer);
             return -1;

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -143,9 +143,6 @@ void wm_oscap_cleanup() {
 
 void wm_oscap_run(wm_oscap_eval *eval) {
     char *command = NULL;
-    int status;
-    char *output = NULL;
-    char *line;
     char *arg_profiles = NULL;
     char msg[OS_MAXSTR];
     wm_oscap_profile *profile;
@@ -171,13 +168,16 @@ void wm_oscap_run(wm_oscap_eval *eval) {
 
     wm_strcat(&command, eval->path, ' ');
 
-    for (profile = eval->profiles; profile; profile = profile->next)
+    for (profile = eval->profiles; profile; profile = profile->next) {
         wm_strcat(&arg_profiles, profile->name, ',');
+    }
 
     if (arg_profiles) {
         wm_strcat(&command, "--profiles", ' ');
         wm_strcat(&command, arg_profiles, ' ');
     }
+    
+    os_free(arg_profiles);
 
     if (eval->xccdf_id) {
         wm_strcat(&command, "--xccdf-id", ' ');
@@ -208,6 +208,8 @@ void wm_oscap_run(wm_oscap_eval *eval) {
 
     mtdebug1(WM_OSCAP_LOGTAG, "Launching command: %s", command);
 
+    int status;
+    char *output = NULL;
     switch (wm_exec(command, &output, &status, eval->timeout, NULL)) {
     case 0:
         if (status > 0) {
@@ -216,6 +218,8 @@ void wm_oscap_run(wm_oscap_eval *eval) {
                 mtdebug2(WM_OSCAP_LOGTAG, "OUTPUT: %s", output);
             } else {
                 mterror(WM_OSCAP_LOGTAG, "OUTPUT: %s", output);
+                os_free(command);
+                os_free(output);
                 pthread_exit(NULL);
             }
             eval->flags.error = 1;
@@ -224,7 +228,7 @@ void wm_oscap_run(wm_oscap_eval *eval) {
         break;
 
     case WM_ERROR_TIMEOUT:
-        free(output);
+        os_free(output);
         output = NULL;
         wm_strcat(&output, "oscap: ERROR: Timeout expired.", '\0');
         mterror(WM_OSCAP_LOGTAG, "Timeout expired executing '%s'.", eval->path);
@@ -232,19 +236,25 @@ void wm_oscap_run(wm_oscap_eval *eval) {
 
     default:
         mterror(WM_OSCAP_LOGTAG, "Internal calling. Exiting...");
+        os_free(command);
+        os_free(output);
         pthread_exit(NULL);
     }
+    
+    os_free(command);
 
-    for (line = strtok(output, "\n"); line; line = strtok(NULL, "\n")){
+    char *line;
+    char *save_ptr;
+    for (line = strtok_r(output, "\n", &save_ptr); line; line = strtok_r(NULL, "\n", &save_ptr)) {
         wm_sendmsg(usec, queue_fd, line, WM_OSCAP_LOCATION, LOCALFILE_MQ);
     }
+
+    os_free(output);
 
     snprintf(msg, OS_MAXSTR, "Ending OpenSCAP scan. File: %s. ", eval->path);
     wm_sendmsg(usec, queue_fd, msg, "rootcheck", ROOTCHECK_MQ);
 
-    free(output);
-    free(command);
-    free(arg_profiles);
+    
 }
 
 // Check configuration

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -163,6 +163,7 @@ void wm_oscap_run(wm_oscap_eval *eval) {
         break;
     default:
         mterror(WM_OSCAP_LOGTAG, "Unspecified content type for file '%s'. This shouldn't happen.", eval->path);
+        os_free(command);
         pthread_exit(NULL);
     }
 

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -252,8 +252,6 @@ void wm_oscap_run(wm_oscap_eval *eval) {
 
     snprintf(msg, OS_MAXSTR, "Ending OpenSCAP scan. File: %s. ", eval->path);
     wm_sendmsg(usec, queue_fd, msg, "rootcheck", ROOTCHECK_MQ);
-
-    
 }
 
 // Check configuration

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -235,9 +235,8 @@ void wm_oscap_run(wm_oscap_eval *eval) {
         break;
 
     default:
-        mterror(WM_OSCAP_LOGTAG, "Internal calling. Exiting...");
+        mterror(WM_OSCAP_LOGTAG, "Internal error. Exiting...");
         os_free(command);
-        os_free(output);
         pthread_exit(NULL);
     }
     

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1505,7 +1505,7 @@ static int wm_sca_read_command(char *command, char *pattern,wm_sca_t * data, cha
     char *cmd_output = NULL;
     int result_code;
 
-    switch( wm_exec(command,&cmd_output,&result_code,data->commands_timeout,NULL)) {
+    switch (wm_exec(command, &cmd_output, &result_code, data->commands_timeout, NULL)) {
     case 0:
         mdebug1("Command (%s) returned code %d.", command, result_code);
         break;
@@ -1524,7 +1524,6 @@ static int wm_sca_read_command(char *command, char *pattern,wm_sca_t * data, cha
             mdebug1("Failed to run command '%s'", command);
             sprintf(*reason, "Failed to run command '%s'", command);
         }
-        os_free(cmd_output);
         return 2;
     }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1509,7 +1509,7 @@ static int wm_sca_read_command(char *command, char *pattern,wm_sca_t * data, cha
     case 0:
         mdebug1("Command (%s) returned code %d.", command, result_code);
         break;
-    case 1:
+    case WM_ERROR_TIMEOUT:
         if (*reason == NULL) {
             os_malloc(OS_MAXSTR, *reason);
             mdebug1("Timeout overtaken running command '%s'", command);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1507,21 +1507,7 @@ static int wm_sca_read_command(char *command, char *pattern,wm_sca_t * data, cha
 
     switch( wm_exec(command,&cmd_output,&result_code,data->commands_timeout,NULL)) {
     case 0:
-        if (result_code > 0) {
-            mdebug1("Command (%s) returned code %d.", command, result_code);
-            if (*reason == NULL){
-                os_malloc(OS_MAXSTR, *reason);
-                if (result_code == EXECVE_ERROR) {
-                    mdebug1("Invalid path or permissions running command '%s'",command);
-                    sprintf(*reason, "Invalid path or permissions running command '%s'",command);
-                } else {
-                    mdebug1("Internal error running command '%s'", command);
-                    sprintf(*reason, "Internal error running command '%s'", command);
-                }
-            }
-            os_free(cmd_output);
-            return 2;
-        }
+        mdebug1("Command (%s) returned code %d.", command, result_code);
         break;
     case 1:
         if (*reason == NULL) {
@@ -1533,12 +1519,12 @@ static int wm_sca_read_command(char *command, char *pattern,wm_sca_t * data, cha
         return 2;
     default:
         mdebug1("Command (%s) returned code %d.", command, result_code);
-
         if (*reason == NULL) {
             os_malloc(OS_MAXSTR, *reason);
             mdebug1("Failed to run command '%s'", command);
             sprintf(*reason, "Failed to run command '%s'", command);
         }
+        os_free(cmd_output);
         return 2;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#3350|

## Description
This PR fixes several usages of `wm_exec` and some potential leaks.

#### execd.c
- `wm_exec() < 0` does not produce output, hence there's nothing to release.

#### wcom.c
- Code generalized.

#### win_whodata.c
- `wm_exec()` error handling was based solely on the command return code.
- `wm_exec()` was requested for an output that was discarted without any further processing.
 
#### wm_aws.c
- Several `pthread_exit()` without performing any frees. 
- `free()` of ` line`, a reference to `output` string.
- Usage of  `strtok()`, which is not reentrant, on a thread.

#### wm_azure.c
- Several `pthread_exit()` without performing any frees. 

#### wm_ciscat.c
- Several `pthread_exit` without performing any frees. 
- command return code was not checked for errors.

#### wm_command.c
- Usage of `strtok()`, which is not reentrant, on a thread.

#### wm_docker.c 
- `output` could be released even when `wm_exec() < 0`
- Fix wm_exec retry code.

#### wm_keyrequest.c
- Unhandled  `wm_exec` timeout case.
- Release command output ASAP.

####  wm_oscap.c
- `pthread_exit` without memory release.
- Release several variables ASAP.
- Usage of `strtok()`, which is not reentrant, on a thread.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Scan-build 
- Memory tests
  - [x] Valgrind report for affected components
  - [ ] RAM usage impact
- [x] Review logs syntax and correct language
