### PR TITLE
Separate TempFile function into two subfunctions with unique tasks.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -584,7 +584,7 @@ $(SELINUX_POLICY): $(SELINUX_MODULE)
 $(SELINUX_MODULE): $(SELINUX_ENFORCEMENT)
 	checkmodule -M -m -o $@ $?
 
-test_programs = tap_os_crypto tap_os_net tap_os_regex tap_shared tap_os_zlib tap_os_xml tap_fluentd_forwarder
+test_programs = tap_os_crypto tap_os_net tap_os_regex tap_shared tap_os_zlib tap_os_xml tap_timestamp_file tap_fluentd_forwarder
 
 WINDOWS_BINS:=win32/ossec-agent.exe win32/ossec-agent-eventchannel.exe win32/ossec-rootcheck.exe win32/manage_agents.exe win32/setup-windows.exe win32/setup-syscheck.exe win32/setup-iis.exe win32/add-localfile.exe win32/os_win32ui.exe win32/agent-auth.exe
 
@@ -1544,6 +1544,9 @@ tap_os_xml: tests/tap_os_xml.o ${os_xml_o}
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 tap_fluentd_forwarder: tests/tap_fluentd_forwarder.o
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
+
+tap_timestamp_file: tests/tap_timestamp_file.o
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 test_valgrind: build_tests

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -320,7 +320,7 @@ int add_agent(int json_output, int no_limit)
                 time3 = time(0);
                 rand2 = os_random();
 
-                if (TempFile(&file, AUTH_FILE, 1) < 0 ) {
+                if (TempFileCopy(&file, AUTH_FILE, 1) < 0 ) {
                     if (json_output) {
                         char buffer[1024];
                         cJSON *json_root = cJSON_CreateObject();

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -139,7 +139,7 @@ int OS_RemoveAgent(const char *u_id) {
 
     fclose(fp);
 
-    if (TempFile(&file, isChroot() ? AUTH_FILE : KEYSFILE_PATH, 0) < 0) {
+    if (TempFileCopy(&file, isChroot() ? AUTH_FILE : KEYSFILE_PATH, 0) < 0) {
         free(buffer);
         return 0;
     }
@@ -768,7 +768,7 @@ void OS_AddAgentTimestamp(const char *id, const char *name, const char *ip, time
     File file;
     char timestamp[40];
 
-    if (TempFile(&file, TIMESTAMP_FILE, 1) < 0) {
+    if (TempFileCopy(&file, TIMESTAMP_FILE, 1) < 0) {
         merror("Couldn't open timestamp file.");
         return;
     }
@@ -819,7 +819,7 @@ void OS_RemoveAgentTimestamp(const char *id)
 
     fclose(fp);
 
-    if (TempFile(&file, TIMESTAMP_FILE, 0) < 0) {
+    if (TempFileCopy(&file, TIMESTAMP_FILE, 0) < 0) {
         merror("Couldn't open timestamp file.");
         free(buffer);
         return;

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -90,7 +90,8 @@ int rename_ex(const char *source, const char *destination) __attribute__((nonnul
 /* Create temporary file */
 int mkstemp_ex(char *tmp_path) __attribute__((nonnull));
 
-int TempFile(File *file, const char *source, int copy);
+int TempFile(const char *source, char *template);
+int TempFileCopy(File *file, const char *source, int copy);
 int OS_MoveFile(const char *src, const char *dst);
 int w_copy_file(const char *src, const char *dst,char mode,char * message,int silent);
 

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -91,6 +91,7 @@ int rename_ex(const char *source, const char *destination) __attribute__((nonnul
 int mkstemp_ex(char *tmp_path) __attribute__((nonnull));
 
 int TempFile(const char *source, char *template);
+int CopyFile(FILE *read_file, FILE *write_file);
 int TempFileCopy(File *file, const char *source, int copy);
 int OS_MoveFile(const char *src, const char *dst);
 int w_copy_file(const char *src, const char *dst,char mode,char * message,int silent);

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -548,7 +548,7 @@ int OS_WriteKeys(const keystore *keys) {
     File file;
     char cidr[20];
 
-    if (TempFile(&file, isChroot() ? AUTH_FILE : KEYSFILE_PATH, 0) < 0)
+    if (TempFileCopy(&file, isChroot() ? AUTH_FILE : KEYSFILE_PATH, 0) < 0)
         return -1;
 
     for (i = 0; i < keys->keysize; i++) {

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2008,10 +2008,8 @@ int cldir_ex_ignore(const char * name, const char ** ignore) {
     return closedir(dir);
 }
 
-int TempFile(File *file, const char *source, int copy) {
-    FILE *fp_src;
+int TempFile(const char *source, char *template) {
     int fd;
-    char template[OS_FLSIZE + 1];
     mode_t old_mask;
 
     snprintf(template, OS_FLSIZE, "%s.XXXXXX", source);
@@ -2021,6 +2019,19 @@ int TempFile(File *file, const char *source, int copy) {
     umask(old_mask);
 
     if (fd < 0) {
+        return -1;
+    }
+
+    return fd;
+}
+
+int TempFileCopy(File *file, const char *source, int copy) {
+    FILE *fp_src;
+    char template[OS_FLSIZE + 1];
+    int fd;
+
+    if (fd = TempFile(source, template), fd < 0) {
+        merror("Couldn't open timestamp file.");
         return -1;
     }
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2052,7 +2052,12 @@ int TempFileCopy(File *file, const char *source, int copy) {
             return -1;
         }
     } else {
+        mode_t old_mask;
+
         mdebug1(FSTAT_ERROR, source, errno, strerror(errno));
+        old_mask = umask(0066);
+        fd = mkstemp(template);
+        umask(old_mask);
     }
 
 #endif

--- a/src/tests/tap.h
+++ b/src/tests/tap.h
@@ -477,36 +477,4 @@ static int tap_fail;
     _w_assert_ptr(X, >=, Y);    \
 })
 
-/**
- * Check two mode_t variables to determine if X OP Y
- *
- * If not X OP Y, the test fails.
- *
- * @param X mode_t
- * @param Y mode_t to compare against X
- * @note If the check fails, the test fails
- *
- */
-#define _w_assert_mode_t(X, OP, Y)  \
-({                                  \
-  const void* _w_x = (X);           \
-  const void* _w_y = (Y);           \
-  if(!(_w_x OP _w_y)){return 0;}    \
-})
-
-/**
- * Check two mode_t variables to determine if X == Y
- *
- * If not X == Y, the test fails.
- *
- * @param X mode_t
- * @param Y mode_t to compare against X
- * @note If the check fails, the test fails
- *
- */
-#define w_assert_mode_t_eq(X, Y)   \
-({                                 \
-    _w_assert_mode_t(X, ==, Y);    \
-})
-
 #endif

--- a/src/tests/tap.h
+++ b/src/tests/tap.h
@@ -477,4 +477,36 @@ static int tap_fail;
     _w_assert_ptr(X, >=, Y);    \
 })
 
+/**
+ * Check two mode_t variables to determine if X OP Y
+ *
+ * If not X OP Y, the test fails.
+ *
+ * @param X mode_t
+ * @param Y mode_t to compare against X
+ * @note If the check fails, the test fails
+ *
+ */
+#define _w_assert_mode_t(X, OP, Y)  \
+({                                  \
+  const void* _w_x = (X);           \
+  const void* _w_y = (Y);           \
+  if(!(_w_x OP _w_y)){return 0;}    \
+})
+
+/**
+ * Check two mode_t variables to determine if X == Y
+ *
+ * If not X == Y, the test fails.
+ *
+ * @param X mode_t
+ * @param Y mode_t to compare against X
+ * @note If the check fails, the test fails
+ *
+ */
+#define w_assert_mode_t_eq(X, Y)   \
+({                                 \
+    _w_assert_mode_t(X, ==, Y);    \
+})
+
 #endif

--- a/src/tests/tap_timestamp_file.c
+++ b/src/tests/tap_timestamp_file.c
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../headers/file_op.h"
+#include "../headers/defs.h"
+#include "tap.h"
+
+int test_temporary_file() {
+    unsigned char test = 0;
+    char template[OS_FLSIZE + 1];
+    struct stat buf;
+
+    int fd = TempFile(TIMESTAMP_FILE, template);
+    w_assert_int_ge(fd, 0);
+
+    fstat(fd, &buf);
+    w_assert_mode_t_eq(buf.st_mode, 0177);
+
+    unlink(template);
+    close(fd);
+
+    return 1;
+}
+
+
+int main(void) {
+    printf("\n\n    STARTING TEST - TIMESTAMP FILE   \n\n");
+
+    // Temporary file with right permissions created successfuly
+    TAP_TEST_MSG(test_success_match(), "Creating temporary file with umask 0177 using TempFile test.");
+
+    TAP_PLAN;
+    TAP_SUMMARY;
+    printf("\n    ENDING TEST  - TIMESTAMP FILE   \n\n");
+    return 0;
+}

--- a/src/tests/tap_timestamp_file.c
+++ b/src/tests/tap_timestamp_file.c
@@ -1,26 +1,77 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "../headers/file_op.h"
 #include "../headers/defs.h"
 #include "tap.h"
 
 int test_temporary_file() {
-    unsigned char test = 0;
     char template[OS_FLSIZE + 1];
     struct stat buf;
+    int ret = 1;
 
-    int fd = TempFile(TIMESTAMP_FILE, template);
-    w_assert_int_ge(fd, 0);
+    int fd = TempFile("/var/ossec/queue/agents-timestamp", template);
+
+    if (fd < 0){
+        ret = 0;
+        goto clean;
+    }
 
     fstat(fd, &buf);
-    w_assert_mode_t_eq(buf.st_mode, 0177);
 
+    if ((buf.st_mode & S_IRUSR) && (buf.st_mode & S_IWUSR)) {
+        goto clean;
+    } else {
+        ret = 0;
+    }
+
+clean:
     unlink(template);
     close(fd);
+    return ret;
+}
 
-    return 1;
+int test_copy_file() {
+    FILE *file_to_read;
+    FILE *file_to_write;
+    char buffer[60];
+    int ret = 1;
+
+    char str[] = "Test file";
+
+    file_to_read = fopen("read_file.txt","w+");
+    fwrite(str, 1, sizeof(str), file_to_read);
+
+    file_to_write = fopen("write_file.txt", "w+");
+
+    CopyFile(file_to_read, file_to_write);
+
+    fclose(file_to_write);
+    file_to_write = fopen("write_file.txt", "r");
+
+    if (file_to_write) {
+        if ((fgets(buffer, 60, file_to_write)) != NULL){
+            if(strcmp(buffer, str) != 0) {
+                ret = 0;
+                goto clean;
+            }
+        }
+    } else {
+        ret = 0;
+        goto clean;
+    }
+
+
+
+clean:
+    fclose(file_to_write);
+    fclose(file_to_read);
+    remove("read_file.txt");
+    remove("write_file.txt");
+
+    return ret;
 }
 
 
@@ -28,7 +79,10 @@ int main(void) {
     printf("\n\n    STARTING TEST - TIMESTAMP FILE   \n\n");
 
     // Temporary file with right permissions created successfuly
-    TAP_TEST_MSG(test_success_match(), "Creating temporary file with umask 0177 using TempFile test.");
+    TAP_TEST_MSG(test_temporary_file(), "Creating temporary file with umask 0177 using TempFile test.");
+
+    // Copy a file's content to a new one
+    TAP_TEST_MSG(test_copy_file(), "Copy a file's content to another file using CopyFile test.");
 
     TAP_PLAN;
     TAP_SUMMARY;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3693|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR separates the `TempFile` function into two different functions, the first one creates a temporary file from a given file. The second one copies the content of the given file to the temporary file. Some tap tests have been added to check their functionality.

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- Memory tests
  - [x] Valgrind report for affected components

![imagen](https://user-images.githubusercontent.com/14914658/61611393-f261ae00-ac5b-11e9-859a-3f2876a5531b.png)

