### PR TITLE
Fix typo in the license of the files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
  Portions Copyright (C) 2015-2019, Wazuh Inc.
  Based on work Copyright (C) 2003 - 2013 Trend Micro, Inc.
 
- This program is a free software; you can redistribute it and/or modify
+ This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License (version 2) as
  published by the FSF - Free Software Foundation.
 

--- a/add_localfiles.sh
+++ b/add_localfiles.sh
@@ -4,7 +4,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # November 24, 2016.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/etc/decoders/0005-wazuh_decoders.xml
+++ b/etc/decoders/0005-wazuh_decoders.xml
@@ -2,7 +2,7 @@
   -  Wazuh decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="wazuh">

--- a/etc/decoders/0006-json_decoders.xml
+++ b/etc/decoders/0006-json_decoders.xml
@@ -3,7 +3,7 @@
 - Copyright (C) 2015-2019, Wazuh Inc.
 - April 21, 2017.
 -
-- This program is a free software; you can redistribute it
+- This program is free software; you can redistribute it
 - and/or modify it under the terms of the GNU General Public
 - License (version 2) as published by the FSF - Free Software
 - Foundation.

--- a/etc/decoders/0010-active-response_decoders.xml
+++ b/etc/decoders/0010-active-response_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0015-aix-ipsec_decoders.xml
+++ b/etc/decoders/0015-aix-ipsec_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0025-apache_decoders.xml
+++ b/etc/decoders/0025-apache_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0030-arpwatch_decoders.xml
+++ b/etc/decoders/0030-arpwatch_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0035-asterisk_decoders.xml
+++ b/etc/decoders/0035-asterisk_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0040-auditd_decoders.xml
+++ b/etc/decoders/0040-auditd_decoders.xml
@@ -2,7 +2,7 @@
   -  Audit decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0045-barracuda_decoders.xml
+++ b/etc/decoders/0045-barracuda_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0050-checkpoint_decoders.xml
+++ b/etc/decoders/0050-checkpoint_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0055-cimserver_decoders.xml
+++ b/etc/decoders/0055-cimserver_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0060-cisco-estreamer_decoders.xml
+++ b/etc/decoders/0060-cisco-estreamer_decoders.xml
@@ -2,7 +2,7 @@
   -  cisco-estreamer decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0065-cisco-ios_decoders.xml
+++ b/etc/decoders/0065-cisco-ios_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0070-cisco-vpn_decoders.xml
+++ b/etc/decoders/0070-cisco-vpn_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0075-clamav_decoders.xml
+++ b/etc/decoders/0075-clamav_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0080-courier_decoders.xml
+++ b/etc/decoders/0080-courier_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0085-dovecot_decoders.xml
+++ b/etc/decoders/0085-dovecot_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0090-dragon-nids_decoders.xml
+++ b/etc/decoders/0090-dragon-nids_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0095-dropbear_decoders.xml
+++ b/etc/decoders/0095-dropbear_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="dropbear">

--- a/etc/decoders/0100-fortigate_decoders.xml
+++ b/etc/decoders/0100-fortigate_decoders.xml
@@ -3,7 +3,7 @@
   -  Author: Tom Hancock <t.m.h.a.ncoc.k+wazuh@gmail.com>
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- FortiOS 3.0 via syslog -->

--- a/etc/decoders/0105-freeipa_decoders.xml
+++ b/etc/decoders/0105-freeipa_decoders.xml
@@ -2,7 +2,7 @@
   -  FreeIPA decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="freeipa">

--- a/etc/decoders/0110-ftpd_decoders.xml
+++ b/etc/decoders/0110-ftpd_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0115-grandstream_decoders.xml
+++ b/etc/decoders/0115-grandstream_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- HT502: [00:0B:82:14:5B:94] Transport error (-1) for transaction 2677 -->

--- a/etc/decoders/0120-horde_decoders.xml
+++ b/etc/decoders/0120-horde_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0125-hp_decoders.xml
+++ b/etc/decoders/0125-hp_decoders.xml
@@ -2,7 +2,7 @@
   -  HP decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0130-imapd_decoders.xml
+++ b/etc/decoders/0130-imapd_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0135-imperva_decoders.xml
+++ b/etc/decoders/0135-imperva_decoders.xml
@@ -2,7 +2,7 @@
   -  Imperva decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0140-kernel_decoders.xml
+++ b/etc/decoders/0140-kernel_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0145-mailscanner_decoders.xml
+++ b/etc/decoders/0145-mailscanner_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0150-mysql_decoders.xml
+++ b/etc/decoders/0150-mysql_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0155-named_decoders.xml
+++ b/etc/decoders/0155-named_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0160-netscaler_decoders.xml
+++ b/etc/decoders/0160-netscaler_decoders.xml
@@ -2,7 +2,7 @@
   -  Netscaler decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0165-netscreen_decoders.xml
+++ b/etc/decoders/0165-netscreen_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0170-nginx_decoders.xml
+++ b/etc/decoders/0170-nginx_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0175-ntpd_decoders.xml
+++ b/etc/decoders/0175-ntpd_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0180-openbsd_decoders.xml
+++ b/etc/decoders/0180-openbsd_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0185-openldap_decoders.xml
+++ b/etc/decoders/0185-openldap_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0190-openvpn_decoders.xml
+++ b/etc/decoders/0190-openvpn_decoders.xml
@@ -3,7 +3,7 @@
   -  Author: Julio Camargo <julio.camargo@trustux.com.br>
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="openvpn">

--- a/etc/decoders/0195-oscap_decoders.xml
+++ b/etc/decoders/0195-oscap_decoders.xml
@@ -2,7 +2,7 @@
   -  OpenSCAP decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0200-ossec_decoders.xml
+++ b/etc/decoders/0200-ossec_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0205-pam_decoders.xml
+++ b/etc/decoders/0205-pam_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0210-pix_decoders.xml
+++ b/etc/decoders/0210-pix_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0215-portsentry_decoders.xml
+++ b/etc/decoders/0215-portsentry_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="portsentry">

--- a/etc/decoders/0220-postfix_decoders.xml
+++ b/etc/decoders/0220-postfix_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0225-postgresql_decoders.xml
+++ b/etc/decoders/0225-postgresql_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0230-proftpd_decoders.xml
+++ b/etc/decoders/0230-proftpd_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0235-puppet_decoders.xml
+++ b/etc/decoders/0235-puppet_decoders.xml
@@ -2,7 +2,7 @@
   -  Puppet decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- PUPPET MASTER -->

--- a/etc/decoders/0240-pure-ftpd_decoders.xml
+++ b/etc/decoders/0240-pure-ftpd_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0245-racoon_decoders.xml
+++ b/etc/decoders/0245-racoon_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0250-redis_decoders.xml
+++ b/etc/decoders/0250-redis_decoders.xml
@@ -2,7 +2,7 @@
   -  Redis decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0255-roundcube_decoders.xml
+++ b/etc/decoders/0255-roundcube_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0260-rsa-auth-manager_decoders.xml
+++ b/etc/decoders/0260-rsa-auth-manager_decoders.xml
@@ -2,7 +2,7 @@
   -  RSA Authentication Manager decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0265-rshd_decoders.xml
+++ b/etc/decoders/0265-rshd_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0270-samba_decoders.xml
+++ b/etc/decoders/0270-samba_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0275-sendmail_decoders.xml
+++ b/etc/decoders/0275-sendmail_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0280-serv-u_decoders.xml
+++ b/etc/decoders/0280-serv-u_decoders.xml
@@ -2,7 +2,7 @@
   -  SERV-U decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0285-snort_decoders.xml
+++ b/etc/decoders/0285-snort_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0290-solaris_decoders.xml
+++ b/etc/decoders/0290-solaris_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0295-sonicwall_decoders.xml
+++ b/etc/decoders/0295-sonicwall_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0300-sophos_decoders.xml
+++ b/etc/decoders/0300-sophos_decoders.xml
@@ -2,7 +2,7 @@
   -  Sophos Anti-Virus decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0305-squid_decoders.xml
+++ b/etc/decoders/0305-squid_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0310-ssh_decoders.xml
+++ b/etc/decoders/0310-ssh_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0315-su_decoders.xml
+++ b/etc/decoders/0315-su_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0320-sudo_decoders.xml
+++ b/etc/decoders/0320-sudo_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0325-suhosin_decoders.xml
+++ b/etc/decoders/0325-suhosin_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0330-symantec_decoders.xml
+++ b/etc/decoders/0330-symantec_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0335-telnet_decoders.xml
+++ b/etc/decoders/0335-telnet_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0340-trend-osce_decoders.xml
+++ b/etc/decoders/0340-trend-osce_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0345-unbound_decoders.xml
+++ b/etc/decoders/0345-unbound_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0350-unix_decoders.xml
+++ b/etc/decoders/0350-unix_decoders.xml
@@ -2,7 +2,7 @@
   -  Unix decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0355-vm-pop3_decoders.xml
+++ b/etc/decoders/0355-vm-pop3_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="vm-pop3d">

--- a/etc/decoders/0360-vmware_decoders.xml
+++ b/etc/decoders/0360-vmware_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0365-vpopmail_decoders.xml
+++ b/etc/decoders/0365-vpopmail_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0370-vsftpd_decoders.xml
+++ b/etc/decoders/0370-vsftpd_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0375-web-accesslog_decoders.xml
+++ b/etc/decoders/0375-web-accesslog_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- NCSA common log decoder (used by apache, Lotus Domino and IIS NCSA).

--- a/etc/decoders/0378-mariadb_decoders.xml
+++ b/etc/decoders/0378-mariadb_decoders.xml
@@ -2,7 +2,7 @@
   -  MariaDB decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0379-dpkg_decoders.xml
+++ b/etc/decoders/0379-dpkg_decoders.xml
@@ -2,7 +2,7 @@
   -  Package decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0385-wordpress_decoders.xml
+++ b/etc/decoders/0385-wordpress_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0390-zeus_decoders.xml
+++ b/etc/decoders/0390-zeus_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0395-sqlserver_decoders.xml
+++ b/etc/decoders/0395-sqlserver_decoders.xml
@@ -2,7 +2,7 @@
   -  SQL Server decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0400-identity_guard_decoders.xml
+++ b/etc/decoders/0400-identity_guard_decoders.xml
@@ -2,7 +2,7 @@
   -  Identity Guard decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="identity_guard">

--- a/etc/decoders/0405-mongodb_decoders.xml
+++ b/etc/decoders/0405-mongodb_decoders.xml
@@ -2,7 +2,7 @@
   -  MongoDB decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0410-docker_decoders.xml
+++ b/etc/decoders/0410-docker_decoders.xml
@@ -2,7 +2,7 @@
   -  Docker decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0415-jenkins_decoders.xml
+++ b/etc/decoders/0415-jenkins_decoders.xml
@@ -2,7 +2,7 @@
   -  Jenkins decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0420-vshell_decoders.xml
+++ b/etc/decoders/0420-vshell_decoders.xml
@@ -3,7 +3,7 @@
   -  Author: Stephen Hill.
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0425-qualysguard_decoders.xml
+++ b/etc/decoders/0425-qualysguard_decoders.xml
@@ -2,7 +2,7 @@
   -  Qualysguard decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0430-cylance_decoders.xml
+++ b/etc/decoders/0430-cylance_decoders.xml
@@ -2,7 +2,7 @@
   -  Cylance decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/decoders/0435-owncloud_decoders.xml
+++ b/etc/decoders/0435-owncloud_decoders.xml
@@ -2,7 +2,7 @@
   -  ownCloud decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0440-proxmox-ve_decoders.xml
+++ b/etc/decoders/0440-proxmox-ve_decoders.xml
@@ -2,7 +2,7 @@
   -  Proxmox Virtual Environment (Proxmox VE) decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0445-exim_decoders.xml
+++ b/etc/decoders/0445-exim_decoders.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modif$
+  -  This program is free software; you can redistribute it and/or modif$
 -->
 
 

--- a/etc/decoders/0450-openvas_decoders.xml
+++ b/etc/decoders/0450-openvas_decoders.xml
@@ -3,7 +3,7 @@
   -  Author: Christian Fischer.
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0455-pfsense_decoders.xml
+++ b/etc/decoders/0455-pfsense_decoders.xml
@@ -3,7 +3,7 @@
   -  Author Mark Alston
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/decoders/0460-kaspersky_decoders.xml
+++ b/etc/decoders/0460-kaspersky_decoders.xml
@@ -2,7 +2,7 @@
   -  Kaspersky decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="kes_parent">

--- a/etc/decoders/0465-azure_decoders.xml
+++ b/etc/decoders/0465-azure_decoders.xml
@@ -2,7 +2,7 @@
   -  Microsoft Azure decoders
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/rules/0010-rules_config.xml
+++ b/etc/rules/0010-rules_config.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,">

--- a/etc/rules/0015-ossec_rules.xml
+++ b/etc/rules/0015-ossec_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="ossec,">

--- a/etc/rules/0016-wazuh_rules.xml
+++ b/etc/rules/0016-wazuh_rules.xml
@@ -2,7 +2,7 @@
   -  Wazuh rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="wazuh,">

--- a/etc/rules/0020-syslog_rules.xml
+++ b/etc/rules/0020-syslog_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/rules/0025-sendmail_rules.xml
+++ b/etc/rules/0025-sendmail_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,sendmail,">

--- a/etc/rules/0030-postfix_rules.xml
+++ b/etc/rules/0030-postfix_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <var name="POSTFIX_FREQ">8</var>

--- a/etc/rules/0035-spamd_rules.xml
+++ b/etc/rules/0035-spamd_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,spamd,">

--- a/etc/rules/0040-imapd_rules.xml
+++ b/etc/rules/0040-imapd_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <var name="IMAPD_FREQ">8</var>

--- a/etc/rules/0045-mailscanner_rules.xml
+++ b/etc/rules/0045-mailscanner_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,mailscanner,">

--- a/etc/rules/0050-ms-exchange_rules.xml
+++ b/etc/rules/0050-ms-exchange_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="ms,exchange,">

--- a/etc/rules/0055-courier_rules.xml
+++ b/etc/rules/0055-courier_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,courier,">

--- a/etc/rules/0060-firewall_rules.xml
+++ b/etc/rules/0060-firewall_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="firewall,">

--- a/etc/rules/0065-pix_rules.xml
+++ b/etc/rules/0065-pix_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pix,">

--- a/etc/rules/0070-netscreenfw_rules.xml
+++ b/etc/rules/0070-netscreenfw_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="netscreenfw,">

--- a/etc/rules/0075-cisco-ios_rules.xml
+++ b/etc/rules/0075-cisco-ios_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,cisco_ios,">

--- a/etc/rules/0080-sonicwall_rules.xml
+++ b/etc/rules/0080-sonicwall_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,sonicwall,">

--- a/etc/rules/0085-pam_rules.xml
+++ b/etc/rules/0085-pam_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="pam,syslog,">

--- a/etc/rules/0090-telnetd_rules.xml
+++ b/etc/rules/0090-telnetd_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,telnetd,">

--- a/etc/rules/0095-sshd_rules.xml
+++ b/etc/rules/0095-sshd_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,sshd,">

--- a/etc/rules/0100-solaris_bsm_rules.xml
+++ b/etc/rules/0100-solaris_bsm_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,solaris_bsm,">

--- a/etc/rules/0105-asterisk_rules.xml
+++ b/etc/rules/0105-asterisk_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,asterisk,">

--- a/etc/rules/0110-ms_dhcp_rules.xml
+++ b/etc/rules/0110-ms_dhcp_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--Server 2003 and 2008 IPv4 Event ID  Meaning

--- a/etc/rules/0115-arpwatch_rules.xml
+++ b/etc/rules/0115-arpwatch_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,arpwatch,">

--- a/etc/rules/0120-symantec-av_rules.xml
+++ b/etc/rules/0120-symantec-av_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="symantec,">

--- a/etc/rules/0125-symantec-ws_rules.xml
+++ b/etc/rules/0125-symantec-ws_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="symantec,">

--- a/etc/rules/0130-trend-osce_rules.xml
+++ b/etc/rules/0130-trend-osce_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="trend_micro,ocse,">

--- a/etc/rules/0135-hordeimp_rules.xml
+++ b/etc/rules/0135-hordeimp_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,hordeimp,">

--- a/etc/rules/0140-roundcube_rules.xml
+++ b/etc/rules/0140-roundcube_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,roundcube,">

--- a/etc/rules/0145-wordpress_rules.xml
+++ b/etc/rules/0145-wordpress_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,wordpress,">

--- a/etc/rules/0150-cimserver_rules.xml
+++ b/etc/rules/0150-cimserver_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,cimserver,">

--- a/etc/rules/0155-dovecot_rules.xml
+++ b/etc/rules/0155-dovecot_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="dovecot,">

--- a/etc/rules/0160-vmpop3d_rules.xml
+++ b/etc/rules/0160-vmpop3d_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,vm-pop3d,">

--- a/etc/rules/0165-vpopmail_rules.xml
+++ b/etc/rules/0165-vpopmail_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,vpopmail,">

--- a/etc/rules/0170-ftpd_rules.xml
+++ b/etc/rules/0170-ftpd_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,ftpd,">

--- a/etc/rules/0175-proftpd_rules.xml
+++ b/etc/rules/0175-proftpd_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,proftpd,">

--- a/etc/rules/0180-pure-ftpd_rules.xml
+++ b/etc/rules/0180-pure-ftpd_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pure-ftpd,">

--- a/etc/rules/0185-vsftpd_rules.xml
+++ b/etc/rules/0185-vsftpd_rules.xml
@@ -6,7 +6,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,vsftpd,">

--- a/etc/rules/0190-ms_ftpd_rules.xml
+++ b/etc/rules/0190-ms_ftpd_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,msftp,">

--- a/etc/rules/0195-named_rules.xml
+++ b/etc/rules/0195-named_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,named,">

--- a/etc/rules/0200-smbd_rules.xml
+++ b/etc/rules/0200-smbd_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,smbd,">

--- a/etc/rules/0205-racoon_rules.xml
+++ b/etc/rules/0205-racoon_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,racoon,">

--- a/etc/rules/0210-vpn_concentrator_rules.xml
+++ b/etc/rules/0210-vpn_concentrator_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,cisco_vpn,">

--- a/etc/rules/0215-policy_rules.xml
+++ b/etc/rules/0215-policy_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="policy_violation,">

--- a/etc/rules/0220-msauth_rules.xml
+++ b/etc/rules/0220-msauth_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <var name="MS_FREQ">8</var>

--- a/etc/rules/0225-mcafee_av_rules.xml
+++ b/etc/rules/0225-mcafee_av_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <var name="MCAFEE_ERROR">^259$|^100$|^1000$|^1001$|^1002$|^1003$|^1004$|^1005$|^1006$|^1007$|^1008$|^5003$|^5005$|^5008$|^5010$|^5011$|^5019$|^5020$|^5021$|^5022$|^5030$|^5031$|^5032$|^5033$|^5034$|^5035$|^5046$|^5047$|^5048$|^5049$|^5051$|^5054$|^5057$|^5059$|^5060$|^5063$|^5063$</var>

--- a/etc/rules/0230-ms-se_rules.xml
+++ b/etc/rules/0230-ms-se_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="windows,mse,">

--- a/etc/rules/0235-vmware_rules.xml
+++ b/etc/rules/0235-vmware_rules.xml
@@ -3,8 +3,8 @@
   -  Author: Daniel Cid.
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc. 
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  Copyright (C) 2009 Trend Micro Inc.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="vmware,">

--- a/etc/rules/0240-ids_rules.xml
+++ b/etc/rules/0240-ids_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <var name="IDS_FREQ">10</var>

--- a/etc/rules/0245-web_rules.xml
+++ b/etc/rules/0245-web_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="web,accesslog,">

--- a/etc/rules/0250-apache_rules.xml
+++ b/etc/rules/0250-apache_rules.xml
@@ -6,7 +6,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="apache,web,">

--- a/etc/rules/0255-zeus_rules.xml
+++ b/etc/rules/0255-zeus_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="zeus,">

--- a/etc/rules/0260-nginx_rules.xml
+++ b/etc/rules/0260-nginx_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="nginx,web,">

--- a/etc/rules/0265-php_rules.xml
+++ b/etc/rules/0265-php_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="apache,">

--- a/etc/rules/0270-web_appsec_rules.xml
+++ b/etc/rules/0270-web_appsec_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- Collection of rules for common web attacks that we are seeing in the wild.

--- a/etc/rules/0275-squid_rules.xml
+++ b/etc/rules/0275-squid_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <var name="SQUID_FREQ">10</var>

--- a/etc/rules/0280-attack_rules.xml
+++ b/etc/rules/0280-attack_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- System users. They should never log in to the system -->

--- a/etc/rules/0285-systemd_rules.xml
+++ b/etc/rules/0285-systemd_rules.xml
@@ -5,7 +5,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="local,systemd,">

--- a/etc/rules/0290-firewalld_rules.xml
+++ b/etc/rules/0290-firewalld_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="local,firewalld,">

--- a/etc/rules/0295-mysql_rules.xml
+++ b/etc/rules/0295-mysql_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="mysql_log,">

--- a/etc/rules/0300-postgresql_rules.xml
+++ b/etc/rules/0300-postgresql_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="postgresql_log,">

--- a/etc/rules/0305-dropbear_rules.xml
+++ b/etc/rules/0305-dropbear_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,sshd,dropbear,">

--- a/etc/rules/0310-openbsd_rules.xml
+++ b/etc/rules/0310-openbsd_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="local,syslog,openbsd,">

--- a/etc/rules/0315-apparmor_rules.xml
+++ b/etc/rules/0315-apparmor_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="local,syslog,apparmor,">

--- a/etc/rules/0320-clam_av_rules.xml
+++ b/etc/rules/0320-clam_av_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="clamd,freshclam,">

--- a/etc/rules/0325-opensmtpd_rules.xml
+++ b/etc/rules/0325-opensmtpd_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0330-sysmon_rules.xml
+++ b/etc/rules/0330-sysmon_rules.xml
@@ -2,7 +2,7 @@
   -  Sysmon rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="sysmon,">
@@ -290,5 +290,5 @@
         <field name="sysmon.parentImage">userinit.exe</field>
         <description>Sysmon - Legitimate Parent Image - explorer.exe</description>
     </rule>
-    
+
 </group>

--- a/etc/rules/0335-unbound_rules.xml
+++ b/etc/rules/0335-unbound_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,unbound,">

--- a/etc/rules/0340-puppet_rules.xml
+++ b/etc/rules/0340-puppet_rules.xml
@@ -2,7 +2,7 @@
   -  Puppet rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 80000 - 80099 -->

--- a/etc/rules/0345-netscaler_rules.xml
+++ b/etc/rules/0345-netscaler_rules.xml
@@ -2,7 +2,7 @@
   -  Netscaler rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0350-amazon_rules.xml
+++ b/etc/rules/0350-amazon_rules.xml
@@ -2,7 +2,7 @@
   -  Amazon rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0360-serv-u_rules.xml
+++ b/etc/rules/0360-serv-u_rules.xml
@@ -2,7 +2,7 @@
   -  Serv-u rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 80500 - 80599 -->

--- a/etc/rules/0365-auditd_rules.xml
+++ b/etc/rules/0365-auditd_rules.xml
@@ -2,7 +2,7 @@
   -  Audit rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="audit,">

--- a/etc/rules/0375-usb_rules.xml
+++ b/etc/rules/0375-usb_rules.xml
@@ -2,7 +2,7 @@
   -  USB rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="usb,">

--- a/etc/rules/0380-redis_rules.xml
+++ b/etc/rules/0380-redis_rules.xml
@@ -2,7 +2,7 @@
   -  Redis rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 81300 - 81399 -->

--- a/etc/rules/0385-oscap_rules.xml
+++ b/etc/rules/0385-oscap_rules.xml
@@ -2,7 +2,7 @@
   -  OpenSCAP rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0390-fortigate_rules.xml
+++ b/etc/rules/0390-fortigate_rules.xml
@@ -3,7 +3,7 @@
   -  Author: Tom Hancock <t.m.h.a.ncoc.k+wazuh@gmail.com>
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0395-hp_rules.xml
+++ b/etc/rules/0395-hp_rules.xml
@@ -2,7 +2,7 @@
   -  HP rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0400-openvpn_rules.xml
+++ b/etc/rules/0400-openvpn_rules.xml
@@ -3,7 +3,7 @@
   -  Author: Julio Camargo <julio.camargo@trustux.com.br>
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 81800 - 81899 -->

--- a/etc/rules/0405-rsa-auth-manager_rules.xml
+++ b/etc/rules/0405-rsa-auth-manager_rules.xml
@@ -2,7 +2,7 @@
   -  RSA Authentication Manager rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 81900 - 81999 -->

--- a/etc/rules/0410-imperva_rules.xml
+++ b/etc/rules/0410-imperva_rules.xml
@@ -2,7 +2,7 @@
   -  Imperva rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 82000 - 82099 -->

--- a/etc/rules/0415-sophos_rules.xml
+++ b/etc/rules/0415-sophos_rules.xml
@@ -2,7 +2,7 @@
   -  Sophos rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 82100 - 82199 -->

--- a/etc/rules/0420-freeipa_rules.xml
+++ b/etc/rules/0420-freeipa_rules.xml
@@ -2,7 +2,7 @@
   -  FreeIPA rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 82200 - 82299 -->

--- a/etc/rules/0425-cisco-estreamer_rules.xml
+++ b/etc/rules/0425-cisco-estreamer_rules.xml
@@ -2,7 +2,7 @@
   -  Cisco eStreamer rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 82400 - 82499 -->

--- a/etc/rules/0430-ms_wdefender_rules.xml
+++ b/etc/rules/0430-ms_wdefender_rules.xml
@@ -2,7 +2,7 @@
   -  Windows defender rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 83000 - 83199 -->

--- a/etc/rules/0435-ms_logs_rules.xml
+++ b/etc/rules/0435-ms_logs_rules.xml
@@ -2,7 +2,7 @@
   -  Windows logs rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 83200 - 83399 -->
@@ -22,8 +22,8 @@
     <!--
     2017 Mar 28 09:46:17 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: Alberto: WIN-P57C9KN929H: WIN-P57C9KN929H: The Internet Explorer log file was cleared.
     2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-CAPI2/Operational log file was cleared.
-    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-IdCtrls/Operational log file was cleared.  
-    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-WebAuth/Operational log file was cleared.  
+    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-IdCtrls/Operational log file was cleared.
+    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-WebAuth/Operational log file was cleared.
     Should not fire on this example:
     2018 Nov 30 13:29:28 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-ResourcePublication: LOCAL SERVICE: NT AUTHORITY: REBEKAH.abcnet.org: BeginPublication
     -->

--- a/etc/rules/0440-ms_sqlserver_rules.xml
+++ b/etc/rules/0440-ms_sqlserver_rules.xml
@@ -2,7 +2,7 @@
   -  SQL Server rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 85000 - 85499 -->

--- a/etc/rules/0445-identity_guard_rules.xml
+++ b/etc/rules/0445-identity_guard_rules.xml
@@ -2,7 +2,7 @@
   -  Identity Guard rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 85500 - 85699 -->

--- a/etc/rules/0450-mongodb_rules.xml
+++ b/etc/rules/0450-mongodb_rules.xml
@@ -2,7 +2,7 @@
   -  MongoDB rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 85750 - 85999 -->

--- a/etc/rules/0455-docker_rules.xml
+++ b/etc/rules/0455-docker_rules.xml
@@ -2,7 +2,7 @@
   -  Docker rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 86000 - 86249 -->

--- a/etc/rules/0460-jenkins_rules.xml
+++ b/etc/rules/0460-jenkins_rules.xml
@@ -2,7 +2,7 @@
   -  Jenkins rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0470-vshell_rules.xml
+++ b/etc/rules/0470-vshell_rules.xml
@@ -3,7 +3,7 @@
   -  Author: Stephen Hill.
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="vshell,">

--- a/etc/rules/0475-suricata_rules.xml
+++ b/etc/rules/0475-suricata_rules.xml
@@ -2,7 +2,7 @@
   -  Suricata rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 86600 - 86699 -->

--- a/etc/rules/0480-qualysguard_rules.xml
+++ b/etc/rules/0480-qualysguard_rules.xml
@@ -2,7 +2,7 @@
   -  Qualysguard rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 86900 - 87000 -->

--- a/etc/rules/0485-cylance_rules.xml
+++ b/etc/rules/0485-cylance_rules.xml
@@ -2,7 +2,7 @@
   -  Cylance rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 87000 - 87100 -->

--- a/etc/rules/0490-virustotal_rules.xml
+++ b/etc/rules/0490-virustotal_rules.xml
@@ -2,7 +2,7 @@
   -  VirusTotal integration rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 87100 - 87199 -->

--- a/etc/rules/0495-proxmox-ve_rules.xml
+++ b/etc/rules/0495-proxmox-ve_rules.xml
@@ -2,7 +2,7 @@
   -  Proxmox Virtual Environment (Proxmox VE) rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 87200 - 87300 -->

--- a/etc/rules/0500-owncloud_rules.xml
+++ b/etc/rules/0500-owncloud_rules.xml
@@ -2,7 +2,7 @@
   -  OwnCloud ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 87300 - 87400 -->

--- a/etc/rules/0505-vuls_rules.xml
+++ b/etc/rules/0505-vuls_rules.xml
@@ -2,7 +2,7 @@
   -  Vuls integration rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0510-ciscat_rules.xml
+++ b/etc/rules/0510-ciscat_rules.xml
@@ -2,7 +2,7 @@
   -  CIS-CAT scanner rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 87400 - 87500 -->

--- a/etc/rules/0515-exim_rules.xml
+++ b/etc/rules/0515-exim_rules.xml
@@ -4,7 +4,7 @@
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="exim,">

--- a/etc/rules/0520-vulnerability-detector_rules.xml
+++ b/etc/rules/0520-vulnerability-detector_rules.xml
@@ -2,7 +2,7 @@
   -  Vulnerability detector module rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="vulnerability-detector,">

--- a/etc/rules/0525-openvas_rules.xml
+++ b/etc/rules/0525-openvas_rules.xml
@@ -3,7 +3,7 @@
   -  Author: Christian Fischer.
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 87600 - 87699 -->

--- a/etc/rules/0530-mysql_audit_rules.xml
+++ b/etc/rules/0530-mysql_audit_rules.xml
@@ -2,7 +2,7 @@
   -  Wazuh rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- ID: 88000 - 88099 -->

--- a/etc/rules/0535-mariadb_rules.xml
+++ b/etc/rules/0535-mariadb_rules.xml
@@ -2,7 +2,7 @@
   -  MariaDB ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 
 ID: 87600-87700
 -->

--- a/etc/rules/0540-pfsense_rules.xml
+++ b/etc/rules/0540-pfsense_rules.xml
@@ -2,7 +2,7 @@
   -  pfSense ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   ID: 87700-87799
 -->
 

--- a/etc/rules/0545-osquery_rules.xml
+++ b/etc/rules/0545-osquery_rules.xml
@@ -2,7 +2,7 @@
   -  Osquery ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="osquery,">

--- a/etc/rules/0550-kaspersky_rules.xml
+++ b/etc/rules/0550-kaspersky_rules.xml
@@ -2,7 +2,7 @@
   -  Kaspersky ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="kaspersky,">

--- a/etc/rules/0555-azure_rules.xml
+++ b/etc/rules/0555-azure_rules.xml
@@ -2,7 +2,7 @@
   -  Microsoft Azure ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 ID: 87800-87899
 -->
 

--- a/etc/rules/0560-docker_integration_rules.xml
+++ b/etc/rules/0560-docker_integration_rules.xml
@@ -2,7 +2,7 @@
   -  Docker integration rules
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--

--- a/etc/rules/0565-ms_ipsec_rules.xml
+++ b/etc/rules/0565-ms_ipsec_rules.xml
@@ -2,7 +2,7 @@
   -  Microsoft Windows Firewall ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="windows, ipsec,">

--- a/etc/rules/0570-sca_rules.xml
+++ b/etc/rules/0570-sca_rules.xml
@@ -2,7 +2,7 @@
   -  Security Configuration Assessment ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="sca,gdpr_IV_35.7.d">

--- a/etc/rules/0575-win-base_rules.xml
+++ b/etc/rules/0575-win-base_rules.xml
@@ -2,7 +2,7 @@
   -  Windows Event Channel ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!-- Group of parent rules for the Windows eventchannel -->
@@ -93,7 +93,7 @@
     <options>no_full_log</options>
     <group>gpg13_4.12,</group>
   </rule>
-  
+
   <rule id="60011" level="5">
     <if_sid>60000</if_sid>
     <field name="win.system.severityValue">^ERROR$</field>

--- a/etc/rules/0580-win-security_rules.xml
+++ b/etc/rules/0580-win-security_rules.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Windows Event Channel ruleset for the Security channel 
+  -  Windows Event Channel ruleset for the Security channel
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 60100 - 60599
 -->
 
@@ -57,7 +57,7 @@
   </rule>
 
   <!--{"win":{"system":{"providerName":"Microsoft-Windows-Security-Auditing","providerGuid":"{54849625-5478-4994-A5BA-3E3B0328C30D}","eventID":"4624","version":"1","level":"0","task":"12544","opcode":"0","keywords":"0x802000000000000","systemTime":"2018-12-18T10:55:48.073081500Z","eventRecordID":"7017","processID":"548","threadID":"3212","channel":"Security","computer":"qnu","severityValue":"AUDIT_SUCCESS","message":"L’ouverture de session d’un compte s’est correctement déroulée."},"eventdata":{"subjectUserSid":"S-1-5-18","subjectUserName":"QNU$","subjectDomainName":"WORKGROUP","subjectLogonId":"0x3e7","targetUserSid":"S-1-5-18","targetUserName":"Système","targetDomainName":"AUTORITE NT","targetLogonId":"0x3e7","logonType":"5","logonProcessName":"Advapi  ","authenticationPackageName":"Negotiate","workstationName":"-","logonGuid":"{00000000-0000-0000-0000-000000000000}","transmittedServices":"-","lmPackageName":"-","keyLength":"0","processId":"0x21c","processName":"C:\\\\Windows\\\\System32\\\\services.exe","ipAddress":"-","ipPort":"-","impersonationLevel":"%%1833"}}}-->
-  
+
   <rule id="60106" level="3">
     <if_sid>60103</if_sid>
     <field name="win.system.eventID">^528$|^540$|^673$|^4624$|^4769$</field>
@@ -186,7 +186,7 @@
     <description>Windows login attempt (ignored). Duplicated</description>
     <options>no_full_log</options>
   </rule>
-  
+
   <rule id="60121" level="5">
     <if_sid>60103</if_sid>
     <field name="win.system.eventID">^646$|^645$|^647$|^4741$|^4742$|^4743$</field>

--- a/etc/rules/0585-win-application_rules.xml
+++ b/etc/rules/0585-win-application_rules.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Windows Event Channel ruleset for the Application channel 
+  -  Windows Event Channel ruleset for the Application channel
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 60600 - 61099
 -->
 
@@ -606,7 +606,7 @@
     <description>Safe mode does not support Shadow Copy</description>
     <options>no_full_log</options>
   </rule>
-  
+
   <rule id="60682" level="4">
     <if_sid>60675</if_sid>
     <field name="win.system.eventID">^19$</field>
@@ -1741,7 +1741,7 @@
     <description>The MS DTC has the same unique identity as the local one</description>
     <options>no_full_log</options>
   </rule>
-  
+
   <rule id="60843" level="5">
     <if_sid>60838</if_sid>
     <field name="win.system.eventID">^4102$</field>

--- a/etc/rules/0590-win-system_rules.xml
+++ b/etc/rules/0590-win-system_rules.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Windows Event Channel ruleset for the System channel 
+  -  Windows Event Channel ruleset for the System channel
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 61100 - 61599
 -->
 

--- a/etc/rules/0595-win-sysmon_rules.xml
+++ b/etc/rules/0595-win-sysmon_rules.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Windows Event Channel ruleset for the Sysmon channel 
+  -  Windows Event Channel ruleset for the Sysmon channel
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 61600 - 62099
 -->
 

--- a/etc/rules/0600-win-wdefender_rules.xml
+++ b/etc/rules/0600-win-wdefender_rules.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Windows Event Channel ruleset for the Windows Defender channel 
+  -  Windows Event Channel ruleset for the Windows Defender channel
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 62100 - 62599
 -->
 
@@ -34,7 +34,7 @@
   </rule>
 
   <!-- {"win":{"system":{"providerName":"Microsoft-Windows-Windows Defender","providerGuid":"{555908d1-a6d7-4695-8e1e-26931d2012f4}","eventSourceName":"Microsoft-Windows-Eventlog","eventID":"1116","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8080000000000000","systemTime":"2018-11-27T13:03:51.594213100Z","eventRecordID":"8453","correlation":"","processID":"608","threadID":"1296","channel":"Microsoft-Windows-Windows Defender/Operational","computer":"hffg","message":"Windows Defender has detected malware or other potentially unwanted software.","severityValue":"WARNING"},"eventdata":{"subjectUserSid":"S-1-5-21-571","subjectUserName":"HFFG$","subjectDomainName":"WORKGROUP","subjectLogonId":"0x3e7","transactionId":"{D2399FF4-F177-11E8-82BA-08002750D7C5}","newState":"52","resourceManager":"{7D5F0E1F-ABCB-11E8-A2E2-D5514FE2B72B}","processId":"0x3f8","processName":"C:\\Windows\\System32\\svchost.exe"}}}    -->
-  
+
   <rule id="62103" level="12">
     <if_sid>62101</if_sid>
     <field name="win.system.eventID">^1116$</field>
@@ -44,7 +44,7 @@
   </rule>
 
   <!-- {"win":{"system":{"providerName":"Microsoft-Windows-Windows Defender","providerGuid":"{555908d1-a6d7-4695-8e1e-26931d2012f4}","eventSourceName":"Microsoft-Windows-Eventlog","eventID":"1117","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8080000000000000","systemTime":"2018-11-27T13:03:51.594213100Z","eventRecordID":"8453","correlation":"","processID":"608","threadID":"1296","channel":"Microsoft-Windows-Windows Defender/Operational","computer":"hffg","message":"Windows Defender has taken action to protect this machine from malware or other potentially unwanted software.   For more information please see the following:  http://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0         Name: Virus:DOS/EICAR_Test_File         ID: 2147519003          Severity: Severe        Category: Virus         Path: file:_C:\Users\spiderman\Downloads\eicar.com.txt;webfile:_C:\Users\spiderman\Downloads\eicar.com.txt|http://www.eicar.org/download/eicar.com.txt|chrome.exe    Detection Origin: Internet      Detection Type: Concrete        Detection Source: Real-Time Protection          User: NT AUTHORITY\SYSTEM       Process Name: C:\Windows\System32\SearchProtocolHost.exe     Action: Quarantine      Action Status:  No additional actions required          Error Code: 0x80508023          Error description: The program could not find the malware and other potentially unwanted software on this computer.","severityValue":"INFORMATION"},"eventdata":{"subjectUserSid":"S-1-5-21-571","subjectUserName":"HFFG$","subjectDomainName":"WORKGROUP","subjectLogonId":"0x3e7","transactionId":"{D2399FF4-F177-11E8-82BA-08002750D7C5}","newState":"52","resourceManager":"{7D5F0E1F-ABCB-11E8-A2E2-D5514FE2B72B}","processId":"0x3f8","processName":"C:\\Windows\\System32\\svchost.exe"}}}    -->
-  
+
   <rule id="62104" level="7">
     <if_sid>62100</if_sid>
     <field name="win.system.eventID">^1117$</field>

--- a/etc/rules/0605-win-mcafee_rules.xml
+++ b/etc/rules/0605-win-mcafee_rules.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Windows Event Channel ruleset for the McAfee channel 
+  -  Windows Event Channel ruleset for the McAfee channel
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 62600 - 63099
 -->
 

--- a/etc/rules/0610-win-ms_logs_rules.xml
+++ b/etc/rules/0610-win-ms_logs_rules.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Windows Event Channel ruleset for the Eventlog channel 
+  -  Windows Event Channel ruleset for the Eventlog channel
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 63100 - 63599
 -->
 <var name="MS_FREQ">8</var>

--- a/etc/rules/0615-win-ms-se_rules.xml
+++ b/etc/rules/0615-win-ms-se_rules.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Windows Event Channel ruleset for the Microsoft Antimalware channel 
+  -  Windows Event Channel ruleset for the Microsoft Antimalware channel
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 63600 - 64099
 -->
 

--- a/etc/rules/0620-win-generic_rules.xml
+++ b/etc/rules/0620-win-generic_rules.xml
@@ -2,7 +2,7 @@
   -  Windows Event Channel ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
   -  ID range: 64100 - 64599
 -->
 
@@ -79,7 +79,7 @@
     <description>TS Gateway user disconnected</description>
     <options>no_full_log</options>
   </rule>
-  
+
   <rule id="64109" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>64101</if_matched_sid>
     <description>Multiple remote access login failures</description>

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_da.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_da.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pure-ftpd,">

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_de.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_de.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_en.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_en.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pure-ftpd,">

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_es.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_es.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pure-ftpd,">

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_fr.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_fr.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_fr_funny.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_fr_funny.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pure-ftpd,">

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_it.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_it.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pure-ftpd,">

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_nl.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_nl.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pure-ftpd,">

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_no.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_no.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <group name="syslog,pure-ftpd,">

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_pt_br.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_pt_br.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_ro.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_ro.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_sk.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_sk.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_sv.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_sv.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/rules/translated/pure_ftpd/pure-ftpd_rules_tr.xml
+++ b/etc/rules/translated/pure_ftpd/pure-ftpd_rules_tr.xml
@@ -5,7 +5,7 @@
   -  Copyright (C) 2009 Trend Micro Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  Updated by Wazuh, Inc. <support@wazuh.com>.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 

--- a/etc/sca/applications/cis_apache2224_rcl.yml
+++ b/etc/sca/applications/cis_apache2224_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Apache
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/applications/cis_mysql5-6_community_rcl.yml
+++ b/etc/sca/applications/cis_mysql5-6_community_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Oracle MySQL Community Edition 5.6
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/applications/cis_mysql5-6_enterprise_rcl.yml
+++ b/etc/sca/applications/cis_mysql5-6_enterprise_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Oracle MySQL Entreprise Edition 5.6
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/darwin/15/cis_apple_macOS_10.11.yml
+++ b/etc/sca/darwin/15/cis_apple_macOS_10.11.yml
@@ -2,7 +2,7 @@
 # CIS Checks for MacOS 10.11
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/darwin/16/cis_apple_macOS_10.12.yml
+++ b/etc/sca/darwin/16/cis_apple_macOS_10.12.yml
@@ -2,7 +2,7 @@
 # CIS Checks for MacOS 10.12
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/darwin/17/cis_apple_macOS_10.13.yml
+++ b/etc/sca/darwin/17/cis_apple_macOS_10.13.yml
@@ -2,7 +2,7 @@
 # CIS Checks for MacOS 10.13
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/darwin/system_audit_rcl_mac.yml
+++ b/etc/sca/darwin/system_audit_rcl_mac.yml
@@ -2,7 +2,7 @@
 # Checks for auditing Mac systems
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation
@@ -15,7 +15,7 @@ policy:
 
 variables:
   $php.ini: /etc/php.ini,/var/www/conf/php.ini,/etc/php5/apache2/php.ini;
-  $web_dirs: /Library/WebServer/Documents,/usr/htdocs,/usr/local/var/htdocs,/usr/local/var/www; 
+  $web_dirs: /Library/WebServer/Documents,/usr/htdocs,/usr/local/var/htdocs,/usr/local/var/www;
 
 
 # PHP checks

--- a/etc/sca/debian/cis_debian_linux_rcl.yml
+++ b/etc/sca/debian/cis_debian_linux_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Debian/Ubuntu
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/debian/cis_debianlinux7-8_L1_rcl.yml
+++ b/etc/sca/debian/cis_debianlinux7-8_L1_rcl.yml
@@ -2,7 +2,7 @@
 # Level 1 CIS Checks for Debian Linux 7 and Debian Linux 8
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/debian/cis_debianlinux7-8_L2_rcl.yml
+++ b/etc/sca/debian/cis_debianlinux7-8_L2_rcl.yml
@@ -2,7 +2,7 @@
 # Level 2 CIS Checks for Debian Linux 7 and Debian Linux 8
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/generic/system_audit_pw.yml
+++ b/etc/sca/generic/system_audit_pw.yml
@@ -2,7 +2,7 @@
 # Checks for Password Security on Linux Systems
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/generic/system_audit_rcl.yml
+++ b/etc/sca/generic/system_audit_rcl.yml
@@ -2,7 +2,7 @@
 # Checks for auditing Linux systems
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/generic/system_audit_ssh.yml
+++ b/etc/sca/generic/system_audit_ssh.yml
@@ -2,7 +2,7 @@
 # Checks for SSH hardening
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/rhel/5/cis_rhel5_linux_rcl.yml
+++ b/etc/sca/rhel/5/cis_rhel5_linux_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for RHEL 5
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/rhel/6/cis_rhel6_linux_rcl.yml
+++ b/etc/sca/rhel/6/cis_rhel6_linux_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for RHEL 6
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/rhel/7/cis_rhel7_linux_rcl.yml
+++ b/etc/sca/rhel/7/cis_rhel7_linux_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for RHEL 7
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/sles/11/cis_sles11_linux_rcl.yml
+++ b/etc/sca/sles/11/cis_sles11_linux_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for SUSE SLES 11
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/sles/12/cis_sles12_linux_rcl.yml
+++ b/etc/sca/sles/12/cis_sles12_linux_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for SUSE SLES 12
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/sunos/cis_solaris11_rcl.yml
+++ b/etc/sca/sunos/cis_solaris11_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Oracle Solaris 11
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/windows/acsc_office2016_rcl.yml
+++ b/etc/sca/windows/acsc_office2016_rcl.yml
@@ -2,7 +2,7 @@
 # Checks for Microsoft Office 2016
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/windows/cis_win10_enterprise_L1_rcl.yml
+++ b/etc/sca/windows/cis_win10_enterprise_L1_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Windows 10 Enterprise L1
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation
@@ -961,7 +961,7 @@ checks:
    rules:
      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\XboxNetApiSvce -> Start -> !4;'
      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\XboxNetApiSvce -> !Start;'
-# 9 Windows Firewall with Advanced Security 
+# 9 Windows Firewall with Advanced Security
  - id: 12077
    title: "Ensure 'Windows Firewall: Domain: Firewall state' is set to 'On (recommended)'"
    description: "Select On (recommended) to have Windows Firewall with Advanced Security use the settings for this profile to filter network traffic. If you select Off, Windows Firewall with Advanced Security will not use any of the firewall rules or connection security rules for this profile. The recommended state for this setting is: On (recommended)."

--- a/etc/sca/windows/cis_win10_enterprise_L2_rcl.yml
+++ b/etc/sca/windows/cis_win10_enterprise_L2_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Windows 10 Enterprise L2
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/windows/cis_win2012r2_domainL1_rcl.yml
+++ b/etc/sca/windows/cis_win2012r2_domainL1_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Windows 2012 R2 Domain Controller L1
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/windows/cis_win2012r2_domainL2_rcl.yml
+++ b/etc/sca/windows/cis_win2012r2_domainL2_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Windows Server 2012 R2 Domain Controller L2
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation
@@ -472,7 +472,7 @@ checks:
      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisableLPT -> !1;'
      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisableLPT;'
  - id: 8535
-   title: "Ensure 'Do not allow supported Plug and Play device redirection' is set to 'Enabled'" 
+   title: "Ensure 'Do not allow supported Plug and Play device redirection' is set to 'Enabled'"
    description: "This policy setting allows you to control the redirection of supported Plug and Play devices, such as Windows Portable Devices, to the remote computer in a Remote Desktop Services session.  The recommended state for this setting is: Enabled."
    rationale: "In a more security-sensitive environment, it is desirable to reduce the possible attack surface. The need for Plug and Play device redirection within a Remote Desktop session is very rare, so makes sense to reduce the number of unexpected avenues for data exfiltration and/or malicious code transfer."
    remediation: "To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection\\Do not allow supported Plug and Play device redirection Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates."

--- a/etc/sca/windows/cis_win2012r2_memberL1_rcl.yml
+++ b/etc/sca/windows/cis_win2012r2_memberL1_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Windows 2012 R2 Member Server L1
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/etc/sca/windows/cis_win2012r2_memberL2_rcl.yml
+++ b/etc/sca/windows/cis_win2012r2_memberL2_rcl.yml
@@ -2,7 +2,7 @@
 # CIS Checks for Windows 2012 R2 Member Server L2
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation
@@ -92,7 +92,7 @@ checks:
     description: "This setting controls the number of times that TCP retransmits an individual data segment (non-connect segment) before the connection is aborted."
     rationale: "A malicious user could exhaust a target computer's resources if it never sent any acknowledgment messages for data that was transmitted by the target computer."
     remedtiation: "To establish the recommended configuration via GP, set the following UI path to Enabled: 3: Computer Configuration\\Policies\\Administrative Templates\\MSS (Legacy)\\MSS:(TcpMaxDataRetransmissions IPv6) How many times unacknowledged data is retransmitted"
-    compliance: 
+    compliance:
       - cis: "18.4.10"
       - cis_csc: "5"
     condition: any
@@ -210,7 +210,7 @@ checks:
     condition: any
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy -> fBlockNonDomain -> !1;'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy -> !fBlockNonDomain;' 
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy -> !fBlockNonDomain;'
 # Section 18.8.22.1 - Internet Communication settings
   - id: 9513
     title: "Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'"
@@ -229,7 +229,7 @@ checks:
     description: "Turns off the handwriting recognition error reporting tool."
     rationale: "A person's handwriting is Personally Identifiable Information (PII), especially when it comes to your signature."
     remediation:  "To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings\\Turn off handwriting recognition error reporting"
-    compliance: 
+    compliance:
       - cis: "18.8.22.1.3"
       - cis_csc: "13"
     condition: any
@@ -496,7 +496,7 @@ checks:
       - cis_csc: "9.1"
     condition: any
     rules:
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisablePNPRedir -> !1;' 
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> fDisablePNPRedir -> !1;'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> !fDisablePNPRedir;'
 # Section 18.9.58.3.10 - Session Time Limits
   - id: 9536
@@ -541,7 +541,7 @@ checks:
     description: "This policy setting allows you to configure a time limit for disconnected Remote Desktop Services sessions."
     rationale: "This setting helps to prevent active Remote Desktop sessions from tying up the computer for long periods of time while not in use, preventing computing resources from being consumed by large numbers of disconnected but still active sessions."
     remediation: "To establish the recommended configuration via GP, set the following UI path to Enabled: 1 minute: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Session Time Limits\\Set time limit for disconnected sessions"
-    compliance: 
+    compliance:
       - cis: "18.9.58.3.10.2"
       - cis_csc: "16.5"
     condition: any
@@ -605,7 +605,7 @@ checks:
     description: "This policy setting controls whether Web-based programs are allowed to install software on the computer without notifying the user."
     rationale: "Suppressing the system warning can pose a security risk and increase the attack surface on the system."
     remediation: "To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Windows Installer\\Prevent Internet Explorer security prompt for Windows Installer scripts"
-    compliance: 
+    compliance:
       - cis: "18.9.85.3"
       - cis_csc: "7"
     condition: any

--- a/etc/sca/windows/win_audit_rcl.yml
+++ b/etc/sca/windows/win_audit_rcl.yml
@@ -2,7 +2,7 @@
 # Checks for Windows audit
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/extensions/elasticsearch/restore_alerts/restore_alerts.sh
+++ b/extensions/elasticsearch/restore_alerts/restore_alerts.sh
@@ -3,7 +3,7 @@
 # Restore alerts from Wazuh alerts folder to Elasticsearch cluster.
 # Copyright (C) 2015-2019, Wazuh Inc.All rights reserved.
 # Wazuh.com
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
@@ -72,7 +72,7 @@ install_logstash () {
     if [[ ! -z $YUM_CMD ]]; then
         # Import the ElasticsearchPGP Key
         rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
-        
+
         echo -e "[elasticsearch-6.x]\nname=Elasticsearch repository for 6.x packages\nbaseurl=https://artifacts.elastic.co/packages/6.x/yum\ngpgcheck=1\ngpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch\nenabled=1\nautorefresh=1\ntype=rpm-md" | \
         tee -a /etc/yum.repos.d/elasticsearch.repo
 
@@ -110,17 +110,17 @@ previous_checks() {
     OSSEC_DIRECTORY="/var/ossec"
     LOGSTASH_BIN="/usr/share/logstash/bin/logstash"
     ALERTS_PATH="${OSSEC_DIRECTORY}/logs/alerts"
-    
+
     if ! [ -f $LOGSTASH_CONF ]; then
         print "Can't find Logstash ($LOGSTASH_CONF) configuration. \nExiting."
         exit 1
     fi
-    
+
     if ! [ -f $LOGSTASH_BIN ]; then
         print "----------------------------------------------------"
         print "  Can't find $LOGSTASH_BIN. Installing Logstash..."
         print "----------------------------------------------------"
-        
+
         print ""
         print "In order to avoid problems with Elasticsearch and"
         print "Logstash, both of them must have the same version."
@@ -189,7 +189,7 @@ setup_conf () {
 }
 
 end_and_exit () {
-    
+
     rm /tmp/$LOGSTASH_CONF
 
     print "\n### [Restoration ended] ###"
@@ -228,9 +228,9 @@ WM2ELS_restore () {
     ## Date to array
     setup_conf
     echo "##### Starting, reindexing alerts from $dateFrom to $dateTo"
-    
+
     dateFromAux=$dateFrom
-    
+
     while : ; do
         edit_conf
         IFS='-' read -r -a current_date <<< "$dateFromAux"

--- a/framework/examples/get_agents.py
+++ b/framework/examples/get_agents.py
@@ -4,7 +4,7 @@
 #  Copyright (C) 2015-2019, Wazuh Inc.All rights reserved.
 #  Wazuh.com
 #
-#  This program is a free software; you can redistribute it
+#  This program is free software; you can redistribute it
 #  and/or modify it under the terms of the GNU General Public
 #  License (version 2) as published by the FSF - Free Software
 #  Foundation.

--- a/framework/examples/rules2csv.py
+++ b/framework/examples/rules2csv.py
@@ -4,7 +4,7 @@
 #  Copyright (C) 2015-2019, Wazuh Inc.All rights reserved.
 #  Wazuh.com
 #
-#  This program is a free software; you can redistribute it
+#  This program is free software; you can redistribute it
 #  and/or modify it under the terms of the GNU General Public
 #  License (version 2) as published by the FSF - Free Software
 #  Foundation.

--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from sys import exit, argv
 from os.path import basename

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from sys import exit, path, argv, stdout
 from os.path import dirname

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import itertools
 import logging

--- a/framework/scripts/update_ruleset.py
+++ b/framework/scripts/update_ruleset.py
@@ -3,7 +3,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 # Requirements:
 #  Python 2.6 or newer

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import logging
 import asyncio
 import argparse

--- a/framework/setup.py
+++ b/framework/setup.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import json
 # Install the package locally: python setup.py install

--- a/framework/tests/__init__.py
+++ b/framework/tests/__init__.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import unittest
 import test_agent

--- a/framework/tests/test_agent.py
+++ b/framework/tests/test_agent.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import unittest
 import os

--- a/framework/wazuh/InputValidator.py
+++ b/framework/wazuh/InputValidator.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import re
 import operator
@@ -25,7 +25,7 @@ class InputValidator:
         matching = regex.match(name)
         if matching:
             return matching.group() == name
-        else: 
+        else:
             return False
 
 

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
 import re

--- a/framework/wazuh/__main__.py
+++ b/framework/wazuh/__main__.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from __init__ import main
 

--- a/framework/wazuh/active_response.py
+++ b/framework/wazuh/active_response.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from wazuh import common
 from wazuh.exception import WazuhException
 from wazuh.agent import Agent
@@ -26,7 +26,7 @@ def shell_escape(command):
     shell_escapes = ['"', '\'', '\t', ';', '`', '>', '<', '|', '#', '*', '[', ']', '{', '}', '&', '$', '!', ':', '(', ')']
     for shell_esc_char in shell_escapes:
         command = command.replace(shell_esc_char, "\\"+shell_esc_char)
-    
+
     return command
 
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import errno
 import hashlib

--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 
 from os import listdir

--- a/framework/wazuh/ciscat.py
+++ b/framework/wazuh/ciscat.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from wazuh import common
 from wazuh.syscollector import get_item_agent, _get_agent_items
 

--- a/framework/wazuh/cluster/__init__.py
+++ b/framework/wazuh/cluster/__init__.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 __version__ = '3.10.0'
 __revision__ = '31004'

--- a/framework/wazuh/cluster/client.py
+++ b/framework/wazuh/cluster/client.py
@@ -1,5 +1,5 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import ssl
 from typing import Tuple, Dict, List

--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import itertools
 from wazuh.utils import md5, mkdir_with_mode
 from wazuh.exception import WazuhException

--- a/framework/wazuh/cluster/common.py
+++ b/framework/wazuh/cluster/common.py
@@ -1,5 +1,5 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import base64
 import hashlib

--- a/framework/wazuh/cluster/control.py
+++ b/framework/wazuh/cluster/control.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from wazuh.cluster import local_client
 from wazuh import common
 import json

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import functools
 import itertools

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from wazuh import Wazuh
 from wazuh import common
 from wazuh.agent import Agent

--- a/framework/wazuh/cluster/local_client.py
+++ b/framework/wazuh/cluster/local_client.py
@@ -1,5 +1,5 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import json
 import logging

--- a/framework/wazuh/cluster/local_server.py
+++ b/framework/wazuh/cluster/local_server.py
@@ -1,5 +1,5 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import functools
 import json

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import json
 import random

--- a/framework/wazuh/cluster/server.py
+++ b/framework/wazuh/cluster/server.py
@@ -1,5 +1,5 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import itertools
 import operator

--- a/framework/wazuh/cluster/tests/test_cluster.py
+++ b/framework/wazuh/cluster/tests/test_cluster.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import time
 from datetime import datetime
 from unittest.mock import patch, mock_open

--- a/framework/wazuh/cluster/tests/test_local_client.py
+++ b/framework/wazuh/cluster/tests/test_local_client.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest.mock import patch
 from wazuh.exception import WazuhException

--- a/framework/wazuh/cluster/tests/test_worker.py
+++ b/framework/wazuh/cluster/tests/test_worker.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest.mock import patch, mock_open
 import pytest

--- a/framework/wazuh/cluster/worker.py
+++ b/framework/wazuh/cluster/worker.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
 import errno
 import glob

--- a/framework/wazuh/common.py
+++ b/framework/wazuh/common.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import json
 import os

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import json
 import random
 import time

--- a/framework/wazuh/database.py
+++ b/framework/wazuh/database.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh import common
 from wazuh.exception import WazuhException

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
 import re
 from glob import glob

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 
 class WazuhException(Exception):

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import json
 import random

--- a/framework/wazuh/ossec_queue.py
+++ b/framework/wazuh/ossec_queue.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh.exception import WazuhException
 from wazuh import common

--- a/framework/wazuh/ossec_socket.py
+++ b/framework/wazuh/ossec_socket.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh.exception import WazuhException
 from wazuh import common

--- a/framework/wazuh/pyDaemonModule.py
+++ b/framework/wazuh/pyDaemonModule.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import errno
 import os

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh.exception import WazuhException
 from wazuh.utils import WazuhDBQuery, WazuhDBQueryDistinct

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import re
 from glob import glob
 from xml.etree.ElementTree import fromstring

--- a/framework/wazuh/security_configuration_assessment.py
+++ b/framework/wazuh/security_configuration_assessment.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from glob import glob
 from itertools import groupby

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh.exception import WazuhException
 from wazuh import common

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from glob import glob
 from operator import itemgetter

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh import common
 from wazuh.exception import WazuhException

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest.mock import patch
 import pytest

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from freezegun import freeze_time
 from shutil import copyfile

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest import TestCase
 

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest.mock import patch, mock_open
 import pytest

--- a/framework/wazuh/tests/test_group.py
+++ b/framework/wazuh/tests/test_group.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest.mock import patch
 import pytest

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import json
 import os
 import pytest
@@ -202,7 +202,7 @@ ossec_log_file = """2019/03/26 20:14:37 wazuh-modulesd:database[27799] wm_databa
 2019/04/11 12:53:37 wazuh-modulesd:aws-s3: WARNING: Bucket:  -  Unexpected error querying/working with objects in S3: db_maintenance() got an unexpected keyword argument 'aws_account_id'
 
 2019/04/11 12:53:37 wazuh-modulesd:aws-s3: INFO: Executing Bucket Analysis: wazuh-aws-wodle
-2019/03/27 10:42:06 wazuh-modulesd:syscollector: INFO: This is a 
+2019/03/27 10:42:06 wazuh-modulesd:syscollector: INFO: This is a
 multiline log
 2019/03/26 13:03:11 ossec-csyslogd: INFO: Remote syslog server not configured. Clean exit."""
 

--- a/framework/wazuh/tests/test_rules.py
+++ b/framework/wazuh/tests/test_rules.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest.mock import patch, mock_open
 import pytest

--- a/framework/wazuh/tests/test_security_configuration_assessment.py
+++ b/framework/wazuh/tests/test_security_configuration_assessment.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
 import re

--- a/framework/wazuh/tests/test_syscheck.py
+++ b/framework/wazuh/tests/test_syscheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from sqlite3 import connect
 from unittest.mock import patch, mock_open
@@ -46,6 +46,6 @@ def test_last_scan(wazuh_conn_mock, connec_mock, db_mock, version, agent_id):
     with patch('wazuh.syscheck.Agent.get_basic_information', return_value=version):
         with patch("wazuh.syscheck.glob", return_value=[join(common.database_path_agents, agent_id)+".db"]):
             result = last_scan(agent_id)
-        
+
             assert isinstance(result, dict)
             assert set(result.keys()) == {'start', 'end'}

--- a/framework/wazuh/tests/test_util.py
+++ b/framework/wazuh/tests/test_util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 
 import pytest

--- a/framework/wazuh/tests/test_utils.py
+++ b/framework/wazuh/tests/test_utils.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from os.path import join, exists
 from tempfile import TemporaryDirectory, NamedTemporaryFile

--- a/framework/wazuh/tests/test_wdb.py
+++ b/framework/wazuh/tests/test_wdb.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from unittest.mock import patch
 import pytest

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh.exception import WazuhException
 from wazuh.database import Connection

--- a/framework/wazuh/wdb.py
+++ b/framework/wazuh/wdb.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh import common
 from wazuh.exception import WazuhException

--- a/framework/wrappers/generic_wrapper.sh
+++ b/framework/wrappers/generic_wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 WPYTHON_BIN="framework/python/bin/python3"
 

--- a/gen_ossec.sh
+++ b/gen_ossec.sh
@@ -4,7 +4,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # November 24, 2016.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/integrations/slack
+++ b/integrations/slack
@@ -2,7 +2,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # March 13, 2018.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/integrations/virustotal
+++ b/integrations/virustotal
@@ -2,7 +2,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # October 19, 2017.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/addagent/read_from_user.c
+++ b/src/addagent/read_from_user.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/agentlessd/agentlessd.h
+++ b/src/agentlessd/agentlessd.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/agentlessd/lessdcom.c
+++ b/src/agentlessd/lessdcom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 28, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/agentlessd/main.c
+++ b/src/agentlessd/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/agentlessd/scripts/main.exp
+++ b/src/agentlessd/scripts/main.exp
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/register_host.sh
+++ b/src/agentlessd/scripts/register_host.sh
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/ssh.exp
+++ b/src/agentlessd/scripts/ssh.exp
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/ssh_asa-fwsmconfig_diff
+++ b/src/agentlessd/scripts/ssh_asa-fwsmconfig_diff
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/ssh_foundry_diff
+++ b/src/agentlessd/scripts/ssh_foundry_diff
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/ssh_generic_diff
+++ b/src/agentlessd/scripts/ssh_generic_diff
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/ssh_integrity_check_bsd
+++ b/src/agentlessd/scripts/ssh_integrity_check_bsd
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/ssh_integrity_check_linux
+++ b/src/agentlessd/scripts/ssh_integrity_check_linux
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/ssh_nopass.exp
+++ b/src/agentlessd/scripts/ssh_nopass.exp
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/ssh_pixconfig_diff
+++ b/src/agentlessd/scripts/ssh_pixconfig_diff
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/sshlogin.exp
+++ b/src/agentlessd/scripts/sshlogin.exp
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/agentlessd/scripts/su.exp
+++ b/src/agentlessd/scripts/su.exp
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/analysisd/accumulator.c
+++ b/src/analysisd/accumulator.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/accumulator.h
+++ b/src/analysisd/accumulator.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/active-response.c
+++ b/src/analysisd/active-response.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/active-response.h
+++ b/src/analysisd/active-response.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/alerts/alerts.h
+++ b/src/analysisd/alerts/alerts.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/alerts/exec.h
+++ b/src/analysisd/alerts/exec.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/alerts/getloglocation.c
+++ b/src/analysisd/alerts/getloglocation.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/alerts/getloglocation.h
+++ b/src/analysisd/alerts/getloglocation.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/alerts/log.h
+++ b/src/analysisd/alerts/log.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010-2012 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/asyscom.c
+++ b/src/analysisd/asyscom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 26, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/cleanevent.h
+++ b/src/analysisd/cleanevent.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/compiled_rules/generic_samples.c
+++ b/src/analysisd/compiled_rules/generic_samples.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -2,7 +2,7 @@
 * Copyright (C) 2015-2019, Wazuh Inc.
 * April 23, 2018.
 *
-* This program is a free software; you can redistribute it
+* This program is free software; you can redistribute it
 * and/or modify it under the terms of the GNU General Public
 * License (version 2) as published by the FSF - Free Software
 * Foundation.

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -5,7 +5,7 @@
  * Copyright (C) 2014 Daniel Cid
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/decoders/hostinfo.c
+++ b/src/analysisd/decoders/hostinfo.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/decoders/plugin_decoders.c
+++ b/src/analysisd/decoders/plugin_decoders.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/plugin_decoders.h
+++ b/src/analysisd/decoders/plugin_decoders.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -2,7 +2,7 @@
 * Copyright (C) 2015-2019, Wazuh Inc.
 * April 18, 2017.
 *
-* This program is a free software; you can redistribute it
+* This program is free software; you can redistribute it
 * and/or modify it under the terms of the GNU General Public
 * License (version 2) as published by the FSF - Free Software
 * Foundation.

--- a/src/analysisd/decoders/plugins/ossecalert_decoder.c
+++ b/src/analysisd/decoders/plugins/ossecalert_decoder.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/plugins/pf_decoder.c
+++ b/src/analysisd/decoders/plugins/pf_decoder.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/plugins/sonicwall_decoder.c
+++ b/src/analysisd/decoders/plugins/sonicwall_decoder.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/plugins/symantecws_decoder.c
+++ b/src/analysisd/decoders/plugins/symantecws_decoder.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/decoders/rootcheck.c
+++ b/src/analysisd/decoders/rootcheck.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -2,7 +2,7 @@
 * Copyright (C) 2015-2019, Wazuh Inc.
 * December 05, 2018.
 *
-* This program is a free software; you can redistribute it
+* This program is free software; you can redistribute it
 * and/or modify it under the terms of the GNU General Public
 * License (version 2) as published by the FSF - Free Software
 * Foundation.

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -2,7 +2,7 @@
 * Copyright (C) 2015-2019, Wazuh Inc.
 * August 30, 2017.
 *
-* This program is a free software; you can redistribute it
+* This program is free software; you can redistribute it
 * and/or modify it under the terms of the GNU General Public
 * License (version 2) as published by the FSF - Free Software
 * Foundation.

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -2,7 +2,7 @@
 * Copyright (C) 2015-2019, Wazuh Inc.
 * December 05, 2018.
 *
-* This program is a free software; you can redistribute it
+* This program is free software; you can redistribute it
 * and/or modify it under the terms of the GNU General Public
 * License (version 2) as published by the FSF - Free Software
 * Foundation.

--- a/src/analysisd/dodiff.c
+++ b/src/analysisd/dodiff.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/dodiff.h
+++ b/src/analysisd/dodiff.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/eventinfo_list.c
+++ b/src/analysisd/eventinfo_list.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/format/to_json.h
+++ b/src/analysisd/format/to_json.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/fts.c
+++ b/src/analysisd/fts.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -123,7 +123,7 @@ int FTS_Init(int threads)
             free(tmp_s);
             merror(LIST_ADD_ERROR);
         }
-        
+
         /* Reset pointer addresses before using strdup() again */
         /* The hash will keep the needed memory references */
         tmp_s = NULL;
@@ -335,14 +335,14 @@ char * FTS(Eventinfo *lf)
         }
 
         fts_node = NULL;
-        
+
         os_strdup(_line, line_for_list);
         if (!line_for_list) {
             merror(MEM_ERROR, errno, strerror(errno));
             free(_line);
             return NULL;
         }
-        
+
         fts_node = OSList_AddData(fts_list, line_for_list);
         if (!fts_node) {
             free(line_for_list);

--- a/src/analysisd/fts.h
+++ b/src/analysisd/fts.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/labels.c
+++ b/src/analysisd/labels.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * February 27, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/labels.h
+++ b/src/analysisd/labels.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * February 27, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 3) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/lists.h
+++ b/src/analysisd/lists.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 3) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/lists_list.c
+++ b/src/analysisd/lists_list.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 3) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/lists_make.c
+++ b/src/analysisd/lists_make.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 3) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/lists_make.h
+++ b/src/analysisd/lists_make.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/output/jsonout.c
+++ b/src/analysisd/output/jsonout.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/output/jsonout.h
+++ b/src/analysisd/output/jsonout.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/output/prelude.c
+++ b/src/analysisd/output/prelude.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/output/prelude.h
+++ b/src/analysisd/output/prelude.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/output/zeromq.c
+++ b/src/analysisd/output/zeromq.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/output/zeromq.h
+++ b/src/analysisd/output/zeromq.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/analysisd/state.h
+++ b/src/analysisd/state.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 22, 2018
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -20,7 +20,7 @@ extern unsigned int s_events_decoded;
 extern unsigned int s_events_processed;
 extern unsigned int s_events_dropped;
 extern volatile unsigned int s_events_received;
-extern unsigned int s_alerts_written; 
+extern unsigned int s_alerts_written;
 extern unsigned int s_firewall_written;
 extern unsigned int s_fts_written;
 

--- a/src/analysisd/stats.c
+++ b/src/analysisd/stats.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -468,7 +468,7 @@ void LastMsg_Change(const char *log, int t_id)
 
 void Start_Time(){
     struct tm *p;
-    
+
     /* Current time */
     p = localtime(&c_time);
 

--- a/src/analysisd/stats.h
+++ b/src/analysisd/stats.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/client-agent/COPYRIGHT
+++ b/src/client-agent/COPYRIGHT
@@ -1,7 +1,7 @@
 Copyright (C) 2015-2019, Wazuh Inc.
 Copyright (C) 2009 Trend Micro Inc.
   All rights reserved.
-  This program is a free software; you can redistribute it
+  This program is free software; you can redistribute it
   and/or modify it under the terms of the GNU General Public
   License (version 2) as published by the FSF - Free Software
   Foundation

--- a/src/client-agent/agcom.c
+++ b/src/client-agent/agcom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 12, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * July 4, 2017
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/event-forward.c
+++ b/src/client-agent/event-forward.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/request.c
+++ b/src/client-agent/request.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 2, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -45,7 +45,7 @@ void req_init() {
     char *socket_sys = NULL;
     char *socket_wodle = NULL;
     char *socket_agent = NULL;
-    
+
     // Get values from internal options
 
     request_pool = getDefine_Int("remoted", "request_pool", 1, 4096);
@@ -68,25 +68,25 @@ void req_init() {
         merror("At req_main(): OSHash_Create()");
         goto ret;
     }
-    
+
     socket_log = strdup(SOCKET_LOGCOLLECTOR);
     socket_sys = strdup(SOCKET_SYSCHECK);
     socket_wodle = strdup(SOCKET_WMODULES);
     socket_agent = strdup(SOCKET_AGENT);
-    
+
     if (!socket_log || !socket_sys || !socket_wodle || !socket_agent) {
         merror("At req_main(): failed to allocate socket strings");
         goto ret;
     }
-    
+
     if (OSHash_Add(allowed_sockets, SOCKET_LOGCOLLECTOR, socket_log) != 2 || OSHash_Add(allowed_sockets, SOCKET_SYSCHECK, socket_sys) != 2 || \
     OSHash_Add(allowed_sockets, SOCKET_WMODULES, socket_wodle) != 2 || OSHash_Add(allowed_sockets, SOCKET_AGENT, socket_agent) != 2) {
         merror("At req_main(): failed to add socket strings to hash list");
         goto ret;
     }
-    
+
     success = 1;
-    
+
 ret:
     if (!success) {
         if (req_pool) free(req_pool);

--- a/src/client-agent/restart_agent.c
+++ b/src/client-agent/restart_agent.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Aug 23, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/client-agent/rotate_log.c
+++ b/src/client-agent/rotate_log.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * June 13, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/active-response.c
+++ b/src/config/active-response.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/active-response.h
+++ b/src/config/active-response.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/agentlessd-config.c
+++ b/src/config/agentlessd-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/agentlessd-config.h
+++ b/src/config/agentlessd-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/alerts-config.c
+++ b/src/config/alerts-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 29, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 29, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/buffer-config.c
+++ b/src/config/buffer-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Oct 16, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -146,13 +146,13 @@ static int read_main_elements(const OS_XML *xml, int modules,
             if ((modules & CWMODULE) && (Read_SCA(xml, node[i], d1) < 0)) {
                 goto fail;
             }
-        } 
+        }
 #ifndef WIN32
         else if (strcmp(node[i]->element, osfluent_forward) == 0) {
             if ((modules & CWMODULE) && (Read_Fluent_Forwarder(xml, node[i], d1) < 0)) {
                 goto fail;
             }
-        } 
+        }
 #endif
         else if (chld_node && (strcmp(node[i]->element, oslabels) == 0)) {
             if ((modules & CLABELS) && (Read_Labels(chld_node, d1, d2) < 0)) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/csyslogd-config.c
+++ b/src/config/csyslogd-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/csyslogd-config.h
+++ b/src/config/csyslogd-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/dbd-config.c
+++ b/src/config/dbd-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/dbd-config.h
+++ b/src/config/dbd-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/email-alerts-config.c
+++ b/src/config/email-alerts-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/integrator-config.c
+++ b/src/config/integrator-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Daniel B. Cid
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/integrator-config.h
+++ b/src/config/integrator-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Daniel B. Cid
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/labels-config.c
+++ b/src/config/labels-config.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * February 20, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/mail-config.h
+++ b/src/config/mail-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/reports-config.c
+++ b/src/config/reports-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/reports-config.h
+++ b/src/config/reports-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/rootcheck-config.c
+++ b/src/config/rootcheck-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/rootcheck-config.h
+++ b/src/config/rootcheck-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/socket-config.c
+++ b/src/config/socket-config.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Feb 7, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 26, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * December, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/wmodules-ciscat.c
+++ b/src/config/wmodules-ciscat.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * December, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/wmodules-command.c
+++ b/src/config/wmodules-command.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 26, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 25, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/wmodules-docker.c
+++ b/src/config/wmodules-docker.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/wmodules-fluent.c
+++ b/src/config/wmodules-fluent.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -48,10 +48,10 @@ int wm_fluent_read(xml_node **nodes, wmodule *module)
         module->context = &WM_FLUENT_CONTEXT;
         module->tag = strdup(module->context->name);
         module->data = fluent;
-    } 
+    }
 
     fluent = module->data;
-    
+
     if (!nodes)
         return 0;
 
@@ -173,7 +173,7 @@ int wm_fluent_read(xml_node **nodes, wmodule *module)
         else if (!strcmp(nodes[i]->element, XML_TIMEOUT))
         {
             char *pt = nodes[i]->content;
-            
+
             while (*pt != '\0') {
                 if (!isdigit((int)*pt)) {
                     merror("Invalid timeout at module '%s'", WM_FLUENT_CONTEXT.name);

--- a/src/config/wmodules-key-request.c
+++ b/src/config/wmodules-key-request.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/wmodules-oscap.c
+++ b/src/config/wmodules-oscap.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 27, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/wmodules-osquery-monitor.c
+++ b/src/config/wmodules-osquery-monitor.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -49,10 +49,10 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
         module->tag = strdup(module->context->name);
         module->data = sca;
         profiles = 0;
-    } 
+    }
 
     sca = module->data;
-    
+
 
     if (!nodes)
         return 0;
@@ -187,7 +187,7 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
                         }
                     }
 
-                    
+
                     if(strlen(children[j]->content) >= PATH_MAX) {
                         merror("Policy path is too long at module '%s'. Max path length is %d", WM_SCA_CONTEXT.name,PATH_MAX);
                         OS_ClearNode(children);
@@ -222,13 +222,13 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
                         } else {
                             policy->remote = 0;
                         }
-                        
+
                         os_strdup(children[j]->content,policy->profile);
                         sca->profile[profiles] = policy;
                         sca->profile[profiles + 1] = NULL;
                         profiles++;
                     }
-                   
+
                 } else {
                     merror(XML_ELEMNULL);
                     OS_ClearNode(children);
@@ -237,7 +237,7 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
             }
             OS_ClearNode(children);
 
-          
+
         }
         else if (!strcmp(nodes[i]->element, XML_SKIP_NFS))
         {

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/config/wmodules_syscollector.c
+++ b/src/config/wmodules_syscollector.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * March 9, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 17, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019
  * January 17
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019
  * January 17
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -63,8 +63,8 @@ int create_multigroup_dir(const char * multigroup);
 
 char* hostname_parse(const char *path);
 
-/* Validates the group name 
- * Returns 0 on success or  -1 on failure 
+/* Validates the group name
+ * Returns 0 on success or  -1 on failure
  */
 int w_validate_group_name(const char *group);
 

--- a/src/headers/ar.h
+++ b/src/headers/ar.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/audit_op.h
+++ b/src/headers/audit_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * December 18, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/auth_client.h
+++ b/src/headers/auth_client.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/cluster_utils.h
+++ b/src/headers/cluster_utils.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 3, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/custom_output_search.h
+++ b/src/headers/custom_output_search.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Contributed by Dan Parriott (@ddpbsd)
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009-2012 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/dirtree_op.h
+++ b/src/headers/dirtree_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/exec_op.h
+++ b/src/headers/exec_op.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 1, 2018
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/file-queue.h
+++ b/src/headers/file-queue.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/fs_op.h
+++ b/src/headers/fs_op.h
@@ -5,7 +5,7 @@
  * Copyright (C) 2014 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/hash_op.h
+++ b/src/headers/hash_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/help.h
+++ b/src/headers/help.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/json-queue.h
+++ b/src/headers/json-queue.h
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/json_op.h
+++ b/src/headers/json_op.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 11, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/labels_op.h
+++ b/src/headers/labels_op.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * February 27, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/list_op.h
+++ b/src/headers/list_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/math_op.h
+++ b/src/headers/math_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/mem_op.h
+++ b/src/headers/mem_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/notify_op.h
+++ b/src/headers/notify_op.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 4, 2018
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/os_err.h
+++ b/src/headers/os_err.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/os_utils.h
+++ b/src/headers/os_utils.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 25, 2019
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/privsep_op.h
+++ b/src/headers/privsep_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/pthreads_op.h
+++ b/src/headers/pthreads_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/queue_op.h
+++ b/src/headers/queue_op.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 2, 2017
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/randombytes.h
+++ b/src/headers/randombytes.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Contributed by Jeremy Rossi (@jrossi)
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/rc.h
+++ b/src/headers/rc.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/read-alert.h
+++ b/src/headers/read-alert.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/regex_op.h
+++ b/src/headers/regex_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/report_op.h
+++ b/src/headers/report_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/request_op.h
+++ b/src/headers/request_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 31, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/rootcheck_op.h
+++ b/src/headers/rootcheck_op.h
@@ -2,7 +2,7 @@
  * Shared functions for Rootcheck events decoding
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/sig_op.h
+++ b/src/headers/sig_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/store_op.h
+++ b/src/headers/store_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -2,7 +2,7 @@
  * Shared functions for Syscheck events decoding
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/time_op.h
+++ b/src/headers/time_op.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 4, 2017
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 3, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/utf8_op.h
+++ b/src/headers/utf8_op.h
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/validate_op.h
+++ b/src/headers/validate_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/vector_op.h
+++ b/src/headers/vector_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 19, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/version_op.h
+++ b/src/headers/version_op.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/wait_op.h
+++ b/src/headers/wait_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/headers/wazuhdb_op.h
+++ b/src/headers/wazuhdb_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 15, 2019.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/headers/yaml2json.h
+++ b/src/headers/yaml2json.h
@@ -2,7 +2,7 @@
  * August 4, 2018
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -4,7 +4,7 @@
 # by Lorenzo Costanzia di Costigliole <mummie@tin.it>
 # Modified by Wazuh, Inc. <info@wazuh.com>.
 # Copyright (C) 2015-2019, Wazuh Inc.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 SERVICE=/Library/LaunchDaemons/com.wazuh.agent.plist
 STARTUP=/Library/StartupItems/WAZUH/StartupParameters.plist

--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -4,7 +4,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # November 18, 2016.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -4,7 +4,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # November 18, 2016.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # March 6, 2019.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/init/replace_manager_ip.sh
+++ b/src/init/replace_manager_ip.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.All rights reserved.
 # Wazuh.com
 
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/init/template-select.sh
+++ b/src/init/template-select.sh
@@ -4,7 +4,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # November 18, 2016.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/logcollector/COPYRIGHT
+++ b/src/logcollector/COPYRIGHT
@@ -1,7 +1,7 @@
 Copyright (C) 2015-2019, Wazuh Inc.
 Copyright (C) 2009 Trend Micro Inc.
   All right reserved.
-  This program is a free software; you can redistribute it
+  This program is free software; you can redistribute it
   and/or modify it under the terms of the GNU General Public
   License (version 2) as published by the FSF - Free Software
   Foundation

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 12, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_command.c
+++ b/src/logcollector/read_command.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/logcollector/read_fullcommand.c
+++ b/src/logcollector/read_fullcommand.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019 Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2012 Daniel B. Cid (http://dcid.me)
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/compress_log.c
+++ b/src/monitord/compress_log.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/generate_reports.c
+++ b/src/monitord/generate_reports.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/main.c
+++ b/src/monitord/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/manage_files.c
+++ b/src/monitord/manage_files.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/moncom.c
+++ b/src/monitord/moncom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Aug 17, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/monitord/monitor_agents.c
+++ b/src/monitord/monitor_agents.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/monitord.h
+++ b/src/monitord/monitord.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * June 12, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_auth/authcom.c
+++ b/src/os_auth/authcom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 22, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_auth/check_cert.c
+++ b/src/os_auth/check_cert.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_auth/check_cert.h
+++ b/src/os_auth/check_cert.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 29, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 20, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -213,7 +213,7 @@ int main(int argc, char **argv)
                 break;
         }
     }
-	
+
     if (optind < argc) {
         mwarn("Extra arguments detected. They will be ignored.");
     }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_crypto/aes/aes_op.c
+++ b/src/os_crypto/aes/aes_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * March 12, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/aes/aes_op.h
+++ b/src/os_crypto/aes/aes_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * March 12, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/blowfish/bf_op.c
+++ b/src/os_crypto/blowfish/bf_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_crypto/blowfish/bf_op.h
+++ b/src/os_crypto/blowfish/bf_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/blowfish/main.c
+++ b/src/os_crypto/blowfish/main.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/hmac/hmac.c
+++ b/src/os_crypto/hmac/hmac.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Jun 21, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/hmac/hmac.h
+++ b/src/os_crypto/hmac/hmac.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Jun 21, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/md5/main.c
+++ b/src/os_crypto/md5/main.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/md5/md5_op.c
+++ b/src/os_crypto/md5/md5_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_crypto/md5/md5_op.h
+++ b/src/os_crypto/md5/md5_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_crypto/md5_sha1/main.c
+++ b/src/os_crypto/md5_sha1/main.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/md5_sha1/md5_sha1_op.c
+++ b/src/os_crypto/md5_sha1/md5_sha1_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_crypto/md5_sha1/md5_sha1_op.h
+++ b/src/os_crypto/md5_sha1/md5_sha1_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
+++ b/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.h
+++ b/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/sha1/main.c
+++ b/src/os_crypto/sha1/main.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_crypto/sha256/sha256_op.c
+++ b/src/os_crypto/sha256/sha256_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Contributed by Arshad Khan (@arshad01)
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/sha256/sha256_op.h
+++ b/src/os_crypto/sha256/sha256_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Contributed by Arshad Khan (@arshad01)
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/sha512/sha512_op.c
+++ b/src/os_crypto/sha512/sha512_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2019, Wazuh Inc.
  * Mar 14, 2019
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/sha512/sha512_op.h
+++ b/src/os_crypto/sha512/sha512_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 14, 2019
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/signature/signature.c
+++ b/src/os_crypto/signature/signature.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 28, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_crypto/signature/signature.h
+++ b/src/os_crypto/signature/signature.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * July 3, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_csyslogd/config.c
+++ b/src/os_csyslogd/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_csyslogd/csyscom.c
+++ b/src/os_csyslogd/csyscom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Apr 01, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_csyslogd/csyslogd.h
+++ b/src/os_csyslogd/csyslogd.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_dbd/alert.c
+++ b/src/os_dbd/alert.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_dbd/config.c
+++ b/src/os_dbd/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_dbd/db_op.c
+++ b/src/os_dbd/db_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_dbd/db_op.h
+++ b/src/os_dbd/db_op.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_dbd/dbd.c
+++ b/src/os_dbd/dbd.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_dbd/dbd.h
+++ b/src/os_dbd/dbd.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_dbd/mysql.schema
+++ b/src/os_dbd/mysql.schema
@@ -2,7 +2,7 @@
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/os_dbd/postgresql.schema
+++ b/src/os_dbd/postgresql.schema
@@ -2,7 +2,7 @@
 -- Copyright (C) 2009 Trend Micro Inc.
 -- All rights reserved.
 --
--- This program is a free software; you can redistribute it
+-- This program is free software; you can redistribute it
 -- and/or modify it under the terms of the GNU General Public
 -- License (version 2) as published by the FSF - Free Software
 -- Foundation.

--- a/src/os_dbd/rules.c
+++ b/src/os_dbd/rules.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_dbd/server.c
+++ b/src/os_dbd/server.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -56,7 +56,7 @@ static void execd_shutdown(int sig)
 {
     /* Remove pending active responses */
     minfo(EXEC_SHUTDOWN);
- 
+
     timeout_node = timeout_list ? OSList_GetFirstNode(timeout_list) : NULL;
     while (timeout_node) {
         timeout_data *list_entry;

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Jun 07, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_integrator/config.c
+++ b/src/os_integrator/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Daniel B. Cid
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Daniel B. Cid
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -385,20 +385,20 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 int dbg_lvl = isDebug();
                 snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL?"":integrator_config[s]->apikey, integrator_config[s]->hookurl==NULL?"":integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
                 if (dbg_lvl <= 0) strncat(exec_full_cmd, " > /dev/null 2>&1", 17);
-				
+
                 mdebug1("Running: %s", exec_full_cmd);
 
                 char **cmd = OS_StrBreak(' ', exec_full_cmd, 5);
 
                 if(cmd) {
                     wfd_t * wfd = wpopenv(integrator_config[s]->path, cmd, W_BIND_STDOUT | W_BIND_STDERR | W_CHECK_WRITE);
-                
+
                     if(wfd){
                         char buffer[4096];
                         while (fgets(buffer, sizeof(buffer), wfd->file)) {
                             mdebug2("integratord: %s", buffer);
                         }
-                        
+
                         int wp_closefd = wpclose(wfd);
                         int wstatus = WEXITSTATUS(wp_closefd);
 
@@ -417,7 +417,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                         merror("Could not launch command %s (%d)", strerror(errno), errno);
                         integrator_config[s]->enabled = 0;
                     }
-                    
+
                     free_strarray(cmd);
                 }
             }

--- a/src/os_integrator/integrator.h
+++ b/src/os_integrator/integrator.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Daniel B. Cid
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_integrator/intgcom.c
+++ b/src/os_integrator/intgcom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 26, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Daniel B. Cid
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_maild/config.c
+++ b/src/os_maild/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_maild/mail_list.c
+++ b/src/os_maild/mail_list.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_maild/mail_list.h
+++ b/src/os_maild/mail_list.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_maild/mailcom.c
+++ b/src/os_maild/mailcom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 26, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_maild/maild.h
+++ b/src/os_maild/maild.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_net/COPYRIGHT
+++ b/src/os_net/COPYRIGHT
@@ -1,7 +1,7 @@
 Copyright (C) 2015-2019, Wazuh Inc.
 Copyright (C) 2009 Trend Micro Inc.
   All rights reserved.
-  This program is a free software; you can redistribute it
+  This program is free software; you can redistribute it
   and/or modify it under the terms of the GNU General Public
   License (version 2) as published by the FSF - Free Software
   Foundation

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/COPYRIGHT
+++ b/src/os_regex/COPYRIGHT
@@ -1,7 +1,7 @@
 Copyright (C) 2015-2019, Wazuh Inc.
 Copyright (C) 2009 Trend Micro Inc.
   All right reserved.
-  This program is a free software; you can redistribute it
+  This program is free software; you can redistribute it
   and/or modify it under the terms of the GNU General Public
   License (version 2) as published by the FSF - Free Software
   Foundation

--- a/src/os_regex/os_match.c
+++ b/src/os_regex/os_match.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_match_compile.c
+++ b/src/os_regex/os_match_compile.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_match_execute.c
+++ b/src/os_regex/os_match_execute.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_match_free_pattern.c
+++ b/src/os_regex/os_match_free_pattern.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_regex.c
+++ b/src/os_regex/os_regex.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_regex/os_regex.h
+++ b/src/os_regex/os_regex.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_regex_compile.c
+++ b/src/os_regex/os_regex_compile.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_regex_free_pattern.c
+++ b/src/os_regex/os_regex_free_pattern.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_regex_internal.h
+++ b/src/os_regex/os_regex_internal.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_regex/os_regex_maps.c
+++ b/src/os_regex/os_regex_maps.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_regex/os_regex_match.c
+++ b/src/os_regex/os_regex_match.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_regex_startswith.c
+++ b/src/os_regex/os_regex_startswith.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_regex/os_regex_str.c
+++ b/src/os_regex/os_regex_str.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_regex/os_regex_strbreak.c
+++ b/src/os_regex/os_regex_strbreak.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_xml/COPYRIGHT
+++ b/src/os_xml/COPYRIGHT
@@ -1,7 +1,7 @@
 Copyright (C) 2015-2019, Wazuh Inc.
 Copyright (C) 2009 Trend Micro Inc.
   All rights reserved.
-  This program is a free software; you can redistribute it
+  This program is free software; you can redistribute it
   and/or modify it under the terms of the GNU General Public
   License (version 2) as published by the FSF - Free Software
   Foundation

--- a/src/os_xml/examples/mem_test.c
+++ b/src/os_xml/examples/mem_test.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_xml/examples/test.c
+++ b/src/os_xml/examples/test.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_xml/os_xml.h
+++ b/src/os_xml/os_xml.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_xml/os_xml_access.c
+++ b/src/os_xml/os_xml_access.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_xml/os_xml_internal.h
+++ b/src/os_xml/os_xml_internal.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_xml/os_xml_node_access.c
+++ b/src/os_xml/os_xml_node_access.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_xml/os_xml_variables.c
+++ b/src/os_xml/os_xml_variables.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_xml/os_xml_writer.c
+++ b/src/os_xml/os_xml_writer.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_zlib/os_zlib.c
+++ b/src/os_zlib/os_zlib.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_zlib/os_zlib.h
+++ b/src/os_zlib/os_zlib.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/os_zlib/zlib-test.c
+++ b/src/os_zlib/zlib-test.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/COPYRIGHT
+++ b/src/remoted/COPYRIGHT
@@ -1,7 +1,7 @@
 Copyright (C) 2015-2019, Wazuh Inc.
 Copyright (C) 2009 Trend Micro Inc.
   All rights reserved.
-  This program is a free software; you can redistribute it
+  This program is free software; you can redistribute it
   and/or modify it under the terms of the GNU General Public
   License (version 2) as published by the FSF - Free Software
   Foundation.

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/cfga-forward.c
+++ b/src/remoted/cfga-forward.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/netbuffer.c
+++ b/src/remoted/netbuffer.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2018 Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/netcounter.c
+++ b/src/remoted/netcounter.c
@@ -2,7 +2,7 @@
  * Network counter library for Remoted
  * Copyright (C) 2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/remoted/queue.c
+++ b/src/remoted/queue.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 2, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 31, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/shared_download.c
+++ b/src/remoted/shared_download.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 3, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/remoted/shared_download.h
+++ b/src/remoted/shared_download.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 3, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/syslog.c
+++ b/src/remoted/syslog.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/reportd/report.c
+++ b/src/reportd/report.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_open_ports.c
+++ b/src/rootcheck/check_open_ports.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_if.c
+++ b/src/rootcheck/check_rc_if.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_pids.c
+++ b/src/rootcheck/check_rc_pids.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_policy.c
+++ b/src/rootcheck/check_rc_policy.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_ports.c
+++ b/src/rootcheck/check_rc_ports.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_readproc.c
+++ b/src/rootcheck/check_rc_readproc.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/check_rc_trojans.c
+++ b/src/rootcheck/check_rc_trojans.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/common_rcl.c
+++ b/src/rootcheck/common_rcl.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/config.c
+++ b/src/rootcheck/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/db/cis_apache2224_rcl.txt
+++ b/src/rootcheck/db/cis_apache2224_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation
@@ -31,7 +31,7 @@
 # Multiple patterns can be specified by using " && " between them.
 # (All of them must match for it to return true).
 
-# CIS Checks for Apache Https Server 
+# CIS Checks for Apache Https Server
 # Based on Center for Internet Security Benchmark for Apache HttpSserver 2.4 v1.3.1 and Apache HttpsServer 2.2 v3.4.1 (https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308)
 #
 #
@@ -91,14 +91,14 @@ d:$conf-dirs -> conf -> !r:^# && r:loadmodule\sinfo;
 d:$mods-en -> info.load;
 #
 #
-#3.2 Give the Apache User Account an Invalid Shell 
+#3.2 Give the Apache User Account an Invalid Shell
 [CIS - Apache Configuration - 3.2: Apache User Account has got a valid shell] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 f:/etc/passwd -> r:/var/www && !r:\.*/bin/false$|/sbin/nologin$;
 #
 #
 #3.3 Lock the Apache User Account
 [CIS - Apache Configuration - 3.3: Lock the Apache User Account] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
-f:/etc/shadow -> r:^daemon|^wwwrun|^www-data|^apache && !r:\p!\.*$; 
+f:/etc/shadow -> r:^daemon|^wwwrun|^www-data|^apache && !r:\p!\.*$;
 #
 #
 #4.4 Restrict Override for All Directories
@@ -123,23 +123,23 @@ d:/var/www/html -> index.html;
 #
 #5.4.2 Remove the Apache user manual
 [CIS - Apache Configuration - 5.4.2: Remove the Apache user manual] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
-d:/etc/httpd/conf.d -> manual.conf; 
+d:/etc/httpd/conf.d -> manual.conf;
 d:/etc/apache2/conf-enabled -> apache2-doc.conf;
 #
 #
-#5.4.5 Verify that no Handler is enabled 
+#5.4.5 Verify that no Handler is enabled
 [CIS - Apache Configuration - 5.4.5: A Handler is configured] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 d:$conf-dirs -> conf -> !r:^# && r:/wsethandler;
 f:$main-conf -> !r:^# && r:/wsethandler;
 #
 #
-#5.5 Remove default CGI content printenv 
+#5.5 Remove default CGI content printenv
 [CIS - Apache Configuration - 5.5: Remove default CGI content printenv] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 d:/var/www/cgi-bin -> printenv;
 d:/usr/lib/cgi-bin -> printenv;
 #
 #
-#5.6 Remove default CGI content test-cgi 
+#5.6 Remove default CGI content test-cgi
 [CIS - Apache Configuration - 5.6: Remove default CGI content test-cgi] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 d:/var/www/cgi-bin -> test-cgi;
 d:/usr/lib/cgi-bin -> test-cgi;
@@ -160,7 +160,7 @@ f:$traceen -> !r:^# && r:traceenable\s+on\s*$;
 f:/etc/httpd/conf/httpd.conf -> !r:loadmodule\srewrite;
 d:$mods-en -> !f:rewrite.load;
 f:$main-conf -> !r:rewriteengine\son;
-f:$main-conf -> !r:rewritecond && !r:%{THE_REQUEST} && !r:!HTTP/1\\.1\$; 
+f:$main-conf -> !r:rewritecond && !r:%{THE_REQUEST} && !r:!HTTP/1\\.1\$;
 f:$main-conf -> !r:rewriterule && !r:.* - [F];
 #
 #
@@ -170,18 +170,18 @@ f:/etc/httpd/conf/httpd.conf -> !r:loadmodule\srewrite;
 d:$mods-en -> !f:rewrite.load;
 f:$main-conf -> !r:rewriteengine\son;
 f:$main-conf -> !r:rewritecond && !r:%{HTTP_HOST} && !r:www\\.\w+\\.\w+ [NC]$;
-f:$main-conf -> !r:rewritecond && !r:%{REQUEST_URI} && !r:/error [NC]$; 
+f:$main-conf -> !r:rewritecond && !r:%{REQUEST_URI} && !r:/error [NC]$;
 f:$main-conf -> !r:rewriterule && !r:.\(.*\) - [L,F]$;
 #
 #
-#5.13 Restrict Listen Directive 
+#5.13 Restrict Listen Directive
 [CIS - Apache Configuration - 5.13: Restrict Listen Directive] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 d:$conf-dirs -> conf -> !r:^# && r:listen\s80$;
 d:$conf-dirs -> conf -> !r:^# && r:listen\s0.0.0.0\p80;
 d:$conf-dirs -> conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p80;
 f:$main-conf -> !r:^# && r:listen\s80$;
 f:$main-conf -> !r:^# && r:listen\s0.0.0.0\p\d*;
-f:$main-conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p\d*; 
+f:$main-conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p\d*;
 f:/etc/apache2/sites-enabled/000-default.conf -> !r:^# && r:listen\s80$;
 f:/etc/apache2/sites-enabled/000-default.conf -> !r:^# && r:listen\s0.0.0.0\p\d*;
 f:/etc/apache2/sites-enabled/000-default.conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p\d*;
@@ -190,9 +190,9 @@ f:/etc/apache2/ports.conf -> !r:^# && r:listen\s0.0.0.0\p\d*;
 f:/etc/apache2/ports.conf -> !r:^# && r:listen\s[\p\pffff\p0.0.0.0]\p\d*;
 #
 #
-#5.14 Restrict Browser Frame Options 
+#5.14 Restrict Browser Frame Options
 [CIS - Apache Configuration - 5.14: Restrict Browser Frame Options] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
-f:$main-conf -> !r:header\salways\sappend\sx-frame-options && !r:sameorigin|deny; 
+f:$main-conf -> !r:header\salways\sappend\sx-frame-options && !r:sameorigin|deny;
 #
 #
 #6.1 Configure the Error Log to notice at least
@@ -201,18 +201,18 @@ f:$main-conf -> !r:^# && r:loglevel\snotice\score\p && r:warn|emerg|alert|crit|e
 f:$main-conf -> !r:loglevel\snotice\score\p && !r:info|debug;
 #
 #
-#6.2 Configure a Syslog facility for Error Log 
+#6.2 Configure a Syslog facility for Error Log
 [CIS - Apache Configuration - 6.2: Configure a Syslog facility for Error Log] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 f:$main-conf -> !r:errorlog\s+\p*syslog\p\.*\p*;
 #
 #
-#7.6 Disable SSL Insecure Renegotiation 
+#7.6 Disable SSL Insecure Renegotiation
 [CIS - Apache Configuration - 7.6: Disable SSL Insecure Renegotiation] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 f:$ssl-confs -> !r:^\t*\s*# && r:sslinsecurerenegotiation\s+on\s*;
 f:$ssl-confs -> !r:^\t*\s*# && r:sslinsecurerenegotiation\s*$;
 #
 #
-#7.7 Ensure SSL Compression is not enabled 
+#7.7 Ensure SSL Compression is not enabled
 [CIS - Apache Configuration - 7.7: Ensure SSL Compression is not enabled] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 f:$ssl-confs -> !r:^\t*\s*# && r:sslcompression\s+on\s*;
 f:$ssl-confs -> !r:^\t*\s*# && r:sslcompression\s*$;
@@ -236,7 +236,7 @@ f:$ssl-confs -> !r:\t*\s*sslusestapling\s+on;
 f:$ssl-confs -> !r:\t*\s*sslstaplingcache\s+\.+;
 #
 #
-#7.10 Enable HTTP Strict Transport Security 
+#7.10 Enable HTTP Strict Transport Security
 [CIS - Apache Configuration - 7.10: Enable HTTP Strict Transport Security] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 f:/etc/apache2/apache2.conf -> !r:Header\salways\sset\sStrict-Transport-Security\s"max-age=\d\d\d\d*";
 f:/etc/apache2/apache2.conf -> !r:^# && r:Header\salways\sset\sStrict-Transport-Security\s"max-age=1\d\d";
@@ -246,7 +246,7 @@ f:/etc/apache2/apache2.conf -> !r:^# && r:Header\salways\sset\sStrict-Transport-
 f:/etc/apache2/apache2.conf -> !r:^# && r:Header\salways\sset\sStrict-Transport-Security\s"max-age=5\d\d";
 #
 #
-#8.1 Set ServerToken to Prod or ProductOnly 
+#8.1 Set ServerToken to Prod or ProductOnly
 [CIS - Apache Configuration - 8.1: Set ServerToken to Prod or ProductOnly] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 d:$conf-dirs -> conf -> !r:^# && r:servertokens\s+major;
 d:$conf-dirs -> conf -> !r:^# && r:servertokens\s+minor;
@@ -262,13 +262,13 @@ d:$conf-dirs -> conf -> !r:^# && r:serversignature\s+email;
 d:$conf-dirs -> conf -> !r:^# && r:serversignature\s+on;
 #
 #
-#8.3: Prevent Information Leakage via Default Apache Content 
+#8.3: Prevent Information Leakage via Default Apache Content
 [CIS - Apache Configuration - 8.3: Prevent Information Leakage via Default Apache Content] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 d:$conf-dirs -> conf -> !r:^\t*\s*# && r:include\s*\w*httpd-autoindex.conf;
 d:$conf-dirs -> conf -> !r:^\t*\s*# && r:alias\s*/icons/\s*\.*;
 #
 #
-#9.1:Set TimeOut to 10 or less 
+#9.1:Set TimeOut to 10 or less
 [CIS - Apache Configuration - 9.1: Set TimeOut to 10 or less] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 f:$main-conf -> !r:^# && r:timeout\s+9\d;
 f:$main-conf -> !r:^# && r:timeout\s+8\d;
@@ -291,7 +291,7 @@ f:$main-conf -> !r:^timeout\s+\d\d*;
 f:$main-conf -> !r:^# && r:timeout\s+\d\d\d+;
 #
 #
-#9.2:Set the KeepAlive directive to On 
+#9.2:Set the KeepAlive directive to On
 [CIS - Apache Configuration - 9.2: Set the KeepAlive directive to On] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 f:$main-conf -> !r:^# && r:keepalive\s+off;
 f:$main-conf -> !r:keepalive\s+on;
@@ -342,7 +342,7 @@ f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D9\
 f:$request-confs -> !r:^\t*\s*# && r:\t*\s*requestreadtimeout\.+header\p\d\d\D\d\d\d+;
 #
 #
-#9.6 Set Timeout Limits for Request Body 
+#9.6 Set Timeout Limits for Request Body
 [CIS - Apache Configuration - 9.6: Set Timeout Limits for Request Body] [any] [https://workbench.cisecurity.org/benchmarks/307, https://workbench.cisecurity.org/benchmarks/308]
 f:/etc/httpd/conf/httpd.conf -> !r:^loadmodule\s+reqtimeout;
 d:$mods-en -> !f:reqtimeout.load;

--- a/src/rootcheck/db/cis_debian_linux_rcl.txt
+++ b/src/rootcheck/db/cis_debian_linux_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_mysql5-6_community_rcl.txt
+++ b/src/rootcheck/db/cis_mysql5-6_community_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation
@@ -31,8 +31,8 @@
 # Multiple patterns can be specified by using " && " between them.
 # (All of them must match for it to return true).
 
-# CIS Checks for MYSQL 
-# Based on Center for Internet Security Benchmark for MYSQL v1.1.0 
+# CIS Checks for MYSQL
+# Based on Center for Internet Security Benchmark for MYSQL v1.1.0
 #
 $home_dirs=/usr2/home/*,/home/*,/home,/*/home/*,/*/home,/;
 $enviroment_files=/*/home/*/\.bashrc,/*/home/*/\.profile,/*/home/*/\.bash_profile,/home/*/\.bashrc,/home/*/\.profile,/home/*/\.bash_profile;
@@ -54,7 +54,7 @@ f:/etc/passwd -> r:^mysql && !r:\.*/bin/false$|/sbin/nologin$;
 f:$enviroment_files -> r:\.*MYSQL_PWD\.*;
 #
 #
-#4.3 Ensure 'allow-suspicious-udfs' Is Set to 'FALSE' 
+#4.3 Ensure 'allow-suspicious-udfs' Is Set to 'FALSE'
 [CIS - MySQL Configuration - 4.3: 'allow-suspicious-udfs' Is Set in my.cnf'] [any] [https://workbench.cisecurity.org/files/1310/download]
 f:$mysql-cnfs -> !r:^# && r:allow-suspicious-udfs\.+true;
 f:$mysql-cnfs -> r:allow-suspicious-udfs\s*$;

--- a/src/rootcheck/db/cis_mysql5-6_enterprise_rcl.txt
+++ b/src/rootcheck/db/cis_mysql5-6_enterprise_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation
@@ -31,8 +31,8 @@
 # Multiple patterns can be specified by using " && " between them.
 # (All of them must match for it to return true).
 
-# CIS Checks for MYSQL 
-# Based on Center for Internet Security Benchmark for MYSQL v1.1.0 
+# CIS Checks for MYSQL
+# Based on Center for Internet Security Benchmark for MYSQL v1.1.0
 #
 $home_dirs=/usr2/home/*,/home/*,/home,/*/home/*,/*/home,/;
 $enviroment_files=/*/home/*/\.bashrc,/*/home/*/\.profile,/*/home/*/\.bash_profile,/home/*/\.bashrc,/home/*/\.profile,/home/*/\.bash_profile;
@@ -54,7 +54,7 @@ f:/etc/passwd -> r:^mysql && !r:\.*/bin/false$|/sbin/nologin$;
 f:$enviroment_files -> r:\.*MYSQL_PWD\.*;
 #
 #
-#4.3 Ensure 'allow-suspicious-udfs' Is Set to 'FALSE' 
+#4.3 Ensure 'allow-suspicious-udfs' Is Set to 'FALSE'
 [CIS - MySQL Configuration - 4.3: 'allow-suspicious-udfs' Is Set in my.cnf'] [any] [https://workbench.cisecurity.org/files/1310/download]
 f:$mysql-cnfs -> !r:^# && r:allow-suspicious-udfs\.+true;
 f:$mysql-cnfs -> r:allow-suspicious-udfs\s*$;
@@ -139,7 +139,7 @@ f:$mysql-cnfs -> !r:^# && r:audit_log_include_accounts\s*=\s* && !r:null\s*$;
 f:$mysql-cnfs -> r:audit_log_include_accounts\s*$;
 #
 #
-#6.9 Ensure audit_log_policy is not set to all 
+#6.9 Ensure audit_log_policy is not set to all
 [CIS - MySQL Configuration - 6.9: audit_log_policy is not set to all] [any] [https://workbench.cisecurity.org/files/1310/download]
 f:$mysql-cnfs -> !r:^# && r:audit_log_policy\s*=\s*queries;
 f:$mysql-cnfs -> !r:^# && r:audit_log_policy\s*=\s*none;

--- a/src/rootcheck/db/cis_rhel5_linux_rcl.txt
+++ b/src/rootcheck/db/cis_rhel5_linux_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_rhel6_linux_rcl.txt
+++ b/src/rootcheck/db/cis_rhel6_linux_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_rhel7_linux_rcl.txt
+++ b/src/rootcheck/db/cis_rhel7_linux_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_rhel_linux_rcl.txt
+++ b/src/rootcheck/db/cis_rhel_linux_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_sles11_linux_rcl.txt
+++ b/src/rootcheck/db/cis_sles11_linux_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_sles12_linux_rcl.txt
+++ b/src/rootcheck/db/cis_sles12_linux_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_win2012r2_domainL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_domainL1_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation
@@ -81,7 +81,7 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> CrashOnAuditFail ->
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> CrashOnAuditFail -> 2;
 #
 #
-#2.3.4.1 Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators' 
+#2.3.4.1 Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators'
 [CIS - Microsoft Windows Server 2012 R2 - 2.3.4.1: Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 1;
 r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 2;
@@ -502,7 +502,7 @@ r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\F
 #
 #9.2.5 Ensure 'Windows Firewall: Private: Settings: Apply local firewall rules' is set to 'Yes (default)'
 [CIS - Microsoft Windows Server 2012 R2 - 9.2.5: Ensure 'Windows Firewall: Private: Settings: Apply local firewall rules' is set to 'Yes'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> AllowLocalPolicyMerge -> 0; 
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile -> AllowLocalPolicyMerge -> 0;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile -> AllowLocalPolicyMerge -> 0;
 #
 #
@@ -526,7 +526,7 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:1\w\w\w;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:2\w\w\w;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging -> LogFileSize -> r:3\w\w\w;
-r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w; 
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w\w;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:\w\w\w;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\Logging -> LogFileSize -> r:1\w\w\w;
@@ -585,7 +585,7 @@ r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\F
 #9.3.7 Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'
 [CIS - Microsoft Windows Server 2012 R2 - 9.3.7: Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SYSTEMROOT%\System32\logfiles\firewall\*.log'] [any] [https://workbench.cisecurity.org/benchmarks/288]
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
-r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog; 
+r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\Logging -> LogFilePath -> r:\psystemroot\p\\system32\logfiles\firewall\\w+\plog;
 #
 #
 #9.3.8 Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16384 KB or greater'

--- a/src/rootcheck/db/cis_win2012r2_domainL2_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_domainL2_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_win2012r2_memberL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_memberL1_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/cis_win2012r2_memberL2_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_memberL2_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/rootkit_files.txt
+++ b/src/rootcheck/db/rootkit_files.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/rootkit_trojans.txt
+++ b/src/rootcheck/db/rootkit_trojans.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/system_audit_rcl.txt
+++ b/src/rootcheck/db/system_audit_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/system_audit_ssh.txt
+++ b/src/rootcheck/db/system_audit_ssh.txt
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/win_applications_rcl.txt
+++ b/src/rootcheck/db/win_applications_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/win_audit_rcl.txt
+++ b/src/rootcheck/db/win_audit_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/db/win_malware_rcl.txt
+++ b/src/rootcheck/db/win_malware_rcl.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation

--- a/src/rootcheck/rootcheck-config.c
+++ b/src/rootcheck/rootcheck-config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/unix-process.c
+++ b/src/rootcheck/unix-process.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/util/ads_dump.c
+++ b/src/rootcheck/util/ads_dump.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/win-common.c
+++ b/src/rootcheck/win-common.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/rootcheck/win-process.c
+++ b/src/rootcheck/win-process.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/selinux/wazuh.te
+++ b/src/selinux/wazuh.te
@@ -1,7 +1,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # July 4, 2018.
 #
-# This program is a free software; you can redistribute it
+# This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/audit_op.c
+++ b/src/shared/audit_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * December 18, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/auth_client.c
+++ b/src/shared/auth_client.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 30, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 26, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/custom_output_search_replace.c
+++ b/src/shared/custom_output_search_replace.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Contributed by Dan Parriott (@ddpbsd)
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/dirtree_op.c
+++ b/src/shared/dirtree_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/exec_op.c
+++ b/src/shared/exec_op.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 1, 2018
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/file-queue.c
+++ b/src/shared/file-queue.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -147,7 +147,7 @@ alert_data *Read_FileMon(file_queue *fileq, const struct tm *p, unsigned int tim
     if(!fileq->fp){
         return (NULL);
     }
-    
+
     if (al_data = GetAlertData(fileq->flags, fileq->fp), al_data) {
         return al_data;
     }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/help.c
+++ b/src/shared/help.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 11, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/labels_op.c
+++ b/src/shared/labels_op.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * February 27, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/list_op.c
+++ b/src/shared/list_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/math_op.c
+++ b/src/shared/math_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/mem_op.c
+++ b/src/shared/mem_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/notify_op.c
+++ b/src/shared/notify_op.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 4, 2018
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/os_utils.c
+++ b/src/shared/os_utils.c
@@ -2,7 +2,7 @@
  * Shared functions for Rootcheck events decoding
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/privsep_op.c
+++ b/src/shared/privsep_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/pthreads_op.c
+++ b/src/shared/pthreads_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 2, 2017
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/randombytes.c
+++ b/src/shared/randombytes.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Contributed by Jeremy Rossi (@jrossi)
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/regex_op.c
+++ b/src/shared/regex_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/report_op.c
+++ b/src/shared/report_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/request_op.c
+++ b/src/shared/request_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * May 31, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/rootcheck_op.c
+++ b/src/shared/rootcheck_op.c
@@ -2,7 +2,7 @@
  * Shared functions for Rootcheck events decoding
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/sig_op.c
+++ b/src/shared/sig_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/store_op.c
+++ b/src/shared/store_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -2,7 +2,7 @@
  * Shared functions for Syscheck events decoding
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/tests/hash_test.c
+++ b/src/shared/tests/hash_test.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
             }
         }
     }
-    
+
     OSHash_Free(mhash);
 
     return (0);

--- a/src/shared/tests/ip_test.c
+++ b/src/shared/tests/ip_test.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/tests/merge_test.c
+++ b/src/shared/tests/merge_test.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/tests/prime_test.c
+++ b/src/shared/tests/prime_test.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/tests/string_test.c
+++ b/src/shared/tests/string_test.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/time_op.c
+++ b/src/shared/time_op.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 4, 2017
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -50,7 +50,7 @@ void time_sub(struct timespec * a, const struct timespec * b) {
 
 long long int get_windows_time_epoch() {
     FILETIME ft = {0};
-    LARGE_INTEGER li = {0};  
+    LARGE_INTEGER li = {0};
 
     GetSystemTimeAsFileTime(&ft);
     li.LowPart = ft.dwLowDateTime;
@@ -62,7 +62,7 @@ long long int get_windows_time_epoch() {
 }
 
 long long int get_windows_file_time_epoch(FILETIME ft) {
-    LARGE_INTEGER li = {0};  
+    LARGE_INTEGER li = {0};
 
     li.LowPart = ft.dwLowDateTime;
     li.HighPart = ft.dwHighDateTime;

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 3, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/utf8_op.c
+++ b/src/shared/utf8_op.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/vector_op.c
+++ b/src/shared/vector_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 19, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/wait_op.c
+++ b/src/shared/wait_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 15, 2019.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/shared/yaml2json.c
+++ b/src/shared/yaml2json.c
@@ -2,7 +2,7 @@
  * August 4, 2018
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 13, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/syscheckd/syscom.c
+++ b/src/syscheckd/syscom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 14, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 13, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/util/clear_stats.c
+++ b/src/util/clear_stats.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/util/list_agents.c
+++ b/src/util/list_agents.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/util/ossec-regex.c
+++ b/src/util/ossec-regex.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/util/parallel-regex.c
+++ b/src/util/parallel-regex.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * September 26, 2018
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/util/rootcheck_control.c
+++ b/src/util/rootcheck_control.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/util/syscheck_control.c
+++ b/src/util/syscheck_control.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/util/syscheck_update.c
+++ b/src/util/syscheck_update.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/util/verify-agent-conf.c
+++ b/src/util/verify-agent-conf.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 03, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 06, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 06, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * July 5, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb_ciscat.c
+++ b/src/wazuh_db/wdb_ciscat.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 23, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 06, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb_metadata.c
+++ b/src/wazuh_db/wdb_metadata.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 06, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 16, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb_sca.c
+++ b/src/wazuh_db/wdb_sca.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 06, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -199,7 +199,7 @@ int wdb_sca_global_update(wdb_t * wdb, int scan_id, char *name,char *description
     sqlite3_bind_int(stmt, 6, failed);
     sqlite3_bind_int(stmt, 7, score);
     sqlite3_bind_text(stmt, 8, name, -1, NULL);
-    
+
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return 0;
     } else {
@@ -303,7 +303,7 @@ int wdb_sca_policy_delete(wdb_t * wdb,char * policy_id) {
     stmt = wdb->stmt[WDB_STMT_SCA_POLICY_DELETE];
 
     sqlite3_bind_text(stmt, 1, policy_id, -1, NULL);
-    
+
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         wdb_sca_scan_info_delete(wdb,policy_id);
         return 0;
@@ -331,7 +331,7 @@ int wdb_sca_scan_info_delete(wdb_t * wdb,char * policy_id) {
     stmt = wdb->stmt[WDB_STMT_SCA_SCAN_INFO_DELETE];
 
     sqlite3_bind_text(stmt, 1, policy_id, -1, NULL);
-    
+
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return 0;
     } else {
@@ -359,7 +359,7 @@ int wdb_sca_check_delete_distinct(wdb_t * wdb,char * policy_id,int scan_id) {
 
     sqlite3_bind_int(stmt, 1, scan_id);
     sqlite3_bind_text(stmt, 2, policy_id, -1, NULL);
-    
+
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return 0;
     } else {
@@ -385,7 +385,7 @@ int wdb_sca_check_delete(wdb_t * wdb,char * policy_id) {
     stmt = wdb->stmt[WDB_STMT_SCA_CHECK_DELETE];
 
     sqlite3_bind_text(stmt, 1, policy_id, -1, NULL);
-    
+
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return 0;
     } else {
@@ -409,7 +409,7 @@ int wdb_sca_check_compliances_delete(wdb_t * wdb) {
     }
 
     stmt = wdb->stmt[WDB_STMT_SCA_CHECK_COMPLIANCE_DELETE];
-    
+
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return 0;
     } else {
@@ -433,7 +433,7 @@ int wdb_sca_check_rules_delete(wdb_t * wdb) {
     }
 
     stmt = wdb->stmt[WDB_STMT_SCA_CHECK_RULES_DELETE];
-    
+
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return 0;
     } else {
@@ -556,7 +556,7 @@ int wdb_sca_compliance_save(wdb_t * wdb, int id_check, char *key, char *value) {
     sqlite3_bind_int(stmt, 1, id_check);
     sqlite3_bind_text(stmt, 2, key, -1, NULL);
     sqlite3_bind_text(stmt, 3, value, -1, NULL);
-    
+
     if (sqlite3_step(stmt) == SQLITE_DONE) {
         return 0;
     } else {

--- a/src/wazuh_db/wdb_scan_info.c
+++ b/src/wazuh_db/wdb_scan_info.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * June 06, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * August 30, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * December 12, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 22, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * March 9, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Sep, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * March 9, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Aug, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/syscollector/syscollector_win_ext.c
+++ b/src/wazuh_modules/syscollector/syscollector_win_ext.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Aug, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -405,14 +405,14 @@ char* parse_raw_smbios_bbserial(BYTE* rawData, DWORD rawDataSize){
 	SMBIOSStructureHeader *header;
 	char *serialNumber = NULL, *tmp = NULL;
 	BYTE serialNumberStrNum = 0, curStrNum = 0;
-	
+
 	if (rawData == NULL || !rawDataSize) return NULL;
-	
+
 	while(pos < rawDataSize)
 	{
 		/* Get structure header */
 		header = (SMBIOSStructureHeader*)(rawData + pos);
-		
+
 		/* Check if this SMBIOS structure represents the Base Board Information */
 		if (header->Type == 2)
 		{
@@ -425,20 +425,20 @@ char* parse_raw_smbios_bbserial(BYTE* rawData, DWORD rawDataSize){
 				break;
 			}
 		}
-		
+
 		/* Skip formatted area length */
 		pos += header->FormattedAreaLength;
-		
+
 		/* Reset current string number */
 		curStrNum = 0;
-		
+
 		/* Read unformatted area */
 		/* This area is formed by NULL-terminated strings */
 		/* The area itself ends with an additional NULL terminator */
 		while(pos < rawDataSize)
 		{
 			tmp = (char*)(rawData + pos);
-			
+
 			/* Check if we found a NULL terminator */
 			if (tmp[0] == 0)
 			{
@@ -456,24 +456,24 @@ char* parse_raw_smbios_bbserial(BYTE* rawData, DWORD rawDataSize){
 					tmp++;
 				}
 			}
-			
+
 			/* Increase current string number */
 			curStrNum++;
-			
+
 			/* Check if we reached the Serial Number */
 			if (header->Type == 2 && curStrNum == serialNumberStrNum)
 			{
 				serialNumber = strdup(tmp);
 				break;
 			}
-			
+
 			/* Prepare position to access the next string */
 			pos += (DWORD)strlen(tmp);
 		}
-		
+
 		if (serialNumber) break;
 	}
-	
+
 	return serialNumber;
 }
 
@@ -482,11 +482,11 @@ __declspec( dllexport ) int get_baseboard_serial(char **serial)
     int ret = 0;
     DWORD smbios_size = 0;
     PRawSMBIOSData smbios = NULL;
-    
+
     DWORD Signature = 0;
     const BYTE byteSignature[] = { 'B', 'M', 'S', 'R' }; // "RSMB" (little endian)
     memcpy(&Signature, byteSignature, 4);
-    
+
     /* Get raw SMBIOS firmware table size */
     /* Reference: https://docs.microsoft.com/en-us/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsystemfirmwaretable */
     smbios_size = GetSystemFirmwareTable(Signature, 0, NULL, 0);
@@ -508,7 +508,7 @@ __declspec( dllexport ) int get_baseboard_serial(char **serial)
             } else {
                 ret = 3;
             }
-            
+
             free(smbios);
         } else {
             ret = 2;
@@ -516,7 +516,7 @@ __declspec( dllexport ) int get_baseboard_serial(char **serial)
     } else {
         ret = 1;
     }
-    
+
     return ret;
 }
 

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Aug, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -5,7 +5,7 @@
  *
  * Updated by Jeremy Phillips <jeremy@uranusbytes.com>
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -5,7 +5,7 @@
  *
  * Updated by Jeremy Phillips <jeremy@uranusbytes.com>
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * September, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_azure.h
+++ b/src/wazuh_modules/wm_azure.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * September, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * December, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -466,7 +466,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
             os_free(ciscat_script);
             pthread_exit(NULL);
     }
-    
+
     os_free(output);
     os_free(command);
     os_free(ciscat_script);

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * December, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 26, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_command.h
+++ b/src/wazuh_modules/wm_command.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October 26, 2017.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January, 2019
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -110,7 +110,7 @@ char* getPrimaryIP(){
             cJSON_Delete(object);
             break;
 #endif
-            
+
         }
         cJSON_Delete(object);
     }

--- a/src/wazuh_modules/wm_control.h
+++ b/src/wazuh_modules/wm_control.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January, 2019
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * November 29, 2016
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_database.h
+++ b/src/wazuh_modules/wm_database.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * November 29, 2016
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_docker.h
+++ b/src/wazuh_modules/wm_docker.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * October, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 25, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_download.h
+++ b/src/wazuh_modules/wm_download.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 25, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 25, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -294,7 +294,7 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
         merror("At wm_exec(): pipe(): %s", strerror(errno));
         return -1;
     }
-    
+
     w_descriptor_cloexec(pipe_fd[0]);
 
     // Fork

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 25, 2019.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_fluent.h
+++ b/src/wazuh_modules/wm_fluent.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * March 26, 2019.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * November 25, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_keyrequest.h
+++ b/src/wazuh_modules/wm_keyrequest.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * November 25, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 25, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -177,7 +177,7 @@ void wm_oscap_run(wm_oscap_eval *eval) {
         wm_strcat(&command, "--profiles", ' ');
         wm_strcat(&command, arg_profiles, ' ');
     }
-    
+
     os_free(arg_profiles);
 
     if (eval->xccdf_id) {
@@ -240,7 +240,7 @@ void wm_oscap_run(wm_oscap_eval *eval) {
         os_free(command);
         pthread_exit(NULL);
     }
-    
+
     os_free(command);
 
     char *line;

--- a/src/wazuh_modules/wm_oscap.h
+++ b/src/wazuh_modules/wm_oscap.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc
  * April 25, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 5, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_osquery_monitor.h
+++ b/src/wazuh_modules/wm_osquery_monitor.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015-2019, Wazuh Inc.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 25, 2019.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * November 25, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
@@ -50,7 +50,7 @@ typedef struct wm_sca_t {
     int scan_on_start:1;
     int skip_nfs:1;
     unsigned int interval;
-    int scan_day;                   
+    int scan_day;
     int scan_wday;
     int msg_delay;
     unsigned int summary_delay;

--- a/src/wazuh_modules/wm_vuln_detector.c
+++ b/src/wazuh_modules/wm_vuln_detector.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 4, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_vuln_detector.h
+++ b/src/wazuh_modules/wm_vuln_detector.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 4, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wm_vuln_detector_db.h
+++ b/src/wazuh_modules/wm_vuln_detector_db.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * January 4, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Mar 14, 2018.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 27, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * April 22, 2016.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/win32/add-localfile.c
+++ b/src/win32/add-localfile.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2019, Wazuh Inc.
  * Contributed by Gael Muller (@gaelmuller)
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/win32/license.rtf
+++ b/src/win32/license.rtf
@@ -4,7 +4,7 @@
  Portions Copyright (C) 2015-2019, Wazuh Inc.\par
  Based on work Copyright (C) 2003 - 2013 Trend Micro, Inc.\par
 \par
- This program is a free software; you can redistribute it and/or modify\par
+ This program is free software; you can redistribute it and/or modify\par
  it under the terms of the GNU General Public License (version 2) as\par
  published by the FSF - Free Software Foundation.\par
 \par

--- a/src/win32/os_win.h
+++ b/src/win32/os_win.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/win32/read-registry.c
+++ b/src/win32/read-registry.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2015-2019, Wazuh Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/win32/setup-iis.c
+++ b/src/win32/setup-iis.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/win32/setup-shared.c
+++ b/src/win32/setup-shared.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/win32/setup-shared.h
+++ b/src/win32/setup-shared.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/win32/setup-syscheck.c
+++ b/src/win32/setup-syscheck.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/win32/setup-win.c
+++ b/src/win32/setup-win.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/win32/ui/os_win32ui.h
+++ b/src/win32/ui/os_win32ui.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
 import pytest


### PR DESCRIPTION
This PR removes a typo in the license.

> This program is a free software;

to

> This program is free software;