### PR TITLE
Fix defects in the sources installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,8 @@ hs=`echo -n "a"`
 if [ ! "X$hs" = "Xa" ]; then
     if [ -x /usr/ucb/echo ]; then
         ECHO="/usr/ucb/echo -n"
+    elif [ -x /bin/echo ]; then
+        ECHO="/bin/echo -n"
     else
         ECHO=echo
     fi

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -949,7 +949,7 @@ InstallLocal()
     chmod 640 ${PREFIX}/logs/integrations.log
     chown ${OSSEC_USER_MAIL}:${OSSEC_GROUP} ${PREFIX}/logs/integrations.log
 
-    if [ "X${OPTIMIZE_CPYTHON}" == "Xy" ]; then
+    if [ "X${OPTIMIZE_CPYTHON}" = "Xy" ]; then
         CPYTHON_FLAGS="OPTIMIZE_CPYTHON=yes"
     fi
 


### PR DESCRIPTION
## Syntax error during installation

This error appears just before installing Python:

```
../install.sh: 952: [: X: unexpected operator
```

That's due to a wrong string comparison syntax in Bash: `==`.

## Unwanted newlines in the installer prompt

The installer adds a newline in the prompts when running on macOS:

```
  ** Para instalação em português, escolha [br].
  ** For installation in English, choose [en].
  (en/br/cn/de/el/es/fr/hu/it/jp/nl/pl/ru/sr/tr) [en]:
█
```

This happens because `echo` is a built-in command that does not accept `-n` on macOS. We must call `/bin/echo`.

## Tests

- [X] Source installer on macOS Mojave.
- [X] Source installer on FreeBSD 13.
- [X] Source installer on Debian Buster (*).

(*) This fix makes the affected line behave like all other string comparisons.