### PR TITLE
Issue 3895 cdb lists compile

### DIFF
--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -354,6 +354,7 @@ buildCDB()
 
 case "$1" in
 start)
+    buildCDB
     testconfig
     lock
     start

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -507,6 +507,7 @@ fi
 
 case "$action" in
 start)
+    buildCDB
     testconfig
     lock
     start

--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -355,7 +355,7 @@ static const char *_OS_Regex(const char *pattern, const char *str, const char **
                 continue;
             }
 
-            else if ((*(pt + 3) == '\0') && (_regex_matched == 1) && (r_code)) {
+            else if ((*(pt + 2) == '\0' || *(pt + 3) == '\0') && (_regex_matched == 1) && (r_code)) {
                 r_code = st;
                 if (!(flags & END_SET) || ((flags & END_SET) && (*st == '\0'))) {
                     return (r_code);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3895|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

By calling the buildCDB function for the start procedure it will build CDB lists when starting the system or when a restart is called with the system's service utility (which will normally issue a stop followed by a start).

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
