### PR TITLE
Fix wildcard folder bug in localfile

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1138,6 +1138,20 @@ int check_pattern_expand(int do_seek) {
                     mwarn(FILE_LIMIT, maximum_files);
                     break;
                 }
+
+                struct stat statbuf;
+                if (lstat(g.gl_pathv[glob_offset], &statbuf) < 0) {
+                    merror("Error on stat '%s' due to [(%d)-(%s)]", g.gl_pathv[glob_offset], errno, strerror(errno));
+                    glob_offset++;
+                    continue;
+                }
+
+                if ((statbuf.st_mode & S_IFMT) != S_IFREG) {
+                    mdebug2("Ignoring '%s'. It's not a regular file", g.gl_pathv[glob_offset]);
+                    glob_offset++;
+                    continue;
+                }
+
                 found = 0;
                 for (i = 0; globs[j].gfiles[i].file; i++) {
                     if (!strcmp(globs[j].gfiles[i].file, g.gl_pathv[glob_offset])) {
@@ -1149,19 +1163,6 @@ int check_pattern_expand(int do_seek) {
                     retval = 1;
                     char *ex_file = OSHash_Get(excluded_files,g.gl_pathv[glob_offset]);
                     int added = 0;
-
-                    struct stat statbuf;
-                    if (lstat(g.gl_pathv[glob_offset], &statbuf) < 0) {
-                        merror("Error on stat '%s' due to [(%d)-(%s)]", g.gl_pathv[glob_offset], errno, strerror(errno));
-                        glob_offset++;
-                        continue;
-                    }
-
-                    if ((statbuf.st_mode & S_IFMT) != S_IFREG) {
-                        minfo("Ignoring '%s'. It's not a regular file", g.gl_pathv[glob_offset]);
-                        glob_offset++;
-                        continue;
-                    }
 
                     if(!ex_file) {
                         minfo(NEW_GLOB_FILE, globs[j].gpath, g.gl_pathv[glob_offset]);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1150,6 +1150,19 @@ int check_pattern_expand(int do_seek) {
                     char *ex_file = OSHash_Get(excluded_files,g.gl_pathv[glob_offset]);
                     int added = 0;
 
+                    struct stat statbuf;
+                    if (lstat(g.gl_pathv[glob_offset], &statbuf) < 0) {
+                        merror("Error on stat '%s' due to [(%d)-(%s)]", g.gl_pathv[glob_offset], errno, strerror(errno));
+                        glob_offset++;
+                        continue;
+                    }
+
+                    if ((statbuf.st_mode & S_IFMT) != S_IFREG) {
+                        minfo("Ignoring '%s'. It's not a regular file", g.gl_pathv[glob_offset]);
+                        glob_offset++;
+                        continue;
+                    }
+
                     if(!ex_file) {
                         minfo(NEW_GLOB_FILE, globs[j].gpath, g.gl_pathv[glob_offset]);
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1341,7 +1341,7 @@ int check_pattern_expand(int do_seek) {
                     DIR *is_dir = NULL;
 
                     if (is_dir = opendir(full_path), is_dir) {
-                        mdebug2("File %s is a directory. Skipping it.", full_path);
+                        mdebug1("File %s is a directory. Skipping it.", full_path);
                         closedir(is_dir);
                         continue;
                     }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1141,13 +1141,13 @@ int check_pattern_expand(int do_seek) {
 
                 struct stat statbuf;
                 if (lstat(g.gl_pathv[glob_offset], &statbuf) < 0) {
-                    merror("Error on stat '%s' due to [(%d)-(%s)]", g.gl_pathv[glob_offset], errno, strerror(errno));
+                    merror("Error on lstat '%s' due to [(%d)-(%s)]", g.gl_pathv[glob_offset], errno, strerror(errno));
                     glob_offset++;
                     continue;
                 }
 
                 if ((statbuf.st_mode & S_IFMT) != S_IFREG) {
-                    mdebug2("Ignoring '%s'. It's not a regular file", g.gl_pathv[glob_offset]);
+                    mdebug1("File %s is not a regular file. Skipping it.", g.gl_pathv[glob_offset]);
                     glob_offset++;
                     continue;
                 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3769|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes the bug that was being caused while indicating a wildcard path in `localfile` and creating folders inside that path. Example configuration:

```
  <localfile>
    <log_format>syslog</log_format>
    <location>/home/logs/*</location>
  </localfile>
```

<!--
Add a clear description of how the problem has been solved.
-->

## Logs/Alerts example

I've included the following debug message when a different file from regular is detected in the wildcard folder:

```
2019/08/01 07:12:08 ossec-logcollector[7973] logcollector.c:1150 at check_pattern_expand(): DEBUG: Ignoring '/home/logs/fifo'. It's not a regular file
2019/08/01 07:12:08 ossec-logcollector[7973] logcollector.c:1150 at check_pattern_expand(): DEBUG: Ignoring '/home/logs/folder5'. It's not a regular file
2019/08/01 07:12:08 ossec-logcollector[7973] logcollector.c:1150 at check_pattern_expand(): DEBUG: Ignoring '/home/logs/link'. It's not a regular file
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- Memory tests
  - [x] Valgrind report for affected components
  - [ ] CPU impact
  - [ ] RAM usage impact
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
