### PR TITLE
Adapt framework to deprecation of internal options

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -138,7 +138,7 @@ if __name__ == '__main__':
     try:
         debug_mode = configuration.get_internal_options_value('wazuh_clusterd', 'debug', 2, 0) or args.debug_level
     except Exception:
-        debug_mode = 0
+        debug_mode = cluster.read_config().get('log_level')
 
     # set correct permissions on cluster.log file
     if os.path.exists('{0}/logs/cluster.log'.format(common.ossec_path)):

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -6,7 +6,7 @@ from wazuh.utils import md5, mkdir_with_mode
 from wazuh.exception import WazuhException
 from wazuh.agent import Agent
 from wazuh.manager import status, restart
-from wazuh.configuration import get_ossec_conf
+from wazuh.configuration import get_ossec_conf, get_internal_options_value
 from wazuh.InputValidator import InputValidator
 from wazuh.database import Connection
 from wazuh import common
@@ -98,7 +98,8 @@ def read_config(config_file=common.ossec_conf):
         'port': 1516,
         'bind_addr': '0.0.0.0',
         'nodes': ['NODE_IP'],
-        'hidden': 'no'
+        'hidden': 'no',
+        'log_level': 0
     }
 
     try:
@@ -117,10 +118,27 @@ def read_config(config_file=common.ossec_conf):
     for value_name in set(cluster_default_configuration.keys()) - set(config_cluster.keys()):
         config_cluster[value_name] = cluster_default_configuration[value_name]
 
+    # check port value
     if isinstance(config_cluster['port'], str) and not config_cluster['port'].isdigit():
         raise WazuhException(3004, "Cluster port must be an integer.")
-
+    # cast port value to integer
     config_cluster['port'] = int(config_cluster['port'])
+
+    # get log_level from internal options if this value exists
+    try:
+        config_cluster['log_level'] = get_internal_options_value('wazuh_clusterd', 'debug', 2, 0)
+    except Exception:
+        pass
+
+    # check log_level value
+    try:
+        config_cluster['log_level'] = int(config_cluster['log_level'])
+        allowed_log_levels = {0, 1, 2}
+        if config_cluster['log_level'] not in allowed_log_levels:
+            raise ValueError
+    except ValueError:
+        raise WazuhException(3004, "Cluster log level only accepts one of these values: 0, 1 or 2")
+
     if config_cluster['disabled'] == 'no':
         config_cluster['disabled'] = False
     elif config_cluster['disabled'] == 'yes':

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -714,7 +714,7 @@ def get_active_configuration(agent_id, component, configuration):
         raise WazuhException(1307)
 
     components = {"agent", "agentless", "analysis", "auth", "com", "csyslog", "integrator", "logcollector", "mail",
-                  "monitor", "request", "syscheck", "wmodules"}
+                  "monitor", "request", "syscheck", "wmodules", "wazuhdb"}
 
     # checks if the component is correct
     if component not in components:


### PR DESCRIPTION
Hi team,

This PR closes #3462 (which is part of #3150).

`wazuhdb` was added to the on-demand configuration components:

```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/master/config/wazuhdb/internal?pretty"
{
   "error": 0,
   "data": {
      "internal": {
         "wdb": {
            "worker_pool_size": 8,
            "commit_time": 60,
            "open_db_limit": 64,
            "rlimit_nofile": 65536,
            "log_level": 0,
            "thread_stack_size": 8192
         }
      }
   }
}
```

Cluster reads the debug configuration from `ossec.conf` if this option is not present into `internal_options` or `local_internal_options`. I made different tests for checking that log level configuration is set properly depending if it was set in `local_internal_options`, `internal_options` or `ossec.conf`.

`log_level` is not set in any configuration:
```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/master/config/com/cluster?pretty"
{
   "error": 0,
   "data": {
      "name": "wazuh",
      "node_name": "master",
      "node_type": "master",
      "key": "9d273b53510fef702b54a92e9cffc82e",
      "port": 1516,
      "bind_addr": "0.0.0.0",
      "nodes": [
         "wazuh-master"
      ],
      "hidden": "no",
      "disabled": false,
      "log_level": 0
   }
}
```

`log_level=1` in `ossec.conf`:
```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/master/config/com/cluster?pretty"
{
   "error": 0,
   "data": {
      "name": "wazuh",
      "node_name": "master",
      "node_type": "master",
      "key": "9d273b53510fef702b54a92e9cffc82e",
      "port": 1516,
      "bind_addr": "0.0.0.0",
      "nodes": [
         "wazuh-master"
      ],
      "hidden": "no",
      "disabled": false,
      "log_level": 1
   }
}
```

`log_level=2` in `internal_options`:
```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/master/config/com/cluster?pretty"
{
   "error": 0,
   "data": {
      "name": "wazuh",
      "node_name": "master",
      "node_type": "master",
      "key": "9d273b53510fef702b54a92e9cffc82e",
      "port": 1516,
      "bind_addr": "0.0.0.0",
      "nodes": [
         "wazuh-master"
      ],
      "hidden": "no",
      "disabled": false,
      "log_level": 2
   }
}
```

`log_level=1` in `local_internal_options`:
```bash
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/master/config/com/cluster?pretty"
{
   "error": 0,
   "data": {
      "name": "wazuh",
      "node_name": "master",
      "node_type": "master",
      "key": "9d273b53510fef702b54a92e9cffc82e",
      "port": 1516,
      "bind_addr": "0.0.0.0",
      "nodes": [
         "wazuh-master"
      ],
      "hidden": "no",
      "disabled": false,
      "log_level": 1
   }
}
```

If `log_level` is set with a value higher than `2`, `log_level` will be equal to `2`, which is the maximum value.

Best regards,

Demetrio.