### PR TITLE
Prevent list-based rule from matching if the list is missing

### DIFF
--- a/src/analysisd/lists_list.c
+++ b/src/analysisd/lists_list.c
@@ -163,7 +163,7 @@ static int OS_DBSearchKeyValue(ListRule *lrule, char *key)
             if (!val){
                 return 0;
             }
-          
+
             w_mutex_lock(&lrule->db->cdb.mutex)
             cdb_read(&lrule->db->cdb, val, vlen, vpos);
             w_mutex_unlock(&lrule->db->cdb.mutex);
@@ -310,7 +310,7 @@ int OS_DBSearch(ListRule *lrule, char *key)
             }
             return 0;
         case LR_ADDRESS_MATCH:
-            return OS_DBSeachKeyAddress(lrule, key);
+            return OS_DBSeachKeyAddress(lrule, key) == 1;
         case LR_ADDRESS_NOT_MATCH:
             if (OS_DBSeachKeyAddress(lrule, key) == 0) {
                 return 1;


### PR DESCRIPTION
|Related issue|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|---|
|#3531| OSSEC v2.7 | Analysisd | Manager | Any | UNIX |

This PR aims to fix a bug that lets Analysisd match a rule with the option `<list lookup="address_match_key" />` if such list is missing.

## Rationale

CDB list handling function `OS_DBSeachKeyAddress()` is expected to return:

- `-1` on error, like missing CDB list file.
- `0` if the key does not match.
- `1` if the key matches.

However, this condition ([lists_list.c:313](https://github.com/wazuh/wazuh/blob/v3.9.2/src/analysisd/lists_list.c#L313)) returns `true` either `OS_DBSeachKeyAddress()` returns `-1` or `1`. That makes Analysisd wrongly match a rule.

## Example

### etc/rules/local_rules.xml
```xml
<rule id="100100" level="10">
  <if_group>web|attack|attacks</if_group>
  <list field="srcip" lookup="address_match_key">etc/lists/test</list>
  <description>IP address found in reputation database.</description>
</rule>
```

### etc/lists/test
```
192.168.2.100:
```

**Do not compile CDB lists**

### Log sample

```
192.168.2.200 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { _; } >_[$($())] { /usr/bin/perl ... }"
```

This log should not match rule 100100 since `192.168.2.200` is not in the CDB list.

### Result

#### Affected version

```
2019/07/02 17:52:21 ossec-testrule: ERROR: (1126): Unable to open file 'etc/lists/test.cdb' due to [(2)-(No such file or directory)].

**Phase 3: Completed filtering (rules).
       Rule id: '100100'
       Level: '10'
       Description: 'IP address found in reputation database.'
**Alert to be generated.
```

#### Fixed version

```
2019/07/02 17:54:50 ossec-testrule: ERROR: (1126): Unable to open file 'etc/lists/test.cdb' due to [(2)-(No such file or directory)].

**Phase 3: Completed filtering (rules).
       Rule id: '31167'
       Level: '15'
       Description: 'Shellshock attack detected'
       Info - CVE: 'CVE-2014-6278'
       Info - Link: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6278'
**Alert to be generated.
```

## Tests

- [X] Compile manager on Linux.
- [X] Source installation.
- [ ] Ruleset QA.