### PR TITLE
Receive the whole IP string to avoid the truncation of the last digit

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -143,7 +143,7 @@ void run_notify()
                 merror("Error sending msg to control socket (%d) %s", errno, strerror(errno));
             }
             else{
-                if(OS_RecvUnix(sock, IPSIZE - 1, agent_ip) == 0){
+                if(OS_RecvUnix(sock, IPSIZE, agent_ip) == 0){
                     merror("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
                 }
                 else{

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -135,7 +135,7 @@ void run_notify()
     int sock;
     char label_ip[50];
     int i;
-    os_calloc(16,sizeof(char),agent_ip);
+    os_calloc(IPSIZE + 1,sizeof(char),agent_ip);
 
     for (i = SOCK_ATTEMPTS; i > 0; --i) {
         if (sock = control_check_connection(), sock >= 0) {

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -197,7 +197,7 @@ void *send_ip(){
             continue;
         }
 
-        os_calloc(IPSIZE, sizeof(char), buffer);
+        os_calloc(IPSIZE + 1, sizeof(char), buffer);
         switch (length = OS_RecvUnix(peer, IPSIZE - 1, buffer), length) {
         case -1:
             mterror(WM_CONTROL_LOGTAG, "At send_ip(): OS_RecvUnix(): %s", strerror(errno));

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -198,7 +198,7 @@ void *send_ip(){
         }
 
         os_calloc(IPSIZE + 1, sizeof(char), buffer);
-        switch (length = OS_RecvUnix(peer, IPSIZE - 1, buffer), length) {
+        switch (length = OS_RecvUnix(peer, IPSIZE, buffer), length) {
         case -1:
             mterror(WM_CONTROL_LOGTAG, "At send_ip(): OS_RecvUnix(): %s", strerror(errno));
             break;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3511|


## Description

When the agent IP had the maximum length, 15, the last digit was truncated because it was being replaced with `\0`. This PR changes the number of characters received to receive the `\0` from the socket too and avoid the truncation.

The field `agent_ip` of the agent-info was truncated before:
![image](https://user-images.githubusercontent.com/9034923/60592598-4128d000-9da1-11e9-9025-0442aecb062e.png)


After the change, the IP field contains the whole IP
![image](https://user-images.githubusercontent.com/9034923/60592686-7503f580-9da1-11e9-928d-826644c3a6b8.png)


## Tests
- [x] Compile agent on Linux
- [x] Source installation
- [x] Agent with IP `XXX.XXX.XXX.XXX`

Memory Test of `ossec-agentd`
![image](https://user-images.githubusercontent.com/9034923/60598508-1cd2f080-9dad-11e9-8f0a-339c73603c60.png)

