### PR TITLE
Allow escaping characters in OS_Match patterns

### DIFF
--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -95,4 +95,7 @@ int w_is_str_in_array(char *const *ar, const char *str);
 /* Similar to strtok_r but checks for full delim appearances */
 char *w_strtok_r_str_delim(const char *delim, char **remaining_str);
 
+char w_escaped_ptr_adv(char **ptr);
+void w_unescape_str(char **str);
+
 #endif

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -601,3 +601,43 @@ char *w_strtok_r_str_delim(const char *delim, char **remaining_str)
 
     return token;
 }
+
+/**
+ * @brief Increases the pointer and returns if the character is escaped
+ *
+ * @param ptr
+ * @return char
+ */
+char w_escaped_ptr_adv(char **ptr) {
+    char escaped = 0;
+
+    if (**ptr == '\\') {
+        // Escape the next character
+        *ptr = *ptr + 1;
+        escaped = 1;
+    }
+
+    return escaped;
+}
+
+/**
+ * @brief Unescape an input str
+ *
+ * @param str
+ */
+void w_unescape_str(char **str) {
+    char *un_str;
+    char *ptr = *str;
+    unsigned int i;
+    size_t size = strlen(ptr) + 1;
+
+    os_calloc(size, sizeof(char), un_str);
+
+    for (i = 0; *ptr; ptr++, i++) {
+        w_escaped_ptr_adv(&ptr);
+        un_str[i] = *ptr;
+    }
+
+    free(*str);
+    *str = un_str;
+}

--- a/src/tests/tap_os_regex.c
+++ b/src/tests/tap_os_regex.c
@@ -47,6 +47,28 @@ int test_success_match() {
     return 1;
 }
 
+int test_escaped_patterns() {
+    int i;
+    // 0: pattern, 1: successful match, 2: unsuccessful match
+    const char *tests[][3] = {
+        {"abc", "abcd", "ZZZ"},
+        {"^bin$|^shell$", "shell", "bina"},
+        {" ^bin\\$|^shell$", " ^bin$", "bina"}, // Escape $
+        {"abc\\|def|gh$|ij", "abc|def", "ghi"}, // Escape |
+        {"abc\\\\\\\\|def|gh$|ij", "abc\\\\", "abc\\"}, // Escape '\\'
+        {"abc\\\\$|def", "abc\\", "abc\\\\\\$"}, // Escape '\\' and $
+        {"\\^abc\\\\\\$\\|$", "^abc\\$|", "$"}, // Escape all
+        {"\\!abc|def", "!abc", "abc"}, // Escape !
+        {NULL, NULL, NULL}
+    };
+
+    for (i = 0; tests[i][0] != NULL ; i++) {
+        w_assert_int_eq(OS_Match2(tests[i][0], tests[i][1]), 1);
+        w_assert_int_ne(OS_Match2(tests[i][0], tests[i][2]), 1);
+    }
+    return 1;
+}
+
 int test_fail_match() {
 
     int i;
@@ -747,11 +769,18 @@ int test_fail_str_starts_with() {
 int main(void) {
     printf("\n\n    STARTING TEST - OS_REGEX   \n\n");
 
+    // *********** OS_Match tests ***********
+
     // Match strings with patterns using OS_Match
     TAP_TEST_MSG(test_success_match(), "Matching strings with patterns using OS_Match2 test.");
 
+    // Processing strings with escaped patterns using OS_Match
+    TAP_TEST_MSG(test_escaped_patterns(), "Processing strings with escaped patterns using OS_Match2 test.");
+
     // Don't match strings with patterns using OS_Match
     TAP_TEST_MSG(test_fail_match(), "Not matching strings with patterns using OS_Regex test.");
+
+    // *********** OS_Regex tests ***********
 
     // Match strings with patterns using OS_Regex
     TAP_TEST_MSG(test_success_regex(), "Matching strings with patterns using OS_Regex test.");

--- a/src/util/ossec-regex.c
+++ b/src/util/ossec-regex.c
@@ -50,10 +50,12 @@ int main(int argc, char **argv)
 
     pattern = argv[1];
 
+    /*
     if (!OSRegex_Compile(pattern, &regex, OS_RETURN_SUBSTRING)) {
         printf("Pattern '%s' does not compile with OSRegex_Compile\n", pattern);
         return (-1);
     }
+    */
     if (!OSMatch_Compile(pattern, &matcher, 0)) {
         printf("Pattern '%s' does not compile with OSMatch_Compile\n", pattern);
         return (-1);
@@ -66,7 +68,7 @@ int main(int argc, char **argv)
         }
 
         string = strdup(msg);
-        if (OSRegex_Execute(string, &regex)) {
+        /*if (OSRegex_Execute(string, &regex)) {
             printf("+OSRegex_Execute: %s\n", string);
             for (i = 0; regex.d_sub_strings[i]; i++) {
                 printf(" -Substring: %s\n", regex.d_sub_strings[i]);
@@ -75,7 +77,7 @@ int main(int argc, char **argv)
 
         if (OS_Regex(pattern, string)) {
             printf("+OS_Regex       : %s\n", string);
-        }
+        }*/
 
         if (OSMatch_Execute(string, strlen(string), &matcher)) {
             printf("+OSMatch_Compile: %s\n", string);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3664|

This PR solves the issue described in #3664, allowing to escape the [reserved characters](https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/regex.html#sregex-os-match-syntax) using in the OSMatch library.

Also, several escaped patterns have been added to the Regex TAP to verify this feature is working as expected. If you run `make test`, the expected output for this TAP is:

```
    STARTING TEST - OS_REGEX   

    ok  1 - Matching strings with patterns using OS_Match2 test.
    ok  2 - Processing strings with escaped patterns using OS_Match2 test.
    ok  3 - Not matching strings with patterns using OS_Regex test.
    ok  4 - Matching strings with patterns using OS_Regex test.
    ok  5 - Not matching strings with patterns using OS_Regex test.
    ok  6 - Matching strings with patterns using OS_WordMatch test.
    ok  7 - Not matching strings with patterns using OS_WordMatch test.
    ok  8 - Matching strings with patterns using OS_StrIsNum test.
    ok  9 - Not matching strings with patterns using OS_StrIsNum test.
    ok 10 - Matching strings with patterns using OS_StrHowClosedMatch test.
    ok 11 - OS_StrBreak test.
    ok 12 - OSRegex_Execute test.
    ok 13 - Validate the characters of a hostname.
    ok 14 - Validate case insensitive char map test.
    ok 15 - Validate back slash char test.
    ok 16 - Validate charset from '\d'.
    ok 17 - Validate charset from '\w' test.
    ok 18 - Validate charset from '\s' test.
    ok 19 - Validate charset from '\p' test.
    ok 20 - Validate charset from '\D' test.
    ok 21 - Validate charset from '\W' test.
    ok 22 - Validate charset from '\S' test.
    ok 23 - Validate charset from '\.' test.
    ok 24 - Validate charset from '\t' test.
    ok 25 - Validate left parenthesis '(' char test.
    ok 26 - Validate right parenthesis ')' char test.
    ok 27 - Validate dollar '$' char test.
    ok 28 - Validate OR '|' char test.
    ok 29 - Validate less than '<' char test.
    ok 30 - Validate string starts with substring test.
    ok 31 - Not matching substring at the beginning of string.
1..31

      [ ALL TESTS PASSED ]

    ENDING TEST  - OS_REGEX   
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
