### PR TITLE
Remove full_log if it's an object in ossec-analysisd

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2361,6 +2361,14 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
             /* Log the alert if configured to */
             if (t_currently_rule->alert_opts & DO_LOGALERT) {
                 lf->comment = ParseRuleComment(lf);
+                
+                if(lf->full_log) {
+                    cJSON *full_log_JSON = cJSON_Parse(lf->full_log);
+                    if(full_log_JSON) {
+                        os_free(lf->full_log);
+                    }
+                    cJSON_Delete(full_log_JSON);
+                }
 
                 os_calloc(1, sizeof(Eventinfo), lf_cpy);
                 w_copy_event_for_log(lf,lf_cpy);


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/3513 |

Related but not needed pull request: https://github.com/wazuh/wazuh/pull/3515

## Description

Before printing the alert to the alerts.json:

```c
if(lf->full_log) {
    cJSON *full_log_JSON = cJSON_Parse(lf->full_log);
    if(full_log_JSON) {
        os_free(lf->full_log);
    }
    cJSON_Delete(full_log_JSON);
}
```

1. The `lf->full_log` may be missing, that's why we use an `if`.
2. Try to parse lf->full_log as JSON, if it fails then it will be `NULL`, otherwise it will be a `cJSON`. 
3. If we could parse it, then `os_free` will release that property, we don't want a JSON in `full_log`.
4. Delete the temporary copy (`full_log_JSON`), the function `cJSON_Delete` looks for `NULL` so it's safe to use.

## Tests

CentOS 7 using type `text` in the template and using modules such as AWS that are expected to generate JSON in `full_log`, it's working as expected.

![image](https://user-images.githubusercontent.com/8860227/59589699-d6ae3980-90ea-11e9-8a25-e0d9e7847653.png)

I've also executed Valgrind, there are just the usual 100 bytes lost for `analysisd`.

```
# pkill -f analysisd
# valgrind --leak-check=full -v /var/ossec/bin/ossec-analysisd -f
...
==12090== LEAK SUMMARY:
==12090==    definitely lost: 100 bytes in 9 blocks
==12090==    indirectly lost: 0 bytes in 0 blocks
==12090==      possibly lost: 41,440 bytes in 74 blocks
==12090==    still reachable: 11,986,611 bytes in 56,961 blocks
==12090==         suppressed: 0 bytes in 0 blocks
==12090== Reachable blocks (those to which a pointer was found) are not shown.
==12090== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

