### PR TITLE
Show node name when a daemon is not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.10.0]
+
+### Changed
+
+- Improved error message when some of required Wazuh daemons are down. Allow restarting cluster nodes except when `ossec-execd` is down ([#3496](https://github.com/wazuh/wazuh/pull/3496))
+
 ## [v3.9.2]
 
 ### Added

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1157,7 +1157,7 @@ class Agent:
 
 
     @staticmethod
-    def insert_agent(name, id, key, ip='any', force=0):
+    def insert_agent(name, id, key, ip='any', force=-1):
         """
         Create a new agent providing the id, name, ip and key to the Manager.
 

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -92,7 +92,7 @@ class DistributedAPI:
                 raise
             return self.print_json(data=str(e), error=1000)
 
-    def check_wazuh_status(self):
+    def check_wazuh_status(self, basic_services=None):
         """
         There are some services that are required for wazuh to correctly process API requests. If any of those services
         is not running, the API must raise an exception indicating that:
@@ -105,7 +105,8 @@ class DistributedAPI:
         """
         if self.input_json['function'] == '/manager/status' or self.input_json['function'] == '/cluster/:node_id/status':
             return
-        basic_services = ('wazuh-modulesd', 'ossec-remoted', 'ossec-analysisd', 'ossec-execd', 'wazuh-db')
+        basic_services = ('wazuh-modulesd', 'ossec-remoted', 'ossec-analysisd', 'ossec-execd', 'wazuh-db') \
+            if basic_services is None else basic_services
 
         status = manager.status()
 
@@ -115,7 +116,6 @@ class DistributedAPI:
             extra_info = {'node_name': self.node_info.get('node', 'UNKNOWN NODE'),
                           'not_ready_daemons': ', '.join([f'{key}->{value}' for key, value in not_ready_daemons.items()])}
             raise exception.WazuhException(1017, extra_message=extra_info)
-
 
     def print_json(self, data: Union[Dict, str], error: int = 0) -> str:
         def encode_json(o):
@@ -141,10 +141,12 @@ class DistributedAPI:
         try:
             before = time.time()
 
-            self.check_wazuh_status()
+            self.check_wazuh_status(basic_services=rq.functions[self.input_json['function']].get('basic_services',
+                                                                                                 None)
+                                    )
 
             timeout = None if self.input_json['arguments']['wait_for_complete'] \
-                           else self.cluster_items['intervals']['communication']['timeout_api_exe']
+                else self.cluster_items['intervals']['communication']['timeout_api_exe']
             local_args = copy.deepcopy(self.input_json['arguments'])
             del local_args['wait_for_complete']  # local requests don't use this parameter
 

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -103,20 +103,6 @@ class DistributedAPI:
 
         The basic services wazuh needs to be running are: wazuh-modulesd, ossec-remoted, ossec-analysisd, ossec-execd and wazuh-db
         """
-        def get_str_not_ready_daemons(not_ready_daemons: Dict) -> str:
-            """
-            Returns a string with the daemons which are not ready
-            :param daemons: dict with daemons which are not ready
-            :return: string with the daemons which are not ready
-            """
-            final_str = ''
-            for key, value in not_ready_daemons.items():
-                if final_str:
-                    final_str = f'{final_str}, {key}->{value}'
-                else:
-                    final_str = f'{key}->{value}'
-            return final_str
-
         if self.input_json['function'] == '/manager/status' or self.input_json['function'] == '/cluster/:node_id/status':
             return
         basic_services = ('wazuh-modulesd', 'ossec-remoted', 'ossec-analysisd', 'ossec-execd', 'wazuh-db')
@@ -126,8 +112,8 @@ class DistributedAPI:
         not_ready_daemons = {k: status[k] for k in basic_services if status[k] in ('failed', 'restarting', 'stopped')}
 
         if not_ready_daemons:
-            extra_info = {**{'node_name': self.node_info['node']},
-                          **{'not_ready_daemons': get_str_not_ready_daemons(not_ready_daemons)}}
+            extra_info = {'node_name': self.node_info.get('node', 'UNKNOWN NODE'),
+                          'not_ready_daemons': ', '.join([f'{key}->{value}' for key, value in not_ready_daemons.items()])}
             raise exception.WazuhException(1017, extra_message=extra_info)
 
 

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -305,7 +305,8 @@ functions = {
     'PUT/manager/restart': {
         'function': manager.restart,
         'type': 'local_any',
-        'is_async': False
+        'is_async': False,
+        'basic_services': ['ossec-execd']
     },
 
     # Cluster
@@ -407,12 +408,14 @@ functions = {
     'PUT/cluster/restart': {
         'function': cluster.restart_all_nodes,
         'type': 'distributed_master',
-        'is_async': False
+        'is_async': False,
+        'basic_services': ['ossec-execd']
     },
     'PUT/cluster/:node_id/restart': {
         'function': manager.restart,
         'type': 'distributed_master',
-        'is_async': False
+        'is_async': False,
+        'basic_services': ['ossec-execd']
     },
     '/cluster/:node_id/files': {
         'function': manager.get_file,

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -29,15 +29,8 @@ class WazuhException(Exception):
         1014: 'Error communicating with socket',
         1015: 'Error agent version is null. Was the agent ever connected?',
         1016: 'Error moving file',
-        1017: 'Wazuh is restarting. Current status is wazuh-modulesd->{wazuh-modulesd}, '
-              'ossec-remoted->{ossec-remoted}, ossec-analysisd->{ossec-analysisd}, ossec-execd->{ossec-execd}, '
-              'wazuh-db->{wazuh-db}',
-        1018: 'Wazuh is stopped. Start Wazuh before using the API. Current status is wazuh-modulesd->{wazuh-modulesd}, '
-              'ossec-remoted->{ossec-remoted}, ossec-analysisd->{ossec-analysisd}, ossec-execd->{ossec-execd},'
-              'wazuh-db->{wazuh-db}',
-        1019: 'There is a failed process. Review that before using the API. Current status is '
-              'wazuh-modulesd->{wazuh-modulesd}, ossec-remoted->{ossec-remoted}, ossec-analysisd->{ossec-analysisd}, '
-              'ossec-execd->{ossec-execd}, wazuh-db->{wazuh-db}',
+        1017: 'Some Wazuh daemons are not ready yet in node "{node_name}": '
+              '{not_ready_daemons}',
 
         # Configuration: 1100 - 1199
         1100: 'Error checking configuration',

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -29,8 +29,8 @@ class WazuhException(Exception):
         1014: 'Error communicating with socket',
         1015: 'Error agent version is null. Was the agent ever connected?',
         1016: 'Error moving file',
-        1017: 'Some Wazuh daemons are not ready yet in node "{node_name}": '
-              '{not_ready_daemons}',
+        1017: 'Some Wazuh daemons are not ready yet in node \'{node_name}\' '
+              '({not_ready_daemons})',
 
         # Configuration: 1100 - 1199
         1100: 'Error checking configuration',


### PR DESCRIPTION
Hi team,

This PR closes #3492. I made changes in order to show the node name when a daemon is not running.

Before these changes, we got this response if a daemon as `execd` was not running in a node:

```bash
# curl -u foo:bar "localhost:55000/syscollector/003/packages?pretty"
{
   "error": 1018,
   "message": "Wazuh is stopped. Start Wazuh before using the API."
}
```

After applying this PR, we can see the daemons which are not running:

```bash
# curl -u foo:bar "localhost:55000/syscollector/003/packages?pretty"
{
   "error": 1017,
   "message": "Some Wazuh daemons are not ready yet in node 'worker-2' (ossec-execd->failed)"
}
```

```bash 
# curl -u foo:bar "localhost:55000/syscollector/003/packages?pretty"
{
   "error": 1017,
   "message": "Some Wazuh daemons are not ready yet in node 'worker-2' (ossec-remoted->failed, ossec-execd->failed)"
}

```

Best regards,

Demetrio.
