### PR TITLE
Replace "{" and "}" from "full_log" with "#"

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2361,6 +2361,18 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
             /* Log the alert if configured to */
             if (t_currently_rule->alert_opts & DO_LOGALERT) {
                 lf->comment = ParseRuleComment(lf);
+                
+                // If full_log exists, replace "{" and "}" with "#"               
+                if(lf->full_log) {
+                  char*p;
+                  for (p = lf->full_log; p = strchr(p, '{'); ++p) {
+                     *p = '#';
+                  }
+                  for (p = lf->full_log; p = strchr(p, '}'); ++p) {
+                     *p = '#';
+                  }
+                  if(p) os_free(p);
+                }
 
                 os_calloc(1, sizeof(Eventinfo), lf_cpy);
                 w_copy_event_for_log(lf,lf_cpy);


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/3513 |

## Description

Before printing the alert to the alerts.json:

```c
// If full_log exists, replace "{" and "}" with "#"               
if(lf->full_log) {
  char*p;
  for (p = lf->full_log; p = strchr(p, '{'); ++p) {
     *p = '#';
  }
  for (p = lf->full_log; p = strchr(p, '}'); ++p) {
     *p = '#';
  }
  if(p) os_free(p);
}
```

1. The `lf->full_log` may be missing, that's why we use an `if`.
2. Try to replace all `{` occurrences with `#`. 
3. Try to replace all `}` occurrences with `#`. 

## Tests

CentOS 7 using type `text` in the template and using modules such as AWS that are expected to generate JSON in `full_log`, it's working as expected.

![image](https://user-images.githubusercontent.com/8860227/59605092-45e95500-910e-11e9-988c-94bb2d45e747.png)


I've also executed Valgrind, there are just the usual 100 bytes lost for `analysisd`.

```
# pkill -f analysisd
# valgrind --leak-check=full -v /var/ossec/bin/ossec-analysisd -f
...
==11463== LEAK SUMMARY:
==11463==    definitely lost: 100 bytes in 9 blocks
==11463==    indirectly lost: 0 bytes in 0 blocks
==11463==      possibly lost: 41,440 bytes in 74 blocks
==11463==    still reachable: 12,019,431 bytes in 57,220 blocks
==11463==         suppressed: 0 bytes in 0 blocks
==11463== Reachable blocks (those to which a pointer was found) are not shown.
==11463== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

