### PR TITLE
Fix wildcard pattern defined file handling in Logcollector

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1167,7 +1167,7 @@ int check_pattern_expand(int do_seek) {
                         current_files++;
                         globs[j].num_files++;
                         mdebug2(CURRENT_FILES, current_files, maximum_files);
-                        if  (!i && !globs[j].gfiles[i].read) {
+                        if  (!globs[j].gfiles[i].read) {
                             set_read(&globs[j].gfiles[i], i, j);
                         } else {
                             handle_file(i, j, do_seek, 1);
@@ -1194,7 +1194,7 @@ int check_pattern_expand(int do_seek) {
                         current_files++;
                         globs[j].num_files++;
                         mdebug2(CURRENT_FILES, current_files, maximum_files);
-                        if  (!i && !globs[j].gfiles[i].read) {
+                        if  (!globs[j].gfiles[i].read) {
                             set_read(&globs[j].gfiles[i], i, j);
                         } else {
                             handle_file(i, j, do_seek, 1);
@@ -1411,7 +1411,7 @@ int check_pattern_expand(int do_seek) {
                             current_files++;
                             globs[j].num_files++;
                             mdebug2(CURRENT_FILES, current_files, maximum_files);
-                            if  (!i && !globs[j].gfiles[i].read) {
+                            if  (!globs[j].gfiles[i].read) {
                                 set_read(&globs[j].gfiles[i], i, j);
                             } else {
                                 handle_file(i, j, do_seek, 1);
@@ -1438,7 +1438,7 @@ int check_pattern_expand(int do_seek) {
                             current_files++;
                             globs[j].num_files++;
                             mdebug2(CURRENT_FILES, current_files, maximum_files);
-                            if  (!i && !globs[j].gfiles[i].read) {
+                            if  (!globs[j].gfiles[i].read) {
                                 set_read(&globs[j].gfiles[i], i, j);
                             } else {
                                 handle_file(i, j, do_seek, 1);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1154,9 +1154,9 @@ int check_pattern_expand(int do_seek) {
                         minfo(NEW_GLOB_FILE, globs[j].gpath, g.gl_pathv[glob_offset]);
 
                         os_realloc(globs[j].gfiles, (i +2)*sizeof(logreader), globs[j].gfiles);
-                        if (i) {
-                            memcpy(&globs[j].gfiles[i], globs[j].gfiles, sizeof(logreader));
-                        }
+
+                        /* Copy the current item to the end mark as it should be a pattern */
+                        memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
 
                         os_strdup(g.gl_pathv[glob_offset], globs[j].gfiles[i].file);
                         w_mutex_init(&globs[j].gfiles[i].mutex, &attr);
@@ -1181,9 +1181,9 @@ int check_pattern_expand(int do_seek) {
                     /* This file could have to non binary file */
                     if (file_excluded_binary && !added) {
                         os_realloc(globs[j].gfiles, (i +2)*sizeof(logreader), globs[j].gfiles);
-                        if (i) {
-                            memcpy(&globs[j].gfiles[i], globs[j].gfiles, sizeof(logreader));
-                        }
+
+                        /* Copy the current item to the end mark as it should be a pattern */
+                        memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
 
                         os_strdup(g.gl_pathv[glob_offset], globs[j].gfiles[i].file);
                         w_mutex_init(&globs[j].gfiles[i].mutex, &attr);
@@ -1314,7 +1314,7 @@ int check_pattern_expand(int do_seek) {
                     if (dirent->d_name[0] == '.' && (dirent->d_name[1] == '\0' || (dirent->d_name[1] == '.' && dirent->d_name[2] == '\0'))) {
                         continue;
                     }
-                            
+
                     if (current_files >= maximum_files) {
                         mwarn(FILE_LIMIT, maximum_files);
                         break;
@@ -1398,9 +1398,9 @@ int check_pattern_expand(int do_seek) {
                             minfo(NEW_GLOB_FILE, globs[j].gpath, full_path);
 
                             os_realloc(globs[j].gfiles, (i +2)*sizeof(logreader), globs[j].gfiles);
-                            if (i) {
-                                memcpy(&globs[j].gfiles[i], globs[j].gfiles, sizeof(logreader));
-                            }
+
+                            /* Copy the current item to the end mark as it should be a pattern */
+                            memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
 
                             os_strdup(full_path, globs[j].gfiles[i].file);
                             w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
@@ -1425,9 +1425,9 @@ int check_pattern_expand(int do_seek) {
                         /* This file could have to non binary file */
                         if (file_excluded_binary && !added) {
                             os_realloc(globs[j].gfiles, (i +2)*sizeof(logreader), globs[j].gfiles);
-                            if (i) {
-                                memcpy(&globs[j].gfiles[i], globs[j].gfiles, sizeof(logreader));
-                            }
+
+                            /* Copy the current item to the end mark as it should be a pattern */
+                            memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
 
                             os_strdup(full_path, globs[j].gfiles[i].file);
                             w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
@@ -2167,7 +2167,7 @@ static void check_pattern_expand_excluded() {
             if (!globs[j].exclude_path) {
                 continue;
             }
-            
+
             char *global_path = NULL;
             char *wildcard = NULL;
             os_strdup(globs[j].exclude_path,global_path);


### PR DESCRIPTION
|Related issue|
|---|
|#3697|

## Rationale

PR #3616 establishes an ordered deletion of the file items in the array. It handles correctly the final item of the arrays.

However, log file arrays for globs (wildcard patterns) have a special item that works as both template and final mark. When Logcollector adds the first file, that item becomes a real stanza and then inserts a null terminator that is not a pattern.

Before #3616, Logcollector worked because it never removed the last valid stanza of an array. However, that altered the order of the items, causing issue #3051.

## Fix

When Logcollector detects a new file matching a glob, it will duplicate the last item of the corresponding array, and mark the copy as the terminator.

## Tests

- [X] Compile manager for Linux.
- [x] Compile agent for macOS.
- [X] Compile agent for Windows.
- [X] Source installation.
- [X] Run Logcollector with Valgrind.
- [X] Run Logcollector with Address Sanitizer.
- [x] Run agent on Windows with Dr. Memory.
- [X] Configuration on-demand reports new parameters
- [ ] QA templates contemplate the added capabilities.