### PR TITLE
Fix duplicated linked files at logcollector

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -75,7 +75,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     }
     memset(log_config->globs + gl, 0, sizeof(logreader_glob));
     memset(logf + pl, 0, sizeof(logreader));
-    //os_calloc(1, sizeof(wlabel_t), logf[pl].labels);
+
     logf[pl].ign = 360;
     logf[pl].exists = 1;
     logf[pl].future = 1;
@@ -480,15 +480,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             }
         }
     }
-
-
-    /*
-    if (!logf[pl].labels) {
-        os_calloc(1, sizeof(wlabel_t), logf[pl].labels);
-    }
-    */
-
-
 
     /* Missing file */
     if (!logf[pl].file) {

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -194,6 +194,7 @@
 #define OPEN_UNABLE     "(1963): Unable to open file '%s'."
 #define NON_TEXT_FILE   "(1964): File '%s' is not ASCII or UTF-8 encoded."
 #define EXCLUDE_FILE    "(1965): File excluded: '%s'."
+#define DUP_FILE_INODE  "(1966): Inode for file '%s' already found. Skipping it."
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1457,13 +1457,13 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
             struct stat statCurrent, statDup;
 
             if (stat(current->file, &statCurrent) < 0){
-                merror("Couldn't stat file %s", current->file);
+                merror("Couldn't stat file '%s'", current->file);
                 d_control = LEAVE_IT;
                 break;
             }
 
             if (stat(dup->file, &statDup) < 0){
-                merror("Couldn't stat file %s", dup->file);
+                merror("Couldn't stat file '%s'", dup->file);
                 d_control = LEAVE_IT;
                 break;
             }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1464,21 +1464,31 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
                 }
             }
 
+            if (!dup->file || dup->command) {
+                continue;
+            }
+
             struct stat statCurrent, statDup;
 
-            if (stat(current->file, &statCurrent) < 0){
-                merror("Couldn't stat file '%s'", current->file);
-                d_control = LEAVE_IT;
-                break;
-            }
+            if (strcmp(current->logformat, "eventchannel") && strcmp(current->logformat, "eventlog") &&
+                strcmp(dup->logformat, "eventchannel") && strcmp(dup->logformat, "eventlog")) {
 
-            if (stat(dup->file, &statDup) < 0){
-                merror("Couldn't stat file '%s'", dup->file);
-                d_control = LEAVE_IT;
-                break;
-            }
+                if (stat(current->file, &statCurrent) < 0){
+                    merror("Couldn't stat file '%s'", current->file);
+                    d_control = LEAVE_IT;
+                    break;
+                }
 
-            same_inode = (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev) ? 1 : 0;
+                if (stat(dup->file, &statDup) < 0){
+                    merror("Couldn't stat file '%s'", dup->file);
+                    d_control = LEAVE_IT;
+                    break;
+                }
+
+                same_inode = (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev) ? 1 : 0;
+            } else {
+                same_inode = 0;
+            }
 
             if (current != dup && dup->file && (!strcmp(current->file, dup->file) || same_inode)) {
                 if (same_inode) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1454,7 +1454,17 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
                 }
             }
 
-            if (current != dup && dup->file && !strcmp(current->file, dup->file)) {
+            struct stat statCurrent, statDup;
+
+            if (stat(current->file, &statCurrent) < 0){
+                merror("Couldn't stat file %s", current->file);
+            }
+
+            if (stat(dup->file, &statDup) < 0){
+                merror("Couldn't stat file %s", current->file);
+            }
+
+            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || statCurrent.st_ino == statDup.st_ino)) {
                 mwarn(DUP_FILE, current->file);
                 int result;
                 if (j < 0) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1480,7 +1480,7 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
 
             same_inode = (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev) ? 1 : 0;
 
-            if ((current != dup && dup->file && (!strcmp(current->file, dup->file))) || same_inode) {
+            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || same_inode)) {
                 if (same_inode) {
                     mdebug1(DUP_FILE_INODE, current->file);
                 } else {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1490,7 +1490,7 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
                 same_inode = (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev) ? 1 : 0;
             }
 
-            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || same_inode)) {
+            if (current != dup && (!strcmp(current->file, dup->file) || same_inode)) {
                 if (same_inode) {
                     mdebug1(DUP_FILE_INODE, current->file);
                 } else {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1456,6 +1456,8 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
 
     if (current->file && !current->command) {
         for (r = 0, k = -1;; r++) {
+            same_inode = 0;
+
             if (f_control = update_current(&dup, &r, &k), f_control) {
                 if (f_control == NEXT_IT) {
                     continue;
@@ -1486,8 +1488,6 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
                 }
 
                 same_inode = (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev) ? 1 : 0;
-            } else {
-                same_inode = 0;
             }
 
             if (current != dup && dup->file && (!strcmp(current->file, dup->file) || same_inode)) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1455,16 +1455,13 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
             }
 
             struct stat statCurrent, statDup;
+            int success_stat = 0;
 
-            if (stat(current->file, &statCurrent) < 0){
-                merror("Couldn't stat file %s", current->file);
+            if (stat(current->file, &statCurrent) == 0 && stat(dup->file, &statDup) == 0) {
+                success_stat = 1;
             }
 
-            if (stat(dup->file, &statDup) < 0){
-                merror("Couldn't stat file %s", current->file);
-            }
-
-            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev))) {
+            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || (success_stat && statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev))) {
                 mwarn(DUP_FILE, current->file);
                 int result;
                 if (j < 0) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1464,7 +1464,7 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
                 merror("Couldn't stat file %s", current->file);
             }
 
-            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || statCurrent.st_ino == statDup.st_ino)) {
+            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev))) {
                 mwarn(DUP_FILE, current->file);
                 int result;
                 if (j < 0) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1455,13 +1455,20 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
             }
 
             struct stat statCurrent, statDup;
-            int success_stat = 0;
 
-            if (stat(current->file, &statCurrent) == 0 && stat(dup->file, &statDup) == 0) {
-                success_stat = 1;
+            if (stat(current->file, &statCurrent) < 0){
+                merror("Couldn't stat file %s", current->file);
+                d_control = LEAVE_IT;
+                break;
             }
 
-            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || (success_stat && statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev))) {
+            if (stat(dup->file, &statDup) < 0){
+                merror("Couldn't stat file %s", dup->file);
+                d_control = LEAVE_IT;
+                break;
+            }
+
+            if (current != dup && dup->file && (!strcmp(current->file, dup->file) || (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev))) {
                 mwarn(DUP_FILE, current->file);
                 int result;
                 if (j < 0) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1469,7 +1469,12 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
             }
 
             if (current != dup && dup->file && (!strcmp(current->file, dup->file) || (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev))) {
-                mwarn(DUP_FILE, current->file);
+                if (statCurrent.st_ino == statDup.st_ino) {
+                    mdebug1(DUP_FILE_INODE, current->file);
+                } else {
+                    mwarn(DUP_FILE, current->file);
+                }
+
                 int result;
                 if (j < 0) {
                     result = Remove_Localfile(&logff, i, 0, 1,NULL);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1132,7 +1132,7 @@ int check_pattern_expand(int do_seek) {
                     int added = 0;
 
                     if(!ex_file) {
-                        minfo(NEW_GLOB_FILE, globs[j].gpath, g.gl_pathv[glob_offset]);
+                        mdebug1(NEW_GLOB_FILE, globs[j].gpath, g.gl_pathv[glob_offset]);
 
                         os_realloc(globs[j].gfiles, (i +2)*sizeof(logreader), globs[j].gfiles);
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #3854|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR extends the duplicate file detection for logcollector with inode comparison, useful for symbolic and hard links.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

Using the next configuration with a symbolic link as _softlink.log_ and a hard link as _hardlink.log_:
```
<localfile>
    <log_format>syslog</log_format>
    <location>/home/cristina/softlink.log</location>
</localfile>

<localfile>
    <log_format>syslog</log_format>
    <location>/home/cristina/hardlink.log</location>
</localfile>

<localfile>
    <log_format>syslog</log_format>
    <location>/home/cristina/test-logcollector/realfile.log</location>
</localfile>
```

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->
The _ossec.log_ file reports the following:
```
2019/08/22 11:31:47 ossec-logcollector: WARNING: (1958): Log file '/home/cristina/softlink.log' is duplicated.
2019/08/22 11:31:47 ossec-logcollector: WARNING: (1958): Log file '/home/cristina/hardlink.log' is duplicated.
2019/08/22 11:31:47 ossec-logcollector: INFO: (1950): Analyzing file: '/home/cristina/test-logcollector/realfile.log'.
```


When writing to one of these files, the _archives.log_ file shows the next event:
`2019 Aug 22 11:31:59 ubuntu->/home/cristina/test-logcollector/realfile.log Aug 14 00:00:00 ubuntu logtest[0]: testing monitored links`
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
```
==14704== 
==14704== HEAP SUMMARY:
==14704==     in use at exit: 36,433 bytes in 26 blocks
==14704==   total heap usage: 4,569 allocs, 4,543 frees, 1,860,495 bytes allocated
==14704== 
==14704== LEAK SUMMARY:
==14704==    definitely lost: 0 bytes in 0 blocks
==14704==    indirectly lost: 0 bytes in 0 blocks
==14704==      possibly lost: 1,632 bytes in 6 blocks
==14704==    still reachable: 34,801 bytes in 20 blocks
==14704==         suppressed: 0 bytes in 0 blocks
==14704== Rerun with --leak-check=full to see details of leaked memory
==14704== 
==14704== For counts of detected and suppressed errors, rerun with: -v
==14704== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
  - [x] AddressSanitizer
- Memory tests for macOS
  - [x] Scan-build report
```
scan-build: Removing directory '/tmp/scan-build-2019-08-23-093445-65672-1' because it contains no reports.
scan-build: No bugs found.
```
  - [x] Leaks
```
# leaks ossec-logcollector 
Process:         ossec-logcollector [68420]
Path:            /private/var/ossec/bin/ossec-logcollector
Load Address:    0x103c05000
Identifier:      ossec-logcollector
Version:         ???
Code Type:       X86-64
Parent Process:  launchd [1]

Date/Time:       2019-08-23 09:40:01.323 +0200
Launch Time:     2019-08-23 09:39:21.439 +0200
OS Version:      Mac OS X 10.13.5 (17F77)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         1100K
Physical footprint (peak):  1100K
----

leaks Report Version: 3.0
Process 68420: 716 nodes malloced for 204 KB
Process 68420: 29 leaks for 9872 total leaked bytes.
```
  - [x] AddressSanitizer

- Functionality tests
  - [x] Check that the configuration from below does only show one message at the archives.log file when modifying one of them.
  - [x] Add a wildcard that includes symbolic and hard links. It should show them as duplicates. Check that writing into one of them does only show one event at the archives.log file.
  - [x] Add a wildcard with one file. After restarting, create a symbolic and hard link from that file. After a while, they should match the pattern and be ignored as they are duplicated. Writing to the file only shows one event.
  - [x] Creating more hard and soft links from the already created hard, soft and regular file has the expected results.
  - [x] If `stat` fails for one of the files, the message: `Couldn't stat file 'file.log'` will appear at ossec.log, then, it continues with the next iteration. This message will appear every time the configuration is reloaded.
  - [x] If the duplicated files have the same inode, the debug message shown is `Inode for file 'file.log' already found. Skipping it.`, else, the message `Log file 'file.log' is duplicated` is printed.
  - [x] Check that eventchannel or eventlog log formats are correctly being removed if they are duplicated.
  - [x] Adding twice a monitored folder with lots of files with hard and symbolic links has the expected result. Every modification to a file is logged once.
  - [x] Check that `full_command` does not log any errors at ossec.log