### PR TITLE
Fix encoding errors when reading agent-info's

### DIFF
--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -417,7 +417,7 @@ def merge_agent_info(merge_type, node_name, files=None, file_type="", time_limit
     files_to_send = 0
     files = "all" if files is None else {path.basename(f) for f in files}
 
-    with open(common.ossec_path + output_file, 'w') as o_f:
+    with open(common.ossec_path + output_file, 'wb') as o_f:
         for filename in os.listdir(merge_path):
             if files != "all" and filename not in files:
                 continue
@@ -430,14 +430,14 @@ def merge_agent_info(merge_type, node_name, files=None, file_type="", time_limit
 
             files_to_send += 1
             if o_f is None:
-                o_f = open(common.ossec_path + output_file, 'w')
+                o_f = open(common.ossec_path + output_file, 'wb')
 
             header = "{} {} {}".format(stat_data.st_size, filename.replace(common.ossec_path, ''),
                                        datetime.utcfromtimestamp(stat_data.st_mtime))
-            with open(full_path, 'r') as f:
+            with open(full_path, 'rb') as f:
                 data = f.read()
 
-            o_f.write(header + '\n' + data)
+            o_f.write((header + '\n').encode() + data)
 
     return files_to_send, output_file
 


### PR DESCRIPTION
|Related issue|
|---|
|#3554|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The fix is mainly based on avoiding the encoding step at the time of reading agent-info file. This is done opening the file in binary mode instead of text utf-8 encoded in `merge_agent_info` function in `cluster.py` module.

## Tests

Creation of a cluster environment with 3 managers and 3 agents, one of them with a label with non UTF-8 characters. The `cluster.log` shows no errors:
```
...
2019/06/19 10:44:23 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Starting to send agent status files
2019/06/19 10:44:23 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Permission to synchronize granted.
2019/06/19 10:44:23 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Compressing files
2019/06/19 10:44:23 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Sending compressed file to master
2019/06/19 10:44:23 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Worker files sent to master.
2019/06/19 10:44:30 wazuh-clusterd: INFO: [Worker worker-2] [Integrity] Permission to synchronize granted.
2019/06/19 10:44:30 wazuh-clusterd: INFO: [Worker worker-2] [Integrity] Compressing files
2019/06/19 10:44:30 wazuh-clusterd: INFO: [Worker worker-2] [Integrity] Sending compressed file to master
2019/06/19 10:44:30 wazuh-clusterd: INFO: [Worker worker-2] [Integrity] Worker files sent to master.
2019/06/19 10:44:30 wazuh-clusterd: INFO: [Worker worker-2] [Integrity] The master has verified that the integrity is right.
2019/06/19 10:44:32 wazuh-clusterd: INFO: [Worker worker-2] [Keep Alive] Sucessful response from master: keepalive
2019/06/19 10:44:33 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Starting to send agent status files
2019/06/19 10:44:33 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Permission to synchronize granted.
2019/06/19 10:44:33 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Compressing files
2019/06/19 10:44:33 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Sending compressed file to master
2019/06/19 10:44:33 wazuh-clusterd: INFO: [Worker worker-2] [Agent info] Worker files sent to master.
...
```

Furthermore, the agent-info gets synchronized in the master node:
```
root@62b319c859dc:/var/ossec/queue/agent-info# cat *
Linux |cc84558e0761 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64 [Ubuntu|ubuntu: 18.04.1 LTS (Bionic Beaver)] - Wazuh v3.9.2 / ab73af41699f13fdd81903b5f23d8d00
"aws.instance-id":i-052a1838c
"aws.sec-group":sg-1103
"network.ip":172.17.0.0
"network.mac":02:42:ac:11:00:02
!"installation":January 1st, 2017
a7d19a28cd5591eade763e852248197b merged.mg
#"_agent_ip":172.19.0.5

#"_manager_hostname":62b319c859dc
#"_node_name":master
Linux |d96e25ee07a6 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64 [Ubuntu|ubuntu: 18.04.1 LTS (Bionic Beaver)] - Wazuh v3.9.2 / ab73af41699f13fdd81903b5f23d8d00
"test":���ñ
"aws.instance-id":i-052a1838c
"aws.sec-group":sg-1103
"network.ip":172.17.0.0
"network.mac":02:42:ac:11:00:02
!"installation":January 1st, 2017
a7d19a28cd5591eade763e852248197b merged.mg
#"_agent_ip":172.19.0.6

#"_manager_hostname":e64713b7eb9a
#"_node_name":worker-1
Linux |da90528dc720 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64 [Ubuntu|ubuntu: 18.04.1 LTS (Bionic Beaver)] - Wazuh v3.5.0 / ab73af41699f13fdd81903b5f23d8d00
a7d19a28cd5591eade763e852248197b merged.mg


#"_manager_hostname":6396d15152b1
#"_node_name":worker-2
```