### PR TITLE
Remove Control module memory leak in MacOS agents

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -760,13 +760,6 @@ hw_info *get_system_bsd(){
 
 }
 
-#ifdef __MACH__
-static void freegate(gateway *gate){
-    os_free(gate->addr);
-    os_free(gate);
-}
-#endif
-
 // Get network inventory
 
 void sys_network_bsd(int queue_fd, const char* LOCATION){

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -760,6 +760,13 @@ hw_info *get_system_bsd(){
 
 }
 
+#ifdef __MACH__
+static void freegate(gateway *gate){
+    os_free(gate->addr);
+    os_free(gate);
+}
+#endif
+
 // Get network inventory
 
 void sys_network_bsd(int queue_fd, const char* LOCATION){
@@ -818,6 +825,7 @@ void sys_network_bsd(int queue_fd, const char* LOCATION){
 
 #if defined(__MACH__)
     gateways = OSHash_Create();
+    OSHash_SetFreeDataPointer(gateways, (void (*)(void *)) freegate);
     if (getGatewayList(gateways) < 0){
         mtwarn(WM_SYS_LOGTAG, "Unable to obtain the Default Gateway list.");
     }
@@ -1075,7 +1083,6 @@ void getNetworkIface_bsd(cJSON *object, char *iface_name, struct ifaddrs *ifaddr
         #if defined(__MACH__)
         if(gate){
             cJSON_AddStringToObject(ipv4, "gateway", gate->addr);
-            free(gate);
         }
         #endif
 
@@ -1251,8 +1258,6 @@ int getGatewayList(OSHash *gateway_list){
 
         ptr = (char *)(msg + 1);
         while (ptr + sizeof (struct sockaddr) <= msgend && addrs) {
-            gateway *gate;
-            os_calloc(1, sizeof (struct gateway *), gate);
             struct sockaddr *sa = (struct sockaddr *)ptr;
             int len = SA_LEN(sa);
 
@@ -1281,23 +1286,28 @@ int getGatewayList(OSHash *gateway_list){
                     break;
         #endif
                 } else {
-                break;
+                    break;
                 }
             }
 
             if (addr == RTA_GATEWAY) {
+                struct gateway *gate;
+                os_calloc(1, sizeof (struct gateway), gate);
                 char strbuf[256];
 
-                if (string_from_sockaddr (sa, strbuf, sizeof(strbuf)) == 0) {
-                os_strdup(strbuf,gate->addr);
-                #ifdef RTF_IFSCOPE
-                    gate->isdefault = !(msg->rtm_flags & RTF_IFSCOPE);
-                #else
-                    gate->isdefault = 1;
-                #endif
-                    OSHash_Add(gateway_list, ifname, gate);
-                    mdebug2("Gateway of interface %s : %s Default: %d", ifname, gate->addr, gate->isdefault);
+                if (string_from_sockaddr (sa, strbuf, sizeof(strbuf)) != 0) {
+                    os_free(gate);
+                    continue;
                 }
+                os_calloc(256, sizeof (char *), gate->addr);
+                snprintf(gate->addr, 255, "%s", strbuf);
+                #ifdef RTF_IFSCOPE
+                gate->isdefault = !(msg->rtm_flags & RTF_IFSCOPE);
+                #else
+                gate->isdefault = 1;
+                #endif
+                OSHash_Add(gateway_list, ifname, gate);
+                mdebug2("Gateway of interface %s : %s Default: %d", ifname, gate->addr, gate->isdefault);
             }
 
             /* These are aligned on a 4-byte boundary */

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -1299,7 +1299,7 @@ int getGatewayList(OSHash *gateway_list){
                     os_free(gate);
                     continue;
                 }
-                os_calloc(256, sizeof (char *), gate->addr);
+                os_calloc(256, sizeof (char), gate->addr);
                 snprintf(gate->addr, 255, "%s", strbuf);
                 #ifdef RTF_IFSCOPE
                 gate->isdefault = !(msg->rtm_flags & RTF_IFSCOPE);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -31,8 +31,8 @@ const wm_context WM_CONTROL_CONTEXT = {
 
 #ifdef __MACH__
     void freegate(gateway *gate){
-        free(gate->addr);
-        free(gate);
+        if (gate->addr)     os_free(gate->addr);
+        if (gate)   os_free(gate);
     }
 #endif
 

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -30,10 +30,10 @@ const wm_context WM_CONTROL_CONTEXT = {
 };
 
 #ifdef __MACH__
-    void freegate(gateway *gate){
-        if (gate->addr)     os_free(gate->addr);
-        if (gate)   os_free(gate);
-    }
+static void freegate(gateway *gate){
+    os_free(gate->addr);
+    os_free(gate);
+}
 #endif
 
 char* getPrimaryIP(){
@@ -68,7 +68,7 @@ char* getPrimaryIP(){
     }
 #ifdef __MACH__
     OSHash *gateways = OSHash_Create();
-    OSHash_SetFreeDataPointer(gateways, (void (*)(void *))freegate);
+    OSHash_SetFreeDataPointer(gateways, (void (*)(void *)) freegate);
     if (getGatewayList(gateways) < 0){
         mtdebug1(WM_CONTROL_LOGTAG, "Unable to obtain the Default Gateway list");
         OSHash_Free(gateways);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -29,13 +29,6 @@ const wm_context WM_CONTROL_CONTEXT = {
     (cJSON * (*)(const void *))wm_control_dump
 };
 
-#ifdef __MACH__
-static void freegate(gateway *gate){
-    os_free(gate->addr);
-    os_free(gate);
-}
-#endif
-
 char* getPrimaryIP(){
      /* Get Primary IP */
     char * agent_ip = NULL;

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -29,6 +29,13 @@ const wm_context WM_CONTROL_CONTEXT = {
     (cJSON * (*)(const void *))wm_control_dump
 };
 
+#ifdef __MACH__
+    void freegate(gateway *gate){
+        free(gate->addr);
+        free(gate);
+    }
+#endif
+
 char* getPrimaryIP(){
      /* Get Primary IP */
     char * agent_ip = NULL;
@@ -61,8 +68,10 @@ char* getPrimaryIP(){
     }
 #ifdef __MACH__
     OSHash *gateways = OSHash_Create();
+    OSHash_SetFreeDataPointer(gateways, (void (*)(void *))freegate);
     if (getGatewayList(gateways) < 0){
         mtdebug1(WM_CONTROL_LOGTAG, "Unable to obtain the Default Gateway list");
+        OSHash_Free(gateways);
         os_free(ifaces_list);
         return agent_ip;
     }
@@ -76,11 +85,11 @@ char* getPrimaryIP(){
 #elif defined __MACH__
         if(gate = OSHash_Get(gateways, ifaces_list[i]), gate){
             if(!gate->isdefault){
-                free(gate);
+                cJSON_Delete(object);
                 continue;
             }
             if(gate->addr[0]=='l'){
-                free(gate);
+                cJSON_Delete(object);
                 continue;
             }
             getNetworkIface_bsd(object, ifaces_list[i], ifaddr, gate);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -51,21 +51,27 @@ char* getPrimaryIP(){
         mterror(WM_CONTROL_LOGTAG, "at getPrimaryIP(): getifaddrs() failed.");
         return agent_ip;
     }
-    else {
-        for (ifa = ifaddr; ifa; ifa = ifa->ifa_next){
-            i++;
-        }
-        os_calloc(i, sizeof(char *), ifaces_list);
 
-        /* Create interfaces list */
-        size = getIfaceslist(ifaces_list, ifaddr);
-
-        if(!ifaces_list[0]){
-            mtdebug1(WM_CONTROL_LOGTAG, "No network interface found when reading agent IP.");
-            os_free(ifaces_list);
-            return agent_ip;
-        }
+    for (ifa = ifaddr; ifa; ifa = ifa->ifa_next){
+        i++;
     }
+
+    if(i == 0){
+        mtdebug1(WM_CONTROL_LOGTAG, "No network interfaces found when reading agent IP.");
+        return agent_ip;
+    }
+
+    os_calloc(i, sizeof(char *), ifaces_list);
+
+    /* Create interfaces list */
+    size = getIfaceslist(ifaces_list, ifaddr);
+
+    if(!ifaces_list[0]){
+        mtdebug1(WM_CONTROL_LOGTAG, "No network interfaces found when reading agent IP.");
+        os_free(ifaces_list);
+        return agent_ip;
+    }
+    
 #ifdef __MACH__
     OSHash *gateways = OSHash_Create();
     OSHash_SetFreeDataPointer(gateways, (void (*)(void *)) freegate);

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -605,3 +605,13 @@ void wm_delay(unsigned int ms) {
     select(0, NULL, NULL, NULL, &timeout);
 #endif
 }
+
+#ifdef __MACH__
+void freegate(gateway *gate){
+    if(!gate){
+        return;
+    }
+    os_free(gate->addr);
+    os_free(gate);
+}
+#endif

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -197,4 +197,8 @@ size_t wmcom_getconfig(const char * section, char ** output);
 // Sleep function for Windows and Unix (milliseconds)
 void wm_delay(unsigned int ms);
 
+#ifdef __MACH__
+void freegate(gateway *gate);
+#endif
+
 #endif // W_MODULES


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3738|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR resolve some memory leaks that Control module has in MacOS agents. It adds a free function to the Hash table of gateways and frees the JSON object when the gate is not the default gateway.

## Errors solved
```
==89222==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000006038 at pc 0x0001000eee05 bp 0x7000065455b0 sp 0x7000065455a8
WRITE of size 4 at 0x602000006038 thread T5
    #0 0x1000eee04 in getGatewayList syscollector_bsd.c:1295
    #1 0x1000b2779 in getPrimaryIP wm_control.c:76
    #2 0x1000b3a1f in send_ip wm_control.c:231
    #3 0x1000b3ad4 in wm_control_main wm_control.c:150
    #4 0x7fffa9c6093a in _pthread_body (libsystem_pthread.dylib:x86_64+0x393a)
    #5 0x7fffa9c60886 in _pthread_start (libsystem_pthread.dylib:x86_64+0x3886)
    #6 0x7fffa9c6008c in thread_start (libsystem_pthread.dylib:x86_64+0x308c)

0x602000006038 is located 0 bytes to the right of 8-byte region [0x602000006030,0x602000006038)
allocated by thread T5 here:
    #0 0x10078c4c0 in wrap_calloc (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x564c0)
    #1 0x1000ee6e0 in getGatewayList syscollector_bsd.c:1256
    #2 0x1000b2779 in getPrimaryIP wm_control.c:76
    #3 0x1000b3a1f in send_ip wm_control.c:231
    #4 0x1000b3ad4 in wm_control_main wm_control.c:150
    #5 0x7fffa9c6093a in _pthread_body (libsystem_pthread.dylib:x86_64+0x393a)
    #6 0x7fffa9c60886 in _pthread_start (libsystem_pthread.dylib:x86_64+0x3886)
    #7 0x7fffa9c6008c in thread_start (libsystem_pthread.dylib:x86_64+0x308c)

Thread T5 created by T0 here:
    #0 0x1007837a6 in wrap_pthread_create (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x4d7a6)
    #1 0x1001221d4 in CreateThreadJoinable pthreads_op.c:47
    #2 0x1000013ee in main main.c:95
    #3 0x7fffa9a47234 in start (libdyld.dylib:x86_64+0x5234)

SUMMARY: AddressSanitizer: heap-buffer-overflow syscollector_bsd.c:1295 in getGatewayList
```

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- [X] Compilation in MAC OS X
- [X] Source installation
- [X] AddressSanitizer analysis of affected components. *No reports during execution*
- [x] Scan-build report

Scan-build report
```
Done building agent
scan-build: 2 bugs found.
scan-build: Run 'scan-view /tmp/scan-build-2019-07-29-091313-2125-1' to examine bug reports.
```
The two bugs found are related to Syscollector. The issue for these bugs is: https://github.com/wazuh/wazuh/issues/3774

Use cases
-------------
I use a RNG to test the error cases of the functionality. As we can see in the logs, the module doesn't stop working after an error is received.
```
2019/07/31 04:58:46 wazuh-modulesd:control[7282] wm_control.c:55 at getPrimaryIP(): ERROR: at getPrimaryIP(): getifaddrs() failed.
2019/07/31 04:58:56 wazuh-modulesd:control[7282] wm_control.c:64 at getPrimaryIP(): DEBUG: No network interfaces found when reading agent IP.
2019/07/31 04:59:06 wazuh-modulesd[7282] syscollector_bsd.c:1310 at getGatewayList(): DEBUG: Gateway of interface en0 : 10.0.2.2 Default: 1
2019/07/31 04:59:16 wazuh-modulesd:control[7282] wm_control.c:55 at getPrimaryIP(): ERROR: at getPrimaryIP(): getifaddrs() failed.
2019/07/31 04:59:26 wazuh-modulesd[7282] syscollector_bsd.c:1310 at getGatewayList(): DEBUG: Gateway of interface en0 : 10.0.2.2 Default: 1
2019/07/31 04:59:26 wazuh-modulesd:control[7282] wm_control.c:85 at getPrimaryIP(): DEBUG: Unable to obtain the Default Gateway list
2019/07/31 04:59:36 wazuh-modulesd:control[7282] wm_control.c:55 at getPrimaryIP(): ERROR: at getPrimaryIP(): getifaddrs() failed.
2019/07/31 04:59:46 wazuh-modulesd:control[7282] wm_control.c:55 at getPrimaryIP(): ERROR: at getPrimaryIP(): getifaddrs() failed.
2019/07/31 04:59:56 wazuh-modulesd:control[7282] wm_control.c:64 at getPrimaryIP(): DEBUG: No network interfaces found when reading agent IP.
2019/07/31 05:00:06 wazuh-modulesd:control[7282] wm_control.c:64 at getPrimaryIP(): DEBUG: No network interfaces found when reading agent IP.
2019/07/31 05:00:16 wazuh-modulesd:control[7282] wm_control.c:55 at getPrimaryIP(): ERROR: at getPrimaryIP(): getifaddrs() failed.
2019/07/31 05:00:26 wazuh-modulesd:control[7282] wm_control.c:64 at getPrimaryIP(): DEBUG: No network interfaces found when reading agent IP.
2019/07/31 05:00:36 wazuh-modulesd:control[7282] wm_control.c:64 at getPrimaryIP(): DEBUG: No network interfaces found when reading agent IP.
```

Uses case for IP:
`char * testing_ip[] = {"0.0.0.0", "192.168.192.168", "1.1", "111.111.111.111.111", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "ƒ∫®∫§®", ""};`

Output:
```
ccc51beb7d35c0fd7294b10f70675a1f merged.mg
#"_agent_ip":192.168.192.168

#"_manager_hostname":pablo-work
#"_node_name":node01
```
```
ccc51beb7d35c0fd7294b10f70675a1f merged.mg
#"_agent_ip":1.1

#"_manager_hostname":pablo-work
#"_node_name":node01
```
```
ccc51beb7d35c0fd7294b10f70675a1f merged.mg
#"_agent_ip":0.0.0.0

#"_manager_hostname":pablo-work
#"_node_name":node01
```
```
ccc51beb7d35c0fd7294b10f70675a1f merged.mg


#"_manager_hostname":pablo-work
#"_node_name":node01
```
```
ccc51beb7d35c0fd7294b10f70675a1f merged.mg
#"_agent_ip":ƒ∫®∫§®

#"_manager_hostname":pablo-work
#"_node_name":node01
```
```
ccc51beb7d35c0fd7294b10f70675a1f merged.mg
#"_agent_ip":aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

#"_manager_hostname":pablo-work
#"_node_name":node01
```
