### PR TITLE
Fix error code when a configuration file of an agent is updated

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -673,8 +673,8 @@ def upload_group_configuration(group_id, file_content):
         try:
             new_conf_path = "{}/{}/agent.conf".format(common.shared_path, group_id)
             safe_move(tmp_file_path, new_conf_path, permissions=0o660)
-        except Exception as e:
-            raise WazuhException(1017, str(e))
+        except Exception:
+            raise WazuhException(1016)
 
         return 'Agent configuration was updated successfully'
     except Exception as e:


### PR DESCRIPTION
Hi team,

I found an error in the number of the exception which is raised if a `move` operation fails and this PR fixes it.

Best regards,

Demetrio.