### PR TITLE
Added the execution of powershell scripts in windows

### DIFF
--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -214,33 +214,28 @@ void ExecCmd_Win32(char *cmd)
     si.cb = sizeof(si);
     ZeroMemory( &pi, sizeof(pi) );
 
-    char *pstr = strstr(cmd, ".ps1\"");
+    char *ps1 = strstr(cmd, ".ps1\"");
+    char *psexe = strstr(cmd, "powershell.exe -file ");
 
-    if (pstr)
+    if (ps1 && psexe==NULL)
     {
         char cmdPs1[OS_SIZE_1024];
-        char c[OS_SIZE_1024];
+        char c[OS_SIZE_1024]="";
         int reMarks = 0;
         for (int i = 1; cmd[i]!='\0'; i++)
         {
             if (cmd[i] == '\"')
-            {
-                if (!reMarks)
-                {                
+                if (!reMarks){
                     i++;
                     reMarks = 1;
                 }
-                else if (cmd[i+1]=='-' && cmd[i+2]=='\"')
-                {
-                    i = i+3;
-                    snprintf(c, OS_SIZE_1024, "%s%s", c, "NULL");
-                }
-            }
             snprintf(c, OS_SIZE_1024, "%s%c", c, cmd[i]);
+            if (cmd[i] == '\"' && cmd[i + 1] == '-' && cmd[i + 1] != '\0')
+                if (cmd[i + 2] == '\"' && cmd[i + 2] != '\0')
+                    i++;
         }
-        snprintf(cmdPs1, OS_SIZE_1024, "powershell -file %s",c);
+        snprintf(cmdPs1, OS_SIZE_1024, "powershell.exe -file %s",c);
         c[0]='\0';
-        minfo("Ejecucion de comando: %s", cmdPs1);
         if (!CreateProcess(NULL, cmdPs1, NULL, NULL, FALSE, 0, NULL, NULL,
                            &si, &pi)){
             merror("Unable to create active response process. (PS1)");


### PR DESCRIPTION
|Related issue|
|---|
|#3002|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
I have added the option to run powershell script on windows with `active response` natively. 

The execution of these scripts will be done in the same way as those that are already available.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform:
  - [x] Windows 
- [x] Package installation
- [x] Package upgrade
- Check behavior in different windows operating systems:
  - [x] Windows server 2016
  - [ ] Windows server 2008
  - [ ] Windows XP
  - [ ] Windows 7
  - [ ] Windows 10
- Memory tests
  - [x] Dr. Memory report for affected components
