### PR TITLE
Add new function for giving information about manager and cluster configuration

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -19,8 +19,9 @@ from time import time, sleep
 import fcntl
 import requests
 
-from wazuh import manager, common, configuration
+from wazuh import common, configuration
 from wazuh.InputValidator import InputValidator
+from wazuh.cluster.utils import get_manager_status
 from wazuh.database import Connection
 from wazuh.exception import WazuhException
 from wazuh.ossec_queue import OssecQueue
@@ -402,7 +403,7 @@ class Agent:
         :return: Message.
         """
 
-        manager_status = manager.status()
+        manager_status = get_manager_status()
         is_authd_running = 'ossec-authd' in manager_status and manager_status['ossec-authd'] == 'running'
 
         if self.use_only_authd():
@@ -558,7 +559,7 @@ class Agent:
         :param force: Remove old agents with same IP if disconnected since <force> seconds
         :return: Agent ID.
         """
-        manager_status = manager.status()
+        manager_status = get_manager_status()
         is_authd_running = 'ossec-authd' in manager_status and manager_status['ossec-authd'] == 'running'
 
         if self.use_only_authd():

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -2,10 +2,10 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 import itertools
+from wazuh.cluster.utils import get_cluster_status, manager_restart, read_cluster_config
 from wazuh.utils import md5, mkdir_with_mode
 from wazuh.exception import WazuhException
 from wazuh.agent import Agent
-from wazuh.manager import status, restart
 from wazuh.configuration import get_ossec_conf
 from wazuh.InputValidator import InputValidator
 from wazuh.database import Connection
@@ -89,67 +89,12 @@ def get_cluster_items_worker_intervals():
 
 
 def read_config(config_file=common.ossec_conf):
-    cluster_default_configuration = {
-        'disabled': False,
-        'node_type': 'master',
-        'name': 'wazuh',
-        'node_name': 'node01',
-        'key': '',
-        'port': 1516,
-        'bind_addr': '0.0.0.0',
-        'nodes': ['NODE_IP'],
-        'hidden': 'no'
-    }
+    """
+    Returns the cluster configuration.
 
-    try:
-        config_cluster = get_ossec_conf(section='cluster', conf_file=config_file)
-    except WazuhException as e:
-        if e.code == 1106:
-            # if no cluster configuration is present in ossec.conf, return default configuration but disabling it.
-            cluster_default_configuration['disabled'] = True
-            return cluster_default_configuration
-        else:
-            raise WazuhException(3006, e.message)
-    except Exception as e:
-        raise WazuhException(3006, str(e))
-
-    # if any value is missing from user's cluster configuration, add the default one:
-    for value_name in set(cluster_default_configuration.keys()) - set(config_cluster.keys()):
-        config_cluster[value_name] = cluster_default_configuration[value_name]
-
-    if isinstance(config_cluster['port'], str) and not config_cluster['port'].isdigit():
-        raise WazuhException(3004, "Cluster port must be an integer.")
-
-    config_cluster['port'] = int(config_cluster['port'])
-    if config_cluster['disabled'] == 'no':
-        config_cluster['disabled'] = False
-    elif config_cluster['disabled'] == 'yes':
-        config_cluster['disabled'] = True
-    elif not isinstance(config_cluster['disabled'], bool):
-        raise WazuhException(3004, "Allowed values for 'disabled' field are 'yes' and 'no'. Found: '{}'".format(
-            config_cluster['disabled']))
-
-    # if config_cluster['node_name'].upper() == '$HOSTNAME':
-    #     # The HOSTNAME environment variable is not always available in os.environ so use socket.gethostname() instead
-    #     config_cluster['node_name'] = gethostname()
-
-    # if config_cluster['node_name'].upper() == '$NODE_NAME':
-    #     if 'NODE_NAME' in environ:
-    #         config_cluster['node_name'] = environ['NODE_NAME']
-    #     else:
-    #         raise WazuhException(3006, 'Unable to get the $NODE_NAME environment variable')
-
-    # if config_cluster['node_type'].upper() == '$NODE_TYPE':
-    #     if 'NODE_TYPE' in environ:
-    #         config_cluster['node_type'] = environ['NODE_TYPE']
-    #     else:
-    #         raise WazuhException(3006, 'Unable to get the $NODE_TYPE environment variable')
-
-    if config_cluster['node_type'] == 'client':
-        logger.info("Deprecated node type 'client'. Using 'worker' instead.")
-        config_cluster['node_type'] = 'worker'
-
-    return config_cluster
+    return: Dictionary with cluster configuration
+    """
+    return read_cluster_config(config_file=common.ossec_conf)
 
 
 def get_node():
@@ -171,8 +116,12 @@ def check_cluster_status():
 
 
 def get_status_json():
-    return {"enabled": "no" if check_cluster_status() else "yes",
-            "running": "yes" if status()['wazuh-clusterd'] == 'running' else "no"}
+    """
+    Returns the cluster status
+
+    :return: Dictionary with the cluster status.
+    """
+    return get_cluster_status()
 
 
 #
@@ -377,7 +326,7 @@ def restart_all_nodes():
 
     :return: Confirmation message.
     """
-    restart()
+    manager_restart()
     return "Restart request sent"
 
 

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -228,7 +228,7 @@ functions = {
 
     # Managers
     '/manager/info': {
-        'function': Wazuh(common.ossec_path).get_ossec_init,
+        'function': manager.get_info,
         'type': 'local_any',
         'is_async': False
     },
@@ -340,7 +340,7 @@ functions = {
         'is_async': True
     },
     '/cluster/:node_id/info': {
-        'function': Wazuh(common.ossec_path).get_ossec_init,
+        'function': manager.get_info,
         'type': 'distributed_master',
         'is_async': False
     },

--- a/framework/wazuh/cluster/utils.py
+++ b/framework/wazuh/cluster/utils.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import fcntl
+import logging
+import re
+import socket
+import typing
+from glob import glob
+from os.path import join, exists
+
+import wazuh.common as common
+from wazuh.configuration import get_ossec_conf
+from wazuh.exception import WazuhException
+
+
+logger = logging.getLogger('wazuh')
+execq_lockfile = join(common.ossec_path, "var/run/.api_execq_lock")
+
+
+def read_cluster_config(config_file=common.ossec_conf) -> typing.Dict:
+    """
+    Reads the cluster configuration
+
+    :return: Dictionary with cluster configuration.
+    """
+    cluster_default_configuration = {
+        'disabled': False,
+        'node_type': 'master',
+        'name': 'wazuh',
+        'node_name': 'node01',
+        'key': '',
+        'port': 1516,
+        'bind_addr': '0.0.0.0',
+        'nodes': ['NODE_IP'],
+        'hidden': 'no'
+    }
+
+    try:
+        config_cluster = get_ossec_conf(section='cluster', conf_file=config_file)
+    except WazuhException as e:
+        if e.code == 1106:
+            # if no cluster configuration is present in ossec.conf, return default configuration but disabling it.
+            cluster_default_configuration['disabled'] = True
+            return cluster_default_configuration
+        else:
+            raise WazuhException(3006, e.message)
+    except Exception as e:
+        raise WazuhException(3006, str(e))
+
+    # if any value is missing from user's cluster configuration, add the default one:
+    for value_name in set(cluster_default_configuration.keys()) - set(config_cluster.keys()):
+        config_cluster[value_name] = cluster_default_configuration[value_name]
+
+    if isinstance(config_cluster['port'], str) and not config_cluster['port'].isdigit():
+        raise WazuhException(3004, "Cluster port must be an integer.")
+
+    config_cluster['port'] = int(config_cluster['port'])
+    if config_cluster['disabled'] == 'no':
+        config_cluster['disabled'] = False
+    elif config_cluster['disabled'] == 'yes':
+        config_cluster['disabled'] = True
+    elif not isinstance(config_cluster['disabled'], bool):
+        raise WazuhException(3004, "Allowed values for 'disabled' field are 'yes' and 'no'. Found: '{}'".format(
+            config_cluster['disabled']))
+
+    # if config_cluster['node_name'].upper() == '$HOSTNAME':
+    #     # The HOSTNAME environment variable is not always available in os.environ so use socket.gethostname() instead
+    #     config_cluster['node_name'] = gethostname()
+
+    # if config_cluster['node_name'].upper() == '$NODE_NAME':
+    #     if 'NODE_NAME' in environ:
+    #         config_cluster['node_name'] = environ['NODE_NAME']
+    #     else:
+    #         raise WazuhException(3006, 'Unable to get the $NODE_NAME environment variable')
+
+    # if config_cluster['node_type'].upper() == '$NODE_TYPE':
+    #     if 'NODE_TYPE' in environ:
+    #         config_cluster['node_type'] = environ['NODE_TYPE']
+    #     else:
+    #         raise WazuhException(3006, 'Unable to get the $NODE_TYPE environment variable')
+
+    if config_cluster['node_type'] == 'client':
+        logger.info("Deprecated node type 'client'. Using 'worker' instead.")
+        config_cluster['node_type'] = 'worker'
+
+    return config_cluster
+
+
+def get_manager_status() -> typing.Dict:
+    """
+    Returns the Manager processes that are running.
+
+    :return: Dictionary (keys: status, daemon).
+    """
+
+    processes = ['ossec-agentlessd', 'ossec-analysisd', 'ossec-authd', 'ossec-csyslogd', 'ossec-dbd', 'ossec-monitord',
+                 'ossec-execd', 'ossec-integratord', 'ossec-logcollector', 'ossec-maild', 'ossec-remoted',
+                 'ossec-reportd', 'ossec-syscheckd', 'wazuh-clusterd', 'wazuh-modulesd', 'wazuh-db']
+
+    data, pidfile_regex, run_dir = {}, re.compile(r'.+\-(\d+)\.pid$'), join(common.ossec_path, 'var/run')
+    for process in processes:
+        pidfile = glob(join(run_dir, f"{process}-*.pid"))
+        if exists(join(run_dir, f'{process}.failed')):
+            data[process] = 'failed'
+        elif exists(join(run_dir, f'.restart')):
+            data[process] = 'restarting'
+        elif exists(join(run_dir, f'{process}.start')):
+            data[process] = 'starting'
+        elif pidfile:
+            process_pid = pidfile_regex.match(pidfile[0]).group(1)
+            # if a pidfile exists but the process is not running, it means the process crashed and
+            # wasn't able to remove its own pidfile.
+            data[process] = 'running' if exists(join('/proc', process_pid)) else 'failed'
+        else:
+            data[process] = 'stopped'
+
+    return data
+
+
+def get_cluster_status() -> typing.Dict:
+    """
+    Returns the cluster status
+
+    :return: Dictionary with cluster status
+    """
+    return {"enabled": "no" if read_cluster_config()['disabled'] else "yes",
+            "running": "yes" if get_manager_status()['wazuh-clusterd'] == 'running' else "no"}
+
+
+def manager_restart():
+    """
+    Restart Wazuh manager.
+
+    :return: Confirmation message.
+    """
+    lock_file = open(execq_lockfile, 'a+')
+    fcntl.lockf(lock_file, fcntl.LOCK_EX)
+    try:
+        # execq socket path
+        socket_path = common.EXECQ
+        # msg for restarting Wazuh manager
+        msg = 'restart-wazuh '
+        # initialize socket
+        if exists(socket_path):
+            try:
+                conn = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+                conn.connect(socket_path)
+            except socket.error:
+                raise WazuhException(1902)
+        else:
+            raise WazuhException(1901)
+
+        try:
+            conn.send(msg.encode())
+            conn.close()
+        except socket.error as e:
+            raise WazuhException(1014, str(e))
+    finally:
+        fcntl.lockf(lock_file, fcntl.LOCK_UN)
+        lock_file.close()
+
+    return "Restart request sent"

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -20,8 +20,11 @@ from xml.parsers.expat import ExpatError
 
 import fcntl
 
+from wazuh.agent import Agent
 from wazuh import common
 from wazuh import configuration
+from wazuh import Wazuh
+from wazuh.cluster.utils import get_manager_status, get_cluster_status, manager_restart, read_cluster_config
 from wazuh.exception import WazuhException
 from wazuh.utils import previous_month, cut_array, sort_array, search_array, tail, load_wazuh_xml, safe_move
 
@@ -32,31 +35,11 @@ execq_lockfile = join(common.ossec_path, "var/run/.api_execq_lock")
 def status() -> Dict:
     """
     Returns the Manager processes that are running.
+
     :return: Dictionary (keys: status, daemon).
     """
 
-    processes = ['ossec-agentlessd', 'ossec-analysisd', 'ossec-authd', 'ossec-csyslogd', 'ossec-dbd', 'ossec-monitord',
-                 'ossec-execd', 'ossec-integratord', 'ossec-logcollector', 'ossec-maild', 'ossec-remoted',
-                 'ossec-reportd', 'ossec-syscheckd', 'wazuh-clusterd', 'wazuh-modulesd', 'wazuh-db']
-
-    data, pidfile_regex, run_dir = {}, re.compile(r'.+\-(\d+)\.pid$'), join(common.ossec_path, 'var/run')
-    for process in processes:
-        pidfile = glob(join(run_dir, f"{process}-*.pid"))
-        if exists(join(run_dir, f'{process}.failed')):
-            data[process] = 'failed'
-        elif exists(join(run_dir, f'.restart')):
-            data[process] = 'restarting'
-        elif exists(join(run_dir, f'{process}.start')):
-            data[process] = 'starting'
-        elif pidfile:
-            process_pid = pidfile_regex.match(pidfile[0]).group(1)
-            # if a pidfile exists but the process is not running, it means the process crashed and
-            # wasn't able to remove its own pidfile.
-            data[process] = 'running' if exists(join('/proc', process_pid)) else 'failed'
-        else:
-            data[process] = 'stopped'
-
-    return data
+    return get_manager_status()
 
 
 def __get_ossec_log_fields(log):
@@ -405,37 +388,11 @@ def delete_file(path):
 
 def restart():
     """
-    Restart Wazuh manager.
+    Wrapper for 'restart_manager' function due to interdependencies with cluster module
 
     :return: Confirmation message.
     """
-    lock_file = open(execq_lockfile, 'a+')
-    fcntl.lockf(lock_file, fcntl.LOCK_EX)
-    try:
-        # execq socket path
-        socket_path = common.EXECQ
-        # msg for restarting Wazuh manager
-        msg = 'restart-wazuh '
-        # initialize socket
-        if exists(socket_path):
-            try:
-                conn = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-                conn.connect(socket_path)
-            except socket.error:
-                raise WazuhException(1902)
-        else:
-            raise WazuhException(1901)
-
-        try:
-            conn.send(msg.encode())
-            conn.close()
-        except socket.error as e:
-            raise WazuhException(1014, str(e))
-    finally:
-        fcntl.lockf(lock_file, fcntl.LOCK_UN)
-        lock_file.close()
-
-    return "Restart request sent"
+    return manager_restart()
 
 
 def _check_wazuh_xml(files):
@@ -566,3 +523,31 @@ def get_config(component, config):
     Returns active configuration loaded in manager
     """
     return configuration.get_active_configuration(agent_id='000', component=component, configuration=config)
+
+
+def get_info() -> Dict:
+    """
+    Returns manager configuration with cluster details
+
+    :return: Dictionary with information about manager and cluster
+    """
+    # get name from agent 000
+    manager = Agent(id=0)
+    manager._load_info_from_DB()
+
+    # read cluster configuration
+    cluster_config = read_cluster_config()
+
+    # get manager status
+    cluster_info = get_cluster_status()
+    # add 'name', 'node_name' and 'node_type' to cluster_info
+    for name in ('name', 'node_name', 'node_type'):
+        cluster_info[name] = cluster_config[name]
+
+    # merge manager information into an unique dictionary
+    manager_info = {**Wazuh(common.ossec_path).get_ossec_init(),
+                    **{'name': manager.name, 'cluster': cluster_info}}
+
+    return manager_info
+
+


### PR DESCRIPTION
Hi team,

This PR closes [#425](https://github.com/wazuh/wazuh-api/issues/425). I added a new function for giving information about cluster status when information about the manager is required. It was necessary to move some functions to a new module (`cluster.utils`) in order to avoid interdependencies between `cluster` and `manager` modules.

There are more details in  [#425](https://github.com/wazuh/wazuh-api/issues/425) of this work.

Best regards,

Demetrio.