### PR TITLE
Prevent Docker listener module from accumulating logs

### DIFF
--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -37,7 +37,6 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
     int status = 0;
     char * command = WM_DOCKER_SCRIPT_PATH;
-    char * output = NULL;
     int attempts = 0;
 
     wm_docker_setup(docker_conf);
@@ -60,33 +59,43 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
         mtdebug1(WM_DOCKER_LOGTAG, "Launching command '%s'.", command);
 
-        switch (wm_exec(command, &output, &status, 0, NULL)) {
-            case 0:
-                if (status > 0) {
-                    mtwarn(WM_DOCKER_LOGTAG, "Returned exit code %d", status);
-                    mterror(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
-                } else {
-                    if (output) {
-                        mtdebug2(WM_DOCKER_LOGTAG, "OUTPUT: %s", output);
-                    }
-                }
-                attempts++;
-                break;
-            default:
-                mterror(WM_DOCKER_LOGTAG, "Internal calling. Exiting...");
-                free(output);
-                pthread_exit(NULL);
-        }
+        wfd_t * wfd = wpopenl(command, W_BIND_STDERR | W_APPEND_POOL, command, NULL);
 
-        os_free(output);
-
-        if (attempts >= docker_conf->attempts) {
-            mterror(WM_DOCKER_LOGTAG, "Maximum attempts reached to run the listener. Exiting...");
+        if (wfd == NULL) {
+            mterror(WM_DOCKER_LOGTAG, "Cannot launch Docker integration due to an internal error.");
             pthread_exit(NULL);
         }
 
-        mtwarn(WM_DOCKER_LOGTAG, "Docker-listener finished unexpectedly (code %d). Retrying to run it in %u seconds...", status, docker_conf->interval);
-        sleep(docker_conf->interval);
+        char buffer[4096];
+
+        while (fgets(buffer, sizeof(buffer), wfd->file)) {
+            char * end = strchr(buffer, '\n');
+            if (end) {
+                *end = '\0';
+            }
+
+            mterror(WM_DOCKER_LOGTAG, "%s", buffer);
+        }
+
+        // At this point, DockerListener terminated
+
+        status = wpclose(wfd);
+        int exitcode = WEXITSTATUS(status);
+
+        switch (exitcode) {
+        case 127:
+            mterror(WM_DOCKER_LOGTAG, "Cannot launch Docker integration. Please check the file '%s'", command);
+            pthread_exit(NULL);
+
+        default:
+            if (++attempts >= docker_conf->attempts) {
+                mterror(WM_DOCKER_LOGTAG, "Maximum attempts reached to run the listener. Exiting...");
+                pthread_exit(NULL);
+            }
+
+            mtwarn(WM_DOCKER_LOGTAG, "Docker-listener finished unexpectedly (code %d). Retrying to run it in %u seconds...", exitcode, docker_conf->interval);
+            sleep(docker_conf->interval);
+        }
     }
 
     return NULL;

--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -7,17 +7,17 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-try:
-    import docker
-except:
-    print("'docker' module needs to be installed. Execute 'pip install docker' to do it.")
-    exit(1)
 import threading
 import json
 import socket
 import sys
 import time
 
+try:
+    import docker
+except:
+    sys.stderr.write("'docker' module needs to be installed. Execute 'pip install docker' to do it.\n")
+    exit(1)
 
 class DockerListener:
 
@@ -32,7 +32,7 @@ class DockerListener:
         # socket variables
         if sys.platform == "win32":
             self.wazuh_path = 'C:\Program Files (x86)\ossec-agent'
-            print("ERROR: This wodle does not work on Windows.")
+            sys.stderr.write("This wodle does not work on Windows.\n")
             sys.exit(1)
         else:
             self.wazuh_path = open('/etc/ossec-init.conf').readline().split('"')[1]
@@ -131,13 +131,13 @@ class DockerListener:
             s.close()
         except socket.error as e:
             if e.errno == 111:
-                print('ERROR: Wazuh must be running.')
+                sys.stderr.write('Wazuh must be running.\n')
                 sys.exit(11)
             else:
-                print("ERROR: Error sending message to wazuh: {}".format(e))
+                sys.stderr.write("Error sending message to wazuh: {}\n".format(e))
                 sys.exit(13)
         except Exception as e:
-            print("ERROR: Error sending message to wazuh: {}".format(e))
+            sys.stderr.write("Error sending message to wazuh: {}\n".format(e))
             sys.exit(13)
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#3764|

Issue #3764 reported an unexpected growth of the memory used by Modulesd when Docker Listener integration was running.

That is because the module runs Docker Listener with `wm_exec()`, that accumulates the output of the subprocess into an array. This involves two problems:

1. Modulesd won't print any data until the integration dies.
2. Docker Listener prints the data sent to the manager to the _stdout_. When this data reaches 64 MiB, the module will restart the integration, up to `max_attempts` times.

## Fix

Replace the call to `wm_exec()` to `wpopen()`, that works like `popen()` and lets the module read the _stdin_ and/or the _stdout_ while the integration is running.

## Modified artifacts

- Binaries.
- Docker listener: _wodles/docker/DockerListener_.

## Tests

- [X] Compile manager for Linux.
- [X] Compile agent for Linux.
- [X] Compile agent for macOS.
- [X] Compile agent for Windows.
- [X] Source installation on CentOS 7.
- [X] Source upgrade on CentOS 7.
- [X] Check memory with Valgrind (see below).
- [X] Run integration with _interval=1_ in normal operation.
- [X] Uninstall the `docker` package and check the log.
- [X] Produce an intentional error on the integration and check the log.

### Error log

This is the error log if the package `docker` is not installed;
```
2019/07/29 13:04:11 wazuh-modulesd:docker-listener: ERROR: 'docker' module needs to be installed. Execute 'pip install docker' to do it.
2019/07/29 13:04:11 wazuh-modulesd:docker-listener: WARNING: Docker-listener finished unexpectedly (code 1). Retrying to run it in 1 seconds...
```

### Valgrind report

Stopping Modulesd while the integration is running reports a memory leak:

```
==27918== HEAP SUMMARY:
==27918==     in use at exit: 3,780 bytes in 43 blocks
==27918==   total heap usage: 11,041 allocs, 10,998 frees, 6,147,840 bytes allocated
==27918==
==27918== 16 bytes in 1 blocks are definitely lost in loss record 15 of 33
==27918==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==27918==    by 0x44B67D: wpopenv (exec_op.c:127)
==27918==    by 0x44BB27: wpopenl (exec_op.c:223)
==27918==    by 0x46D247: wm_docker_main (wm_docker.c:62)
==27918==    by 0x59D8DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==27918==    by 0x5CEB02C: clone (in /usr/lib64/libc-2.17.so)
==27918==
==27918== LEAK SUMMARY:
==27918==    definitely lost: 16 bytes in 1 blocks
==27918==    indirectly lost: 0 bytes in 0 blocks
==27918==      possibly lost: 0 bytes in 0 blocks
==27918==    still reachable: 3,764 bytes in 42 blocks
==27918==         suppressed: 0 bytes in 0 blocks
```

However, this is due to the allocation of `wfd_t`, that is always freed with `wpclose()`.

This is the memory report after running the integration 10 times, and stopping Modulesd before the next attempt:

```
==27947== LEAK SUMMARY:
==27947==    definitely lost: 0 bytes in 0 blocks
==27947==    indirectly lost: 0 bytes in 0 blocks
==27947==      possibly lost: 4,480 bytes in 8 blocks
==27947==    still reachable: 3,196 bytes in 41 blocks
==27947==         suppressed: 0 bytes in 0 blocks
```