### PR TITLE
New method for restarting agents by group

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -16,6 +16,7 @@ from os import chown, chmod, path, makedirs, urandom, listdir, stat, remove
 from platform import platform
 from shutil import copyfile, rmtree
 from time import time, sleep
+from typing import Dict
 
 import fcntl
 import requests
@@ -866,6 +867,20 @@ class Agent:
 
             return final_dict
 
+    @staticmethod
+    def restart_agents_by_group(group_id: str) -> Dict:
+        """Restart all the agents which belong to a group.
+
+        :param group_id: Name of the group
+        :return: Confirmation message
+        """
+        # list with agent IDs to restart. Contains key-value pairs.
+        agent_list = Agent.get_agent_group(group_id=group_id,
+                                           select={'fields': ['id']}).get('items')
+        # format agent_list as a list with strings of agent IDs
+        agent_list = [elem.get('id') for elem in agent_list]
+
+        return Agent.restart_agents(agent_id=agent_list)
 
     @staticmethod
     def get_agent_by_name(agent_name, select=None):

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -101,6 +101,11 @@ functions = {
         'type': 'distributed_master',
         'is_async': False
     },
+    'PUT/agents/groups/:group_id/restart': {
+        'function': Agent.restart_agents_by_group,
+        'type': 'local_master',
+        'is_async': False
+    },
     'PUT/agents/:agent_name': {
         'function': Agent.add_agent,
         'type': 'local_master',


### PR DESCRIPTION
Hi team,

This PR add a new method in `Agent` class (`agent.py` module) for restarting agents by group. There are more details about this development in [#411](https://github.com/wazuh/wazuh-api/issues/411).

Best regards,

Demetrio.