### PR TITLE
Log type for inability to resolve manager address

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -83,9 +83,9 @@ bool connect_server(int server_id, bool verbose)
     if (tmp_str == NULL || *tmp_str == '\0') {
         if (agt->server[server_id].rip != NULL) {
             const int rip_l = strlen(agt->server[server_id].rip);
-            mdebug2("Could not resolve hostname '%.*s'", agt->server[server_id].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[server_id].rip);
+            minfo("Could not resolve hostname '%.*s'", agt->server[server_id].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[server_id].rip);
         } else {
-            mdebug2("Could not resolve hostname");
+            minfo("Could not resolve hostname");
         }
 
         return false;

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -165,7 +165,7 @@ static int teardown_test(void **state) {
 /* connect_server */
 static void test_connect_server(void **state) {
     bool connected = false;
-    expect_any(__wrap__mdebug2, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
     /* Connect to first server (UDP)*/
     will_return(__wrap_getDefine_Int, 5);
     will_return(__wrap_OS_ConnectUDP, 11);


### PR DESCRIPTION
As explained in #3658 when an agent is unable to connect to the manager the log should be more visible than a debug level 2 message. This PR proposes an INFO type of message (although it could arguably be an ERROR message).

|Related issue|
|---|
|Closes #3658|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The log message uses the `minfo` function instead of the `mdebug2` function so it is visible even if debugging is not allowed. 

## Logs/Alerts example
Currently the following log appears in an agent's `ossec.log` file when the manager's address is misconfigured only if debugging of a level 2 is enabled.
`[TIMESTAMP] ossec-agentd[9496] start_agent.c:64 at connect_server(): DEBUG: Could not resolve hostname 'master01.lab.wazuh.info '`

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [ ] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
