### PR TITLE
Avoid to incluide empty sregex array in rootcheck

### DIFF
--- a/src/rootcheck/config.c
+++ b/src/rootcheck/config.c
@@ -83,19 +83,21 @@ cJSON *getRootcheckConfig(void) {
 #endif
 
     if (rootcheck.ignore) {
-        cJSON *igns = cJSON_CreateArray();
-        cJSON *ignsregex = cJSON_CreateArray();
+        cJSON *igns = NULL;
+        cJSON *ignsregex = NULL;
 
         for (i=0; rootcheck.ignore[i]; i++) {
             if (rootcheck.ignore_sregex[i]) {
+                if (!ignsregex) ignsregex = cJSON_CreateArray();
                 cJSON_AddItemToArray(ignsregex, cJSON_CreateString(rootcheck.ignore_sregex[i]->raw));
             } else {
+                if (!igns) igns = cJSON_CreateArray();
                 cJSON_AddItemToArray(igns, cJSON_CreateString(rootcheck.ignore[i]));
             }
         }
 
-        cJSON_AddItemToObject(rtck, "ignore", igns);
-        cJSON_AddItemToObject(rtck, "ignore_sregex", ignsregex);
+        if (igns) cJSON_AddItemToObject(rtck, "ignore", igns);
+        if (ignsregex) cJSON_AddItemToObject(rtck, "ignore_sregex", ignsregex);
     }
 
     cJSON_AddItemToObject(root, "rootcheck", rtck);


### PR DESCRIPTION
When the remote configuration of Rootcheck is requested, and no `sregex` ignore has been configured, this array appears empty. The same case happens if not only `sregex` filters are included.

``` XML
  <rootcheck>
        <disabled>no</disabled>
        <ignore >path1</ignore>
        <ignore >path2</ignore>
        <ignore >path3</ignore>
  </rootcheck>
```

``` BASH
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/000/config/syscheck/rootcheck?pretty"
{
   "error": 0,
   "data": {
      "rootcheck": {
         "disabled": "no",
         "scanall": "no",
         "skip_nfs": "no",
         "frequency": 43200,
         "check_dev": "yes",
         "check_files": "no",
         "check_if": "yes",
         "check_pids": "yes",
         "check_ports": "yes",
         "check_sys": "yes",
         "check_trojans": "no",
         "check_unixaudit": "no",
         "ignore": [
            "path1",
            "path2",
            "path3"
         ],
         "ignore_sregex": []
      }
   }
}
```

This PR solve this invalid behaviour, unifying it with the Syscheck has, and complements #3617.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions

