### PR TITLE
Fix bug when displaying hostname in JSON alerts

### DIFF
--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -21,7 +21,7 @@ static const char *hostname_pattern =
         "[0-9]{2,4} [A-Za-z]{3} [0-9]{1,2} [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}"
     ") "
     "([^ ]+)";
-regex_t * regexCompiled;
+regex_t * regexCompiled = NULL;
 
 void W_ParseJSON(cJSON* root, const Eventinfo* lf)
 {
@@ -324,11 +324,15 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
         }
     }
 
-    if(regexec(regexCompiled, lf->full_log, 3, match, 0) == 0){
+    if (lf->hostname) {
+        os_strdup(lf->hostname, agent_hostname);
+    } else if(regexec(regexCompiled, lf->full_log, 3, match, 0) == 0){
         match_size = match[2].rm_eo - match[2].rm_so;
         agent_hostname = malloc(match_size + 1);
-        snprintf (agent_hostname, match_size + 1, "%.*s", match_size, lf->full_log + match[2].rm_so);
+        snprintf(agent_hostname, match_size + 1, "%.*s", match_size, lf->full_log + match[2].rm_so);
+    }
 
+    if (agent_hostname) {
         if (!cJSON_HasObjectItem(root, "predecoder")) {
             cJSON_AddItemToObject(root, "predecoder", predecoder = cJSON_CreateObject());
         } else {

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -324,15 +324,11 @@ void W_JSON_ParseHostname(cJSON* root,const Eventinfo* lf)
         }
     }
 
-    if (lf->hostname) {
-        os_strdup(lf->hostname, agent_hostname);
-    } else if(regexec(regexCompiled, lf->full_log, 3, match, 0) == 0){
+    if(regexec(regexCompiled, lf->full_log, 3, match, 0) == 0) {
         match_size = match[2].rm_eo - match[2].rm_so;
         agent_hostname = malloc(match_size + 1);
         snprintf(agent_hostname, match_size + 1, "%.*s", match_size, lf->full_log + match[2].rm_so);
-    }
 
-    if (agent_hostname) {
         if (!cJSON_HasObjectItem(root, "predecoder")) {
             cJSON_AddItemToObject(root, "predecoder", predecoder = cJSON_CreateObject());
         } else {


### PR DESCRIPTION
|Related issue|
|---|
|#3644|

The reason for the issue is that the JSON alerts display a hostname extracted from the `full_log` by a regular expression, while the `ossec-logtest` tool uses the value extracted from the `predecoder`.

https://github.com/wazuh/wazuh/blob/68aaf6d31557106bc8b3cb58b81388644cb27ff5/src/analysisd/cleanevent.c#L149

The re-extraction of this field in the JSON alert generator may be considered an inconsistence, but it should work. If you is not doing so, it is because the regular expression does not cover all the `timestamp` formats that precede the `hostname`.

https://github.com/wazuh/wazuh/blob/68aaf6d31557106bc8b3cb58b81388644cb27ff5/src/analysisd/format/json_extended.c#L15

In 98e4f52ab445a163c9701dc75e18f7571c627dfa the variety of date formats covered by the regular expression has expanded. 

These are the timestamps tested for each regular subexpression:

https://github.com/wazuh/wazuh/blob/0711f27e8a563684082a5ec1c5dc5aedbaf77e0b/src/analysisd/format/json_extended.c#L17

> Dec 29 10:00:01 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command

https://github.com/wazuh/wazuh/blob/0711f27e8a563684082a5ec1c5dc5aedbaf77e0b/src/analysisd/format/json_extended.c#L19

> 2007-06-14T15:48:55-04:00 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command
> 2009-05-22T09:36:46.214994-07:00 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command
> 2015-04-16 21:51:02,805 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command
> 2019-07-10T22:00:43.000000+00:00 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command

https://github.com/wazuh/wazuh/blob/0711f27e8a563684082a5ec1c5dc5aedbaf77e0b/src/analysisd/format/json_extended.c#L21

> 2015 Dec 29 10:00:01 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command

The following logs can be handled by the regular expression used to get the `hostname` when the JSON alert is being generated, but they will never get to this section because they are not valid for `pre-decoder`:

> 19-6-2T5:48:55-4:00 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command
> Dec 29 9:0:5 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command
> 15 Dec 9 10:00:01 test_hostname sudo[12345]:     myUser : TTY=unknown ; PWD=/my/path ; USER=root ; COMMAND=/my/secret/command

It is possible to think that to extract the hostname from the `full_log` at this point is to repeat the work of the `pre-decoder`. 0711f27 avoids using the regular expression if this field is other than NULL.

However, this only works as expected for plain events generated by the manager due to:

- **For agents**, these fields take the agent name value and not the hostname extracted from the event.
- **For non-plain events** as Syscheck or SCA, the `pre-decoder` does not extract the hostname, so we that commit forces this alert field with an invalid value (the agent name).

``` JSON
"predecoder":{
        "hostname":"agcent7"
 }
```

For this reason, this behavior has been reversed in b19a2e60cc553b8d0c5a1306d7d963be8306b500.

## Tests

- For registered agents with a name other than its hostname.
  - [x] There is no `predecoder.hostname` field for Syscheck events.
  - [x] There is no `predecoder.hostname` field for SCA events.
  - [x] For plain text logs, the `predecoder.hostname` field takes the value extracted from the log and not the agent name.
- For managers.
  - [x] There is no `predecoder.hostname` field for Syscheck events.
  - [x] There is no `predecoder.hostname` field for SCA events.
  - [x] For plain text logs, the `predecoder.hostname` field takes the value extracted from the log other than the name of the agent (hostname).
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
