### PR TITLE
Makefile help typo

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -474,7 +474,7 @@ help: failtarget
 	@echo "   make USE_ZEROMQ=yes          Build with zeromq support. Allowed values are auto, 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make USE_PRELUDE=yes         Build with prelude support. Allowed values are auto, 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make USE_INOTIFY=yes         Build with inotify support. Allowed values are auto, 1, yes, YES, y and Y, otherwise, the flag is ignored"
-	@echo "   make BIG_ENDIAN=yes          Build with big endian support. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
+	@echo "   make USE_BIG_ENDIAN=yes      Build with big endian support. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make USE_SELINUX=yes         Build with SELinux policies. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make USE_AUDIT=yes           Build with audit service support. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make USE_FRAMEWORK_LIB=yes   Use external SQLite library for the framework. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3603|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

This PR fixes a minor error in `"help"` Makefile option.


## Tests

Partial `make help` output:
```
   make USE_ZEROMQ=0            Build with zeromq support
   make USE_PRELUDE=0           Build with prelude support
   make USE_INOTIFY=0           Build with inotify support
   make BIG_ENDIAN=0            Build with big endian support
   make USE_SELINUX=0           Build with SELinux policies
   make USE_AUDIT=1             Build with audit service support
```



Partial `make help` output after fix:
```
   make USE_ZEROMQ=0            Build with zeromq support
   make USE_PRELUDE=0           Build with prelude support
   make USE_INOTIFY=0           Build with inotify support
   make USE_BIG_ENDIAN=yes      Build with big endian support
   make USE_SELINUX=0           Build with SELinux policies
   make USE_AUDIT=1             Build with audit service support
```
