### PR TITLE
Remove calls to thread-unsafe cJSON_GetErrorPtr()

### DIFF
--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -63,7 +63,8 @@ int DecodeCiscat(Eventinfo *lf, int *socket)
     // Parsing event.
     logJSON = cJSON_Parse(lf->log);
     if (!logJSON) {
-        mdebug1("Error parsing JSON event. %s", cJSON_GetErrorPtr());
+        mdebug1("Error parsing JSON event.");
+        mdebug2("Input JSON: '%s", lf->log);
         return (0);
     }
 

--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -61,7 +61,8 @@ int DecodeCiscat(Eventinfo *lf, int *socket)
     }
 
     // Parsing event.
-    logJSON = cJSON_Parse(lf->log);
+    const char *jsonErrPtr;
+    logJSON = cJSON_ParseWithOpts(lf->log, &jsonErrPtr, 0);
     if (!logJSON) {
         mdebug1("Error parsing JSON event.");
         mdebug2("Input JSON: '%s", lf->log);

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -386,7 +386,8 @@ void *JSON_Decoder_Exec(Eventinfo *lf, __attribute__((unused)) regex_matching *d
 
     mdebug2("Decoding JSON: '%.32s'", input);
 
-    logJSON = cJSON_Parse(input);
+    const char *jsonErrPtr;
+    logJSON = cJSON_ParseWithOpts(input, &jsonErrPtr, 0);
     if (!logJSON)
         mdebug2("Malformed JSON string '%s'", input);
     else

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -388,7 +388,7 @@ void *JSON_Decoder_Exec(Eventinfo *lf, __attribute__((unused)) regex_matching *d
 
     logJSON = cJSON_Parse(input);
     if (!logJSON)
-        mdebug2("Malformed JSON string '%s', near '%.20s'", input, cJSON_GetErrorPtr());
+        mdebug2("Malformed JSON string '%s'", input);
     else
     {
         readJSON (logJSON, NULL, lf);

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -163,8 +163,9 @@ int DecodeSCA(Eventinfo *lf, int *socket)
     cJSON *json_event = NULL;
     cJSON *type = NULL;
     lf->decoder_info = sca_json_dec;
+    const char *jsonErrPtr;
 
-    if (json_event = cJSON_Parse(lf->log), !json_event)
+    if (json_event = cJSON_ParseWithOpts(lf->log, &jsonErrPtr, 0), !json_event)
     {
         merror("Malformed configuration assessment JSON event");
         return ret_val;

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -75,7 +75,9 @@ int DecodeSyscollector(Eventinfo *lf,int *socket)
     }
 
     // Parsing event.
-    logJSON = cJSON_Parse(lf->log);
+
+    const char *jsonErrPtr;
+    logJSON = cJSON_ParseWithOpts(lf->log, &jsonErrPtr, 0);
     if (!logJSON) {
         mdebug1("Error parsing JSON event.");
         mdebug2("Input JSON: '%s", lf->log);

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -77,7 +77,8 @@ int DecodeSyscollector(Eventinfo *lf,int *socket)
     // Parsing event.
     logJSON = cJSON_Parse(lf->log);
     if (!logJSON) {
-        mdebug1("Error parsing JSON event. %s", cJSON_GetErrorPtr());
+        mdebug1("Error parsing JSON event.");
+        mdebug2("Input JSON: '%s", lf->log);
         return (0);
     }
 

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -84,8 +84,8 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 #endif
-
-        if (obj = cJSON_Parse(str), obj && cJSON_IsObject(obj)) {
+        const char *jsonErrPtr;
+        if (obj = cJSON_ParseWithOpts(str, &jsonErrPtr, 0), obj && cJSON_IsObject(obj)) {
           for (i = 0; lf->labels && lf->labels[i].key; i++) {
               W_JSON_AddField(obj, lf->labels[i].key, lf->labels[i].value);
           }

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -165,7 +165,8 @@ char* local_dispatch(const char *input) {
     int ierror;
 
     if (input[0] == '{') {
-        if (request = cJSON_Parse(input), !request) {
+        const char *jsonErrPtr;
+        if (request = cJSON_ParseWithOpts(input, &jsonErrPtr, 0), !request) {
             ierror = EJSON;
             goto fail;
         }

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -328,7 +328,7 @@ cJSON *getClusterConfig(void) {
 
     cluster_config_cJSON = cJSON_Parse(buffer);
     if (!cluster_config_cJSON) {
-        mdebug1("Error parsing JSON event. %s", cJSON_GetErrorPtr());
+        mdebug1("Error parsing JSON event. %s", buffer);
         free(buffer);
         return NULL;
     }

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -326,7 +326,8 @@ cJSON *getClusterConfig(void) {
         }
 	}
 
-    cluster_config_cJSON = cJSON_Parse(buffer);
+    const char *jsonErrPtr;
+    cluster_config_cJSON = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0);
     if (!cluster_config_cJSON) {
         mdebug1("Error parsing JSON event. %s", buffer);
         free(buffer);

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -343,7 +343,7 @@ int set_agent_multigroup(char * group){
 #ifndef WIN32
             int retval = mkdir(multigroup_path, 0770);
 #else
-            int retval = mkdir(multigroup_path); 
+            int retval = mkdir(multigroup_path);
 #endif
             umask(oldmask);
 
@@ -614,7 +614,7 @@ int auth_add_agent(int sock, char *id, const char *name, const char *ip,const ch
     if(agent_id) {
         cJSON_AddStringToObject(arguments, "id", agent_id);
     }
-        
+
     if (force >= 0) {
         cJSON_AddNumberToObject(arguments, "force", force);
     }
@@ -651,7 +651,8 @@ int auth_add_agent(int sock, char *id, const char *name, const char *ip,const ch
 
         // Decode response
 
-        if (response = cJSON_Parse(buffer), !response) {
+        const char *jsonErrPtr;
+        if (response = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0), !response) {
             if(exit_on_error){
                 merror_exit("Parsing JSON response.");
             }
@@ -719,7 +720,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 
     fp = fopen(path,"r");
 
-    if(!fp) { 
+    if(!fp) {
         mdebug1("Couldnt open file '%s'",path);
         os_free(path);
         os_free(buffer);

--- a/src/shared/auth_client.c
+++ b/src/shared/auth_client.c
@@ -52,7 +52,8 @@ int auth_remove_agent(int sock, const char *id, int json_format) {
 
         // Decode response
 
-        if (response = cJSON_Parse(buffer), !response) {
+        const char *jsonErrPtr;
+        if (response = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0), !response) {
             merror_exit("Parsing JSON response.");
         }
 

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -57,6 +57,7 @@ cJSON * jqueue_next(file_queue * queue) {
     struct stat buf;
     char buffer[OS_MAXSTR + 1];
     char *end;
+    const char *jsonErrPtr;
 
     if (!queue->fp && jqueue_open(queue, 1) < 0) {
         return NULL;
@@ -69,7 +70,7 @@ cJSON * jqueue_next(file_queue * queue) {
             *end = '\0';
         }
 
-        return cJSON_Parse(buffer);
+        return cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0);
     } else {
 
         if (stat(queue->file_name, &buf) < 0) {
@@ -93,7 +94,7 @@ cJSON * jqueue_next(file_queue * queue) {
                     *end = '\0';
                 }
 
-                return cJSON_Parse(buffer);
+                return cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0);
             } else {
                 return NULL;
             }

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -49,13 +49,14 @@ cJSON * json_fread(const char * path, char retry) {
     }
 
     buffer[size] = '\0';
+    const char *jsonErrPtr;
 
-    if (item = cJSON_Parse(buffer), !item) {
+    if (item = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0), !item) {
         if (retry) {
             mdebug1("Couldn't parse JSON file '%s'. Trying to clear comments.", path);
             json_strip(buffer);
 
-            if (item = cJSON_Parse(buffer), !item) {
+            if (item = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0), !item) {
                 mdebug1("Couldn't parse JSON file '%s'.", path);
             }
         }

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -195,7 +195,8 @@ void W_JSON_AddField(cJSON *root, const char *key, const char *value) {
            (string_end != NULL) &&
            (']' == *(string_end - 1)))
         {
-            cJSON_AddItemToObject(root, key, cJSON_Parse(value));
+            const char *jsonErrPtr;
+            cJSON_AddItemToObject(root, key, cJSON_ParseWithOpts(value, &jsonErrPtr, 0));
         } else {
             cJSON_AddStringToObject(root, key, value);
         }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -519,7 +519,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         *next++ = '\0';
         result_check = next;
-        
+
         curr = next;
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid Security Configuration Assessment query syntax.");
@@ -569,7 +569,8 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         curr = next;
         cJSON *event;
-        if (event = cJSON_Parse(curr), !event)
+        const char *jsonErrPtr;
+        if (event = cJSON_ParseWithOpts(curr, &jsonErrPtr, 0), !event)
         {
             mdebug1("Invalid Security Configuration Assessment query syntax. JSON object not found or invalid");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
@@ -700,18 +701,18 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
                 mdebug1("Malformed JSON: field 'command' must be a string");
                 return -1;
             }
-            
+
             if ( status = cJSON_GetObjectItem(check, "status"), status) {
                 if ( reason = cJSON_GetObjectItem(check, "reason"), !reason) {
                     merror("Malformed JSON: field 'reason' not found");
                     return -1;
                 }
-                
+
                 if( !status->valuestring ) {
                     merror("Malformed JSON: field 'status' must be a string");
                     return -1;
                 }
-                
+
                 if( !reason->valuestring ) {
                     merror("Malformed JSON: field 'reason' must be a string");
                     return -1;
@@ -731,7 +732,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             }
         }
 
-        
+
         if (result = wdb_sca_save(wdb,id->valueint,scan_id->valueint,title->valuestring,description ? description->valuestring : NULL,rationale ? rationale->valuestring : NULL,remediation ? remediation->valuestring : NULL,file ? file->valuestring : NULL,directory ? directory->valuestring : NULL,process ? process->valuestring : NULL,registry ? registry->valuestring : NULL,reference ? reference->valuestring : NULL ,result_check ? result_check->valuestring : "",policy_id->valuestring,command ? command->valuestring : NULL,status ? status->valuestring : NULL,reason ? reason->valuestring : NULL), result < 0) {
             mdebug1("Cannot save Security Configuration Assessment information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save Security Configuration Assessment information.");
@@ -812,7 +813,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         }
 
         return result;
-        
+
     } else if (strcmp(curr, "delete_check") == 0) {
 
         char *policy_id;
@@ -991,7 +992,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
             return -1;
         }
-        
+
         description = curr;
         *next++ = '\0';
 
@@ -1083,7 +1084,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             pass = strtol(curr,NULL,10);
 
         *next++ = '\0';
-       
+
         curr = next;
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid Security Configuration Assessment query syntax.");
@@ -1167,7 +1168,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
             return -1;
         }
-        
+
         id_check = strtol(curr,NULL,10);
         *next++ = '\0';
 
@@ -1217,7 +1218,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             pm_start_scan = -1;
         else
             pm_start_scan = strtol(curr,NULL,10);
-        
+
         *next++ = '\0';
         curr = next;
 
@@ -1249,7 +1250,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             scan_id = strtol(curr,NULL,10);
 
         *next++ = '\0';
-        curr = next;   
+        curr = next;
 
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid configuration assessment query syntax.");
@@ -1303,7 +1304,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             invalid = -1;
         else
             invalid = strtol(curr,NULL,10);
-        
+
         *next++ = '\0';
         curr = next;
 
@@ -1318,7 +1319,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             total_checks = -1;
         else
             total_checks = strtol(curr,NULL,10);
-        
+
         *next++ = '\0';
         curr = next;
 
@@ -1365,7 +1366,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         if (!strcmp(module, "NULL"))
             module = NULL;
-        
+
         *next++ = '\0';
         curr = next;
 
@@ -1384,7 +1385,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         return result;
     } else if (strcmp(curr, "update_check_scan") == 0) {
 
-        curr = next;  
+        curr = next;
         int scan_id_old;
         int scan_id_new;
         char * policy_id;
@@ -1421,7 +1422,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         policy_id = curr;
 
-       
+
         if (result = wdb_sca_check_update_scan_id(wdb,scan_id_old,scan_id_new,policy_id), result < 0) {
             mdebug1("Cannot save configuration assessment information.");
             snprintf(output, OS_MAXSTR + 1, "err Cannot save configuration assessment information.");
@@ -1465,7 +1466,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         if (!strcmp(policy_id, "NULL"))
             policy_id = NULL;
-        
+
         *next++ = '\0';
         curr = next;
 
@@ -1489,7 +1490,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         *next++ = '\0';
         curr = next;
-        
+
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid configuration assessment query syntax.");
             mdebug2("configuration assessment query: %s", curr);
@@ -1504,7 +1505,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         *next++ = '\0';
         curr = next;
-        
+
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid configuration assessment query syntax.");
             mdebug2("configuration assessment query: %s", curr);
@@ -1519,7 +1520,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         *next++ = '\0';
         curr = next;
-        
+
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid configuration assessment query syntax.");
             mdebug2("configuration assessment query: %s", curr);
@@ -1534,7 +1535,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
         *next++ = '\0';
         curr = next;
-        
+
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid configuration assessment query syntax.");
             mdebug2("configuration assessment query: %s", curr);
@@ -1546,10 +1547,10 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             invalid = -1;
         else
             invalid = strtol(curr,NULL,10);
-        
+
         *next++ = '\0';
         curr = next;
-        
+
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid configuration assessment query syntax.");
             mdebug2("configuration assessment query: %s", curr);
@@ -1561,10 +1562,10 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             total_checks = -1;
         else
             total_checks = strtol(curr,NULL,10);
-        
+
         *next++ = '\0';
         curr = next;
-        
+
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid configuration assessment query syntax.");
             mdebug2("configuration assessment query: %s", curr);

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -285,7 +285,8 @@ int wm_key_request_dispatch(char * buffer, const wm_krequest_t * data) {
         }
     }
 
-    agent_infoJSON = cJSON_Parse(output);
+    const char *jsonErrPtr;
+    agent_infoJSON = cJSON_ParseWithOpts(output, &jsonErrPtr, 0);
 
     if (!agent_infoJSON) {
         mdebug1("Error parsing JSON event. %s", output);

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -288,7 +288,7 @@ int wm_key_request_dispatch(char * buffer, const wm_krequest_t * data) {
     agent_infoJSON = cJSON_Parse(output);
 
     if (!agent_infoJSON) {
-        mdebug1("Error parsing JSON event. %s", cJSON_GetErrorPtr());
+        mdebug1("Error parsing JSON event. %s", output);
     } else {
 
         int error = 0;

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -116,7 +116,8 @@ void *Read_Log(wm_osquery_monitor_t * osquery)
                     *end = '\0';
                 }
 
-                if (osquery_json = cJSON_Parse(line), osquery_json) {
+                const char *jsonErrPtr;
+                if (osquery_json = cJSON_ParseWithOpts(line, &jsonErrPtr, 0), osquery_json) {
 
                     // Nest object into a "osquery" object
 

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -2310,6 +2310,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, OSHash *agen
     cJSON *package_list = NULL;
     last_scan *scan;
     int result;
+    const char *jsonErrPtr;
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_SOFTWARE_REQ, agent->agent_id);
 
@@ -2347,7 +2348,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, OSHash *agen
         goto end;
     }
 
-    if (obj = cJSON_Parse(json_str), obj && cJSON_IsObject(obj)) {
+    if (obj = cJSON_ParseWithOpts(json_str, &jsonErrPtr, 0), obj && cJSON_IsObject(obj)) {
         cJSON_GetObjectItem(obj, "data");
     } else {
         retval = OS_INVALID;
@@ -2408,7 +2409,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, OSHash *agen
             if (obj) {
                 cJSON *new_obj;
                 cJSON *data;
-                if (new_obj = cJSON_Parse(json_str), !new_obj) {
+                if (new_obj = cJSON_ParseWithOpts(json_str, &jsonErrPtr, 0), !new_obj) {
                     retval = OS_INVALID;
                     goto end;
                 } else if (!cJSON_IsObject(new_obj)) {
@@ -2423,7 +2424,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, OSHash *agen
                     free(data);
                 }
                 free(new_obj);
-            } else if (obj = cJSON_Parse(json_str), obj && cJSON_IsObject(obj)) {
+            } else if (obj = cJSON_ParseWithOpts(json_str, &jsonErrPtr, 0), obj && cJSON_IsObject(obj)) {
                 package_list = cJSON_GetObjectItem(obj, "data");
                 if (!package_list) {
                     retval = OS_INVALID;

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -638,7 +638,8 @@ char *get_win_agent_ip(){
                     string = get_network_xp(pCurrAddresses, AdapterInfo, 0, NULL);
                 }
 
-                cJSON *object = cJSON_Parse(string);
+                const char *jsonErrPtr;
+                cJSON *object = cJSON_ParseWithOpts(string, &jsonErrPtr, 0);
                 cJSON *iface = cJSON_GetObjectItem(object, "iface");
                 cJSON *ipv4 = cJSON_GetObjectItem(iface, "IPv4");
                 if(ipv4){


### PR DESCRIPTION
|Related issues|
|---|
|#3618 #3542|

` cJSON_GetErrorPtr()` is a function that returns the pointer to the first character of a JSON string that could not be parsed.

Internally, `cJSON_Parse()` sets that pointer on error. Such pointer is static and shared between every thread in the process. The following decoders in Analysisd call `cJSON_GetErrorPtr()`:
- JSON plugin decoder.
- CIS-CAT decoder.
- Syscollector decoder.

This issue may produce:
- A null pointer dereference if `cJSON_GetErrorPtr()` is called just after `cJSON_Parse()`.
- A use-after-free hazard if `cJSON_GetErrorPtr()` is called just after `cJSON_Parse()` fails again.

On the other hand, Execd and Modulesd (key request module) use `cJSON_GetErrorPtr()` too. 

## Proposed fix

Remove all these calls. Since that function is used in debug logging only, we replaced `cJSON_GetErrorPtr()` with a pointer to the full input, that we could use for debugging.

## ThreadSanitizer report
```
WARNING: ThreadSanitizer: data race (pid=9488)
  Read of size 1 at 0x7b6400010175 by thread T31:
    #0 vfprintf <null> (libtsan.so.0+0x34e34)
    #1 _log shared/debug_op.c:191 (ossec-analysisd+0x1187b9)
    #2 _mdebug2 shared/debug_op.c:325 (ossec-analysisd+0x1192ee)
    #3 JSON_Decoder_Exec analysisd/decoders/plugins/json_decoder.c:392 (ossec-analysisd+0x795f4)
    #4 DecodeEvent analysisd/decoders/decoder.c:150 (ossec-analysisd+0x5224f)
    #5 w_decode_event_thread analysisd/analysisd.c:2124 (ossec-analysisd+0x411d4)
    #6 <null> <null> (libtsan.so.0+0x29b3d)

  Previous write of size 8 at 0x7b6400010170 by thread T33:
    #0 malloc <null> (libtsan.so.0+0x2b1a3)
    #1 OS_CleanMSG analysisd/cleanevent.c:56 (ossec-analysisd+0x1f5ec)
    #2 w_decode_event_thread analysisd/analysisd.c:2110 (ossec-analysisd+0x4112d)
    #3 <null> <null> (libtsan.so.0+0x29b3d)

  As if synchronized via sleep:
    #0 sleep <null> (libtsan.so.0+0x4965b)
    #1 JSON_Decoder_Exec analysisd/decoders/plugins/json_decoder.c:391 (ossec-analysisd+0x795be)
    #2 DecodeEvent analysisd/decoders/decoder.c:150 (ossec-analysisd+0x5224f)
    #3 w_decode_event_thread analysisd/analysisd.c:2124 (ossec-analysisd+0x411d4)
    #4 <null> <null> (libtsan.so.0+0x29b3d)

  Location is heap block of size 1243 at 0x7b640000ff00 allocated by thread T33:
    #0 malloc <null> (libtsan.so.0+0x2b1a3)
    #1 OS_CleanMSG analysisd/cleanevent.c:56 (ossec-analysisd+0x1f5ec)
    #2 w_decode_event_thread analysisd/analysisd.c:2110 (ossec-analysisd+0x4112d)
    #3 <null> <null> (libtsan.so.0+0x29b3d)

  Thread T31 (tid=9520, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (ossec-analysisd+0x102acd)
    #2 CreateThread shared/pthreads_op.c:62 (ossec-analysisd+0x102b6d)
    #3 OS_ReadMSG analysisd/analysisd.c:937 (ossec-analysisd+0x3c728)
    #4 main analysisd/analysisd.c:711 (ossec-analysisd+0x3bcee)

  Thread T33 (tid=9522, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (ossec-analysisd+0x102acd)
    #2 CreateThread shared/pthreads_op.c:62 (ossec-analysisd+0x102b6d)
    #3 OS_ReadMSG analysisd/analysisd.c:937 (ossec-analysisd+0x3c728)
    #4 main analysisd/analysisd.c:711 (ossec-analysisd+0x3bcee)

SUMMARY: ThreadSanitizer: data race (/usr/lib/x86_64-linux-gnu/libtsan.so.0+0x34e34) in vfprintf
```

## AddressSanitizer report
```
==12008==ERROR: AddressSanitizer: heap-use-after-free on address 0x619000973861 at pc 0x7f11f1df3514 bp 0x7f11dfcdc810 sp 0x7f11dfcdbfc0
READ of size 20 at 0x619000973861 thread T30
    #0 0x7f11f1df3513  (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x53513)
    #1 0x7f11f1df41b2 in __interceptor_vfprintf (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x541b2)
    #2 0x55b866fc5dc7 in _log shared/debug_op.c:213
    #3 0x55b866fc6a73 in _mdebug2 shared/debug_op.c:325
    #4 0x55b866ecfb90 in JSON_Decoder_Exec analysisd/decoders/plugins/json_decoder.c:392
    #5 0x55b866e9478e in DecodeEvent analysisd/decoders/decoder.c:150
    #6 0x55b866e7c738 in w_decode_event_thread analysisd/analysisd.c:2124
    #7 0x7f11f177afa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486
    #8 0x7f11f16ab4ce in clone (/lib/x86_64-linux-gnu/libc.so.6+0xf94ce)

0x619000973861 is located 481 bytes inside of 947-byte region [0x619000973680,0x619000973a33)
freed by thread T36 here:
    #0 0x7f11f1e88fb0 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe8fb0)
    #1 0x55b866e6a26f in Free_Eventinfo analysisd/eventinfo.c:837
    #2 0x55b866e7a7eb in w_free_event_info analysisd/analysisd.c:1782
    #3 0x55b866e7ef18 in w_process_event_thread analysisd/analysisd.c:2474
    #4 0x7f11f177afa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486

previously allocated by thread T31 here:
    #0 0x7f11f1e89330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x55b866e3b8af in OS_CleanMSG analysisd/cleanevent.c:56
    #2 0x55b866e7c649 in w_decode_event_thread analysisd/analysisd.c:2110
    #3 0x7f11f177afa2 in start_thread /build/glibc-vjB4T1/glibc-2.28/nptl/pthread_create.c:486

Thread T30 created by T0 here:
    #0 0x7f11f1df0db0 in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x50db0)
    #1 0x55b866fa3ad7 in CreateThreadJoinable shared/pthreads_op.c:47
    #2 0x55b866fa3c5c in CreateThread shared/pthreads_op.c:62
    #3 0x55b866e76409 in OS_ReadMSG analysisd/analysisd.c:937
    #4 0x55b866e756b5 in main analysisd/analysisd.c:711
    #5 0x7f11f15d609a in __libc_start_main ../csu/libc-start.c:308

Thread T36 created by T0 here:
    #0 0x7f11f1df0db0 in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x50db0)
    #1 0x55b866fa3ad7 in CreateThreadJoinable shared/pthreads_op.c:47
    #2 0x55b866fa3c5c in CreateThread shared/pthreads_op.c:62
    #3 0x55b866e76454 in OS_ReadMSG analysisd/analysisd.c:942
    #4 0x55b866e756b5 in main analysisd/analysisd.c:711
    #5 0x7f11f15d609a in __libc_start_main ../csu/libc-start.c:308

Thread T31 created by T0 here:
    #0 0x7f11f1df0db0 in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x50db0)
    #1 0x55b866fa3ad7 in CreateThreadJoinable shared/pthreads_op.c:47
    #2 0x55b866fa3c5c in CreateThread shared/pthreads_op.c:62
    #3 0x55b866e76409 in OS_ReadMSG analysisd/analysisd.c:937
    #4 0x55b866e756b5 in main analysisd/analysisd.c:711
    #5 0x7f11f15d609a in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: heap-use-after-free (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x53513)
Shadow bytes around the buggy address:
  0x0c32801266b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c32801266c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c32801266d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c32801266e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c32801266f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c3280126700: fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd fd
  0x0c3280126710: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3280126720: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3280126730: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3280126740: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
  0x0c3280126750: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==12008==ABORTING
```

## Tests

- [X] Compile manager on Linux.
- [X] Source installation.
- [X] AddressSanitizer report (shown above).
- [X] ThreadSanitizer report (shown above).