### PR TITLE
Prevent the agent from sending unitialized data to the manager

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -164,7 +164,7 @@ void run_notify()
     }
 
     /* Create message */
-    if(strcmp(agent_ip,"Err")){
+    if(*agent_ip && strcmp(agent_ip,"Err")){
         if ((File_DateofChange(AGENTCONFIGINT) > 0 ) &&
                 (OS_MD5_File(AGENTCONFIGINT, md5sum, OS_TEXT) == 0)) {
             snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%s%s%s\n%s",


### PR DESCRIPTION
|Related issue|
|---|
|#3552|

## Description

As described in #3552, the agent is sending some uninitialized data when it's not able to obtain its IP address.

### Expected result

If the agent is not able to send its IP address, it will simply ignore such string. The resulting agent-info 
file is:

```
Linux |centos7 |3.10.0-957.5.1.el7.x86_64 |#1 SMP Fri Feb 1 14:54:57 UTC 2019 |x86_64 [CentOS Linux|centos: 7.6] - Wazuh v3.9.3 / ab73af41699f13fdd81903b5f23d8d00
c6309ff81a74781f6b55b68129a76738 merged.mg


#"_manager_hostname":stretch64
#"_node_name":node01
```

## Tests
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] MAC OS X
- [X] Source installation
- [X] Source upgrade
- [X] Valgrind report for affected components
- [X] QA templates contemplate the added capabilities: https://github.com/wazuh/wazuh-qa/commit/93b958cec4f4bb0d33860fe8c92d69b0a035348f