### PR TITLE
Fix memory leak when CIS-CAT cannot read reports

### DIFF
--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -468,18 +468,31 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
 
     if (!ciscat->flags.error) {
         scan_info = wm_ciscat_txt_parser();
-        if (eval->profile) {
-            os_strdup(eval->profile, scan_info->profile);
-        } else {
-            scan_info->profile = wm_ciscat_get_profile();
-        }
         if (!ciscat->flags.error) {
+            if (eval->profile) {
+                os_strdup(eval->profile, scan_info->profile);
+            } else {
+                scan_info->profile = wm_ciscat_get_profile();
+            }
             wm_ciscat_preparser();
             if (!ciscat->flags.error) {
                 wm_ciscat_xml_parser();
                 wm_ciscat_send_scan(scan_info, id);
             }
         }
+
+        if (ciscat->flags.error) {
+            mterror(WM_CISCAT_LOGTAG, "Failed reading scan results for policy '%s'", eval->path);
+        }
+    }
+
+    if (scan_info) {
+        os_free(scan_info->profile);
+        os_free(scan_info->benchmark);
+        os_free(scan_info->hostname);
+        os_free(scan_info->timestamp);
+        os_free(scan_info->score);
+        os_free(scan_info);
     }
 
     snprintf(msg, OS_MAXSTR, "Ending CIS-CAT scan. File: %s. ", eval->path);
@@ -636,18 +649,31 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
 
     if (!ciscat->flags.error) {
         scan_info = wm_ciscat_txt_parser();
-        if (eval->profile) {
-            os_strdup(eval->profile, scan_info->profile);
-        } else {
-            scan_info->profile = wm_ciscat_get_profile();
-        }
         if (!ciscat->flags.error) {
+            if (eval->profile) {
+                os_strdup(eval->profile, scan_info->profile);
+            } else {
+                scan_info->profile = wm_ciscat_get_profile();
+            }
             wm_ciscat_preparser();
             if (!ciscat->flags.error) {
                 wm_ciscat_xml_parser();
                 wm_ciscat_send_scan(scan_info, id);
             }
         }
+
+        if (ciscat->flags.error) {
+            mterror(WM_CISCAT_LOGTAG, "Failed reading scan results for policy '%s'", eval->path);
+        }
+    }
+
+    if (scan_info) {
+        os_free(scan_info->profile);
+        os_free(scan_info->benchmark);
+        os_free(scan_info->hostname);
+        os_free(scan_info->timestamp);
+        os_free(scan_info->score);
+        os_free(scan_info);
     }
 
     snprintf(msg, OS_MAXSTR, "Ending CIS-CAT scan. File: %s. ", eval->path);
@@ -717,11 +743,6 @@ wm_scan_data* wm_ciscat_txt_parser(){
     wm_scan_data *info = NULL;
     wm_rule_data *rule = NULL;
 
-    os_calloc(1, sizeof(wm_scan_data), info);
-    os_calloc(1, sizeof(wm_rule_data), rule);
-
-    head = rule;
-
     // Define report location
 
 #ifdef WIN32
@@ -731,6 +752,11 @@ wm_scan_data* wm_ciscat_txt_parser(){
 #endif
 
     if ((fp = fopen(file, "r"))){
+
+        os_calloc(1, sizeof(wm_scan_data), info);
+        os_calloc(1, sizeof(wm_rule_data), rule);
+
+        head = rule;
 
         while (fgets(readbuff, OS_MAXSTR, fp) != NULL){
 
@@ -896,7 +922,7 @@ wm_scan_data* wm_ciscat_txt_parser(){
 
         fclose(fp);
     } else {
-        mterror(WM_CISCAT_LOGTAG, "Unable to read file %s: %s", file, strerror(errno));
+        mtdebug1(WM_CISCAT_LOGTAG, "Report result file '%s' missing: %s", file, strerror(errno));
         ciscat->flags.error = 1;
     }
 
@@ -1420,12 +1446,6 @@ void wm_ciscat_send_scan(wm_scan_data *info, int id){
     cJSON_Delete(object);
 
     free(msg);
-    free(info->benchmark);
-    free(info->profile);
-    free(info->hostname);
-    free(info->timestamp);
-    free(info->score);
-    free(info);
 
     // Send scan results
 


### PR DESCRIPTION
|Related issue|
|---|
|#3486|

## Description

During the testing of the CIS-CAT module with different wrong inputs, we noticed a memory leak when trying to parse the scan output without success.

In `wm_ciscat_txt_parser()`, `info` and `rule` were being allocated even if the report file couldn't be opened, when this happens, the function returns without freeing those variables.

https://github.com/wazuh/wazuh/blob/8dfea182176937e90791339b163c641cad69476a/src/wazuh_modules/wm_ciscat.c#L720

The solution goes through allocating them only when will be used. In addition, now the variable `scan_info` is freed in `wm_ciscat_run()` instead of `wm_ciscat_send_scan()` to avoid a memory leak when the parsing process is interrupted by any error.

## Logs/Alerts example

Testing case: the next configuration has been used for the testing:

```xml
<wodle name="cis-cat">
    <disabled>no</disabled>
    <timeout>20</timeout>
    <interval>1d</interval>
    <scan-on-start>yes</scan-on-start>
    <java_path>/usr/bin/java</java_path>
    <ciscat_path>/root/cis-cat/cis-cat-full</ciscat_path>
    <content type="xccdf" path="benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml" />
    <content type="xccdf" path="benchmarks/CIS_CentOS_Linux_7_Benchmark_v2.1.1-xccdf.xml">
       <profile>fake_profile</profile>
    </content>
    <content type="xccdf" path="benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml" />
</wodle>
```

Log output for each scan:

```
2019/06/17 06:06:16 wazuh-modulesd:ciscat[21746] wm_ciscat.c:596 at wm_ciscat_run(): DEBUG: Launching command: ./CIS-CAT.sh -a -b /root/cis-cat/cis-cat-full/benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml -r /var/ossec/tmp -rn ciscat-report -x -t -n -y
2019/06/17 06:06:16 wazuh-modulesd[21746] wm_exec.c:340 at wm_exec(): DEBUG: New 'PATH' environment variable set: '/usr/bin/java:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/var/ossec/bin'
2019/06/17 06:06:18 wazuh-modulesd:ciscat[21746] wm_ciscat.c:607 at wm_ciscat_run(): INFO: Scan finished successfully. File: /root/cis-cat/cis-cat-full/benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml
2019/06/17 06:06:18 wazuh-modulesd:ciscat[21746] wm_ciscat.c:921 at wm_ciscat_txt_parser(): DEBUG: Finished parse of the TXT report.
2019/06/17 06:06:18 wazuh-modulesd:ciscat[21746] wm_ciscat.c:1100 at wm_ciscat_preparser(): DEBUG: Finished preparse of the XML report.
2019/06/17 06:06:18 wazuh-modulesd:ciscat[21746] wm_ciscat.c:1256 at wm_ciscat_xml_parser(): DEBUG: Finished parse of the XML report.
----------------------------------
2019/06/17 06:06:18 wazuh-modulesd:ciscat[21746] wm_ciscat.c:596 at wm_ciscat_run(): DEBUG: Launching command: ./CIS-CAT.sh -a -b /root/cis-cat/cis-cat-full/benchmarks/CIS_CentOS_Linux_7_Benchmark_v2.1.1-xccdf.xml -p fake_profile -r /var/ossec/tmp -rn ciscat-report -x -t -n -y
2019/06/17 06:06:18 wazuh-modulesd[21746] wm_exec.c:340 at wm_exec(): DEBUG: New 'PATH' environment variable set: '/usr/bin/java:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/var/ossec/bin'
2019/06/17 06:06:20 wazuh-modulesd:ciscat[21746] wm_ciscat.c:602 at wm_ciscat_run(): ERROR: Ignoring content '/root/cis-cat/cis-cat-full/benchmarks/CIS_CentOS_Linux_7_Benchmark_v2.1.1-xccdf.xml' due to error (232).
2019/06/17 06:06:20 wazuh-modulesd:ciscat[21746] wm_ciscat.c:603 at wm_ciscat_run(): ERROR: OUTPUT: This is CIS-CAT-Pro Assessor version 3.0.43
An error occurred configuring the profile fake_profile selected for assessment.  Ensure the profile is valid for the selected benchmark.
CIS-CAT will now exit -- Error Code: ERR-CLI-0012
----------------------------------
2019/06/17 06:06:20 wazuh-modulesd:ciscat[21746] wm_ciscat.c:596 at wm_ciscat_run(): DEBUG: Launching command: ./CIS-CAT.sh -a -b /root/cis-cat/cis-cat-full/benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml -r /var/ossec/tmp -rn ciscat-report -x -t -n -y
2019/06/17 06:06:20 wazuh-modulesd[21746] wm_exec.c:340 at wm_exec(): DEBUG: New 'PATH' environment variable set: '/usr/bin/java:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/var/ossec/bin'
2019/06/17 06:06:40 wazuh-modulesd:ciscat[21746] wm_ciscat.c:616 at wm_ciscat_run(): ERROR: Timeout expired executing '/root/cis-cat/cis-cat-full/benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml'.
2019/06/17 06:06:40 wazuh-modulesd:ciscat[21746] wm_ciscat.c:925 at wm_ciscat_txt_parser(): DEBUG: Report result file '/var/ossec/tmp/ciscat-report.txt' missing: No such file or directory
2019/06/17 06:06:40 wazuh-modulesd:ciscat[21746] wm_ciscat.c:666 at wm_ciscat_run(): ERROR: Failed reading scan results for policy '/root/cis-cat/cis-cat-full/benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml'
2019/06/17 06:06:41 wazuh-modulesd:ciscat[21746] wm_ciscat.c:260 at wm_ciscat_main(): INFO: Evaluation finished.
```

Valgrind report:

```
==23484== LEAK SUMMARY:
==23484==    definitely lost: 0 bytes in 0 blocks
==23484==    indirectly lost: 0 bytes in 0 blocks
==23484==      possibly lost: 6,008 bytes in 8 blocks
==23484==    still reachable: 446,499 bytes in 152 blocks
==23484==                       of which reachable via heuristic:
==23484==                         length64           : 223,848 bytes in 121 blocks
==23484==         suppressed: 0 bytes in 0 blocks
==23484== Reachable blocks (those to which a pointer was found) are not shown.
==23484== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

The memory leak has disappeared.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- Memory tests
  - [x] Valgrind report for affected components
- [x] Review logs syntax and correct language
- CIS-CAT scan tests:
  - [x] Valid policy scanned with success.
  - [x] Policy timeout works as expected.
  - [x] Invalid policies are scanned and logged correctly.