### PR TITLE
 Let Remoted filter UTF-8 characters for agent-info data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,13 +87,7 @@ src/win32/REVISION
 *.gcda
 src/coverage-report/
 src/ossec.test
-src/tap_os_crypto
-src/tap_os_net
-src/tap_os_regex
-src/tap_os_xml
-src/tap_os_zlib
-src/test_shared
-src/tap_shared
+src/tap_*
 etc/preloaded-vars.conf
 
 # Old firewall-drop.sh (moved to default-firewall-drop.sh)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1535,7 +1535,7 @@ tap_os_regex: tests/tap_os_regex.c ${os_regex_o}
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 tap_shared: tests/tap_shared.c ${shared_o} ${os_xml_o} ${os_net_o} ${os_regex_o}
-	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
+	${OSSEC_CCBIN} $(OSSEC_CFLAGS) ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 tap_os_zlib: tests/tap_os_zlib.o
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -70,6 +70,7 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <signal.h>
+#include <stdbool.h>
 
 /* The mingw32 builder used by travis.ci can't find glob.h
  * Yet glob must work on actual win32.
@@ -227,6 +228,7 @@ extern const char *__local_name;
 #include "json_op.h"
 #include "notify_op.h"
 #include "version_op.h"
+#include "utf8_op.h"
 
 #include "os_xml/os_xml.h"
 #include "os_regex/os_regex.h"

--- a/src/headers/utf8_op.h
+++ b/src/headers/utf8_op.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2015-2019, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * June 19, 2019
+ */
+
+/* Return whether a string is UTF-8 */
+bool w_utf8_valid(const char * string);
+
+/* Return pointer to the first character that does not match UTF-8, or the last byte (0) */
+const char * w_utf8_drop(const char * string);
+
+/* Return a new string with valid UTF-8 characters only */
+char * w_utf8_filter(const char * string, bool replacement);

--- a/src/shared/utf8_op.c
+++ b/src/shared/utf8_op.c
@@ -1,0 +1,116 @@
+/* Copyright (C) 2015-2019, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * June 19, 2019
+ * https://en.wikipedia.org/wiki/UTF-8
+ */
+
+#include <shared.h>
+
+#define REPLACEMENT_INC 4096
+
+/* Single byte: 0xxxxxxx */
+#define valid_1(x) (x[0] & 0x80) == 0
+
+/* Two bytes: 110xxxxx 10xxxxxx */
+/* Starting bytes 0xC0 and 0xC1 are forbidden (overlong) */
+#define valid_2(x) (x[0] & 0xE0) == 0xC0 && (x[0] & 0x1E) != 0 && (x[1] & 0xC0) == 0x80
+
+/* Three bytes: 1110xxxx 10xxxxxx 10xxxxxx */
+/* 0xE0 could start overlong encodings */
+/* 0xED (range U+D800–U+DFFF) is reserved for UTF-16 surrogate halves */
+#define valid_3(x) (x[0] & 0xF0) == 0xE0 && x[0] != (char)0xE0 && x[0] != (char)0xED && (x[1] & 0xC0) == 0x80 && (x[2] & 0xC0) == 0x80
+
+/* Four bytes: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
+/* 0xF0 could start overlong encodings */
+/* Starting bytes 111101xx are forbidden (Unicode limit) */
+#define valid_4(x) (x[0] & 0xF8) == 0xF0 && x[0] != (char)0xF0 && (x[0] & 0x04) == 0 && (x[1] & 0xC0) == 0x80 && (x[2] & 0xC0) == 0x80 && (x[3] & 0xC0) == 0x80
+
+/* Return whether a string is UTF-8 */
+bool w_utf8_valid(const char * string) {
+    assert(string != NULL);
+    return *(w_utf8_drop(string)) == '\0';
+}
+
+/* Return pointer to the first character that does not match UTF-8, or the last byte (0) */
+const char * w_utf8_drop(const char * string) {
+    assert(string != NULL);
+
+    while (*string) {
+        if (valid_1(string)) {
+            string++;
+        } else if (valid_2(string)) {
+            string += 2;
+        } else if (valid_3(string)) {
+            string += 3;
+        } else if (valid_4(string)) {
+            string += 4;
+        } else {
+            return string;
+        }
+    }
+
+    return string;
+}
+
+/* Return a new string with valid UTF-8 characters only */
+char * w_utf8_filter(const char * string, bool replacement) {
+    assert(string != NULL);
+
+    const char * valid = w_utf8_drop(string);
+
+    if (*valid == '\0') {
+        char * copy;
+        os_strdup(string, copy);
+        return copy;
+    }
+
+    size_t size = strlen(string) + 1;
+    char * copy;
+    size_t i = valid - string;
+    size_t repl = 0;
+
+    os_malloc(size, copy);
+    memcpy(copy, string, i);
+
+    while (*valid) {
+        if (valid_1(valid)) {
+            copy[i++] = *valid++;
+        } else if (valid_2(valid)) {
+            copy[i++] = *valid++;
+            copy[i++] = *valid++;
+        } else if (valid_3(valid)) {
+            copy[i++] = *valid++;
+            copy[i++] = *valid++;
+            copy[i++] = *valid++;
+        } else if (valid_4(valid)) {
+            copy[i++] = *valid++;
+            copy[i++] = *valid++;
+            copy[i++] = *valid++;
+            copy[i++] = *valid++;
+        } else {
+            if (replacement) {
+                if (repl < 3) {
+                    size += REPLACEMENT_INC;
+                    os_realloc(copy, size, copy);
+                    repl += REPLACEMENT_INC;
+                }
+
+                copy[i++] = 0xEF;
+                copy[i++] = 0xBF;
+                copy[i++] = 0xBD;
+                repl -= 3;
+            }
+
+            valid++;
+        }
+    }
+
+    copy[i] = '\0';
+    return copy;
+}

--- a/src/tests/tap_shared.c
+++ b/src/tests/tap_shared.c
@@ -1,8 +1,4 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-
-#include "../headers/custom_output_search.h"
+#include "../headers/shared.h"
 #include "tap.h"
 
 int test_search_and_replace(){
@@ -32,11 +28,39 @@ int test_search_and_replace(){
     return 1;
 }
 
+int test_utf8_random(bool replacement) {
+    int i;
+    const size_t LENGTH = 4096;
+    char buffer[LENGTH];
+
+    randombytes(buffer, LENGTH - 1);
+
+    /* Avoid zeroes */
+
+    for (i = 0; i < LENGTH - 1; i++) {
+        buffer[i] = buffer[i] ? buffer[i] : '0';
+    }
+
+    buffer[LENGTH - 1] = '\0';
+
+    char * copy = w_utf8_filter(buffer, replacement);
+    int r = w_utf8_valid(copy);
+    free(copy);
+
+    return r;
+}
+
 int main(void) {
     printf("\n\n   STARTING TEST - OS_SHARED   \n\n");
 
     // Search and replace strings test
     TAP_TEST_MSG(test_search_and_replace(), "Search and replace strings test.");
+
+    /* Test UTF-8 string operations */
+    TAP_TEST_MSG(test_utf8_random(true), "Filter a random string into UTF-8 with character replacement.");
+
+    /* Test UTF-8 string operations */
+    TAP_TEST_MSG(test_utf8_random(false), "Filter a random string into UTF-8 without character replacement.");
 
     TAP_PLAN;
     TAP_SUMMARY;


### PR DESCRIPTION
|Related issue|
|---|
|#3569|

## Description

Issue #3552 reported that an agent with a version between 3.8.0 and 3.9.2 may deliver a heartbeat with invalid characters due to an uninitialized string.

Despite this problem is solved as of 3.9.3, old agents are still able to send spurious data. So, this PR aims to filter such string when Remoted handles it.

## Corrupt file case

This is a sample of _agent-info_ file with a tampered IP address. Note that Remoted already converted the data into a UTF-8 string with replacement characters (�).

```
Linux |centos |3.10.0-957.5.1.el7.x86_64 |#1 SMP Fri Feb 1 14:54:57 UTC 2019 |x86_64 [CentOS Linux|centos: 7.6] - Wazuh v3.9.3 / ab73af41699f13fdd81903b5f23d8d00
c6309ff81a74781f6b55b68129a76738 merged.mg
j�N镆|�?3�:u�|����4vب����<W���aы�7De��v�0�

#"_manager_hostname":stretch64
#"_node_name":node01
```

### Database content

|Key|Value|
|---|---|
|id|1|
|name|centos|
|ip||
|register_ip|192.168.33.11|
|internal_key|aa0ef81ed265d7cda91b60ed4ba1c80c4752c1839a1799a5ec96721a5f7809ee|
|os_name|CentOS Linux|
|os_version|7.6|
|os_major|7|
|os_minor|6|
|os_codename|centos|
|os_build||
|os_platform|centos|
|os_uname|Linux &#124;centos &#124;3.10.0-957.5.1.el7.x86_64 &#124;#1 SMP Fri Feb 1 14:54:57 UTC 2019 &#124;x86_64|
|os_arch| |
|os_arch x86_64|
|version|Wazuh v3.9.3|
|config_sum|ab73af41699f13fdd81903b5f23d8d00|
|merged_sum|c6309ff81a74781f6b55b68129a76738|
|manager_host|stretch64|
|node_name|node01|
|date_add|2019-06-26 18:09:11|
|last_keepalive|2019-06-26 19:16:34|
|status|updated|
|fim_offset|0|
|reg_offset|0|
|group|default|

## Tests

- [X] Compile manager on Linux.
- [X] Compile agent on Linux.
- [X] Compile agent on macOS.
- [X] Compile agent for Windows.
- [X] Source installation.
- [X] Source upgrade.
- [X] Run Remoted on Valgrind.
- [X] Review logs syntax and correct language.
- [X] Implement unit tests.

### CPU impact

We measured the UTF-8 filter throughput with 100 MB files. The agent-info events per second is calculated assuming that events are 300 bytes long.

#### Best case: data is already UTF-8

|100 MB file parse time|Throughput|Agent-info EPS|
|---|---|---|
|134,022 ms|746,15 MiB/s|2.607.983 EPS|

#### Worst case: fully random data

|100 MB file parse time|Throughput|Agent-info EPS|
|---|---|---|
|885,180 ms|112,97 MiB/s|334.858 EPS|

### Valgrind report

```
==27387== LEAK SUMMARY:
==27387==    definitely lost: 0 bytes in 0 blocks
==27387==    indirectly lost: 0 bytes in 0 blocks
==27387==      possibly lost: 5,168 bytes in 19 blocks
==27387==    still reachable: 1,120,266 bytes in 98 blocks
==27387==         suppressed: 0 bytes in 0 blocks
```