### PR TITLE
Fix descriptor leakage in Syscheck 3.9.4

### DIFF
--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -74,6 +74,7 @@ void run_rk_check()
 
     /* Set basedir */
     if (rootcheck.basedir == NULL || !strlen(rootcheck.basedir)) {
+        free(rootcheck.basedir);
         rootcheck.basedir = strdup(basedir);
     } else {
         if (rootcheck.basedir[strlen(rootcheck.basedir)-1] == PATH_SEP) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -755,6 +755,8 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
     }
 
     if (pos = find_dir_pos (dir_name, 1, 1, 0), dir_position != pos) {
+        free(f_name);
+        closedir(dp);
         return (0);
     }
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -754,10 +754,10 @@ int read_dir(const char *dir_name, const char *link, int dir_position, whodata_e
         return (-1);
     }
 
-    if (pos = find_dir_pos (dir_name, 1, 1, 0), dir_position != pos) {
+    if (pos = find_dir_pos(dir_name, 1, 1, 0), dir_position != pos) {
         free(f_name);
         closedir(dp);
-        return (0);
+        return 0;
     }
 
     int opts = syscheck.opts[pos];

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -364,14 +364,14 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
         } else {
             mtwarn(WM_SYS_LOGTAG, "Unable to read file '%s'", filepath);
         }
-        
+
         if (strstr(app_folder, "/Utilities") != NULL) {
             cJSON_AddStringToObject(package, "source", "utilities");
         } else {
             cJSON_AddStringToObject(package, "source", "applications");
         }
         cJSON_AddStringToObject(package, "location", app_folder);
-        
+
         if (invalid) {
             char * program_name;
             char * end;
@@ -766,7 +766,7 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
 
     char ** ifaces_list;
     int i = 0, size_ifaces = 0;
-    struct ifaddrs *ifaddrs_ptr, *ifa;
+    struct ifaddrs *ifaddrs_ptr = NULL, *ifa;
     int random_id = os_random();
     char *timestamp;
     time_t now;
@@ -790,6 +790,9 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
     mtdebug1(WM_SYS_LOGTAG, "Starting network inventory.");
 
     if (getifaddrs(&ifaddrs_ptr) == -1){
+        if (ifaddrs_ptr) {
+            freeifaddrs(ifaddrs_ptr);
+        }
         mterror(WM_SYS_LOGTAG, "getifaddrs() failed.");
         return;
     }

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -957,7 +957,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
 
     char ** ifaces_list;
     int i = 0, size_ifaces = 0;
-    struct ifaddrs *ifaddr, *ifa;
+    struct ifaddrs *ifaddr = NULL, *ifa;
     int random_id = os_random();
     char *timestamp;
     time_t now;
@@ -981,6 +981,9 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
     mtdebug1(WM_SYS_LOGTAG, "Starting network inventory.");
 
     if (getifaddrs(&ifaddr) == -1) {
+        if (ifaddr) {
+            freeifaddrs(ifaddr);
+        }
         mterror(WM_SYS_LOGTAG, "getifaddrs() failed.");
         free(timestamp);
         return;

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -997,6 +997,7 @@ void sys_network_linux(int queue_fd, const char* LOCATION){
     if(!ifaces_list[0]){
         mterror(WM_SYS_LOGTAG, "No interface found. Network inventory suspended.");
         free(ifaces_list);
+        freeifaddrs(ifaddr);
         free(timestamp);
         return;
     }
@@ -1687,7 +1688,7 @@ int read_entry(u_int8_t* bytes, rpm_data *info) {
 }
 
 void getNetworkIface_linux(cJSON *object, char *iface_name, struct ifaddrs *ifaddr){
-    
+
     struct ifaddrs *ifa;
     int k = 0;
     int family = 0;
@@ -1707,7 +1708,7 @@ void getNetworkIface_linux(cJSON *object, char *iface_name, struct ifaddrs *ifad
     state = get_oper_state(iface_name);
     cJSON_AddStringToObject(interface, "state", state);
     free(state);
-  
+
     /* Get MAC address */
     char addr_path[PATH_LENGTH] = {'\0'};
     snprintf(addr_path, PATH_LENGTH, "%s%s/address", WM_SYS_IFDATA_DIR, iface_name);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -79,10 +79,12 @@ char* getPrimaryIP(){
         if(gate = OSHash_Get(gateways, ifaces_list[i]), gate){
             if(!gate->isdefault){
                 free(gate);
+                cJSON_Delete(object);
                 continue;
             }
             if(gate->addr[0]=='l'){
                 free(gate);
+                cJSON_Delete(object);
                 continue;
             }
             getNetworkIface_bsd(object, ifaces_list[i], ifaddr, gate);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -56,6 +56,7 @@ char* getPrimaryIP(){
         if(!ifaces_list[0]){
             mtdebug1(WM_CONTROL_LOGTAG, "No network interface found when reading agent IP.");
             os_free(ifaces_list);
+            freeifaddrs(ifaddr);
             return agent_ip;
         }
     }
@@ -64,6 +65,7 @@ char* getPrimaryIP(){
     if (getGatewayList(gateways) < 0){
         mtdebug1(WM_CONTROL_LOGTAG, "Unable to obtain the Default Gateway list");
         os_free(ifaces_list);
+        freeifaddrs(ifaddr);
         return agent_ip;
     }
     gateway *gate;
@@ -110,7 +112,7 @@ char* getPrimaryIP(){
             cJSON_Delete(object);
             break;
 #endif
-            
+
         }
         cJSON_Delete(object);
     }

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -33,7 +33,7 @@ char* getPrimaryIP(){
      /* Get Primary IP */
     char * agent_ip = NULL;
     char **ifaces_list;
-    struct ifaddrs *ifaddr, *ifa;
+    struct ifaddrs *ifaddr = NULL, *ifa;
     int size;
     int i = 0;
 #ifdef __linux__
@@ -41,6 +41,9 @@ char* getPrimaryIP(){
 #endif
 
     if (getifaddrs(&ifaddr) == -1) {
+        if (ifaddr) {
+            freeifaddrs(ifaddr);
+        }
         mterror(WM_CONTROL_LOGTAG, "at getPrimaryIP(): getifaddrs() failed.");
         return agent_ip;
     }


### PR DESCRIPTION
This PR fixes a descriptor leakage and a memory leak in Syscheck. It also prevents the appearance of other memory leaks in Modulesd.

The Syscheck issue has been fixed in https://github.com/wazuh/wazuh/commit/c8f526b2951ae29617bfe48858a5440986041f75. It appears when analyzed recursively directories whose parents changed. 

For example, a call to `read_dir` over `/home/test` with the following configuration can generate a descriptor leak:

``` XML
<directories check_all="yes" realtime="yes">/home/test</directories>
<directories check_all="yes" whodata="yes">/home/test/subfolder</directories>
```

This bug affects only 3.9.4.

The commits on `wazuh-modulesd` solve memory leaks in uncommon environments, such as those without network interfaces.

## Valgrind reports

After this branch, Valgrind reports the following memory leaks about an agent Centos 7. However, after analyzing them, we can confirm that they are false positives.



> ==10459== 6 bytes in 1 blocks are definitely lost in loss record 6 of 104
> ==10459==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
> ==10459==    by 0x5C7A249: strdup (in /usr/lib64/libc-2.17.so)
> ==10459==    by 0x42E5D8: wm_osquery_already_running (wm_osquery_monitor.c:388)
> ==10459==    by 0x42E2A1: Execute_Osquery (wm_osquery_monitor.c:319)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 64 bytes in 1 blocks are definitely lost in loss record 52 of 104
> ==10459==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
> ==10459==    by 0x446EA5: sys_network_linux (syscollector_linux.c:972)
> ==10459==    by 0x4433FF: wm_sys_main (syscollector_common.c:86)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 65 bytes in 1 blocks are definitely lost in loss record 53 of 104
> ==10459==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
> ==10459==    by 0x44796A: get_if_type (syscollector_linux.c:1166)
> ==10459==    by 0x4495F6: getNetworkIface_linux (syscollector_linux.c:1702)
> ==10459==    by 0x44713F: sys_network_linux (syscollector_linux.c:1014)
> ==10459==    by 0x4433FF: wm_sys_main (syscollector_common.c:86)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 89 bytes in 1 blocks are definitely lost in loss record 63 of 104
> ==10459==    at 0x4C2BB58: realloc (vg_replace_malloc.c:785)
> ==10459==    by 0x4146A9: wm_strcat (string_op.c:532)
> ==10459==    by 0x43C8E7: wm_oscap_run (wm_oscap.c:175)
> ==10459==    by 0x43C590: wm_oscap_main (wm_oscap.c:80)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 161 bytes in 1 blocks are definitely lost in loss record 69 of 104
> ==10459==    at 0x4C2BB58: realloc (vg_replace_malloc.c:785)
> ==10459==    by 0x4146A9: wm_strcat (string_op.c:532)
> ==10459==    by 0x43C931: wm_oscap_run (wm_oscap.c:179)
> ==10459==    by 0x43C590: wm_oscap_main (wm_oscap.c:80)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 453 (64 direct, 389 indirect) bytes in 1 blocks are definitely lost in loss record 78 of 104
> ==10459==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
> ==10459==    by 0x5318428: cJSON_New_Item (cJSON.c:160)
> ==10459==    by 0x531B770: cJSON_CreateObject (cJSON.c:2163)
> ==10459==    by 0x4470B5: sys_network_linux (syscollector_linux.c:1009)
> ==10459==    by 0x4433FF: wm_sys_main (syscollector_common.c:86)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 568 bytes in 1 blocks are definitely lost in loss record 85 of 104
> ==10459==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
> ==10459==    by 0x5C5CAFC: __fopen_internal (in /usr/lib64/libc-2.17.so)
> ==10459==    by 0x447A09: get_if_type (syscollector_linux.c:1171)
> ==10459==    by 0x4495F6: getNetworkIface_linux (syscollector_linux.c:1702)
> ==10459==    by 0x44713F: sys_network_linux (syscollector_linux.c:1014)
> ==10459==    by 0x4433FF: wm_sys_main (syscollector_common.c:86)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 1,128 (104 direct, 1,024 indirect) bytes in 1 blocks are definitely lost in loss record 92 of 104
> ==10459==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
> ==10459==    by 0x446FEE: sys_network_linux (syscollector_linux.c:992)
> ==10459==    by 0x4433FF: wm_sys_main (syscollector_common.c:86)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 2,872 bytes in 1 blocks are definitely lost in loss record 95 of 104
> ==10459==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
> ==10459==    by 0x5D10D5D: getifaddrs_internal (in /usr/lib64/libc-2.17.so)
> ==10459==    by 0x5D118DF: getifaddrs (in /usr/lib64/libc-2.17.so)
> ==10459==    by 0x446F82: sys_network_linux (syscollector_linux.c:983)
> ==10459==    by 0x4433FF: wm_sys_main (syscollector_common.c:86)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 9,210 (88 direct, 9,122 indirect) bytes in 1 blocks are definitely lost in loss record 101 of 104
> ==10459==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
> ==10459==    by 0x44ED03: OSHash_Create (hash_op.c:28)
> ==10459==    by 0x43243F: wm_sca_read_files (wm_sca.c:404)
> ==10459==    by 0x432158: wm_sca_start (wm_sca.c:341)
> ==10459==    by 0x431B83: wm_sca_main (wm_sca.c:222)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)
> 
> ==10459== 65,537 bytes in 1 blocks are definitely lost in loss record 104 of 104
> ==10459==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
> ==10459==    by 0x438E6D: wm_sca_request_thread (wm_sca.c:2798)
> ==10459==    by 0x59D9DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
> ==10459==    by 0x5CEC02C: clone (in /usr/lib64/libc-2.17.so)

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
