### PR TITLE
Issue 3895 cdb lists compile

### DIFF
--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -354,6 +354,7 @@ buildCDB()
 
 case "$1" in
 start)
+    buildCDB
     testconfig
     lock
     start

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -507,6 +507,7 @@ fi
 
 case "$action" in
 start)
+    buildCDB
     testconfig
     lock
     start


### PR DESCRIPTION
|Related issue|
|---|
|#3895|
 
Description
By calling the buildCDB function for the start procedure it will build CDB lists when starting the system or when a restart is called with the system's service utility (which will normally issue a stop followed by a start).
 - Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Source installation
  - [ ] Package installation
  - [ ] Source upgrade
  - [ ] Package upgrade
  - [ ] Review logs syntax and correct language
  - [ ] QA templates contemplate the added capabilities