### PR TITLE
Remove forced whodata mode reporting in Windows

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -455,6 +455,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             else if (strcmp(*attrs, xml_whodata) == 0) {
                 if (strcmp(*values, "yes") == 0) {
                     opts |= CHECK_WHODATA;
+                    opts &= ~ CHECK_REALTIME;
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_WHODATA;
                 } else {
@@ -554,7 +555,9 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             /* Check real time */
             else if (strcmp(*attrs, xml_real_time) == 0) {
                 if (strcmp(*values, "yes") == 0) {
-                    opts |= CHECK_REALTIME;
+                    if(!(opts & CHECK_WHODATA)) {
+                        opts |= CHECK_REALTIME;
+                    }
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_REALTIME;
                 } else {

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -140,7 +140,6 @@ typedef struct whodata_directory {
 
 typedef struct whodata {
     OSHash *fd;                         // Open file descriptors
-    OSHash *ignored_paths;              // Files or directories marked as ignored
     OSHash *directories;                // Directories checked by whodata mode
     int interval_scan;                  // Time interval between scans of the checking thread
     int whodata_setup;                  // Worth 1 when there is some directory configured with whodata

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -79,7 +79,7 @@
 #define FIM_CANNOT_ACCESS_FILE              "(6210): Cannot access '%s': it was removed during scan."
 #define FIM_SCANNING_FILE                   "(6211): File '%s'"
 #define FIM_SIMBOLIC_LINK_DISABLE           "(6212): Follow symbolic links disabled."
-#define FIM_CHECK_LINK_REALPATH             "(6213): Error checking realpath() of link '%s'"
+#define FIM_CHECK_LINK_REALPATH             "(6213): Cannot get the real path of the link '%s'"
 #define FIM_HASH_ADD_FAIL                   "(6214): Not enough memory to add inode to db: '%s' (%s) "
 #define FIM_HASH_UPDATE                     "(6215): Updating path '%s' in inode hash table: '%s' (%s) "
 #define FIM_SCANNING_IRREGFILE              "(6216): IRREG File: '%s'"

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -858,7 +858,7 @@ int run_dbcheck()
 
         for (curr_node = OSHash_Begin(last_backup, i); curr_node && curr_node->data; curr_node = OSHash_Next(last_backup, i, curr_node)) {
             char *esc_linked_file = NULL;
-            if (pos = find_dir_pos(curr_node->key, 1, 0, 0), pos >= 0) {
+            if (pos = find_dir_pos(curr_node->key, 1, 0), pos >= 0) {
                 *linked_file = '\0';
                 if (syscheck.converted_links[pos]) {
                     replace_linked_path(curr_node->key, pos, linked_file);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -201,6 +201,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
     os_calloc(OS_SIZE_6144 + 1, sizeof(char), wd_sum);
 
     if (pos = find_dir_pos (file_name, 1, 0), pos != dir_position) {
+        os_free(wd_sum);
         return (0);
     }
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -576,7 +576,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
             buf = s_node->checksum;
 
             /* If it returns < 0, we have already alerted */
-            if (c_read_file(file_name, linked_file, buf, c_sum, dir_position, NULL) < 0) {
+            if (c_read_file(file_name, linked_file, buf, c_sum, dir_position, evt) < 0) {
                 goto end;
             }
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -649,7 +649,6 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
     short is_nfs;
     DIR *dp;
     struct dirent *entry;
-    int opts;
     size_t dir_size;
     char linked_read_file[PATH_MAX + 1] = {'\0'};
 
@@ -688,7 +687,6 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
 #endif
 
     os_calloc(PATH_MAX + 2, sizeof(char), f_name);
-    opts = syscheck.opts[dir_position];
 
     /* Directory should be valid */
     if (dir_size = strlen(dir_name), dir_size > PATH_MAX) {
@@ -754,6 +752,12 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
         free(f_name);
         return (-1);
     }
+
+    if (dir_position = find_dir_pos (dir_name, 1, 0), dir_position < 0) {
+        return (0);
+    }
+
+    int opts = syscheck.opts[dir_position];
 
     /* Check for real time flag */
     if (opts & CHECK_REALTIME || opts & CHECK_WHODATA) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -294,7 +294,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
     if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))
 #endif
     {
-        mdebug1(FIM_SCANNING_FILE, file_name);
+        mdebug2(FIM_SCANNING_FILE, file_name);
         os_md5 mf_sum = {'\0'};
         os_sha1 sf_sum = {'\0'};
         os_sha256 sf256_sum = {'\0'};
@@ -1038,7 +1038,7 @@ int fim_check_ignore (const char *file_name) {
         int i = 0;
         while (syscheck.ignore[i] != NULL) {
             if (strncasecmp(syscheck.ignore[i], file_name, strlen(syscheck.ignore[i])) == 0) {
-                mdebug1(FIM_IGNORE_ENTRY, "file", file_name, syscheck.ignore[i]);
+                mdebug2(FIM_IGNORE_ENTRY, "file", file_name, syscheck.ignore[i]);
                 return (1);
             }
             i++;
@@ -1050,7 +1050,7 @@ int fim_check_ignore (const char *file_name) {
         int i = 0;
         while (syscheck.ignore_regex[i] != NULL) {
             if (OSMatch_Execute(file_name, strlen(file_name), syscheck.ignore_regex[i])) {
-                mdebug1(FIM_IGNORE_SREGEX, "file", file_name, syscheck.ignore_regex[i]->raw);
+                mdebug2(FIM_IGNORE_SREGEX, "file", file_name, syscheck.ignore_regex[i]->raw);
                 return (1);
             }
             i++;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -188,7 +188,6 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
     char *alert_msg = NULL;
     char *esc_linked_file = NULL;
     char *c_sum = NULL;
-    int pos;
 #ifdef WIN32
     char *sid = NULL;
     char *user = NULL;
@@ -199,11 +198,6 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
 #endif
 
     os_calloc(OS_SIZE_6144 + 1, sizeof(char), wd_sum);
-
-    if (pos = find_dir_pos (file_name, 1, 0), pos != dir_position) {
-        os_free(wd_sum);
-        return (0);
-    }
 
     opts = syscheck.opts[dir_position];
     restriction = syscheck.filerestrict[dir_position];
@@ -582,7 +576,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
             buf = s_node->checksum;
 
             /* If it returns < 0, we have already alerted */
-            if (c_read_file(file_name, linked_file, buf, c_sum, NULL) < 0) {
+            if (c_read_file(file_name, linked_file, buf, c_sum, dir_position, NULL) < 0) {
                 goto end;
             }
 
@@ -658,7 +652,6 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
     int opts;
     size_t dir_size;
     char linked_read_file[PATH_MAX + 1] = {'\0'};
-    int pos;
 
     if (!dir_name) {
         merror(NULL_ERROR);
@@ -668,10 +661,6 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
     if(max_depth < 0) {
         mdebug1(FIM_MAX_RECURSION_LEVEL, dir_name);
         return 0;
-    }
-
-    if (pos = find_dir_pos (dir_name, 1, 0), pos != dir_position) {
-        return (0);
     }
 
 #ifdef WIN32

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -188,7 +188,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
     char *alert_msg = NULL;
     char *esc_linked_file = NULL;
     char *c_sum = NULL;
-    os_calloc(OS_SIZE_6144 + 1, sizeof(char), wd_sum);
+    int pos;
 #ifdef WIN32
     char *sid = NULL;
     char *user = NULL;
@@ -198,6 +198,11 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
     char *hash_file_name;
 #endif
 
+    os_calloc(OS_SIZE_6144 + 1, sizeof(char), wd_sum);
+
+    if (pos = find_dir_pos (file_name, 1, 0), pos != dir_position) {
+        return (0);
+    }
 
     opts = syscheck.opts[dir_position];
     restriction = syscheck.filerestrict[dir_position];
@@ -652,6 +657,7 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
     int opts;
     size_t dir_size;
     char linked_read_file[PATH_MAX + 1] = {'\0'};
+    int pos;
 
     if (!dir_name) {
         merror(NULL_ERROR);
@@ -661,6 +667,10 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
     if(max_depth < 0) {
         mdebug1(FIM_MAX_RECURSION_LEVEL, dir_name);
         return 0;
+    }
+
+    if (pos = find_dir_pos (dir_name, 1, 0), pos != dir_position) {
+        return (0);
     }
 
 #ifdef WIN32

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -754,7 +754,7 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
         return (-1);
     }
 
-    if (pos = find_dir_pos (dir_name, 1, 0), dir_position != pos) {
+    if (pos = find_dir_pos (dir_name, 1, 1, 0), dir_position != pos) {
         return (0);
     }
 
@@ -863,7 +863,7 @@ int run_dbcheck()
 
         for (curr_node = OSHash_Begin(last_backup, i); curr_node && curr_node->data; curr_node = OSHash_Next(last_backup, i, curr_node)) {
             char *esc_linked_file = NULL;
-            if (pos = find_dir_pos(curr_node->key, 1, 0), pos >= 0) {
+            if (pos = find_dir_pos(curr_node->key, 1, 0, 0), pos >= 0) {
                 *linked_file = '\0';
                 if (syscheck.converted_links[pos]) {
                     replace_linked_path(curr_node->key, pos, linked_file);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -650,6 +650,7 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
     DIR *dp;
     struct dirent *entry;
     size_t dir_size;
+    int pos;
     char linked_read_file[PATH_MAX + 1] = {'\0'};
 
     if (!dir_name) {
@@ -753,11 +754,11 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
         return (-1);
     }
 
-    if (dir_position = find_dir_pos (dir_name, 1, 0), dir_position < 0) {
+    if (pos = find_dir_pos (dir_name, 1, 0), dir_position != pos) {
         return (0);
     }
 
-    int opts = syscheck.opts[dir_position];
+    int opts = syscheck.opts[pos];
 
     /* Check for real time flag */
     if (opts & CHECK_REALTIME || opts & CHECK_WHODATA) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -372,7 +372,7 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
         // If this flag is enable, the remove event will be notified at another point
         if (evt && evt->ignore_remove_event) {
             mdebug2(FIM_WHODATA_FILENOEXIST, file_name);
-            return 0;
+            return -1;
         }
 #endif
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -688,7 +688,7 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
 
 static void update_link_monitoring(int pos, char *old_path, char *new_path) {
     w_rwlock_wrlock((pthread_rwlock_t *)&syscheck.fp->mutex);
-    free( syscheck.converted_links[pos]);
+    free(syscheck.converted_links[pos]);
     os_strdup(new_path, syscheck.converted_links[pos]);
     w_rwlock_unlock((pthread_rwlock_t *)&syscheck.fp->mutex);
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -385,7 +385,7 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
         }
 
         /* Find tag position for the evaluated file name */
-        if (pos = find_dir_pos(file_name, 1, 0, 0), pos >= 0) {
+        if (pos = find_dir_pos(file_name, 1, 0), pos >= 0) {
             //Alert for deleted file
             snprintf(alert_msg, sizeof(alert_msg), "-1!%s:%s:%s: %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", linked_file ? linked_file : "", file_name);
             send_syscheck_msg(alert_msg);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -334,7 +334,7 @@ void start_daemon()
 }
 
 /* Read file information and return a pointer to the checksum */
-int c_read_file(const char *file_name, const char *linked_file, const char *oldsum, char *newsum, whodata_evt * evt)
+int c_read_file(const char *file_name, const char *linked_file, const char *oldsum, char *newsum, int dir_position, whodata_evt *evt)
 {
     int size = 0, perm = 0, owner = 0, group = 0, md5sum = 0, sha1sum = 0, sha256sum = 0, mtime = 0, inode = 0;
     struct stat statbuf;
@@ -367,7 +367,6 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
     {
         char alert_msg[OS_SIZE_6144 + OS_SIZE_2048];
         char wd_sum[OS_SIZE_6144 + 1];
-        int pos;
 
 #ifdef WIN_WHODATA
         // If this flag is enable, the remove event will be notified at another point
@@ -384,12 +383,9 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
             merror(FIM_ERROR_WHODATA_SUM_MAX, file_name);
         }
 
-        /* Find tag position for the evaluated file name */
-        if (pos = find_dir_pos(file_name, 1, 0), pos >= 0) {
-            //Alert for deleted file
-            snprintf(alert_msg, sizeof(alert_msg), "-1!%s:%s:%s: %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", linked_file ? linked_file : "", file_name);
-            send_syscheck_msg(alert_msg);
-        }
+        //Alert for deleted file
+        snprintf(alert_msg, sizeof(alert_msg), "-1!%s:%s:%s: %s", wd_sum, syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", linked_file ? linked_file : "", file_name);
+        send_syscheck_msg(alert_msg);
 
 #ifndef WIN32
         if(evt && evt->inode) {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -62,7 +62,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
         pos = evt->dir_position;
     } else {
 #endif
-        pos = find_dir_pos(path, 1, 0, 0);
+        pos = find_dir_pos(path, 1, 0);
 #ifdef WIN_WHODATA
     }
 #endif
@@ -169,12 +169,11 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
 }
 
 /* Find container directory */
-int find_dir_pos(const char *filename, int full_compare, int check_find, int deep_search) {
+int find_dir_pos(const char *filename, int full_compare, int check_find) {
     char buf[PATH_MAX + 1];
     int i;
     char *c;
     int retval = -1;
-    int path_length = PATH_MAX;
     char path_end = 0;
 
     if (full_compare) {
@@ -201,23 +200,14 @@ int find_dir_pos(const char *filename, int full_compare, int check_find, int dee
                 continue;
             }
             if (!strcmp(dir, buf)) {
-                // If deep_search is activated we will continue searching for parent directories
-                if (deep_search) {
-                    int buf_len = strlen(buf);
-                    if (buf_len < path_length) {
-                        path_length = buf_len;
-                        retval = i;
-                    }
-                } else {
-                    retval = i;
-                }
+                retval = i;
                 free(cdir);
                 break;
             }
             free(cdir);
         }
 
-        if (!deep_search && syscheck.dir[i]) {
+        if (retval != -1) {
             // The directory has been found
             break;
         }

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -77,7 +77,7 @@ void init_whodata_event(whodata_evt *w_evt);
 void free_whodata_event(whodata_evt *w_evt);
 
 /* Get checksum changes */
-int c_read_file(const char *file_name, const char *linked_file, const char *oldsum, char *newsum, whodata_evt * evt) __attribute__((nonnull(1,3,4)));
+int c_read_file(const char *file_name, const char *linked_file, const char *oldsum, char *newsum, int dir_position, whodata_evt *evt) __attribute__((nonnull(1,3,4)));
 
 int send_syscheck_msg(const char *msg) __attribute__((nonnull));
 int send_rootcheck_msg(const char *msg) __attribute__((nonnull));

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -86,7 +86,7 @@ int send_rootcheck_msg(const char *msg) __attribute__((nonnull));
 int realtime_checksumfile(const char *file_name, whodata_evt *evt) __attribute__((nonnull(1)));
 
 /* Find container directory */
-int find_dir_pos(const char *filename, int full_compare, int check_find, int deep_search) __attribute__((nonnull(1)));
+int find_dir_pos(const char *filename, int full_compare, int check_find) __attribute__((nonnull(1)));
 
 /* Return the version with symbolic link */
 void replace_linked_path(const char *file_name, int dir_position, char *linked_file);

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -86,7 +86,7 @@ int send_rootcheck_msg(const char *msg) __attribute__((nonnull));
 int realtime_checksumfile(const char *file_name, whodata_evt *evt) __attribute__((nonnull(1)));
 
 /* Find container directory */
-int find_dir_pos(const char *filename, int full_compare, int check_find) __attribute__((nonnull(1)));
+int find_dir_pos(const char *filename, char full_compare, char check_recursion, int check_find) __attribute__((nonnull(1)));
 
 /* Return the version with symbolic link */
 void replace_linked_path(const char *file_name, int dir_position, char *linked_file);

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -330,7 +330,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch, const char *
     if (fullkey_name && syscheck.registry_ignore) {
         while (syscheck.registry_ignore[i].entry != NULL) {
             if (syscheck.registry_ignore[i].arch == arch && strcasecmp(syscheck.registry_ignore[i].entry, fullkey_name) == 0) {
-                mdebug1(FIM_IGNORE_ENTRY, "registry", fullkey_name, syscheck.registry_ignore[i].entry);
+                mdebug2(FIM_IGNORE_ENTRY, "registry", fullkey_name, syscheck.registry_ignore[i].entry);
                 return;
             }
             i++;
@@ -341,7 +341,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int arch, const char *
             if (syscheck.registry_ignore_regex[i].arch == arch &&
                 OSMatch_Execute(fullkey_name, strlen(fullkey_name),
                                 syscheck.registry_ignore_regex[i].regex)) {
-                mdebug1(FIM_IGNORE_SREGEX, "registry", fullkey_name, syscheck.registry_ignore_regex[i].regex->raw);
+                mdebug2(FIM_IGNORE_SREGEX, "registry", fullkey_name, syscheck.registry_ignore_regex[i].regex->raw);
                 return;
             }
             i++;
@@ -391,7 +391,7 @@ void os_winreg_check()
         }
 
         /* Read syscheck registry entry */
-        mdebug1(FIM_READING_REGISTRY, syscheck.registry[i].arch == ARCH_64BIT ? "[x64] " : "", syscheck.registry[i].entry);
+        mdebug2(FIM_READING_REGISTRY, syscheck.registry[i].arch == ARCH_64BIT ? "[x64] " : "", syscheck.registry[i].entry);
 
         rk = os_winreg_sethkey(syscheck.registry[i].entry);
         if (sub_tree == NULL) {

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -822,7 +822,7 @@ add_whodata_evt:
                             int pos;
                             if (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA), pos >= 0) {
                                 int diff = fim_find_child_depth(syscheck.dir[pos], w_evt->path);
-                                int depth = syscheck.recursion_level[pos] - diff;
+                                int depth = syscheck.recursion_level[pos] - diff + 1;
                                 read_dir(w_evt->path, NULL, pos, w_evt, depth, 0, '-');
                             }
 

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -597,7 +597,6 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 if (s_node = OSHash_Get_ex(syscheck.fp, path), !s_node) {
                     int device_type;
                     if (strchr(path, ':')) {
-
                         if (position = find_dir_pos(path, 1, CHECK_WHODATA), position < 0) {
                             // Discard the file or directory if its monitoring has not been activated
                             mdebug2(FIM_WHODATA_NOT_ACTIVE, path);
@@ -632,7 +631,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                         merror(FIM_ERROR_WHODATA_NOTFIND_DIRPOS, path);
                         goto clean;
                     }
-
+                    position = s_node->dir_position;
                     // Check if the file belongs to a directory that has been transformed to real-time
                     if (!(syscheck.wdata.dirs_status[s_node->dir_position].status & WD_CHECK_WHODATA)) {
                         mdebug2(FIM_WHODATA_CANCELED, path);
@@ -1109,12 +1108,11 @@ void send_whodata_del(whodata_evt *w_evt, char remove_hash) {
     }
 
     /* Find tag if defined for this file */
-    if (pos < 0) {
-        pos = find_dir_pos(w_evt->path, 1, 0);
+    if (pos >= 0 || (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA)) >= 0) {
+        snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s:%s:: %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", w_evt->path);
+        send_syscheck_msg(del_msg);
     }
 
-    snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s:%s:: %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", w_evt->path);
-    send_syscheck_msg(del_msg);
     whodata_rlist_add(w_evt->path);
 }
 

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -597,7 +597,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 if (s_node = OSHash_Get_ex(syscheck.fp, path), !s_node) {
                     int device_type;
                     if (strchr(path, ':')) {
-                        if (position = find_dir_pos(path, 1, CHECK_WHODATA), position < 0) {
+                        if (position = find_dir_pos(path, 1, 1, CHECK_WHODATA), position < 0) {
                             // Discard the file or directory if its monitoring has not been activated
                             mdebug2(FIM_WHODATA_NOT_ACTIVE, path);
                             break;
@@ -718,7 +718,7 @@ add_whodata_evt:
                                     mdebug2(FIM_WHODATA_DIRECTORY_SCANNED, path);
                                 } else {
                                     // Check if is a valid directory
-                                    if (position = find_dir_pos(path, 1, CHECK_WHODATA), position < 0) {
+                                    if (position = find_dir_pos(path, 1, 1, CHECK_WHODATA), position < 0) {
                                         mdebug2(FIM_WHODATA_DIRECTORY_DISCARDED, path);
                                         w_evt->scan_directory = 2;
                                         break;
@@ -803,6 +803,7 @@ add_whodata_evt:
                                     w_evt->path = saved_path;
 
                                     // Find new files
+                                    mdebug2(FIM_WHODATA_SCAN, w_evt->path);
                                     read_dir(syscheck.dir[w_evt->dir_position], NULL, w_evt->dir_position, w_evt, syscheck.recursion_level[w_evt->dir_position], 0, '-');
 
                                     last_mdir_tm = now;
@@ -818,7 +819,7 @@ add_whodata_evt:
                             // Check that a new file has been added
                             GetSystemTime(&w_dir->timestamp);
                             int pos;
-                            if (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA), pos >= 0) {
+                            if (pos = find_dir_pos(w_evt->path, 1, 1, CHECK_WHODATA), pos >= 0) {
                                 int diff = fim_find_child_depth(syscheck.dir[pos], w_evt->path);
                                 int depth = syscheck.recursion_level[pos] - diff + 1;
                                 mdebug2(FIM_WHODATA_SCAN, w_evt->path);
@@ -1101,7 +1102,7 @@ void send_whodata_del(whodata_evt *w_evt, char remove_hash) {
     }
 
     /* Find tag if defined for this file */
-    if (pos >= 0 || (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA)) >= 0) {
+    if (pos >= 0 || (pos = find_dir_pos(w_evt->path, 1, 1, CHECK_WHODATA)) >= 0) {
         snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s:%s:: %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", w_evt->path);
         send_syscheck_msg(del_msg);
     }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -632,7 +632,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                     }
                     position = s_node->dir_position;
                     // Check if the file belongs to a directory that has been transformed to real-time
-                    if (!(syscheck.wdata.dirs_status[s_node->dir_position].status & WD_CHECK_WHODATA)) {
+                    if (!(syscheck.wdata.dirs_status[position].status & WD_CHECK_WHODATA)) {
                         mdebug2(FIM_WHODATA_CANCELED, path);
                         goto clean;
                     }
@@ -821,10 +821,9 @@ add_whodata_evt:
                             if (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA), pos >= 0) {
                                 int diff = fim_find_child_depth(syscheck.dir[pos], w_evt->path);
                                 int depth = syscheck.recursion_level[pos] - diff + 1;
+                                mdebug2(FIM_WHODATA_SCAN, w_evt->path);
                                 read_dir(w_evt->path, NULL, pos, w_evt, depth, 0, '-');
                             }
-
-                            mdebug1(FIM_WHODATA_SCAN, w_evt->path);
                         } else {
                             mdebug2(FIM_WHODATA_NO_NEW_FILES, w_evt->path, w_evt->mask);
                         }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -597,7 +597,8 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 if (s_node = OSHash_Get_ex(syscheck.fp, path), !s_node) {
                     int device_type;
                     if (strchr(path, ':')) {
-                        if (position = find_dir_pos(path, 1, CHECK_WHODATA, 1), position < 0) {
+
+                        if (position = find_dir_pos(path, 1, CHECK_WHODATA), position < 0) {
                             // Discard the file or directory if its monitoring has not been activated
                             mdebug2(FIM_WHODATA_NOT_ACTIVE, path);
                             whodata_hash_add(syscheck.wdata.ignored_paths, path, &fields_number, "ignored");
@@ -720,7 +721,7 @@ add_whodata_evt:
                                     mdebug2(FIM_WHODATA_DIRECTORY_SCANNED, path);
                                 } else {
                                     // Check if is a valid directory
-                                    if (position = find_dir_pos(path, 1, CHECK_WHODATA, 1), position < 0) {
+                                    if (position = find_dir_pos(path, 1, CHECK_WHODATA), position < 0) {
                                         mdebug2(FIM_WHODATA_DIRECTORY_DISCARDED, path);
                                         w_evt->scan_directory = 2;
                                         break;
@@ -820,7 +821,7 @@ add_whodata_evt:
                             // Check that a new file has been added
                             GetSystemTime(&w_dir->timestamp);
                             int pos;
-                            if (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA, 1), pos >= 0) {
+                            if (pos = find_dir_pos(w_evt->path, 1, CHECK_WHODATA), pos >= 0) {
                                 int diff = fim_find_child_depth(syscheck.dir[pos], w_evt->path);
                                 int depth = syscheck.recursion_level[pos] - diff;
                                 read_dir(w_evt->path, NULL, pos, w_evt, depth, 0, '-');
@@ -1109,7 +1110,7 @@ void send_whodata_del(whodata_evt *w_evt, char remove_hash) {
 
     /* Find tag if defined for this file */
     if (pos < 0) {
-        pos = find_dir_pos(w_evt->path, 1, 0, 0);
+        pos = find_dir_pos(w_evt->path, 1, 0);
     }
 
     snprintf(del_msg, PATH_MAX + OS_SIZE_6144 + 6, "-1!%s:%s:: %s", wd_sum, syscheck.tag[pos] ? syscheck.tag[pos] : "", w_evt->path);

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -600,7 +600,6 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                         if (position = find_dir_pos(path, 1, CHECK_WHODATA), position < 0) {
                             // Discard the file or directory if its monitoring has not been activated
                             mdebug2(FIM_WHODATA_NOT_ACTIVE, path);
-                            whodata_hash_add(syscheck.wdata.ignored_paths, path, &fields_number, "ignored");
                             break;
                         } else {
                             // The file or directory is new and has to be notified
@@ -635,7 +634,6 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                     // Check if the file belongs to a directory that has been transformed to real-time
                     if (!(syscheck.wdata.dirs_status[s_node->dir_position].status & WD_CHECK_WHODATA)) {
                         mdebug2(FIM_WHODATA_CANCELED, path);
-                        whodata_hash_add(syscheck.wdata.ignored_paths, path, &fields_number, "ignored");
                         goto clean;
                     }
                     // If the file or directory is already in the hash table, it is not necessary to set its position
@@ -859,10 +857,6 @@ clean:
 }
 
 int whodata_audit_start() {
-    // Set the hash table of ignored paths
-    if (syscheck.wdata.ignored_paths = OSHash_Create(), !syscheck.wdata.ignored_paths) {
-        return 1;
-    }
     // Set the hash table of directories
     if (syscheck.wdata.directories = OSHash_Create(), !syscheck.wdata.directories) {
         return 1;
@@ -1553,12 +1547,6 @@ int whodata_path_filter(char **path) {
 
     if (sys_64) {
         whodata_adapt_path(path);
-    }
-
-    if (OSHash_Get_ex(syscheck.wdata.ignored_paths, *path)) {
-        // The file has been marked as ignored
-        mdebug2(FIM_WHODATA_IGNORE, *path);
-        return 1;
     }
 
     return 0;


### PR DESCRIPTION
This PR solves the issue described in #3599 and #3582 for whodata in Windows. 

By design, and whenever possible, all FIM events reported by Syscheck will have whodata information. This is achieved by checking for each processed patch if it has whodata information.

The problem appears when a path, whose closest parent does not have whodata, has a more distant parent with whodata enabled.

This path can be reported with whodata information because it has inherited the audit policies, but the results with certain configurations may not working as expected.

As explained in the issue, the problem is the deep search, so this PR removes it so that each path is processed with the attributes of its nearest directory, regardless of whether it has inherited audit policies and has extra information.

## Possible invalid behaviours

The issue can be replied with only two monitored directories, being one of them parent to the other and being monitored in whodata mode.

In the following example, the events from the subfolders will be reported in realtime with audit information. This is not the expected behaviour because the subfolder has to be scanned every `frequency` period.

``` XML
<directories check_all="yes" whodata="yes">C:\test_folder</directories>
<directories check_all="yes">C:\test_folder\subfolder</directories>
```

The following example will work as expected because the realtime mode is faster than the whodata mode, so the files reported in the subfolder will not have audit information. In spite of that, it is an invisible race condition.

``` XML
<directories check_all="yes" whodata="yes">C:\test_folder</directories>
<directories check_all="yes" realtime="yes">C:\test_folder\subfolder</directories>
```

If both directories are monitored with whodata, may seem to report correctly, but they do not. If we apply a specific configuration for the subfolder, we will never see it. In this example, subfolder events should include `tag1` in the alert, but include `tag0` by the less restrictive parent with whodata enabled.

``` XML
<directories check_all="yes" whodata="yes" tags="tag0">C:\test_folder</directories>
<directories check_all="yes" whodata="yes" tags="tag1">C:\test_folder\subfolder</directories>
```

## Tags only work in added events

If the monitored folder (in whodata mode) is not the first configured directory, its reports will only display the correct tags in added events, regardless of the directories scope. For example:

``` XML
<directories check_all="yes" tags="tag0">C:\another\test\folder</directories>
<directories check_all="yes" whodata="yes" tags="tag1">C:\test_folder\subfolder</directories>
```

If a modification event is generated on `C:\test_folder\subfolder\file.txt` with the previous configuration, it will have the attributes of whodata but will include the tag `tag0`, which belongs to a directory without whodata and without parent relation, because the position of the directory is not being properly controlled in these operations. The PR also solves this issue.

A good way to check that this PR fixes the issue is to move a file from the child directory to the parent directory. An alert should appear for each directory with their respective tags. For example:

``` XML
<directories check_all="yes" whodata="yes" tags="tag0">C:\test_folder</directories>
<directories check_all="yes" whodata="yes" tags="tag1">C:\test_folder\subfolder</directories>
```


> ** Alert 1562062628.342679: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
> 2019 Jul 02 10:17:08 (agwin2016) any->syscheck
> Rule: 554 (level 5) -> 'File added to the system.'
> File 'c:\test_folder\file.txt' was added.
> 
> Attributes:
>  - Size: 22
>  - Date: Tue Jul  2 10:00:26 2019
>  - User: Administrators (S-1-5-32-544)
>  - MD5: 76cdb2bad9582d23c1f6f4d868218d6c
>  - SHA1: b04f3ee8f5e43fa3b162981b50bb72fe1acabb33
>  - SHA256: 8739c76e681f900923b900c9df0ef75cf421d39cabb54650c4b9ad19b6a76d85
>  - File attributes: ARCHIVE
>  - Permissions: 
>    SYSTEM  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
>    Administrators  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
>    Administrator  (ALLOWED) - DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, SYNCHRONIZE, FILE_READ_DATA, FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_READ_EA, FILE_WRITE_EA, FILE_EXECUTE, FILE_READ_ATTRIBUTES, FILE_WRITE_ATTRIBUTES
> 
> Tags:
>  - tag0

> 
> ** Alert 1562062628.344165: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,
> 2019 Jul 02 10:17:08 (agwin2016) any->syscheck
> Rule: 553 (level 7) -> 'File deleted.'
> File 'c:\test_folder\subfolder\file.txt' was deleted.
> (Audit) User: 'Administrator (S-1-5-21-3292556202-24657078-706277677-500)'
> (Audit) Process id: '4084'
> (Audit) Process name: 'C:\Windows\explorer.exe'
> 
> 
> Tags:
>  - tag1


- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
