### PR TITLE
Prevent the generation of audit alerts that should be realtime

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -166,7 +166,10 @@ typedef struct registry_regex {
 #endif
 
 typedef struct syscheck_node {
-    char *checksum;
+    union {
+        char *checksum;
+        char *path;
+    };
     int dir_position;
 } syscheck_node;
 
@@ -246,6 +249,7 @@ char *syscheck_opts2str(char *buf, int buflen, int opts);
 /* Frees the Syscheck struct  */
 void Free_Syscheck(syscheck_config * config);
 char* check_ascci_hex (char *input);
+void free_syscheck_node(syscheck_node *node);
 
 void log_realtime_status(int);
 

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -68,6 +68,7 @@ static regex_t regexCompiled_inode;
 static regex_t regexCompiled_dir;
 static regex_t regexCompiled_syscall;
 
+static void report_inode_file(const char *path, int dir_position, whodata_evt *w_evt);
 
 // Check if Auditd is installed and running
 int check_auditd_enabled(void) {
@@ -510,7 +511,7 @@ void audit_parse(char *buffer) {
     char *real_path = NULL;
     whodata_evt *w_evt;
     unsigned int items = 0;
-    char *inode_temp;
+    syscheck_node *in_node;
     unsigned int filter_key;
 
     // Checks if the key obtained is one of those configured to monitor
@@ -692,8 +693,8 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
-                                    realtime_checksumfile(inode_temp, w_evt);
+                                if (in_node = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), in_node) {
+                                    report_inode_file(in_node->path, in_node->dir_position, w_evt);
                                 } else {
                                     realtime_checksumfile(w_evt->path, w_evt);
                                 }
@@ -726,8 +727,8 @@ void audit_parse(char *buffer) {
                             w_evt->path = real_path;
 
                             if (w_evt->inode) {
-                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
-                                    realtime_checksumfile(inode_temp, w_evt);
+                                if (in_node = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), in_node) {
+                                    report_inode_file(in_node->path, in_node->dir_position, w_evt);
                                 } else {
                                     realtime_checksumfile(w_evt->path, w_evt);
                                 }
@@ -757,8 +758,8 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
-                                    realtime_checksumfile(inode_temp, w_evt);
+                                if (in_node = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), in_node) {
+                                    report_inode_file(in_node->path, in_node->dir_position, w_evt);
                                 } else {
                                     realtime_checksumfile(w_evt->path, w_evt);
                                 }
@@ -797,8 +798,8 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
-                                    realtime_checksumfile(inode_temp, w_evt);
+                                if (in_node = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), in_node) {
+                                    report_inode_file(in_node->path, in_node->dir_position, w_evt);
                                 } else {
                                     realtime_checksumfile(w_evt->path, w_evt);
                                 }
@@ -823,8 +824,8 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
-                                    realtime_checksumfile(inode_temp, w_evt);
+                                if (in_node = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), in_node) {
+                                    report_inode_file(in_node->path, in_node->dir_position, w_evt);
                                 } else {
                                     realtime_checksumfile(w_evt->path, w_evt);
                                 }
@@ -857,8 +858,8 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                if (inode_temp = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), inode_temp) {
-                                    realtime_checksumfile(inode_temp, w_evt);
+                                if (in_node = OSHash_Get_ex(syscheck.inode_hash, w_evt->inode), in_node) {
+                                    report_inode_file(in_node->path, in_node->dir_position, w_evt);
                                 } else {
                                     realtime_checksumfile(w_evt->path, w_evt);
                                 }
@@ -1261,6 +1262,14 @@ exit_err:
     hc_thread_active = 0;
     return -1;
 
+}
+
+void report_inode_file(const char *path, int dir_position, whodata_evt *w_evt) {
+    if (syscheck.opts[dir_position] & CHECK_WHODATA) {
+        realtime_checksumfile(path, w_evt);
+    } else {
+        
+    }
 }
 
 #endif

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1093,8 +1093,7 @@ void send_whodata_del(whodata_evt *w_evt, char remove_hash) {
             return;
         }
 
-        free(s_node->checksum);
-        free(s_node);
+        free_syscheck_node(s_node);
     }
 
     if (extract_whodata_sum(w_evt, wd_sum, OS_SIZE_6144)) {
@@ -1771,8 +1770,7 @@ void whodata_remove_folder(OSHashNode **row, OSHashNode **node, void *data) {
 
         free(r_node->key);
         free(r_node);
-        free(s_node->checksum);
-        free(s_node);
+        free_syscheck_node(s_node);
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#3733|

The reason for the bug is an inconsistency in the process of detecting that the file being processed may have an inode previously saved for another path. The following code section corresponds to the part that checks the event inode. 

https://github.com/wazuh/wazuh/blob/68aaf6d31557106bc8b3cb58b81388644cb27ff5/src/syscheckd/create_db.c#L491-L504

If the inode of the file being processed was related to another file previously, Syscheck will check the status of the old path, which will possibly have been removed, to send the corresponding alert.

The problem comes when the `dir_position` variable is reused. In this case, the old path is reported with the attributes of the path that replaces its inode.

To replicate it, you can configure the following directories:

``` XML
  <directories check_all="yes" whodata="yes" tags="WD">/tmp/test_wd</directories>
  <directories check_all="yes" realtime="yes" tags="RT">/tmp/test_rt</directories>
```

If you move a file from `/tmp/test_wd` to `/tmp/test_rt`, you should see a removal alert with the `WD` tag and an addition alert with the `RT` tag. However, both events are reported with the attributes of the realtime directory (including the `RT` tags).

Two solutions have been proposed to solve this bug. The first and the easier solution of them is calling to `find_dir_pos()` function for the `inode_path` variable. This will return the real parent of this file, allowing Syscheck to set the corresponding attributes by indicating its position to `read_file()`. 

https://github.com/wazuh/wazuh/blob/68aaf6d31557106bc8b3cb58b81388644cb27ff5/src/syscheckd/create_db.c#L492

However, this solution is inefficient because we are repeating calls to `find_dir_pos()`.

The second solution, and the one that has finally been implemented, is to reutilice the parent position of the old path previously calculated. To do this, we have to modify the data structure saved in the hash table for inodes. Before, this hash table contained the path associated with the inode, and now the position of its closest parent directory is also saved.

Thanks to this, we only have to calculate the position of the parent directory once and the issue is fixed.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [x] CPU impact
  - [x] RAM usage impact
- [x] Retrocompatibility with older Wazuh versions
