### PR TITLE
Changed type for "full_log" (text)

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -68,8 +68,7 @@
         "doc_values": "true"
       },
       "full_log": {
-        "enabled": false,
-        "type": "object"
+        "type": "text"
       },
       "previous_log": {
         "type": "text"


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/3513 | 

## Description

Changes mapping definition for "full_log" from:

```
"type": "object",
"enabled": "false"
```

to 

```
"type": "text"
```
