### PR TITLE
Remove ossec-init.conf deps

### DIFF
--- a/framework/examples/get_agents.py
+++ b/framework/examples/get_agents.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     # Creating wazuh object
     # It is possible to specify the ossec path (path argument) or get /etc/ossec-init.conf (get_init argument)
     print("\nWazuh:")
-    myWazuh = Wazuh(get_init=True)
+    myWazuh = Wazuh()
     print(myWazuh)
 
     print("\nAgents:")

--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -285,9 +285,6 @@ def main():
 
 
 if __name__ == "__main__":
-    # Initialize framework
-    myWazuh = Wazuh(get_init=True)
-
     logger = logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
     try:

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -49,9 +49,6 @@ def main():
     # Capture Ctrl + C
     signal(SIGINT, signal_handler)
 
-    # Initialize framework
-    myWazuh = Wazuh(get_init=True)
-
     # Check arguments
     if args.list_outdated:
         list_outdated()

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -9,7 +9,6 @@ import logging
 import argparse
 import operator
 import sys
-from wazuh import Wazuh
 from wazuh.cluster import control, cluster
 
 
@@ -140,8 +139,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.ERROR, format='%(levelname)s: %(message)s')
-
-    my_wazuh = Wazuh(get_init=True)
 
     cluster_status = cluster.get_status_json()
     if cluster_status['enabled'] == 'no' or cluster_status['running'] == 'no':

--- a/framework/scripts/update_ruleset.py
+++ b/framework/scripts/update_ruleset.py
@@ -581,7 +581,6 @@ def usage():
 
 
 if __name__ == "__main__":
-    mywazuh = Wazuh(get_init=True)
     cluster_config = read_config()
 
     if cluster_config['node_type'] != 'master' and not cluster_config['disabled']:

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -101,7 +101,6 @@ async def worker_main(args, cluster_config, cluster_items, logger):
 # Main
 #
 if __name__ == '__main__':
-    my_wazuh = Wazuh(get_init=True)
 
     parser = argparse.ArgumentParser()
     ####################################################################################################################
@@ -143,7 +142,7 @@ if __name__ == '__main__':
 
     # set correct permissions on cluster.log file
     if os.path.exists('{0}/logs/cluster.log'.format(common.ossec_path)):
-        os.chown('{0}/logs/cluster.log'.format(common.ossec_path), common.ossec_uid, common.ossec_gid)
+        os.chown('{0}/logs/cluster.log'.format(common.ossec_path), common.ossec_uid(), common.ossec_gid())
         os.chmod('{0}/logs/cluster.log'.format(common.ossec_path), 0o660)
 
     main_logger = set_logging(debug_mode)
@@ -170,8 +169,8 @@ if __name__ == '__main__':
 
     # Drop privileges to ossec
     if not args.root:
-        os.setgid(common.ossec_gid)
-        os.setuid(common.ossec_uid)
+        os.setgid(common.ossec_gid())
+        os.setuid(common.ossec_uid())
 
     pyDaemonModule.create_pid('wazuh-clusterd', os.getpid())
 

--- a/framework/setup.py
+++ b/framework/setup.py
@@ -4,10 +4,40 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from setuptools import setup, find_packages
-
+import json
 # Install the package locally: python setup.py install
 # Install the package dev: python setup.py develop
+import os
+from datetime import datetime
+
+from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+
+class InstallCommand(install):
+    user_options = install.user_options + [
+        ('wazuh-version=', None, 'Wazuh Version'),
+        ('install-type=', None, 'Installation type: manager, local, hybrid')
+    ]
+
+    def initialize_options(self):
+        install.initialize_options(self)
+        self.wazuh_version = None
+        self.install_type = None
+
+    def finalize_options(self):
+        install.finalize_options(self)
+
+    def run(self):
+        here = os.path.abspath(os.path.dirname(__file__))
+        with open(os.path.join(here, 'wazuh', 'wazuh.json'), 'w') as f:
+            json.dump({'install_type': self.install_type,
+                       'wazuh_version': self.wazuh_version,
+                       'installation_date': datetime.now().strftime('%a %b %d %H:%M:%S UTC %Y')
+                       }, f)
+        # install.run(self)  # OR: install.do_egg_install(self)
+        install.do_egg_install(self)
+
 
 setup(name='wazuh',
       version='3.10.0',
@@ -17,5 +47,11 @@ setup(name='wazuh',
       author_email='hello@wazuh.com',
       license='GPLv2',
       packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+      package_data={'wazuh': ['wazuh.json']},
+      include_package_data=True,
       install_requires=[],
-      zip_safe=False)
+      zip_safe=False,
+      cmdclass={
+          'install': InstallCommand,
+      }
+      )

--- a/framework/tests/test_imports.py
+++ b/framework/tests/test_imports.py
@@ -127,6 +127,4 @@ from wazuh.utils import (WazuhDBQuery, WazuhDBQueryDistinct,
                          search_array, sort_array, tail)
 from wazuh.wdb import WazuhDBConnection
 
-my_wazuh = Wazuh(get_init=True)
-
 print("All modules were imported successfully.")

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -4,13 +4,14 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from wazuh import common
-from wazuh.utils import execute
-from wazuh.database import Connection
-from time import strftime
-from wazuh.exception import WazuhException
+import os
 import re
+from time import strftime
 
+from wazuh import common
+from wazuh.database import Connection
+from wazuh.exception import WazuhException
+from wazuh.utils import execute
 
 """
 Wazuh HIDS Python package
@@ -29,78 +30,54 @@ msg += "\n  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rh/python27/root/usr/li
 
 try:
     from sys import version_info as python_version
-    if python_version.major < 2 or (python_version.major == 2 and python_version.minor < 7 ):
+    if python_version.major < 2 or (python_version.major == 2 and python_version.minor < 7):
         raise WazuhException(999, msg)
 except Exception as e:
     raise WazuhException(999, msg)
+
 
 class Wazuh:
     """
     Basic class to set up OSSEC directories
     """
 
-    OSSEC_INIT = '/etc/ossec-init.conf'
-
-    def __init__(self, ossec_path='/var/ossec', get_init=False):
+    def __init__(self):
         """
         Initialize basic information and directories.
-        :param ossec_path: OSSEC Path. By default it is /var/ossec.
-        :param get_init: Get information from /etc/ossec-init.conf.
         :return:
         """
 
-        self.version = None
-        self.installation_date = None
-        self.type = None
-        self.path = ossec_path
+        self.version = common.wazuh_version
+        self.installation_date = common.installation_date
+        self.type = common.install_type
+        self.path = common.ossec_path
         self.max_agents = 'N/A'
         self.openssl_support = 'N/A'
         self.ruleset_version = None
         self.tz_offset = None
         self.tz_name = None
 
-        if get_init:
-            self.get_ossec_init()
-
-        common.set_paths_based_on_ossec(self.path)
+        self._initialize()
 
     def __str__(self):
         return str(self.to_dict())
 
     def to_dict(self):
-        return {'path': self.path, 'version': self.version, 'compilation_date': self.installation_date, 'type': self.type, 'max_agents': self.max_agents, 'openssl_support': self.openssl_support, 'ruleset_version': self.ruleset_version, 'tz_offset': self.tz_offset, 'tz_name': self.tz_name}
+        return {'path': self.path,
+                'version': self.version,
+                'compilation_date': self.installation_date,
+                'type': self.type,
+                'max_agents': self.max_agents,
+                'openssl_support': self.openssl_support,
+                'ruleset_version': self.ruleset_version,
+                'tz_offset': self.tz_offset,
+                'tz_name': self.tz_name
+                }
 
-    def get_ossec_init(self):
+    def _initialize(self):
         """
-        Gets information from /etc/ossec-init.conf.
-
-        :return: ossec-init.conf as dictionary
+        Calculates all Wazuh installation metadata
         """
-
-        try:
-            with open(self.OSSEC_INIT, 'r') as f:
-                line_regex = re.compile(r'(^\w+)="(.+)"')
-                for line in f:
-                    match = line_regex.match(line)
-                    if match and len(match.groups()) == 2:
-                        key = match.group(1).lower()
-                        if key == "version":
-                            self.version = match.group(2)
-                        elif key == "directory":
-                            # Read 'directory' when ossec_path (__init__) is set by default.
-                            # It could mean that get_init is True and ossec_path is not used.
-                            if self.path == '/var/ossec':
-                                self.path = match.group(2)
-                                common.set_paths_based_on_ossec(self.path)
-                        elif key == "date":
-                            self.installation_date = match.group(2)
-                        elif key == "type":
-                            if (str(match.group(2)) == "server"):
-                                self.type = "manager"
-                            else:
-                                self.type = match.group(2)
-        except:
-            raise WazuhException(1005, self.OSSEC_INIT)
 
         # info DB if possible
         try:
@@ -109,17 +86,17 @@ class Wazuh:
             query = "SELECT * FROM info"
             conn.execute(query)
 
-            for tuple in conn:
-                if tuple[0] == 'max_agents':
-                    self.max_agents = tuple[1]
-                elif tuple[0] == 'openssl_support':
-                    self.openssl_support = tuple[1]
-        except:
+            for tuple_ in conn:
+                if tuple_[0] == 'max_agents':
+                    self.max_agents = tuple_[1]
+                elif tuple_[0] == 'openssl_support':
+                    self.openssl_support = tuple_[1]
+        except Exception:
             self.max_agents = "N/A"
             self.openssl_support = "N/A"
 
         # Ruleset version
-        ruleset_version_file = "{0}/ruleset/VERSION".format(self.path)
+        ruleset_version_file = os.path.join(self.path, 'ruleset', 'VERSION')
         try:
             with open(ruleset_version_file, 'r') as f:
                 line_regex = re.compile(r'(^\w+)="(.+)"')
@@ -127,14 +104,14 @@ class Wazuh:
                     match = line_regex.match(line)
                     if match and len(match.groups()) == 2:
                         self.ruleset_version = match.group(2)
-        except:
+        except Exception:
             raise WazuhException(1005, ruleset_version_file)
 
         # Timezone info
         try:
             self.tz_offset = strftime("%z")
             self.tz_name = strftime("%Z")
-        except:
+        except Exception:
             self.tz_offset = None
             self.tz_name = None
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -468,7 +468,7 @@ class Agent:
                 raise WazuhException(1701, self.id)
             else:
                 f_keys_st = stat(common.client_keys)
-                chown(f_keys_temp, common.ossec_uid, common.ossec_gid)
+                chown(f_keys_temp, common.ossec_uid(), common.ossec_gid())
                 chmod(f_keys_temp, f_keys_st.st_mode)
         except Exception as e:
             raise WazuhException(1746, str(e))
@@ -722,7 +722,7 @@ class Agent:
                 open(f_keys_temp, 'a').close()
 
                 f_keys_st = stat(common.client_keys)
-                chown(f_keys_temp, common.ossec_uid, common.ossec_gid)
+                chown(f_keys_temp, common.ossec_uid(), common.ossec_gid())
                 chmod(f_keys_temp, f_keys_st.st_mode)
 
                 copyfile(common.client_keys, f_keys_temp)
@@ -1464,7 +1464,7 @@ class Agent:
         try:
             mkdir_with_mode(group_path)
             copyfile(group_def_path, group_path + "/agent.conf")
-            chown_r(group_path, common.ossec_uid, common.ossec_gid)
+            chown_r(group_path, common.ossec_uid(), common.ossec_gid())
             chmod_r(group_path, 0o660)
             chmod(group_path, 0o770)
             msg = "Group '{0}' created.".format(group_id)
@@ -1490,7 +1490,7 @@ class Agent:
             folder = hashlib.sha256(group_id.encode()).hexdigest()[:8]
             multi_group_path = "{0}/{1}".format(common.multi_groups_path, folder)
             mkdir_with_mode(multi_group_path)
-            chown(multi_group_path, common.ossec_uid, common.ossec_gid)
+            chown(multi_group_path, common.ossec_uid(), common.ossec_gid())
             chmod(multi_group_path, 0o770)
             msg = "Group '{0}' created.".format(group_id)
             return msg
@@ -1697,7 +1697,7 @@ class Agent:
                 f_group.write(group_id)
 
             if new_file:
-                chown(agent_group_path, common.ossec_uid, common.ossec_gid)
+                chown(agent_group_path, common.ossec_uid(), common.ossec_gid())
                 chmod(agent_group_path, 0o660)
         except Exception as e:
             raise WazuhException(1005, str(e))

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -482,7 +482,7 @@ class CustomFileRotatingHandler(logging.handlers.TimedRotatingFileHandler):
         logging.handlers.TimedRotatingFileHandler.doRollover(self)
 
         # Set appropiate permissions
-        chown(self.baseFilename, common.ossec_uid, common.ossec_gid)
+        chown(self.baseFilename, common.ossec_uid(), common.ossec_gid())
         chmod(self.baseFilename, 0o660)
 
         # Save rotated file in /logs/ossec directory

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -228,7 +228,7 @@ functions = {
 
     # Managers
     '/manager/info': {
-        'function': Wazuh(common.ossec_path).get_ossec_init,
+        'function': Wazuh().to_dict,
         'type': 'local_any',
         'is_async': False
     },
@@ -341,7 +341,7 @@ functions = {
         'is_async': True
     },
     '/cluster/:node_id/info': {
-        'function': Wazuh(common.ossec_path).get_ossec_init,
+        'function': Wazuh().to_dict,
         'type': 'distributed_master',
         'is_async': False
     },

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -584,7 +584,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
                             mtime_epoch = timegm(mtime.timetuple())
                             os.utime(tmp_unmerged_path, (mtime_epoch, mtime_epoch))  # (atime, mtime)
-                            os.chown(tmp_unmerged_path, common.ossec_uid, common.ossec_gid)
+                            os.chown(tmp_unmerged_path, common.ossec_uid(), common.ossec_gid())
                             os.chmod(tmp_unmerged_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
                             os.rename(tmp_unmerged_path, full_unmerged_name)
                         except Exception as e:
@@ -601,7 +601,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
                 else:
                     zip_path = "{}{}".format(decompressed_files_path, name)
-                    os.chown(zip_path, common.ossec_uid, common.ossec_gid)
+                    os.chown(zip_path, common.ossec_uid(), common.ossec_gid())
                     os.chmod(zip_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
                     os.rename(zip_path, full_path)
 

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -438,14 +438,14 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     tmp_unmerged_path = full_unmerged_name + '.tmp'
                     with open(tmp_unmerged_path, 'wb') as f:
                         f.write(content)
-                    os.chown(tmp_unmerged_path, common.ossec_uid, common.ossec_gid)
+                    os.chown(tmp_unmerged_path, common.ossec_uid(), common.ossec_gid())
                     os.chmod(tmp_unmerged_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
                     os.rename(tmp_unmerged_path, full_unmerged_name)
             else:
                 if not os.path.exists(os.path.dirname(full_filename_path)):
                     utils.mkdir_with_mode(os.path.dirname(full_filename_path))
                 os.rename("{}{}".format(zip_path, filename), full_filename_path)
-                os.chown(full_filename_path, common.ossec_uid, common.ossec_gid)
+                os.chown(full_filename_path, common.ossec_uid(), common.ossec_gid())
                 os.chmod(full_filename_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
 
         logger = self.task_loggers['Integrity']

--- a/framework/wazuh/common.py
+++ b/framework/wazuh/common.py
@@ -4,122 +4,120 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from pwd import getpwnam
+import json
+import os
 from grp import getgrnam
+from pwd import getpwnam
 
-def set_paths_based_on_ossec(o_path='/var/ossec'):
+try:
+    here = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(here, 'wazuh.json'), 'r') as f:
+        metadata = json.load(f)
+except Exception:
+    metadata = {
+        'install_type': '',
+        'installation_date': '',
+        'wazuh_version': ''
+    }
+
+
+def find_wazuh_path():
     """
-    Set paths based on ossec location.
-    :param o_path: OSSEC Path, by default it is '/var/ossec'.
-    :return:
+    Gets the path where Wazuh is installed dinamically
+
+    :return: str path where Wazuh is installed or empty string if there is no framework in the environment
     """
+    abs_path = os.path.abspath(os.path.dirname(__file__))
+    allparts = []
+    while 1:
+        parts = os.path.split(abs_path)
+        if parts[0] == abs_path:  # sentinel for absolute paths
+            allparts.insert(0, parts[0])
+            break
+        elif parts[1] == abs_path:  # sentinel for relative paths
+            allparts.insert(0, parts[1])
+            break
+        else:
+            abs_path = parts[0]
+            allparts.insert(0, parts[1])
 
-    global ossec_path
-    ossec_path = o_path
+    wazuh_path = ''
+    try:
+        for i in range(0, allparts.index('framework')):
+            wazuh_path = os.path.join(wazuh_path, allparts[i])
+    except ValueError:
+        pass
 
-    global ossec_conf
-    ossec_conf = "{0}/etc/ossec.conf".format(ossec_path)
+    return wazuh_path
 
-    global internal_options
-    internal_options = "{0}/etc/internal_options.conf".format(ossec_path)
-    global local_internal_options
-    local_internal_options = "{0}/etc/local_internal_options.conf".format(ossec_path)
 
-    global ossec_log
-    ossec_log = "{0}/logs/ossec.log".format(ossec_path)
+ossec_path = find_wazuh_path()
 
-    global client_keys
-    client_keys = '{0}/etc/client.keys'.format(ossec_path)
+install_type = metadata['install_type']
+wazuh_version = metadata['wazuh_version']
+installation_date = metadata['installation_date']
+ossec_conf = os.path.join(ossec_path, 'etc', 'ossec.conf')
+internal_options = os.path.join(ossec_path, 'etc', 'internal_options.conf')
+local_internal_options = os.path.join(ossec_path, 'etc', 'local_internal_options.conf')
+ossec_log = os.path.join(ossec_path, 'logs', 'ossec.log')
+client_keys = os.path.join(ossec_path, 'etc', 'client.keys')
+stats_path = os.path.join(ossec_path, 'stats')
+ruleset_path = os.path.join(ossec_path, 'ruleset')
+groups_path = os.path.join(ossec_path, 'queue', 'agent-groups')
+multi_groups_path = os.path.join(ossec_path, 'var', 'multigroups')
+shared_path = os.path.join(ossec_path, 'etc', 'shared')
+backup_path = os.path.join(ossec_path, 'backup')
+ruleset_rules_path = os.path.join(ruleset_path, 'rules')
+database_path = os.path.join(ossec_path, 'var', 'db')
+database_path_global = os.path.join(database_path, 'global.db')
+wdb_socket_path = os.path.join(ossec_path, 'queue', 'db', 'wdb')
+wdb_path = os.path.join(ossec_path, 'queue', 'db')
+api_config_path = os.path.join(ossec_path, 'api', 'configuration', 'config.js')
+database_path_agents = os.path.join(database_path, 'agents')
+os_pidfile = os.path.join('var', 'run')
+analysisd_stats = os.path.join(ossec_path, 'var', 'run', 'ossec-analysisd.state')
+remoted_stats = os.path.join(ossec_path, 'var', 'run', 'ossec-remoted.state')
+lists_path = os.path.join(ossec_path, 'etc', 'lists')
 
-    global stats_path
-    stats_path = '{0}/stats'.format(ossec_path)
+# Queues
+ARQUEUE = os.path.join(ossec_path, 'queue', 'alerts', 'ar')
+EXECQ = os.path.join(ossec_path, 'queue', 'alerts', 'execq')
 
-    global ruleset_path
-    ruleset_path = '{0}/ruleset'.format(ossec_path)
-
-    global groups_path
-    groups_path = "{0}/queue/agent-groups".format(ossec_path)
-
-    global multi_groups_path
-    multi_groups_path = "{0}/var/multigroups".format(ossec_path)
-
-    global shared_path
-    shared_path = "{0}/etc/shared".format(ossec_path)
-
-    global backup_path
-    backup_path = "{0}/backup".format(ossec_path)
-
-    global ruleset_rules_path
-    ruleset_rules_path = '{0}/rules'.format(ruleset_path)
-
-    global database_path
-    database_path = ossec_path + '/var/db'
-
-    global database_path_global
-    database_path_global = database_path + '/global.db'
-
-    global wdb_socket_path
-    wdb_socket_path = '{0}/queue/db/wdb'.format(ossec_path)
-
-    global wdb_path
-    wdb_path = '{0}/queue/db'.format(ossec_path)
-
-    global api_config_path
-    api_config_path = "{0}/api/configuration/config.js".format(ossec_path)
-
-    global database_path_agents
-    database_path_agents = database_path + '/agents'
-
-    global os_pidfile
-    os_pidfile = "/var/run"
-
-    global analysisd_stats
-    analysisd_stats = "{0}/var/run/ossec-analysisd.state".format(ossec_path)
-
-    global remoted_stats
-    remoted_stats = "{0}/var/run/ossec-remoted.state".format(ossec_path)
-
-    global lists_path
-    lists_path = "{0}/etc/lists".format(ossec_path)
-
-    # Queues
-    global ARQUEUE
-    ARQUEUE = "{0}/queue/alerts/ar".format(ossec_path)
-
-    global EXECQ
-    EXECQ = "{0}/queue/alerts/execq".format(ossec_path)
-
-    # Socket
-    global AUTHD_SOCKET
-    AUTHD_SOCKET = "{0}/queue/ossec/auth".format(ossec_path)
-
-    global REQUEST_SOCKET
-    REQUEST_SOCKET = "{0}/queue/ossec/request".format(ossec_path)
+# Socket
+AUTHD_SOCKET = os.path.join(ossec_path, 'queue', 'ossec', 'auth')
+REQUEST_SOCKET = os.path.join(ossec_path, 'queue', 'ossec', 'request')
 
 # Agent upgrading variables
 wpk_repo_url = "packages.wazuh.com/wpk/"
 
 wpk_chunk_size = 512
 
-open_retries = 10 # Retries until get open ok message
-open_sleep = 5 # Seconds between retries
+open_retries = 10  # Retries until get open ok message
+open_sleep = 5  # Seconds between retries
 
-upgrade_result_retries = 60 # Retries until get upgrade_result ok message
-upgrade_result_sleep = 5 # Seconds between retries
+upgrade_result_retries = 60  # Retries until get upgrade_result ok message
+upgrade_result_sleep = 5  # Seconds between retries
 
-agent_info_retries = 100 # Retries to detect when agent_info file is updated
-agent_info_sleep = 2 # Seconds between retries
+agent_info_retries = 100  # Retries to detect when agent_info file is updated
+agent_info_sleep = 2  # Seconds between retries
 
 # Common variables
 database_limit = 500
 maximum_database_limit = 1000
-limit_seconds = 1800 # 600*3
+limit_seconds = 1800  # 600*3
 
-ossec_uid = getpwnam("ossec").pw_uid
-ossec_gid = getgrnam("ossec").gr_gid
 
-# Common variables based on ossec path (/var/ossec by default)
-set_paths_based_on_ossec()
+_ossec_uid = None
+_ossec_gid = None
+
+
+def ossec_uid():
+    return getpwnam("ossec").pw_uid if globals()['_ossec_uid'] is None else globals()['_ossec_uid']
+
+
+def ossec_gid():
+    return getgrnam("ossec").gr_gid if globals()['_ossec_gid'] is None else globals()['_ossec_gid']
+
 
 # Multigroup variables
 max_groups_per_multigroup = 256

--- a/framework/wazuh/pyDaemonModule.py
+++ b/framework/wazuh/pyDaemonModule.py
@@ -53,7 +53,7 @@ def pyDaemon():
     os.chdir('/')
 
 def create_pid(name, pid):
-    filename = "{0}{1}/{2}-{3}.pid".format(common.ossec_path, common.os_pidfile, name, pid)
+    filename = "{0}/{1}/{2}-{3}.pid".format(common.ossec_path, common.os_pidfile, name, pid)
 
     with open(filename, 'a') as fp:
         try:
@@ -63,7 +63,7 @@ def create_pid(name, pid):
             raise WazuhException(3002, str(e))
 
 def delete_pid(name, pid):
-    filename = "{0}{1}/{2}-{3}.pid".format(common.ossec_path, common.os_pidfile, name, pid)
+    filename = "{0}/{1}/{2}-{3}.pid".format(common.ossec_path, common.os_pidfile, name, pid)
     try:
         if os.path.exists(filename):
             os.unlink(filename)

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -264,7 +264,7 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
         m.assert_any_call(common.client_keys)
         m.assert_any_call(common.client_keys + '.tmp', 'w')
         stat_mock.assert_called_once_with(common.client_keys)
-        chown_mock.assert_called_once_with(common.client_keys + '.tmp', common.ossec_uid, common.ossec_gid)
+        chown_mock.assert_called_once_with(common.client_keys + '.tmp', common.ossec_uid(), common.ossec_gid())
         remove_mock.assert_any_call(os.path.join(common.ossec_path, 'queue/rids/001'))
         assert len((rename_mock if backup else rmtree_mock).mock_calls) == 5
         # make sure the mock is called with a string according to a non-backup path

--- a/framework/wazuh/tests/test_common.py
+++ b/framework/wazuh/tests/test_common.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+import pytest
+
+from wazuh.common import find_wazuh_path
+
+
+@pytest.mark.parametrize('fake_path, expected', [
+    ('/var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.10.0-py3.7.egg/wazuh', '/var/ossec'),
+    ('/my/custom/path/framework/python/lib/python3.7/site-packages/wazuh-3.10.0-py3.7.egg/wazuh', '/my/custom/path'),
+    ('/my/fake/path', '')
+])
+def test_find_wazuh_path(fake_path, expected):
+    with patch('wazuh.common.__file__', new=fake_path):
+        assert(find_wazuh_path() == expected)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1490,7 +1490,7 @@ install_dependencies: install_python
 
 
 install_framework: install_python
-	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py install --prefix=${WPYTHON_DIR}
+	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET}
 
 
 ####################

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1029,7 +1029,7 @@ InstallServer()
     fi
 
     ### Install Python
-    ${MAKEBIN} wpython PREFIX=${PREFIX}
+    ${MAKEBIN} wpython PREFIX=${PREFIX} TARGET=${INSTYPE}
 }
 
 InstallAgent()

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -27,7 +27,7 @@ import datetime
 import argparse
 import hashlib
 from wazuh import Wazuh, common
-my_wazuh = Wazuh(get_init=True)
+
 try:
 	import requests
 except Exception as e:


### PR DESCRIPTION
|Related issue|
|---|
|#3495|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR includes the following changes:
- `setup.py` now accepts two parameters to be provided during installation: `wazuh-version` and `install-type`.
- `Makefile` and `inst-functions.sh` have been modified to catch the installation type for wazuh Python package
- `common.py` module and `Wazuh` class have been refactored to decouple from `ossec-init.conf` file. Consequently, `Wazuh` does not need the `get_init` or `ossec_path` params to be passed.
- `Wazuh` class is not used to initialize global variables anymore, since `common.py` is a fully independent module.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

### Unit tests
- Unit tests for `find_wazuh_path` function has been added
```
================================================ test session starts =================================================
platform linux -- Python 3.7.1, pytest-4.6.2, py-1.8.0, pluggy-0.12.0
rootdir: /home/danielruiz/git/wazuh/framework
collected 3 items                                                                                                    

framework/wazuh/tests/test_common.py ...                                                                       [100%]

============================================== 3 passed in 0.25 seconds ==============================================
```
- Manual testing in Docker containers:
  - Installation of Wazuh from sources (both in `/var/ossec` and in `/my/custom/path`, setting up a cluster environment. Check ossec.log and cluster.log for errors. Checks cluster ownership is correct. Installation of Wazuh API from sources and executing requests. Some errors were found (to be solved in https://github.com/wazuh/wazuh-api/issues/406).
  - Installation of Wazuh from deb packages for `/my/custom/path`,  setting up a cluster environment. Check ossec.log and cluster.log for errors. Checks cluster ownership is correct. Installation of Wazuh API from sources and executing requests.
  - Installation of Wazuh from rpm packages for `/my/custom/path`,  setting up a cluster environment. Check ossec.log and cluster.log for errors. Checks cluster ownership is correct. Installation of Wazuh API from sources and executing requests.


- [x] Source installation
- [x] Package installation
- [x] Working on cluster environments