### PR TITLE
Let Wazuh DB remove agent databases immediately

### DIFF
--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -125,7 +125,6 @@ typedef struct wdb_t {
     time_t last;
     pthread_mutex_t mutex;
     struct wdb_t * next;
-    int remove;
 } wdb_t;
 
 typedef struct wdb_config {
@@ -498,14 +497,14 @@ void wdb_commit_old();
 
 void wdb_close_old();
 
-void wdb_remove_database(wdb_t *wdb);
+int wdb_remove_database(const char * agent_id);
 
 cJSON * wdb_exec(sqlite3 * db, const char * sql);
 
 // Execute SQL script into an database
 int wdb_sql_exec(wdb_t *wdb, const char *sql_exec);
 
-int wdb_close(wdb_t * wdb);
+int wdb_close(wdb_t * wdb, bool commit);
 
 void wdb_leave(wdb_t * wdb);
 

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -59,7 +59,7 @@ wdb_t * wdb_backup(wdb_t *wdb, int version) {
     os_strdup(wdb->agent_id, sagent_id),
     snprintf(path, PATH_MAX, "%s/%s.db", WDB2_DIR, sagent_id);
 
-    if (wdb_close(wdb) != -1) {
+    if (wdb_close(wdb, TRUE) != -1) {
         if (wdb_create_backup(sagent_id, version) != -1) {
             mwarn("Creating DB backup and create clear DB for agent: '%s'", sagent_id);
             unlink(path);


### PR DESCRIPTION
|Related issue|Depends on|
|---|---|
|#3671|#3627|

Currently, agent deletion queries to Wazuh DB make the database mark the agent as pending to delete. The agent database is removed when Wazuh DB commits or closes it, about a minute after the last query to that agent.

We detected two issues:

1. If Wazuh DB receives a query for an agent pending to remove, it ignores the request. That blocks the client (Analysisd, Vulnerability Detector and Wazuh API).
2. Wazuh DB removes only one agent per scan cycle, in order to avoid an _use-after-free_ hazard. That may delay the disposer thread and make Wazuh DB use too much resources.

## Fix proposed

The agent deletion queries will close and remove the database immediately. If the database is in transaction mode (needs to commit changes), those pending changes will be discarded.

## Affected queries

- Single agent deletion
```
agent ID remove
```

- Multiple agent deletion
```
wazuhdb remove ID1 ID2 (...) IDn
```

## Logs/Alerts example

```
2019/07/18 19:15:24 wazuh-db[7121] wdb.c:894 at wdb_remove_multiple_agents(): DEBUG: Deleting databases. JSON output: {"agents":{"001":"ok","002":"ok","099":"ok","100":"ok","101":"Can't delete"}}
```

## Tests

### Functional tests

- [X] Run 100 parallel clients running 1000 load/save queries for FIM.
- [X] Remove 100 databases in one query.
- [X] Try to remove 12.000 databases in one query.

### Standard tests

- [X] Compile manager on Linux.
- [X] Source installation.
- [X] Source upgrade.
- [X] Run Wazuh DB on Valgrind.
- [x] QA templates contemplate the added capabilities.

### Valgrind report

```
==7121== HEAP SUMMARY:
==7121==     in use at exit: 8,616 bytes in 3 blocks
==7121==   total heap usage: 343,964 allocs, 343,961 frees, 103,123,038 bytes allocated
==7121==
==7121== 272 bytes in 1 blocks are possibly lost in loss record 2 of 3
==7121==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==7121==    by 0x40116D1: allocate_dtv (dl-tls.c:286)
==7121==    by 0x401203D: _dl_allocate_tls (dl-tls.c:532)
==7121==    by 0x4E5FB95: allocate_stack (allocatestack.c:621)
==7121==    by 0x4E5FB95: pthread_create@@GLIBC_2.2.5 (pthread_create.c:669)
==7121==    by 0x112D26: main (main.c:197)
==7121==
==7121== LEAK SUMMARY:
==7121==    definitely lost: 0 bytes in 0 blocks
==7121==    indirectly lost: 0 bytes in 0 blocks
==7121==      possibly lost: 272 bytes in 1 blocks
==7121==    still reachable: 8,344 bytes in 2 blocks
==7121==         suppressed: 0 bytes in 0 blocks
==7121== Reachable blocks (those to which a pointer was found) are not shown.
```