### PR TITLE
Add global id validator for SCA policies

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -582,7 +582,7 @@ static void wm_sca_read_files(wm_sca_t * data) {
 
                 minfo("Evaluation finished for policy '%s'.",data->profile[i]->profile);
                 wm_sca_reset_summary();
-                
+
                 w_rwlock_unlock(&dump_rwlock);
             }
 
@@ -705,7 +705,7 @@ static int wm_sca_check_policy(cJSON * policy, cJSON * profiles, OSHash *global_
             size_t key_length = snprintf(NULL, 0, "%d", check_id->valueint);
             os_malloc(key_length + 1, key_id);
             snprintf(key_id, key_length + 1, "%d", check_id->valueint);
-            
+
             if((coincident_policy = (char *)OSHash_Get(global_check_list, key_id)), coincident_policy){
                 // Invalid ID
                 mwarn("Invalid check ID: %d. It was found in policy %s", check_id->valueint, coincident_policy);
@@ -1203,7 +1203,7 @@ static int wm_sca_do_scan(cJSON *profile_check, OSStore *vars, wm_sca_t * data, 
                         g_found = -1;
                     }
                 }
-                
+
                 if (g_found != 2) {
                     os_free(reason);
                 }
@@ -1461,7 +1461,7 @@ static int wm_sca_check_file(char * const file, char * const pattern, char **rea
         }
         return 2;
     }
-    
+
     char *pattern_ref = pattern;
 
     /* by default, assume a negative rule, i.e, an NIN rule */
@@ -1487,7 +1487,7 @@ static int wm_sca_check_file(char * const file, char * const pattern, char **rea
         } else {
             merror("Complex rule without IN/NIN: %s. Invalid.", pattern_ref);
             return 0;
-        }   
+        }
     }
 
     int result_accumulator = pattern_ref ? 0 : 1;
@@ -2158,9 +2158,9 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
                 } else {
                     merror("Complex rule without IN/NIN: %s. Invalid.", pattern_ref);
                     return 0;
-                }   
+                }
             }
-            
+
             int result = wm_sca_pt_matches(var_storage, pattern_ref);
             if (result){
                 mdebug2("Result for %s(%s) -> 1", reg_value, var_storage);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -637,6 +637,12 @@ static int wm_sca_check_policy(cJSON * policy, cJSON * profiles, OSHash *global_
         mwarn("Invalid format for field 'id'.");
         return retval;
     }
+    
+    char *coincident_policy_file;
+    if((coincident_policy_file = OSHash_Get(global_check_list,id->valuestring)), coincident_policy_file) {
+        mwarn("Duplicated policy ID: %s. File '%s' has the same policy ID.", id->valuestring, coincident_policy_file);
+        return 1;
+    }
 
     name = cJSON_GetObjectItem(policy, "name");
     if(!name) {
@@ -780,6 +786,9 @@ static int wm_sca_check_policy(cJSON * policy, cJSON * profiles, OSHash *global_
         }
 
         int i;
+        char *policy_file = NULL;
+        os_strdup(file->valuestring, policy_file);
+        OSHash_Add(global_check_list, id->valuestring, policy_file);
         for (i = 0; read_id[i] != 0; ++i) {
             char *local_id;
             size_t key_length = snprintf(NULL, 0, "%d", read_id[i]);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -561,7 +561,7 @@ static void wm_sca_read_files(wm_sca_t * data) {
                 minfo("Starting evaluation of policy: '%s'", data->profile[i]->profile);
 
                 if (wm_sca_do_scan(profiles,vars,data,id,policy,0,cis_db_index,data->profile[i]->remote,first_scan,&checks_number) != 0) {
-                    merror("Evaluating the policy file: '%s'. Set debug mode for more detailed information.", data->profile[i]->profile);
+                    merror("Error while evaluating the policy '%s'", data->profile[i]->profile);
                 }
                 mdebug1("Calculating hash for scanned results.");
                 char * integrity_hash = wm_sca_hash_integrity(cis_db_index);
@@ -704,7 +704,7 @@ static int wm_sca_check_policy(cJSON * policy, cJSON * profiles, OSHash *global_
 
             if((coincident_policy = (char *)OSHash_Get(global_check_list, key_id)), coincident_policy){
                 // Invalid ID
-                mwarn("Invalid check ID: %d. It was found in policy %s", check_id->valueint, coincident_policy);
+                mwarn("Duplicated check ID: %d. First appearance at policy '%s'", check_id->valueint, coincident_policy);
                 os_free(key_id);
                 os_free(read_id);
                 return 1;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -779,14 +779,14 @@ static int wm_sca_check_policy(cJSON * policy, cJSON * profiles, OSHash *global_
             rules_n = 0;
         }
 
-        char *policy_id;
-        os_strdup(id->valuestring, policy_id);
         int i;
-        for(i = 0; read_id[i] != 0; ++i) {
+        for (i = 0; read_id[i] != 0; ++i) {
             char *local_id;
             size_t key_length = snprintf(NULL, 0, "%d", read_id[i]);
             os_malloc(key_length + 1, local_id);
             snprintf(local_id, key_length + 1, "%d", read_id[i]);
+            char *policy_id = NULL;
+            os_strdup(id->valuestring, policy_id);
             OSHash_Add(global_check_list, local_id, policy_id);
             os_free(local_id);
         }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -637,10 +637,10 @@ static int wm_sca_check_policy(cJSON * policy, cJSON * profiles, OSHash *global_
         mwarn("Invalid format for field 'id'.");
         return retval;
     }
-    
+
     char *coincident_policy_file;
     if((coincident_policy_file = OSHash_Get(global_check_list,id->valuestring)), coincident_policy_file) {
-        mwarn("Duplicated policy ID: %s. File '%s' has the same policy ID.", id->valuestring, coincident_policy_file);
+        mwarn("Duplicated policy ID: %s. File '%s' contains the same ID.", id->valuestring, coincident_policy_file);
         return 1;
     }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -50,8 +50,8 @@ static int wm_sca_send_event_check(wm_sca_t * data,cJSON *event);  // Send check
 static void wm_sca_read_files(wm_sca_t * data);  // Read policy monitoring files
 static int wm_sca_do_scan(cJSON *profile_check,OSStore *vars,wm_sca_t * data,int id,cJSON *policy,int requirements_scan,int cis_db_index,unsigned int remote_policy,int first_scan, int *checks_number);
 static int wm_sca_send_summary(wm_sca_t * data, int scan_id,unsigned int passed, unsigned int failed,unsigned int invalid,cJSON *policy,int start_time,int end_time, char * integrity_hash, char * integrity_hash_file, int first_scan, int id, int checks_number);
-static int wm_sca_check_policy(cJSON * policy, cJSON * profiles, OSHash *global_check_list);
-static int wm_sca_check_requirements(cJSON * requirements);
+static int wm_sca_check_policy(cJSON *policy, cJSON *profiles, OSHash *global_check_list);
+static int wm_sca_check_requirements(cJSON *requirements);
 static void wm_sca_summary_increment_passed();
 static void wm_sca_summary_increment_failed();
 static void wm_sca_summary_increment_invalid();
@@ -91,10 +91,6 @@ static int wm_sca_test_key(char *subkey, char *full_key_name, unsigned long arch
 static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *reg_option, char *reg_value, char **reason);
 static char *wm_sca_getrootdir(char *root_dir, int dir_size);
 #endif
-
-void clean_data(void* data){
-    os_free(data);
-}
 
 cJSON *wm_sca_dump(const wm_sca_t * data);     // Read config
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3657|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The checks of SCA policies must have a unique ID among all the policies. This PR mark as invalid a policy with a repeated ID and avoid to scan it. This way, we avoid generating inconsistency in the database

## Logs/Alerts example

```
2019/07/16 12:55:57 sca: WARNING: Invalid check ID: 1500. It was found in policy system_audit
2019/07/16 12:55:57 sca: WARNING: Validating policy file: 
/var/ossec/ruleset/sca/system_audit_ssh.yml'. Skipping it.
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
  - [x] Scan build
- [x] Retrocompatibility with older Wazuh versions
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

Valgrind report
-------
![image](https://user-images.githubusercontent.com/9034923/61289996-0a07e500-a7cb-11e9-966a-6355dc6d87cd.png)

Scan-build report
-------
![image](https://user-images.githubusercontent.com/9034923/61300430-3b3fdf80-a7e2-11e9-8356-48321799931d.png)
