### PR TITLE
Clear osquery results log feof state before reading

### DIFF
--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -104,6 +104,8 @@ void *Read_Log(wm_osquery_monitor_t * osquery)
         // Read the file
 
         while (active) {
+            clearerr(result_log);
+
             // Get file until EOF
 
             while (fgets(line, OS_MAXSTR, result_log)) {


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 3.9.2 | osquery integration | Agent | All | Ubuntu 18.10+ |

That will prevent the integration from losing events after reaching _feof_ for the first time.

This issue applies to _libc_ as of 2.28 (on Ubuntu 18.10).

Related PR fixing the same bug in the JSON alert reader: #2498.

## Tests

- [X] Compile manager on Linux.
- [x] Compile agent on Windows.
- [x] Compile agent on macOS.
- [X] Source installation on Ubuntu 19.04.
- [x] Package upgrade on Windows Server 2019.
- [x] QA templates contemplate the added capabilities