### PR TITLE
Fix pointer to compare the log level of Prelude and the current event

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1848,7 +1848,7 @@ void * w_writer_log_thread(__attribute__((unused)) void * args ){
     #ifdef PRELUDE_OUTPUT_ENABLED
                 /* Log to prelude */
                 if (Config.prelude) {
-                    if (Config.prelude_log_level <= currently_rule->level) {
+                    if (Config.prelude_log_level <= lf->currently_rule->level) {
                         OS_PreludeLog(lf);
                     }
                 }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1848,7 +1848,7 @@ void * w_writer_log_thread(__attribute__((unused)) void * args ){
     #ifdef PRELUDE_OUTPUT_ENABLED
                 /* Log to prelude */
                 if (Config.prelude) {
-                    if (Config.prelude_log_level <= lf->currently_rule->level) {
+                    if (Config.prelude_log_level <= lf->generated_rule->level) {
                         OS_PreludeLog(lf);
                     }
                 }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1847,7 +1847,7 @@ void * w_writer_log_thread(__attribute__((unused)) void * args ){
 
     #ifdef PRELUDE_OUTPUT_ENABLED
                 /* Log to prelude */
-                if (Config.prelude) {
+                if (Config.prelude && lf->generated_rule != NULL) {
                     if (Config.prelude_log_level <= lf->generated_rule->level) {
                         OS_PreludeLog(lf);
                     }


### PR DESCRIPTION
The pointer used for comparison was not updated.

|Related issue|
|---|
|#2552|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The pointer `lf` contains the `current_rule` object, which was used before, but not updated.

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation