### PR TITLE
Fix compilation error on FreeBSD 13 and macOS 10.14

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -549,13 +549,13 @@ int OS_SetKeepalive(int socket)
 #ifndef CLIENT
 void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
 {
-    if (setsockopt(socket, SOL_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {
+    if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {
         merror("OS_SetKeepalive_Options(TCP_KEEPCNT) failed with error '%s'", strerror(errno));
     }
-    if (setsockopt(socket, SOL_TCP, TCP_KEEPIDLE, (void *)&idle, sizeof(idle)) < 0) {
+    if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPIDLE, (void *)&idle, sizeof(idle)) < 0) {
         merror("OS_SetKeepalive_Options(SO_KEEPIDLE) failed with error '%s'", strerror(errno));
     }
-    if (setsockopt(socket, SOL_TCP, TCP_KEEPINTVL, (void *)&intvl, sizeof(intvl)) < 0) {
+    if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPINTVL, (void *)&intvl, sizeof(intvl)) < 0) {
         merror("OS_SetKeepalive_Options(TCP_KEEPINTVL) failed with error '%s'", strerror(errno));
     }
 }

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -90,6 +90,11 @@ int OS_SetKeepalive(int socket);
  * Enable SO_KEEPALIVE options for TCP
  */
 #ifndef CLIENT
+
+#ifdef __MACH__
+#define TCP_KEEPIDLE TCP_KEEPALIVE
+#endif
+
 void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt);
 #endif
 /* Set the delivery timeout for a socket


### PR DESCRIPTION
`SOL_TCP` is deprecated. We should use `IPPROTO_TCP`.

|Related issue|
|---|
|#3831|

This PR replaces the deprecated definition `SOL_TCP` with `IPPROTO_TCP`.

## Facts

- This allows the manager to compile on FreeBSD 13.
- This code is enclosed in a `#ifndef client` sentence so it won't affect agents.
- CentOS 6 and Debian 10 have both define `SOL_TCP` and `IPPROTO_TCP` with the same value `6` so this change won't affect runtime.
- The definition of `TCP_IDLE` affects exclusively manager code on macOS.

## Affected artifacts

- Manager's binaries that use network functions.

## Tests

- [X] Manager compilation on CentOS 6.
- [X] Manager compilation on Debian 10 "Buster".
- [X] Manager compilation on macOS 10.14 "Mojave".
- [X] Run _ossec-remoted_ on Debian 10 "Buster" with no errors.