### PR TITLE
Fix compilation issue on CentOS 5 due to O_CLOEXEC

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -405,7 +405,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define DEFAULT_SYSLOG 514 /* Default syslog port - udp */
 #endif
 
-#ifdef AIX
+#ifndef O_CLOEXEC
 #define O_CLOEXEC 0
 #endif
 

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -405,6 +405,10 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define DEFAULT_SYSLOG 514 /* Default syslog port - udp */
 #endif
 
+#ifdef AIX
+#define O_CLOEXEC 0
+#endif
+
 /* XML global elements */
 #ifndef xml_global
 #define xml_global "global"

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -15,7 +15,7 @@
 #include "addagent/manage_agents.h" // FILE_SIZE
 #include "external/cJSON/cJSON.h"
 
-#ifndef WIN32
+#ifndef CLIENT
 
 #ifdef INOTIFY_ENABLED
 #include <sys/inotify.h>


### PR DESCRIPTION
|Related issue|
|---|
|#3820|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

@BraulioV noticed that we had a compilation error in AIX 5.3 with O_CLOEXEC function call.
To fix it, we have include:
~~~
#ifdef AIX
#define O_CLOEXEC 0
#endif
~~~
in `src/headers/defs.h` file.

AIX doesn't support *close on exec*, so we could see file descriptors inherited in this SO. However it's not a serious problem.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in 
  - [x] AIX 5.3
  - [x] CentOS 5



