### PR TITLE
Include a page failure limit when using the Red Hat API

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -330,7 +330,7 @@
 #define VU_API_REQ_INV_NEW          "(5499): There was no valid response to '%s' after %d attempts. Trying the next page..."
 #define VU_UNC_SEVERITY             "(5500): Uncontrolled severity has been found: '%s'."
 #define VU_FEED_NODE_NULL_ELM       "(5506): Null elements needing value have been found in a node of the feed. The update will not continue."
-
+#define VU_RH_REQ_FAIL_MAX          "(5541): The allowed number of failed pages (%d) has been exhausted. The feed will not be updated."
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -1971,6 +1971,7 @@ int wm_vuldet_fetch_feed(update_node *update, const char *OS, int *need_update) 
 
     if (update->dist_ref == DIS_REDHAT) {
         int page = 1;
+        int invalid_its = 0;
         int attempt = 0;
         char first_line;
         char first_page = 0;
@@ -1993,6 +1994,12 @@ int wm_vuldet_fetch_feed(update_node *update, const char *OS, int *need_update) 
                     mtwarn(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV_NEW, repo, RED_HAT_REPO_MAX_ATTEMPTS);
                     attempt = 0;
                     page++;
+
+                    if (invalid_its++, invalid_its == RED_HAT_REPO_MAX_FAIL_ITS) {
+                        mterror(WM_VULNDETECTOR_LOGTAG, VU_RH_REQ_FAIL_MAX, RED_HAT_REPO_MAX_FAIL_ITS);
+                        goto end;
+                    }
+
                     continue;
                 }
                 if (wurl_request(repo, CVE_TEMP_FILE)) {

--- a/src/wazuh_modules/wm_vuln_detector.h
+++ b/src/wazuh_modules/wm_vuln_detector.h
@@ -27,6 +27,7 @@
 #define RED_HAT_REPO_DEFAULT_MIN_YEAR 2010
 #define RED_HAT_REPO_MIN_YEAR 1999
 #define RED_HAT_REPO_MAX_ATTEMPTS 3
+#define RED_HAT_REPO_MAX_FAIL_ITS 5
 #define RED_HAT_REPO_REQ_SIZE 1000
 #define RED_HAT_REPO "https://access.redhat.com/labs/securitydataapi/cve.json?after=%d-01-01&per_page=%d&page=%d"
 #define CISECURITY_REPO "oval.cisecurity.org"


### PR DESCRIPTION
This PR import to 3.9 the solution given in [vuln-windows](https://github.com/wazuh/wazuh/tree/vuln-windows) (3.10) to limit the maximum number of failed attempts to download a page from the Red Hat Security Data API.

The solution consists of stopping attempts to get the next page if 5 of them have failed, which have up to 3 download retries.

https://github.com/wazuh/wazuh/blob/51d8d3521cb58be05026a21481b7c51dff07ff03/src/error_messages/error_messages.h#L356

https://github.com/wazuh/wazuh/blob/51d8d3521cb58be05026a21481b7c51dff07ff03/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h#L39

https://github.com/wazuh/wazuh/blob/51d8d3521cb58be05026a21481b7c51dff07ff03/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c#L1123-L1127

If this happens, the following error will be displayed and the download will stop. 

> 2019/07/04 15:09:46 wazuh-modulesd:vulnerability-detector: ERROR: (5541): The allowed number of failed pages (5) has been exhausted. The feed will not be updated.

This avoids the risk of falling into infinite attempts, as has happened to the user of [this thread](https://groups.google.com/forum/#!topic/wazuh/67RXW8ujuFY).

To replicate it, you can add a firewall rule to block the connections to https://access.redhat.com.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [ ] Review logs syntax and correct language
