### PR TITLE
Reconnect EventLog and EventChannel when service is restarted

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -141,7 +141,12 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             os_strdup(node[i]->content, logf[pl].out_format[n]->format);
             logf[pl].out_format[n + 1] = NULL;
         } else if (strcmp(node[i]->element, xml_localfile_reconnect_time) == 0) {
-            logf[pl].reconnect_time = atoi(node[i]->content);
+            int time = atoi(node[i]->content);
+            if(time < 5){
+                mwarn("Reconnection time too low. Changed to 5 seconds.");
+                time = 5;
+            }
+            logf[pl].reconnect_time = time;
         } else if (strcmp(node[i]->element, xml_localfile_label) == 0) {
             flags.hidden = flags.system = 0;
             char *key_value = 0;

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -80,7 +80,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     logf[pl].ign = 360;
     logf[pl].exists = 1;
     logf[pl].future = 1;
-    logf[pl].reconnect_time = 5;
+    logf[pl].reconnect_time = MIN_EVENTCHANNEL_REC_TIME;
 
     /* Search for entries related to files */
     i = 0;
@@ -142,9 +142,9 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             logf[pl].out_format[n + 1] = NULL;
         } else if (strcmp(node[i]->element, xml_localfile_reconnect_time) == 0) {
             int time = atoi(node[i]->content);
-            if(time < 5){
-                mwarn("Reconnection time too low. Changed to 5 seconds.");
-                time = 5;
+            if(time < MIN_EVENTCHANNEL_REC_TIME){
+                mwarn("Reconnection time too low. Changed to %d seconds.", MIN_EVENTCHANNEL_REC_TIME);
+                time = MIN_EVENTCHANNEL_REC_TIME;
             }
             logf[pl].reconnect_time = time;
         } else if (strcmp(node[i]->element, xml_localfile_label) == 0) {

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -33,6 +33,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_label = "label";
     const char *xml_localfile_target = "target";
     const char *xml_localfile_outformat = "out_format";
+    const char *xml_localfile_reconnect_time = "reconnect_time";
     const char *xml_localfile_age = "age";
     const char *xml_localfile_exclude = "exclude";
     const char *xml_localfile_binaries = "ignore_binaries";
@@ -79,6 +80,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     logf[pl].ign = 360;
     logf[pl].exists = 1;
     logf[pl].future = 1;
+    logf[pl].reconnect_time = 5;
 
     /* Search for entries related to files */
     i = 0;
@@ -138,6 +140,8 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             logf[pl].out_format[n]->target = target ? strdup(target) : NULL;
             os_strdup(node[i]->content, logf[pl].out_format[n]->format);
             logf[pl].out_format[n + 1] = NULL;
+        } else if (strcmp(node[i]->element, xml_localfile_reconnect_time) == 0) {
+            logf[pl].reconnect_time = atoi(node[i]->content);
         } else if (strcmp(node[i]->element, xml_localfile_label) == 0) {
             flags.hidden = flags.system = 0;
             char *key_value = 0;

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -80,7 +80,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     logf[pl].ign = 360;
     logf[pl].exists = 1;
     logf[pl].future = 1;
-    logf[pl].reconnect_time = MIN_EVENTCHANNEL_REC_TIME;
+    logf[pl].reconnect_time = DEFAULT_EVENTCHANNEL_REC_TIME;
 
     /* Search for entries related to files */
     i = 0;
@@ -164,9 +164,9 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     return (OS_INVALID);
                 }
             }
-            if(time < MIN_EVENTCHANNEL_REC_TIME){
-                mwarn("Reconnection time too low. Changed to %d seconds.", MIN_EVENTCHANNEL_REC_TIME);
-                time = MIN_EVENTCHANNEL_REC_TIME;
+            if(time < 1 ||  time == UINT_MAX){
+                mwarn("Invalid reconnection time value. Changed to %d seconds.", DEFAULT_EVENTCHANNEL_REC_TIME);
+                time = DEFAULT_EVENTCHANNEL_REC_TIME;
             }
             logf[pl].reconnect_time = time;
         } else if (strcmp(node[i]->element, xml_localfile_label) == 0) {

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -141,7 +141,29 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             os_strdup(node[i]->content, logf[pl].out_format[n]->format);
             logf[pl].out_format[n + 1] = NULL;
         } else if (strcmp(node[i]->element, xml_localfile_reconnect_time) == 0) {
-            int time = atoi(node[i]->content);
+            char *c;
+            int time = strtoul(node[i]->content, &c, 0);
+            if(time) {
+                switch (c[0]) {
+                case 'w':
+                    time *= 604800;
+                    break;
+                case 'd':
+                    time *= 86400;
+                    break;
+                case 'h':
+                    time *= 3600;
+                    break;
+                case 'm':
+                    time *= 60;
+                    break;
+                case 's':
+                    break;
+                default:
+                    merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                    return (OS_INVALID);
+                }
+            }
             if(time < MIN_EVENTCHANNEL_REC_TIME){
                 mwarn("Reconnection time too low. Changed to %d seconds.", MIN_EVENTCHANNEL_REC_TIME);
                 time = MIN_EVENTCHANNEL_REC_TIME;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -14,6 +14,7 @@
 #define EVENTLOG     "eventlog"
 #define EVENTCHANNEL "eventchannel"
 #define DATE_MODIFIED   1
+#define MIN_EVENTCHANNEL_REC_TIME 5
 
 #include <pthread.h>
 

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -14,7 +14,7 @@
 #define EVENTLOG     "eventlog"
 #define EVENTCHANNEL "eventchannel"
 #define DATE_MODIFIED   1
-#define MIN_EVENTCHANNEL_REC_TIME 5
+#define DEFAULT_EVENTCHANNEL_REC_TIME 5
 
 #include <pthread.h>
 

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -68,6 +68,7 @@ typedef struct _logreader {
     char *djb_program_name;
     char *command;
     char *alias;
+    int reconnect_time;
     char future;
     char *query;
     int filter_binary;

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -142,8 +142,9 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
             }
             cJSON_AddItemToObject(file,"labels",label);
         }
-        if (list[i].ign) cJSON_AddNumberToObject(file,"frequency",list[i].ign);
-        if (list[i].future) cJSON_AddStringToObject(file,"only-future-events","yes");
+        if (list[i].ign && (strcmp(list[i].logformat,"command")==0 || strcmp(list[i].logformat,"full_command")==0)) cJSON_AddNumberToObject(file,"frequency",list[i].ign);
+        if (list[i].future && strcmp(list[i].logformat,"eventchannel")==0) cJSON_AddStringToObject(file,"only-future-events","yes");
+        if (list[i].reconnect_time && strcmp(list[i].logformat,"eventchannel")==0) cJSON_AddNumberToObject(file,"reconnect_time",list[i].reconnect_time);
 
         cJSON_AddItemToArray(array, file);
         i++;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -170,7 +170,7 @@ void LogCollectorStart()
 
 #ifdef EVENTCHANNEL_SUPPORT
             minfo(READING_EVTLOG, current->file);
-            win_start_event_channel(current->file, current->future, current->query);
+            win_start_event_channel(current->file, current->future, current->query, current->reconnect_time);
 #else
             mwarn("eventchannel not available on this version of Windows");
 #endif

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -97,7 +97,7 @@ void *read_json(logreader *lf, int *rc, int drop_it);
 void win_startel();
 void win_readel();
 void win_read_vista_sec();
-void win_start_event_channel(char *evt_log, char future, char *query);
+int win_start_event_channel(char *evt_log, char future, char *query);
 void win_format_event_string(char *string);
 #endif
 

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -97,7 +97,7 @@ void *read_json(logreader *lf, int *rc, int drop_it);
 void win_startel();
 void win_readel();
 void win_read_vista_sec();
-int win_start_event_channel(char *evt_log, char future, char *query);
+int win_start_event_channel(char *evt_log, char future, char *query, int reconnect_time);
 void win_format_event_string(char *string);
 #endif
 

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -513,7 +513,7 @@ void readel(os_el *el, int printit)
 
     /* Event log was closed and re-opened */
     else if (id == ERROR_INVALID_HANDLE) {
-        mdebug1("EventLog service has been restarted. Trying to reconnect '%s' channel...", el->name);
+        mdebug1("EventLog service has been restarted. Reconnecting '%s' channel.", el->name);
 
         CloseEventLog(el->h);
         el->h = NULL;
@@ -533,7 +533,7 @@ void readel(os_el *el, int printit)
     else if (id == RPC_S_SERVER_UNAVAILABLE || id == RPC_S_UNKNOWN_IF) {
         /* Prevent message flooding when EventLog is stopped */
         if (counter == 0) {
-            mwarn("Eventlog is down. Please restart the service.");
+            mwarn("The eventlog service is down. Unable to collect logs from its channels.");
             counter = 1;
         }
     }

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -509,6 +509,20 @@ void readel(os_el *el, int printit)
         }
     }
 
+
+    /* Event log was closed and re-opened */
+    else if (id == ERROR_INVALID_HANDLE) {
+        mdebug1("EventLog was closed and re-opened");
+
+        CloseEventLog(el->h);
+        el->h = NULL;
+
+        /* Reopen */
+        if (startEL(el->name, el) < 0) {
+            merror("Unable to reopen event log '%s'", el->name);
+        }
+    }
+
     else {
         mdebug1("Error reading event log: %d", id);
     }

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -512,15 +512,23 @@ void readel(os_el *el, int printit)
 
     /* Event log was closed and re-opened */
     else if (id == ERROR_INVALID_HANDLE) {
-        mdebug1("EventLog was closed and re-opened");
+        mdebug1("EventLog service is down. Trying to reconnect channel '%s'...", el->name);
 
         CloseEventLog(el->h);
         el->h = NULL;
 
         /* Reopen */
         if (startEL(el->name, el) < 0) {
-            merror("Unable to reopen event log '%s'", el->name);
+            merror(
+            "Could not subscribe for (%s) which returned (%d)",
+            el->name,
+            id);
         }
+    }
+
+    /* These error codes are returned in different Windows versions when EventLog is not available. This message is prompted for coherence with EventChannel */
+    else if (id == RPC_S_SERVER_UNAVAILABLE || id == RPC_S_UNKNOWN_IF) {
+        merror("Could not subscribe for (%s) which returned (%d)", el->name, id);
     }
 
     else {

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -513,7 +513,7 @@ void readel(os_el *el, int printit)
 
     /* Event log was closed and re-opened */
     else if (id == ERROR_INVALID_HANDLE) {
-        mdebug1("EventLog service has been restarted. Reconnecting '%s' channel.", el->name);
+        mdebug1("The EventLog service has been restarted. Reconnecting to '%s' channel.", el->name);
 
         CloseEventLog(el->h);
         el->h = NULL;
@@ -533,7 +533,7 @@ void readel(os_el *el, int printit)
     else if (id == RPC_S_SERVER_UNAVAILABLE || id == RPC_S_UNKNOWN_IF) {
         /* Prevent message flooding when EventLog is stopped */
         if (counter == 0) {
-            mwarn("The eventlog service is down. Unable to collect logs from its channels.");
+            mwarn("The EventLog service is down. Unable to collect logs from its channels.");
             counter = 1;
         }
     }
@@ -570,8 +570,7 @@ void win_read_vista_sec()
 
         p = strchr(buf, ',');
         if (!p) {
-            merror("Invalid entry on the Vista security "
-                   "description.");
+            merror("Invalid entry on the Vista security description.");
             continue;
         }
 

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -652,15 +652,13 @@ cleanup:
         if (result != NULL) {
             EvtClose(result);
         }
-
-        return -1;
     }
 
     if (bookmark != NULL) {
         EvtClose(bookmark);
     }
 
-    return 0;
+    return status ? 0 : -1;
 }
 
 #endif /* EVENTCHANNEL_SUPPORT */

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -87,14 +87,14 @@ wchar_t *convert_unix_string(char *string)
                                0);
 
     if (size == 0) {
-        mferror(
+        merror(
             "Could not MultiByteToWideChar() when determining size which returned (%lu)",
             GetLastError());
         return (NULL);
     }
 
     if ((dest = calloc(size, sizeof(wchar_t))) == NULL) {
-        mferror(
+        merror(
             "Could not calloc() memory for MultiByteToWideChar() which returned [(%d)-(%s)]",
             errno,
             strerror(errno));
@@ -109,7 +109,7 @@ wchar_t *convert_unix_string(char *string)
                                  size);
 
     if (result == 0) {
-        mferror(
+        merror(
             "Could not MultiByteToWideChar() which returned (%lu)",
             GetLastError());
         free(dest);
@@ -160,7 +160,7 @@ char *get_message(EVT_HANDLE evt, LPCWSTR provider_name, DWORD flags)
                               NULL,
                               &size);
     if (result != FALSE || GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        mferror(
+        merror(
             "Could not EvtFormatMessage() to determine buffer size with flags (%lu) which returned (%lu)",
             flags,
             GetLastError());
@@ -168,7 +168,7 @@ char *get_message(EVT_HANDLE evt, LPCWSTR provider_name, DWORD flags)
     }
 
     if ((buffer = calloc(size, sizeof(wchar_t))) == NULL) {
-        mferror(
+        merror(
             "Could not calloc() memory which returned [(%d)-(%s)]",
             errno,
             strerror(errno));
@@ -185,7 +185,7 @@ char *get_message(EVT_HANDLE evt, LPCWSTR provider_name, DWORD flags)
                               buffer,
                               &size);
     if (result == FALSE) {
-        mferror(
+        merror(
             "Could not EvtFormatMessage() with flags (%lu) which returned (%lu)",
             flags,
             GetLastError());
@@ -218,7 +218,7 @@ EVT_HANDLE read_bookmark(os_channel *channel)
          * file did not exist which should be logged
          */
         if (errno != ENOENT) {
-            mferror(
+            merror(
                 "Could not fopen() existing bookmark (%s) for (%s) which returned [(%d)-(%s)]",
                 channel->bookmark_filename,
                 channel->evt_log,
@@ -230,7 +230,7 @@ EVT_HANDLE read_bookmark(os_channel *channel)
 
     size = fread(bookmark_xml, sizeof(wchar_t), OS_MAXSTR, fp);
     if (ferror(fp)) {
-        mferror(
+        merror(
             "Could not fread() bookmark (%s) for (%s) which returned [(%d)-(%s)]",
             channel->bookmark_filename,
             channel->evt_log,
@@ -252,7 +252,7 @@ EVT_HANDLE read_bookmark(os_channel *channel)
 
     /* Create bookmark from saved XML */
     if ((bookmark = EvtCreateBookmark(bookmark_xml)) == NULL) {
-        mferror(
+        merror(
             "Could not EvtCreateBookmark() bookmark (%s) for (%s) which returned (%lu)",
             channel->bookmark_filename,
             channel->evt_log,
@@ -275,7 +275,7 @@ int update_bookmark(EVT_HANDLE evt, os_channel *channel)
     FILE *fp = NULL;
 
     if ((bookmark = EvtCreateBookmark(NULL)) == NULL) {
-        mferror(
+        merror(
             "Could not EvtCreateBookmark() bookmark (%s) for (%s) which returned (%lu)",
             channel->bookmark_filename,
             channel->evt_log,
@@ -284,7 +284,7 @@ int update_bookmark(EVT_HANDLE evt, os_channel *channel)
     }
 
     if (!EvtUpdateBookmark(bookmark, evt)) {
-        mferror(
+        merror(
             "Could not EvtUpdateBookmark() bookmark (%s) for (%s) which returned (%lu)",
             channel->bookmark_filename,
             channel->evt_log,
@@ -301,7 +301,7 @@ int update_bookmark(EVT_HANDLE evt, os_channel *channel)
                        &size,
                        &count);
     if (result != FALSE || GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        mferror(
+        merror(
             "Could not EvtRender() to get buffer size to update bookmark (%s) for (%s) which returned (%lu)",
             channel->bookmark_filename,
             channel->evt_log,
@@ -310,7 +310,7 @@ int update_bookmark(EVT_HANDLE evt, os_channel *channel)
     }
 
     if ((buffer = calloc(size, sizeof(char))) == NULL) {
-        mferror(
+        merror(
             "Could not calloc() memory to save bookmark (%s) for (%s) which returned [(%d)-(%s)]",
             channel->bookmark_filename,
             channel->evt_log,
@@ -326,7 +326,7 @@ int update_bookmark(EVT_HANDLE evt, os_channel *channel)
                    buffer,
                    &size,
                    &count)) {
-        mferror(
+        merror(
             "Could not EvtRender() bookmark (%s) for (%s) which returned (%lu)",
             channel->bookmark_filename, channel->evt_log,
             GetLastError());
@@ -344,7 +344,7 @@ int update_bookmark(EVT_HANDLE evt, os_channel *channel)
     }
 
     if ((fwrite(buffer, 1, size, fp)) < size) {
-        mferror(
+        merror(
             "Could not fwrite() to bookmark (%s) for (%s) which returned [(%d)-(%s)]",
             channel->bookmark_filename,
             channel->evt_log,
@@ -401,7 +401,7 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
                        &buffer_length,
                        &count);
     if (result != FALSE || GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        mferror(
+        merror(
             "Could not EvtRender() to determine buffer size for (%s) which returned (%lu)",
             channel->evt_log,
             GetLastError());
@@ -409,7 +409,7 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
     }
 
     if ((properties_values = malloc(buffer_length)) == NULL) {
-        mferror(
+        merror(
             "Could not malloc() memory to process event (%s) which returned [(%d)-(%s)]",
             channel->evt_log,
             errno,
@@ -424,7 +424,7 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
                    properties_values,
                    &buffer_length,
                    &count)) {
-        mferror(
+        merror(
             "Could not EvtRender() for (%s) which returned (%lu)",
             channel->evt_log,
             GetLastError());
@@ -464,7 +464,7 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
         wprovider_name = convert_unix_string(provider_name);
 
         if (wprovider_name && (msg_from_prov = get_message(evt, wprovider_name, EvtFormatMessageEvent)) == NULL) {
-            mferror(
+            merror(
                 "Could not get message for (%s)",
                 channel->evt_log);
         }
@@ -530,7 +530,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
     static int counter = 0;
 
     if ((channel = calloc(1, sizeof(os_channel))) == NULL) {
-        mferror(
+        merror(
             "Could not calloc() memory for channel to start reading (%s) which returned [(%d)-(%s)]",
             evt_log,
             errno,
@@ -542,7 +542,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
 
     /* Create copy of event log string */
     if ((channel->bookmark_name = strdup(channel->evt_log)) == NULL) {
-        mferror(
+        merror(
             "Could not strdup() event log name to start reading (%s) which returned [(%d)-(%s)]",
             channel->evt_log,
             errno,
@@ -553,7 +553,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
     if (query) {
         /* Create copy of query string */
         if ((channel->query = strdup(query)) == NULL) {
-            mferror(
+            merror(
                 "Could not strdup() query (%s) which returned [(%d)-(%s)]",
                 query,
                 errno,
@@ -569,7 +569,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
 
     /* Convert evt_log to Windows string */
     if ((wchannel = convert_unix_string(channel->evt_log)) == NULL) {
-        mferror(
+        merror(
             "Could not convert_unix_string() evt_log for (%s) which returned [(%d)-(%s)]",
             channel->evt_log,
             errno,
@@ -580,7 +580,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
     /* Convert query to Windows string */
     if (query) {
         if ((filtered_query = filter_special_chars(query)) == NULL) {
-            mferror(
+            merror(
                 "Could not filter_special_chars() query for (%s) which returned [(%d)-(%s)]",
                 channel->evt_log,
                 errno,
@@ -589,7 +589,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
         }
 
         if ((wquery = convert_unix_string(filtered_query)) == NULL) {
-            mferror(
+            merror(
                 "Could not convert_unix_string() query for (%s) which returned [(%d)-(%s)]",
                 channel->evt_log,
                 errno,
@@ -635,7 +635,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
     if (result == NULL) {
         unsigned long id = GetLastError();
         if (id != RPC_S_SERVER_UNAVAILABLE && id != RPC_S_UNKNOWN_IF) {
-            mferror(
+            merror(
                 "Could not EvtSubscribe() for (%s) which returned (%lu)",
                 channel->evt_log,
                 id);

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -541,26 +541,10 @@ int win_start_event_channel(char *evt_log, char future, char *query)
     channel->evt_log = evt_log;
 
     /* Create copy of event log string */
-    if ((channel->bookmark_name = strdup(channel->evt_log)) == NULL) {
-        merror(
-            "Could not strdup() event log name to start reading (%s) which returned [(%d)-(%s)]",
-            channel->evt_log,
-            errno,
-            strerror(errno));
-        goto cleanup;
-    }
+    os_strdup(channel->evt_log, channel->bookmark_name);
 
-    if (query) {
-        /* Create copy of query string */
-        if ((channel->query = strdup(query)) == NULL) {
-            merror(
-                "Could not strdup() query (%s) which returned [(%d)-(%s)]",
-                query,
-                errno,
-                strerror(errno));
-            goto cleanup;
-        }
-    }
+    /* Create copy of query string */
+    channel->query = query;
 
     /* Replace '/' with '_' */
     if (strchr(channel->bookmark_name, '/')) {

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -642,7 +642,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
         } else {
             /* Prevent message flooding when EventLog is stopped */
             if (counter == 0) {
-                mwarn("Eventlog is down. Please restart the service.");
+                mwarn("The eventlog service is down. Unable to collect logs from its channels.");
                 counter = 1;
             }
         }

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -642,7 +642,7 @@ int win_start_event_channel(char *evt_log, char future, char *query)
         } else {
             /* Prevent message flooding when EventLog is stopped */
             if (counter == 0) {
-                mwarn("The eventlog service is down. Unable to collect logs from its channels.");
+                mwarn("The EventLog service is down. Unable to collect logs from its channels.");
                 counter = 1;
             }
         }

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -503,8 +503,8 @@ DWORD WINAPI event_channel_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, os_chann
     if (action == EvtSubscribeActionDeliver) {
         send_channel_event(evt, channel);
     } else {
-        for (int i = 0; i < 3; i++) {
-            mdebug1("Trying to restart channel '%s'...", channel->evt_log);
+        while(1) {
+            mdebug1("EventLog service is down. Trying to reconnect channel '%s'...", channel->evt_log);
             /* Try to restart EventChannel */
             if (win_start_event_channel(channel->evt_log, !channel->bookmark_enabled, channel->query) == -1) {
                 sleep(5);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3792|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes the error occurred while stopping the `EventLog` service in Windows. If a `localfile` had `eventchannel` or `eventlog` as `log_format`. If `eventlog` was set, the following message was being shown infinitely:
```
DEBUG: Error reading event log: 6
DEBUG: Error reading event log: 6
DEBUG: Error reading event log: 6
DEBUG: Error reading event log: 6
```
And the log collection function didn't work again for these logs (though the `EventLog` service is restarted.
In the case of `eventchannel` no message was being shown but the log collection function wasn't working again for these logs either.

## Configuration options

- For `eventchannel`:
```
<!-- Log analysis -->
  <localfile>
    <location>Application</location>
    <log_format>eventchannel</log_format>
  </localfile>

  <localfile>
    <location>Security</location>
    <log_format>eventchannel</log_format>
    <query>Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and
      EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and
      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and
      EventID != 5152 and EventID != 5157]</query>
  </localfile>

  <localfile>
    <location>System</location>
    <log_format>eventchannel</log_format>
  </localfile>
```

- For `eventlog`:
```
<!-- Log analysis -->
  <localfile>
    <location>Application</location>
    <log_format>eventlog</log_format>
  </localfile>

  <localfile>
    <location>Security</location>
    <log_format>eventlog</log_format>
    <query>Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and
      EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and
      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and
      EventID != 5152 and EventID != 5157]</query>
  </localfile>

  <localfile>
    <location>System</location>
    <log_format>eventlog</log_format>
  </localfile>
```

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

- For `eventlog`:
```
2019/08/12 11:10:42 ossec-agent[12844] read_win_el.c:527 at readel(): DEBUG: Error reading event log: 1722
2019/08/12 11:10:42 ossec-agent[12844] read_win_el.c:527 at readel(): DEBUG: Error reading event log: 1722
2019/08/12 11:10:42 ossec-agent[12844] read_win_el.c:527 at readel(): DEBUG: Error reading event log: 1722
2019/08/12 11:10:46 ossec-agent[12844] read_win_el.c:515 at readel(): DEBUG: EventLog was closed and re-opened
2019/08/12 11:10:46 ossec-agent[12844] read_win_el.c:515 at readel(): DEBUG: EventLog was closed and re-opened
2019/08/12 11:10:46 ossec-agent[12844] read_win_el.c:515 at readel(): DEBUG: EventLog was closed and re-opened
```
After this, we trigger a `eventlog` event and the alerts appears:
```
** Alert 1565601128.877280: - windows,policy_changed,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,
2019 Aug 12 09:12:08 (Win) 10.0.0.1->WinEvtLog
Rule: 18113 (level 8) -> 'Windows Audit Policy changed.'
User: (no user)
2019 Aug 12 11:12:05 WinEvtLog: Security: AUDIT_SUCCESS(4719): Microsoft-Windows-Security-Auditing: (no user): no domain: COMPUTERNAME: System audit policy was changed. Subject:  Security ID:  S-1-5-18  Account Name:  DESKTOP-04BL6CF$  Account Domain:  WORKGROUP  Logon ID:  0x3e7  Audit Policy Change:  Category:  %%8274  Subcategory:  %%12800  Subcategory GUID: {0cce921d-69ae-11d9-bed3-505054503030}  Changes:  %%8449
type: Security
subject.security_id: S-1-5-18
subject.account_name: COMPUTERNAME
subject.account_domain: WORKGROUP
subject.logon_id: 0x3e7
```

- For `eventchannel`:
```
2019/08/12 11:14:00 ossec-agent[12308] read_win_event_channel.c:528 at event_channel_callback(): DEBUG: Trying to restart channel 'Security'...
2019/08/12 11:14:00 ossec-agent[12308] read_win_event_channel.c:528 at event_channel_callback(): DEBUG: Trying to restart channel 'Application'...
2019/08/12 11:14:00 ossec-agent[12308] read_win_event_channel.c:528 at event_channel_callback(): DEBUG: Trying to restart channel 'System'...
2019/08/12 11:14:00 ossec-agent[12308] read_win_event_channel.c:659 at win_start_event_channel(): ERROR: Could not EvtSubscribe() for (Security) which returned (1717)
2019/08/12 11:14:00 ossec-agent[12308] read_win_event_channel.c:659 at win_start_event_channel(): ERROR: Could not EvtSubscribe() for (Application) which returned (1717)
2019/08/12 11:14:00 ossec-agent[12308] read_win_event_channel.c:659 at win_start_event_channel(): ERROR: Could not EvtSubscribe() for (System) which returned (1717)
2019/08/12 11:14:04 ossec-agent[12308] win_agent.c:503 at SendMSG(): DEBUG: Sending info to server (ctime2)...
2019/08/12 11:14:04 ossec-agent[12308] win_agent.c:703 at send_win32_info(): DEBUG: Sending keep alive message.
2019/08/12 11:14:05 ossec-agent[12308] read_win_event_channel.c:528 at event_channel_callback(): DEBUG: Trying to restart channel 'System'...

2019/08/12 11:14:05 ossec-agent[12308] read_win_event_channel.c:528 at event_channel_callback(): DEBUG: Trying to restart channel 'Application'...
```
After this, we trigger a `eventchannel` event and the alerts appears:
```
** Alert 1565601296.881471: - windows, windows_security,policy_changed,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,
2019 Aug 12 09:14:56 (Win) 10.0.0.1->EventChannel
Rule: 60112 (level 8) -> 'Windows Audit Policy changed'
{"win":{"system":{"providerName":"Microsoft-Windows-Security-Auditing","providerGuid":"{54849625-5478-4994-a5ba-3e3b0328c30d}","eventID":"4719","version":"0","level":"0","task":"13568","opcode":"0","keywords":"0x8020000000000000","systemTime":"2019-08-12T09:14:55.326974700Z","eventRecordID":"7412761","processID":"836","threadID":"10528","channel":"Security","computer":"COMPUTERID","severityValue":"AUDIT_SUCCESS","message":"Se cambió la directiva de auditoría del sistema."},"eventdata":{"subjectUserSid":"S-1-5-18","subjectUserName":"COMPUTERNAME","subjectDomainName":"WORKGROUP","subjectLogonId":"0x3e7","categoryId":"%%8274","subcategoryId":"%%12800","subcategoryGuid":"{0cce921d-69ae-11d9-bed3-505054503030}","auditPolicyChangesId":"%%8449","category":"Object Access","subcategory":"File System","auditPolicyChanges":"Success added"}}}
win.system.providerName: Microsoft-Windows-Security-Auditing
win.system.providerGuid: {54849625-5478-4994-a5ba-3e3b0328c30d}
win.system.eventID: 4719
win.system.version: 0
win.system.level: 0
win.system.task: 13568
win.system.opcode: 0
win.system.keywords: 0x8020000000000000
win.system.systemTime: 2019-08-12T09:14:55.326974700Z
win.system.eventRecordID: 7412761
win.system.processID: 836
win.system.threadID: 10528
win.system.channel: Security
win.system.computer: COMPUTERNAME
win.system.severityValue: AUDIT_SUCCESS
win.system.message: Se cambió la directiva de auditoría del sistema.
win.eventdata.subjectUserSid: S-1-5-18
win.eventdata.subjectUserName: COMPUTERNAME
win.eventdata.subjectDomainName: WORKGROUP
win.eventdata.subjectLogonId: 0x3e7
win.eventdata.categoryId: %%8274
win.eventdata.subcategoryId: %%12800
win.eventdata.subcategoryGuid: {0cce921d-69ae-11d9-bed3-505054503030}
win.eventdata.auditPolicyChangesId: %%8449
win.eventdata.category: Object Access
win.eventdata.subcategory: File System
win.eventdata.auditPolicyChanges: Success added
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Dr. Memory

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
