### PR TITLE
Fix memory leak in Modulesd when querying configuration

### DIFF
--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -266,8 +266,13 @@ cJSON *getModulesConfig(void) {
     cJSON *wm_mod = cJSON_CreateArray();
 
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
-        if (cur_module->context->dump(cur_module->data))
-            cJSON_AddItemToArray(wm_mod,cur_module->context->dump(cur_module->data));
+        if (cur_module->context->dump) {
+            cJSON * item = cur_module->context->dump(cur_module->data);
+
+            if (item) {
+                cJSON_AddItemToArray(wm_mod, item);
+            }
+        }
     }
 
     cJSON_AddItemToObject(root,"wmodules",wm_mod);


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 3.9.2 | Modules | Manager / Agent | All | All |

Running a `wmodules` configuration query produces a memory leak:

```sh
curl -XGET -u foo:bar http://localhost:55000/agents/000/config/wmodules/wmodules
```

### Enable AddressSanitizer

```sh
CFLAGS='-fsanitize=address --no-omit-frame-pointer' LDFLAGS='-fsanitize=address' make TARGET=agent -j2
```

### Report by AddressSanitizer

```
==1507==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7fd22bc9b330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7fd22b6f2346  (libwazuhext.so+0xd6346)
    #2 0x7fd22b6f572a  (libwazuhext.so+0xd972a)
    #3 0x55f247340373 in wm_control_dump wazuh_modules/wm_control.c:154
    #4 0x55f247315b11 in getModulesConfig wazuh_modules/wmodules.c:269
    #5 0x55f247318d1f in wmcom_getconfig wazuh_modules/wmcom.c:48
    #6 0x55f247318c9f in wmcom_dispatch wazuh_modules/wmcom.c:33
    #7 0x55f24731921d in wmcom_main wazuh_modules/wmcom.c:141
    #8 0x7fd22b602fa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7fd22bc9b330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7fd22b6f2346  (libwazuhext.so+0xd6346)
    #2 0x7fd22b6f572a  (libwazuhext.so+0xd972a)
    #3 0x55f24734037c in wm_control_dump wazuh_modules/wm_control.c:155
    #4 0x55f247315b11 in getModulesConfig wazuh_modules/wmodules.c:269
    #5 0x55f247318d1f in wmcom_getconfig wazuh_modules/wmcom.c:48
    #6 0x55f247318c9f in wmcom_dispatch wazuh_modules/wmcom.c:33
    #7 0x55f24731921d in wmcom_main wazuh_modules/wmcom.c:141
    #8 0x7fd22b602fa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7fd22bc9b330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7fd22b6f2346  (libwazuhext.so+0xd6346)
    #2 0x7fd22b6f561a  (libwazuhext.so+0xd961a)
    #3 0x55f24734038c in wm_control_dump wazuh_modules/wm_control.c:156
    #4 0x55f247315b11 in getModulesConfig wazuh_modules/wmodules.c:269
    #5 0x55f247318d1f in wmcom_getconfig wazuh_modules/wmcom.c:48
    #6 0x55f247318c9f in wmcom_dispatch wazuh_modules/wmcom.c:33
    #7 0x55f24731921d in wmcom_main wazuh_modules/wmcom.c:141
    #8 0x7fd22b602fa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486

Indirect leak of 14 byte(s) in 1 object(s) allocated from:
    #0 0x7fd22bc9b330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7fd22b6f222c  (libwazuhext.so+0xd622c)
    #2 0x7fd22b6f4e86  (libwazuhext.so+0xd8e86)
    #3 0x55f2473403b9 in wm_control_dump wazuh_modules/wm_control.c:157
    #4 0x55f247315b11 in getModulesConfig wazuh_modules/wmodules.c:269
    #5 0x55f247318d1f in wmcom_getconfig wazuh_modules/wmcom.c:48
    #6 0x55f247318c9f in wmcom_dispatch wazuh_modules/wmcom.c:33
    #7 0x55f24731921d in wmcom_main wazuh_modules/wmcom.c:141
    #8 0x7fd22b602fa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fd22bc9b330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7fd22b6f222c  (libwazuhext.so+0xd622c)
    #2 0x7fd22b6f4e86  (libwazuhext.so+0xd8e86)
    #3 0x55f2473403a2 in wm_control_dump wazuh_modules/wm_control.c:156
    #4 0x55f247315b11 in getModulesConfig wazuh_modules/wmodules.c:269
    #5 0x55f247318d1f in wmcom_getconfig wazuh_modules/wmcom.c:48
    #6 0x55f247318c9f in wmcom_dispatch wazuh_modules/wmcom.c:33
    #7 0x55f24731921d in wmcom_main wazuh_modules/wmcom.c:141
    #8 0x7fd22b602fa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486

Indirect leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7fd22bc9b330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7fd22b6f222c  (libwazuhext.so+0xd622c)
    #2 0x7fd22b6f5643  (libwazuhext.so+0xd9643)
    #3 0x55f24734038c in wm_control_dump wazuh_modules/wm_control.c:156
    #4 0x55f247315b11 in getModulesConfig wazuh_modules/wmodules.c:269
    #5 0x55f247318d1f in wmcom_getconfig wazuh_modules/wmcom.c:48
    #6 0x55f247318c9f in wmcom_dispatch wazuh_modules/wmcom.c:33
    #7 0x55f24731921d in wmcom_main wazuh_modules/wmcom.c:141
    #8 0x7fd22b602fa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486

SUMMARY: AddressSanitizer: 218 byte(s) leaked in 6 allocation(s).
```

## Cause of this bug

This issue is due to a typo in the configuration gatherer: it called the dumper when it meant to check if such function exists.

### Fix

Replace the accidental call with a function pointer test. 

## Tests

- [X] Compile manager for Linux.
- [X] Compile agent for Linux.
- [X] Compile agent for Windows.
- [X] Compile agent for macOS.
- [X] Source installation.
- [X] Source upgrade.
- [X] Address Sanitizer reports no memory leaks.
- [X] Get on-demand configuration for _wmodules_.
- [ ] QA integration test.