### PR TITLE
Changed the ELASTIC_SERVER to LOGSTASH_SERVER in filebeat.yml

### DIFF
--- a/extensions/filebeat/6.x/filebeat.yml
+++ b/extensions/filebeat/6.x/filebeat.yml
@@ -11,6 +11,6 @@ filebeat:
 output:
  logstash:
    # The Logstash hosts
-   hosts: ["YOUR_ELASTIC_SERVER_IP:5000"]
+   hosts: ["YOUR_LOGSTASH_SERVER_IP:5000"]
 #   ssl:
 #     certificate_authorities: ["/etc/filebeat/logstash.crt"]


### PR DESCRIPTION
Version: 3.9.3
Filebeat version: 6.x

The filebeat.yml file had hosts mentioned as:
```
output:
 logstash:
   # The Logstash hosts
   hosts: ["YOUR_ELASTIC_SERVER_IP:5000"]
```
Which should be YOUR_LOGSTASH_SERVER
Correcting the placeholder in this PR.
