### PR TITLE
Add 'summary/agents' endpoint to new API

### DIFF
--- a/api/api/controllers/summary_controller.py
+++ b/api/api/controllers/summary_controller.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+
+import asyncio
+import connexion
+import datetime
+import logging
+
+from wazuh.agent import Agent as Agent
+from api.models.base_model_ import Data
+from api.util import remove_nones_to_dict, exception_handler, parse_api_param, raise_if_exc
+from wazuh import common
+from wazuh.cluster.dapi.dapi import DistributedAPI
+
+loop = asyncio.get_event_loop()
+logger = logging.getLogger('wazuh')
+
+
+@exception_handler
+def get_agents_summary(pretty=False, wait_for_complete=False):
+    """Get full summary of agents.
+
+    Returns a full summary of agents
+
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :return: Dict with a full summary of agents
+    """
+    f_kwargs = {}
+
+    dapi = DistributedAPI(f=Agent.get_full_summary,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          pretty=pretty,
+                          logger=logger
+                          )
+    data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
+    response = Data(data)
+
+    return response, 200

--- a/api/api/controllers/summary_controller.py
+++ b/api/api/controllers/summary_controller.py
@@ -8,10 +8,11 @@ import connexion
 import datetime
 import logging
 
-from wazuh.agent import Agent as Agent
 from api.models.base_model_ import Data
-from api.util import remove_nones_to_dict, exception_handler, parse_api_param, raise_if_exc
+from api.util import (exception_handler, parse_api_param, raise_if_exc,
+                      remove_nones_to_dict)
 from wazuh import common
+from wazuh.agent import Agent
 from wazuh.cluster.dapi.dapi import DistributedAPI
 
 loop = asyncio.get_event_loop()

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2098,10 +2098,10 @@ components:
           description: Active nodes in the cluster.
         groups:
           type: object
-          description:  Recount of the number of Wazuh agents group by Wazuh groups.
+          description: Recount of the number of Wazuh agents group by Wazuh groups.
         agent_os:
           type: object
-          description:  Recount of the number of Wazuh agents group by OS.
+          description: Recount of the number of Wazuh agents group by OS.
         agent_status:
           type: object
           description: Recount of the number of Wazuh agents group by status (active, disconnected, never connected, pending).
@@ -10807,7 +10807,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
         '200':
-          description: 'SCA database elements'
+          description: 'Full summary of agents'
           content:
             application/json:
               schema:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2082,6 +2082,36 @@ components:
           type: string
           description: Value of the CDB list item value.
 
+    # Summary models
+    SummaryAgents:
+      type: object
+      required:
+        - nodes
+        - groups
+        - agent_os
+        - agent_status
+        - agent_version
+        - last_registered_agent
+      properties:
+        nodes:
+          type: object
+          description: Active nodes in the cluster.
+        groups:
+          type: object
+          description:  Recount of the number of Wazuh agents group by Wazuh groups.
+        agent_os:
+          type: object
+          description:  Recount of the number of Wazuh agents group by OS.
+        agent_status:
+          type: object
+          description: Recount of the number of Wazuh agents group by status (active, disconnected, never connected, pending).
+        agent_version:
+          type: object
+          description: Recount of the number of Wazuh agents group by version.
+        last_registered_agent:
+          type: object
+          description: Information about last registered agent.
+
   securitySchemes:
     basicAuth:
       type: http
@@ -3568,6 +3598,8 @@ tags:
     description: 'Capability to collect interesting information for each agent'
   - name: security
     description: 'Roles administration and user authentication'
+  - name: summary
+    description: 'Summary of Wazuh'
 
 #security:
   #- jwt: []
@@ -10760,6 +10792,92 @@ paths:
                   rule:
                     normal: 'normal'
                   policies: []
+        default:
+          $ref: '#/components/responses/ResponseError'
+
+  /summary/agents:
+    get:
+      tags:
+      - summary
+      summary: 'Get a full summary of agents'
+      description: 'Returns a dictionary with a full summary of agents.'
+      operationId: api.controllers.summary_controller.get_agents_summary
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      responses:
+        '200':
+          description: 'SCA database elements'
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      $ref: '#/components/schemas/SummaryAgents'
+              example:
+               data:
+                nodes:
+                  items:
+                    - count: 1
+                      node_name: master-node
+                    - count: 1
+                      node_name: worker1
+                  totalItems: 2
+                groups:
+                  items:
+                    - count: 5
+                      name: default
+                      mergedSum: 8cf9a9972b793548a1bb6fbb00e58af6
+                      configSum: ab73af41699f13fdd81903b5f23d8d00
+                  totalItems: 1
+                agent_os:
+                  items:
+                    - os:
+                        name: Ubuntu
+                        platform: ubuntu
+                        version: 18.04.2 LTS
+                      count: 6
+                  totalItems: 6
+                agent_status:
+                  Total: 6
+                  Active: 6
+                  Disconnected: 0
+                  Never connected: 0
+                  Pending: 0
+                agent_version:
+                  items:
+                    - version: Wazuh v4.0.0
+                      count: 1
+                    - version : Wazuh v3.11.0
+                      count: 5
+                  totalItems: 6
+                last_registered_agent:
+                  os:
+                    arch: x86_64
+                    codename: Bionic Beaver
+                    minor: "18"
+                    major: "04"
+                    name: Ubuntu
+                    platform: ubuntu
+                    uname: Linux |ee7d4f51c0ae |4.18.0-16-generic |#17~18.04.1-Ubuntu SMP Tue Feb 12 13:35:51 UTC 2019 |x86_64
+                    version: 18.04.2 LTS
+                  version: Wazuh v3.9.5
+                  dateAdd: "2019-08-20 11:42:14"
+                  node_name: master-node
+                  status: Active
+                  group:
+                    - default
+                  mergedSum: 8cf9a9972b793548a1bb6fbb00e58af6
+                  name: ee7d4f51c0ae
+                  lastKeepAlive: "2019-08-20 11:48:20"
+                  configSum: ab73af41699f13fdd81903b5f23d8d00
+                  registerIP: any
+                  ip: "172.20.0.8"
+                  id: "005"
+                  manager: 1a683501f77f
         default:
           $ref: '#/components/responses/ResponseError'
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -324,7 +324,6 @@ components:
       - id
       - name
       $ref: '#/components/schemas/AgentSimple'
-      
 
     AgentStatus:
       type: string
@@ -334,6 +333,25 @@ components:
       - neverconnected
       - disconnected
       description: Agent status. It is calculated based on the last keep alive and the Wazuh version.
+
+    AgentsSummary:
+      type: object
+      properties:
+        Total:
+          type: integer
+          format: int32
+        Active:
+          type: integer
+          format: int32
+        Disconnected:
+          type: integer
+          format: int32
+        Never connected:
+          type: integer
+          format: int32
+        Pending:
+          type: integer
+          format: int32
 
     AgentID:
       type: string
@@ -2082,8 +2100,8 @@ components:
           type: string
           description: Value of the CDB list item value.
 
-    # Summary models
-    SummaryAgents:
+    # Overview models
+    OverviewAgents:
       type: object
       required:
         - nodes
@@ -2096,21 +2114,79 @@ components:
         nodes:
           type: object
           description: Active nodes in the cluster.
+          properties:
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  node_name:
+                    type: string
+                  count:
+                    type: integer
+            totalItems:
+              type: integer
+              format: int32
         groups:
           type: object
           description: Recount of the number of Wazuh agents group by Wazuh groups.
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/AgentGroup'
+            totalItems:
+              type: integer
+              format: int32
         agent_os:
           type: object
           description: Recount of the number of Wazuh agents group by OS.
+          properties:
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    format: int32
+                  os:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        format: alphanumeric
+                      platform:
+                        type: string
+                        format: alphanumeric
+                      version:
+                        type: string
+                        format: alphanumeric
+            totalItems:
+              type: integer
+              format: int32
         agent_status:
-          type: object
-          description: Recount of the number of Wazuh agents group by status (active, disconnected, never connected, pending).
+          $ref: '#/components/schemas/AgentsSummary'
         agent_version:
           type: object
           description: Recount of the number of Wazuh agents group by version.
+          properties:
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    format: int32
+                  version:
+                    type: string
+                    format: alphanumeric
+            totalItems:
+              type: integer
+              format: int32
         last_registered_agent:
-          type: object
-          description: Information about last registered agent.
+          $ref: '#/components/schemas/Agent'
 
   securitySchemes:
     basicAuth:
@@ -5241,17 +5317,7 @@ paths:
                 - type: object
                   properties:
                     data:
-                      properties:
-                        Total:
-                          type: integer
-                        Active:
-                          type: integer
-                        Disconnected:
-                          type: integer
-                        Never connected:
-                          type: integer
-                        Pending:
-                          type: integer
+                      $ref: '#/components/schemas/AgentsSummary'
               example:
                 data:
                   Total: 7
@@ -10795,7 +10861,7 @@ paths:
         default:
           $ref: '#/components/responses/ResponseError'
 
-  /summary/agents:
+  /overview/agents:
     get:
       tags:
       - summary
@@ -10807,7 +10873,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
         '200':
-          description: 'Full summary of agents'
+          description: 'Overview of agents'
           content:
             application/json:
               schema:
@@ -10816,7 +10882,7 @@ paths:
                 - type: object
                   properties:
                     data:
-                      $ref: '#/components/schemas/SummaryAgents'
+                      $ref: '#/components/schemas/OverviewAgents'
               example:
                data:
                 nodes:

--- a/api/test/integration/test_summary_endpoints.tavern.yaml
+++ b/api/test/integration/test_summary_endpoints.tavern.yaml
@@ -1,0 +1,53 @@
+test_name: GET /summary
+
+includes:
+ - !include common.yaml
+
+stages:
+   # Authentication stage
+ - type: ref
+   id: login_get_token
+
+ - name: Get full summary of agents
+
+   request:
+     url: "{protocol:s}://{host:s}:{port:d}/summary/agents"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+
+   response:
+     status_code: 200
+     body:
+       data:
+        nodes:
+          items: !anything
+          totalItems: !anything
+        groups:
+          items: !anything
+          totalItems: !anything
+        agent_os:
+          items: !anything
+          totalItems: !anything
+        agent_status:
+          Active: !anyint
+          Disconnected: !anyint
+          Never connected: !anyint
+          Pending: !anyint
+          Total: !anyint
+        agent_version:
+          items: !anything
+          totalItems: !anything
+        last_registered_agent:
+          configSum: !anystr
+          dateAdd: !anystr
+          group: !anything
+          id: !anystr
+          lastKeepAlive: !anystr
+          manager: !anystr
+          mergedSum: !anystr
+          node_name: !anystr
+          os: !anything
+          registerIP: !anystr
+          status: !anystr
+          version: !anystr

--- a/api/test/integration/test_summary_endpoints.tavern.yaml
+++ b/api/test/integration/test_summary_endpoints.tavern.yaml
@@ -1,4 +1,4 @@
-test_name: GET /summary
+test_name: GET /summary/agents
 
 includes:
  - !include common.yaml
@@ -9,7 +9,6 @@ stages:
    id: login_get_token
 
  - name: Get full summary of agents
-
    request:
      url: "{protocol:s}://{host:s}:{port:d}/summary/agents"
      method: GET

--- a/api/test/integration/test_summary_endpoints.tavern.yaml
+++ b/api/test/integration/test_summary_endpoints.tavern.yaml
@@ -14,7 +14,6 @@ stages:
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
-
    response:
      status_code: 200
      body:

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -12,7 +12,6 @@ from time import strftime
 from wazuh import common
 from wazuh.database import Connection
 from wazuh.exception import WazuhException, WazuhError, WazuhInternalError
-from wazuh.utils import execute
 
 """
 Wazuh HIDS Python package

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -17,6 +17,7 @@ from os import chown, chmod, path, makedirs, urandom, listdir, stat, remove
 from platform import platform
 from shutil import copyfile, rmtree
 from time import time, sleep
+from typing import Dict
 
 import requests
 
@@ -2564,3 +2565,29 @@ class Agent:
             raise WazuhError(1710)
 
         return configuration.upload_group_file(group_id, tmp_file, file_name)
+
+    @staticmethod
+    def get_full_summary() -> Dict:
+        """Get information about agents.
+        :return: Dictionary with information about agents
+        """
+        # get information from different methods of Agent class
+        stats_distinct_node = Agent.get_distinct_agents(fields=['node_name'])
+        groups = Agent.get_all_groups()
+        stats_distinct_os = Agent.get_distinct_agents(fields=['os.name',
+                                                      'os.platform', 'os.version'])
+        stats_version = Agent.get_distinct_agents(fields=['version'])
+        summary = Agent.get_agents_summary()
+        try:
+            last_registered_agent = Agent.get_agents_overview(limit=1,
+                                                              sort={'fields': ['dateAdd'], 'order': 'desc'},
+                                                              q='id!=000').get('items')[0]
+        except IndexError:  # an IndexError could happen if there are not registered agents
+            last_registered_agent = {}
+        # combine results in an unique dictionary
+        result = {'nodes': stats_distinct_node, 'groups': groups,
+                  'agent_os': stats_distinct_os, 'agent_status': summary,
+                  'agent_version': stats_version,
+                  'last_registered_agent': last_registered_agent}
+
+        return result

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -2569,6 +2569,7 @@ class Agent:
     @staticmethod
     def get_full_summary() -> Dict:
         """Get information about agents.
+
         :return: Dictionary with information about agents
         """
         # get information from different methods of Agent class

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -580,3 +580,16 @@ def test_get_outdated_agents(test_data):
         for item in result['items']:
             assert set(item.keys()) == {'version', 'id', 'name'}
             assert WazuhVersion(item['version']) < WazuhVersion(get_manager_version())
+
+
+@patch('wazuh.agent.Agent.get_all_groups')
+@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'var', 'db', 'global.db'))
+def test_get_full_summary(mock_get_all_groups, test_data):
+    """Test get_full_sumary method."""
+    expected_keys = {'nodes', 'groups', 'agent_os', 'agent_status',
+                     'agent_version', 'last_registered_agent'}
+    with patch('sqlite3.connect') as mock_db:
+        mock_db.return_value = test_data.global_db
+        result = Agent.get_full_summary()
+        # check keys of result
+        assert(set(result.keys()) == expected_keys)

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -13,6 +13,9 @@ import pytest
 import re
 import requests
 
+import sys
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
+
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         from wazuh import common


### PR DESCRIPTION
Hi team,

This PR closes #3879.

I had to made some changes in order to run unit tests properly. It is necessary to adapt unit tests for `dev-flask-poc` branch.

Below there is an example of this new API call:

```bash
# curl -X GET "localhost:55000/summary/agents"
{
  "data": {
    "agent_os": {
      "items": [
        {
          "count": 1
        },
        {
          "count": 2,
          "os": {
            "name": "Ubuntu",
            "platform": "ubuntu",
            "version": "18.04.2 LTS"
          }
        }
      ],
      "totalItems": 3
    },
    "agent_status": {
      "Active": 2,
      "Disconnected": 0,
      "Never connected": 1,
      "Pending": 0,
      "Total": 3
    },
    "agent_version": {
      "items": [
        {
          "count": 1,
          "version": "Wazuh v3.11.0"
        },
        {
          "count": 1
        },
        {
          "count": 1,
          "version": "Wazuh v3.9.5"
        }
      ],
      "totalItems": 3
    },
    "groups": {
      "items": [
        {
          "configSum": "c190d25e26b9f21c716906bce74c1949",
          "count": 1,
          "mergedSum": "37a9b15f71b26ea6d68aa4e31e6e956c",
          "name": "default"
        }
      ],
      "totalItems": 1
    },
    "last_registered_agent": {
      "configSum": "c190d25e26b9f21c716906bce74c1949",
      "dateAdd": "2019-08-27T05:54:03Z",
      "group": [
        "default"
      ],
      "id": "002",
      "ip": "192.168.16.6",
      "lastKeepAlive": "2019-08-27T09:04:31Z",
      "manager": "db71c837b8af",
      "mergedSum": "37a9b15f71b26ea6d68aa4e31e6e956c",
      "name": "2099ba6b5710",
      "node_name": "worker-1",
      "os": {
        "arch": "x86_64",
        "codename": "Bionic Beaver",
        "major": "18",
        "minor": "04",
        "name": "Ubuntu",
        "platform": "ubuntu",
        "uname": "Linux |2099ba6b5710 |5.2.9-200.fc30.x86_64 |#1 SMP Fri Aug 16 21:37:45 UTC 2019 |x86_64",
        "version": "18.04.2 LTS"
      },
      "registerIP": "192.168.16.6",
      "status": "active",
      "version": "Wazuh v3.9.5"
    },
    "nodes": {
      "items": [
        {
          "count": 1,
          "node_name": "master"
        },
        {
          "count": 1,
          "node_name": "worker-2"
        },
        {
          "count": 1,
          "node_name": "worker-1"
        }
      ],
      "totalItems": 3
    }
  }
}

```

## Tests performed

### Unit tests

Only the test of the function which was added was ran.

```python
% pytest test_agent.py -vv
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.7.4, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/druizz/Git/wazuh/framework, inifile:
plugins: tavern-0.26.3
collected 1 item                                                                                                                                                                                    

test_agent.py::test_get_full_summary PASSED                                                                                                                                                   [100%]

========================================================================================= warnings summary ==========================================================================================
/home/druizz/Git/wazuh/framework/wazuh/tests/../../wazuh/InputValidator.py:23
  /home/druizz/Git/wazuh/framework/wazuh/tests/../../wazuh/InputValidator.py:23: DeprecationWarning: invalid escape sequence \w
    """

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================================================== 1 passed, 1 warnings in 0.17 seconds ================================================================================
```

## Tavern tests

```python
# /var/ossec/framework/python/bin/pytest /wazuh/api/test/integration/test_summary_endpoints.tavern.yaml 
================================================ test session starts =================================================
platform linux -- Python 3.7.2, pytest-4.5.0, py-1.8.0, pluggy-0.12.0
rootdir: /wazuh/api
plugins: tavern-0.28.0
collected 1 item                                                                                                     

api/test/integration/test_summary_endpoints.tavern.yaml .                                                      [100%]

================================================== warnings summary ==================================================
/var/ossec/framework/python/lib/python3.7/site-packages/yaml/constructor.py:126
  /var/ossec/framework/python/lib/python3.7/site-packages/yaml/constructor.py:126: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if not isinstance(key, collections.Hashable):

test/integration/test_summary_endpoints.tavern.yaml::GET /summary
  /var/ossec/framework/python/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================== 1 passed, 2 warnings in 0.59 seconds ========================================

```