### PR TITLE
Fix timestamp in JSON alerts

### DIFF
--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -343,7 +343,7 @@ void W_JSON_AddTimestamp(cJSON* root, const Eventinfo* lf)
         localtime_r(&lf->time.tv_sec, &tm);
         strftime(datetime, sizeof(datetime), "%FT%T", &tm);
         strftime(timezone, sizeof(timezone), "%z", &tm);
-        snprintf(timestamp, sizeof(timestamp), "%s.%ld%s", datetime, lf->time.tv_nsec / 1000000, timezone);
+        snprintf(timestamp, sizeof(timestamp), "%s.%03ld%s", datetime, lf->time.tv_nsec / 1000000, timezone);
         cJSON_AddStringToObject(root, "timestamp", timestamp);
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|[3293](https://github.com/wazuh/wazuh/issues/3293)|

## Description

This PR solves the problem related with the milliseconds in the timestamp of the alerts in JSON format.
The timestamp was not matching the required format in Elastic 7 because the the size of the milliseconds must be 3 digits. 
Example:

> {"timestamp":"2019-08-08T12:30:12.**4**+0200"

The correct format must be the following:

> {"timestamp":"2019-08-08T12:30:12.**004**+0200"



## Fixed alert example

```JSON
{"timestamp":"2019-08-08T12:36:06.003+0200","rule":{"level":3,"description":"Ossec server started.","id":"502","firedtimes":1,"mail":true,"groups":["ossec"],"pci_dss":["10.6.1"],"gpg13":["10.1"],"gdpr":["IV_35.7.d"]},"agent":{"id":"000","name":"ubuntu1904"},"manager":{"name":"ubuntu1904"},"id":"1565260566.168366","full_log":"ossec: Ossec started.","decoder":{"name":"ossec"},"location":"ossec-monitord"}
```

