### PR TITLE
Fix overwriting agents when 'force' is less than '0'

### DIFF
--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -283,7 +283,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, const char *k
     // Check for duplicated ID
 
     if (id && (index = OS_IsAllowedID(&keys, id), index >= 0)) {
-        if (force) {
+        if (force >= 0) {
             id_exist = keys.keyentries[index]->id;
             minfo("Duplicated ID '%s' (%s). Saving backup.", id, id_exist);
             add_backup(keys.keyentries[index]);

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -283,7 +283,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, const char *k
     // Check for duplicated ID
 
     if (id && (index = OS_IsAllowedID(&keys, id), index >= 0)) {
-        if (force >= 0) {
+        if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
             id_exist = keys.keyentries[index]->id;
             minfo("Duplicated ID '%s' (%s). Saving backup.", id, id_exist);
             add_backup(keys.keyentries[index]);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3526|

## Description

`authd` was overwriting an agent with the same IP when `force` was less than `0`.
A case when this happens is making the following API call:

```
curl -u foo:bar -k -X POST -d curl -u foo:bar -k -X POST -d '{"name":"NewHost_4","ip":"10.0.10.16","id":"126","key":"1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza2cdefghi64"}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/agents/insert?pretty"
```

## Logs/Alerts example

This is what was happening before while making that API call:

```
curl -u foo:bar -k -X POST -d '{"name":"NewHost_4","ip":"10.0.10.16","id":"126","key":"1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza2cdefghi64","force":"0"}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/agents/insert?pretty"
{
   "error": 0,
   "data": {
      "id": "126",
      "key": "MTI2IE5ld0hvc3RfNCAxMC4wLjEwLjE2IDFhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YTJjZGVmZ2hpNjQ="
   }
}
```

As it can be seen the process went well when it should say that the ID is duplicated. Also, it shouldn't overwrite the agent.

## Tests

It's been checked that the agents with the same ID are not overwritten anymore making a call like the described above. Now the result is the following:

```
curl -u foo:bar -k -X POST -d '{"name":"NewHost_4","ip":"10.0.10.16","id":"126","key":"1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza2cdefghi64"}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/agents/insert?pretty"
{
   "error": 9012,
   "message": "Duplicated ID"
}
```