### PR TITLE
mwarn to minfo for duplicated localfile entries

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1474,7 +1474,7 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
             }
 
             if (current != dup && dup->file && !strcmp(current->file, dup->file)) {
-                mwarn(DUP_FILE, current->file);
+                minfo(DUP_FILE, current->file);
                 int result;
                 if (j < 0) {
                     result = Remove_Localfile(&logff, i, 0, 1,NULL);


### PR DESCRIPTION
| Related Issue|
|---|
| https://github.com/wazuh/wazuh/issues/2730 | 


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR changes the way Wazuh notifies that a localfile entry is duplicated. Previously it was reported by means of a Warning as in the example below:
```
2019/07/08 15:12:49 ossec-logcollector: WARNING: (1958): Log file '/var/log/apache2/error.log' is duplicated.
```
<br></br>
This message is now an INFO message:
```
2019/07/08 15:32:54 ossec-logcollector: INFO: (1958): Log file '/var/log/apache2/error.log' is duplicated.
```

## Tests

- Compilation without warnings in every supported platform
- [x] Linux
- [x] Source installation
