### PR TITLE
Fix conflicts between rule context options

### DIFF
--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -28,8 +28,8 @@
 #define SAME_SRCPORT        0x020
 #define SAME_DSTPORT        0x040
 #define SAME_DODIFF         0x100
-#define SAME_FIELD          0x200
-#define NOT_SAME_FIELD      0x400
+#define SAME_FIELD          0x080
+#define NOT_SAME_FIELD      0x800
 #define NOT_SAME_USER       0xffe /* 0xfff - 0x001  */
 #define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002  */
 #define NOT_SAME_ID         0xffb /* 0xfff - 0x004  */


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 3.9.3 | Analysisd | Manager | Any | Any |

## Description

We found that _ossec-logtest_ crashed with a particular ruleset:

```xml
<rule id="100001" level="5">
  <decoded_as>json</decoded_as>
  <description>Test rule 1</description>
</rule>

<rule id="100002" level="6" frequency="2" timeframe="60">
  <if_matched_sid>100001</if_matched_sid>
  <description>Test rule 2</description>
  <different_srcgeoip />
</rule>
```

### Input log

```
{"name":"testing"}
```

## Cause

The following definitions ([rules.h:26-32](https://github.com/wazuh/wazuh/blob/v3.9.2/src/analysisd/rules.h#L26-L32)) make these rule options conflict:

- `<different_srcip>` conflicts with `<same_field>`.
- `<different_srcgeoip>` conflicts with `<not_same_field>`.

In the example above, `<different_srcgeoip>` makes Analysisd scan the _not_same_field_ array. If that array is null, then the program crashes.

## Tests

- [X] Compile manager on Linux.
- [X] Source installation.
- [X] Source upgrade.
- [X] Run _ossec-logtest_ on Valgrind for the example above.
- [X] Ruleset test suite.