### PR TITLE
Avoid double-free in Analysisd's decoder for Windows Eventchannel

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -380,7 +380,7 @@ int DecodeWinevt(Eventinfo *lf){
                 // Event category, subcategory and Audit Policy Changes
 
                 if (categoryId && subcategoryId){
-                    
+
                     char *category = NULL;
                     char *subcategory = NULL;
                     int categoryId_n;
@@ -690,8 +690,9 @@ int DecodeWinevt(Eventinfo *lf){
                 os_free(audit_final_field);
                 free_strarray(audit_split);
             }
+
+            xml_init = 1;
         }
-        xml_init = 1;
     }
 
     find_msg = strstr(lf->log, "Message");


### PR DESCRIPTION
|Related issue|
|---|
|#3618|

Messages from Windows Eventchannel (as of Wazuh 3.8) contain XML data. Analysisd parses it as part of the decoding stage.

This decoder is clearing (freeing) the XML structure either the parsing was successful or not. However, according to the rest of the components that parse XML, the structure must only be cleaned in case of success.

This may produce a double-free condition.

## AddressSanitizer report

Forcing an XML parsing error with a randomly initialized XML structure:

```
    #0 0x55f0997b6cff in OS_ClearXML os_xml/os_xml.c:92
    #1 0x55f099668f6f in DecodeWinevt analysisd/decoders/winevtchannel.c:813
    #2 0x55f099646a4f in w_decode_winevt_thread analysisd/analysisd.c:2167
    #3 0x7f083ff3afa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486
    #4 0x7f083fe6b4ce in clone (/lib/x86_64-linux-gnu/libc.so.6+0xf94ce)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV os_xml/os_xml.c:92 in OS_ClearXML
Thread T52 created by T0 here:
    #0 0x7f0840589db0 in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x50db0)
    #1 0x55f099768dac in CreateThreadJoinable shared/pthreads_op.c:47
    #2 0x55f099768f31 in CreateThread shared/pthreads_op.c:62
    #3 0x55f099640489 in OS_ReadMSG analysisd/analysisd.c:947
    #4 0x55f09963f6a5 in main analysisd/analysisd.c:711
    #5 0x7f083fd9609a in __libc_start_main ../csu/libc-start.c:308

==8095==ABORTING
```

## Tests

- [X] Compile manager on Linux.
- [X] Source installation.
- [X] AddressSanitizer report (shown above).