### PR TITLE
Close a possible handler leak in Windows

### DIFF
--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -129,7 +129,7 @@ int set_winsacl(const char *dir, int position) {
 
 	if (set_privilege(hdle, priv, TRUE)) {
 		merror(FIM_ERROR_SACL_ELEVATE_PRIVILEGE, GetLastError());
-		return 1;
+		goto end;
 	}
 
     privilege_enabled = 1;


### PR DESCRIPTION
This PR closes a handler that can remain open if the `set_privilege` call fails in whodata for Windows. 

We are not aware that this has happened in any environment.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
