### PR TITLE
Fix framework dapi.py check_status basic services

### DIFF
--- a/framework/setup.py
+++ b/framework/setup.py
@@ -17,7 +17,7 @@ from setuptools.command.install import install
 class InstallCommand(install):
     user_options = install.user_options + [
         ('wazuh-version=', None, 'Wazuh Version'),
-        ('install-type=', None, 'Installation type: manager, local, hybrid')
+        ('install-type=', None, 'Installation type: server, local, hybrid')
     ]
 
     def initialize_options(self):

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -105,12 +105,11 @@ class DistributedAPI:
         """
         if self.input_json['function'] == '/manager/status' or self.input_json['function'] == '/cluster/:node_id/status':
             return
-        if common.install_type == "local":
-            basic_services = ('wazuh-modulesd', 'ossec-analysisd', 'ossec-execd', 'wazuh-db') \
-                if basic_services is None else basic_services
-        else:
-            basic_services = ('wazuh-modulesd', 'ossec-remoted', 'ossec-analysisd', 'ossec-execd', 'wazuh-db') \
-                if basic_services is None else basic_services
+
+        if not basic_services:
+            basic_services = ('wazuh-modulesd', 'ossec-analysisd', 'ossec-execd', 'wazuh-db')
+            if common.install_type != "local":
+                basic_services += ('ossec-remoted', )
 
         status = manager.status()
 

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -105,8 +105,12 @@ class DistributedAPI:
         """
         if self.input_json['function'] == '/manager/status' or self.input_json['function'] == '/cluster/:node_id/status':
             return
-        basic_services = ('wazuh-modulesd', 'ossec-remoted', 'ossec-analysisd', 'ossec-execd', 'wazuh-db') \
-            if basic_services is None else basic_services
+        if common.install_type == "local":
+            basic_services = ('wazuh-modulesd', 'ossec-analysisd', 'ossec-execd', 'wazuh-db') \
+                if basic_services is None else basic_services
+        else:
+            basic_services = ('wazuh-modulesd', 'ossec-remoted', 'ossec-analysisd', 'ossec-execd', 'wazuh-db') \
+                if basic_services is None else basic_services
 
         status = manager.status()
 

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -29,7 +29,7 @@ class WazuhException(Exception):
         1014: 'Error communicating with socket',
         1015: 'Error agent version is null. Was the agent ever connected?',
         1016: 'Error moving file',
-        1017: 'Some Wazuh daemons are not ready yet in node \'{node_name}\' '
+        1017: 'Some Wazuh daemons are not ready in node \'{node_name}\' '
               '({not_ready_daemons})',
 
         # Configuration: 1100 - 1199

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -948,6 +948,13 @@ InstallLocal()
     touch ${PREFIX}/logs/integrations.log
     chmod 640 ${PREFIX}/logs/integrations.log
     chown ${OSSEC_USER_MAIL}:${OSSEC_GROUP} ${PREFIX}/logs/integrations.log
+
+    if [ "X${OPTIMIZE_CPYTHON}" == "Xy" ]; then
+        CPYTHON_FLAGS="OPTIMIZE_CPYTHON=yes"
+    fi
+
+    ### Install Python
+    ${MAKEBIN} wpython PREFIX=${PREFIX} TARGET=${INSTYPE}
 }
 
 TransferShared()
@@ -1024,12 +1031,6 @@ InstallServer()
     ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../framework/wrappers/generic_wrapper.sh ${PREFIX}/integrations/slack
     ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../framework/wrappers/generic_wrapper.sh ${PREFIX}/integrations/virustotal
 
-    if [ "X${OPTIMIZE_CPYTHON}" == "Xy" ]; then
-        CPYTHON_FLAGS="OPTIMIZE_CPYTHON=yes"
-    fi
-
-    ### Install Python
-    ${MAKEBIN} wpython PREFIX=${PREFIX} TARGET=${INSTYPE}
 }
 
 InstallAgent()


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3451|
|https://github.com/wazuh/wazuh/issues/3448|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR adds a previous check to the necessary daemons that have to be running, when the installation is of `local` type it doesn't check the `ossec-remoted` daemon.

## Tests
### Mocha test

#### Active Response
```javascript
Active Response
    PUT/active-response/:agent_id
      ✓ Request (169ms)
      ✓ Command not found (147ms)
      ✓ Agent does not exist (140ms)
      ✓ Agent ID not valid


  4 passing (467ms)
```

#### Agents
```javascript
Agents
    GET/agents
      ✓ Request (141ms)
      ✓ Pagination (141ms)
      ✓ Retrieve all elements with limit=0 (142ms)
      ✓ Sort (143ms)
      ✓ Wrong Sort (144ms)
      ✓ Search (149ms)
      ✓ Selector (143ms)
      ✓ Not allowed selector (141ms)
      ✓ Version (143ms)
      ✓ Os.platform (143ms)
      ✓ Os.version (143ms)
      ✓ ManagerHost (143ms)
      ✓ Filters: status (142ms)
      ✓ Filters: status 2 (142ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: older_than (142ms)
      ✓ Filters: group (146ms)
      ✓ Select: single field (143ms)
      ✓ Select: multiple fields (141ms)
      ✓ Select: wrong field (145ms)
      ✓ Select: invalid character
      ✓ Filters: query (145ms)
    GET/agents/summary
      ✓ Request (144ms)
    GET/agents/summary/os
      ✓ Request (144ms)
    GET/agents/outdated
      ✓ Request (145ms)
    GET/agents/:agent_id
      ✓ Request (manager) (144ms)
      ✓ Request (agent) (142ms)
      ✓ Selector (146ms)
      ✓ Not allowed selector (143ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (141ms)
      ✓ Select (143ms)
      ✓ Select: wrong field (144ms)
    GET/agents/name/:agent_name
      ✓ Request (144ms)
      ✓ Wrong name (142ms)
      ✓ Selector (144ms)
      ✓ Not allowed selector (141ms)
    GET/agents/:agent_id/key
      ✓ Request (143ms)
      ✓ Params: Bad agent id
      ✓ Errors: No key (143ms)
    PUT/agents/groups/:group_id
      ✓ Request (143ms)
      ✓ Params: Bad group name
      ✓ Params: Group already exists (143ms)
    PUT/agents/:agent_id/group/:group_id
      ✓ Request (143ms)
      ✓ Params: Bad agent name
      ✓ Params: Agent does not exist (142ms)
      ✓ Params: Replace parameter (143ms)
    POST/agents/groups/:group_id/files/:file_name
      ✓ Request (154ms)
      ✓ ErrorOnBadGroup (141ms)
      ✓ ErrorOnEmptyConf
      ✓ OnlyAgentConfAllowed (141ms)
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (149ms)
      ✓ TooBigXML
    GET/agents/no_group
      ✓ Request (146ms)
      ✓ Pagination (145ms)
      ✓ Retrieve all elements with limit=0 (141ms)
      ✓ Sort (142ms)
      ✓ Search (146ms)
      ✓ Select (142ms)
      ✓ Wrong select (142ms)
      ✓ Filter: status (143ms)
    GET/agents/groups
      ✓ Request (144ms)
      ✓ Retrieve all elements with limit=0 (145ms)
      ✓ Hash algorithm (145ms)
      ✓ Wrong Hash algorithm (143ms)
    GET/agents/groups/:group_id
      ✓ Request (144ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (142ms)
      ✓ Select (143ms)
      ✓ Filter: status (144ms)
    GET/agents/groups/:group_id/configuration
      ✓ Request (141ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (146ms)
    GET/agents/groups/:group_id/files
      ✓ Request (142ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (143ms)
      ✓ Hash algorithm (142ms)
      ✓ Wrong Hash algorithm (140ms)
    GET/agents/groups/:group_id/files/:filename
      ✓ Request (146ms)
      ✓ UsingFormatAgentConfXML (143ms)
      ✓ UsingFormatAgentConfJSON (143ms)
      ✓ UsingFormatRootcheckXML (145ms)
      ✓ UsingFormatRootcheckJSON (143ms)
      ✓ Params: Bad group name
    POST/agents/groups/:group_id/configuration
      ✓ Request (150ms)
      ✓ ErrorOnBadGroup (142ms)
      ✓ ErrorOnEmptyConf
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (151ms)
      ✓ TooBigXML
    DELETE/agents/:agent_id/group
      ✓ Request (141ms)
      ✓ Errors: ID is not present (142ms)
      ✓ Params: Bad agent id
    DELETE/agents/:agent_id/group/:group_id
      ✓ Request (144ms)
      ✓ Errors: ID is not present (143ms)
      ✓ Errors: Group is not present (141ms)
      ✓ Params: Bad agent id
      ✓ Params: Bad group id (143ms)
    DELETE/agents/groups/:group_id
      ✓ Request (143ms)
      ✓ Params: Bad group id
    DELETE/agents
      ✓ Request
      ✓ Filter: older_than, status and ids (3686ms)
      ✓ Errors: Get deleted agent (174ms)
      ✓ Filter: older_than (146ms)
    GET/agents/stats/distinct
      ✓ Request (145ms)
      ✓ Pagination (143ms)
      ✓ Retrieve all elements with limit=0 (142ms)
      ✓ Sort (145ms)
      ✓ Search (145ms)
      ✓ Select (142ms)
      ✓ Wrong select (146ms)
    GET/agents/:agent/config/:component/:configuration
      ✓ Request-Agent-Client (153ms)
      ✓ Request-Agent-Buffer (145ms)
      ✓ Request-Agent-Labels (153ms)
      ✓ Request-Agent-Internal (154ms)
      ✓ Request-Agentless-Agentless (144ms)
      ✓ Request-Analysis-Global (147ms)
      ✓ Request-Analysis-Active-response (145ms)
      ✓ Request-Analysis-Alerts (146ms)
      ✓ Request-Analysis-Command (147ms)
      ✓ Request-Analysis-Internal (144ms)
      ✓ Request-Auth-Auth (144ms)
      ✓ Request-Com-Active-response (152ms)
      ✓ Request-Com-Internal (150ms)
      ✓ Request-Csyslog-Csyslog (145ms)
      ✓ Request-Integrator-Integration (144ms)
      ✓ Request-Logcollector-Localfile (150ms)
      ✓ Request-Logcollector-Socket (149ms)
      ✓ Request-Logcollector-Internal (151ms)
      ✓ Request-Mail-Global (144ms)
      ✓ Request-Mail-Alerts (146ms)
      ✓ Request-Mail-Internal (146ms)
      ✓ Request-Monitor-Internal (147ms)
      ✓ Request-Request-Remote (144ms)
      ✓ Request-Request-Internal (146ms)
      ✓ Request-Syscheck-Syscheck (153ms)
      ✓ Request-Syscheck-Rootcheck (151ms)
      ✓ Request-Syscheck-Internal (151ms)
      ✓ Request-Wmodules-Wmodules (154ms)
    PUT/agents/restart
      ✓ Request (171ms)
    PUT/agents/:agent_id/restart
      ✓ Request (151ms)
      ✓ Params: Bad agent id
      ✓ Request (144ms)
    POST/agents/restart
      ✓ Request (153ms)
      ✓ Params: A good id and a bad one (158ms)
      ✓ Params: Bad agent id
      ✓ Request (145ms)


  149 passing (24s)
```

#### Agents 2
```javascript
Agents
    PUT/agents/:agent_name
      ✓ Request (151ms)
      ✓ Errors: Name already present (146ms)
      ✓ Params: Bad agent name
    DELETE/agents/:agent_id
      ✓ Request (180ms)
      ✓ Errors: ID is not present (145ms)
      ✓ Params: Bad agent id
    POST/agents
      Any
        ✓ Request (176ms)
        ✓ Check key (168ms)
        ✓ Errors: Name already present (147ms)
        ✓ Filters: Missing field name
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (176ms)
        ✓ Errors: Duplicated IP (154ms)
      IP
        ✓ Request (145ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2
    POST/agents/insert
      Any
        ✓ Request (174ms)
        1) Insert agent with force parameter (ID and name already presents)
        ✓ Errors: Name already present (144ms)
        2) Errors: ID already present
        ✓ Errors: Invalid key (142ms)
        ✓ Filters: Missing fields
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (145ms)
        ✓ Errors: Duplicated IP (146ms)
      IP
        ✓ Request (144ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2


  26 passing (5s)
  2 failing

  1) Agents
       POST/agents/insert
         Any
           Insert agent with force parameter (ID and name already presents):
     Uncaught AssertionError: expected Object { error: 9012, message: 'Duplicated ID' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:485:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)

  2) Agents
       POST/agents/insert
         Any
           Errors: ID already present:
     Uncaught AssertionError: expected Object {
  error: 0,
  data: Object {
    id: '750',
    key: 'NzUwIE5ld0FnZW50UG9zdEluc2VydCBhbnkgMWFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGk2NA=='
  }
} to have property message
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:526:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)
```

#### App
```javascript
App
    Authentication
      ✓ Wrong USER
      ✓ Wrong password
      ✓ Home
    Requests
      ✓ Inexistent request
      ✓ API version


  5 passing (30ms)
```

#### Cluster
```javascript
Cluster
    GET/cluster/nodes
      ✓ Request (160ms)
      ✓ Pagination (152ms)
      ✓ Retrieve all elements with limit=0 (149ms)
      ✓ Sort (149ms)
      ✓ Search (149ms)
      ✓ Filters: type (151ms)
      ✓ Filters: invalid type (149ms)
      ✓ Select (149ms)
      ✓ Select 2 (148ms)
      ✓ Wrong select (151ms)
    GET/cluster/:node_id/stats
      ✓ Cluster stats (142ms)
      ✓ Unexisting node stats (146ms)
      ✓ Analysisd stats (173ms)
      ✓ Remoted stats (155ms)
    GET/cluster/nodes/:node_name
      ✓ Request (149ms)
      ✓ Request wrong name (149ms)
    GET/cluster/status
      ✓ Request (145ms)
    GET/cluster/config
      ✓ Request (146ms)
    GET/cluster/healthcheck
      ✓ Request (150ms)
      ✓ Filter: node name (149ms)
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (150ms)
      ✓ Upload ossec.conf (worker) (165ms)
      ✓ Upload new rules (147ms)
      ✓ Upload rules (overwrite=true) (144ms)
      ✓ Upload rules (overwrite=false) (144ms)
      ✓ Upload new decoder (145ms)
      ✓ Upload decoder (overwrite=true) (145ms)
      ✓ Upload decoder (without overwrite parameter) (144ms)
      ✓ Upload new list (144ms)
      ✓ Upload list (overwrite=true) (145ms)
      ✓ Upload list (overwrite=false) (145ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (148ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (149ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (148ms)
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/cluster/:node_id/files
      ✓ Request ossec.conf (master) (147ms)
      ✓ Request ossec.conf (worker) (152ms)
      ✓ Request rules (local) (147ms)
      ✓ Request rules (global) (142ms)
      ✓ Request decoders (local) (145ms)
      ✓ Request decoders (global) (152ms)
      ✓ Request lists (144ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (145ms)
      ✓ Request file from unexisting node (145ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (154ms)
    GET/cluster/:node_id/configuration/validation (manager and worker OK)
      ✓ Request validation (master) (490ms)
      ✓ Request validation (worker) (503ms)
      ✓ Request validation (all nodes) (534ms)
    GET/cluster/:node_id/configuration/validation (manager KO, worker OK)
      ✓ Request validation (master) (151ms)
      ✓ Request validation (worker) (527ms)
      ✓ Request validation (all nodes) (537ms)
    GET/cluster/:node_id/configuration/validation (manager OK, worker KO)
      ✓ Request validation (master) (493ms)
      ✓ Request validation (worker) (156ms)
      ✓ Request validation (all nodes) (514ms)
    GET/cluster/:node_id/configuration/validation (manager and worker KO)
      ✓ Request validation (master) (152ms)
      ✓ Request validation (worker) (155ms)
      ✓ Request validation (all nodes) (160ms)
    DELETE/cluster/:node_id/files
      ✓ Delete rules (master) (147ms)
      ✓ Delete decoders (master) (143ms)
      ✓ Delete CDB list (master) (143ms)
      ✓ Delete file with empty path
    GET/cluster/master/config/:component/:configuration
      ✓ Request-Agentless-Agentless (155ms)
      ✓ Request-Analysis-Global (149ms)
      ✓ Request-Analysis-Active-response (144ms)
      ✓ Request-Analysis-Alerts (151ms)
      ✓ Request-Analysis-Command (147ms)
      ✓ Request-Analysis-Internal (153ms)
      ✓ Request-Auth-Auth (146ms)
      ✓ Request-Com-Active-response (149ms)
      ✓ Request-Com-Internal (144ms)
      ✓ Request-Csyslog-Csyslog (144ms)
      ✓ Request-Integrator-Integration (145ms)
      ✓ Request-Logcollector-Localfile (150ms)
      ✓ Request-Logcollector-Socket (149ms)
      ✓ Request-Logcollector-Internal (149ms)
      ✓ Request-Mail-Global (144ms)
      ✓ Request-Mail-Alerts (142ms)
      ✓ Request-Mail-Internal (145ms)
      ✓ Request-Monitor-Internal (148ms)
      ✓ Request-Request-Remote (145ms)
      ✓ Request-Request-Internal (150ms)
      ✓ Request-Syscheck-Syscheck (144ms)
      ✓ Request-Syscheck-Rootcheck (148ms)
      ✓ Request-Syscheck-Internal (143ms)
      ✓ Request-Wmodules-Wmodules (144ms)
    PUT/cluster/:node_id/restart
      ✓ Request (worker) (154ms)
      ✓ Request (master) (149ms)


  97 passing (17s)
```

#### Decoders
```javascript
Decoders
    GET/decoders
      ✓ Request (183ms)
      ✓ Pagination (168ms)
      ✓ Retrieve all elements with limit=0 (164ms)
      ✓ Sort (174ms)
      ✓ Search (170ms)
      ✓ Filters: File (165ms)
      ✓ Filters: Path (163ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/decoders/files
      ✓ Request (146ms)
      ✓ Pagination (148ms)
      ✓ Retrieve all elements with limit=0 (146ms)
      ✓ Sort (146ms)
      ✓ Search (148ms)
    GET/decoders/parents
      ✓ Request (164ms)
      ✓ Pagination (163ms)
      ✓ Retrieve all elements with limit=0 (164ms)
      ✓ Sort (165ms)
      ✓ Search (165ms)
    GET/decoders/:decoder_name
      ✓ Request (162ms)
      ✓ Pagination (163ms)
      ✓ Retrieve all elements with limit=0 (162ms)
      ✓ Sort (161ms)
      ✓ Search (164ms)


  24 passing (4s)
```

#### Lists
```javascript
Lists
    GET/lists
      ✓ Request (158ms)
      ✓ Pagination (143ms)
      ✓ Retrieve all elements with limit=0 (146ms)
      ✓ Sort (144ms)
      ✓ Search (144ms)
      ✓ Filters: Path (141ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/lists/files
      ✓ Request (146ms)
      ✓ Pagination (142ms)
      ✓ Retrieve all elements with limit=0 (142ms)
      ✓ Sort (144ms)
      ✓ Search (141ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field


  15 passing (2s)
```

#### Manager
```javascript
Manager
    GET/manager/status
      ✓ Request (153ms)
    GET/manager/info
      ✓ Request (146ms)
    GET/manager/configuration
      ✓ Request (145ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (154ms)
      ✓ Errors: Invalid Section (149ms)
      ✓ Filters: Section - field (145ms)
      ✓ Errors: Invalid field (146ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (155ms)
      ✓ Filters: date (153ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (145ms)
    GET/manager/stats/weekly
      ✓ Request (143ms)
    GET/manager/stats/analysisd
      ✓ Request (145ms)
    GET/manager/stats/remoted
      ✓ Request (144ms)
    GET/manager/logs
      ✓ Request (153ms)
      ✓ Pagination (154ms)
      ✓ Retrieve all elements with limit=0 (172ms)
      ✓ Sort (155ms)
      ✓ SortField (152ms)
      ✓ Search (157ms)
      ✓ Filters: type_log (169ms)
      ✓ Filters: category (159ms)
      ✓ Filters: type_log and category (155ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (160ms)
    POST/manager/files
      ✓ Upload ossec.conf (149ms)
      ✓ Upload ossec.conf (overwrite=false) (142ms)
      ✓ Upload rules (new rule) (145ms)
      ✓ Upload rules (overwrite=true) (144ms)
      ✓ Upload rules (overwrite=false) (143ms)
      ✓ Upload decoder (overwrite=true) (149ms)
      ✓ Upload decoder (without overwrite parameter) (142ms)
      ✓ Upload list (overwrite=true) (154ms)
      ✓ Upload list (without overwrite parameter) (142ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/manager/files
      ✓ Request ossec.conf (144ms)
      ✓ Request rules (local) (146ms)
      ✓ Request rules (global) (142ms)
      ✓ Request decoders (local) (142ms)
      ✓ Request decoders (global) (145ms)
      ✓ Request lists (144ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (142ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (150ms)
    DELETE/manager/files
      ✓ Delete rules (146ms)
      ✓ Delete decoders (144ms)
      ✓ Delete CDB list (143ms)
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (497ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (158ms)
    GET/manager/config/:component/:configuration
      ✓ Request-Agentless-Agentless (142ms)
      ✓ Request-Analysis-Global (144ms)
      ✓ Request-Analysis-Active-response (145ms)
      ✓ Request-Analysis-Alerts (145ms)
      ✓ Request-Analysis-Command (144ms)
      ✓ Request-Analysis-Internal (144ms)
      ✓ Request-Auth-Auth (144ms)
      ✓ Request-Com-Active-response (140ms)
      ✓ Request-Com-Internal (163ms)
      ✓ Request-Csyslog-Csyslog (145ms)
      ✓ Request-Integrator-Integration (142ms)
      ✓ Request-Logcollector-Localfile (141ms)
      ✓ Request-Logcollector-Socket (144ms)
      ✓ Request-Logcollector-Internal (144ms)
      ✓ Request-Mail-Global (141ms)
      ✓ Request-Mail-Alerts (149ms)
      ✓ Request-Mail-Internal (183ms)
      ✓ Request-Monitor-Internal (153ms)
      ✓ Request-Request-Remote (145ms)
      ✓ Request-Request-Internal (144ms)
      ✓ Request-Syscheck-Syscheck (144ms)
      ✓ Request-Syscheck-Rootcheck (145ms)
      ✓ Request-Syscheck-Internal (142ms)
      ✓ Request-Wmodules-Wmodules (141ms)
    PUT/manager/restart
      ✓ Request (144ms)


  88 passing (12s)
```

#### Rootcheck
```javascript
Rootcheck
    GET/rootcheck/:agent_id/last_scan
      ✓ Request (156ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (142ms)
    DELETE/rootcheck/:agent_id
      ✓ Request (153ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (140ms)
    DELETE/rootcheck
      ✓ Request (197ms)
    PUT/rootcheck/:agent_id
      ✓ Request (146ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (151ms)
    PUT/rootcheck
      ✓ Request (162ms)


  11 passing (1s)
```

#### Rules
```javascript
Rules
    GET/rules
      ✓ Request (237ms)
      ✓ Pagination (223ms)
      ✓ Retrieve all elements with limit=0 (227ms)
      ✓ Sort (235ms)
      ✓ Search (294ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (233ms)
      ✓ Filters: group (250ms)
      ✓ Filters: level (1) (234ms)
      ✓ Filters: level (2) (333ms)
      ✓ Filters: path (230ms)
      ✓ Filters: file (228ms)
      ✓ Filters: pci (302ms)
      ✓ Filters: gdpr (226ms)
      ✓ Filters: hipaa (404ms)
      ✓ Filters: nist-800-53 (220ms)
      ✓ Filters: gpg13 (231ms)
    GET/rules/groups
      ✓ Request (220ms)
      ✓ Pagination (225ms)
      ✓ Retrieve all elements with limit=0 (221ms)
      ✓ Sort (223ms)
      ✓ Search (220ms)
      ✓ Filters: Invalid filter
    GET/rules/pci
      ✓ Request (223ms)
      ✓ Pagination (224ms)
      ✓ Retrieve all elements with limit=0 (223ms)
      ✓ Sort (221ms)
      ✓ Search (222ms)
      ✓ Filters: Invalid filter
    GET/rules/gdpr
      ✓ Request (223ms)
      ✓ Pagination (221ms)
      ✓ Retrieve all elements with limit=0 (223ms)
      ✓ Sort (221ms)
      ✓ Search (225ms)
      ✓ Filters: Invalid filter
    GET/rules/gpg13
      ✓ Request (224ms)
      ✓ Pagination (222ms)
      ✓ Retrieve all elements with limit=0 (221ms)
      ✓ Sort (224ms)
      ✓ Search (229ms)
      ✓ Filters: Invalid filter
    GET/rules/hipaa
      ✓ Request (226ms)
      ✓ Pagination (222ms)
      ✓ Retrieve all elements with limit=0 (226ms)
      ✓ Sort (228ms)
      ✓ Search (223ms)
      ✓ Filters: Invalid filter
    GET/rules/nist-800-53
      ✓ Request (225ms)
      ✓ Pagination (223ms)
      ✓ Retrieve all elements with limit=0 (230ms)
      ✓ Sort (225ms)
      ✓ Search (222ms)
      ✓ Filters: Invalid filter
    GET/rules/files
      ✓ Request (144ms)
      ✓ Pagination (148ms)
      ✓ Retrieve all elements with limit=0 (146ms)
      ✓ Sort (146ms)
      ✓ Search (144ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (147ms)
      ✓ Filters: download (145ms)
    GET/rules/:rule_id
      ✓ Request (220ms)
      ✓ Pagination (220ms)
      ✓ Retrieve all elements with limit=0 (221ms)
      ✓ Sort (221ms)
      ✓ Search (223ms)
      ✓ Filters: Invalid filter
      ✓ Params: Bad rule id
      ✓ Params: No rule (218ms)


  71 passing (13s)
```

#### SCA
```javascript
SecurityConfigurationAssessment
    GET/sca/:agent_id
      ✓ Request (161ms)
      ✓ Pagination (147ms)
      ✓ Retrieve all elements with limit=0 (148ms)
      ✓ Sort (149ms)
      ✓ Search (152ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (139ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: query (151ms)
      ✓ Retrieve all elements with limit=0 (147ms)
    GET/sca/:agent_id/checks/:policy_id
      ✓ Request (153ms)
      ✓ Pagination (148ms)
      ✓ Retrieve all elements with limit=0 (146ms)
      ✓ Sort (153ms)
      ✓ Search (152ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (139ms)
      ✓ Check not found (151ms)
      ✓ Retrieve all elements with limit=0 (147ms)


  20 passing (2s)
```

#### Syscheck
```javascript
Syscheck
    GET/syscheck/:agent_id
      ✓ Request (174ms)
      ✓ Pagination (147ms)
      ✓ Retrieve all elements with limit=0 (144ms)
      ✓ Sort (148ms)
      ✓ Search (146ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (139ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: file (147ms)
      ✓ Filters: type (145ms)
      ✓ Filters: summary (144ms)
      ✓ Filters: md5 (153ms)
      ✓ Filters: sha1 (150ms)
      ✓ Filters: sha256 (151ms)
      ✓ Filters: hash (154ms)
    GET/syscheck/:agent_id/last_scan
      ✓ Request (149ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (140ms)
    DELETE/syscheck/:agent_id
      ✓ Request (147ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (136ms)
    DELETE/experimental/syscheck
      ✓ Request (343ms)
    PUT/syscheck/:agent_id
      ✓ Request (158ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (139ms)
    PUT/syscheck
      ✓ Request (160ms)


  27 passing (3s)
```

#### Syscollector
```javascript
Syscollector
    GET/syscollector/:agent_id/os
      ✓ Request (147ms)
      ✓ Selector (149ms)
      ✓ Not allowed selector (144ms)
    GET/syscollector/:agent_id/hardware
      ✓ Request (146ms)
      ✓ Selector (147ms)
      ✓ Not allowed selector (143ms)
    GET/syscollector/:agent_id/packages
      ✓ Request (164ms)
      ✓ Selector (154ms)
      ✓ Not allowed selector (147ms)
      ✓ Pagination (149ms)
      ✓ Wrong limit
      ✓ Sort - (146ms)
      ✓ Sort + (146ms)
      ✓ Wrong Sort (145ms)
      ✓ Search (158ms)
      ✓ Filter: vendor (149ms)
      ✓ Filter: name (150ms)
      ✓ Filter: architecture (160ms)
      ✓ Filter: format (165ms)
      ✓ Wrong filter
    GET/experimental/syscollector/packages
      ✓ Request (263ms)
      ✓ Selector (262ms)
      ✓ Not allowed selector (178ms)
      ✓ Pagination (167ms)
      ✓ Wrong limit
      ✓ Sort - (168ms)
      ✓ Sort + (168ms)
      ✓ Wrong Sort (164ms)
      ✓ Search (200ms)
      ✓ Filter: vendor (179ms)
      ✓ Filter: name (177ms)
      ✓ Filter: architecture (249ms)
      ✓ Filter: format (263ms)
      ✓ Wrong filter
    GET/experimental/syscollector/os
      ✓ Request (175ms)
      ✓ Selector (180ms)
      ✓ Not allowed selector (166ms)
      ✓ Pagination (171ms)
      ✓ Wrong limit
      ✓ Search (181ms)
      ✓ Wrong filter
      ✓ Filter: architecture (180ms)
      ✓ Filter: os_name (181ms)
      ✓ Filter: release (178ms)
    GET/experimental/syscollector/hardware
      ✓ Request (175ms)
      ✓ Selector (173ms)
      ✓ Not allowed selector (166ms)
      ✓ Pagination (168ms)
      ✓ Wrong limit
      ✓ Search (176ms)
      ✓ Wrong filter
      ✓ Wrong Sort (165ms)
      ✓ Filter: ram_total (176ms)
      ✓ Filter: cpu_cores (178ms)
      ✓ Filter: cpu_mhz (175ms)
      ✓ Filter: board_serial (175ms)
    GET/experimental/syscollector/processes
      ✓ Request (182ms)
      ✓ Selector (178ms)
      ✓ Not allowed selector (162ms)
      ✓ Pagination (168ms)
      ✓ Wrong limit
      ✓ Search (190ms)
      ✓ Wrong filter
      ✓ Wrong Sort (163ms)
      ✓ Filter: state (169ms)
      ✓ Filter: ppid (170ms)
      ✓ Filter: egroup (172ms)
      ✓ Filter: euser (168ms)
      ✓ Filter: fgroup (172ms)
      ✓ Filter: name (175ms)
      ✓ Filter: nlwp (174ms)
      ✓ Filter: pgrp (178ms)
      ✓ Filter: priority (171ms)
      ✓ Filter: rgroup (171ms)
      ✓ Filter: ruser (167ms)
      ✓ Filter: sgroup (168ms)
      ✓ Filter: suser (167ms)
    GET/experimental/syscollector/ports
      ✓ Request (224ms)
      ✓ Selector (201ms)
      ✓ Not allowed selector (167ms)
      ✓ Pagination (168ms)
      ✓ Wrong limit
      ✓ Search (176ms)
      ✓ Wrong filter
      ✓ Wrong Sort (163ms)
      ✓ Filter: protocol (173ms)
      ✓ Filter: local_ip (175ms)
      ✓ Filter: local_port (175ms)
      ✓ Filter: remote_ip (176ms)
      ✓ Filter: tx_queue (177ms)
      ✓ Filter: state (174ms)
    GET/syscollector/netaddr
      ✓ Request (171ms)
      ✓ Selector (172ms)
      ✓ Not allowed selector (166ms)
      ✓ Pagination (169ms)
      ✓ Wrong limit
      ✓ Search (177ms)
      ✓ Wrong filter
      ✓ Wrong Sort (164ms)
      ✓ Filter: iface (173ms)
      ✓ Filter: proto (176ms)
      ✓ Filter: address (175ms)
      ✓ Filter: broadcast (177ms)
      ✓ Filter: netmask (180ms)
    GET/experimental/syscollector/netproto
      ✓ Request (171ms)
      ✓ Selector (174ms)
      ✓ Not allowed selector (165ms)
      ✓ Pagination (166ms)
      ✓ Wrong limit
      ✓ Search (172ms)
      ✓ Wrong filter
      ✓ Wrong Sort (163ms)
      ✓ Filter: iface (173ms)
      ✓ Filter: type (172ms)
      ✓ Filter: gateway (177ms)
      ✓ Filter: dhcp (175ms)
    GET/experimental/syscollector/netiface
      ✓ Request (172ms)
      ✓ Selector (174ms)
      ✓ Not allowed selector (166ms)
      ✓ Pagination (167ms)
      ✓ Wrong limit
      ✓ Search (180ms)
      ✓ Wrong filter
      ✓ Wrong Sort (166ms)
      ✓ Filter: name (173ms)
      ✓ Filter: type (174ms)
      ✓ Filter: state (182ms)
      ✓ Filter: mtu (177ms)
      ✓ Filter: tx_packets (178ms)
      ✓ Filter: rx_packets (174ms)
      ✓ Filter: tx_bytes (175ms)
      ✓ Filter: rx_bytes (175ms)
      ✓ Filter: tx_errors (179ms)
      ✓ Filter: rx_errors (176ms)
      ✓ Filter: tx_dropped (174ms)
      ✓ Filter: rx_dropped (179ms)
    GET/syscollector/000/processes
      ✓ Request (151ms)
      ✓ Selector (154ms)
      ✓ Not allowed selector (147ms)
      ✓ Pagination (148ms)
      ✓ Wrong limit
      ✓ Search (153ms)
      ✓ Wrong filter
      ✓ Wrong Sort (144ms)
      ✓ Filter: state (149ms)
      ✓ Filter: ppid (149ms)
      ✓ Filter: egroup (149ms)
      ✓ Filter: euser (147ms)
      ✓ Filter: fgroup (148ms)
      ✓ Filter: name (153ms)
      ✓ Filter: nlwp (149ms)
      ✓ Filter: pgrp (150ms)
      ✓ Filter: priority (150ms)
      ✓ Filter: rgroup (152ms)
      ✓ Filter: ruser (146ms)
      ✓ Filter: sgroup (148ms)
      ✓ Filter: suser (146ms)
    GET/syscollector/000/ports
      ✓ Request (148ms)
      ✓ Selector (151ms)
      ✓ Not allowed selector (148ms)
      ✓ Pagination (151ms)
      ✓ Wrong limit
      ✓ Search (149ms)
      ✓ Wrong filter
      ✓ Wrong Sort (144ms)
      ✓ Filter: protocol (148ms)
      ✓ Filter: local_ip (149ms)
      ✓ Filter: local_port (149ms)
      ✓ Filter: remote_ip (148ms)
      ✓ Filter: tx_queue (148ms)
      ✓ Filter: state (147ms)
    GET/syscollector/000/netaddr
      ✓ Request (148ms)
      ✓ Selector (152ms)
      ✓ Not allowed selector (145ms)
      ✓ Pagination (148ms)
      ✓ Wrong limit
      ✓ Search (149ms)
      ✓ Wrong filter
      ✓ Wrong Sort (147ms)
      ✓ Filter: iface (150ms)
      ✓ Filter: proto (148ms)
      ✓ Filter: address (150ms)
      ✓ Filter: broadcast (150ms)
      ✓ Filter: netmask (151ms)
    GET/syscollector/000/netproto
      ✓ Request (149ms)
      ✓ Selector (149ms)
      ✓ Not allowed selector (149ms)
      ✓ Pagination (150ms)
      ✓ Wrong limit
      ✓ Search (150ms)
      ✓ Wrong filter
      ✓ Wrong Sort (147ms)
      ✓ Filter: iface (149ms)
      ✓ Filter: type (150ms)
      ✓ Filter: gateway (148ms)
      ✓ Filter: dhcp (148ms)
    GET/syscollector/000/netiface
      ✓ Request (148ms)
      ✓ Selector (147ms)
      ✓ Not allowed selector (147ms)
      ✓ Pagination (148ms)
      ✓ Wrong limit
      ✓ Search (149ms)
      ✓ Wrong filter
      ✓ Wrong Sort (146ms)
      ✓ Filter: name (150ms)
      ✓ Filter: type (147ms)
      ✓ Filter: state (150ms)
      ✓ Filter: mtu (152ms)
      ✓ Filter: tx_packets (160ms)
      ✓ Filter: rx_packets (150ms)
      ✓ Filter: tx_bytes (149ms)
      ✓ Filter: rx_bytes (155ms)
      ✓ Filter: tx_errors (149ms)
      ✓ Filter: rx_errors (150ms)
      ✓ Filter: tx_dropped (149ms)
      ✓ Filter: rx_dropped (148ms)


  216 passing (36s)
```