### PR TITLE
Improve error message when a bucket is empty (AWS)

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -796,9 +796,11 @@ class AWSBucket(WazuhIntegration):
             sys.exit(7)
 
     def check_empty_bucket(self):
-        # exit if bucket is empty
+        """
+        Exits if the bucket is empty
+        """
         if not 'CommonPrefixes' in self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.prefix, Delimiter='/'):
-            print("ERROR: Empty bucket")
+            print("ERROR: No files were found in '{0}'. No logs will be processed.".format(self.bucket_path))
             exit(14)
 
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -21,6 +21,7 @@
 #   11 - Unable to connect to Wazuh
 #   12 - Invalid type of bucket
 #   13 - Unexpected error sending message to Wazuh
+#   14 - Empty bucket
 
 import signal
 import sys
@@ -793,6 +794,12 @@ class AWSBucket(WazuhIntegration):
                 debug("+++ Unexpected error: {}".format(err), 2)
             print("ERROR: Unexpected error querying/working with objects in S3: {}".format(err))
             sys.exit(7)
+
+    def check_empty_bucket(self):
+        # exit if bucket is empty
+        if not 'CommonPrefixes' in self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.prefix, Delimiter='/'):
+            print("ERROR: Empty bucket")
+            exit(14)
 
 
 class AWSLogsBucket(AWSBucket):
@@ -2228,6 +2235,8 @@ def main(argv):
                                  account_alias=options.aws_account_alias,
                                  prefix=options.trail_prefix, delete_file=options.deleteFile,
                                  aws_organization_id=options.aws_organization_id)
+            # check if bucket is empty
+            bucket.check_empty_bucket()
             bucket.iter_bucket(options.aws_account_id, options.regions)
         elif options.service:
             if options.service.lower() == 'inspector':

--- a/wodles/aws/tests/data/ossec-init.conf
+++ b/wodles/aws/tests/data/ossec-init.conf
@@ -1,0 +1,6 @@
+DIRECTORY="/var/ossec"
+NAME="Wazuh"
+VERSION="v3.10.0"
+REVISION="31004"
+DATE="Thu Jul 25 10:12:43 UTC 2019"
+TYPE="server"


### PR DESCRIPTION
Hi team,

This issue  closes #3715. I added a fix for detecting invalid types of buckets in #3652 (`3.10` version):

```bash
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix macie --type cloudtrail --debug 3 --skip_on_error
DEBUG: +++ Debug mode on - Level: 3
ERROR: Invalid type of bucket. The bucket was set up as 'cloudtrail' type and this bucket does not contain log files from this type. Try with other type: {'guardduty', 'config', 'vpcflow', 'custom'}
```

Before applying this PR, an error as above was shown when a bucket was empty. This PR checks if a bucket is empty:

```bash
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix empty_bucket --type cloudtrail --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
ERROR: Empty bucket
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix empty_bucket --type vpcflow --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
ERROR: Empty bucket
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix empty_bucket --type config --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
ERROR: Empty bucket
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix empty_bucket --type guardduty --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
ERROR: Empty bucket
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix empty_bucket --type custom --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
ERROR: Empty bucket
```

If bucket type is wrong (bucket type should be `custom`):
```bash
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix macie --type cloudtrail --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
ERROR: Invalid type of bucket. The bucket was set up as 'cloudtrail' type and this bucket does not contain log files from this type. Try with other type: {'config', 'guardduty', 'custom', 'vpcflow'}
```

Furthermore, I updated unit tests for `AWS` wodle for running them without a Wazuh installation:
```bash
$ pytest test_aws.py -vv
================================================ test session starts =================================================
platform linux -- Python 3.7.3, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/druizz/Git/wazuh/wodles/aws/tests, inifile:
plugins: tavern-0.26.3
collected 11 items                                                                                                   

test_aws.py::test_metadata_version_buckets[AWSCloudTrailBucket] PASSED                                         [  9%]
test_aws.py::test_metadata_version_buckets[AWSConfigBucket] PASSED                                             [ 18%]
test_aws.py::test_metadata_version_buckets[AWSVPCFlowBucket] PASSED                                            [ 27%]
test_aws.py::test_metadata_version_buckets[AWSCustomBucket] PASSED                                             [ 36%]
test_aws.py::test_metadata_version_buckets[AWSGuardDutyBucket] PASSED                                          [ 45%]
test_aws.py::test_metadata_version_services[AWSInspector] PASSED                                               [ 54%]
test_aws.py::test_db_maintenance[AWSCloudTrailBucket-schema_cloudtrail_test.sql-cloudtrail] PASSED             [ 63%]
test_aws.py::test_db_maintenance[AWSConfigBucket-schema_config_test.sql-config] PASSED                         [ 72%]
test_aws.py::test_db_maintenance[AWSVPCFlowBucket-schema_vpcflow_test.sql-vpcflow] PASSED                      [ 81%]
test_aws.py::test_db_maintenance[AWSCustomBucket-schema_custom_test.sql-custom] PASSED                         [ 90%]
test_aws.py::test_db_maintenance[AWSGuardDutyBucket-schema_guardduty_test.sql-guardduty] PASSED                [100%]

============================================= 11 passed in 0.17 seconds ==============================================
```

Best regards,

Demetrio.