### PR TITLE
Fix to Segmentation fault in wazuh-modulesd when it is ran within differents O.S. architectures

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -110,10 +110,12 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             }
             logf[pl].target = OS_StrBreak(',', node[i]->content, count);
             char * tmp;
-            for (n=0; n<count; n++) {
-                os_strdup(w_strtrim(logf[pl].target[n]), tmp);
-                free(logf[pl].target[n]);
-                logf[pl].target[n] = tmp;
+            if(logf[pl].target) {
+                for (n=0; n<count; n++) {
+                    os_strdup(w_strtrim(logf[pl].target[n]), tmp);
+                    free(logf[pl].target[n]);
+                    logf[pl].target[n] = tmp;
+                }
             }
         } else if (strcmp(node[i]->element, xml_localfile_outformat) == 0) {
             char * target = NULL;

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -159,9 +159,11 @@ char * w_strtrim(char * string) {
     char *c;
     char *d;
 
-    string = &string[strspn(string, " ")];
-    for (c = string + strcspn(string, " "); *(d = c + strspn(c, " ")); c = d + strcspn(d, " "));
-    *c = '\0';
+    if(string != NULL) {
+        string = &string[strspn(string, " ")];
+        for (c = string + strcspn(string, " "); *(d = c + strspn(c, " ")); c = d + strcspn(d, " "));
+        *c = '\0';
+    }
     return string;
 }
 

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -232,5 +232,8 @@ void getNetworkIface_bsd(cJSON *object, char *iface_name, struct ifaddrs *ifaddr
 // Create the interface list
 int getIfaceslist(char **ifaces_list, struct ifaddrs *ifaddr);
 
+// Initialize hw_info struct values
+void init_hw_info(hw_info *info);
+
 #endif
 #endif

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -630,14 +630,16 @@ void sys_hw_bsd(int queue_fd, const char* LOCATION){
     /* Get CPU and memory information */
     hw_info *sys_info;
     if (sys_info = get_system_bsd(), sys_info){
-        cJSON_AddStringToObject(hw_inventory, "cpu_name", w_strtrim(sys_info->cpu_name));
+        if(sys_info->cpu_name) {
+            cJSON_AddStringToObject(hw_inventory, "cpu_name", w_strtrim(sys_info->cpu_name));
+        }
         cJSON_AddNumberToObject(hw_inventory, "cpu_cores", sys_info->cpu_cores);
         cJSON_AddNumberToObject(hw_inventory, "cpu_MHz", sys_info->cpu_MHz);
         cJSON_AddNumberToObject(hw_inventory, "ram_total", sys_info->ram_total);
         cJSON_AddNumberToObject(hw_inventory, "ram_free", sys_info->ram_free);
         cJSON_AddNumberToObject(hw_inventory, "ram_usage", sys_info->ram_usage);
 
-        free(sys_info->cpu_name);
+        os_free(sys_info->cpu_name);
         free(sys_info);
     }
 
@@ -655,6 +657,7 @@ hw_info *get_system_bsd(){
 
     hw_info *info;
     os_calloc(1, sizeof(hw_info), info);
+    init_hw_info(info);
 
     int mib[2];
     size_t len;

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -279,6 +279,19 @@ cJSON *wm_sys_dump(const wm_sys_t *sys) {
     return root;
 }
 
+// Initialize hw_info structure
+
+void init_hw_info(hw_info *info) {
+    if(info != NULL) {
+        info->cpu_name = NULL;
+        info->cpu_cores = 0;
+        info->cpu_MHz = 0.0;
+        info->ram_total = 0;
+        info->ram_free = 0;
+        info->ram_usage = 0;
+    }
+}
+
 void wm_sys_destroy(wm_sys_t *sys) {
     free(sys);
 }

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -35,6 +35,20 @@ char* get_mtu(char *ifa_name);                  // Get MTU
 char* check_dhcp(char *ifa_name, int family);   // Check DHCP status for network interfaces
 char* get_default_gateway(char *ifa_name);      // Get Default Gateway for network interfaces
 
+
+// Initialize hw_info structure
+
+void init_hw_info(hw_info *info) {
+    if(info != NULL) {
+        info->cpu_name = NULL;
+        info->cpu_cores = 0;
+        info->cpu_MHz = 0.0;
+        info->ram_total = 0;
+        info->ram_free = 0;
+        info->ram_usage = 0;
+    }
+}
+
 // Get port state
 
 char* get_port_state(int state){
@@ -864,14 +878,17 @@ void sys_hw_linux(int queue_fd, const char* LOCATION){
     /* Get CPU and memory information */
     hw_info *sys_info;
     if (sys_info = get_system_linux(), sys_info){
-        cJSON_AddStringToObject(hw_inventory, "cpu_name", w_strtrim(sys_info->cpu_name));
+        
+        if(sys_info->cpu_name) {
+            cJSON_AddStringToObject(hw_inventory, "cpu_name", w_strtrim(sys_info->cpu_name));
+        }
         cJSON_AddNumberToObject(hw_inventory, "cpu_cores", sys_info->cpu_cores);
         cJSON_AddNumberToObject(hw_inventory, "cpu_MHz", sys_info->cpu_MHz);
         cJSON_AddNumberToObject(hw_inventory, "ram_total", sys_info->ram_total);
         cJSON_AddNumberToObject(hw_inventory, "ram_free", sys_info->ram_free);
         cJSON_AddNumberToObject(hw_inventory, "ram_usage", sys_info->ram_usage);
 
-        free(sys_info->cpu_name);
+        os_free(sys_info->cpu_name);
         free(sys_info);
     }
 
@@ -1063,6 +1080,7 @@ hw_info *get_system_linux(){
     char *end;
 
     os_calloc(1, sizeof(hw_info), info);
+    init_hw_info(info);
 
     if (!(fp = fopen("/proc/cpuinfo", "r"))) {
         mterror(WM_SYS_LOGTAG, "Unable to read the CPU name.");
@@ -1827,12 +1845,14 @@ void getNetworkIface_linux(cJSON *object, char *iface_name, struct ifaddrs *ifad
                     char ** parts = NULL;
                     char *ip_addrr;
                     parts = OS_StrBreak('%', host, 2);
-                    ip_addrr = w_strtrim(parts[0]);
-                    cJSON_AddItemToArray(ipv6_addr, cJSON_CreateString(ip_addrr));
-                    for (k=0; parts[k]; k++){
-                        free(parts[k]);
+                    if(parts) {
+                        ip_addrr = w_strtrim(parts[0]);
+                        cJSON_AddItemToArray(ipv6_addr, cJSON_CreateString(ip_addrr));
+                        for (k=0; parts[k]; k++){
+                            free(parts[k]);
+                        }
+                        free(parts);
                     }
-                    free(parts);
                 } else {
                     mterror(WM_SYS_LOGTAG, "Can't obtain the IPv6 address for interface '%s': %s\n", iface_name, gai_strerror(result));
                 }

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -35,20 +35,6 @@ char* get_mtu(char *ifa_name);                  // Get MTU
 char* check_dhcp(char *ifa_name, int family);   // Check DHCP status for network interfaces
 char* get_default_gateway(char *ifa_name);      // Get Default Gateway for network interfaces
 
-
-// Initialize hw_info structure
-
-void init_hw_info(hw_info *info) {
-    if(info != NULL) {
-        info->cpu_name = NULL;
-        info->cpu_cores = 0;
-        info->cpu_MHz = 0.0;
-        info->ram_total = 0;
-        info->ram_free = 0;
-        info->ram_usage = 0;
-    }
-}
-
 // Get port state
 
 char* get_port_state(int state){
@@ -878,7 +864,6 @@ void sys_hw_linux(int queue_fd, const char* LOCATION){
     /* Get CPU and memory information */
     hw_info *sys_info;
     if (sys_info = get_system_linux(), sys_info){
-        
         if(sys_info->cpu_name) {
             cJSON_AddStringToObject(hw_inventory, "cpu_name", w_strtrim(sys_info->cpu_name));
         }
@@ -1109,6 +1094,9 @@ hw_info *get_system_linux(){
                 }
                 info->cpu_MHz = atof(frec);
             }
+        }
+        if (!info->cpu_name) {
+            info->cpu_name = strdup("unknown");
         }
         fclose(fp);
     }

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1305,7 +1305,7 @@ void sys_hw_windows(const char* LOCATION){
         if (sys_info->ram_usage)
             cJSON_AddNumberToObject(hw_inventory, "ram_usage", sys_info->ram_usage);
 
-        free(sys_info->cpu_name);
+        os_free(sys_info->cpu_name);
         free(sys_info);
     }
 
@@ -1952,6 +1952,7 @@ hw_info *get_system_windows(){
     DWORD dwCount = MAX_VALUE_NAME;
 
     os_calloc(1,sizeof(hw_info),info);
+    init_hw_info(info);
 
     // Get CPU name and frequency
 

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -2061,14 +2061,14 @@ int ntpath_to_win32path(char *ntpath, char **outbuf)
 				break;
 			}
 		} else {
-			mtwarn(WM_SYS_LOGTAG, "Unable to retrieve Windows kernel path for drive '%s\\'. Error '%lu'.", msdos_drive, GetLastError());
+			mtwarn(WM_SYS_LOGTAG, "Unable to retrieve Windows kernel path for drive '%s\\'. Error '%lu'", msdos_drive, GetLastError());
 		}
 
 		/* Get the next drive */
 		SingleDrive += (strlen(SingleDrive) + 1);
 	}
 
-	if (!success) mtwarn(WM_SYS_LOGTAG, "Unable to find a matching Windows kernel drive path for '%s'.", ntpath);
+	if (!success) mtwarn(WM_SYS_LOGTAG, "Unable to find a matching Windows kernel drive path for '%s'", ntpath);
 
 	return success;
 }


### PR DESCRIPTION
|Related issue|
|---|
|#3586|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
<!--
Add a clear description of how the problem has been solved.
-->

This pull request solves a segmentation fault in `wazuh-modulesd` triggered by `syscollector`. 
`syscollector` was getting NULL values while it was trying to read hardware information 
(`/proc/cpuinfo` and `/proc/meminfo` files). It is because this information could be different according to system architecture. We are going to show a few examples: 

**amd64 architecture**
```# cat /proc/cpuinfo
model name: Intel(R) Core(TM) i7-7660U CPU @ 2.50GHz
stepping      : 10
cpu MHz		: 1991.999
cpu cores         : 2 
```

Meanwhile, in **ppc64le architecture** we found this : 
```
# cat /proc/cpuinfo
processor	: 0
cpu		: POWER8 (architected), altivec supported
clock		: 3425.000000MHz
revision	: 2.1 (pvr 004b 0201)

timebase	: 512000000
platform	: pSeries
model		: IBM pSeries (emulated by qemu)
machine		: CHRP IBM pSeries (emulated by qemu)
MMU		: Hash
```

So since these fields are different from one architecture to another, we achieved `NULL` values when we searching for _**model name**_ or _**cpu MHz**_ tags.

In the next code line, when **sys_info->cpu_name**  is NULL :
https://github.com/wazuh/wazuh/blob/38893cd7ac5255f52dc06d755ffff31bb59df798/src/wazuh_modules/syscollector/syscollector_linux.c#L866

`w_strtrim` function receives a NULL input makes the module crash here :
https://github.com/wazuh/wazuh/blob/38893cd7ac5255f52dc06d755ffff31bb59df798/src/shared/string_op.c#L162

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests
<!--
At least, the following checks should be marked to accept the PR.
-->

To test if the issue it is solved, we made differents changes in `cpu_info` and `mem_info` files : 
- Changing tags and values
``` # cat /tmp/tmp_cpuinfo
cpuModelName	: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
...
cpuClockMHz	: 1000

# cat /tmp/tmp_meminfo
TotalMemory:      wR0ngv4lue
FreeMemory:        ?@341ḉç[]{}z
MemAvailable:    1753508 kB
```
_model name_ -> **cpuModelName** ; _cpu MHz_ -> **cpuClockMHz** ; _MemTotal_ -> **TotalMemory** ; _MemFree_ -> **FreeMemory**

-  Run `wazuh-modulesd` with `logall` option enabled, we can check the values achieved in `archives.log` :

The below images shows a manager with the above files modified and a centos agent with original files : 
![Compare2](https://user-images.githubusercontent.com/51230985/60792995-0d65f580-a167-11e9-83c2-7f702e8c30cd.png)
![Compare1](https://user-images.githubusercontent.com/51230985/60793001-1060e600-a167-11e9-8491-680473d9ffac.png)

So, as we can see the manager information is incomplete, values such as cpu_name, cpu_MHz, ram_total, ram_free and ram_usage could not achieved, however the seg fault was avoided.
 
- Valgrind Test : 
Manager :
![Valgrind from manager modulesd](https://user-images.githubusercontent.com/51230985/60793295-b14fa100-a167-11e9-9e82-930fe61c175f.png)
Agent :
![Valgrind from client Centos - modulesd](https://user-images.githubusercontent.com/51230985/60793143-59189f00-a167-11e9-83d1-3c35819b05d1.png)


## Summary Test
- Compilation without warnings in every supported platform
  - [x] Linux
     - [x] Ubuntu
     - [x] centOS7
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
- [x] Review logs syntax and correct language

