### PR TITLE
Fix invalid memory read issue

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -685,7 +685,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             strncpy(expandedpath, tmp_dir, sizeof(expandedpath) - 1);
 #endif
             ptfile = expandedpath;
-            ptfile += strlen(expandedpath)+1;
+            ptfile += strlen(expandedpath) - 1;
             if (*ptfile == '/' || *ptfile == '\\') {
                 *ptfile = '\0';
             }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1152,11 +1152,8 @@ int checkVista()
     /* Check if the system is Vista (must be called during the startup) */
     isVista = 0;
 
-    OSVERSIONINFOEX osvi;
+    OSVERSIONINFOEX osvi = { .dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX) };
     BOOL bOsVersionInfoEx;
-
-    ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
-    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 
     if (!(bOsVersionInfoEx = GetVersionEx ((OSVERSIONINFO *) &osvi))) {
         osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
@@ -2701,7 +2698,7 @@ int is_ascii_utf8(const char * file, unsigned int max_lines_ascii,unsigned int m
     char *buffer = NULL;
     unsigned int lines_readed_ascii = 0;
     unsigned int chars_readed_utf8 = 0;
-    fpos_t begin; 
+    fpos_t begin;
     FILE *fp;
 
     fp = fopen(file,"r");
@@ -2780,7 +2777,7 @@ int is_ascii_utf8(const char * file, unsigned int max_lines_ascii,unsigned int m
                 }
                 goto next;
             }
-        } 
+        }
 
         /* Exclude overlongs */
         if ( b[0] == 0xE0 ) {
@@ -2803,8 +2800,8 @@ int is_ascii_utf8(const char * file, unsigned int max_lines_ascii,unsigned int m
                     }
                     goto next;
                 }
-            } 
-        } 
+            }
+        }
 
         /* Exclude surrogates */
         if (b[0] == 0xED) {
@@ -2885,7 +2882,7 @@ int is_usc2(const char * file) {
     size_t nbytes = 0;
 
     while (nbytes = fread(b,sizeof(char),2,fp), nbytes) {
-        
+
         /* Check for UCS-2 LE BOM */
         if (b[0] == 0xFF && b[1] == 0xFE) {
             retval = UCS2_LE;
@@ -2935,15 +2932,15 @@ DWORD FileSizeWin(const char * file) {
 int64_t w_ftell (FILE *x) {
 
 #ifndef WIN32
-    int64_t z = ftell(x); 
+    int64_t z = ftell(x);
 #else
-    int64_t z = _ftelli64(x); 
+    int64_t z = _ftelli64(x);
 #endif
 
-    if (z < 0)  { 
-        merror("Ftell function failed due to [(%d)-(%s)]", errno, strerror(errno)); 
+    if (z < 0)  {
+        merror("Ftell function failed due to [(%d)-(%s)]", errno, strerror(errno));
         return -1;
-    } else {  
-        return z; 
+    } else {
+        return z;
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|#3499|

## Description

This PR aims to fix two of the issues reported by Dr. Memory on Windows Server 2012.

### Impact

The old code would apply two `<directories>` instances that differ by a slash, like:
```xml
<directories check_all="yes">/etc</directories>
<directories check_all="yes">/etc/</directories>
```

## Tests

- [X] Compile manager on Linux
- [X] Compile agent for Windows
- [X] Source installation (Linux)
- [X] Package upgrade (Windows)
- [X] Dr. Memory
- [x] Configuration on-demand reports new parameters
- [x] QA templates contemplate the added capabilities: https://github.com/wazuh/wazuh-qa/commit/677533acb520a8da9ccf14b9d8daa752ad8afd72