### PR TITLE
Fix defects reported by Coverity

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -226,12 +226,6 @@ void *receiver_thread(__attribute__((unused)) void *none)
                     /* No error */
                     os_md5 currently_md5;
 
-                    /* Close for the rename to work */
-                    if (fp) {
-                        fclose(fp);
-                        fp = NULL;
-                    }
-
                     if (file[0] == '\0') {
                         /* Nothing to be done */
                     }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -672,6 +672,8 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 #ifdef WIN32
         if(!ExpandEnvironmentStrings(tmp_dir, expandedpath, sizeof(expandedpath) - 1)){
             merror("Could not expand the environment variable %s (%ld)", expandedpath, GetLastError());
+            os_free(restrictfile);
+            os_free(tag);
             continue;
         }
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -904,6 +904,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
                 while(node[i]->attributes[j]) {
                     if (strcmp(node[i]->attributes[j], xml_tag) == 0) {
+                        os_free(tag);
                         os_strdup(node[i]->values[j], tag);
                     } else if (strcmp(node[i]->attributes[j], xml_arch) == 0) {
                         if (strcmp(node[i]->values[j], xml_32bit) == 0) {
@@ -913,12 +914,12 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                             snprintf(arch, 6, "%s", "both");
                         } else {
                             merror(XML_INVATTR, node[i]->attributes[j], node[i]->content);
-                            free(tag);
+                            os_free(tag);
                             return OS_INVALID;
                         }
                     } else {
                         merror(XML_INVATTR, node[i]->attributes[j], node[i]->content);
-                        free(tag);
+                        os_free(tag);
                         return OS_INVALID;
                     }
                     j++;

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -56,18 +56,12 @@ static void WinExecd_Shutdown()
 int WinExecd_Start()
 {
     int c;
-    int test_config = 0;
     char *cfg = DEFAULTCPATH;
     winexec_queue = queue_init(OS_SIZE_128);
 
     /* Read config */
     if ((c = ExecdConfig(cfg)) < 0) {
         merror_exit(CONFIG_ERROR, cfg);
-    }
-
-    /* Exit if test_config */
-    if (test_config) {
-        return (0);
     }
 
     /* Active response disabled */

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1073,7 +1073,7 @@ static void read_controlmsg(const char *agent_id, char *msg)
             }
 
             // Copy sum before unlock mutex
-            if (f_sum[0]->sum) {
+            if (*f_sum[0]->sum) {
                 memcpy(tmp_sum, f_sum[0]->sum, sizeof(tmp_sum));
             }
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2962,6 +2962,8 @@ void w_file_cloexec(__attribute__((unused)) FILE * fp) {
 /* Prevent children processes from inheriting a file descriptor */
 void w_descriptor_cloexec(__attribute__((unused)) int fd){
 #ifndef WIN32
-    fcntl(fd, F_SETFD, FD_CLOEXEC);
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) < 0) {
+        mwarn("Cannot set close-on-exec flag to the descriptor: %s (%d)", strerror(errno), errno);
+    }
 #endif
 }

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -29,8 +29,6 @@ os_info *get_win_version()
     const DWORD vsize = 1024;
     TCHAR value[vsize];
     DWORD dwCount = vsize;
-    char arch[64] = "";
-    char nodename[1024] = "";
     char version[64] = "";
     const DWORD size = 30;
 
@@ -227,46 +225,47 @@ os_info *get_win_version()
 
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
         merror(SK_REG_OPEN, subkey);
-        info->machine = strdup("unknown");
     } else {
-        dwCount = vsize;
+        char arch[64] = "";
+        dwCount = sizeof(arch);
         dwRet = RegQueryValueEx(RegistryKey, TEXT("PROCESSOR_ARCHITECTURE"), NULL, NULL, (LPBYTE)&arch, &dwCount);
 
         if (dwRet != ERROR_SUCCESS) {
             merror("Error reading 'Architecture' from Windows registry. (Error %u)",(unsigned int)dwRet);
-            info->machine = strdup("unknown");
         } else {
-
             if (!strncmp(arch, "AMD64", 5) || !strncmp(arch, "IA64", 4) || !strncmp(arch, "ARM64", 5)) {
                 info->machine = strdup("x86_64");
             } else if (!strncmp(arch, "x86", 3)) {
                 info->machine = strdup("i686");
-            } else {
-                info->machine = strdup("unknown");
             }
-
         }
         RegCloseKey(RegistryKey);
+    }
+
+    if (!info->machine) {
+        info->machine = strdup("unknown");
     }
 
     // Read Hostname
 
     snprintf(subkey, vsize - 1, "%s", "System\\CurrentControlSet\\Control\\ComputerName\\ActiveComputerName");
-
+    char nodename[1024] = "";
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
         merror(SK_REG_OPEN, subkey);
-        info->nodename = strdup("unknown");
     } else {
         dwCount = size;
         dwRet = RegQueryValueEx(RegistryKey, TEXT("ComputerName"), NULL, NULL, (LPBYTE)&nodename, &dwCount);
 
         if (dwRet != ERROR_SUCCESS) {
             merror("Error reading 'hostname' from Windows registry. (Error %u)",(unsigned int)dwRet);
-            info->nodename = strdup("unknown");
         } else {
             info->nodename = strdup(nodename);
         }
         RegCloseKey(RegistryKey);
+    }
+
+    if (!info->nodename) {
+        info->nodename = strdup("unknown");
     }
 
     free(subkey);

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -973,6 +973,8 @@ time_t get_agent_date_added(int agent_id) {
 
             if (sscanf(date, "%d-%d-%d %d:%d:%d",&t.tm_year, &t.tm_mon, &t.tm_mday, &t.tm_hour, &t.tm_min, &t.tm_sec)<6) {
                 merror("Invalid date format in file '%s' for agent '%d'", TIMESTAMP_FILE, agent_id);
+                free(date);
+                fclose(fp);
                 return 0;
             }
             t.tm_year -= 1900;

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -1106,28 +1106,35 @@ hw_info *get_system_linux(){
     if (!(fp = fopen("/proc/meminfo", "r"))) {
         mterror(WM_SYS_LOGTAG, "Unable to read the RAM memory information.");
     } else {
-        char *aux_string = NULL;
         while (fgets(string, OS_MAXSTR, fp) != NULL){
+            char *aux_string = NULL;
+
             if ((aux_string = strstr(string, "MemTotal")) != NULL){
 
-                char *end_string;
+                char *end_string = NULL;
                 strtok_r(string, ":", &saveptr);
                 aux_string = strtok_r(NULL, "\n", &saveptr);
-                if (aux_string[0] == '\"' && (end = strchr(++aux_string, '\"'), end)) {
-                    *end = '\0';
+                if (aux_string) {
+                    if (aux_string[0] == '\"' && (end = strchr(++aux_string, '\"'), end)) {
+                        *end = '\0';
+                    }
+                    info->ram_total = strtol(aux_string, &end_string, 10);
+                } else {
+                    info->ram_total = 0;
                 }
-                info->ram_total = strtol(aux_string, &end_string, 10);
-
             } else if ((aux_string = strstr(string, "MemFree")) != NULL){
 
-                char *end_string;
+                char *end_string = NULL;
                 strtok_r(string, ":", &saveptr);
                 aux_string = strtok_r(NULL, "\n", &saveptr);
-                if (aux_string[0] == '\"' && (end = strchr(++aux_string, '\"'), end)) {
-                    *end = '\0';
+                if (aux_string) {
+                    if (aux_string[0] == '\"' && (end = strchr(++aux_string, '\"'), end)) {
+                        *end = '\0';
+                    }
+                    info->ram_free = strtol(aux_string, &end_string, 10);
+                } else {
+                    info->ram_free = 0;
                 }
-                info->ram_free = strtol(aux_string, &end_string, 10);
-
             }
         }
 

--- a/src/wazuh_modules/syscollector/syscollector_win_ext.c
+++ b/src/wazuh_modules/syscollector/syscollector_win_ext.c
@@ -330,8 +330,6 @@ char* length_to_ipv6_mask(int mask_length){
                 case 1:
                     string[j++] = '8';
                     break;
-                case 0:
-                    break;
             }
             length = 0;
         }

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -54,7 +54,12 @@ void * wm_command_main(wm_command_t * command) {
     if (command->md5_hash || command->sha1_hash || command->sha256_hash) {
 
         command_cpy = strdup(command->command);
-        argv = wm_strtok(command_cpy);
+
+        if (argv = wm_strtok(command_cpy), !argv) {
+            merror("Could not split command: %s", command_cpy);
+            pthread_exit(NULL);
+        }
+
         binary = argv[0];
 
         if (!wm_get_path(binary, &full_path)) {

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -593,9 +593,7 @@ char *get_win_agent_ip(){
 
                 Iterations++;
             } while ((dwRetVal == ERROR_BUFFER_OVERFLOW) && (Iterations < MAX_TRIES));
-        }
-
-        if (checkVista()) {
+        } else {
             if (!sys_library) {
                 sys_library = LoadLibrary("syscollector_win_ext.dll");
             }
@@ -626,6 +624,11 @@ char *get_win_agent_ip(){
                 }
 
                 if (checkVista()) {
+                    if (!sys_library) {
+                        merror("Could not load library 'syscollector_win_ext.dll'");
+                        goto end;
+                    }
+
                     /* Call function get_network_vista() in syscollector_win_ext.dll */
                     string = _get_network_vista(pCurrAddresses, 0, NULL);
                 } else {

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -671,6 +671,8 @@ end:
         win_free((HLOCAL)pAddresses);
     }
 
+    FreeLibrary(sys_library);
+
     return agent_ip;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#3898|

The solutions have been explained in the description of the commits.

It has been decided to ignore the report on the waiting while holding a lock in `wm_sca_dump_db_thread` function because it is intentional. 

The absence of extra validation when reading from `/proc/meminfo` has also been ignored, but in this case, we have detected a possible segmentation if `strtok_r` function return NULL, which has been handled in https://github.com/wazuh/wazuh/pull/3899/commits/a032a871862b6b323749651b231689c2c3499db5. 