### PR TITLE
Added missing ipaddress in some AWS GuardDuty events

### DIFF
--- a/extensions/logstash/01-wazuh-local.conf
+++ b/extensions/logstash/01-wazuh-local.conf
@@ -18,6 +18,21 @@ filter {
             add_field => [ "@src_ip", "%{[data][aws][sourceIPAddress]}" ]
         }
     }
+    if [data][aws][service][action][portProbeAction][portProbeDetails][remoteIpDetails][ipAddressV4] {
+        mutate {
+            add_field => [ "@src_ip", "%{[data][aws][service][action][portProbeAction][portProbeDetails][remoteIpDetails][ipAddressV4]}" ]
+        }
+    }
+    if [data][aws][service][action][networkConnectionAction][remoteIpDetails][ipAddressV4] {
+        mutate {
+            add_field => [ "@src_ip", "%{[data][aws][service][action][networkConnectionAction][remoteIpDetails][ipAddressV4]}" ]
+        }
+    }
+    if [data][aws][service][action][awsApiCallAction][remoteIpDetails][ipAddressV4] {
+        mutate {
+            add_field => [ "@src_ip", "%{[data][aws][service][action][awsApiCallAction][remoteIpDetails][ipAddressV4]}" ]
+        }
+    }
 }
 filter {
     geoip {

--- a/extensions/logstash/01-wazuh-remote.conf
+++ b/extensions/logstash/01-wazuh-remote.conf
@@ -20,6 +20,21 @@ filter {
             add_field => [ "@src_ip", "%{[data][aws][sourceIPAddress]}" ]
         }
     }
+    if [data][aws][service][action][portProbeAction][portProbeDetails][remoteIpDetails][ipAddressV4] {
+        mutate {
+            add_field => [ "@src_ip", "%{[data][aws][service][action][portProbeAction][portProbeDetails][remoteIpDetails][ipAddressV4]}" ]
+        }
+    }
+    if [data][aws][service][action][networkConnectionAction][remoteIpDetails][ipAddressV4] {
+        mutate {
+            add_field => [ "@src_ip", "%{[data][aws][service][action][networkConnectionAction][remoteIpDetails][ipAddressV4]}" ]
+        }
+    }
+    if [data][aws][service][action][awsApiCallAction][remoteIpDetails][ipAddressV4] {
+        mutate {
+            add_field => [ "@src_ip", "%{[data][aws][service][action][awsApiCallAction][remoteIpDetails][ipAddressV4]}" ]
+        }
+    }
 }
 filter {
     geoip {


### PR DESCRIPTION
|Related issue|
|---|
|#2665|

## Description

The some AWS guardduty events have the ip address in different fields and the current logstash configuration is missing, added check for three fields to use it as `@src_ip` after the two already existing ones.

```[data][aws][service][action][portProbeAction][portProbeDetails][remoteIpDetails][ipAddressV4]
[data][aws][service][action][networkConnectionAction][remoteIpDetails][ipAddressV4]
[data][aws][service][action][awsApiCallAction][remoteIpDetails][ipAddressV4]```
