### PR TITLE
Restructuring of the function os_ReportdStart

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -91,6 +91,7 @@ ifeq (${uname_S},Linux)
 #		OSSEC_LDFLAGS+=-lmagic
 		CFLAGS+=-Wl,--start-group
 		USE_AUDIT=yes
+		OSSEC_CFLAGS+=-std=gnu99
 ifneq (,$(filter ${USE_AUDIT},yes y Y 1))
 		CFLAGS+=-I$(EXTERNAL_AUDIT)lib
 endif

--- a/src/shared/report_op.c
+++ b/src/shared/report_op.c
@@ -664,6 +664,8 @@ void os_ReportdStart(report_filter *r_filter)
         fclose(fileq->fp);
     }
 
+    os_free(first_alert);
+    os_free(last_alert);
     os_free(msg_show_alerts);
     free(fileq);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#2832|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

I modified the function `os_ReportdStart`. Now don't saves in the variable `data_to_clean` when is prepared to send the alert log in the report. My changes save the alert log, if it has to be sent, instead of all alerts. This not modified the functioning of `os_ReportdStart` but, prevents using the memory from rising, when we have millions of alerts.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

``` logs
2019/08/13 09:09:23 ossec-monitord[15631] generate_reports.c:55 at generate_reports(): INFO: Starting daily reporting for 'Daily report: File changes'
2019/08/13 09:09:29 ossec-monitord[15631] report_op.c:593 at os_ReportdStart(): INFO: Report 'Daily report: File changes' completed. Creating output...
==6478== 
==6478== HEAP SUMMARY:
==6478==     in use at exit: 305,632 bytes in 12,665 blocks
==6478==   total heap usage: 66,927 allocs, 54,262 frees, 7,874,717 bytes allocated
==6478== 
==6478== LEAK SUMMARY:
==6478==    definitely lost: 0 bytes in 0 blocks
==6478==    indirectly lost: 0 bytes in 0 blocks
==6478==      possibly lost: 0 bytes in 0 blocks
==6478==    still reachable: 305,632 bytes in 12,665 blocks
==6478==         suppressed: 0 bytes in 0 blocks
==6478== Reachable blocks (those to which a pointer was found) are not shown.
==6478== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==6478== 
==6478== For counts of detected and suppressed errors, rerun with: -v
==6478== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [X] Stress test for affected components