### PR TITLE
Fix deletion of duplicate entries in Logcollector

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -596,6 +596,7 @@ void Free_Logreader(logreader * logf) {
 int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *globf) {
     if (*logf) {
         int size = 0;
+        int x;
         while ((*logf)[size].file || (!gl && (*logf)[size].logformat)) {
             size++;
         }
@@ -613,19 +614,9 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *gl
                 }
             #endif
             }
-            if (i != size -1) {
-                memcpy(&(*logf)[i], &(*logf)[size - 1], sizeof(logreader));
-            }
 
-            (*logf)[size - 1].file = NULL;
-            (*logf)[size - 1].fp = NULL;
-
-            if(!gl) {
-                (*logf)[size - 1].target = NULL;
-                (*logf)[size - 1].ffile = NULL;
-                (*logf)[size - 1].logformat = NULL;
-                (*logf)[size - 1].command = NULL;
-                (*logf)[size - 1].exclude = NULL;
+            for (x = i; x < size; x++) {
+                memcpy(&(*logf)[x], &(*logf)[x + 1], sizeof(logreader));
             }
 
             if (!size)

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -575,6 +575,8 @@ void Free_Logreader(logreader * logf) {
             free(logf->target);
         }
 
+        free(logf->log_target);
+
         labels_free(logf->labels);
 
         if (logf->fp) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3051|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR solves the problem related with the order in the read configuration in `ossec-logcollector`. The function `Remove_Localfile` was changing the array positions during the duplicates deletion. This behavior changed the value to keep in the array.


## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Configuration on demand reports new parameters
- [x] Review logs syntax and correct language
