### PR TITLE
API: Flask Implement Active-response endpoints

### DIFF
--- a/api/api/controllers/active_response_controller.py
+++ b/api/api/controllers/active_response_controller.py
@@ -1,5 +1,3 @@
-
-
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
@@ -19,25 +17,13 @@ logger = logging.getLogger('wazuh')
 
 
 @exception_handler
-def run_command(pretty=False, wait_for_complete=False, agent_id=None, command=None, custom=None, arguments=None):
-    """Run an AR command
-    Runs an Active Response command on a specified agent
+def run_command(pretty=False, wait_for_complete=False, agent_id=None):
+    """Runs an Active Response command on a specified agent
 
     :param pretty: Show results in human-readable format
-    :type pretty: bool
     :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
     :param agent_id: Agent ID. All posible values since 000 onwards
-    :type agent_id: str
-    :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of
-    a command name
-    :type command: str
-    :param custom: Whether the specified command is a custom command or not
-    :type custom: bool
-    :param arguments: Command arguments
-    :type arguments: str
-
-    :rtype: message
+    :return: message
     """
     # Get body parameters
     active_response_model = ActiveResponse.from_dict(connexion.request.get_json())
@@ -51,30 +37,18 @@ def run_command(pretty=False, wait_for_complete=False, agent_id=None, command=No
                           pretty=pretty,
                           logger=logger
                           )
-
     data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
 
     return data, 200
 
 
 @exception_handler
-def run_command_all(pretty=False, wait_for_complete=False, command=None, custom=None, arguments=None):
-    """ Run an AR command
-    Runs an Active Response command on all agents
+def run_command_all(pretty=False, wait_for_complete=False):
+    """ Runs an Active Response command on all agents
 
     :param pretty: Show results in human-readable format
-    :type pretty: bool
     :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of
-    a command name
-    :type command: str
-    :param custom: Whether the specified command is a custom command or not
-    :type custom: bool
-    :param arguments: Command arguments
-    :type arguments: str
-
-    :rtype: message
+    :return: message
     """
     # Get body parameters
     active_response_model = ActiveResponse.from_dict(connexion.request.get_json())
@@ -89,7 +63,6 @@ def run_command_all(pretty=False, wait_for_complete=False, command=None, custom=
                           logger=logger,
                           broadcasting=True
                           )
-
     data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
 
     return data, 200

--- a/api/api/controllers/active_response_controller.py
+++ b/api/api/controllers/active_response_controller.py
@@ -1,7 +1,95 @@
+
+
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import asyncio
+import logging
 
-def active_response():
-    pass
+import connexion
+
+import wazuh.active_response as active_response
+from api.models.active_response_model import ActiveResponse
+from api.util import remove_nones_to_dict, exception_handler, raise_if_exc
+from wazuh.cluster.dapi.dapi import DistributedAPI
+
+loop = asyncio.get_event_loop()
+logger = logging.getLogger('wazuh')
+
+
+@exception_handler
+def run_command(pretty=False, wait_for_complete=False, agent_id=None, command=None, custom=None, arguments=None):
+    """Run an AR command
+    Runs an Active Response command on a specified agent
+
+    :param pretty: Show results in human-readable format
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response
+    :type wait_for_complete: bool
+    :param agent_id: Agent ID. All posible values since 000 onwards
+    :type agent_id: str
+    :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of
+    a command name
+    :type command: str
+    :param custom: Whether the specified command is a custom command or not
+    :type custom: bool
+    :param arguments: Command arguments
+    :type arguments: str
+
+    :rtype: message
+    """
+    # Get body parameters
+    active_response_model = ActiveResponse.from_dict(connexion.request.get_json())
+
+    f_kwargs = {**{'agent_id': agent_id}, **active_response_model.to_dict()}
+    dapi = DistributedAPI(f=active_response.run_command,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='distributed_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          pretty=pretty,
+                          logger=logger
+                          )
+
+    data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
+
+    return data, 200
+
+
+@exception_handler
+def run_command_all(pretty=False, wait_for_complete=False, command=None, custom=None, arguments=None):
+    """ Run an AR command
+    Runs an Active Response command on all agents
+
+    :param pretty: Show results in human-readable format
+    :type pretty: bool
+    :param wait_for_complete: Disable timeout response
+    :type wait_for_complete: bool
+    :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of
+    a command name
+    :type command: str
+    :param custom: Whether the specified command is a custom command or not
+    :type custom: bool
+    :param arguments: Command arguments
+    :type arguments: str
+
+    :rtype: message
+    """
+    # Get body parameters
+    active_response_model = ActiveResponse.from_dict(connexion.request.get_json())
+
+    f_kwargs = {**active_response_model.to_dict()}
+    dapi = DistributedAPI(f=active_response.run_command_all,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='distributed_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          pretty=pretty,
+                          logger=logger,
+                          broadcasting=True
+                          )
+
+    data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
+
+    return data, 200

--- a/api/api/models/active_response_model.py
+++ b/api/api/models/active_response_model.py
@@ -1,0 +1,96 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+from datetime import date, datetime  # noqa: F401
+
+from typing import List, Dict  # noqa: F401
+
+from api.models.base_model_ import Model
+from api import util
+
+
+class ActiveResponse(Model):
+
+    def __init__(self, command: str=None, custom: bool=False, arguments: List[str]=None):
+        """ActiveResponse body model
+
+        :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of a command name
+        :type command: str
+        :param custom: Whether the specified command is a custom command or not
+        :type custom: bool
+        :param arguments: Command arguments
+        :type arguments: str
+        """
+        self.swagger_types = {
+            'command': str,
+            'custom': bool,
+            'arguments': List[str]
+        }
+
+        self.attribute_map = {
+            'command': 'command',
+            'custom': 'custom',
+            'arguments': 'arguments'
+        }
+
+        self._command = command
+        self._custom = custom
+        self._arguments = arguments
+
+    @classmethod
+    def from_dict(cls, dikt) -> 'ActiveResponse':
+        """Returns the dict as a model
+
+        :param dikt: A dict.
+        :type: dict
+        :return: The Agent of this Agent.
+        :rtype: dict
+        """
+        return util.deserialize_model(dikt, cls)
+
+    @property
+    def command(self) -> str:
+        """
+        :return: Command to run in the agent
+        :rtype: str
+        """
+        return self._command
+
+    @command.setter
+    def command(self, command: str):
+        """Command running in the agent.
+
+        :param command: Command to run in the agent
+        """
+        self._command = command
+
+    @property
+    def custom(self) -> bool:
+        """
+        :return: Whether the specified command is a custom command or not
+        :rtype: bool
+        """
+        return self._custom
+
+    @custom.setter
+    def custom(self, custom: bool):
+        """
+        :param command: Whether the specified command is a custom command or not
+        """
+        self._custom = custom
+
+    @property
+    def arguments(self) -> List[str]:
+        """
+        :return: Command arguments
+        :rtype: List[str]
+        """
+        return self._arguments
+
+    @arguments.setter
+    def arguments(self, arguments: List[str]):
+        """Command running in the agent.
+
+        :param arguments: Command arguments
+        """
+        self._arguments = arguments

--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -10,14 +10,17 @@ a human readable message is shown, the new field `message` will be used instead.
 * Changed search negation from `!` to `-`.
 
 ## Active Response
-### /active-response/:agent_id
+### PUT /active-response
+* New endpoint that provides the old functionality of PUT /active-response/all
+* Parameters **command**, **Custom** and **Arguments** must be in body.
+
+### PUT /active-response/:agent_id
 * Parameters **command**, **Custom** and **Arguments** must be in body.
 * **command** description changed.
 * In response, `data` key is now moved to new `message` key
+* Option to send command to all agents removed
 
 ## Agents
-
-
 ### DELETE /agents
 * Parameter **ids** must be in query, not in body because DELETE operations can't have a requestBody in OpenAPI 3
 * In response, `msg` key is now moved to new `message` key

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -176,6 +176,25 @@ components:
       type: string
       format: alphanumeric
 
+    ## Active-response models
+    ActiveResponseBody:
+      type: object
+      properties:
+        arguments:
+          description: Command arguments.
+          type: array
+          items:
+            type: string
+        command:
+          description: Command running in the agent. If this value starts by `!`, then it refers to a script name instead of a command name.
+          type: string
+        custom:
+          description: Whether the specified command is a custom command or not.
+          type: boolean
+          default: false
+      required:
+        - command
+
     ## Agents models
     ExtraAgentFields:
       type: object
@@ -3359,41 +3378,53 @@ paths:
                 license_url: "https://github.com/wazuh/wazuh/blob/master/LICENSE"
                 hostname: "wazuh"
                 timestamp: "2019-04-02T08:08:11+0000"
- 
+
+  /active-response:
+    put:
+      tags:
+        - active-response
+      summary: 'Run AR command in all agents'
+      description: 'Runs an Active Response command on all agents'
+      operationId: api.controllers.active_response_controller.run_command_all
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActiveResponseBody'
+      responses:
+        '200':
+          description: 'Command sent to agents'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              example:
+                message: "Command sent to all agents."
+        default:
+          $ref: '#/components/responses/ResponseError'
+
   /active-response/{agent_id}:
     put:
       tags:
         - active-response
-      summary: 'Run an AR command in the agent'
+      summary: 'Run AR command in an agent'
       description: 'Runs an Active Response command on a specified agent'
-      operationId: api.controllers.active_response_controller.active_response
+      operationId: api.controllers.active_response_controller.run_command
       parameters:
         - $ref: '#/components/parameters/agent_id'
-
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
       requestBody:
         content:
           application/json:
-              schema:
-                properties:
-                  command:
-                    description: Command running in the agent. If this value starts by `!`, then it refers to a script name instead of a command name.
-                    type: string
-
-                  custom:
-                    description: Whether the specified command is a custom command or not.
-                    type: boolean
-                    default: false
-
-                  arguments:
-                    description: Command arguments.
-                    type: array
-                    items:
-                      type: string
-                required:
-                  - command
+            schema:
+              $ref: '#/components/schemas/ActiveResponseBody'
       responses:
         '200':
-          description: 'Command send to agent'
+          description: 'Command sent to agent'
           content:
             application/json:
               schema:
@@ -4588,6 +4619,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/group_id'
         - $ref: '#/components/parameters/file_name'
+
       requestBody:
         required: true
         content:
@@ -4597,6 +4629,7 @@ paths:
                 tmp_file:
                   description: Updated file
                   type: string
+
       responses:
         '200':
           description: 'Post group file'
@@ -4605,7 +4638,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
-                message: Group configuration was updated successfully
+                message: Agent configuration was updated successfully
         default:
           $ref: '#/components/responses/ResponseError'
 

--- a/api/test/integration/test_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active_response_endpoints.tavern.yaml
@@ -1,0 +1,163 @@
+---
+test_name: GET authentication token
+
+includes:
+  - !include common.yaml
+
+stages:
+    # Authentication stage
+  - type: ref
+    id: login_get_token
+
+---
+test_name: PUT /active-response/{:agent_id}
+
+stages:
+
+  - name: Runs an Active Response command on a specified agent
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response/001"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+      json:
+        command: restart-ossec0
+        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+
+    response:
+        status_code: 200
+        body:
+          message: Command sent.
+
+  - name: Send a message to one agent (Status=Active)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response/001"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+      json:
+          command: "restart-ossec0"
+          arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+    response:
+      status_code: 200
+      body:
+        message: Command sent.
+
+  - name: Send a message to one agent (Status=Not active/never connected)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response/009"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+      json:
+          command: "restart-ossec0"
+          arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+    response:
+      status_code: 400
+      body:
+        code: 1651
+        dapi_errors: !anything
+        detail: !anystr
+        status: 400
+        title: !anystr
+        type: !anystr
+
+  - name: Send a message to one agent (Active response disabled)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response/003"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+      json:
+        command: "restart-ossec0"
+        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+    response:
+      status_code: 400
+      body:
+        code: 1750
+        dapi_errors: !anything
+        detail: !anystr
+        status: 400
+        title: !anystr
+        type: !anystr
+
+  - name: Send a message unexisting agent
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response/251"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+      json:
+          command: "restart-ossec0"
+          arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+    response:
+      status_code: 400
+      body:
+        code: 1701
+        dapi_errors: !anything
+        detail: !anystr
+        status: 400
+        title: !anystr
+        type: !anystr
+
+  - name: Send a message to one agent, without body
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response/001"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 400
+
+  - name: Send a message to one agent, malformed body
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response/001"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+      json:
+        comMmand: "restart-ossec0"
+        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+    response:
+      status_code: 400
+
+---
+test_name: PUT /active-response
+
+stages:
+
+  - name: Runs an Active Response command on all agents
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+      json:
+        command: restart-ossec0
+        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+    response:
+        status_code: 200
+        body:
+          message: Command sent to all agents.
+
+  - name: Send a message to all agents, malformed body
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+      json:
+        comMmand: "restart-ossec0"
+        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+
+    response:
+      status_code: 400
+

--- a/framework/wazuh/active_response.py
+++ b/framework/wazuh/active_response.py
@@ -1,10 +1,14 @@
+
+
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 from wazuh import common
-from wazuh.exception import WazuhException
 from wazuh.agent import Agent
+from wazuh.exception import WazuhError
 from wazuh.ossec_queue import OssecQueue
+from wazuh.results import WazuhResult
 
 
 def get_commands():
@@ -31,21 +35,25 @@ def shell_escape(command):
 
 
 def run_command(agent_id=None, command=None, arguments=[], custom=False):
-    """
-    Run AR command.
+    """Run AR command in a specific agent
 
     :param agent_id: Run AR command in the agent.
+    :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of
+    a command name
+    :type command: str
+    :param custom: Whether the specified command is a custom command or not
+    :type custom: bool
+    :param arguments: Command arguments
+    :type arguments: str
+
     :return: Message.
     """
     if not command:
-        raise WazuhException(1650)
-
-    if not agent_id:
-        raise WazuhException(1653)
+        raise WazuhError(1650)
 
     commands = get_commands()
     if not custom and command not in commands:
-        raise WazuhException(1655, command)
+        raise WazuhError(1652)
 
     # Create message
     msg_queue = command
@@ -60,21 +68,60 @@ def run_command(agent_id=None, command=None, arguments=[], custom=False):
     # Send
     if agent_id == "000":
         oq = OssecQueue(common.EXECQ)
-        ret_msg = oq.send_msg_to_agent(msg=msg_queue, agent_id=agent_id, msg_type=OssecQueue.AR_TYPE)
+        ret_msg = oq.send_msg_to_agent(msg=msg_queue, agent_id="000", msg_type=OssecQueue.AR_TYPE)
         oq.close()
-
     else:
-        if agent_id != "all":
-            # Check if agent exists and it is active
-            agent_info = Agent(agent_id).get_basic_information()
+        # Check if agent exists and it is active
+        agent_info = Agent(agent_id).get_basic_information()
 
-            if agent_info['status'].lower() != 'active':
-                raise WazuhException(1651)
+        if agent_info['status'].lower() != 'active':
+            raise WazuhError(1651)
+
+        # Check if agent has active-response disabled
+        agent_conf = Agent.get_config(agent_id, 'com', 'active-response')
+        if agent_conf['active-response']['disabled'] == 'yes':
+            raise WazuhError(1750)
         else:
-            agent_id = None
+            oq = OssecQueue(common.ARQUEUE)
+            ret_msg = oq.send_msg_to_agent(msg=msg_queue, agent_id=agent_id, msg_type=OssecQueue.AR_TYPE)
+            oq.close()
 
-        oq = OssecQueue(common.ARQUEUE)
-        ret_msg = oq.send_msg_to_agent(msg=msg_queue, agent_id=agent_id, msg_type=OssecQueue.AR_TYPE)
-        oq.close()
+    return WazuhResult({'message': ret_msg})
 
-    return ret_msg
+
+def run_command_all(command=None, arguments=[], custom=False):
+    """Run AR command in all agents
+
+    :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of
+    a command name
+    :type command: str
+    :param custom: Whether the specified command is a custom command or not
+    :type custom: bool
+    :param arguments: Command arguments
+    :type arguments: str
+
+    :return: Message.
+    """
+    if not command:
+        raise WazuhError(1650)
+
+    commands = get_commands()
+    if not custom and command not in commands:
+        raise WazuhError(1652)
+
+    # Create message
+    msg_queue = command
+    if custom:
+        msg_queue = "!{}".format(command)
+
+    if arguments:
+        msg_queue += " " + " ".join(shell_escape(str(x)) for x in arguments)
+    else:
+        msg_queue += " - -"
+
+    # Send
+    oq = OssecQueue(common.ARQUEUE)
+    oq.send_msg_to_agent(msg=msg_queue, agent_id=None, msg_type=OssecQueue.AR_TYPE)
+    oq.close()
+
+    return WazuhResult({'message': 'Command sent to all agents.'})

--- a/framework/wazuh/active_response.py
+++ b/framework/wazuh/active_response.py
@@ -1,5 +1,3 @@
-
-
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
@@ -24,29 +22,24 @@ def get_commands():
 
 
 def shell_escape(command):
-    """
-    Escapes some characters in the command before sending it
-    """
-    shell_escapes = ['"', '\'', '\t', ';', '`', '>', '<', '|', '#', '*', '[', ']', '{', '}', '&', '$', '!', ':', '(', ')']
+    """Escapes some characters in the command before sending it"""
+    shell_escapes = \
+        ['"', '\'', '\t', ';', '`', '>', '<', '|', '#', '*', '[', ']', '{', '}', '&', '$', '!', ':', '(', ')']
     for shell_esc_char in shell_escapes:
         command = command.replace(shell_esc_char, "\\"+shell_esc_char)
     
     return command
 
 
-def run_command(agent_id=None, command=None, arguments=[], custom=False):
+def run_command(agent_id=None, command=None, arguments=None, custom=False):
     """Run AR command in a specific agent
 
     :param agent_id: Run AR command in the agent.
     :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of
     a command name
-    :type command: str
     :param custom: Whether the specified command is a custom command or not
-    :type custom: bool
     :param arguments: Command arguments
-    :type arguments: str
-
-    :return: Message.
+    :return: WazuhResult.
     """
     if not command:
         raise WazuhError(1650)
@@ -89,18 +82,14 @@ def run_command(agent_id=None, command=None, arguments=[], custom=False):
     return WazuhResult({'message': ret_msg})
 
 
-def run_command_all(command=None, arguments=[], custom=False):
+def run_command_all(command=None, arguments=None, custom=False):
     """Run AR command in all agents
 
     :param command: Command running in the agent. If this value starts by !, then it refers to a script name instead of
     a command name
-    :type command: str
     :param custom: Whether the specified command is a custom command or not
-    :type custom: bool
     :param arguments: Command arguments
-    :type arguments: str
-
-    :return: Message.
+    :return: WazuhResult.
     """
     if not command:
         raise WazuhError(1650)

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -186,6 +186,10 @@ class WazuhException(Exception):
         1653: 'Active response - Agent ID not specified',
         1654: 'Unable to clear rootcheck database',
         1655: 'Active response - Command not available',
+        1656: {'message': 'No parameters provided for request',
+               'remediation': 'Please, visit [official documentation]'
+               '(https://documentation.wazuh.com/current/user-manual/api/reference.html#active-response) '
+               'to get more information about `active-response` API call'},
 
         # Agents: 1700 - 1799
         1700: 'Bad arguments. Accepted arguments: [id] or [name and ip]',
@@ -315,9 +319,8 @@ class WazuhException(Exception):
         1749: {'message': "Downgrading an agent requires the force flag.",
                'remediation': "Use -F to force the downgrade"
                },
-        1750: {'message': 'No parameters provided for request',
-               'remediation': 'Please, visit [official documentation](https://documentation.wazuh.com/current/user-manual/api/reference.html) to get more information about available requests'
-               },
+        1750: {'message': 'Could not restart selected agent, active-response is disabled in the agent',
+               'remediation': 'You can activate it in `WAZUH_HOME/etc/ossec.conf`'},
 
         # CDB List: 1800 - 1899
         1800: {'message': 'Bad format in CDB list {path}'},

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -320,7 +320,7 @@ class WazuhException(Exception):
                'remediation': "Use -F to force the downgrade"
                },
         1750: {'message': 'Could not restart selected agent, active-response is disabled in the agent',
-               'remediation': 'You can activate it in `WAZUH_HOME/etc/ossec.conf`'},
+               'remediation': "You can activate it in agents' `WAZUH_HOME/etc/ossec.conf`"},
 
         # CDB List: 1800 - 1899
         1800: {'message': 'Bad format in CDB list {path}'},

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -4,9 +4,11 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest.mock import patch
+
 import pytest
-from wazuh.exception import WazuhException
+
 from wazuh import active_response
+from wazuh.exception import WazuhException
 
 
 @patch('wazuh.active_response.OssecQueue')
@@ -14,8 +16,8 @@ from wazuh import active_response
 @patch('wazuh.active_response.get_commands', return_value=['valid_cmd', 'another_valid_cmd', 'one_more'])
 @pytest.mark.parametrize('expected_exception, agent_id, command, arguments, custom', [
     (1650, '000', None, [], False),
-    (1653, None, 'random', [], False),
-    (1655, '000', 'invalid_cmd', [], False),
+    (1652, None, 'random', [], False),
+    (1652, '000', 'invalid_cmd', [], False),
     (1651, '001', 'valid_cmd', [], False),
     (None, '001', 'valid_cmd', [], False),
     (None, '001', 'valid_cmd', ["arg1", "arg2"], False)
@@ -24,16 +26,43 @@ def test_run_command(cmd_patch, agent_patch, queue_patch, expected_exception, ag
     """
     Tests run_command function
     """
-    agent_patch.return_value.get_basic_information.return_value = {'status': 'disconnected' if expected_exception else 'active'}
+    agent_patch.return_value.get_basic_information.return_value = {
+        'status': 'disconnected' if expected_exception else 'active'}
     queue_patch.return_value.send_msg_to_agent.return_value = "success"
     queue_patch.AR_TYPE = "AR"
 
     if expected_exception is not None:
         with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
-            active_response.run_command(agent_id, command, arguments, custom)
+            active_response.run_command(agent_id=agent_id, command=command, arguments=arguments, custom=custom)
     else:
-        ret = active_response.run_command(agent_id, command, arguments, custom)
-        assert ret == "success"
+        ret = active_response.run_command(agent_id=agent_id, command=command, arguments=arguments, custom=custom)
+        assert ret == {'message': 'success'}
         handle = queue_patch()
         msg = f'{"!" if custom else ""}{command} {"- -" if not arguments else " ".join(arguments)}'
         handle.send_msg_to_agent.assert_called_with(agent_id=agent_id, msg=msg, msg_type='AR')
+
+
+@patch('wazuh.active_response.OssecQueue')
+@patch('wazuh.active_response.get_commands', return_value=['valid_cmd', 'another_valid_cmd', 'one_more'])
+@pytest.mark.parametrize('expected_exception, command, arguments, custom', [
+    (1650, None, [], False),
+    (1652, 'random', [], False),
+    (1652, 'invalid_cmd', [], False),
+    (None, 'valid_cmd', [], False),
+    (None, 'valid_cmd', ["arg1", "arg2"], False)
+])
+def test_run_command_all(cmd_patch, queue_patch, expected_exception, command, arguments, custom):
+    """
+    Tests run_command_all function
+    """
+    queue_patch.AR_TYPE = "AR"
+
+    if expected_exception is not None:
+        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+            active_response.run_command_all(command=command, arguments=arguments, custom=custom)
+    else:
+        ret = active_response.run_command_all(command=command, arguments=arguments, custom=custom)
+        assert ret == {'message': 'Command sent to all agents.'}
+        handle = queue_patch()
+        msg = f'{"!" if custom else ""}{command} {"- -" if not arguments else " ".join(arguments)}'
+        handle.send_msg_to_agent.assert_called_with(agent_id=None, msg=msg, msg_type='AR')


### PR DESCRIPTION
Hi team,

This PR closes #2836.

Best regards,

David J. Iglesias

**Integration tests**
```
======================================================================== test session starts ========================================================================
platform linux -- Python 3.7.2, pytest-4.5.0, py-1.8.0, pluggy-0.12.0 -- /var/ossec/framework/python/bin/python3.7
cachedir: .pytest_cache
rootdir: /var/ossec/framework/python/bin
plugins: cov-2.7.1, tavern-0.26.4
collected 3 items                                                                                                                                                   

test/test_active_response_endpoints.tavern.yaml::GET authentication token PASSED                                                                              [ 33%]
test/test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} PASSED                                                                      [ 66%]
test/test_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                                                  [100%]

========================================================================= warnings summary ==========================================================================
/var/ossec/framework/python/lib/python3.7/site-packages/yaml/constructor.py:126
  /var/ossec/framework/python/lib/python3.7/site-packages/yaml/constructor.py:126: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if not isinstance(key, collections.Hashable):

test/test_active_response_endpoints.tavern.yaml::GET authentication token
  /var/ossec/framework/python/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================================== 3 passed, 2 warnings in 0.61 seconds ================================================================
```
**Unit tests**
```
============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /opt/project/frameworkcollected 11 items

test_active_response.py ...........                                      [100%]

========================== 11 passed in 0.12 seconds ===========================
```