### PR TITLE
Fix unnecessary dist-detect.sh calling

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -6,7 +6,7 @@
 
 UN=${NUNAME};
 service="wazuh";
-./dist-detect.sh
+./src/init/dist-detect.sh
 
 runInit()
 {

--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -6,7 +6,6 @@
 
 UN=${NUNAME};
 service="wazuh";
-. ./src/init/dist-detect.sh
 
 runInit()
 {

--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -6,7 +6,7 @@
 
 UN=${NUNAME};
 service="wazuh";
-./src/init/dist-detect.sh
+. ./src/init/dist-detect.sh
 
 runInit()
 {


### PR DESCRIPTION
|Related issue|
|----------|
[3753](https://github.com/wazuh/wazuh/issues/3753)

## Description
The file `init.sh` is calling the function `dist-detect.sh` with the wrong path. Preventing this function from running. Also, the funtion `dist-detect.sh` is called in the first lines of `install.sh`, so that prevents the program from malfuntion, the information requested from dist-detec, version of the OS an the OS, and been requested. To solution this problem I have eliminated the line, with this, the error message dissapear. 
## Logs
```
2019/08/02 11:16:05 - Generating Backup.
2019/08/02 11:16:06 - Upgrade started.
./src/init/init.sh: line 9: ./dist-detect.sh: No existe el fichero o el directorio

 CentOS Linux 7 (Core) (Rev. 3932) Installation Script - http://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux centos7 3.10.0-957.5.1.el7.x86_64 (centos 7.6)
  - User: root
  - Host: centos7
```
This error message happens because the program can not find the the fuction `dist-detec.sh`.

## Tests
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Custom test
  - [x] Check if the error message in upgrade.log has disappear once we delete the line
```
2019/08/02 11:33:15 - Generating Backup.
2019/08/02 11:33:16 - Upgrade started.

 CentOS Linux 7 (Core) (Rev. 3932) Installation Script - http://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux centos7 3.10.0-957.5.1.el7.x86_64 (centos 7.6)
  - User: root
  - Host: centos7
```
  - [x] Check if the manager and the agent have been propertly installed. 
