### PR TITLE
New function for getting a full summary of agents

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2595,9 +2595,9 @@ class Agent:
         except IndexError:  # an IndexError could happen if there are not registered agents
             last_registered_agent = {}
         # combine results in an unique dictionary
-        result = {'unique_node_names': stats_distinct_node, 'groups': groups,
-                  'unique_agent_os': stats_distinct_os, 'summary': summary,
-                  'unique_agent_version': stats_version,
+        result = {'nodes': stats_distinct_node, 'groups': groups,
+                  'agent_os': stats_distinct_os, 'agent_status': summary,
+                  'agent_version': stats_version,
                   'last_registered_agent': last_registered_agent}
 
         return result

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -15,6 +15,7 @@ from os import chown, chmod, path, makedirs, urandom, listdir, stat, remove
 from platform import platform
 from shutil import copyfile, rmtree
 from time import time, sleep
+from typing import Dict
 
 import fcntl
 import requests
@@ -2574,3 +2575,29 @@ class Agent:
             raise WazuhException(1710)
 
         return configuration.upload_group_file(group_id, tmp_file, file_name)
+
+    @staticmethod
+    def get_full_summary() -> Dict:
+        """Get information about agents.
+        :return: Dictionary with information about agents
+        """
+        # get information from different methods of Agent class
+        stats_distinct_node = Agent.get_distinct_agents(fields={'fields': ['node_name']})
+        groups = Agent.get_all_groups()
+        stats_distinct_os = Agent.get_distinct_agents(fields={'fields': ['os.name',
+                                                      'os.platform', 'os.version']})
+        stats_version = Agent.get_distinct_agents(fields={'fields': ['version']})
+        summary = Agent.get_agents_summary()
+        try:
+            last_registered_agent = Agent.get_agents_overview(limit=1,
+                                                              sort={'fields': ['dateAdd'], 'order': 'desc'},
+                                                              q='id!=000').get('items')[0]
+        except IndexError:  # an IndexError could happen if there are not registered agents
+            last_registered_agent = {}
+        # combine results in an unique dictionary
+        result = {'unique_node_names': stats_distinct_node, 'groups': groups,
+                  'unique_agent_os': stats_distinct_os, 'summary': summary,
+                  'unique_agent_version': stats_version,
+                  'last_registered_agent': last_registered_agent}
+
+        return result

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -51,11 +51,6 @@ functions = {
         'type': 'local_master',
         'is_async': False
     },
-    '/agents/full_summary': {
-        'function': Agent.get_full_summary,
-        'type': 'local_master',
-        'is_async': False
-    },
     '/agents/summary/os': {
         'function': Agent.get_os_summary,
         'type': 'local_master',
@@ -666,6 +661,11 @@ functions = {
         'is_async': False
     },
 
+    # Summary
+    '/summary/agents': {
+        'function': Agent.get_full_summary,
+        'type': 'local_master',
+        'is_async': False
+    },
 
 }
-

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -51,6 +51,11 @@ functions = {
         'type': 'local_master',
         'is_async': False
     },
+    '/agents/full_summary': {
+        'function': Agent.get_full_summary,
+        'type': 'local_master',
+        'is_async': False
+    },
     '/agents/summary/os': {
         'function': Agent.get_os_summary,
         'type': 'local_master',

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -493,8 +493,8 @@ def test_get_outdated_agents(test_data):
 @patch('wazuh.agent.Agent.get_all_groups')
 def test_get_full_summary(mock_get_all_groups, test_data):
     """Test get_full_sumary method."""
-    expected_keys = {'unique_node_names', 'groups', 'unique_agent_os',
-                     'summary', 'unique_agent_version', 'last_registered_agent'}
+    expected_keys = {'nodes', 'groups', 'agent_os', 'agent_status',
+                     'agent_version', 'last_registered_agent'}
     result = Agent.get_full_summary()
     # check keys of result
     assert(set(result.keys()) == expected_keys)

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -471,6 +471,7 @@ def test_send_wpk_file(_get_wpk_mock, get_req_mock, stat_mock, ossec_socket_mock
 
             assert result == ["WPK file sent", version[0]]
 
+
 @patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'var', 'db', 'global.db'))
 def test_get_outdated_agents(test_data):
     """
@@ -486,3 +487,14 @@ def test_get_outdated_agents(test_data):
         for item in result['items']:
             assert set(item.keys()) == {'version', 'id', 'name'}
             assert WazuhVersion(item['version']) < WazuhVersion(get_manager_version())
+
+
+@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'var', 'db', 'global.db'))
+@patch('wazuh.agent.Agent.get_all_groups')
+def test_get_full_summary(mock_get_all_groups, test_data):
+    """Test get_full_sumary method."""
+    expected_keys = {'unique_node_names', 'groups', 'unique_agent_os',
+                     'summary', 'unique_agent_version', 'last_registered_agent'}
+    result = Agent.get_full_summary()
+    # check keys of result
+    assert(set(result.keys()) == expected_keys)


### PR DESCRIPTION
Hi team,

This endpoint is for giving support in framework to [#429](https://github.com/wazuh/wazuh-api/pull/428). A new endpoint was required in [426](https://github.com/wazuh/wazuh-api/issues/426) and this PR gives support to it:

```python
# /var/ossec/framework/python/bin/python3
Python 3.7.2 (default, Apr  9 2019, 17:29:11) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-23)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh.agent import Agent
>>> Agent.get_full_summary()
{'unique_node_names': {'items': [{'node_name': 'master', 'count': 2}, {'node_name': 'worker-1', 'count': 1}, {'node_name': 'worker-2', 'count': 1}], 'totalItems': 4}, 'groups': {'items': [{'count': 3, 'name': 'default', 'mergedSum': 'ddda4e15b99efad1d3be7ae9d7ff14ff', 'configSum': 'ab73af41699f13fdd81903b5f23d8d00'}, {'count': 0, 'name': 'dmz', 'mergedSum': 'dd77862c4a41ae1b3854d67143f3d3e4', 'configSum': 'ab73af41699f13fdd81903b5f23d8d00'}, {'count': 0, 'name': 'testsagentconf', 'mergedSum': '2acdb385658097abb9528aa5ec18c490', 'configSum': '297b4cea942e0b7d2d9c59f9433e3e97'}, {'count': 0, 'name': 'testsagentconf2', 'mergedSum': '391ae29c1b0355c610f45bf133d5ea55', 'configSum': '297b4cea942e0b7d2d9c59f9433e3e97'}], 'totalItems': 4}, 'unique_agent_os': {'items': [{'os': {'name': 'CentOS Linux', 'platform': 'centos', 'version': '7.6'}, 'count': 3}, {'os': {'name': 'CentOS Linux', 'platform': 'centos', 'version': '7'}, 'count': 1}], 'totalItems': 4}, 'summary': {'Total': 4, 'Active': 4, 'Disconnected': 0, 'Never connected': 0, 'Pending': 0}, 'unique_agent_version': {'items': [{'version': 'Wazuh v3.11.0', 'count': 1}, {'version': 'Wazuh v3.9.3', 'count': 2}, {'version': 'Wazuh v3.5.0', 'count': 1}], 'totalItems': 4}, 'last_registered_agent': {'os': {'arch': 'x86_64', 'codename': 'Core', 'major': '7', 'name': 'CentOS Linux', 'platform': 'centos', 'uname': 'Linux |7e2159a46bff |5.2.5-200.fc30.x86_64 |#1 SMP Wed Jul 31 14:37:17 UTC 2019 |x86_64', 'version': '7'}, 'version': 'Wazuh v3.5.0', 'node_name': 'worker-2', 'status': 'Active', 'group': ['default'], 'dateAdd': '2019-08-08 11:25:03', 'name': '7e2159a46bff', 'id': '003', 'ip': '172.30.0.7', 'lastKeepAlive': '2019-08-09 07:15:20', 'manager': '636a34fa474a', 'mergedSum': 'ddda4e15b99efad1d3be7ae9d7ff14ff', 'configSum': 'ab73af41699f13fdd81903b5f23d8d00', 'registerIP': '172.30.0.7'}}
```

A unit test was added too:
```python
@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'var', 'db', 'global.db'))
@patch('wazuh.agent.Agent.get_all_groups')
def test_get_full_summary(mock_get_all_groups, test_data):
    """Test get_full_sumary method."""
    expected_keys = {'unique_node_names', 'groups', 'unique_agent_os',
                     'summary', 'unique_agent_version', 'last_registered_agent'}
    result = Agent.get_full_summary()
    # check keys of result
    assert(set(result.keys()) == expected_keys)
```

All unit tests work:

```python
% pytest test_agent.py -vv
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.7.4, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/druizz/Git/wazuh/framework, inifile:
plugins: tavern-0.26.3
collected 52 items                                                                                                                                                                                  

test_agent.py::test_get_agents_overview_default PASSED                                                                                                                                        [  1%]
test_agent.py::test_get_agents_overview_select[select0-all-None-0] PASSED                                                                                                                     [  3%]
test_agent.py::test_get_agents_overview_select[select1-all-None-1] PASSED                                                                                                                     [  5%]
test_agent.py::test_get_agents_overview_select[select2-all-None-1] PASSED                                                                                                                     [  7%]
test_agent.py::test_get_agents_overview_select[select3-Active,Pending-None-0] PASSED                                                                                                          [  9%]
test_agent.py::test_get_agents_overview_select[select4-Disconnected-None-1] PASSED                                                                                                            [ 11%]
test_agent.py::test_get_agents_overview_select[select5-Disconnected-1s-1] PASSED                                                                                                              [ 13%]
test_agent.py::test_get_agents_overview_select[select6-Disconnected-2h-0] PASSED                                                                                                              [ 15%]
test_agent.py::test_get_agents_overview_select[select7-all-15m-2] PASSED                                                                                                                      [ 17%]
test_agent.py::test_get_agents_overview_select[select8-Active-15m-0] PASSED                                                                                                                   [ 19%]
test_agent.py::test_get_agents_overview_select[select9-Active,Pending-15m-1] PASSED                                                                                                           [ 21%]
test_agent.py::test_get_agents_overview_select[select10-status10-15m-1] PASSED                                                                                                                [ 23%]
test_agent.py::test_get_agents_overview_query[ip=172.17.0.201] PASSED                                                                                                                         [ 25%]
test_agent.py::test_get_agents_overview_query[ip=172.17.0.202] PASSED                                                                                                                         [ 26%]
test_agent.py::test_get_agents_overview_query[ip=172.17.0.202;registerIP=any] PASSED                                                                                                          [ 28%]
test_agent.py::test_get_agents_overview_query[status=Disconnected;lastKeepAlive>34m] PASSED                                                                                                   [ 30%]
test_agent.py::test_get_agents_overview_query[(status=Active,status=Pending);lastKeepAlive>5m] PASSED                                                                                         [ 32%]
test_agent.py::test_get_agents_overview_search[search0-3] PASSED                                                                                                                              [ 34%]
test_agent.py::test_get_agents_overview_search[search1-3] PASSED                                                                                                                              [ 36%]
test_agent.py::test_get_agents_overview_search[search2-1] PASSED                                                                                                                              [ 38%]
test_agent.py::test_get_agents_overview_search[search3-5] PASSED                                                                                                                              [ 40%]
test_agent.py::test_get_agents_overview_search[search4-2] PASSED                                                                                                                              [ 42%]
test_agent.py::test_get_agents_overview_status_olderthan[active-9m-1-None] PASSED                                                                                                             [ 44%]
test_agent.py::test_get_agents_overview_status_olderthan[all-1s-5-None] PASSED                                                                                                                [ 46%]
test_agent.py::test_get_agents_overview_status_olderthan[pending,neverconnected-30m-1-None] PASSED                                                                                            [ 48%]
test_agent.py::test_get_agents_overview_status_olderthan[55-30m-0-1729] PASSED                                                                                                                [ 50%]
test_agent.py::test_get_config_error[100-logcollector-internal-1701] PASSED                                                                                                                   [ 51%]
test_agent.py::test_get_config_error[005-logcollector-internal-1740] PASSED                                                                                                                   [ 53%]
test_agent.py::test_get_config_error[002-logcollector-internal-1735] PASSED                                                                                                                   [ 55%]
test_agent.py::test_get_config_error[000-None-None-1307] PASSED                                                                                                                               [ 57%]
test_agent.py::test_get_config_error[000-random-random-1101] PASSED                                                                                                                           [ 59%]
test_agent.py::test_get_config_error[000-analysis-internal-1117] PASSED                                                                                                                       [ 61%]
test_agent.py::test_get_config_error[000-analysis-internal-1118] PASSED                                                                                                                       [ 63%]
test_agent.py::test_get_config_error[000-analysis-random-1116] PASSED                                                                                                                         [ 65%]
test_agent.py::test_get_config_error[000-analysis-internal-None] PASSED                                                                                                                       [ 67%]
test_agent.py::test_remove_manual[False] PASSED                                                                                                                                               [ 69%]
test_agent.py::test_remove_manual[True] PASSED                                                                                                                                                [ 71%]
test_agent.py::test_remove_manual_error[001-1746] PASSED                                                                                                                                      [ 73%]
test_agent.py::test_remove_manual_error[100-1701] PASSED                                                                                                                                      [ 75%]
test_agent.py::test_remove_manual_error[001-1600] PASSED                                                                                                                                      [ 76%]
test_agent.py::test_remove_manual_error[001-1748] PASSED                                                                                                                                      [ 78%]
test_agent.py::test_remove_manual_error[001-1747] PASSED                                                                                                                                      [ 80%]
test_agent.py::test_get_available_versions[001] PASSED                                                                                                                                        [ 82%]
test_agent.py::test_get_available_versions[002] PASSED                                                                                                                                        [ 84%]
test_agent.py::test_upgrade[001] PASSED                                                                                                                                                       [ 86%]
test_agent.py::test_upgrade[002] PASSED                                                                                                                                                       [ 88%]
test_agent.py::test_get_wpk_file[001] PASSED                                                                                                                                                  [ 90%]
test_agent.py::test_get_wpk_file[002] PASSED                                                                                                                                                  [ 92%]
test_agent.py::test_send_wpk_file[001] PASSED                                                                                                                                                 [ 94%]
test_agent.py::test_send_wpk_file[002] PASSED                                                                                                                                                 [ 96%]
test_agent.py::test_get_outdated_agents PASSED                                                                                                                                                [ 98%]
test_agent.py::test_get_full_summary PASSED                                                                                                                                                   [100%]
=============================================================================== 52 passed, 1 warnings in 0.78 seconds ===============================================================================
```

```python
% pytest
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.7.4, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: /home/druizz/Git/wazuh/framework, inifile:
plugins: tavern-0.26.3
collected 580 items                                                                                                                                                                                 

test_active_response.py ..........                                                                                                                                                            [  1%]
test_agent.py ....................................................                                                                                                                            [ 10%]
test_cdb_list.py ..............                                                                                                                                                               [ 13%]
test_ciscat.py ..                                                                                                                                                                             [ 13%]
test_common.py ......                                                                                                                                                                         [ 14%]
test_decoders.py ..........................................................                                                                                                                   [ 24%]
test_group.py ........                                                                                                                                                                        [ 25%]
test_input_validator.py ...                                                                                                                                                                   [ 26%]
test_manager.py .................................................                                                                                                                             [ 34%]
test_ossec_queue.py ...................                                                                                                                                                       [ 38%]
test_ossec_socket.py ..............                                                                                                                                                           [ 40%]
test_pyDaemonModule.py ......                                                                                                                                                                 [ 41%]
test_rules.py ........................................................................................................                                                                        [ 59%]
test_security_configuration_assessment.py .......                                                                                                                                             [ 60%]
test_stats.py ...................                                                                                                                                                             [ 63%]
test_syscheck.py ...................                                                                                                                                                          [ 67%]
test_syscollector.py .........................                                                                                                                                                [ 71%]
test_utils.py ..................................................................................................................................................                              [ 96%]
test_wdb.py ...................                                                                                                                                                               [100%]

============================================================================== 580 passed, 4 warnings in 11.79 seconds ==============================================================================
```

Best regards,

Demetrio.