### PR TITLE
Fix issues reported by scan-build

### DIFF
--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -72,7 +72,10 @@ char shost[512];
 int main(int argc, char **argv)
 {
     char *user_msg;
-    int c = 0, cmdlist = 0, json_output = 0, no_limit = 0;
+    int c = 0, cmdlist = 0, json_output = 0;
+#ifndef CLIENT
+    int no_limit = 0;
+#endif
     int force_antiquity;
     char *end;
     const char *cmdexport = NULL;
@@ -172,7 +175,9 @@ int main(int argc, char **argv)
                 setenv("OSSEC_REMOVE_DUPLICATED", optarg, 1);
                 break;
             case 'L':
+#ifndef CLIENT
                 no_limit = 1;
+#endif
                 break;
             default:
                 helpmsg();
@@ -284,9 +289,9 @@ int main(int argc, char **argv)
             case 'a':
 #ifdef CLIENT
                 printf("\n ** Agent adding only available on a master ** \n\n");
-                break;
-#endif
+#else
                 add_agent(json_output, no_limit);
+#endif
                 break;
             case 'e':
             case 'E':

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -292,38 +292,39 @@ cJSON *getClusterConfig(void) {
 		default:
 			merror("At getClusterConfig(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
 		}
-	} else {
-		if (OS_SendSecureTCPCluster(sock, req, "", 0) != 0) {
-			merror("send(): %s", strerror(errno));
-            close(sock);
-            return NULL;
-		}
-
-        os_calloc(OS_MAXSTR,sizeof(char),buffer);
-
-        switch (length = OS_RecvSecureClusterTCP(sock, buffer, OS_MAXSTR), length) {
-        case -1:
-            merror("At wcom_main(): OS_RecvSecureClusterTCP(): %s", strerror(errno));
-            free(buffer);
-            close(sock);
-            return NULL;
-
-        case 0:
-            mdebug1("Empty message from local client.");
-            free(buffer);
-            close(sock);
-            return NULL;
-
-        case OS_MAXLEN:
-            merror("Received message > %i", OS_MAXSTR);
-            free(buffer);
-            close(sock);
-            return NULL;
-
-        default:
-            close(sock);
-        }
+        return NULL;
 	}
+
+    if (OS_SendSecureTCPCluster(sock, req, "", 0) != 0) {
+        merror("send(): %s", strerror(errno));
+        close(sock);
+        return NULL;
+    }
+
+    os_calloc(OS_MAXSTR,sizeof(char),buffer);
+
+    switch (length = OS_RecvSecureClusterTCP(sock, buffer, OS_MAXSTR), length) {
+    case -1:
+        merror("At wcom_main(): OS_RecvSecureClusterTCP(): %s", strerror(errno));
+        free(buffer);
+        close(sock);
+        return NULL;
+
+    case 0:
+        mdebug1("Empty message from local client.");
+        free(buffer);
+        close(sock);
+        return NULL;
+
+    case OS_MAXLEN:
+        merror("Received message > %i", OS_MAXSTR);
+        free(buffer);
+        close(sock);
+        return NULL;
+
+    default:
+        close(sock);
+    }
 
     const char *jsonErrPtr;
     cluster_config_cJSON = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0);

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -272,28 +272,28 @@ cJSON *getClusterConfig(void) {
     char req[] = "get_config";
     char *buffer = NULL;
     int sock = -1;
-	char sockname[PATH_MAX + 1];
+    char sockname[PATH_MAX + 1];
     ssize_t length;
 
     cJSON *cluster_config_cJSON;
 
-	if (isChroot()) {
-		strcpy(sockname, CLUSTER_SOCK);
-	} else {
-		strcpy(sockname, DEFAULTDIR CLUSTER_SOCK);
-	}
+    if (isChroot()) {
+        strcpy(sockname, CLUSTER_SOCK);
+    } else {
+        strcpy(sockname, DEFAULTDIR CLUSTER_SOCK);
+    }
 
-	if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-		switch (errno) {
-		case ECONNREFUSED:
-			merror("At getClusterConfig(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
-			break;
+    if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
+        switch (errno) {
+        case ECONNREFUSED:
+            merror("At getClusterConfig(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
+            break;
 
-		default:
-			merror("At getClusterConfig(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
-		}
+        default:
+            merror("At getClusterConfig(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
+        }
         return NULL;
-	}
+    }
 
     if (OS_SendSecureTCPCluster(sock, req, "", 0) != 0) {
         merror("send(): %s", strerror(errno));

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -315,7 +315,7 @@ static void ExecdStart(int q)
             /* Timed out */
             if ((curr_time - list_entry->time_of_addition) > list_entry->time_to_block) {
 
-                mdebug1("Executing command '%s %s' after a timeout of '%ds'.",
+                mdebug1("Executing command '%s %s' after a timeout of '%ds'",
                     list_entry->command[0],
                     list_entry->command[1] ? list_entry->command[1] : "",
                     list_entry->time_to_block
@@ -500,7 +500,7 @@ static void ExecdStart(int q)
 
         if (name[0] != '!') {
             if (!timeout_args[2] || !timeout_args[3]) {
-                merror("Invalid number of arguments (%s).", name);
+                merror("Invalid number of arguments (%s)", name);
 
                 char **ss_ta = timeout_args;
                 while (*timeout_args) {

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -290,12 +290,13 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
 
     // Create pipe for child's stdout
 
-    if (output && pipe(pipe_fd) < 0) {
-        merror("At wm_exec(): pipe(): %s", strerror(errno));
-        return -1;
+    if (output) {
+        if (pipe(pipe_fd) < 0){
+            merror("At wm_exec(): pipe(): %s", strerror(errno));
+            return -1;
+        }
+        w_descriptor_cloexec(pipe_fd[0]);
     }
-
-    w_descriptor_cloexec(pipe_fd[0]);
 
     // Fork
 

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -568,7 +568,8 @@ int wm_osquery_packs(wm_osquery_monitor_t *osquery)
 
 void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
 {
-    pthread_t tlauncher = 0, treader;
+    pthread_t tlauncher = 0;
+    pthread_t treader = 0;
 
     if (osquery->disable) {
         minfo("Module disabled. Exiting...");
@@ -595,6 +596,11 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
 
 #endif
 
+    if( pthread_create(&treader, NULL, (void *)&Read_Log, osquery) != 0){
+        merror("Error while creating Read_Log thread.");
+        return NULL;
+    }
+
     if (osquery->run_daemon) {
         // Handle configuration
 
@@ -603,20 +609,12 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
         }
 
         if( pthread_create(&tlauncher, NULL, (void *)&Execute_Osquery, osquery) != 0){
-            merror("creating thread Execute_Osquery");
+            merror("Error while creating Execute_Osquery thread.");
             return NULL;
         }
+        pthread_join(tlauncher, NULL);
     } else {
         minfo("run_daemon disabled, finding detached osquery process results.");
-    }
-
-    if( pthread_create(&treader, NULL, (void *)&Read_Log, osquery) != 0){
-        merror("creating thread Read_Log");
-        return NULL;
-    }
-
-    if (osquery->run_daemon) {
-        pthread_join(tlauncher, NULL);
     }
 
     pthread_join(treader, NULL);


### PR DESCRIPTION
|Related issue|
|---|
|#3774|

## Description
This PR fixes the issues reported by scan-build while building in MacOS

Bug Group | Bug Type | File | Function/Method | Line | Fixed in
-- | -- | -- | -- | -- | --
Logic error | Dereference of null pointer | os_xml/os_xml.c | _xml_sgetc | 52 | Won't fix. Also disappears when scanning with a newer llvm (in Linux)
Logic error | Dereference of null pointer | os_regex/os_regex_execute.c | OSRegex_Execute_ex | 118 | Won't fix. Also disappears when scanning with a newer llvm (in Linux)
Memory Error | Memory leak | syscheckd/create_db.c | read_dir | 760 | Already fixed in 3.9
Unix API | Allocator sizeof operand mismatch | wazuh_modules/syscollector/syscollector_bsd.c | getGatewayList | 1255 | #3773
Unix API | Undefined allocation of 0 bytes (CERT MEM04-C; CWE-131) | wazuh_modules/wm_control.c | getPrimaryIP | 51 | #3773
Memory Error | Memory leak | wazuh_modules/syscollector/syscollector_bsd.c | getGatewayList | 1307 | #3773
Dead store | Dead assignment | addagent/main.c | main | 175 | 2ddd149a196a60c6b18213ba1a3b7fc936a71fd8, #3795
Memory Error | Memory leak | wazuh_modules/syscollector/syscollector_bsd.c | sys_hw_bsd | 572 | 70b3def6e074f4fcb0f6177cec691463e1fc6a7a, #3795
Memory Error | Memory leak | wazuh_modules/syscollector/syscollector_bsd.c | sys_hw_bsd | 586 | 5744ae0f27e9e37c08c8426f8b3903285b538eeb, #3795
API | Argument with 'nonnull' attribute passed null | os_execd/config.c | getClusterConfig | 331 | 5f9a5116921812646e12ed6b07803a449b73e9ef
Memory error | Nullability | wazuh_modules/wm_osquery_monitor.c | wm_osquery_monitor_main | 619 | bacf62a37d746834f07bcfa83e08d586df781544
Logic error | Uninitialized argument value | wazuh_modules/wm_exec.c | wm_exec | 298 | 958d474d4d007ac7962e760c040a0f64e9bea50a
API | Argument with 'nonnull' attribute passed null | os_execd/execd.c | ExecdStart | 507 | be77f158c7c37c4af1147c7ff7b675f373d55b35

# Fix rationale

- Argument with 'nonnull' attribute passed null	os_execd/config.c	getClusterConfig	331
    * Missing early return on failure, leading to parsing an invalid pointer.
- Dead assignment addagent/main.c main 175
    * Unused variable when builiding the agent.
- Memory leak  wazuh_modules/syscollector/syscollector_bsd.c  sys_hw_bsd  572
    * String not released. String duplication is unnecesary as `OS_StrBreak`  does not modify the original string.
- Memory leak  wazuh_modules/syscollector/syscollector_bsd.c  sys_hw_bsd  586
    * String not released.
- Nullability  wazuh_modules/wm_osquery_monitor.c wm_osquery_monitor_main 619
    * False positive. "Fixed" after little refactoring.
- Uninitialized argument value	wazuh_modules/wm_exec.c	wm_exec	298	
    *  Because boolean expresions use Short-Circuit Evaluation, if output evaluates to false pipe() is not executed and w_descriptor_cloexec(pipe_fd[0]); is called with an undefined pipe_fd.
- Argument with 'nonnull' attribute passed null  os_execd/execd.c  ExecdStart  507
   * There's an invalid acess (leading to a SEGFAULT), that can be triggered by with incomplete timeout information, as commands are assumed to have 4 components (`timeout_args[0-3]`)


## Tests
With this set of changes, scan-build reports only those marked as "Won't fix"

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
- Memory tests
  - [x] Valgrind report for affected components
  - [x] RAM usage impact
- [ ] Working on cluster environments
- [x] Review logs syntax and correct language
