### PR TITLE
Fix array above bounds

### DIFF
--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -134,7 +134,7 @@ char *get_message(EVT_HANDLE evt, LPCWSTR provider_name, DWORD flags)
     if (publisher == NULL) {
         LSTATUS err = GetLastError();
         char error_msg[OS_SIZE_1024];
-        error_msg[OS_SIZE_1024] = '\0';
+        error_msg[OS_SIZE_1024 - 1] = '\0';
         FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS
                 | FORMAT_MESSAGE_MAX_WIDTH_MASK,
                 NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),


### PR DESCRIPTION

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an array out of bounds at logcollector code.


<!--
Paste here related logs and alerts
-->

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation

Complete output from Dr. Memory with every module disabled but localfile:
```
Dr. Memory version 2.1.0 build 1 built on Mar 18 2019 00:02:08
Windows version: WinVer=63;Rel=;Build=9600;Edition=Professional
Dr. Memory results for pid 1012: "ossec-agent.exe"
Application cmdline: ".\ossec-agent.exe start"
Recorded 117 suppression(s) from default C:\Program Files (x86)\Dr. Memory\bin\suppress-default.txt
```