### PR TITLE
remove duplicated command

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1492,6 +1492,30 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
         }
     }
 
+    if (current->command) {
+        for (r = 0, k = -1;; r++) {
+            if (f_control = update_current(&dup, &r, &k), f_control) {
+                if (f_control == NEXT_IT) {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+
+            if (current != dup && dup->command && !strcmp(current->command, dup->command)) {
+                mwarn(DUP_FILE, current->command);
+                int result = Remove_Localfile(&logff, i, 0, 1,NULL);
+                if (result) {
+                    merror_exit(REM_ERROR, current->command);
+                } else {
+                    mdebug1(CURRENT_FILES, current_files, maximum_files);
+                }
+                d_control = NEXT_IT;
+                break;
+            }
+        }
+    }
+
     return d_control;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|[3487](https://github.com/wazuh/wazuh/issues/3487)|

## Description

A user wants to modify the frequency at which this command is executed in a group of agents.

```xml
  <localfile>
    <log_format>full_command</log_format>
    <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
    <alias>netstat listening ports</alias>
    <frequency>360</frequency>
  </localfile>
```
To do this, write the same command with different frequency in agent.conf

The problem is that the agent.conf configuration does not overwrite the ossec.conf configuration. This PR does.

## Configuration options
You can test it adding following configuration block in agent.conf:

```xml
  <localfile>
    <log_format>full_command</log_format>
    <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
    <alias>netstat listening ports</alias>
    <frequency>30</frequency>
  </localfile>
```

## Logs/Alerts example

It's de ossec-logcollector log when Wazuh agent restart:

```
2019/06/17 14:25:30 ossec-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2019/06/17 14:25:30 ossec-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2019/06/17 14:25:30 ossec-logcollector: INFO: (1950): Analyzing file: '/var/log/auth.log'.
2019/06/17 14:25:30 ossec-logcollector: INFO: (1950): Analyzing file: '/var/log/syslog'.
2019/06/17 14:25:30 ossec-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2019/06/17 14:25:30 ossec-logcollector: INFO: (1950): Analyzing file: '/var/log/kern.log'.
2019/06/17 14:25:30 ossec-logcollector: INFO: Monitoring output of command(360): df -P
2019/06/17 14:25:30 ossec-logcollector: WARNING: (1958): Log file 'netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d' is duplicated.
2019/06/17 14:25:30 ossec-logcollector: INFO: Monitoring full output of command(30): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2019/06/17 14:25:30 ossec-logcollector: INFO: Monitoring full output of command(360): last -n 20
2019/06/17 14:25:30 ossec-logcollector: INFO: Started (pid: 8300).
2019/06/17 14:25:35 ossec-logcollector: INFO: Agent is now online. Process unlocked, continuing...
```

The duplicate command is deleted. And the command executed is in agent.conf (look timestaps):

```
2019 Jun 17 16:37:34 (agent) 10.0.0.5->last -n 20 ossec: output: 'last -n 20':
2019 Jun 17 16:37:37 (agent) 10.0.0.5->netstat listening ports ossec: output: 'netstat listening ports':
2019 Jun 17 16:38:07 (agent) 10.0.0.5->netstat listening ports ossec: output: 'netstat listening ports':
2019 Jun 17 16:38:38 (agent) 10.0.0.5->netstat listening ports ossec: output: 'netstat listening ports':
2019 Jun 17 16:39:08 (agent) 10.0.0.5->netstat listening ports ossec: output: 'netstat listening ports':
2019 Jun 17 16:39:38 (agent) 10.0.0.5->netstat listening ports ossec: output: 'netstat listening ports':
2019 Jun 17 16:40:08 (agent) 10.0.0.5->netstat listening ports ossec: output: 'netstat listening ports':
```


## Tests
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [ ] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
