### PR TITLE
Handle exception when invalid bucket in AWS wodle

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -847,8 +847,9 @@ class AWSLogsBucket(AWSBucket):
                                                 Prefix=self.get_base_prefix(),
                                                 Delimiter='/')['CommonPrefixes']
                     ]
-        except KeyError:
-            print("ERROR: Invalid type of bucket")
+        except KeyError as err:
+            bucket_types = {'cloudtrail', 'config', 'vpcflow', 'guardduty', 'custom'}
+            print("ERROR: Invalid type of bucket. The bucket was set up as '{}' type and this bucket does not contain log files from this type. Try with other type: {}".format(get_script_arguments().type.lower(), bucket_types - {get_script_arguments().type.lower()}))
             sys.exit(12)
 
     def find_regions(self, account_id):

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -841,11 +841,15 @@ class AWSLogsBucket(AWSBucket):
         return alert_msg
 
     def find_account_ids(self):
-        return [common_prefix['Prefix'].split('/')[-2] for common_prefix in
-                self.client.list_objects_v2(Bucket=self.bucket,
-                                            Prefix=self.get_base_prefix(),
-                                            Delimiter='/')['CommonPrefixes']
-                ]
+        try:
+            return [common_prefix['Prefix'].split('/')[-2] for common_prefix in
+                    self.client.list_objects_v2(Bucket=self.bucket,
+                                                Prefix=self.get_base_prefix(),
+                                                Delimiter='/')['CommonPrefixes']
+                    ]
+        except KeyError:
+            print("ERROR: Invalid type of bucket")
+            sys.exit(12)
 
     def find_regions(self, account_id):
         regions = self.client.list_objects_v2(Bucket=self.bucket,

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -43,7 +43,8 @@ def test_metadata_version_buckets(mocked_db, class_):
     """
     Checks if metadata version has been updated
     """
-    with patch(f'aws_s3.{class_.__name__}.get_client'):
+    with patch(f'aws_s3.{class_.__name__}.get_client'), \
+        patch(f'aws_s3.{class_.__name__}.get_sts_client'):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test',
                         'only_logs_after': '19700101', 'skip_on_error': True,
@@ -64,7 +65,8 @@ def test_metadata_version_services(mocked_db, class_):
     """
     Checks if metadata version has been updated
     """
-    with patch(f'aws_s3.{class_.__name__}.get_client'):
+    with patch(f'aws_s3.{class_.__name__}.get_client'), \
+        patch(f'aws_s3.{class_.__name__}.get_sts_client'):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'aws_profile': None, 'iam_role_arn': None,
                         'only_logs_after': '19700101', 'region': None})
@@ -87,6 +89,7 @@ def test_db_maintenance(class_, sql_file, db_name):
     Checks DB maintenance
     """
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
+        patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
         patch('sqlite3.connect', side_effect=get_fake_s3_db(sql_file)):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test-bucket',


### PR DESCRIPTION
Hi team,

This PR solves #2586. I added a try/except block to catch a `KeyError` which happens when we introduce a bad type of bucket:

```bash
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix macie --type cloudtrail --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
ERROR: Invalid type of bucket
```

Furthermore, I updated unit tests for AWS wodle.

Best regards,

Demetrio.