### PR TITLE
Request SCA scan when the table sca_check is empty

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1137,9 +1137,6 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
 
     switch (result_db)
     {
-        case -1:
-            merror("Error querying policy monitoring database for agent %s", lf->agent_id);
-            break;
         case 0:
         case 1:
 
@@ -1156,7 +1153,9 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             }
 
             break;
+            
         default:
+            merror("Error querying policy monitoring database for agent %s", lf->agent_id);
             break;
     }
 

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1141,6 +1141,7 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
             merror("Error querying policy monitoring database for agent %s", lf->agent_id);
             break;
         case 0:
+        case 1:
 
             /* Integrity check */
             if(strcmp(wdb_response,hash->valuestring)) {


### PR DESCRIPTION
|Related issue|
|---|
|#3882|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

To fix the issue the manager will request a scan when the integrity fails and when the table of results is empty.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
