### PR TITLE
Fix bugs reported by Clang analyzer

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1395,7 +1395,6 @@ int Rules_OP_ReadRules(const char *rulefile)
                 if (!config_ruleinfo->group_search) {
                     merror_exit(MEM_ERROR, errno, strerror(errno));
                 }
-                //OSList_SetFreeDataPointer(config_ruleinfo->group_search, (void (*)(void *)) Free_Eventinfo);
 
                 /* Mark rules that match this group */
                 OS_MarkGroup(NULL, config_ruleinfo);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -153,6 +153,7 @@ int Rules_OP_ReadRules(const char *rulefile)
     char *extra_data = NULL;
     char *program_name = NULL;
     char *location = NULL;
+    RuleInfo *config_ruleinfo = NULL;
 
     size_t i;
     default_timeframe = 360;
@@ -247,7 +248,7 @@ int Rules_OP_ReadRules(const char *rulefile)
         }
 
         while (rule[j]) {
-            RuleInfo *config_ruleinfo = NULL;
+            config_ruleinfo = NULL;
 
             /* Check if the rule element is correct */
             if (!rule[j]->element) {
@@ -1457,14 +1458,12 @@ cleanup:
     free(url);
     free(if_matched_group);
     free(if_matched_regex);
-
-
-
-
-
-
     free(rulepath);
     OS_ClearNode(rule);
+
+    if (retval) {
+        free(config_ruleinfo);
+    }
 
     /* Clean global node */
     OS_ClearNode(node);

--- a/src/config/reports-config.c
+++ b/src/config/reports-config.c
@@ -116,20 +116,13 @@ int Read_CReports(XML_NODE node, void *config, __attribute__((unused)) void *con
                 mon_config->reports[s]->r_filter.show_alerts = 1;
             }
         } else if (strcmp(node[i]->element, xml_categories) == 0) {
-            char *ncat = NULL;
             int result;
 
             _filter_arg(node[i]->content);
 
-            os_strdup(node[i]->content, ncat);
-
-            if (result = os_report_configfilter("group", ncat,
+            if (result = os_report_configfilter("group", node[i]->content,
                                        &mon_config->reports[s]->r_filter, REPORT_FILTER), result < 0) {
                 merror(CONFIG_ERROR, "user argument");
-            }
-
-            if (result < 0 || result == 1) {
-                free(ncat);
             }
         } else if ((strcmp(node[i]->element, xml_group) == 0) ||
                    (strcmp(node[i]->element, xml_rule) == 0) ||
@@ -139,7 +132,6 @@ int Read_CReports(XML_NODE node, void *config, __attribute__((unused)) void *con
                    (strcmp(node[i]->element, xml_user) == 0)) {
             int result;
             int reportf = REPORT_FILTER;
-            char *ncat = NULL;
             _filter_arg(node[i]->content);
 
             if (node[i]->attributes && node[i]->values) {
@@ -160,15 +152,9 @@ int Read_CReports(XML_NODE node, void *config, __attribute__((unused)) void *con
                 }
             }
 
-            os_strdup(node[i]->content, ncat);
-
-            if (result = os_report_configfilter(node[i]->element, ncat,
+            if (result = os_report_configfilter(node[i]->element, node[i]->content,
                                        &mon_config->reports[s]->r_filter, reportf), result < 0) {
                 merror("Invalid filter: %s:%s (ignored).", node[i]->element, node[i]->content);
-            }
-
-            if (result < 0 || result == 1) {
-                free(ncat);
             }
         } else if (strcmp(node[i]->element, xml_email) == 0) {
             mon_config->reports[s]->emailto = os_AddStrArray(node[i]->content, mon_config->reports[s]->emailto);

--- a/src/config/reports-config.c
+++ b/src/config/reports-config.c
@@ -116,12 +116,10 @@ int Read_CReports(XML_NODE node, void *config, __attribute__((unused)) void *con
                 mon_config->reports[s]->r_filter.show_alerts = 1;
             }
         } else if (strcmp(node[i]->element, xml_categories) == 0) {
-            int result;
-
             _filter_arg(node[i]->content);
 
-            if (result = os_report_configfilter("group", node[i]->content,
-                                       &mon_config->reports[s]->r_filter, REPORT_FILTER), result < 0) {
+            if (os_report_configfilter("group", node[i]->content,
+                                       &mon_config->reports[s]->r_filter, REPORT_FILTER)) {
                 merror(CONFIG_ERROR, "user argument");
             }
         } else if ((strcmp(node[i]->element, xml_group) == 0) ||
@@ -130,7 +128,6 @@ int Read_CReports(XML_NODE node, void *config, __attribute__((unused)) void *con
                    (strcmp(node[i]->element, xml_location) == 0) ||
                    (strcmp(node[i]->element, xml_srcip) == 0) ||
                    (strcmp(node[i]->element, xml_user) == 0)) {
-            int result;
             int reportf = REPORT_FILTER;
             _filter_arg(node[i]->content);
 
@@ -152,8 +149,8 @@ int Read_CReports(XML_NODE node, void *config, __attribute__((unused)) void *con
                 }
             }
 
-            if (result = os_report_configfilter(node[i]->element, node[i]->content,
-                                       &mon_config->reports[s]->r_filter, reportf), result < 0) {
+            if (os_report_configfilter(node[i]->element, node[i]->content,
+                                       &mon_config->reports[s]->r_filter, reportf)) {
                 merror("Invalid filter: %s:%s (ignored).", node[i]->element, node[i]->content);
             }
         } else if (strcmp(node[i]->element, xml_email) == 0) {

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -518,12 +518,17 @@ char *OS_GetHost(const char *host, unsigned int attempts)
             continue;
         }
 
+// Avoid a false positive with a casting of non-structure
+#ifndef __clang_analyzer__
         sz = strlen(inet_ntoa(*((struct in_addr *)h->h_addr))) + 1;
+#endif
         if ((ip = (char *) calloc(sz, sizeof(char))) == NULL) {
             return (NULL);
         }
 
+#ifndef __clang_analyzer__
         strncpy(ip, inet_ntoa(*((struct in_addr *)h->h_addr)), sz - 1);
+#endif
 
         return (ip);
     }

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -518,7 +518,7 @@ char *OS_GetHost(const char *host, unsigned int attempts)
             continue;
         }
 
-// Avoid a false positive with a casting of non-structure
+// Avoid a false positive due to a casting of non-structure
 #ifndef __clang_analyzer__
         sz = strlen(inet_ntoa(*((struct in_addr *)h->h_addr))) + 1;
 #endif

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -518,10 +518,7 @@ char *OS_GetHost(const char *host, unsigned int attempts)
             continue;
         }
 
-// Avoid a false positive due to a casting of non-structure
-#ifndef __clang_analyzer__
         sz = strlen(inet_ntoa(*((struct in_addr *)h->h_addr))) + 1;
-#endif
         if ((ip = (char *) calloc(sz, sizeof(char))) == NULL) {
             return (NULL);
         }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1070,7 +1070,7 @@ static void read_controlmsg(const char *agent_id, char *msg)
             }
 
             // Copy sum before unlock mutex
-            if (*f_sum[0]->sum) {
+            if (f_sum[0]->sum && *(f_sum[0]->sum)) {
                 memcpy(tmp_sum, f_sum[0]->sum, sizeof(tmp_sum));
             }
 

--- a/src/reportd/report.c
+++ b/src/reportd/report.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
                 related_values = argv[optind];
 
                 if (os_report_configfilter(related_of, related_values,
-                                           &r_filter, REPORT_RELATED) < 0) {
+                                           &r_filter, REPORT_RELATED)) {
                     merror_exit(CONFIG_ERROR, "user argument");
                 }
                 optind++;
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
                 filter_value = argv[optind];
 
                 if (os_report_configfilter(filter_by, filter_value,
-                                           &r_filter, REPORT_FILTER) < 0) {
+                                           &r_filter, REPORT_FILTER)) {
                     merror_exit(CONFIG_ERROR, "user argument");
                 }
                 optind++;

--- a/src/rootcheck/check_rc_pids.c
+++ b/src/rootcheck/check_rc_pids.c
@@ -247,7 +247,7 @@ static void loop_all_pids(const char *ps, pid_t max_pid, int *_errors, int *_tot
                    _gpid1 != _kill1 ||
                    _gpid1 != _gsid1) {
             /* See defunct process comment above */
-            if (! (_kill1 == 1 && _gsid1 == 0 && _gpid0 == 0 && _gsid1 == 0) ) {
+            if (! (_kill1 == 1 && _gsid1 == 0 && _gpid0 == 0) ) {
                 char op_msg[OS_SIZE_1024 + 1];
 
                 snprintf(op_msg, OS_SIZE_1024, "Process '%d' hidden from "

--- a/src/rootcheck/os_string.c
+++ b/src/rootcheck/os_string.c
@@ -180,7 +180,7 @@ int os_string(char *file, char *regex)
     oss.head_len = 0;
     oss.read_len = -1;
 #ifndef __clang_analyzer__
-    // Avoid a false positive with a casting of non-structure: hbfr is a pointer to a sizeof(EXEC) memory
+    // Avoid a false positive due to a casting of non-structure: hbfr is a pointer to a sizeof(EXEC) memory
     head = (EXEC *)oss.hbfr;
 #endif
 

--- a/src/rootcheck/os_string.c
+++ b/src/rootcheck/os_string.c
@@ -179,10 +179,7 @@ int os_string(char *file, char *regex)
     oss.foff = 0;
     oss.head_len = 0;
     oss.read_len = -1;
-#ifndef __clang_analyzer__
-    // Avoid a false positive due to a casting of non-structure: hbfr is a pointer to a sizeof(EXEC) memory
     head = (EXEC *)oss.hbfr;
-#endif
 
     if ((oss.head_len = read(fileno(oss.fp), head, sizeof(EXEC))) == -1) {
         oss.head_len = 0;

--- a/src/rootcheck/os_string.c
+++ b/src/rootcheck/os_string.c
@@ -150,7 +150,7 @@ int os_string(char *file, char *regex)
     unsigned char *bfr;
     char line[OS_SIZE_1024 + 1];
     char *buf;
-    EXEC *head;
+    EXEC *head = NULL;
     os_strings oss;
 
     /* Return didn't match */
@@ -179,7 +179,10 @@ int os_string(char *file, char *regex)
     oss.foff = 0;
     oss.head_len = 0;
     oss.read_len = -1;
+#ifndef __clang_analyzer__
+    // Avoid a false positive with a casting of non-structure: hbfr is a pointer to a sizeof(EXEC) memory
     head = (EXEC *)oss.hbfr;
+#endif
 
     if ((oss.head_len = read(fileno(oss.fp), head, sizeof(EXEC))) == -1) {
         oss.head_len = 0;

--- a/src/shared/report_op.c
+++ b/src/shared/report_op.c
@@ -83,7 +83,7 @@ static int _os_report_str_int_compare(const char *str, int id)
             }
             pt_check = 1;
         } else {
-            return (-1);
+            return -1;
         }
     } while (*str++ != '\0');
 
@@ -195,7 +195,7 @@ static int _report_filter_value(const char *filter_by, int prev_filter)
         return (prev_filter);
     } else {
         merror("Invalid relation '%s'.", filter_by);
-        return (-1);
+        return -1;
     }
 }
 
@@ -665,7 +665,7 @@ int os_report_configfilter(const char *filter_by, const char *filter_value,
                            report_filter *r_filter, int arg_type)
 {
     if (!filter_by || !filter_value) {
-        return (-1);
+        return -1;
     }
 
     if (arg_type == REPORT_FILTER) {
@@ -685,7 +685,7 @@ int os_report_configfilter(const char *filter_by, const char *filter_value,
             os_strdup(filter_value, r_filter->files);
         } else {
             merror("Invalid filter '%s'.", filter_by);
-            return (-1);
+            return -1;
         }
     } else {
         if (strcmp(filter_by, "group") == 0) {
@@ -693,56 +693,55 @@ int os_report_configfilter(const char *filter_by, const char *filter_value,
                 _report_filter_value(filter_value, r_filter->related_group);
 
             if (r_filter->related_group == -1) {
-                return (-1);
+                return -1;
             }
         } else if (strcmp(filter_by, "rule") == 0) {
             r_filter->related_rule =
                 _report_filter_value(filter_value, r_filter->related_rule);
 
             if (r_filter->related_rule == -1) {
-                return (-1);
+                return -1;
             }
         } else if (strcmp(filter_by, "level") == 0) {
             r_filter->related_level =
                 _report_filter_value(filter_value, r_filter->related_level);
 
             if (r_filter->related_level == -1) {
-                return (-1);
+                return -1;
             }
         } else if (strcmp(filter_by, "location") == 0) {
             r_filter->related_location =
                 _report_filter_value(filter_value, r_filter->related_location);
 
             if (r_filter->related_location == -1) {
-                return (-1);
+                return -1;
             }
         } else if (strcmp(filter_by, "srcip") == 0) {
             r_filter->related_srcip =
                 _report_filter_value(filter_value, r_filter->related_srcip);
 
             if (r_filter->related_srcip == -1) {
-                return (-1);
+                return -1;
             }
         } else if (strcmp(filter_by, "user") == 0) {
             r_filter->related_user =
                 _report_filter_value(filter_value, r_filter->related_user);
 
             if (r_filter->related_user == -1) {
-                return (-1);
+                return -1;
             }
         } else if (strcmp(filter_by, "filename") == 0) {
             r_filter->related_file =
                 _report_filter_value(filter_value, r_filter->related_file);
 
             if (r_filter->related_file == -1) {
-                return (-1);
+                return -1;
             }
         } else {
             merror("Invalid related entry '%s'.", filter_by);
-            return (-1);
+            return -1;
         }
-        return 1;
     }
 
-    return (0);
+    return 0;
 }

--- a/src/shared/report_op.c
+++ b/src/shared/report_op.c
@@ -46,10 +46,10 @@ static void *_os_report_sort_compare(void *d1, void *d2)
     OSList *d2l = (OSList *)d2;
 
     if (d1l->currently_size > d2l->currently_size) {
-        return (d1l);
+        return d1l;
     }
 
-    return (NULL);
+    return NULL;
 }
 
 /* Print output header */
@@ -78,7 +78,7 @@ static int _os_report_str_int_compare(const char *str, int id)
         } else if (isdigit((int)*str)) {
             if (pt_check == 0) {
                 if (id == atoi(str)) {
-                    return (1);
+                    return 1;
                 }
             }
             pt_check = 1;
@@ -87,7 +87,7 @@ static int _os_report_str_int_compare(const char *str, int id)
         }
     } while (*str++ != '\0');
 
-    return (0);
+    return 0;
 }
 
 /* Check if the al_data should be filtered */
@@ -97,62 +97,62 @@ static int _os_report_check_filters(const alert_data *al_data, const report_filt
     if (r_filter->group) {
         if (al_data->group) {   /* Probably unnecessary, all (?) alerts should have groups) */
             if (!strstr(al_data->group, r_filter->group)) {
-                return (0);
+                return 0;
             }
         }
     }
     if (r_filter->rule) {
         if (_os_report_str_int_compare(r_filter->rule, al_data->rule) != 1) {
-            return (0);
+            return 0;
         }
     }
     if (r_filter->location) {
         if (!OS_Match(r_filter->location, al_data->location)) {
-            return (0);
+            return 0;
         }
     }
     if (r_filter->level) {
         if (al_data->level < (unsigned int) atoi(r_filter->level)) {
-            return (0);
+            return 0;
         }
     }
     if (r_filter->srcip) {
         if(!al_data->srcip) {
-            return(0);
+            return 0;
         }
         if (al_data->srcip) {
             if (!strstr(al_data->srcip, r_filter->srcip)) {
-                return (0);
+                return 0;
             }
         } else {
-            return (0);
+            return 0;
         }
     }
     if (r_filter->user) {
         if(!al_data->user) {
-            return(0);
+            return 0;
         }
         if (al_data->user) {
             if (!strstr(al_data->user, r_filter->user)) {
-                return (0);
+                return 0;
             }
         } else {
-            return (0);
+            return 0;
         }
     }
     if (r_filter->files) {
         if(!al_data->filename) {
-            return(0);
+            return 0;
         }
         if (al_data->filename) {
             if (!strstr(al_data->filename, r_filter->files)) {
-                return (0);
+                return 0;
             }
         } else {
-            return (0);
+            return 0;
         }
     }
-    return (1);
+    return 1;
 }
 
 /* Set the proper value for the related entries */
@@ -162,37 +162,37 @@ static int _report_filter_value(const char *filter_by, int prev_filter)
         if (!(prev_filter & REPORT_REL_GROUP)) {
             prev_filter |= REPORT_REL_GROUP;
         }
-        return (prev_filter);
+        return prev_filter;
     } else if (strcmp(filter_by, "rule") == 0) {
         if (!(prev_filter & REPORT_REL_RULE)) {
             prev_filter |= REPORT_REL_RULE;
         }
-        return (prev_filter);
+        return prev_filter;
     } else if (strcmp(filter_by, "level") == 0) {
         if (!(prev_filter & REPORT_REL_LEVEL)) {
             prev_filter |= REPORT_REL_LEVEL;
         }
-        return (prev_filter);
+        return prev_filter;
     } else if (strcmp(filter_by, "location") == 0) {
         if (!(prev_filter & REPORT_REL_LOCATION)) {
             prev_filter |= REPORT_REL_LOCATION;
         }
-        return (prev_filter);
+        return prev_filter;
     } else if (strcmp(filter_by, "srcip") == 0) {
         if (!(prev_filter & REPORT_REL_SRCIP)) {
             prev_filter |= REPORT_REL_SRCIP;
         }
-        return (prev_filter);
+        return prev_filter;
     } else if (strcmp(filter_by, "user") == 0) {
         if (!(prev_filter & REPORT_REL_USER)) {
             prev_filter |= REPORT_REL_USER;
         }
-        return (prev_filter);
+        return prev_filter;
     } else if (strcmp(filter_by, "filename") == 0) {
         if (!(prev_filter & REPORT_REL_FILE)) {
             prev_filter |= REPORT_REL_FILE;
         }
-        return (prev_filter);
+        return prev_filter;
     } else {
         merror("Invalid relation '%s'.", filter_by);
         return -1;
@@ -286,7 +286,7 @@ static int _os_report_print_related(int print_related, OSList *st_data)
         list_entry = OSList_GetNextNode(st_data);
     }
 
-    return (0);
+    return 0;
 }
 
 /* Add the entry to the hash */
@@ -302,14 +302,14 @@ static int _os_report_add_tostore(const char *key, OSStore *top, void *data)
         top_list = OSList_Create();
         if (!top_list) {
             merror(MEM_ERROR, errno, strerror(errno));
-            return (0);
+            return 0;
         }
         OSList_AddData(top_list, data);
 
         OSStore_Put(top, key, top_list);
     }
 
-    return (1);
+    return 1;
 }
 
 void os_report_printtop(void *topstore_pt, const char *hname, int print_related)

--- a/src/shared/report_op.c
+++ b/src/shared/report_op.c
@@ -670,19 +670,19 @@ int os_report_configfilter(const char *filter_by, const char *filter_value,
 
     if (arg_type == REPORT_FILTER) {
         if (strcmp(filter_by, "group") == 0) {
-            r_filter->group = filter_value;
+            os_strdup(filter_value, r_filter->group);
         } else if (strcmp(filter_by, "rule") == 0) {
-            r_filter->rule = filter_value;
+            os_strdup(filter_value, r_filter->rule);
         } else if (strcmp(filter_by, "level") == 0) {
-            r_filter->level = filter_value;
+            os_strdup(filter_value, r_filter->level);
         } else if (strcmp(filter_by, "location") == 0) {
-            r_filter->location = filter_value;
+            os_strdup(filter_value, r_filter->location);
         } else if (strcmp(filter_by, "user") == 0) {
-            r_filter->user = filter_value;
+            os_strdup(filter_value, r_filter->user);
         } else if (strcmp(filter_by, "srcip") == 0) {
-            r_filter->srcip = filter_value;
+            os_strdup(filter_value, r_filter->srcip);
         } else if (strcmp(filter_by, "filename") == 0) {
-            r_filter->files = filter_value;
+            os_strdup(filter_value, r_filter->files);
         } else {
             merror("Invalid filter '%s'.", filter_by);
             return (-1);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -1277,7 +1277,7 @@ void audit_read_events(int *audit_sock, int mode) {
 
                 // Append to cache
                 len = endline - line;
-                if (cache_i + len + 1 > sizeof(cache)) {
+                if (cache_i + len + 1 > BUF_SIZE) {
                     strncpy(cache + cache_i, line, len);
                     cache_i += len;
                     cache[cache_i++] = '\n';

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -1277,7 +1277,7 @@ void audit_read_events(int *audit_sock, int mode) {
 
                 // Append to cache
                 len = endline - line;
-                if (cache_i + len + 1 > BUF_SIZE) {
+                if (cache_i + len + 1 <= BUF_SIZE) {
                     strncpy(cache + cache_i, line, len);
                     cache_i += len;
                     cache[cache_i++] = '\n';

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -1431,10 +1431,7 @@ static void * wm_inotify_start(__attribute__((unused)) void * args) {
             buffer[count - 1] = '\0';
 
             for (i = 0; i < (size_t)count; i += (ssize_t)(sizeof(struct inotify_event) + event->len)) {
-#ifndef __clang_analyzer__
-                // Avoid a false positive due to a casting of non-structure
                 event = (struct inotify_event*)&buffer[i];
-#endif
                 mtdebug2(WM_DATABASE_LOGTAG, "inotify: i='%zu', name='%s', mask='%u', wd='%d'", i, event->name, event->mask, event->wd);
 
                 if (event->len > IN_BUFFER_SIZE) {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -1431,7 +1431,10 @@ static void * wm_inotify_start(__attribute__((unused)) void * args) {
             buffer[count - 1] = '\0';
 
             for (i = 0; i < (size_t)count; i += (ssize_t)(sizeof(struct inotify_event) + event->len)) {
+#ifndef __clang_analyzer__
+                // Avoid a false positive due to a casting of non-structure
                 event = (struct inotify_event*)&buffer[i];
+#endif
                 mtdebug2(WM_DATABASE_LOGTAG, "inotify: i='%zu', name='%s', mask='%u', wd='%d'", i, event->name, event->mask, event->wd);
 
                 if (event->len > IN_BUFFER_SIZE) {


### PR DESCRIPTION
|Related issue|
|---|
|#3870|

This PR solves the bugs reported by Clang which can be seen in the linked issue.

The reports of dangerous castings to a struct from a non-struct type will be ignored (except for `os_net.c`). The reason for this is that we need to add strange and confusing code to silent these warnings, which are controlled situations (false positives). These reports cannot be omitted by just adding the `#ifndef __clang_analyzer__` expression.

The undesired use of the `sizeof` function in `syscheck_audit.c` has been solved by using the size of the memory allocated in the `cache` variable.

The memory leak in `rules.c` has been solved by releasing the `config_ruleinfo` variable with the program flow jumps to `cleanup` tag in case of error. Fixing this is not dangerous since the error case of this function end in a `merror_exit` call (the program finishes), and for this reason, it didn't suppose a real memory leak.

The possibly memory leak reported in `reports-config.c` was a false positive because if `os_report_configfilter` function returns 0, the memory allocated in `ncat` is now referenced by another variable. For some reason, Clang analyzer does not verify the function flow. To solve it, the memory allocated for the `filter_value` parameter is not allocated in the function when `arg_type` is `REPORT_FILTER`.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer