### PR TITLE
modify header help message in makelists

### DIFF
--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -10,7 +10,7 @@
 
 #ifdef ARGV0
 #undef ARGV0
-#define ARGV0 "ossec-testrule"
+#define ARGV0 "ossec-makelists"
 #endif
 
 #include "shared.h"


### PR DESCRIPTION
|Related issue|
|---|
| [3558](https://github.com/wazuh/wazuh/issues/3558) |


## Description
The help message is not correct.  It confuses the name program with ossec-logtest. The rest of the message is okay.
```
Wazuh v3.9.2 - Wazuh Inc. (info@wazuh.com)
http://www.wazuh.com
ossec-testrule: -[VhdtF] [-u user] [-g group] [-c config] [-D dir]
```
This PR change program name.
 
## Logs/Alerts example
Both messages helps (ossec-logtest and new ossec-makelist):
```
lopezziur-S551LN ossec # bin/ossec-makelists -h
 
Wazuh v3.10.0 - Wazuh Inc. (info@wazuh.com)
http://www.wazuh.com
  ossec-makelists: -[VhdtF] [-u user] [-g group] [-c config] [-D dir]
    -V          Version and license message
    -h          This help message
    -d          Execute in debug mode. This parameter
                can be specified multiple times
                to increase the debug level.
    -t          Test configuration
    -F          Force rebuild of all databases
    -u <user>   User to run as (default: ossec)
    -g <group>  Group to run as (default: ossec)
    -c <config> Configuration file to use (default: /var/ossec/etc/ossec.conf)
    -D <dir>    Directory to chroot into (default: /var/ossec)
 
lopezziur-S551LN ossec # bin/ossec-logtest -h
 
Wazuh v3.10.0 - Wazuh Inc. (info@wazuh.com)
http://www.wazuh.com
  ossec-testrule: -[Vhdtva] [-c config] [-D dir] [-U rule:alert:decoder]
    -V          Version and license message
    -h          This help message
    -d          Execute in debug mode. This parameter
                can be specified multiple times
                to increase the debug level.
    -t          Test configuration
    -a          Alerts output
    -v          Verbose (full) output/rule debugging
    -c <config> Configuration file to use (default: /var/ossec/etc/ossec.conf)
    -D <dir>    Directory to chroot into (default: /var/ossec)
    -U <rule:alert:decoder>  Unit test. Refer to contrib/ossec-testing/runtests.py
 
lopezziur-S551LN ossec # 
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [ ] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
