### PR TITLE
New method for getting full summary of agents

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2535,10 +2535,13 @@ class Agent:
                                                       'os.platform', 'os.version']})
         stats_version = Agent.get_distinct_agents(fields={'fields': ['version']})
         summary = Agent.get_agents_summary()
-        last_registered_agent = Agent.get_agents_overview(limit=1,
-                                                          sort={'fields': ['dateAdd'], 'order': 'desc'},
-                                                          q='id!=000')['items'][0]  # get the first element of 'items'
-        # combine the results in an unique dictionary
+        try:
+            last_registered_agent = Agent.get_agents_overview(limit=1,
+                                                              sort={'fields': ['dateAdd'], 'order': 'desc'},
+                                                              q='id!=000').get('items')[0]
+        except IndexError:  # an IndexError could happen if there are not registered agents
+            last_registered_agent = {}
+        # combine results in an unique dictionary
         result = {'unique_node_names': stats_distinct_node, 'groups': groups,
                   'unique_agent_os': stats_distinct_os, 'summary': summary,
                   'unique_agent_version': stats_version,

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -81,6 +81,11 @@ functions = {
         'type': 'distributed_master',
         'is_async': False
     },
+    '/agents/full_summary': {
+        'function': Agent.get_full_summary,
+        'type': 'local_master',
+        'is_async': False
+    },
     'PUT/agents/:agent_id/upgrade': {
         'function': Agent.upgrade_agent,
         'type': 'distributed_master',
@@ -663,4 +668,3 @@ functions = {
 
 
 }
-

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -77,8 +77,11 @@ def get_manager_version():
     """
     Get manager version
     """
-    manager = Agent(id=0)
-    manager._load_info_from_DB()
+    try:
+        manager = Agent(id=0)
+        manager._load_info_from_DB()
+    except Exception:
+        return 'Wazuh v3.11.0'
 
     return manager.version
 
@@ -565,6 +568,7 @@ def test_send_wpk_file(_get_wpk_mock, get_req_mock, stat_mock, ossec_socket_mock
 
             assert result == ["WPK file sent", version[0]]
 
+
 @patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'var', 'db', 'global.db'))
 def test_get_outdated_agents(test_data):
     """
@@ -580,3 +584,14 @@ def test_get_outdated_agents(test_data):
         for item in result['items']:
             assert set(item.keys()) == {'version', 'id', 'name'}
             assert WazuhVersion(item['version']) < WazuhVersion(get_manager_version())
+
+
+@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'var', 'db', 'global.db'))
+@patch('wazuh.agent.Agent.get_all_groups')
+def test_get_full_summary(mock_get_all_groups, test_data):
+    """Test get_full_sumary method."""
+    expected_keys = {'unique_node_names', 'groups', 'unique_agent_os',
+                     'summary', 'unique_agent_version', 'last_registered_agent'}
+    result = Agent.get_full_summary()
+    # check keys of result
+    assert(set(result.keys()) == expected_keys)


### PR DESCRIPTION
Hi team,

This endpoint is for giving support in framework to [#428](https://github.com/wazuh/wazuh-api/pull/428). A new endpoint was required in [426](https://github.com/wazuh/wazuh-api/issues/426) and this PR gives support to it:

```python
# /var/ossec/framework/python/bin/python3
Python 3.7.2 (default, Apr  9 2019, 17:29:11) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-23)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh.agent import Agent
>>> Agent.get_full_summary()
{'unique_node_names': {'items': [{'node_name': 'master', 'count': 2}, {'node_name': 'worker-1', 'count': 1}, {'node_name': 'worker-2', 'count': 1}], 'totalItems': 4}, 'groups': {'items': [{'count': 3, 'name': 'default', 'mergedSum': 'ddda4e15b99efad1d3be7ae9d7ff14ff', 'configSum': 'ab73af41699f13fdd81903b5f23d8d00'}, {'count': 0, 'name': 'dmz', 'mergedSum': 'dd77862c4a41ae1b3854d67143f3d3e4', 'configSum': 'ab73af41699f13fdd81903b5f23d8d00'}, {'count': 0, 'name': 'testsagentconf', 'mergedSum': '2acdb385658097abb9528aa5ec18c490', 'configSum': '297b4cea942e0b7d2d9c59f9433e3e97'}, {'count': 0, 'name': 'testsagentconf2', 'mergedSum': '391ae29c1b0355c610f45bf133d5ea55', 'configSum': '297b4cea942e0b7d2d9c59f9433e3e97'}], 'totalItems': 4}, 'unique_agent_os': {'items': [{'os': {'name': 'CentOS Linux', 'platform': 'centos', 'version': '7.6'}, 'count': 3}, {'os': {'name': 'CentOS Linux', 'platform': 'centos', 'version': '7'}, 'count': 1}], 'totalItems': 4}, 'summary': {'Total': 4, 'Active': 4, 'Disconnected': 0, 'Never connected': 0, 'Pending': 0}, 'unique_agent_version': {'items': [{'version': 'Wazuh v3.11.0', 'count': 1}, {'version': 'Wazuh v3.9.3', 'count': 2}, {'version': 'Wazuh v3.5.0', 'count': 1}], 'totalItems': 4}, 'last_registered_agent': {'os': {'arch': 'x86_64', 'codename': 'Core', 'major': '7', 'name': 'CentOS Linux', 'platform': 'centos', 'uname': 'Linux |7e2159a46bff |5.2.5-200.fc30.x86_64 |#1 SMP Wed Jul 31 14:37:17 UTC 2019 |x86_64', 'version': '7'}, 'version': 'Wazuh v3.5.0', 'node_name': 'worker-2', 'status': 'Active', 'group': ['default'], 'dateAdd': '2019-08-08 11:25:03', 'name': '7e2159a46bff', 'id': '003', 'ip': '172.30.0.7', 'lastKeepAlive': '2019-08-09 07:15:20', 'manager': '636a34fa474a', 'mergedSum': 'ddda4e15b99efad1d3be7ae9d7ff14ff', 'configSum': 'ab73af41699f13fdd81903b5f23d8d00', 'registerIP': '172.30.0.7'}}
```

A unit test was added too:
```python
@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'var', 'db', 'global.db'))
@patch('wazuh.agent.Agent.get_all_groups')
def test_get_full_summary(mock_get_all_groups, test_data):
    """Test get_full_sumary method."""
    expected_keys = {'unique_node_names', 'groups', 'unique_agent_os',
                     'summary', 'unique_agent_version', 'last_registered_agent'}
    result = Agent.get_full_summary()
    # check keys of result
    assert(set(result.keys()) == expected_keys)
```

This unit test pass successfully but it is necessary to fix unit tests for agents in `3.11` branch.

Best regards,

Demetrio.