### PR TITLE
Fix dangerous initialization of mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fix a handler leak in the FIM whodata engine for Windows. ([#3690](https://github.com/wazuh/wazuh/issues/3690))
 - The Docker listener module was storing and ignoring the output of the integration. ([#3768](https://github.com/wazuh/wazuh/issues/3768))
 - Fixed memory leaks in Syscollector for macOS agents. ([#3795](https://github.com/wazuh/wazuh/pull/3795))
+- Fix dangerous mutex initialization in Windows hosts. ([#3805](https://github.com/wazuh/wazuh/issues/3805))
 
 ## [v3.9.3] - 2019-07-08
 

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -27,6 +27,9 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     /* Initial random numbers must happen before chroot */
     srandom_init();
 
+    /* Initialize sender */
+    sender_init();
+
     // Resolve hostnames
     rc = 0;
     while (rc < agt->rip_id) {

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -77,6 +77,9 @@ int buffer_append(const char *msg);
 /* Thread to dispatch messages from the buffer */
 void *dispatch_buffer(void * arg);
 
+/* Initialize sender structure */
+void sender_init();
+
 /* Send message to server */
 int send_msg(const char *msg, ssize_t msg_length);
 

--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -35,8 +35,8 @@ struct{
 } buff;
 
 static char ** buffer;
-static pthread_mutex_t mutex_lock = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t cond_no_empty = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mutex_lock;
+static pthread_cond_t cond_no_empty;
 
 static time_t start, end;
 
@@ -52,6 +52,9 @@ void buffer_init(){
     warn_level = getDefine_Int("agent", "warn_level", 1, 100);
     normal_level = getDefine_Int("agent", "normal_level", 0, warn_level-1);
     tolerance = getDefine_Int("agent", "tolerance", 0, 600);
+
+    pthread_mutex_init(&mutex_lock, NULL);
+    pthread_cond_init(&cond_no_empty, NULL);
 
     if (tolerance == 0)
         mwarn(TOLERANCE_TIME);

--- a/src/client-agent/request.c
+++ b/src/client-agent/request.c
@@ -27,9 +27,9 @@ static req_node_t ** req_pool;
 static volatile int pool_i = 0;
 static volatile int pool_j = 0;
 
-static pthread_mutex_t mutex_table = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t mutex_pool = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t pool_available = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mutex_table;
+static pthread_mutex_t mutex_pool;
+static pthread_cond_t pool_available;
 
 int request_pool;
 int rto_sec;
@@ -45,13 +45,17 @@ void req_init() {
     char *socket_sys = NULL;
     char *socket_wodle = NULL;
     char *socket_agent = NULL;
-    
+
     // Get values from internal options
 
     request_pool = getDefine_Int("remoted", "request_pool", 1, 4096);
     rto_sec = getDefine_Int("remoted", "request_rto_sec", 0, 60);
     rto_msec = getDefine_Int("remoted", "request_rto_msec", 0, 999);
     max_attempts = getDefine_Int("remoted", "max_attempts", 1, 16);
+
+    pthread_mutex_init(&mutex_table, NULL);
+    pthread_mutex_init(&mutex_pool, NULL);
+    pthread_cond_init(&pool_available, NULL);
 
     // Create hash table and request pool
 
@@ -68,25 +72,25 @@ void req_init() {
         merror("At req_main(): OSHash_Create()");
         goto ret;
     }
-    
+
     socket_log = strdup(SOCKET_LOGCOLLECTOR);
     socket_sys = strdup(SOCKET_SYSCHECK);
     socket_wodle = strdup(SOCKET_WMODULES);
     socket_agent = strdup(SOCKET_AGENT);
-    
+
     if (!socket_log || !socket_sys || !socket_wodle || !socket_agent) {
         merror("At req_main(): failed to allocate socket strings");
         goto ret;
     }
-    
+
     if (OSHash_Add(allowed_sockets, SOCKET_LOGCOLLECTOR, socket_log) != 2 || OSHash_Add(allowed_sockets, SOCKET_SYSCHECK, socket_sys) != 2 || \
     OSHash_Add(allowed_sockets, SOCKET_WMODULES, socket_wodle) != 2 || OSHash_Add(allowed_sockets, SOCKET_AGENT, socket_agent) != 2) {
         merror("At req_main(): failed to add socket strings to hash list");
         goto ret;
     }
-    
+
     success = 1;
-    
+
 ret:
     if (!success) {
         if (req_pool) free(req_pool);

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -12,7 +12,12 @@
 #include "agentd.h"
 #include "os_net/os_net.h"
 
-static pthread_mutex_t send_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t send_mutex;
+
+/* Initialize sender structure */
+void sender_init() {
+    pthread_mutex_init(&send_mutex, NULL);
+}
 
 /* Send a message to the server */
 int send_msg(const char *msg, ssize_t msg_length)

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -14,13 +14,14 @@
 #include <pthread.h>
 
 agent_state_t agent_state = { .status = GA_STATUS_PENDING };
-pthread_mutex_t state_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t state_mutex;
 
 static int write_state();
 
 int interval;
 
 void * state_main(__attribute__((unused)) void * args) {
+    pthread_mutex_init(&state_mutex, NULL);
     interval = getDefine_Int("agent", "state_interval", 0, 86400);
 
     if (!interval) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -48,7 +48,7 @@ int OUTPUT_QUEUE_SIZE = OUTPUT_MIN_QUEUE_SIZE;
 logsocket default_agent = { .name = "agent" };
 
 /* Output thread variables */
-static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t mutex;
 #ifdef WIN32
 static pthread_mutex_t win_el_mutex;
 static pthread_mutexattr_t win_el_mutex_attr;
@@ -109,6 +109,8 @@ void LogCollectorStart()
     // Check for expanded files
     check_pattern_expand(1);
     check_pattern_expand_excluded();
+
+    pthread_mutex_init(&mutex, NULL);
 
 #ifndef WIN32
     /* To check for inode changes */

--- a/src/os_regex/os_regex_compile.c
+++ b/src/os_regex/os_regex_compile.c
@@ -51,7 +51,7 @@ int OSRegex_Compile(const char *pattern, OSRegex *reg, int flags)
     reg->prts_closure = NULL;
     reg->raw = NULL;
     memset(&reg->d_size, 0, sizeof(regex_dynamic_size));
-    reg->mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_init(&reg->mutex, NULL);
 
     /* The pattern can't be null */
     if (pattern == NULL) {

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -13,27 +13,22 @@
 #include "../os_net/os_net.h"
 #include "../addagent/manage_agents.h"
 
-static pthread_mutex_t restart_syscheck = PTHREAD_MUTEX_INITIALIZER;
 
 /* Check if syscheck is to be executed/restarted
  * Returns 1 on success or 0 on failure (shouldn't be executed now)
  */
 int os_check_restart_syscheck()
 {
-    w_mutex_lock(&restart_syscheck);
     /* If the restart is not present, return 0 */
     if (isChroot()) {
         if (unlink(SYSCHECK_RESTART) == -1) {
-            w_mutex_unlock(&restart_syscheck);
             return (0);
         }
     } else {
         if (unlink(SYSCHECK_RESTART_PATH) == -1) {
-            w_mutex_unlock(&restart_syscheck);
             return (0);
         }
     }
-    w_mutex_unlock(&restart_syscheck);
     return (1);
 }
 

--- a/src/shared/list_op.c
+++ b/src/shared/list_op.c
@@ -32,8 +32,8 @@ OSList *OSList_Create()
     my_list->count = 0;
     my_list->pending_remove = 0;
     my_list->free_data_function = NULL;
-    my_list->wr_mutex = (pthread_rwlock_t)PTHREAD_RWLOCK_INITIALIZER;
-    my_list->mutex = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+    pthread_rwlock_init(&my_list->wr_mutex, NULL);
+    pthread_mutex_init(&my_list->mutex, NULL);
 
     return (my_list);
 }

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -322,7 +322,7 @@ int OS_ReadXMLRules(const char *rulefile,
                     if(config_ruleinfo->srcip == NULL) {
                         merror_exit(MEM_ERROR, errno, strerror(errno));
                     }
-                    
+
                     /* Allocate memory for the individual entries */
                     os_calloc(1, sizeof(os_ip),
                               config_ruleinfo->srcip[ip_s]);
@@ -576,7 +576,7 @@ int OS_ReadXMLRules(const char *rulefile,
                                         xml_notsame_field) == 0) {
 
                     if (config_ruleinfo->context_opts & NOT_SAME_FIELD) {
-                            
+
                         int size;
                         for (size = 0; config_ruleinfo->not_same_fields[size] != NULL; size++);
 
@@ -1036,7 +1036,7 @@ static RuleInfo *_OS_AllocateRule()
 
     ruleinfo_pt->event_search = NULL;
 
-    ruleinfo_pt->mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_init(&ruleinfo_pt->mutex, NULL);
 
     return (ruleinfo_pt);
 }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -24,7 +24,7 @@ static int read_file(const char *dir_name, const char *linked_file, int dir_posi
 
 static int read_dir_diff(char *dir_name);
 
-pthread_mutex_t lastcheck_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t lastcheck_mutex;
 
 /* Global variables */
 static int __counter = 0;
@@ -904,6 +904,8 @@ int create_db()
 {
     int i = 0;
     char sym_link_thread = 0;
+
+    pthread_mutex_init(&lastcheck_mutex, NULL);
 
     if (!syscheck.fp) {
         merror_exit(FIM_CRITICAL_ERROR_DB);

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -33,7 +33,7 @@ volatile int audit_db_consistency_flag;
 #include "syscheck.h"
 #include "syscheck_op.h"
 
-pthread_mutex_t adddir_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t adddir_mutex;
 
 /* Checksum of the realtime file being monitored */
 int realtime_checksumfile(const char *file_name, whodata_evt *evt)
@@ -244,6 +244,8 @@ end:
 int realtime_start()
 {
     minfo(FIM_REALTIME_STARTING);
+
+    pthread_mutex_init(&adddir_mutex, NULL);
 
     syscheck.realtime = (rtfim *) calloc(1, sizeof(rtfim));
     if (syscheck.realtime == NULL) {
@@ -470,6 +472,9 @@ void free_win32rtfim_data(win32rtfim *data) {
 int realtime_start()
 {
     minfo(FIM_REALTIME_STARTING);
+
+    pthread_mutex_init(&adddir_mutex, NULL);
+
     os_calloc(1, sizeof(rtfim), syscheck.realtime);
 
     syscheck.realtime->dirtb = OSHash_Create();

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -126,7 +126,6 @@ int set_winsacl(const char *dir, int position);
 long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void);
 #endif
 
-extern pthread_mutex_t lastcheck_mutex;
 int fim_initialize();
 
 /* Check for restricts and ignored files */

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -37,9 +37,9 @@
 W_Vector *audit_added_rules;
 W_Vector *audit_added_dirs;
 W_Vector *audit_loaded_rules;
-pthread_mutex_t audit_mutex = PTHREAD_MUTEX_INITIALIZER;
-pthread_mutex_t audit_hc_mutex = PTHREAD_MUTEX_INITIALIZER;
-pthread_mutex_t audit_rules_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t audit_mutex;
+pthread_mutex_t audit_hc_mutex;
+pthread_mutex_t audit_rules_mutex;
 int auid_err_reported;
 volatile int hc_thread_active;
 
@@ -339,6 +339,10 @@ int audit_init(void) {
 
     audit_health_check_creation = 0;
     audit_health_check_deletion = 0;
+
+    pthread_mutex_init(&audit_mutex, NULL);
+    pthread_mutex_init(&audit_hc_mutex, NULL);
+    pthread_mutex_init(&audit_rules_mutex, NULL);
 
     // Check if auditd is installed and running.
     int aupid = check_auditd_enabled();

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -183,6 +183,9 @@ void wm_setup()
 
     if (CreatePID(ARGV0, getpid()) < 0)
         merror_exit("Couldn't create PID file: (%s)", strerror(errno));
+
+    // Initialize children pool
+    wm_children_pool_init();
 }
 
 // Cleanup function, called on exiting.

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -16,7 +16,7 @@
 #include <mach/mach.h>
 #endif
 
-static pthread_mutex_t wm_children_mutex = PTHREAD_MUTEX_INITIALIZER;   // Mutex for child process pool
+static pthread_mutex_t wm_children_mutex;   // Mutex for child process pool
 
 // Data structure to share with the reader thread
 
@@ -31,6 +31,12 @@ typedef struct ThreadInfo {
     char *output;
 #endif
 } ThreadInfo;
+
+// Initialize children pool
+
+void wm_children_pool_init() {
+    pthread_mutex_init(&wm_children_mutex, NULL);
+}
 
 #ifdef WIN32
 

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -141,6 +141,9 @@ void wm_append_sid(pid_t sid);
 void wm_remove_sid(pid_t sid);
 #endif
 
+// Initialize children pool
+void wm_children_pool_init();
+
 // Terminate every child process group
 void wm_kill_children();
 

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -249,6 +249,9 @@ int local_start()
     srandom(time(0));
     os_random();
 
+    // Initialize children pool
+    wm_children_pool_init();
+
     /* Launch rotation thread */
     if (CreateThread(NULL,
                      0,

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -232,6 +232,9 @@ int local_start()
         agt->execdq = -1;
     }
 
+    /* Initialize sender */
+    sender_init();
+
     /* Read keys */
     minfo(ENC_READ);
 


### PR DESCRIPTION
Platform|
|---|
| Windows |

## Symptom

We noticed an increase in the memory used by the agent on Windows. We managed to locate the bug in the Logcollector's file checking function.

If we run the file checking thousands of times per second, we note this growth:

![image (1)](https://user-images.githubusercontent.com/10536251/62560892-4684a900-b87e-11e9-8225-9348a3ad740a.png)

This is due to the static initialization of a mutex in the _regex_ library: [os_regex_compile.c:54](https://github.com/wazuh/wazuh/blob/v3.9.3/src/os_regex/os_regex_compile.c#L54).

## Rationale

There is a bug in the implementation of the POSIX Threads library for Windows that may produce a race condition and a memory leak when locking a mutex that has been initialized this way:

```c
pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
```

## Fix

Replace the sentence above with a call to `pthread_mutex_init()`, that will create a valid mutex handler on Windows:

```c
pthread_mutex_t m;
pthread_mutex_init(&m, NULL);
```


## Configuration options

We noticed this bug with a `<localfile>` stanza that includes a wildcard:

```xml
<localfile>
  <location>C:\*.log</location>
  <log_format>syslog</log_format>
</localfile>
```

## Tests

- [X] Compilation on Debian Buster.
- [X] Cross-compilation on Debian 10 for Windows.
- [X] Compilation on macOS Mojave.
- [X] Source installation.
- [X] Stress test on Logcollector's file checking thread.
- [X] Memory test on Windows agent (see below).

### Notes

- No artifacts have been changed so we won't test package installation.

### Memory usage graph

This is the evolution of the memory used by _ossec-agent.exe_ on Windows after 3 hours of execution with an infinite loop on the file reload thread:

<img width="850" alt="Screenshot 2019-08-06 at 19 27 37" src="https://user-images.githubusercontent.com/10536251/62561906-6b7a1b80-b880-11e9-98a4-59f9f41bc25b.png">