### PR TITLE
parsing static fields for rules

### DIFF
--- a/extensions/elasticsearch/6.x/wazuh-template.json
+++ b/extensions/elasticsearch/6.x/wazuh-template.json
@@ -383,6 +383,10 @@
               "type": "keyword",
               "doc_values": "true"
             },
+            "extra_data": {
+              "type": "keyword",
+              "doc_values": "true"
+            },
             "system_name": {
               "type": "keyword",
               "doc_values": "true"

--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -162,6 +162,7 @@
       "data.dstip",
       "data.dstport",
       "data.dstuser",
+      "data.extra_data",
       "data.hardware.serial",
       "data.id",
       "data.integration",
@@ -941,6 +942,9 @@
             "type": "keyword"
           },
           "data": {
+            "type": "keyword"
+          },
+          "extra_data": {
             "type": "keyword"
           },
           "system_name": {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1032,6 +1032,24 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
     }
+    
+    /* Check for the system name */
+    if (rule->system_name) {
+        if(!lf->systemname){
+            return(NULL);
+        }
+
+        if (!OSMatch_Execute(lf->systemname, strlen(lf->systemname), rule->system_name)) {
+            return (NULL);
+        }
+    }
+
+    /* Check for the protocol */
+    if (rule->protocol) {
+        if (!OSMatch_Execute(lf->protocol, strlen(lf->protocol), rule->protocol)) {
+            return (NULL);
+        }
+    }
 
     /* Check if any word to match exists */
     if (rule->match) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1050,6 +1050,20 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
     }
+    
+    /* Check for the data */
+    if (rule->data) {
+        if (!OSMatch_Execute(lf->data, strlen(lf->data), rule->data)) {
+            return (NULL);
+        }
+    }
+
+    /* Check for the extra_data */
+    if (rule->extra_data) {
+        if (!OSMatch_Execute(lf->extra_data, strlen(lf->extra_data), rule->extra_data)) {
+            return (NULL);
+        }
+    }
 
     /* Check if any word to match exists */
     if (rule->match) {
@@ -1402,6 +1416,38 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     }
                     if (!OS_DBSearch(list_holder, lf->action)) {
                         return (NULL);
+                    }
+                    break;
+                case RULE_SYSTEMNAME:
+                    if(!lf->systemname){
+                        return (NULL);
+                    }
+                    if (!OS_DBSearch(list_holder, lf->systemname)){
+                        return (NULL);
+                    }
+                    break;
+                case RULE_PROTOCOL:
+                    if(!lf->protocol){
+                        return(NULL);
+                    }
+                    if (!OS_DBSearch(list_holder, lf->protocol)){
+                        return(NULL);
+                    }
+                    break;
+                case RULE_DATA:
+                    if(!lf->data){
+                        return(NULL);
+                    }
+                    if (!OS_DBSearch(list_holder, lf->data)){
+                        return(NULL);
+                    }
+                    break;
+                case RULE_EXTRA_DATA:
+                    if(!lf->extra_data){
+                        return(NULL);
+                    }
+                    if (!OS_DBSearch(list_holder, lf->extra_data)){
+                        return(NULL);
                     }
                     break;
                 case RULE_DYNAMIC:

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -995,7 +995,6 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                   rule->comment);
 #endif
 
-
     /* Check if any decoder pre-matched here for syscheck event */
     if(lf->decoder_syscheck_id != 0 && (rule->decoded_as &&
             rule->decoded_as != lf->decoder_syscheck_id)){
@@ -1032,11 +1031,11 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
     }
-    
+
     /* Check for the system name */
     if (rule->system_name) {
-        if(!lf->systemname){
-            return(NULL);
+        if (!lf->systemname) {
+            return (NULL);
         }
 
         if (!OSMatch_Execute(lf->systemname, strlen(lf->systemname), rule->system_name)) {
@@ -1046,30 +1045,10 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
 
     /* Check for the protocol */
     if (rule->protocol) {
-        if(!lf->protocol){
-            return(NULL);
+        if (!lf->protocol) {
+            return (NULL);
         }
         if (!OSMatch_Execute(lf->protocol, strlen(lf->protocol), rule->protocol)) {
-            return (NULL);
-        }
-    }
-    
-    /* Check for the data */
-    if (rule->data) {
-        if(!lf->data){
-            return(NULL);
-        }
-        if (!OSMatch_Execute(lf->data, strlen(lf->data), rule->data)) {
-            return (NULL);
-        }
-    }
-
-    /* Check for the extra_data */
-    if (rule->extra_data) {
-        if(!lf->extra_data){
-            return(NULL);
-        }
-        if (!OSMatch_Execute(lf->extra_data, strlen(lf->extra_data), rule->extra_data)) {
             return (NULL);
         }
     }
@@ -1254,6 +1233,29 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             }
         }
 
+        /* Check for the data */
+        if (rule->data) {
+            if (!lf->data) {
+                return (NULL);
+            }
+            if (!OSMatch_Execute(lf->data, strlen(lf->data), rule->data)) {
+                return (NULL);
+            }
+        }
+
+        /* Check for the extra_data */
+        if (rule->extra_data) {
+            if(!lf->extra_data){
+                return(NULL);
+            }
+
+            if (!OSMatch_Execute(lf->extra_data,
+                                 strlen(lf->extra_data),
+                                 rule->extra_data)) {
+                return (NULL);
+            }
+        }
+
         /* Check hostname */
         if (rule->hostname) {
             if (!lf->hostname) {
@@ -1415,7 +1417,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     }
                     break;
                 case RULE_SYSTEMNAME:
-                    if(!lf->systemname){
+                    if (!lf->systemname) {
                         return (NULL);
                     }
                     if (!OS_DBSearch(list_holder, lf->systemname)){
@@ -1423,27 +1425,27 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     }
                     break;
                 case RULE_PROTOCOL:
-                    if(!lf->protocol){
-                        return(NULL);
+                    if (!lf->protocol) {
+                        return (NULL);
                     }
                     if (!OS_DBSearch(list_holder, lf->protocol)){
-                        return(NULL);
+                        return (NULL);
                     }
                     break;
                 case RULE_DATA:
-                    if(!lf->data){
-                        return(NULL);
+                    if (!lf->data) {
+                        return (NULL);
                     }
                     if (!OS_DBSearch(list_holder, lf->data)){
-                        return(NULL);
+                        return (NULL);
                     }
                     break;
                 case RULE_EXTRA_DATA:
-                    if(!lf->extra_data){
-                        return(NULL);
+                    if (!lf->extra_data) {
+                        return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->extra_data)){
-                        return(NULL);
+                    if (!OS_DBSearch(list_holder, lf->extra_data)) {
+                        return (NULL);
                     }
                     break;
                 case RULE_DYNAMIC:

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1254,19 +1254,6 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             }
         }
 
-        /* Get extra data */
-        /*/if (rule->extra_data) {
-            if (!lf->extra_data) {
-                return (NULL);
-            }
-
-            if (!OSMatch_Execute(lf->extra_data,
-                                 strlen(lf->extra_data),
-                                 rule->extra_data)) {
-                return (NULL);
-            }
-        }*/
-
         /* Check hostname */
         if (rule->hostname) {
             if (!lf->hostname) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1046,6 +1046,9 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
 
     /* Check for the protocol */
     if (rule->protocol) {
+        if(!lf->protocol){
+            return(NULL);
+        }
         if (!OSMatch_Execute(lf->protocol, strlen(lf->protocol), rule->protocol)) {
             return (NULL);
         }
@@ -1053,6 +1056,9 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
     
     /* Check for the data */
     if (rule->data) {
+        if(!lf->data){
+            return(NULL);
+        }
         if (!OSMatch_Execute(lf->data, strlen(lf->data), rule->data)) {
             return (NULL);
         }
@@ -1060,6 +1066,9 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
 
     /* Check for the extra_data */
     if (rule->extra_data) {
+        if(!lf->extra_data){
+            return(NULL);
+        }
         if (!OSMatch_Execute(lf->extra_data, strlen(lf->extra_data), rule->extra_data)) {
             return (NULL);
         }
@@ -1246,17 +1255,17 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
         }
 
         /* Get extra data */
-        if (rule->extra_data) {
-            if (!lf->data) {
+        /*/if (rule->extra_data) {
+            if (!lf->extra_data) {
                 return (NULL);
             }
 
-            if (!OSMatch_Execute(lf->data,
-                                 strlen(lf->data),
+            if (!OSMatch_Execute(lf->extra_data,
+                                 strlen(lf->extra_data),
                                  rule->extra_data)) {
                 return (NULL);
             }
-        }
+        }*/
 
         /* Check hostname */
         if (rule->hostname) {

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -316,7 +316,6 @@ cJSON *getRulesConfig(void) {
 
 cJSON *getManagerLabelsConfig(void) {
 
-    unsigned int i;
     cJSON *root = cJSON_CreateObject();
     cJSON *labels = cJSON_CreateArray();
 

--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -199,6 +199,8 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         if (node->ruleinfo->user) cJSON_AddStringToObject(rule,"user",node->ruleinfo->user->raw);
         if (node->ruleinfo->url) cJSON_AddStringToObject(rule,"url",node->ruleinfo->url->raw);
         if (node->ruleinfo->id) cJSON_AddStringToObject(rule,"id",node->ruleinfo->id->raw);
+        if (node->ruleinfo->protocol) cJSON_AddStringToObject(rule,"protocol",node->ruleinfo->protocol->raw);
+        if (node->ruleinfo->system_name) cJSON_AddStringToObject(rule,"system_name",node->ruleinfo->system_name->raw);        
         if (node->ruleinfo->status) cJSON_AddStringToObject(rule,"status",node->ruleinfo->status->raw);
         if (node->ruleinfo->hostname) cJSON_AddStringToObject(rule,"hostname",node->ruleinfo->hostname->raw);
         if (node->ruleinfo->program_name) cJSON_AddStringToObject(rule,"program_name",node->ruleinfo->program_name->raw);

--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -199,8 +199,9 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         if (node->ruleinfo->user) cJSON_AddStringToObject(rule,"user",node->ruleinfo->user->raw);
         if (node->ruleinfo->url) cJSON_AddStringToObject(rule,"url",node->ruleinfo->url->raw);
         if (node->ruleinfo->id) cJSON_AddStringToObject(rule,"id",node->ruleinfo->id->raw);
+        if (node->ruleinfo->system_name) cJSON_AddStringToObject(rule,"system_name",node->ruleinfo->system_name->raw);
         if (node->ruleinfo->protocol) cJSON_AddStringToObject(rule,"protocol",node->ruleinfo->protocol->raw);
-        if (node->ruleinfo->system_name) cJSON_AddStringToObject(rule,"system_name",node->ruleinfo->system_name->raw);        
+        if (node->ruleinfo->data) cJSON_AddStringToObject(rule, "data", node->ruleinfo->data->raw);     
         if (node->ruleinfo->status) cJSON_AddStringToObject(rule,"status",node->ruleinfo->status->raw);
         if (node->ruleinfo->hostname) cJSON_AddStringToObject(rule,"hostname",node->ruleinfo->hostname->raw);
         if (node->ruleinfo->program_name) cJSON_AddStringToObject(rule,"program_name",node->ruleinfo->program_name->raw);

--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -65,6 +65,9 @@ void _getDecodersListJSON(OSDecoderNode *list, cJSON *array) {
                 else if (node->osdecoder->order[i] == Data_FP) {
                     cJSON_AddItemToArray(_list,cJSON_CreateString("data"));
                 }
+                else if (node->osdecoder->order[i] == Extra_Data_FP) {
+                    cJSON_AddItemToArray(_list,cJSON_CreateString("extra_data"));
+                }
                 else if (node->osdecoder->order[i] == Status_FP) {
                     cJSON_AddItemToArray(_list,cJSON_CreateString("status"));
                 }

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -515,7 +515,7 @@ int ReadDecodeXML(const char *file)
                     } else if (!strcmp(word, "data")) {
                         pi->order[order_int] = Data_FP;
                     } else if (!strcmp(word, "extra_data")) {
-                        pi->order[order_int] = Data_FP;
+                        pi->order[order_int] = Extra_Data_FP;
                     } else if (!strcmp(word, "status")) {
                         pi->order[order_int] = Status_FP;
                     } else if (!strcmp(word, "system_name")) {

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -391,11 +391,23 @@ void *Data_FP(Eventinfo *lf, char *field, __attribute__((unused)) const char *or
 {
 #ifdef TESTRULE
     if (!alert_only) {
-        print_out("       extra_data: '%s'", field);
+        print_out("       data: '%s'", field);
     }
 #endif
 
     lf->data = field;
+    return (NULL);
+}
+
+void *Extra_Data_FP(Eventinfo *lf, char *field, __attribute__((unused)) const char *order)
+{
+#ifdef TESTRULE
+    if (!alert_only) {
+        print_out("       extra_data: '%s'", field);
+    }
+#endif
+
+    lf->extra_data = field;
     return (NULL);
 }
 

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -171,6 +171,16 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
         return;
     }
 
+    if (strcmp(key, "extra_data") == 0){
+        os_strdup(value, lf->extra_data);
+#ifdef TESTRULE
+        if (!alert_only) {
+            print_out("       extra_data: '%s'", lf->extra_data);
+        }
+#endif
+        return;
+    }
+
     if (strcmp(key, "systemname") == 0){
         lf->systemname = strdup(value);
 #ifdef TESTRULE

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -718,6 +718,7 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->command = NULL;
     lf->url = NULL;
     lf->data = NULL;
+    lf->extra_data = NULL;
     lf->systemname = NULL;
 
     if (lf->fields) {
@@ -933,6 +934,10 @@ void Free_Eventinfo(Eventinfo *lf)
 
     if (lf->data) {
         free(lf->data);
+    }
+
+    if (lf->extra_data) {
+        free(lf->extra_data);
     }
 
     if (lf->systemname) {
@@ -1266,6 +1271,10 @@ void w_copy_event_for_log(Eventinfo *lf,Eventinfo *lf_cpy){
 
     if(lf->data){
         os_strdup(lf->data,lf_cpy->data);
+    }
+
+    if(lf->extra_data){
+        os_strdup(lf->extra_data, lf_cpy->extra_data);
     }
 
     if(lf->systemname){

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1148,8 +1148,6 @@ char* ParseRuleComment(Eventinfo *lf) {
             field = lf->status;
         } else if (strcmp(var, "extra_data") == 0) {
             field = lf->extra_data;
-        } else if (strcmp(var, "url") == 0) {
-            field = lf->url;
         } else if (strcmp(var, "system_name") == 0) {
             field = lf->systemname;
         }

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1139,6 +1139,8 @@ char* ParseRuleComment(Eventinfo *lf) {
             field = lf->url;
         } else if (strcmp(var, "data") == 0) {
             field = lf->data;
+        } else if (strcmp(var, "status") == 0) {
+            field = lf->status;
         } else if (strcmp(var, "extra_data") == 0) {
             field = lf->extra_data;
         } else if (strcmp(var, "url") == 0) {

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1137,10 +1137,12 @@ char* ParseRuleComment(Eventinfo *lf) {
             field = lf->id;
         } else if (strcmp(var, "url") == 0) {
             field = lf->url;
-        } else if (strcmp(var, "data") == 0 || strcmp(var, "extra_data") == 0) {
+        } else if (strcmp(var, "data") == 0) {
             field = lf->data;
-        } else if (strcmp(var, "status") == 0) {
-            field = lf->status;
+        } else if (strcmp(var, "extra_data") == 0) {
+            field = lf->extra_data;
+        } else if (strcmp(var, "url") == 0) {
+            field = lf->url;
         } else if (strcmp(var, "system_name") == 0) {
             field = lf->systemname;
         }

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -52,6 +52,7 @@ typedef struct _Eventinfo {
     char *command;
     char *url;
     char *data;
+    char *extra_data;
     char *systemname;
     DynamicField *fields;
     int nfields;

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -231,6 +231,7 @@ void *Action_FP(Eventinfo *lf, char *field, const char *order);
 void *ID_FP(Eventinfo *lf, char *field, const char *order);
 void *Url_FP(Eventinfo *lf, char *field, const char *order);
 void *Data_FP(Eventinfo *lf, char *field, const char *order);
+void *Extra_Data_FP(Eventinfo *lf, char *field, const char *order);
 void *Status_FP(Eventinfo *lf, char *field, const char *order);
 void *SystemName_FP(Eventinfo *lf, char *field, const char *order);
 void *DynamicField_FP(Eventinfo *lf, char *field, const char *order);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -371,6 +371,9 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
 
     if(lf->data)
         cJSON_AddStringToObject(data, "data", lf->data);
+    
+    if(lf->extra_data)
+        cJSON_AddStringToObject(data, "extra_data", lf->extra_data);
 
     if(lf->systemname)
         cJSON_AddStringToObject(data, "system_name", lf->systemname);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -82,7 +82,8 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_dstuser = "dstuser";
     const char *xml_url = "url";
     const char *xml_id = "id";
-    const char *xml_data = "extra_data";
+    const char *xml_data = "data";
+    const char *xml_extra_data = "extra_data";
     const char *xml_hostname = "hostname";
     const char *xml_program_name = "program_name";
     const char *xml_status = "status";
@@ -599,7 +600,7 @@ int Rules_OP_ReadRules(const char *rulefile)
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
-                    } else if (strcasecmp(rule_opt[k]->element, "data") == 0) {
+                    } else if (strcasecmp(rule_opt[k]->element, xml_data) == 0) {
                         data =
                             loadmemory(data,
                                        rule_opt[k]->content);
@@ -607,7 +608,7 @@ int Rules_OP_ReadRules(const char *rulefile)
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
-                    } else if (strcasecmp(rule_opt[k]->element, xml_data) == 0) {
+                    } else if (strcasecmp(rule_opt[k]->element, xml_extra_data) == 0) {
                         extra_data =
                             loadmemory(extra_data,
                                        rule_opt[k]->content);
@@ -651,8 +652,8 @@ int Rules_OP_ReadRules(const char *rulefile)
                                     strcasecmp(rule_opt[k]->values[0], xml_action) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_id) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_url) &&
-                                    strcasecmp(rule_opt[k]->values[0], "data") &&
                                     strcasecmp(rule_opt[k]->values[0], xml_data) &&
+                                    strcasecmp(rule_opt[k]->values[0], xml_extra_data) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_status) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_system_name))
                                     config_ruleinfo->fields[ifield]->name = loadmemory(config_ruleinfo->fields[ifield]->name, rule_opt[k]->values[0]);
@@ -735,9 +736,9 @@ int Rules_OP_ReadRules(const char *rulefile)
                                         rule_type = RULE_PROTOCOL;
                                     } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_system_name) == 0) {
                                         rule_type = RULE_SYSTEMNAME;
-                                    } else if (strcasecmp(rule_opt[k]->values[list_att_num], "data") == 0) {
-                                        rule_type = RULE_DATA;
                                     } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_data) == 0) {
+                                        rule_type = RULE_DATA;
+                                    } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_extra_data) == 0) {
                                         rule_type = RULE_EXTRA_DATA;
                                     } else {
                                         rule_type = RULE_DYNAMIC;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -148,6 +148,8 @@ int Rules_OP_ReadRules(const char *rulefile)
     char *dstport = NULL;
     char *srcgeoip = NULL;
     char *dstgeoip = NULL;
+    char *protocol = NULL;
+    char *system_name = NULL;
 
     char *status = NULL;
     char *hostname = NULL;
@@ -351,6 +353,8 @@ int Rules_OP_ReadRules(const char *rulefile)
                 dstport = NULL;
                 srcgeoip = NULL;
                 dstgeoip = NULL;
+                system_name = NULL;
+                protocol = NULL;
 
                 status = NULL;
                 hostname = NULL;
@@ -610,6 +614,14 @@ int Rules_OP_ReadRules(const char *rulefile)
                         config_ruleinfo->action =
                             loadmemory(config_ruleinfo->action,
                                        rule_opt[k]->content);
+                    } else if(strcasecmp(rule_opt[k]->element, xml_system_name) == 0){
+                        system_name =
+                            loadmemory(system_name,
+                                       rule_opt[k]->content);
+                    } else if(strcasecmp(rule_opt[k]->element, xml_protocol) == 0){
+                        protocol =
+                            loadmemory(protocol,
+                                       rule_opt[k]->content);
                     } else if (strcasecmp(rule_opt[k]->element, xml_location) == 0) {
                             location = loadmemory(location, rule_opt[k]->content);
                     } else if (strcasecmp(rule_opt[k]->element, xml_field) == 0) {
@@ -709,6 +721,10 @@ int Rules_OP_ReadRules(const char *rulefile)
                                         rule_type = RULE_STATUS;
                                     } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_action) == 0) {
                                         rule_type = RULE_ACTION;
+                                    } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_protocol) == 0) {
+                                        rule_type = RULE_PROTOCOL;
+                                    } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_system_name) == 0) {
+                                        rule_type = RULE_SYSTEMNAME;
                                     } else {
                                         rule_type = RULE_DYNAMIC;
 
@@ -1351,6 +1367,28 @@ int Rules_OP_ReadRules(const char *rulefile)
                     if_matched_regex = NULL;
                 }
 
+                /* Add protocol */
+                if(protocol){
+                    os_calloc(1, sizeof(OSMatch), config_ruleinfo->protocol);
+                    if(!OSMatch_Compile(protocol, config_ruleinfo->protocol, 0)){
+                        merror(REGEX_COMPILE, protocol, config_ruleinfo->protocol->error);
+                        goto cleanup;
+                    }
+                    free(protocol);
+                    protocol = NULL;
+                }
+
+                /* Add system_name */
+                if(system_name){
+                    os_calloc(1, sizeof(OSMatch), config_ruleinfo->system_name);
+                    if(!OSMatch_Compile(system_name, config_ruleinfo->system_name, 0)){
+                        merror(REGEX_COMPILE, system_name, config_ruleinfo->system_name->error);
+                        goto cleanup;
+                    }
+                    free(system_name);
+                    system_name = NULL;
+                }
+
                 OS_ClearNode(rule_opt);
             } /* end of elements block */
 
@@ -1461,6 +1499,14 @@ cleanup:
     free(url);
     free(if_matched_group);
     free(if_matched_regex);
+    free(system_name);
+    free(protocol);
+
+
+
+
+
+
     free(rulepath);
     OS_ClearNode(rule);
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1530,12 +1530,6 @@ cleanup:
     free(system_name);
     free(protocol);
     free(data);
-
-
-
-
-
-
     free(rulepath);
     OS_ClearNode(rule);
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -735,6 +735,10 @@ int Rules_OP_ReadRules(const char *rulefile)
                                         rule_type = RULE_PROTOCOL;
                                     } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_system_name) == 0) {
                                         rule_type = RULE_SYSTEMNAME;
+                                    } else if (strcasecmp(rule_opt[k]->values[list_att_num], "data") == 0) {
+                                        rule_type = RULE_DATA;
+                                    } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_data) == 0) {
+                                        rule_type = RULE_EXTRA_DATA;
                                     } else {
                                         rule_type = RULE_DYNAMIC;
 
@@ -1523,6 +1527,7 @@ cleanup:
     free(if_matched_group);
     free(if_matched_regex);
     free(system_name);
+    free(protocol);
     free(data);
 
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -62,6 +62,8 @@
 #define RULE_STATUS     1024
 #define RULE_ACTION     2048
 #define RULE_DYNAMIC    4096
+#define RULE_PROTOCOL   8192
+#define RULE_SYSTEMNAME 16384
 
 #define RULEINFODETAIL_TEXT     0
 #define RULEINFODETAIL_LINK     1
@@ -153,6 +155,8 @@ typedef struct _RuleInfo {
     OSMatch *program_name;
     OSMatch *extra_data;
     OSMatch *location;
+    OSMatch *system_name;
+    OSMatch *protocol;
     FieldInfo **fields;
     char *action;
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -64,6 +64,8 @@
 #define RULE_DYNAMIC    4096
 #define RULE_PROTOCOL   8192
 #define RULE_SYSTEMNAME 16384
+#define RULE_DATA       32768
+#define RULE_EXTRA_DATA 65536
 
 #define RULEINFODETAIL_TEXT     0
 #define RULEINFODETAIL_LINK     1
@@ -153,6 +155,7 @@ typedef struct _RuleInfo {
     OSMatch *status;
     OSMatch *hostname;
     OSMatch *program_name;
+    OSMatch *data;
     OSMatch *extra_data;
     OSMatch *location;
     OSMatch *system_name;

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -536,6 +536,7 @@ void OS_ReadMSG(char *ut_str)
                     print_out("       Rule id: '%d'", currently_rule->sigid);
                     print_out("       Level: '%d'", currently_rule->level);
                     print_out("       Description: '%s'", lf->comment);
+                    print_out("       extra data: '%s'", lf->extra_data);
                     for (last_info_detail = currently_rule->info_details; last_info_detail != NULL; last_info_detail = last_info_detail->next) {
                         print_out("       Info - %s: '%s'", ruleinfodetail_text[last_info_detail->type], last_info_detail->data);
                     }

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -536,7 +536,6 @@ void OS_ReadMSG(char *ut_str)
                     print_out("       Rule id: '%d'", currently_rule->sigid);
                     print_out("       Level: '%d'", currently_rule->level);
                     print_out("       Description: '%s'", lf->comment);
-                    print_out("       extra data: '%s'", lf->extra_data);
                     for (last_info_detail = currently_rule->info_details; last_info_detail != NULL; last_info_detail = last_info_detail->next) {
                         print_out("       Info - %s: '%s'", ruleinfodetail_text[last_info_detail->type], last_info_detail->data);
                     }


### PR DESCRIPTION
|Related issue|
|---|
[3407](https://github.com/wazuh/wazuh/issues/3407)

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The fields `protocol`, `system_name`, `data` and `extra_data`  are not being recognized in the rules parsing.
Those fields are blocked to be used as dynamic fields, but they are not being read from the rules XML files.
To resolve this issue, we change the code to read these fields from the rules XML
<!--
Add a clear description of how the problem has been solved.
-->

## Logs/Alerts example
Before this PR, when we had a rule with the fields mentioned in the description, obtained this message
```
ERROR: Invalid option 'system_name' for rule '100050'.
```
As we can see, we do not recognize those fields. 

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- Custom tests
  - [x] Create a custom rule with these fields and check the correct reading of them
rule 
```
  <rule id="100003" level="3">
    <if_sid>18149</if_sid>
    <id>^538$|^551$|^4634$|^4647$</id>
    <system_name>host</system_name>
    <extra_data>Security</extra_data>
    <description>Windows User Logoff. system_name and extra_data</description>
    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
  </rule>
```
Once create the rule, check the reading of them with `ossec-logtest`
```
2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(538): Security: lac: host: host: User Logoff: User Name: lac Domain: host Logon ID: (0×0,0xF784D5) Logon Type: 2


**Phase 1: Completed pre-decoding.
       full event: '2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(538): Security: lac: host: host: User Logoff: User Name: lac Domain: host Logon ID: (0×0,0xF784D5) Logon Type: 2'
       timestamp: '2016 Oct 14 11:44:25'
       hostname: 'Carlos'
       program_name: 'WinEvtLog'
       log: 'Security: AUDIT_SUCCESS(538): Security: lac: host: host: User Logoff: User Name: lac Domain: host Logon ID: (0×0,0xF784D5) Logon Type: 2'

**Phase 2: Completed decoding.
       decoder: 'windows'
       type: 'Security'
       status: 'AUDIT_SUCCESS'
       id: '538'
       extra_data: 'Security'
       dstuser: 'lac'
       system_name: 'host'
       logon_type: '2'

**Phase 3: Completed filtering (rules).
       Rule id: '18149'
       Level: '3'
       Description: 'Windows User Logoff.'
**Alert to be generated.
```
We create another rule to test the field protocol:
```
<rule id="100006" level="3">
     <if_sid>81629</if_sid>
     <match>attack</match>
     <action>dropped</action>
     <protocol>NONE</protocol>
     <description>Fortigate Attack Dropped</description>
     <group>attack,gdpr_IV_35.7.d,</group>
  </rule>

**Phase 2: Completed decoding.
       decoder: 'fortigate-firewall-v5'
       status: 'critical'
       srcip: '10.10.10.61'
       dstip: '10.10.10.84'
       action: 'dropped'
       protocol: 'NONE'
       id: 'attack'
       extra_data: 'IP.Bad.Header'

**Phase 3: Completed filtering (rules).
       Rule id: '100006'
       Level: '3'
       Description: 'Fortigate Attack Dropped'
       extra data: 'IP.Bad.Header'
**Alert to be generated.
```
- Memory tests
  - [x] Valgrind report for affected components
```
==11569== For counts of detected and suppressed errors, rerun with: -v
==11569== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
==11646== 12 bytes in 2 blocks are definitely lost in loss record 4 of 33
==11646==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11646==    by 0x5B249B9: strdup (strdup.c:42)
==11646==    by 0x16D9CA: Read_Rules (rules-config.c:202)
==11646==    by 0x1638DA: read_main_elements (config.c:95)
==11646==    by 0x16459B: ReadConfig (config.c:245)
==11646==    by 0x11912B: GlobalConf (config.c:99)
==11646==    by 0x131AE8: main (analysisd.c:382)
==11646== 
==11646== 12 bytes in 2 blocks are definitely lost in loss record 5 of 33
==11646==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11646==    by 0x5B249B9: strdup (strdup.c:42)
==11646==    by 0x16DEC7: Read_Rules (rules-config.c:232)
==11646==    by 0x1638DA: read_main_elements (config.c:95)
==11646==    by 0x16459B: ReadConfig (config.c:245)
==11646==    by 0x11912B: GlobalConf (config.c:99)
==11646==    by 0x131AE8: main (analysisd.c:382)
==11646== 
==11646== 22 bytes in 1 blocks are definitely lost in loss record 11 of 33
==11646==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11646==    by 0x5B249B9: strdup (strdup.c:42)
==11646==    by 0x16D301: Read_Rules (rules-config.c:171)
==11646==    by 0x1638DA: read_main_elements (config.c:95)
==11646==    by 0x16459B: ReadConfig (config.c:245)
==11646==    by 0x11912B: GlobalConf (config.c:99)
==11646==    by 0x131AE8: main (analysisd.c:382)
==11646== 
==11646== 24 bytes in 2 blocks are definitely lost in loss record 16 of 33
==11646==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11646==    by 0x5B249B9: strdup (strdup.c:42)
==11646==    by 0x16DBE5: Read_Rules (rules-config.c:216)
==11646==    by 0x1638DA: read_main_elements (config.c:95)
==11646==    by 0x16459B: ReadConfig (config.c:245)
==11646==    by 0x11912B: GlobalConf (config.c:99)
==11646==    by 0x131AE8: main (analysisd.c:382)
==11646== 
==11646== 30 bytes in 2 blocks are definitely lost in loss record 17 of 33
==11646==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11646==    by 0x5B249B9: strdup (strdup.c:42)
==11646==    by 0x16D6E8: Read_Rules (rules-config.c:186)
==11646==    by 0x1638DA: read_main_elements (config.c:95)
==11646==    by 0x16459B: ReadConfig (config.c:245)
==11646==    by 0x11912B: GlobalConf (config.c:99)
==11646==    by 0x131AE8: main (analysisd.c:382)
==11646== 
==11646== LEAK SUMMARY:
==11646==    definitely lost: 100 bytes in 9 blocks
==11646==    indirectly lost: 0 bytes in 0 blocks
==11646==      possibly lost: 0 bytes in 0 blocks
==11646==    still reachable: 12,299 bytes in 295 blocks
==11646==         suppressed: 0 bytes in 0 blocks
==11646== Reachable blocks (those to which a pointer was found) are not shown.
==11646== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==11646== 
==11646== For counts of detected and suppressed errors, rerun with: -v
==11646== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
```
 - [x] No errors found with scan-build.
 - [x] No erros found with address-sanitizer.