### PR TITLE
Fix memleaks in BSD syscollector

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -583,6 +583,7 @@ void sys_hw_bsd(int queue_fd, const char* LOCATION){
             free(parts);
         }
         cJSON_AddStringToObject(hw_inventory, "board_serial", serial);
+        os_free(serial);
 
         if (status = pclose(output), status) {
             mtwarn(WM_SYS_LOGTAG, "Command 'system_profiler' returned %d getting board serial.", status);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -1293,7 +1293,7 @@ int getGatewayList(OSHash *gateway_list){
                     os_free(gate);
                     continue;
                 }
-                os_calloc(256, sizeof (char *), gate->addr);
+                os_calloc(256, sizeof (char), gate->addr);
                 snprintf(gate->addr, 255, "%s", strbuf);
                 #ifdef RTF_IFSCOPE
                 gate->isdefault = !(msg->rtm_flags & RTF_IFSCOPE);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -52,6 +52,7 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
 
 // Get installed programs inventory
 
+
 void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
     int random_id = os_random();
@@ -274,10 +275,10 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
                             os_free(parts);
                         }
                         else if((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
-                          char ** parts = OS_StrBreak('>', read_buff, 2);
-                          char ** _parts = OS_StrBreak('<', parts[1], 2);
+                            char ** parts = OS_StrBreak('>', read_buff, 2);
+                            char ** _parts = OS_StrBreak('<', parts[1], 2);
 
-                          cJSON_AddStringToObject(package, "name", _parts[0]);
+                            cJSON_AddStringToObject(package, "name", _parts[0]);
 
                             for (i = 0; _parts[i]; i++) {
                                 os_free(_parts[i]);
@@ -418,8 +419,8 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
 
         char *string;
         string = cJSON_PrintUnformatted(object);
+        cJSON_Delete(object);
         fclose(fp);
-
         return string;
 
     }

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -550,7 +550,6 @@ void sys_hw_bsd(int queue_fd, const char* LOCATION){
 
 #elif defined(__MACH__)
 
-    char *serial_str = NULL;
     char *serial = NULL;
     char *command;
     FILE *output;

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -567,9 +567,8 @@ void sys_hw_bsd(int queue_fd, const char* LOCATION){
         }else{
             char ** parts = NULL;
             parts = OS_StrBreak('\n', read_buff, 2);
-            if (parts[0]){
-                serial_str = strdup(parts[0]);
-                parts = OS_StrBreak(':', serial_str, 2);
+            if (parts[0]) {
+                parts = OS_StrBreak(':', parts[0], 2);
                 if (parts[1]){
                     serial = strdup(parts[1]);
                 }else{

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -187,6 +187,11 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
                                 found = 1;
                                 char ** parts = OS_StrBreak('"', read_buff, 3);
                                 cJSON_AddStringToObject(package, "description", parts[1]);
+                                int i;
+                                for (i = 0; parts[i]; ++i) {
+                                    free(parts[i]);
+                                }
+                                free(parts);
                             }
                         }
                         fclose(fp);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -52,7 +52,6 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
 
 // Get installed programs inventory
 
-
 void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
     int random_id = os_random();

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -264,11 +264,14 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
                             cJSON_AddStringToObject(package, "name", _parts[0]);
 
                             for (i = 0; _parts[i]; i++) {
-                                free(_parts[i]);
-                                free(parts[i]);
+                                os_free(_parts[i]);
                             }
-                            free(parts);
-                            free(_parts);
+                            os_free(_parts);
+
+                            for (i = 0; parts[i]; i++) {
+                                os_free(parts[i]);
+                            }
+                            os_free(parts);
                         }
                         else if((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
                           char ** parts = OS_StrBreak('>', read_buff, 2);
@@ -276,12 +279,15 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
 
                           cJSON_AddStringToObject(package, "name", _parts[0]);
 
-                          for (i = 0; _parts[i]; i++) {
-                              free(_parts[i]);
-                              free(parts[i]);
-                          }
-                          free(parts);
-                          free(_parts);
+                            for (i = 0; _parts[i]; i++) {
+                                os_free(_parts[i]);
+                            }
+                            os_free(_parts);
+
+                            for (i = 0; parts[i]; i++) {
+                                os_free(parts[i]);
+                            }
+                            os_free(parts);
                         }
 
                     } else if (strstr(read_buff, "CFBundleShortVersionString")){
@@ -292,11 +298,14 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
                             cJSON_AddStringToObject(package, "version", _parts[0]);
 
                             for (i = 0; _parts[i]; i++) {
-                                free(_parts[i]);
-                                free(parts[i]);
+                                os_free(_parts[i]);
                             }
-                            free(parts);
-                            free(_parts);
+                            os_free(_parts);
+
+                            for (i = 0; parts[i]; i++) {
+                                os_free(parts[i]);
+                            }
+                            os_free(parts);
                         }
                         else if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
                             char ** parts = OS_StrBreak('>', read_buff, 2);
@@ -305,11 +314,14 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
                             cJSON_AddStringToObject(package, "version", _parts[0]);
 
                             for (i = 0; _parts[i]; i++) {
-                                free(_parts[i]);
-                                free(parts[i]);
+                                os_free(_parts[i]);
                             }
-                            free(parts);
-                            free(_parts);
+                            os_free(_parts);
+
+                            for (i = 0; parts[i]; i++) {
+                                os_free(parts[i]);
+                            }
+                            os_free(parts);
                         }
                     } else if (strstr(read_buff, "LSApplicationCategoryType")){
                         if (strstr(read_buff, "<string>")){
@@ -319,24 +331,30 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
                             cJSON_AddStringToObject(package, "group", _parts[0]);
 
                             for (i = 0; _parts[i]; i++) {
-                                free(_parts[i]);
-                                free(parts[i]);
+                                os_free(_parts[i]);
                             }
-                            free(parts);
-                            free(_parts);
+                            os_free(_parts);
+
+                            for (i = 0; parts[i]; i++) {
+                                os_free(parts[i]);
+                            }
+                            os_free(parts);
                         }
                         else if((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
-                          char ** parts = OS_StrBreak('>', read_buff, 2);
-                          char ** _parts = OS_StrBreak('<', parts[1], 2);
+                            char ** parts = OS_StrBreak('>', read_buff, 2);
+                            char ** _parts = OS_StrBreak('<', parts[1], 2);
 
-                          cJSON_AddStringToObject(package, "group", _parts[0]);
+                            cJSON_AddStringToObject(package, "group", _parts[0]);
 
-                          for (i = 0; _parts[i]; i++) {
-                              free(_parts[i]);
-                              free(parts[i]);
-                          }
-                          free(parts);
-                          free(_parts);
+                            for (i = 0; _parts[i]; i++) {
+                                os_free(_parts[i]);
+                            }
+                            os_free(_parts);
+
+                            for (i = 0; parts[i]; i++) {
+                                os_free(parts[i]);
+                            }
+                            os_free(parts);
                         }
                     } else if (strstr(read_buff, "CFBundleIdentifier")){
                         if (strstr(read_buff, "<string>")){
@@ -346,24 +364,30 @@ char* sys_parse_pkg(const char * app_folder, const char * timestamp, int random_
                             cJSON_AddStringToObject(package, "description", _parts[0]);
 
                             for (i = 0; _parts[i]; i++) {
-                                free(_parts[i]);
-                                free(parts[i]);
+                                os_free(_parts[i]);
                             }
-                            free(parts);
-                            free(_parts);
+                            os_free(_parts);
+
+                            for (i = 0; parts[i]; i++) {
+                                os_free(parts[i]);
+                            }
+                            os_free(parts);
                         }
                         else if((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
-                          char ** parts = OS_StrBreak('>', read_buff, 2);
-                          char ** _parts = OS_StrBreak('<', parts[1], 2);
+                            char ** parts = OS_StrBreak('>', read_buff, 2);
+                            char ** _parts = OS_StrBreak('<', parts[1], 2);
 
-                          cJSON_AddStringToObject(package, "description", _parts[0]);
+                            cJSON_AddStringToObject(package, "description", _parts[0]);
 
-                          for (i = 0; _parts[i]; i++) {
-                              free(_parts[i]);
-                              free(parts[i]);
-                          }
-                          free(parts);
-                          free(_parts);
+                            for (i = 0; _parts[i]; i++) {
+                                os_free(_parts[i]);
+                            }
+                            os_free(_parts);
+
+                            for (i = 0; parts[i]; i++) {
+                                os_free(parts[i]);
+                            }
+                            os_free(parts);
                         }
                     }
                 }

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -792,13 +792,6 @@ hw_info *get_system_bsd(){
 
 }
 
-#ifdef __MACH__
-static void freegate(gateway *gate){
-    os_free(gate->addr);
-    os_free(gate);
-}
-#endif
-
 // Get network inventory
 
 void sys_network_bsd(int queue_fd, const char* LOCATION){

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -92,7 +92,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
         while ((de = readdir(dr)) != NULL) {
 
             // Skip not intereset files
-            if (!strncmp(de->d_name, ".", 1)) {
+            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0)) {
                 continue;
             } else if (strstr(de->d_name, ".app")) {
                 snprintf(path, PATH_LENGTH - 1, "%s/%s", MAC_APPS, de->d_name);
@@ -119,7 +119,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
         while ((de = readdir(dr)) != NULL) {
 
             // Skip not intereset files
-            if (!strncmp(de->d_name, ".", 1)) {
+            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0)) {
                 continue;
             } else if (strstr(de->d_name, ".app")) {
                 snprintf(path, PATH_LENGTH - 1, "%s/%s", UTILITIES, de->d_name);
@@ -150,8 +150,9 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
         while ((de = readdir(dr)) != NULL) {
 
-            if (!strncmp(de->d_name, ".", 1))
+            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0)) {
                 continue;
+            }
 
             cJSON *object = cJSON_CreateObject();
             cJSON *package = cJSON_CreateObject();
@@ -169,8 +170,9 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
             dir = opendir(path);
             if (dir != NULL) {
                 while ((version = readdir(dir)) != NULL) {
-                    if (!strncmp(version->d_name, ".", 1))
+                    if (strncmp(version->d_name, ".", 1) == 0 || strncmp(version->d_name, "..", 2) == 0)) {
                         continue;
+                    }
 
                     cJSON_AddStringToObject(package, "version", version->d_name);
                     snprintf(path, PATH_LENGTH - 1, "%s/%s/%s/.brew/%s.rb", HOMEBREW_APPS, de->d_name, version->d_name, de->d_name);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -92,7 +92,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
         while ((de = readdir(dr)) != NULL) {
 
             // Skip not intereset files
-            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0)) {
+            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0) {
                 continue;
             } else if (strstr(de->d_name, ".app")) {
                 snprintf(path, PATH_LENGTH - 1, "%s/%s", MAC_APPS, de->d_name);
@@ -119,7 +119,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
         while ((de = readdir(dr)) != NULL) {
 
             // Skip not intereset files
-            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0)) {
+            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0) {
                 continue;
             } else if (strstr(de->d_name, ".app")) {
                 snprintf(path, PATH_LENGTH - 1, "%s/%s", UTILITIES, de->d_name);
@@ -150,7 +150,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
 
         while ((de = readdir(dr)) != NULL) {
 
-            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0)) {
+            if (strncmp(de->d_name, ".", 1) == 0 || strncmp(de->d_name, "..", 2) == 0) {
                 continue;
             }
 
@@ -170,7 +170,7 @@ void sys_packages_bsd(int queue_fd, const char* LOCATION){
             dir = opendir(path);
             if (dir != NULL) {
                 while ((version = readdir(dir)) != NULL) {
-                    if (strncmp(version->d_name, ".", 1) == 0 || strncmp(version->d_name, "..", 2) == 0)) {
+                    if (strncmp(version->d_name, ".", 1) == 0 || strncmp(version->d_name, "..", 2) == 0) {
                         continue;
                     }
 

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -31,8 +31,8 @@ const wm_context WM_CONTROL_CONTEXT = {
 
 #ifdef __MACH__
     void freegate(gateway *gate){
-        free(gate->addr);
-        free(gate);
+        if (gate->addr)     os_free(gate->addr);
+        if (gate)   os_free(gate);
     }
 #endif
 

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -54,22 +54,28 @@ char* getPrimaryIP(){
         mterror(WM_CONTROL_LOGTAG, "at getPrimaryIP(): getifaddrs() failed.");
         return agent_ip;
     }
-    else {
-        for (ifa = ifaddr; ifa; ifa = ifa->ifa_next){
-            i++;
-        }
-        os_calloc(i, sizeof(char *), ifaces_list);
 
-        /* Create interfaces list */
-        size = getIfaceslist(ifaces_list, ifaddr);
-
-        if(!ifaces_list[0]){
-            mtdebug1(WM_CONTROL_LOGTAG, "No network interface found when reading agent IP.");
-            os_free(ifaces_list);
-            freeifaddrs(ifaddr);
-            return agent_ip;
-        }
+    for (ifa = ifaddr; ifa; ifa = ifa->ifa_next){
+        i++;
     }
+
+    if(i == 0){
+        mtdebug1(WM_CONTROL_LOGTAG, "No network interfaces found when reading agent IP.");
+        return agent_ip;
+    }
+
+    os_calloc(i, sizeof(char *), ifaces_list);
+
+    /* Create interfaces list */
+    size = getIfaceslist(ifaces_list, ifaddr);
+
+    if(!ifaces_list[0]){
+        mtdebug1(WM_CONTROL_LOGTAG, "No network interfaces found when reading agent IP.");
+        os_free(ifaces_list);
+        freeifaddrs(ifaddr);
+        return agent_ip;
+    }
+
 #ifdef __MACH__
     OSHash *gateways = OSHash_Create();
     OSHash_SetFreeDataPointer(gateways, (void (*)(void *)) freegate);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -30,10 +30,10 @@ const wm_context WM_CONTROL_CONTEXT = {
 };
 
 #ifdef __MACH__
-    void freegate(gateway *gate){
-        if (gate->addr)     os_free(gate->addr);
-        if (gate)   os_free(gate);
-    }
+static void freegate(gateway *gate){
+    os_free(gate->addr);
+    os_free(gate);
+}
 #endif
 
 char* getPrimaryIP(){
@@ -72,7 +72,7 @@ char* getPrimaryIP(){
     }
 #ifdef __MACH__
     OSHash *gateways = OSHash_Create();
-    OSHash_SetFreeDataPointer(gateways, (void (*)(void *))freegate);
+    OSHash_SetFreeDataPointer(gateways, (void (*)(void *)) freegate);
     if (getGatewayList(gateways) < 0){
         mtdebug1(WM_CONTROL_LOGTAG, "Unable to obtain the Default Gateway list");
         OSHash_Free(gateways);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -29,13 +29,6 @@ const wm_context WM_CONTROL_CONTEXT = {
     (cJSON * (*)(const void *))wm_control_dump
 };
 
-#ifdef __MACH__
-static void freegate(gateway *gate){
-    os_free(gate->addr);
-    os_free(gate);
-}
-#endif
-
 char* getPrimaryIP(){
      /* Get Primary IP */
     char * agent_ip = NULL;

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -602,3 +602,13 @@ void wm_delay(unsigned int ms) {
     select(0, NULL, NULL, NULL, &timeout);
 #endif
 }
+
+#ifdef __MACH__
+void freegate(gateway *gate){
+    if(!gate){
+        return;
+    }
+    os_free(gate->addr);
+    os_free(gate);
+}
+#endif

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -197,4 +197,8 @@ size_t wmcom_getconfig(const char * section, char ** output);
 // Sleep function for Windows and Unix (milliseconds)
 void wm_delay(unsigned int ms);
 
+#ifdef __MACH__
+void freegate(gateway *gate);
+#endif
+
 #endif // W_MODULES


### PR DESCRIPTION
|Related issue|
|---|
|#3773 and #3785|


## Description

This PR fixes several memory leaks, some of them cherry-picked from #3773 and #3785.
Most of this leaks aren't detected by Memcheck.

## Tests
- [x] Scan-build Reports one issue already reported on one the aforementioned PRs
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [x] MAC OS X
- Memory tests
  - [ ] Valgrind report for affected components
  - [x] RAM usage impact
