### PR TITLE
Added the ignores of type 'os_regex' in the request of the configurat…

### DIFF
--- a/src/rootcheck/config.c
+++ b/src/rootcheck/config.c
@@ -47,6 +47,7 @@ cJSON *getRootcheckConfig(void) {
 
     cJSON *root = cJSON_CreateObject();
     cJSON *rtck = cJSON_CreateObject();
+    unsigned int i;
 
     if (rootcheck.disabled) cJSON_AddStringToObject(rtck,"disabled","yes"); else cJSON_AddStringToObject(rtck,"disabled","no");
     if (rootcheck.basedir) cJSON_AddStringToObject(rtck,"base_directory",rootcheck.basedir);
@@ -70,7 +71,6 @@ cJSON *getRootcheckConfig(void) {
     if (rootcheck.winmalware) cJSON_AddStringToObject(rtck,"windows_malware",rootcheck.winmalware);
     if (rootcheck.winaudit) cJSON_AddStringToObject(rtck,"windows_audit",rootcheck.winaudit);
 #else
-    unsigned int i;
     if (rootcheck.checks.rc_unixaudit) cJSON_AddStringToObject(rtck,"check_unixaudit","yes"); else cJSON_AddStringToObject(rtck,"check_unixaudit","no");
     if (rootcheck.unixaudit) {
         cJSON *uaudit = cJSON_CreateArray();
@@ -79,6 +79,8 @@ cJSON *getRootcheckConfig(void) {
         }
         cJSON_AddItemToObject(rtck,"system_audit",uaudit);
     }
+
+#endif
 
     if (rootcheck.ignore) {
         cJSON *igns = cJSON_CreateArray();
@@ -95,8 +97,6 @@ cJSON *getRootcheckConfig(void) {
         cJSON_AddItemToObject(rtck, "ignore", igns);
         cJSON_AddItemToObject(rtck, "ignore_sregex", ignsregex);
     }
-
-#endif
 
     cJSON_AddItemToObject(root, "rootcheck", rtck);
 

--- a/src/rootcheck/config.c
+++ b/src/rootcheck/config.c
@@ -79,6 +79,22 @@ cJSON *getRootcheckConfig(void) {
         }
         cJSON_AddItemToObject(rtck,"system_audit",uaudit);
     }
+
+    if (rootcheck.ignore) {
+        cJSON *igns = cJSON_CreateArray();
+        for (i=0;rootcheck.ignore[i];i++) {
+            cJSON_AddItemToArray(igns, cJSON_CreateString(rootcheck.ignore[i]));
+        }
+        cJSON_AddItemToObject(rtck,"ignore",igns);
+    }
+
+    if (rootcheck.ignore_sregex) {
+        cJSON *igns = cJSON_CreateArray();
+        for (i=0;rootcheck.ignore_sregex[i];i++) {
+            cJSON_AddItemToArray(igns, cJSON_CreateString(rootcheck.ignore_sregex[i]->raw));
+        }
+        cJSON_AddItemToObject(rtck,"ignore_sregex",igns);
+    }
 #endif
 
     cJSON_AddItemToObject(root,"rootcheck",rtck);

--- a/src/rootcheck/config.c
+++ b/src/rootcheck/config.c
@@ -84,7 +84,7 @@ cJSON *getRootcheckConfig(void) {
         cJSON *igns = cJSON_CreateArray();
         cJSON *ignsregex = cJSON_CreateArray();
 
-        for (i=0;rootcheck.ignore[i];i++) {
+        for (i=0; rootcheck.ignore[i]; i++) {
             if (rootcheck.ignore_sregex[i]) {
                 cJSON_AddItemToArray(ignsregex, cJSON_CreateString(rootcheck.ignore_sregex[i]->raw));
             } else {
@@ -92,15 +92,13 @@ cJSON *getRootcheckConfig(void) {
             }
         }
 
-        cJSON_AddItemToObject(rtck,"ignore",igns);
-        cJSON_AddItemToObject(rtck,"ignore_sregex",ignsregex);
+        cJSON_AddItemToObject(rtck, "ignore", igns);
+        cJSON_AddItemToObject(rtck, "ignore_sregex", ignsregex);
     }
 
-    if (rootcheck.ignore_sregex) {
-    }
 #endif
 
-    cJSON_AddItemToObject(root,"rootcheck",rtck);
+    cJSON_AddItemToObject(root, "rootcheck", rtck);
 
     return root;
 }

--- a/src/rootcheck/config.c
+++ b/src/rootcheck/config.c
@@ -82,18 +82,21 @@ cJSON *getRootcheckConfig(void) {
 
     if (rootcheck.ignore) {
         cJSON *igns = cJSON_CreateArray();
+        cJSON *ignsregex = cJSON_CreateArray();
+
         for (i=0;rootcheck.ignore[i];i++) {
-            cJSON_AddItemToArray(igns, cJSON_CreateString(rootcheck.ignore[i]));
+            if (rootcheck.ignore_sregex[i]) {
+                cJSON_AddItemToArray(ignsregex, cJSON_CreateString(rootcheck.ignore_sregex[i]->raw));
+            } else {
+                cJSON_AddItemToArray(igns, cJSON_CreateString(rootcheck.ignore[i]));
+            }
         }
+
         cJSON_AddItemToObject(rtck,"ignore",igns);
+        cJSON_AddItemToObject(rtck,"ignore_sregex",ignsregex);
     }
 
     if (rootcheck.ignore_sregex) {
-        cJSON *igns = cJSON_CreateArray();
-        for (i=0;rootcheck.ignore_sregex[i];i++) {
-            cJSON_AddItemToArray(igns, cJSON_CreateString(rootcheck.ignore_sregex[i]->raw));
-        }
-        cJSON_AddItemToObject(rtck,"ignore_sregex",igns);
     }
 #endif
 

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -236,41 +236,74 @@ cJSON *getSyscheckConfig(void) {
     }
     cJSON_AddItemToObject(syscfg,"whodata",whodata);
 #endif
+
 #ifdef WIN32
-    cJSON_AddNumberToObject(syscfg,"windows_audit_interval",syscheck.wdata.interval_scan);
+    cJSON_AddNumberToObject(syscfg, "windows_audit_interval", syscheck.wdata.interval_scan);
+
     if (syscheck.registry) {
         cJSON *rg = cJSON_CreateArray();
-        for (i=0;syscheck.registry[i].entry;i++) {
+
+        for (i=0; syscheck.registry[i].entry; i++) {
             cJSON *pair = cJSON_CreateObject();
-            cJSON_AddStringToObject(pair,"entry",syscheck.registry[i].entry);
-            if (syscheck.registry[i].arch == 0) cJSON_AddStringToObject(pair,"arch","32bit"); else cJSON_AddStringToObject(pair,"arch","64bit");
-            if (syscheck.registry[i].tag) cJSON_AddStringToObject(pair,"tags",syscheck.registry[i].tag);
+
+            cJSON_AddStringToObject(pair, "entry", syscheck.registry[i].entry);
+
+            if (syscheck.registry[i].arch == 0) {
+                cJSON_AddStringToObject(pair, "arch", "32bit");
+            } else {
+                cJSON_AddStringToObject(pair, "arch", "64bit");
+            }
+
+            if (syscheck.registry[i].tag) {
+                cJSON_AddStringToObject(pair, "tags", syscheck.registry[i].tag);
+            }
+
             cJSON_AddItemToArray(rg, pair);
         }
-        cJSON_AddItemToObject(syscfg,"registry",rg);
+        cJSON_AddItemToObject(syscfg, "registry", rg);
     }
+
     if (syscheck.registry_ignore) {
         cJSON *rgi = cJSON_CreateArray();
-        for (i=0;syscheck.registry_ignore[i].entry;i++) {
+
+        for (i=0; syscheck.registry_ignore[i].entry; i++) {
             cJSON *pair = cJSON_CreateObject();
-            cJSON_AddStringToObject(pair,"entry",syscheck.registry_ignore[i].entry);
-            if (syscheck.registry_ignore[i].arch == 0) cJSON_AddStringToObject(pair,"arch","32bit"); else cJSON_AddStringToObject(pair,"arch","64bit");
+
+            cJSON_AddStringToObject(pair, "entry", syscheck.registry_ignore[i].entry);
+
+            if (syscheck.registry_ignore[i].arch == 0) {
+                cJSON_AddStringToObject(pair,"arch","32bit");
+            } else {
+                cJSON_AddStringToObject(pair,"arch","64bit");
+            }
+
             cJSON_AddItemToArray(rgi, pair);
         }
-        cJSON_AddItemToObject(syscfg,"registry_ignore",rgi);
+        cJSON_AddItemToObject(syscfg, "registry_ignore", rgi);
     }
+
     if (syscheck.registry_ignore_regex) {
         cJSON *rgi = cJSON_CreateArray();
+
         for (i=0;syscheck.registry_ignore_regex[i].regex;i++) {
             cJSON *pair = cJSON_CreateObject();
+
             cJSON_AddStringToObject(pair,"entry",syscheck.registry_ignore_regex[i].regex->raw);
-            if (syscheck.registry_ignore_regex[i].arch == 0) cJSON_AddStringToObject(pair,"arch","32bit"); else cJSON_AddStringToObject(pair,"arch","64bit");
+
+            if (syscheck.registry_ignore_regex[i].arch == 0) {
+                cJSON_AddStringToObject(pair,"arch","32bit");
+            } else {
+                cJSON_AddStringToObject(pair,"arch","64bit");
+            }
+
             cJSON_AddItemToArray(rgi, pair);
         }
         cJSON_AddItemToObject(syscfg,"registry_ignore_regex",rgi);
     }
 #endif
-    if (syscheck.prefilter_cmd) cJSON_AddStringToObject(syscfg,"prefilter_cmd",syscheck.prefilter_cmd);
+    if (syscheck.prefilter_cmd) {
+        cJSON_AddStringToObject(syscfg,"prefilter_cmd",syscheck.prefilter_cmd);
+    }
 
     cJSON_AddItemToObject(root,"syscheck",syscfg);
 

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -209,7 +209,7 @@ cJSON *getSyscheckConfig(void) {
         for (i=0;syscheck.ignore_regex[i];i++) {
             cJSON_AddItemToArray(igns, cJSON_CreateString(syscheck.ignore_regex[i]->raw));
         }
-        cJSON_AddItemToObject(syscfg,"ignore_regex",igns);
+        cJSON_AddItemToObject(syscfg,"ignore_sregex",igns);
     }
 #ifndef WIN32
     cJSON *whodata = cJSON_CreateObject();
@@ -298,7 +298,7 @@ cJSON *getSyscheckConfig(void) {
 
             cJSON_AddItemToArray(rgi, pair);
         }
-        cJSON_AddItemToObject(syscfg,"registry_ignore_regex",rgi);
+        cJSON_AddItemToObject(syscfg,"registry_ignore_sregex",rgi);
     }
 #endif
     if (syscheck.prefilter_cmd) {

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -204,6 +204,13 @@ cJSON *getSyscheckConfig(void) {
         }
         cJSON_AddItemToObject(syscfg,"ignore",igns);
     }
+    if (syscheck.ignore_regex) {
+        cJSON *igns = cJSON_CreateArray();
+        for (i=0;syscheck.ignore_regex[i];i++) {
+            cJSON_AddItemToArray(igns, cJSON_CreateString(syscheck.ignore_regex[i]->raw));
+        }
+        cJSON_AddItemToObject(syscfg,"ignore_regex",igns);
+    }
 #ifndef WIN32
     cJSON *whodata = cJSON_CreateObject();
     if (syscheck.restart_audit) {
@@ -251,6 +258,16 @@ cJSON *getSyscheckConfig(void) {
             cJSON_AddItemToArray(rgi, pair);
         }
         cJSON_AddItemToObject(syscfg,"registry_ignore",rgi);
+    }
+    if (syscheck.registry_ignore_regex) {
+        cJSON *rgi = cJSON_CreateArray();
+        for (i=0;syscheck.registry_ignore_regex[i].regex;i++) {
+            cJSON *pair = cJSON_CreateObject();
+            cJSON_AddStringToObject(pair,"entry",syscheck.registry_ignore_regex[i].regex->raw);
+            if (syscheck.registry_ignore_regex[i].arch == 0) cJSON_AddStringToObject(pair,"arch","32bit"); else cJSON_AddStringToObject(pair,"arch","64bit");
+            cJSON_AddItemToArray(rgi, pair);
+        }
+        cJSON_AddItemToObject(syscfg,"registry_ignore_regex",rgi);
     }
 #endif
     if (syscheck.prefilter_cmd) cJSON_AddStringToObject(syscfg,"prefilter_cmd",syscheck.prefilter_cmd);


### PR DESCRIPTION
|*Related issue*|
|---|
|#3611|

## Description

Added the ignores of type 'os_regex' in the request of the configuration on demand of Rootcheck and Syscheck modules.


## Configuration options
```
## Syscheck
    <!-- File types to ignore -->
    <ignore type="sregex">^/proc</ignore>
    <ignore type="sregex">.log$|.swp$</ignore>
    <ignore type="sregex">^/sys</ignore>
    <ignore type="sregex">.jpg$|.swf$|.mp4</ignore>

...

## Rootcheck
    <ignore>/etc/group</ignore>
    <ignore>/etc/shadow</ignore>
    <ignore type="sregex">^/etc</ignore>
    <ignore type="sregex">$.conf</ignore>
    <ignore type="sregex">$.log|^/usr/sbin</ignore>


```
Checked with empty configuration,

## Logs/Alerts example

The JSON output in Windows and Linux agent. Windows agent includes os_regex type ignores in registry entries:


_Linux_
```
...

         "ignore": [
            "/etc/mtab",
            "/etc/hosts.deny",
            "/etc/mail/statistics",
            "/etc/random-seed",
            "/etc/random.seed",
            "/etc/adjtime",
            "/etc/httpd/logs",
            "/etc/utmpx",
            "/etc/wtmpx",
            "/etc/cups/certs",
            "/etc/dumpdates",
            "/etc/svc/volatile",
            "/sys/kernel/security",
            "/sys/kernel/debug",
            "/dev/core"
         ],
         "ignore_regex": [
            "^/proc",
            ".log$|.swp$",
            "^/sys",
            ".jpg$|.swf$|.mp4"
         ],
         "whodata": {
            "restart_audit": "yes",
            "startup_healthcheck": "yes"
         }
      }
   }
}


```

_Windows agent_
```
...

            {
               "entry": "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx",
               "arch": "32bit"
            },
            {
               "entry": "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\ADOVMPPackage\\Final",
               "arch": "32bit"
            }
         ],
         "registry_ignore_regex": [
            {
               "entry": "\\Enum$",
               "arch": "32bit"
            }
         ]
      }
   }
}

```

_Rootcheck_
```
         "ignore": [
            "/etc/group",
            "/etc/shadow"
         ],
         "ignore_sregex": [
            "^/etc",
            "$.conf",
            "$.log|^/usr/sbin"
         ]
```


## Tests
*Valgrind Report*

```
==1728== 
==1728== LEAK SUMMARY:
==1728==    definitely lost: 0 bytes in 0 blocks
==1728==    indirectly lost: 0 bytes in 0 blocks
==1728==      possibly lost: 544 bytes in 2 blocks
==1728==    still reachable: 2,103,548 bytes in 44,661 blocks
==1728==         suppressed: 0 bytes in 0 blocks
==1728== 
==1728== For counts of detected and suppressed errors, rerun with: -v
==1728== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
