### PR TITLE
Fix errors in file permissions to avoid problems synchronizing cluster files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.9.4]
 
+### Fixed
+
+- Cluster could fail synchronizing some files located in Docker volumes. ([#3669](https://github.com/wazuh/wazuh/issues/3669))
 
 ## [v3.9.3] - 2019-07-08
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -531,10 +531,10 @@ class Agent:
                         else:
                             remove(agent_file)
                     elif not path.exists(backup_file):
-                        move(agent_file, backup_file, copy_function=copyfile)
+                        safe_move(agent_file, backup_file, permissions=0o660)
 
             # Overwrite client.keys
-            safe_move(f_keys_temp, common.client_keys)
+            safe_move(f_keys_temp, common.client_keys, permissions=0o640)
         except Exception as e:
             raise WazuhException(1748, str(e))
 
@@ -731,7 +731,7 @@ class Agent:
                     f_kt.write('{0} {1} {2} {3}\n'.format(agent_id, name, ip, agent_key))
 
                 # Overwrite client.keys
-                move(f_keys_temp, common.client_keys, copy_function=copyfile)
+                safe_move(f_keys_temp, common.client_keys, permissions=f_keys_st.st_mode)
             except WazuhException as ex:
                 fcntl.lockf(lock_file, fcntl.LOCK_UN)
                 lock_file.close()
@@ -771,7 +771,7 @@ class Agent:
         group_path = "{0}/{1}".format(common.shared_path, group_id)
         group_backup = "{0}/groups/{1}_{2}".format(common.backup_path, group_id, int(time()))
         if path.exists(group_path):
-            move(group_path, group_backup, copy_function=copyfile)
+            safe_move(group_path, group_backup, permissions=0o660)
 
         msg = "Group '{0}' removed.".format(group_id)
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2,31 +2,34 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import errno
+import hashlib
 import operator
-from wazuh.utils import cut_array, sort_array, search_array, chmod_r, chown_r, WazuhVersion, plain_dict_to_nested_dict, \
-                        get_fields_to_nest, get_hash, WazuhDBQuery, WazuhDBQueryDistinct, WazuhDBQueryGroupBy, mkdir_with_mode, \
-                        md5, safe_move
+import socket
+from base64 import b64encode
+from datetime import date, datetime, timedelta
+from functools import reduce
+from glob import glob
+from json import loads
+from os import chown, chmod, path, makedirs, urandom, listdir, stat, remove
+from platform import platform
+from shutil import copyfile, rmtree
+from time import time, sleep
+
+import fcntl
+import requests
+
+from wazuh import manager, common, configuration
+from wazuh.InputValidator import InputValidator
+from wazuh.database import Connection
 from wazuh.exception import WazuhException
 from wazuh.ossec_queue import OssecQueue
 from wazuh.ossec_socket import OssecSocket, OssecSocketJSON
-from wazuh.database import Connection
+from wazuh.utils import cut_array, sort_array, search_array, chmod_r, chown_r, WazuhVersion, plain_dict_to_nested_dict, \
+    get_fields_to_nest, get_hash, WazuhDBQuery, WazuhDBQueryDistinct, WazuhDBQueryGroupBy, mkdir_with_mode, \
+    md5, safe_move
 from wazuh.wdb import WazuhDBConnection
-from wazuh.InputValidator import InputValidator
-from wazuh import manager, common, configuration
-from glob import glob
-from datetime import date, datetime, timedelta
-from base64 import b64encode
-from shutil import copyfile, move, rmtree
-from platform import platform
-from os import chown, chmod, path, makedirs, urandom, listdir, stat, remove
-from time import time, sleep
-import socket
-import hashlib
-import fcntl
-from json import loads
-from functools import reduce
-import errno
-import requests
+
 
 def create_exception_dic(id, e):
     """

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1,5 +1,3 @@
-
-
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
@@ -7,7 +5,7 @@
 import operator
 from wazuh.utils import cut_array, sort_array, search_array, chmod_r, chown_r, WazuhVersion, plain_dict_to_nested_dict, \
                         get_fields_to_nest, get_hash, WazuhDBQuery, WazuhDBQueryDistinct, WazuhDBQueryGroupBy, mkdir_with_mode, \
-                        md5
+                        md5, safe_move
 from wazuh.exception import WazuhException
 from wazuh.ossec_queue import OssecQueue
 from wazuh.ossec_socket import OssecSocket, OssecSocketJSON
@@ -20,7 +18,7 @@ from datetime import date, datetime, timedelta
 from base64 import b64encode
 from shutil import copyfile, move, rmtree
 from platform import platform
-from os import chown, chmod, path, makedirs, rename, urandom, listdir, stat, remove
+from os import chown, chmod, path, makedirs, urandom, listdir, stat, remove
 from time import time, sleep
 import socket
 import hashlib
@@ -533,10 +531,10 @@ class Agent:
                         else:
                             remove(agent_file)
                     elif not path.exists(backup_file):
-                        rename(agent_file, backup_file)
+                        move(agent_file, backup_file, copy_function=copyfile)
 
             # Overwrite client.keys
-            move(f_keys_temp, common.client_keys, copy_function=copyfile)
+            safe_move(f_keys_temp, common.client_keys)
         except Exception as e:
             raise WazuhException(1748, str(e))
 

--- a/framework/wazuh/cluster/cluster.json
+++ b/framework/wazuh/cluster/cluster.json
@@ -12,7 +12,7 @@
         },
 
         "/etc/shared/": {
-            "permissions": "0o640",
+            "permissions": "0o660",
             "source": "master",
             "files": ["merged.mg"],
             "recursive": true,
@@ -23,7 +23,7 @@
         },
 
         "/var/multigroups/": {
-            "permissions": "0o640",
+            "permissions": "0o660",
             "source": "master",
             "files": ["merged.mg"],
             "recursive": true,
@@ -34,7 +34,7 @@
         },
 
         "/etc/rules/": {
-            "permissions": "0o640",
+            "permissions": "0o660",
             "source": "master",
             "files": ["all"],
             "recursive": true,
@@ -45,7 +45,7 @@
         },
 
         "/etc/decoders/": {
-            "permissions": "0o640",
+            "permissions": "0o660",
             "source": "master",
             "files": ["all"],
             "recursive": true,

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -421,13 +421,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
                 else:
                     zip_path = "{}{}".format(decompressed_files_path, name)
-                    shutil.move(zip_path, full_path, copy_function=shutil.copyfile)
-                    try:
-                        os.chown(full_path, common.ossec_uid, common.ossec_gid)
-                        os.chmod(full_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
-                    except PermissionError:
-                        # We don't care for errors since shutil.move preserve ownership and permissions
-                        pass
                     utils.safe_move(zip_path, full_path,
                                     ownership=(common.ossec_uid, common.ossec_gid),
                                     permissions=self.cluster_items['files'][data['cluster_item_key']]['permissions']

--- a/framework/wazuh/cluster/tests/test_cluster.py
+++ b/framework/wazuh/cluster/tests/test_cluster.py
@@ -97,7 +97,7 @@ def test_checking_configuration(read_config):
             cluster.check_cluster_config(configuration)
 
 
-agent_info = """Linux |agent1 |3.10.0-862.el7.x86_64 |#1 SMP Fri Apr 20 16:44:24 UTC 2018 |x86_64 [CentOS Linux|centos: 7 (Core)] - Wazuh v3.7.2 / d10d46b48c280384e8773a5fa24ecacb
+agent_info = b"""Linux |agent1 |3.10.0-862.el7.x86_64 |#1 SMP Fri Apr 20 16:44:24 UTC 2018 |x86_64 [CentOS Linux|centos: 7 (Core)] - Wazuh v3.7.2 / d10d46b48c280384e8773a5fa24ecacb
 5b458d5fa953a391de1130a2625f3df2 merged.mg
 
 
@@ -117,12 +117,12 @@ def test_merge_agent_info(stat_mock, listdir_mock):
 
     with patch('builtins.open', mock_open(read_data=agent_info)) as m:
         cluster.merge_agent_info('agent-info', 'worker1')
-        m.assert_any_call('/var/ossec/queue/cluster/worker1/agent-info.merged', 'w')
-        m.assert_any_call('/var/ossec/queue/agent-info/agent1-any', 'r')
-        m.assert_any_call('/var/ossec/queue/agent-info/agent2-any', 'r')
+        m.assert_any_call('/var/ossec/queue/cluster/worker1/agent-info.merged', 'wb')
+        m.assert_any_call('/var/ossec/queue/agent-info/agent1-any', 'rb')
+        m.assert_any_call('/var/ossec/queue/agent-info/agent2-any', 'rb')
         handle = m()
-        handle.write.assert_any_call(f'{len(agent_info)} agent1-any '
-                                     f'{datetime.utcfromtimestamp(stat_mock.return_value.st_mtime)}\n{agent_info}')
+        expected = f'{len(agent_info)} agent1-any {datetime.utcfromtimestamp(stat_mock.return_value.st_mtime)}\n'.encode() + agent_info
+        handle.write.assert_any_call(expected)
 
 
 @pytest.mark.parametrize('agent_info, exception', [

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -18,6 +18,7 @@ from wazuh.agent import Agent
 from wazuh.database import Connection
 from wazuh.cluster.dapi import dapi
 from wazuh.wdb import WazuhDBConnection
+from wazuh.utils import safe_move
 
 
 class ReceiveIntegrityTask(c_common.ReceiveFileTask):
@@ -331,15 +332,17 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     tmp_unmerged_path = full_unmerged_name + '.tmp'
                     with open(tmp_unmerged_path, 'wb') as f:
                         f.write(content)
-                    os.chown(tmp_unmerged_path, common.ossec_uid, common.ossec_gid)
-                    os.chmod(tmp_unmerged_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
-                    os.rename(tmp_unmerged_path, full_unmerged_name)
+                    safe_move(tmp_unmerged_path, full_unmerged_name,
+                              permissions=self.cluster_items['files'][data['cluster_item_key']]['permissions'],
+                              ownership=(common.ossec_uid, common.ossec_gid)
+                              )
             else:
                 if not os.path.exists(os.path.dirname(full_filename_path)):
                     utils.mkdir_with_mode(os.path.dirname(full_filename_path))
-                os.rename("{}{}".format(zip_path, filename), full_filename_path)
-                os.chown(full_filename_path, common.ossec_uid, common.ossec_gid)
-                os.chmod(full_filename_path, self.cluster_items['files'][data['cluster_item_key']]['permissions'])
+                safe_move("{}{}".format(zip_path, filename), full_filename_path,
+                          permissions=self.cluster_items['files'][data['cluster_item_key']]['permissions'],
+                          ownership=(common.ossec_uid, common.ossec_gid)
+                          )
 
         logger = self.task_loggers['Integrity']
         errors = {'shared': 0, 'missing': 0, 'extra': 0}

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -8,12 +8,11 @@ import random
 import time
 from os import remove, path as os_path
 import re
-from shutil import move, copyfile
 from xml.dom.minidom import parseString
 from wazuh.exception import WazuhException
 from wazuh import common
 from wazuh.ossec_socket import OssecSocket
-from wazuh.utils import cut_array, load_wazuh_xml
+from wazuh.utils import cut_array, load_wazuh_xml, safe_move
 import subprocess
 
 # Python 2/3 compability
@@ -673,7 +672,7 @@ def upload_group_configuration(group_id, file_content):
         # move temporary file to group folder
         try:
             new_conf_path = "{}/{}/agent.conf".format(common.shared_path, group_id)
-            move(tmp_file_path, new_conf_path, copy_function=copyfile)
+            safe_move(tmp_file_path, new_conf_path, permissions=0o660)
         except Exception as e:
             raise WazuhException(1017, str(e))
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -206,7 +206,6 @@ def test_get_config_error(ossec_socket_mock, test_data, agent_id, component, con
 @patch('wazuh.agent.WazuhDBConnection')
 @patch('wazuh.agent.remove')
 @patch('wazuh.agent.rmtree')
-@patch('wazuh.agent.move')
 @patch('wazuh.agent.chown')
 @patch('wazuh.agent.chmod')
 @patch('wazuh.agent.stat')
@@ -214,12 +213,12 @@ def test_get_config_error(ossec_socket_mock, test_data, agent_id, component, con
 @patch('wazuh.agent.path.exists', side_effect=lambda x: not (common.backup_path in x))
 @patch('wazuh.database.isfile', return_value=True)
 @patch('wazuh.agent.path.isdir', return_value=True)
-@patch('wazuh.agent.rename')
+@patch('wazuh.agent.safe_move')
 @patch('wazuh.agent.makedirs')
 @patch('wazuh.agent.chmod_r')
 @freeze_time('1975-01-01')
-def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isfile_mock, exists_mock, glob_mock,
-                       stat_mock, chmod_mock, chown_mock, move_mock, rmtree_mock, remove_mock, wdb_mock, test_data,
+def test_remove_manual(chmod_r_mock, makedirs_mock, safe_move_mock, isdir_mock, isfile_mock, exists_mock, glob_mock,
+                       stat_mock, chmod_mock, chown_mock, rmtree_mock, remove_mock, wdb_mock, test_data,
                        backup):
     """
     Test the _remove_manual function
@@ -238,10 +237,10 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
         stat_mock.assert_called_once_with(common.client_keys)
         chown_mock.assert_called_once_with(common.client_keys + '.tmp', common.ossec_uid, common.ossec_gid)
         remove_mock.assert_any_call(os.path.join(common.ossec_path, 'queue/rids/001'))
-        assert len((rename_mock if backup else rmtree_mock).mock_calls) == 5
+
         # make sure the mock is called with a string according to a non-backup path
         exists_mock.assert_any_call('/var/ossec/queue/agent-info/agent-1-any')
-        move_mock.assert_called_once_with(common.client_keys + '.tmp', common.client_keys, copy_function=copyfile)
+        safe_move_mock.assert_called_with(common.client_keys + '.tmp', common.client_keys, permissions=0o640)
         if backup:
             backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any')
             makedirs_mock.assert_called_once_with(backup_path)
@@ -258,7 +257,6 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
 @patch('wazuh.agent.WazuhDBConnection')
 @patch('wazuh.agent.remove')
 @patch('wazuh.agent.rmtree')
-@patch('wazuh.agent.move')
 @patch('wazuh.agent.chown')
 @patch('wazuh.agent.chmod')
 @patch('wazuh.agent.stat')
@@ -266,12 +264,12 @@ def test_remove_manual(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isf
 @patch('wazuh.agent.path.exists', side_effect=lambda x: not (common.backup_path in x))
 @patch('wazuh.database.isfile', return_value=True)
 @patch('wazuh.agent.path.isdir', return_value=True)
-@patch('wazuh.agent.rename')
+@patch('wazuh.agent.safe_move')
 @patch('wazuh.agent.makedirs')
 @patch('wazuh.agent.chmod_r')
 @freeze_time('1975-01-01')
-def test_remove_manual_error(chmod_r_mock, makedirs_mock, rename_mock, isdir_mock, isfile_mock, exists_mock, glob_mock,
-                             stat_mock, chmod_mock, chown_mock, move_mock, rmtree_mock, remove_mock, wdb_mock,
+def test_remove_manual_error(chmod_r_mock, makedirs_mock, safe_move_mock, isdir_mock, isfile_mock, exists_mock, glob_mock,
+                             stat_mock, chmod_mock, chown_mock, rmtree_mock, remove_mock, wdb_mock,
                              test_data, agent_id, expected_exception):
     """
     Test the _remove_manual function error cases

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -95,9 +95,9 @@ def test_restart_ok(test_manager):
 @patch('time.time', return_value=0)
 @patch('random.randint', return_value=0)
 @patch('wazuh.manager.chmod')
-@patch('wazuh.manager.move')
+@patch('wazuh.manager.safe_move')
 @patch('wazuh.manager.remove')
-def test_upload_file(remove_mock, move_mock, chmod_mock, mock_rand, mock_time, test_manager, input_file, output_file):
+def test_upload_file(remove_mock, safe_move_mock, chmod_mock, mock_rand, mock_time, test_manager, input_file, output_file):
     """
     Tests uploading a file to the manager
     """
@@ -112,9 +112,9 @@ def test_upload_file(remove_mock, move_mock, chmod_mock, mock_rand, mock_time, t
     m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'))
     m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 'w')
     m.assert_any_call(os.path.join(test_data_path, input_file))
-    move_mock.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'),
-                                      os.path.join(test_data_path, output_file),
-                                      copy_function=copyfile)
+    safe_move_mock.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'),
+                                           os.path.join(test_data_path, output_file),
+                                           permissions=0o660)
     remove_mock.assert_called_once_with(os.path.join(test_data_path, input_file))
 
 

--- a/framework/wazuh/tests/test_utils.py
+++ b/framework/wazuh/tests/test_utils.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from os.path import join, exists
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+from unittest.mock import patch
+
+import pytest
+
+from wazuh.utils import safe_move
+
+
+@patch('wazuh.utils.chown')
+@patch('wazuh.utils.chmod')
+@patch('wazuh.utils.utime')
+@pytest.mark.parametrize('ownership, time, permissions',
+    [((1000, 1000), None, None),
+     ((1000, 1000), (12345, 12345), None),
+     ((1000, 1000), None, 0o660),
+     ((1000, 1000), (12345, 12345), 0o660)
+     ]
+)
+def test_safe_move(mock_utime, mock_chmod, mock_chown, ownership, time, permissions):
+    """Tests safe_move function works"""
+
+    with TemporaryDirectory() as tmpdirname:
+        tmp_file = NamedTemporaryFile(dir=tmpdirname, delete=False)
+        target_file = join(tmpdirname, 'target')
+        safe_move(tmp_file.name, target_file, ownership=ownership, time=time, permissions=permissions)
+        assert(exists(target_file))
+        mock_chown.assert_called_once_with(target_file, *ownership)
+        if time is not None:
+            mock_utime.assert_called_once_with(target_file, time)
+        if permissions is not None:
+            mock_chmod.assert_called_once_with(target_file, permissions)

--- a/src/analysisd/lists_make.c
+++ b/src/analysisd/lists_make.c
@@ -149,6 +149,10 @@ void Lists_OP_MakeCDB(const char *txt_filename, const char *cdb_filename, int fo
             merror(RENAME_ERROR, tmp_filename, cdb_filename, errno, strerror(errno));
             return;
         }
+        if( chmod(cdb_filename, 0660) == -1 ) {
+            merror("Could not chmod cdb list '%s' to 660 due to: [%d - %s]", cdb_filename, errno, strerror(errno));
+            return;
+        }
     } else {
         printf(" * File %s does not need to be compiled\n", cdb_filename);
     }

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -826,9 +826,9 @@ InstallCommon()
 
     if [ ! -f ${PREFIX}/etc/ossec.conf ]; then
         if [ -f  ../etc/ossec.mc ]; then
-            ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../etc/ossec.mc ${PREFIX}/etc/ossec.conf
+            ${INSTALL} -m 0660 -o root -g ${OSSEC_GROUP} ../etc/ossec.mc ${PREFIX}/etc/ossec.conf
         else
-            ${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ${OSSEC_CONF_SRC} ${PREFIX}/etc/ossec.conf
+            ${INSTALL} -m 0660 -o root -g ${OSSEC_GROUP} ${OSSEC_CONF_SRC} ${PREFIX}/etc/ossec.conf
         fi
     fi
 
@@ -868,8 +868,8 @@ InstallLocal()
     ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc/decoders
     ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc/rules
     ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/var/multigroups
-    ${INSTALL} -d -m 770 -o root -g ${OSSEC_GROUP} ${PREFIX}/var/db
-    ${INSTALL} -d -m 770 -o root -g ${OSSEC_GROUP} ${PREFIX}/var/db/agents
+    ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/var/db
+    ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/var/db/agents
     ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/var/download
     ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/logs/archives
     ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/logs/alerts
@@ -916,10 +916,10 @@ InstallLocal()
     ${MAKEBIN} --quiet -C ../framework install PREFIX=${PREFIX} USE_FRAMEWORK_LIB=${LIB_FLAG}
 
     if [ ! -f ${PREFIX}/etc/decoders/local_decoder.xml ]; then
-        ${INSTALL} -m 0640 -o ossec -g ${OSSEC_GROUP} -b ../etc/local_decoder.xml ${PREFIX}/etc/decoders/local_decoder.xml
+        ${INSTALL} -m 0660 -o ossec -g ${OSSEC_GROUP} -b ../etc/local_decoder.xml ${PREFIX}/etc/decoders/local_decoder.xml
     fi
     if [ ! -f ${PREFIX}/etc/rules/local_rules.xml ]; then
-        ${INSTALL} -m 0640 -o ossec -g ${OSSEC_GROUP} -b ../etc/local_rules.xml ${PREFIX}/etc/rules/local_rules.xml
+        ${INSTALL} -m 0660 -o ossec -g ${OSSEC_GROUP} -b ../etc/local_rules.xml ${PREFIX}/etc/rules/local_rules.xml
     fi
     if [ ! -f ${PREFIX}/etc/lists ]; then
         ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc/lists
@@ -929,10 +929,10 @@ InstallLocal()
         ${INSTALL} -m 0660 -o ossec -g ${OSSEC_GROUP} -b ../etc/lists/amazon/* ${PREFIX}/etc/lists/amazon/
     fi
     if [ ! -f ${PREFIX}/etc/lists/audit-keys ]; then
-        ${INSTALL} -m 0640 -o ossec -g ${OSSEC_GROUP} -b ../etc/lists/audit-keys ${PREFIX}/etc/lists/audit-keys
+        ${INSTALL} -m 0660 -o ossec -g ${OSSEC_GROUP} -b ../etc/lists/audit-keys ${PREFIX}/etc/lists/audit-keys
     fi
     if [ ! -f ${PREFIX}/etc/lists/security-eventchannel ]; then
-        ${INSTALL} -m 0640 -o ossec -g ${OSSEC_GROUP} -b ../etc/lists/security-eventchannel ${PREFIX}/etc/lists/security-eventchannel
+        ${INSTALL} -m 0660 -o ossec -g ${OSSEC_GROUP} -b ../etc/lists/security-eventchannel ${PREFIX}/etc/lists/security-eventchannel
     fi
 
     ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/fts
@@ -966,7 +966,7 @@ InstallServer()
     ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/cluster
     ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/logs/cluster
 
-    ${INSTALL} -d -m 760 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/vulnerabilities
+    ${INSTALL} -d -m 0760 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/vulnerabilities
     ${INSTALL} -d -m 0770 -o ossec -g ${OSSEC_GROUP} ${PREFIX}/etc/shared/default
     ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/backup/shared
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -790,7 +790,7 @@ int MergeAppendFile(const char *finalpath, const char *files, const char *tag, i
 
         fclose(finalfp);
 
-        if (chmod(finalpath, 0640) < 0) {
+        if (chmod(finalpath, 0660) < 0) {
             merror(CHMOD_ERROR, finalpath, errno, strerror(errno));
             return 0;
         }


### PR DESCRIPTION
|Related issue|
|---|
|#3669|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

A new util function has been created called `safe_move` to move files even between the file systems. It works by creating a temp file in the same path where the target file is located and then moves the file. This is done to avoid collateral effects to `remoted` due to bad race conditions if several processes modify `client.keys` data concurrently. 

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- [x] Source installation
- [x] Package installation
- [x] Working on cluster environments
- [x] Check cluster sychronizing agent-info files. Permissions are OK.
- [x] Edit configuration through the App (`ossec.conf`, `agent.conf` in groups)
- [x] Check agent status after rebalancing