### PR TITLE
Fix error handling agent upgrade when the repository is not reachable

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1939,8 +1939,9 @@ class Agent:
 
         try:
             result = requests.get(versions_url)
-        except requests.exceptions.RequestException as e:
-            raise WazuhException(1713, e.code)
+        except requests.exceptions.RequestException:
+            error = "Selected version repository ({}) isn't reachable".format(versions_url)
+            raise WazuhException(1713, error)
 
         if result.ok:
             versions = [version.split() for version in result.text.split('\n')]

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -11,6 +11,7 @@ import sqlite3
 import os
 import pytest
 import re
+import requests
 
 from wazuh import common
 from wazuh.agent import Agent

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -373,6 +373,22 @@ def test_upgrade(_send_wpk_file, ossec_socket_mock, test_data, agent_id):
 
         assert result == 'Upgrade procedure started'
 
+@patch('wazuh.agent.OssecSocket')
+@patch('requests.get', side_effect=requests.exceptions.RequestException)
+def test_upgrade_not_access_repo(request_mock, ossec_socket_mock, test_data):
+    """
+    Test upgrade method when repo isn't reachable
+    """
+    # get manager version before mock DB
+    manager_version = get_manager_version()
+    ossec_socket_mock.return_value.receive.return_value = b'ok'
+
+    with patch('sqlite3.connect') as mock_db:
+        mock_db.return_value = test_data.global_db
+        agent = Agent("001")
+        with pytest.raises(WazuhException, match=".* 1713 .*"):
+            agent.upgrade()
+
 
 @pytest.mark.parametrize('agent_id', [
     ('001'),


### PR DESCRIPTION
Hi team, this PR closes https://github.com/wazuh/wazuh/issues/3441

## Description

This PR solves the problem when a RequestException happens when trying to access the selected repository and tries to return a WazuhException to which we will pass the `code` parameter of the exception.

The result of the `code` parameter has been replaced by an error message to avoid that when the exception does not have a `code` value, an error is caused.

The corresponding unit test has also been added to check the operation of this new case.

## Test results

### Unit test
#### Agent
```
================================================= test session starts =================================================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /wazuh-test/tests
collected 52 items                                                                                                    

test_agent.py::test_get_agents_overview_default PASSED                                                          [  1%]
test_agent.py::test_get_agents_overview_select[select0-all-None-0] PASSED                                       [  3%]
test_agent.py::test_get_agents_overview_select[select1-all-None-1] PASSED                                       [  5%]
test_agent.py::test_get_agents_overview_select[select2-all-None-1] PASSED                                       [  7%]
test_agent.py::test_get_agents_overview_select[select3-Active,Pending-None-0] PASSED                            [  9%]
test_agent.py::test_get_agents_overview_select[select4-Disconnected-None-1] PASSED                              [ 11%]
test_agent.py::test_get_agents_overview_select[select5-Disconnected-1s-1] PASSED                                [ 13%]
test_agent.py::test_get_agents_overview_select[select6-Disconnected-2h-0] PASSED                                [ 15%]
test_agent.py::test_get_agents_overview_select[select7-all-15m-2] PASSED                                        [ 17%]
test_agent.py::test_get_agents_overview_select[select8-Active-15m-0] PASSED                                     [ 19%]
test_agent.py::test_get_agents_overview_select[select9-Active,Pending-15m-1] PASSED                             [ 21%]
test_agent.py::test_get_agents_overview_select[select10-status10-15m-1] PASSED                                  [ 23%]
test_agent.py::test_get_agents_overview_query[ip=172.17.0.201] PASSED                                           [ 25%]
test_agent.py::test_get_agents_overview_query[ip=172.17.0.202] PASSED                                           [ 26%]
test_agent.py::test_get_agents_overview_query[ip=172.17.0.202;registerIP=any] PASSED                            [ 28%]
test_agent.py::test_get_agents_overview_query[status=Disconnected;lastKeepAlive>34m] PASSED                     [ 30%]
test_agent.py::test_get_agents_overview_query[(status=Active,status=Pending);lastKeepAlive>5m] PASSED           [ 32%]
test_agent.py::test_get_agents_overview_search[search0-3] PASSED                                                [ 34%]
test_agent.py::test_get_agents_overview_search[search1-3] PASSED                                                [ 36%]
test_agent.py::test_get_agents_overview_search[search2-1] PASSED                                                [ 38%]
test_agent.py::test_get_agents_overview_search[search3-5] PASSED                                                [ 40%]
test_agent.py::test_get_agents_overview_search[search4-2] PASSED                                                [ 42%]
test_agent.py::test_get_agents_overview_status_olderthan[active-9m-1-None] PASSED                               [ 44%]
test_agent.py::test_get_agents_overview_status_olderthan[all-1s-5-None] PASSED                                  [ 46%]
test_agent.py::test_get_agents_overview_status_olderthan[pending,neverconnected-30m-1-None] PASSED              [ 48%]
test_agent.py::test_get_agents_overview_status_olderthan[55-30m-0-1729] PASSED                                  [ 50%]
test_agent.py::test_get_config_error[100-logcollector-internal-1701] PASSED                                     [ 51%]
test_agent.py::test_get_config_error[005-logcollector-internal-1740] PASSED                                     [ 53%]
test_agent.py::test_get_config_error[002-logcollector-internal-1735] PASSED                                     [ 55%]
test_agent.py::test_get_config_error[000-None-None-1307] PASSED                                                 [ 57%]
test_agent.py::test_get_config_error[000-random-random-1101] PASSED                                             [ 59%]
test_agent.py::test_get_config_error[000-analysis-internal-1117] PASSED                                         [ 61%]
test_agent.py::test_get_config_error[000-analysis-internal-1118] PASSED                                         [ 63%]
test_agent.py::test_get_config_error[000-analysis-random-1116] PASSED                                           [ 65%]
test_agent.py::test_get_config_error[000-analysis-internal-None] PASSED                                         [ 67%]
test_agent.py::test_remove_manual[False] PASSED                                                                 [ 69%]
test_agent.py::test_remove_manual[True] PASSED                                                                  [ 71%]
test_agent.py::test_remove_manual_error[001-1746] PASSED                                                        [ 73%]
test_agent.py::test_remove_manual_error[100-1701] PASSED                                                        [ 75%]
test_agent.py::test_remove_manual_error[001-1600] PASSED                                                        [ 76%]
test_agent.py::test_remove_manual_error[001-1748] PASSED                                                        [ 78%]
test_agent.py::test_remove_manual_error[001-1747] PASSED                                                        [ 80%]
test_agent.py::test_get_available_versions[001] PASSED                                                          [ 82%]
test_agent.py::test_get_available_versions[002] PASSED                                                          [ 84%]
test_agent.py::test_upgrade[001] PASSED                                                                         [ 86%]
test_agent.py::test_upgrade[002] PASSED                                                                         [ 88%]
test_agent.py::test_upgrade_not_access_repo PASSED                                                              [ 90%]
test_agent.py::test_get_wpk_file[001] PASSED                                                                    [ 92%]
test_agent.py::test_get_wpk_file[002] PASSED                                                                    [ 94%]
test_agent.py::test_send_wpk_file[001] PASSED                                                                   [ 96%]
test_agent.py::test_send_wpk_file[002] PASSED                                                                   [ 98%]
test_agent.py::test_get_outdated_agents PASSED                                                                  [100%]

============================================== 52 passed in 0.34 seconds ==============================================
```

### Mocha test

#### Active Response
```javascript
Active Response
    PUT/active-response/:agent_id
      ✓ Request (175ms)
      ✓ Command not found (153ms)
      ✓ Agent does not exist (143ms)
      ✓ Agent ID not valid


  4 passing (483ms)
```

#### Agents
```javascript
Agents
    GET/agents
      ✓ Request (141ms)
      ✓ Pagination (142ms)
      ✓ Retrieve all elements with limit=0 (143ms)
      ✓ Sort (144ms)
      ✓ Wrong Sort (140ms)
      ✓ Search (143ms)
      ✓ Selector (140ms)
      ✓ Not allowed selector (141ms)
      ✓ Version (142ms)
      ✓ Os.platform (141ms)
      ✓ Os.version (144ms)
      ✓ ManagerHost (153ms)
      ✓ Filters: status (144ms)
      ✓ Filters: status 2 (140ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: older_than (140ms)
      ✓ Filters: group (142ms)
      ✓ Select: single field (140ms)
      ✓ Select: multiple fields (141ms)
      ✓ Select: wrong field (143ms)
      ✓ Select: invalid character
      ✓ Filters: query (144ms)
    GET/agents/summary
      ✓ Request (141ms)
    GET/agents/summary/os
      ✓ Request (141ms)
    GET/agents/outdated
      ✓ Request (143ms)
    GET/agents/:agent_id
      ✓ Request (manager) (139ms)
      ✓ Request (agent) (141ms)
      ✓ Selector (141ms)
      ✓ Not allowed selector (141ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (142ms)
      ✓ Select (141ms)
      ✓ Select: wrong field (140ms)
    GET/agents/name/:agent_name
      ✓ Request (141ms)
      ✓ Wrong name (143ms)
      ✓ Selector (144ms)
      ✓ Not allowed selector (141ms)
    GET/agents/:agent_id/key
      ✓ Request (139ms)
      ✓ Params: Bad agent id
      ✓ Errors: No key (139ms)
    PUT/agents/groups/:group_id
      ✓ Request (140ms)
      ✓ Params: Bad group name
      ✓ Params: Group already exists (142ms)
    PUT/agents/:agent_id/group/:group_id
      ✓ Request (142ms)
      ✓ Params: Bad agent name
      ✓ Params: Agent does not exist (141ms)
      ✓ Params: Replace parameter (142ms)
    POST/agents/groups/:group_id/files/:file_name
      ✓ Request (154ms)
      ✓ ErrorOnBadGroup (141ms)
      ✓ ErrorOnEmptyConf
      ✓ OnlyAgentConfAllowed (144ms)
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (148ms)
      ✓ TooBigXML
    GET/agents/no_group
      ✓ Request (141ms)
      ✓ Pagination (145ms)
      ✓ Retrieve all elements with limit=0 (141ms)
      ✓ Sort (141ms)
      ✓ Search (144ms)
      ✓ Select (142ms)
      ✓ Wrong select (142ms)
      ✓ Filter: status (143ms)
    GET/agents/groups
      ✓ Request (142ms)
      ✓ Retrieve all elements with limit=0 (146ms)
      ✓ Hash algorithm (144ms)
      ✓ Wrong Hash algorithm (141ms)
    GET/agents/groups/:group_id
      ✓ Request (144ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (140ms)
      ✓ Select (143ms)
      ✓ Filter: status (145ms)
    GET/agents/groups/:group_id/configuration
      ✓ Request (160ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (149ms)
    GET/agents/groups/:group_id/files
      ✓ Request (140ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (150ms)
      ✓ Hash algorithm (156ms)
      ✓ Wrong Hash algorithm (155ms)
    GET/agents/groups/:group_id/files/:filename
      ✓ Request (152ms)
      ✓ UsingFormatAgentConfXML (146ms)
      ✓ UsingFormatAgentConfJSON (152ms)
      ✓ UsingFormatRootcheckXML (152ms)
      ✓ UsingFormatRootcheckJSON (143ms)
      ✓ Params: Bad group name
    POST/agents/groups/:group_id/configuration
      ✓ Request (203ms)
      ✓ ErrorOnBadGroup (150ms)
      ✓ ErrorOnEmptyConf
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (159ms)
      ✓ TooBigXML
    DELETE/agents/:agent_id/group
      ✓ Request (150ms)
      ✓ Errors: ID is not present (151ms)
      ✓ Params: Bad agent id
    DELETE/agents/:agent_id/group/:group_id
      ✓ Request (152ms)
      ✓ Errors: ID is not present (148ms)
      ✓ Errors: Group is not present (160ms)
      ✓ Params: Bad agent id
      ✓ Params: Bad group id (148ms)
    DELETE/agents/groups/:group_id
      ✓ Request (153ms)
      ✓ Params: Bad group id
    DELETE/agents
      ✓ Request
      ✓ Filter: older_than, status and ids (3684ms)
      ✓ Errors: Get deleted agent (181ms)
      ✓ Filter: older_than (159ms)
    GET/agents/stats/distinct
      ✓ Request (146ms)
      ✓ Pagination (143ms)
      ✓ Retrieve all elements with limit=0 (143ms)
      ✓ Sort (145ms)
      ✓ Search (144ms)
      ✓ Select (143ms)
      ✓ Wrong select (143ms)
    GET/agents/:agent/config/:component/:configuration
      ✓ Request-Agent-Client (158ms)
      ✓ Request-Agent-Buffer (147ms)
      ✓ Request-Agent-Labels (151ms)
      ✓ Request-Agent-Internal (153ms)
      ✓ Request-Agentless-Agentless (146ms)
      ✓ Request-Analysis-Global (148ms)
      ✓ Request-Analysis-Active-response (147ms)
      ✓ Request-Analysis-Alerts (147ms)
      ✓ Request-Analysis-Command (148ms)
      ✓ Request-Analysis-Internal (147ms)
      ✓ Request-Auth-Auth (147ms)
      ✓ Request-Com-Active-response (154ms)
      ✓ Request-Com-Internal (153ms)
      ✓ Request-Csyslog-Csyslog (147ms)
      ✓ Request-Integrator-Integration (146ms)
      ✓ Request-Logcollector-Localfile (153ms)
      ✓ Request-Logcollector-Socket (155ms)
      ✓ Request-Logcollector-Internal (152ms)
      ✓ Request-Mail-Global (145ms)
      ✓ Request-Mail-Alerts (147ms)
      ✓ Request-Mail-Internal (148ms)
      ✓ Request-Monitor-Internal (146ms)
      ✓ Request-Request-Remote (147ms)
      ✓ Request-Request-Internal (147ms)
      ✓ Request-Syscheck-Syscheck (153ms)
      ✓ Request-Syscheck-Rootcheck (151ms)
      ✓ Request-Syscheck-Internal (152ms)
      ✓ Request-Wmodules-Wmodules (150ms)
    PUT/agents/restart
      ✓ Request (172ms)
    PUT/agents/:agent_id/restart
      ✓ Request (153ms)
      ✓ Params: Bad agent id
      ✓ Request (144ms)
    POST/agents/restart
      ✓ Request (157ms)
      ✓ Params: A good id and a bad one (157ms)
      ✓ Params: Bad agent id
      ✓ Request (145ms)


  149 passing (24s)
```

#### Agents 2
```javascript
Agents
    PUT/agents/:agent_name
      ✓ Request (154ms)
      ✓ Errors: Name already present (147ms)
      ✓ Params: Bad agent name
    DELETE/agents/:agent_id
      ✓ Request (144ms)
      ✓ Errors: ID is not present (142ms)
      ✓ Params: Bad agent id
    POST/agents
      Any
        ✓ Request (172ms)
        ✓ Check key (144ms)
        ✓ Errors: Name already present (141ms)
        ✓ Filters: Missing field name
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (174ms)
        ✓ Errors: Duplicated IP (143ms)
      IP
        ✓ Request (144ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2
    POST/agents/insert
      Any
        ✓ Request (174ms)
        ✓ Errors: Name already present (148ms)
        1) Errors: ID already present
        ✓ Errors: Invalid key (142ms)
        ✓ Filters: Missing fields
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (143ms)
        ✓ Errors: Duplicated IP (142ms)
      IP
        ✓ Request (146ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2


  26 passing (4s)
  1 failing

  1) Agents
       POST/agents/insert
         Any
           Errors: ID already present:
     Uncaught AssertionError: expected Object {
  error: 0,
  data: Object {
    id: '750',
    key: 'NzUwIE5ld0FnZW50UG9zdEluc2VydCBhbnkgMWFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGk2NA=='
  }
} to have property message
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:503:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)
```

#### App
```javascript
App
    Authentication
      ✓ Wrong USER
      ✓ Wrong password
      ✓ Home
    Requests
      ✓ Inexistent request
      ✓ API version


  5 passing (34ms)
```

#### Cluster
```javascript
Cluster
    GET/cluster/nodes
      ✓ Request (159ms)
      ✓ Pagination (147ms)
      ✓ Retrieve all elements with limit=0 (147ms)
      ✓ Sort (158ms)
      ✓ Search (178ms)
      ✓ Filters: type (145ms)
      ✓ Filters: invalid type (147ms)
      ✓ Select (148ms)
      ✓ Select 2 (146ms)
      ✓ Wrong select (150ms)
    GET/cluster/:node_id/stats
      1) Cluster stats
      ✓ Unexisting node stats (147ms)
      ✓ Analysisd stats (158ms)
      ✓ Remoted stats (151ms)
    GET/cluster/nodes/:node_name
      ✓ Request (144ms)
      ✓ Request wrong name (148ms)
    GET/cluster/status
      ✓ Request (147ms)
    GET/cluster/config
      ✓ Request (142ms)
    GET/cluster/healthcheck
      ✓ Request (147ms)
      ✓ Filter: node name (147ms)
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (150ms)
      ✓ Upload ossec.conf (worker) (163ms)
      ✓ Upload new rules (146ms)
      ✓ Upload rules (overwrite=true) (143ms)
      ✓ Upload rules (overwrite=false) (142ms)
      ✓ Upload new decoder (143ms)
      ✓ Upload decoder (overwrite=true) (147ms)
      ✓ Upload decoder (without overwrite parameter) (146ms)
      ✓ Upload new list (144ms)
      ✓ Upload list (overwrite=true) (142ms)
      ✓ Upload list (overwrite=false) (142ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (144ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (146ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (145ms)
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/cluster/:node_id/files
      ✓ Request ossec.conf (master) (142ms)
      ✓ Request ossec.conf (worker) (147ms)
      ✓ Request rules (local) (144ms)
      ✓ Request rules (global) (143ms)
      ✓ Request decoders (local) (145ms)
      ✓ Request decoders (global) (145ms)
      ✓ Request lists (143ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (143ms)
      ✓ Request file from unexisting node (144ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (147ms)
    GET/cluster/:node_id/configuration/validation (manager and worker OK)
      ✓ Request validation (master) (481ms)
      ✓ Request validation (worker) (493ms)
      ✓ Request validation (all nodes) (522ms)
    GET/cluster/:node_id/configuration/validation (manager KO, worker OK)
      ✓ Request validation (master) (146ms)
      ✓ Request validation (worker) (487ms)
      ✓ Request validation (all nodes) (503ms)
    GET/cluster/:node_id/configuration/validation (manager OK, worker KO)
      ✓ Request validation (master) (485ms)
      ✓ Request validation (worker) (160ms)
      ✓ Request validation (all nodes) (509ms)
    GET/cluster/:node_id/configuration/validation (manager and worker KO)
      ✓ Request validation (master) (156ms)
      ✓ Request validation (worker) (154ms)
      ✓ Request validation (all nodes) (162ms)
    DELETE/cluster/:node_id/files
      ✓ Delete rules (master) (145ms)
      ✓ Delete decoders (master) (144ms)
      ✓ Delete CDB list (master) (150ms)
      ✓ Delete file with empty path
    GET/cluster/master/config/:component/:configuration
      ✓ Request-Agentless-Agentless (162ms)
      ✓ Request-Analysis-Global (154ms)
      ✓ Request-Analysis-Active-response (143ms)
      ✓ Request-Analysis-Alerts (149ms)
      ✓ Request-Analysis-Command (146ms)
      ✓ Request-Analysis-Internal (149ms)
      ✓ Request-Auth-Auth (149ms)
      ✓ Request-Com-Active-response (150ms)
      ✓ Request-Com-Internal (143ms)
      ✓ Request-Csyslog-Csyslog (146ms)
      ✓ Request-Integrator-Integration (144ms)
      ✓ Request-Logcollector-Localfile (150ms)
      ✓ Request-Logcollector-Socket (146ms)
      ✓ Request-Logcollector-Internal (151ms)
      ✓ Request-Mail-Global (144ms)
      ✓ Request-Mail-Alerts (146ms)
      ✓ Request-Mail-Internal (144ms)
      ✓ Request-Monitor-Internal (149ms)
      ✓ Request-Request-Remote (143ms)
      ✓ Request-Request-Internal (168ms)
      ✓ Request-Syscheck-Syscheck (143ms)
      ✓ Request-Syscheck-Rootcheck (143ms)
      ✓ Request-Syscheck-Internal (143ms)
      ✓ Request-Wmodules-Wmodules (143ms)
    PUT/cluster/:node_id/restart
      ✓ Request (worker) (150ms)
      ✓ Request (master) (148ms)


  96 passing (17s)
  1 failing

  1) Cluster
       GET/cluster/:node_id/stats
         Cluster stats:
     Uncaught AssertionError: expected Object { error: 1308, message: 'Stats file has not been created yet' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_cluster.js:243:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)
```

#### Decoders
```javascript
Decoders
    GET/decoders
      ✓ Request (197ms)
      ✓ Pagination (168ms)
      ✓ Retrieve all elements with limit=0 (168ms)
      ✓ Sort (176ms)
      ✓ Search (170ms)
      ✓ Filters: File (165ms)
      ✓ Filters: Path (165ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/decoders/files
      ✓ Request (147ms)
      ✓ Pagination (149ms)
      ✓ Retrieve all elements with limit=0 (148ms)
      ✓ Sort (153ms)
      ✓ Search (147ms)
    GET/decoders/parents
      ✓ Request (165ms)
      ✓ Pagination (164ms)
      ✓ Retrieve all elements with limit=0 (166ms)
      ✓ Sort (163ms)
      ✓ Search (164ms)
    GET/decoders/:decoder_name
      ✓ Request (161ms)
      ✓ Pagination (162ms)
      ✓ Retrieve all elements with limit=0 (162ms)
      ✓ Sort (164ms)
      ✓ Search (161ms)


  24 passing (4s)
```

#### Lists
```javascript
Lists
    GET/lists
      ✓ Request (153ms)
      ✓ Pagination (142ms)
      ✓ Retrieve all elements with limit=0 (140ms)
      ✓ Sort (147ms)
      ✓ Search (143ms)
      ✓ Filters: Path (143ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/lists/files
      ✓ Request (143ms)
      ✓ Pagination (144ms)
      ✓ Retrieve all elements with limit=0 (142ms)
      ✓ Sort (142ms)
      ✓ Search (141ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field


  15 passing (2s)
```

#### Manager
```javascript
Manager
    GET/manager/status
      ✓ Request (149ms)
    GET/manager/info
      ✓ Request (144ms)
    GET/manager/configuration
      ✓ Request (145ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (149ms)
      ✓ Errors: Invalid Section (142ms)
      ✓ Filters: Section - field (142ms)
      ✓ Errors: Invalid field (143ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (143ms)
      ✓ Filters: date (162ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (143ms)
    GET/manager/stats/weekly
      ✓ Request (144ms)
    GET/manager/stats/analysisd
      ✓ Request (145ms)
    GET/manager/stats/remoted
      ✓ Request (141ms)
    GET/manager/logs
      ✓ Request (156ms)
      ✓ Pagination (154ms)
      ✓ Retrieve all elements with limit=0 (156ms)
      ✓ Sort (154ms)
      ✓ SortField (158ms)
      ✓ Search (158ms)
      ✓ Filters: type_log (158ms)
      ✓ Filters: category (154ms)
      ✓ Filters: type_log and category (151ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (158ms)
    POST/manager/files
      ✓ Upload ossec.conf (147ms)
      ✓ Upload ossec.conf (overwrite=false) (142ms)
      ✓ Upload rules (new rule) (142ms)
      ✓ Upload rules (overwrite=true) (144ms)
      ✓ Upload rules (overwrite=false) (140ms)
      ✓ Upload decoder (overwrite=true) (144ms)
      ✓ Upload decoder (without overwrite parameter) (142ms)
      ✓ Upload list (overwrite=true) (144ms)
      ✓ Upload list (without overwrite parameter) (140ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/manager/files
      ✓ Request ossec.conf (144ms)
      ✓ Request rules (local) (147ms)
      ✓ Request rules (global) (142ms)
      ✓ Request decoders (local) (141ms)
      ✓ Request decoders (global) (144ms)
      ✓ Request lists (143ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (147ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (148ms)
    DELETE/manager/files
      ✓ Delete rules (146ms)
      ✓ Delete decoders (143ms)
      ✓ Delete CDB list (147ms)
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (491ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (154ms)
    GET/manager/config/:component/:configuration
      ✓ Request-Agentless-Agentless (143ms)
      ✓ Request-Analysis-Global (145ms)
      ✓ Request-Analysis-Active-response (142ms)
      ✓ Request-Analysis-Alerts (142ms)
      ✓ Request-Analysis-Command (148ms)
      ✓ Request-Analysis-Internal (145ms)
      ✓ Request-Auth-Auth (141ms)
      ✓ Request-Com-Active-response (143ms)
      ✓ Request-Com-Internal (142ms)
      ✓ Request-Csyslog-Csyslog (143ms)
      ✓ Request-Integrator-Integration (141ms)
      ✓ Request-Logcollector-Localfile (150ms)
      ✓ Request-Logcollector-Socket (142ms)
      ✓ Request-Logcollector-Internal (148ms)
      ✓ Request-Mail-Global (144ms)
      ✓ Request-Mail-Alerts (144ms)
      ✓ Request-Mail-Internal (143ms)
      ✓ Request-Monitor-Internal (143ms)
      ✓ Request-Request-Remote (148ms)
      ✓ Request-Request-Internal (144ms)
      ✓ Request-Syscheck-Syscheck (144ms)
      ✓ Request-Syscheck-Rootcheck (142ms)
      ✓ Request-Syscheck-Internal (144ms)
      ✓ Request-Wmodules-Wmodules (145ms)
    PUT/manager/restart
      ✓ Request (146ms)


  88 passing (12s)
```

#### Rootcheck
```javascript
Rootcheck
    GET/rootcheck/:agent_id/last_scan
      ✓ Request (154ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (138ms)
    DELETE/rootcheck/:agent_id
      ✓ Request (151ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (138ms)
    DELETE/rootcheck
      ✓ Request (194ms)
    PUT/rootcheck/:agent_id
      ✓ Request (145ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (137ms)
    PUT/rootcheck
      ✓ Request (160ms)


  11 passing (1s)
```

#### Rules
```javascript
Rules
    GET/rules
      ✓ Request (253ms)
      ✓ Pagination (221ms)
      ✓ Retrieve all elements with limit=0 (224ms)
      ✓ Sort (230ms)
      ✓ Search (288ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (234ms)
      ✓ Filters: group (253ms)
      ✓ Filters: level (1) (236ms)
      ✓ Filters: level (2) (333ms)
      ✓ Filters: path (231ms)
      ✓ Filters: file (232ms)
      ✓ Filters: pci (304ms)
      ✓ Filters: gdpr (229ms)
      ✓ Filters: hipaa (406ms)
      ✓ Filters: nist-800-53 (236ms)
      ✓ Filters: gpg13 (230ms)
    GET/rules/groups
      ✓ Request (220ms)
      ✓ Pagination (220ms)
      ✓ Retrieve all elements with limit=0 (219ms)
      ✓ Sort (223ms)
      ✓ Search (221ms)
      ✓ Filters: Invalid filter
    GET/rules/pci
      ✓ Request (222ms)
      ✓ Pagination (225ms)
      ✓ Retrieve all elements with limit=0 (221ms)
      ✓ Sort (225ms)
      ✓ Search (221ms)
      ✓ Filters: Invalid filter
    GET/rules/gdpr
      ✓ Request (221ms)
      ✓ Pagination (227ms)
      ✓ Retrieve all elements with limit=0 (220ms)
      ✓ Sort (222ms)
      ✓ Search (223ms)
      ✓ Filters: Invalid filter
    GET/rules/gpg13
      ✓ Request (225ms)
      ✓ Pagination (225ms)
      ✓ Retrieve all elements with limit=0 (224ms)
      ✓ Sort (222ms)
      ✓ Search (224ms)
      ✓ Filters: Invalid filter
    GET/rules/hipaa
      ✓ Request (223ms)
      ✓ Pagination (222ms)
      ✓ Retrieve all elements with limit=0 (221ms)
      ✓ Sort (222ms)
      ✓ Search (223ms)
      ✓ Filters: Invalid filter
    GET/rules/nist-800-53
      ✓ Request (224ms)
      ✓ Pagination (222ms)
      ✓ Retrieve all elements with limit=0 (223ms)
      ✓ Sort (222ms)
      ✓ Search (223ms)
      ✓ Filters: Invalid filter
    GET/rules/files
      ✓ Request (144ms)
      ✓ Pagination (145ms)
      ✓ Retrieve all elements with limit=0 (145ms)
      ✓ Sort (145ms)
      ✓ Search (145ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (145ms)
      ✓ Filters: download (147ms)
    GET/rules/:rule_id
      ✓ Request (223ms)
      ✓ Pagination (220ms)
      ✓ Retrieve all elements with limit=0 (224ms)
      ✓ Sort (221ms)
      ✓ Search (220ms)
      ✓ Filters: Invalid filter
      ✓ Params: Bad rule id
      ✓ Params: No rule (218ms)


  71 passing (13s)
```

#### SCA
```javascript
SecurityConfigurationAssessment
    GET/sca/:agent_id
      ✓ Request (164ms)
      ✓ Pagination (146ms)
      ✓ Retrieve all elements with limit=0 (143ms)
      ✓ Sort (150ms)
      ✓ Search (151ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (138ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: query (148ms)
      ✓ Retrieve all elements with limit=0 (145ms)
    GET/sca/:agent_id/checks/:policy_id
      ✓ Request (148ms)
      ✓ Pagination (147ms)
      ✓ Retrieve all elements with limit=0 (144ms)
      ✓ Sort (146ms)
      ✓ Search (151ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (136ms)
      ✓ Check not found (146ms)
      ✓ Retrieve all elements with limit=0 (145ms)


  20 passing (2s)
```

#### Syscheck
```javascript
Syscheck
    GET/syscheck/:agent_id
      ✓ Request (175ms)
      ✓ Pagination (148ms)
      ✓ Retrieve all elements with limit=0 (146ms)
      ✓ Sort (143ms)
      ✓ Search (148ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (139ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: file (145ms)
      ✓ Filters: type (145ms)
      ✓ Filters: summary (147ms)
      ✓ Filters: md5 (156ms)
      ✓ Filters: sha1 (152ms)
      ✓ Filters: sha256 (150ms)
      ✓ Filters: hash (156ms)
    GET/syscheck/:agent_id/last_scan
      ✓ Request (148ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (139ms)
    DELETE/syscheck/:agent_id
      ✓ Request (149ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (138ms)
    DELETE/experimental/syscheck
      ✓ Request (336ms)
    PUT/syscheck/:agent_id
      ✓ Request (156ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (138ms)
    PUT/syscheck
      ✓ Request (159ms)


  27 passing (3s)
```

#### Syscollector
```javascript
Syscollector
    GET/syscollector/:agent_id/os
      ✓ Request (150ms)
      ✓ Selector (161ms)
      ✓ Not allowed selector (148ms)
    GET/syscollector/:agent_id/hardware
      ✓ Request (149ms)
      ✓ Selector (148ms)
      ✓ Not allowed selector (145ms)
    GET/syscollector/:agent_id/packages
      ✓ Request (163ms)
      ✓ Selector (152ms)
      ✓ Not allowed selector (144ms)
      ✓ Pagination (143ms)
      ✓ Wrong limit
      ✓ Sort - (146ms)
      ✓ Sort + (151ms)
      ✓ Wrong Sort (148ms)
      ✓ Search (158ms)
      ✓ Filter: vendor (150ms)
      ✓ Filter: name (152ms)
      ✓ Filter: architecture (162ms)
      ✓ Filter: format (164ms)
      ✓ Wrong filter
    GET/experimental/syscollector/packages
      ✓ Request (324ms)
      ✓ Selector (261ms)
      ✓ Not allowed selector (161ms)
      ✓ Pagination (168ms)
      ✓ Wrong limit
      ✓ Sort - (169ms)
      ✓ Sort + (170ms)
      ✓ Wrong Sort (163ms)
      ✓ Search (197ms)
      ✓ Filter: vendor (265ms)
      ✓ Filter: name (175ms)
      ✓ Filter: architecture (248ms)
      ✓ Filter: format (267ms)
      ✓ Wrong filter
    GET/experimental/syscollector/os
      ✓ Request (178ms)
      ✓ Selector (174ms)
      ✓ Not allowed selector (169ms)
      ✓ Pagination (174ms)
      ✓ Wrong limit
      ✓ Search (186ms)
      ✓ Wrong filter
      ✓ Filter: architecture (194ms)
      ✓ Filter: os_name (179ms)
      ✓ Filter: release (183ms)
    GET/experimental/syscollector/hardware
      ✓ Request (170ms)
      ✓ Selector (178ms)
      ✓ Not allowed selector (164ms)
      ✓ Pagination (166ms)
      ✓ Wrong limit
      ✓ Search (178ms)
      ✓ Wrong filter
      ✓ Wrong Sort (165ms)
      ✓ Filter: ram_total (179ms)
      ✓ Filter: cpu_cores (175ms)
      ✓ Filter: cpu_mhz (178ms)
      ✓ Filter: board_serial (177ms)
    GET/experimental/syscollector/processes
      ✓ Request (183ms)
      ✓ Selector (190ms)
      ✓ Not allowed selector (164ms)
      ✓ Pagination (168ms)
      ✓ Wrong limit
      ✓ Search (188ms)
      ✓ Wrong filter
      ✓ Wrong Sort (165ms)
      ✓ Filter: state (170ms)
      ✓ Filter: ppid (169ms)
      ✓ Filter: egroup (167ms)
      ✓ Filter: euser (168ms)
      ✓ Filter: fgroup (220ms)
      ✓ Filter: name (181ms)
      ✓ Filter: nlwp (170ms)
      ✓ Filter: pgrp (176ms)
      ✓ Filter: priority (170ms)
      ✓ Filter: rgroup (166ms)
      ✓ Filter: ruser (166ms)
      ✓ Filter: sgroup (170ms)
      ✓ Filter: suser (170ms)
    GET/experimental/syscollector/ports
      ✓ Request (171ms)
      ✓ Selector (174ms)
      ✓ Not allowed selector (166ms)
      ✓ Pagination (174ms)
      ✓ Wrong limit
      ✓ Search (177ms)
      ✓ Wrong filter
      ✓ Wrong Sort (167ms)
      ✓ Filter: protocol (175ms)
      ✓ Filter: local_ip (173ms)
      ✓ Filter: local_port (177ms)
      ✓ Filter: remote_ip (173ms)
      ✓ Filter: tx_queue (174ms)
      ✓ Filter: state (176ms)
    GET/syscollector/netaddr
      ✓ Request (178ms)
      ✓ Selector (174ms)
      ✓ Not allowed selector (163ms)
      ✓ Pagination (168ms)
      ✓ Wrong limit
      ✓ Search (176ms)
      ✓ Wrong filter
      ✓ Wrong Sort (162ms)
      ✓ Filter: iface (172ms)
      ✓ Filter: proto (174ms)
      ✓ Filter: address (175ms)
      ✓ Filter: broadcast (173ms)
      ✓ Filter: netmask (177ms)
    GET/experimental/syscollector/netproto
      ✓ Request (171ms)
      ✓ Selector (176ms)
      ✓ Not allowed selector (163ms)
      ✓ Pagination (168ms)
      ✓ Wrong limit
      ✓ Search (179ms)
      ✓ Wrong filter
      ✓ Wrong Sort (165ms)
      ✓ Filter: iface (172ms)
      ✓ Filter: type (175ms)
      ✓ Filter: gateway (171ms)
      ✓ Filter: dhcp (176ms)
    GET/experimental/syscollector/netiface
      ✓ Request (174ms)
      ✓ Selector (174ms)
      ✓ Not allowed selector (164ms)
      ✓ Pagination (166ms)
      ✓ Wrong limit
      ✓ Search (179ms)
      ✓ Wrong filter
      ✓ Wrong Sort (164ms)
      ✓ Filter: name (172ms)
      ✓ Filter: type (174ms)
      ✓ Filter: state (178ms)
      ✓ Filter: mtu (177ms)
      ✓ Filter: tx_packets (175ms)
      ✓ Filter: rx_packets (176ms)
      ✓ Filter: tx_bytes (175ms)
      ✓ Filter: rx_bytes (174ms)
      ✓ Filter: tx_errors (176ms)
      ✓ Filter: rx_errors (179ms)
      ✓ Filter: tx_dropped (179ms)
      ✓ Filter: rx_dropped (177ms)
    GET/syscollector/000/processes
      ✓ Request (151ms)
      ✓ Selector (151ms)
      ✓ Not allowed selector (147ms)
      ✓ Pagination (148ms)
      ✓ Wrong limit
      ✓ Search (152ms)
      ✓ Wrong filter
      ✓ Wrong Sort (147ms)
      ✓ Filter: state (147ms)
      ✓ Filter: ppid (149ms)
      ✓ Filter: egroup (146ms)
      ✓ Filter: euser (146ms)
      ✓ Filter: fgroup (147ms)
      ✓ Filter: name (153ms)
      ✓ Filter: nlwp (149ms)
      ✓ Filter: pgrp (151ms)
      ✓ Filter: priority (147ms)
      ✓ Filter: rgroup (147ms)
      ✓ Filter: ruser (148ms)
      ✓ Filter: sgroup (147ms)
      ✓ Filter: suser (148ms)
    GET/syscollector/000/ports
      ✓ Request (150ms)
      ✓ Selector (150ms)
      ✓ Not allowed selector (145ms)
      ✓ Pagination (152ms)
      ✓ Wrong limit
      ✓ Search (151ms)
      ✓ Wrong filter
      ✓ Wrong Sort (146ms)
      ✓ Filter: protocol (152ms)
      ✓ Filter: local_ip (150ms)
      ✓ Filter: local_port (149ms)
      ✓ Filter: remote_ip (150ms)
      ✓ Filter: tx_queue (152ms)
      ✓ Filter: state (149ms)
    GET/syscollector/000/netaddr
      ✓ Request (149ms)
      ✓ Selector (152ms)
      ✓ Not allowed selector (146ms)
      ✓ Pagination (147ms)
      ✓ Wrong limit
      ✓ Search (150ms)
      ✓ Wrong filter
      ✓ Wrong Sort (148ms)
      ✓ Filter: iface (148ms)
      ✓ Filter: proto (148ms)
      ✓ Filter: address (147ms)
      ✓ Filter: broadcast (149ms)
      ✓ Filter: netmask (150ms)
    GET/syscollector/000/netproto
      ✓ Request (148ms)
      ✓ Selector (151ms)
      ✓ Not allowed selector (145ms)
      ✓ Pagination (146ms)
      ✓ Wrong limit
      ✓ Search (148ms)
      ✓ Wrong filter
      ✓ Wrong Sort (145ms)
      ✓ Filter: iface (147ms)
      ✓ Filter: type (148ms)
      ✓ Filter: gateway (152ms)
      ✓ Filter: dhcp (148ms)
    GET/syscollector/000/netiface
      ✓ Request (149ms)
      ✓ Selector (149ms)
      ✓ Not allowed selector (147ms)
      ✓ Pagination (146ms)
      ✓ Wrong limit
      ✓ Search (150ms)
      ✓ Wrong filter
      ✓ Wrong Sort (146ms)
      ✓ Filter: name (150ms)
      ✓ Filter: type (150ms)
      ✓ Filter: state (148ms)
      ✓ Filter: mtu (149ms)
      ✓ Filter: tx_packets (155ms)
      ✓ Filter: rx_packets (151ms)
      ✓ Filter: tx_bytes (151ms)
      ✓ Filter: rx_bytes (150ms)
      ✓ Filter: tx_errors (151ms)
      ✓ Filter: rx_errors (149ms)
      ✓ Filter: tx_dropped (149ms)
      ✓ Filter: rx_dropped (148ms)


  216 passing (36s)
``
    