### PR TITLE
Decode audit logs hex fields

### DIFF
--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -95,6 +95,8 @@ int w_is_str_in_array(char *const *ar, const char *str);
 /* Similar to strtok_r but checks for full delim appearances */
 char *w_strtok_r_str_delim(const char *delim, char **remaining_str);
 
-const char * find_string_in_array(char * const string_array[], size_t array_len, const char * const str, const size_t str_len);
+const char *find_string_in_array(char * const string_array[], size_t array_len, const char * const str, const size_t str_len);
+
+char *decode_hex_buffer_2_ascii_buffer(const char * const encoded_buffer, const size_t buffer_size);
 
 #endif

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -602,7 +602,7 @@ char *w_strtok_r_str_delim(const char *delim, char **remaining_str)
     return token;
 }
 
-const char * find_string_in_array(char * const string_array[], size_t array_len, const char * const str, const size_t str_len)
+const char *find_string_in_array(char * const string_array[], size_t array_len, const char * const str, const size_t str_len)
 {
     if (!string_array || !str){
         return NULL;
@@ -614,5 +614,32 @@ const char * find_string_in_array(char * const string_array[], size_t array_len,
             return string_array[i];
         }
     }
+
     return NULL;
+}
+
+char* decode_hex_buffer_2_ascii_buffer(const char * const encoded_buffer, const size_t buffer_size)
+{
+    if (!encoded_buffer) {
+        return NULL;
+    }
+
+    /* each ASCII character has 2 digits in its HEX form, hence its length must be even */
+    if (buffer_size % 2 != 0) {
+        return NULL;
+    }
+
+    const size_t decoded_len = buffer_size / 2;
+    char *decoded_buffer;
+    os_calloc(decoded_len, sizeof(char), decoded_buffer);
+
+    size_t i;
+    for(i = 0; i < decoded_len; ++i) {
+        if (1 != sscanf(encoded_buffer + 2 * i, "%2hhx", decoded_buffer + i)) {
+            os_free(decoded_buffer);
+            return NULL;
+        }
+    }
+
+    return decoded_buffer;
 }

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -17,6 +17,7 @@
 #include <os_net/os_net.h>
 #include "syscheck_op.h"
 #include "audit_op.h"
+#include "string_op.h"
 
 #define AUDIT_CONF_FILE DEFAULTDIR "/etc/af_wazuh.conf"
 #define PLUGINS_DIR_AUDIT_2 "/etc/audisp/plugins.d"
@@ -56,6 +57,7 @@ static regex_t regexCompiled_ppid;
 static regex_t regexCompiled_gid;
 static regex_t regexCompiled_auid;
 static regex_t regexCompiled_euid;
+
 static regex_t regexCompiled_cwd;
 static regex_t regexCompiled_pname;
 static regex_t regexCompiled_path0;
@@ -63,9 +65,19 @@ static regex_t regexCompiled_path1;
 static regex_t regexCompiled_path2;
 static regex_t regexCompiled_path3;
 static regex_t regexCompiled_path4;
+
+static regex_t regexCompiled_cwd_hex;
+static regex_t regexCompiled_pname_hex;
+static regex_t regexCompiled_path0_hex;
+static regex_t regexCompiled_path1_hex;
+static regex_t regexCompiled_path2_hex;
+static regex_t regexCompiled_path3_hex;
+static regex_t regexCompiled_path4_hex;
+
 static regex_t regexCompiled_items;
 static regex_t regexCompiled_inode;
 static regex_t regexCompiled_dir;
+static regex_t regexCompiled_dir_hex;
 static regex_t regexCompiled_syscall;
 
 
@@ -280,6 +292,19 @@ int init_regex(void) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "inode");
         return -1;
     }
+
+    static const char *pattern_items = " items=([0-9]*) ";
+    if (regcomp(&regexCompiled_items, pattern_items, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "items");
+        return -1;
+    }
+
+    static const char *pattern_syscall = " syscall=([0-9]*)";
+    if (regcomp(&regexCompiled_syscall, pattern_syscall, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "syscall");
+        return -1;
+    }
+
     static const char *pattern_pname = " exe=\"([^ ]*)\"";
     if (regcomp(&regexCompiled_pname, pattern_pname, REG_EXTENDED)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "pname");
@@ -290,6 +315,13 @@ int init_regex(void) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "cwd");
         return -1;
     }
+
+    static const char *pattern_dir = " dir=\"([^ ]*)\"";
+    if (regcomp(&regexCompiled_dir, pattern_dir, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "dir");
+        return -1;
+    }
+
     static const char *pattern_path0 = " item=0 name=\"([^ ]*)\"";
     if (regcomp(&regexCompiled_path0, pattern_path0, REG_EXTENDED)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path0");
@@ -315,21 +347,55 @@ int init_regex(void) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path4");
         return -1;
     }
-    static const char *pattern_items = " items=([0-9]*) ";
-    if (regcomp(&regexCompiled_items, pattern_items, REG_EXTENDED)) {
-        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "items");
+
+    static const char *pattern_pname_hex = " exe=([A-F0-9]*)";
+    if (regcomp(&regexCompiled_pname_hex, pattern_pname_hex, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "pname_hex");
         return -1;
     }
-    static const char *pattern_dir = " dir=\"([^ ]*)\"";
-    if (regcomp(&regexCompiled_dir, pattern_dir, REG_EXTENDED)) {
-        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "dir");
+
+    static const char *pattern_cwd_hex = " cwd=([A-F0-9]*)";
+    if (regcomp(&regexCompiled_cwd_hex, pattern_cwd_hex, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "cwd_hex");
         return -1;
     }
-    static const char *pattern_syscall = " syscall=([0-9]*)";
-    if (regcomp(&regexCompiled_syscall, pattern_syscall, REG_EXTENDED)) {
-        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "syscall");
+
+    static const char *pattern_dir_hex = " dir=([A-F0-9]*)";
+    if (regcomp(&regexCompiled_dir_hex, pattern_dir_hex, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "dir_hex");
         return -1;
     }
+
+    static const char *pattern_path0_hex = " item=0 name=([A-F0-9]*)";
+    if (regcomp(&regexCompiled_path0_hex, pattern_path0_hex, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path0_hex");
+        return -1;
+    }
+
+    static const char *pattern_path1_hex = " item=1 name=([A-F0-9]*)";
+    if (regcomp(&regexCompiled_path1_hex, pattern_path1_hex, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path1_hex");
+        return -1;
+    }
+
+    static const char *pattern_path2_hex = " item=2 name=([A-F0-9]*)";
+    if (regcomp(&regexCompiled_path2_hex, pattern_path2_hex, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path2_hex");
+        return -1;
+    }
+
+    static const char *pattern_path3_hex = " item=3 name=([A-F0-9]*)";
+    if (regcomp(&regexCompiled_path3_hex, pattern_path3_hex, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path3_hex");
+        return -1;
+    }
+
+    static const char *pattern_path4_hex = " item=4 name=([A-F0-9]*)";
+    if (regcomp(&regexCompiled_path4_hex, pattern_path4_hex, REG_EXTENDED)) {
+        merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path4_hex");
+        return -1;
+    }
+
     return 0;
 }
 
@@ -441,7 +507,6 @@ char * audit_get_id(const char * event) {
     return id;
 }
 
-
 char *gen_audit_path(char *cwd, char *path0, char *path1) {
 
     char *gen_path = NULL;
@@ -495,13 +560,6 @@ void audit_parse(char *buffer) {
     char *pdelete;
     regmatch_t match[2];
     int match_size;
-    char *uid = NULL;
-    char *gid = NULL;
-    char *auid = NULL;
-    char *euid = NULL;
-    char *pid = NULL;
-    char *ppid = NULL;
-    char *pname = NULL;
     char *path0 = NULL;
     char *path1 = NULL;
     char *path2 = NULL;
@@ -509,9 +567,6 @@ void audit_parse(char *buffer) {
     char *path4 = NULL;
     char *cwd = NULL;
     char *file_path = NULL;
-    char *syscall = NULL;
-    char *inode = NULL;
-    char *real_path = NULL;
     whodata_evt *w_evt;
     unsigned int items = 0;
     char *inode_temp;
@@ -532,6 +587,21 @@ void audit_parse(char *buffer) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_calloc(1, match_size + 1, p_dir);
                 snprintf (p_dir, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+            }
+
+
+            else if (regexec(&regexCompiled_dir_hex, buffer, 2, match, 0) == 0) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                if (decoded_buffer) {
+                    const int decoded_length = match_size / 2;
+                    os_malloc(decoded_length + 1, p_dir);
+                    snprintf (p_dir, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                    os_free(decoded_buffer);
+                } else {
+                    merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                }
+
             }
 
             if (p_dir && *p_dir != '\0') {
@@ -582,16 +652,15 @@ void audit_parse(char *buffer) {
             // user_name & user_id
             if(regexec(&regexCompiled_uid, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
-                os_malloc(match_size + 1, uid);
-                snprintf (uid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                const char *user = get_user("",atoi(uid), NULL);
+                os_malloc(match_size + 1, w_evt->user_id);
+                snprintf (w_evt->user_id, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+                const char *user = get_user("", atoi(w_evt->user_id), NULL);
                 w_evt->user_name = strdup(user);
-                w_evt->user_id = strdup(uid);
-                free(uid);
             }
             // audit_name & audit_uid
             if(regexec(&regexCompiled_auid, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
+                char *auid = NULL;
                 os_malloc(match_size + 1, auid);
                 snprintf (auid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
                 if (strcmp(auid, "4294967295") == 0) { // Invalid auid (-1)
@@ -606,30 +675,27 @@ void audit_parse(char *buffer) {
                     w_evt->audit_name = strdup(user);
                     w_evt->audit_uid = strdup(auid);
                 }
-                free(auid);
+                os_free(auid);
             }
             // effective_name && effective_uid
             if(regexec(&regexCompiled_euid, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
-                os_malloc(match_size + 1, euid);
-                snprintf (euid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                const char *user = get_user("",atoi(euid), NULL);
+                os_malloc(match_size + 1, w_evt->effective_uid);
+                snprintf (w_evt->effective_uid, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
+                const char *user = get_user("",atoi(w_evt->effective_uid), NULL);
                 w_evt->effective_name = strdup(user);
-                w_evt->effective_uid = strdup(euid);
-                free(euid);
             }
             // group_name & group_id
             if(regexec(&regexCompiled_gid, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
-                os_malloc(match_size + 1, gid);
-                snprintf (gid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                w_evt->group_name = strdup(get_group(atoi(gid)));
-                w_evt->group_id = strdup(gid);
-                free(gid);
+                os_malloc(match_size + 1, w_evt->group_id);
+                snprintf (w_evt->group_id, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
+                w_evt->group_name = strdup(get_group(atoi(w_evt->group_id)));
             }
             // process_id
             if(regexec(&regexCompiled_pid, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
+                char *pid = NULL;
                 os_malloc(match_size + 1, pid);
                 snprintf (pid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
                 w_evt->process_id = atoi(pid);
@@ -638,6 +704,7 @@ void audit_parse(char *buffer) {
             // ppid
             if(regexec(&regexCompiled_ppid, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
+                char *ppid = NULL;
                 os_malloc(match_size + 1, ppid);
                 snprintf (ppid, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
                 w_evt->ppid = atoi(ppid);
@@ -646,36 +713,81 @@ void audit_parse(char *buffer) {
             // process_name
             if(regexec(&regexCompiled_pname, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
-                os_malloc(match_size + 1, pname);
-                snprintf (pname, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                w_evt->process_name = strdup(pname);
-                free(pname);
+                os_malloc(match_size + 1, w_evt->process_name);
+                snprintf (w_evt->process_name, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+            } else if (regexec(&regexCompiled_pname_hex, buffer, 2, match, 0) == 0) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                if (decoded_buffer) {
+                    const int decoded_length = match_size / 2;
+                    os_malloc(decoded_length + 1, w_evt->process_name);
+                    snprintf(w_evt->process_name, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                    os_free(decoded_buffer);
+                } else {
+                    merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                }
+
             }
+
             // cwd
             if(regexec(&regexCompiled_cwd, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, cwd);
                 snprintf (cwd, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+            } else if (regexec(&regexCompiled_cwd_hex, buffer, 2, match, 0) == 0) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                if (decoded_buffer) {
+                    const int decoded_length = match_size / 2;
+                    os_malloc(decoded_length + 1, cwd);
+                    snprintf(cwd, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                    os_free(decoded_buffer);
+                } else {
+                    merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                }
             }
+
             // path0
             if(regexec(&regexCompiled_path0, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, path0);
                 snprintf (path0, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+            } else if (regexec(&regexCompiled_path0_hex, buffer, 2, match, 0) == 0) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                if (decoded_buffer) {
+                    const int decoded_length = match_size / 2;
+                    os_malloc(decoded_length + 1, path0);
+                    snprintf(path0, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                    os_free(decoded_buffer);
+                } else {
+                    merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                }
             }
+
             // path1
             if(regexec(&regexCompiled_path1, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, path1);
                 snprintf (path1, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+            } else if (regexec(&regexCompiled_path1_hex, buffer, 2, match, 0) == 0) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                if (decoded_buffer) {
+                    const int decoded_length = match_size / 2;
+                    os_malloc(decoded_length + 1, path1);
+                    snprintf(path1, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                    os_free(decoded_buffer);
+                } else {
+                    merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                }
             }
+
             // inode
             if(regexec(&regexCompiled_inode, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
-                os_malloc(match_size + 1, inode);
-                snprintf (inode, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                w_evt->inode = strdup(inode);
-                free(inode);
+                os_malloc(match_size + 1, w_evt->inode);
+                snprintf (w_evt->inode, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
             }
 
             switch(items) {
@@ -720,6 +832,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->path)?w_evt->path:"",
                                 (w_evt->process_name)?w_evt->process_name:"");
 
+                            char *real_path = NULL;
                             os_calloc(PATH_MAX + 2, sizeof(char), real_path);
                             if (realpath(w_evt->path, real_path), !real_path) {
                                 mdebug1(FIM_CHECK_LINK_REALPATH, w_evt->path);
@@ -744,8 +857,20 @@ void audit_parse(char *buffer) {
                     if(regexec(&regexCompiled_path2, buffer, 2, match, 0) == 0) {
                         match_size = match[1].rm_eo - match[1].rm_so;
                         os_malloc(match_size + 1, path2);
-                        snprintf (path2, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+                        snprintf (path2, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
+                    } else if (regexec(&regexCompiled_path2_hex, buffer, 2, match, 0) == 0) {
+                        match_size = match[1].rm_eo - match[1].rm_so;
+                        char * decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                        if (decoded_buffer) {
+                            const int decoded_length = match_size / 2;
+                            os_malloc(decoded_length + 1, path2);
+                            snprintf (path2, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                            os_free(decoded_buffer);
+                        } else {
+                            merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                        }
                     }
+
                     if (cwd && path1 && path2) {
                         if (file_path = gen_audit_path(cwd, path1, path2), file_path) {
                             w_evt->path = file_path;
@@ -776,14 +901,38 @@ void audit_parse(char *buffer) {
                     if(regexec(&regexCompiled_path2, buffer, 2, match, 0) == 0) {
                         match_size = match[1].rm_eo - match[1].rm_so;
                         os_malloc(match_size + 1, path2);
-                        snprintf (path2, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+                        snprintf (path2, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
+                    } else if (regexec(&regexCompiled_path2_hex, buffer, 2, match, 0) == 0) {
+                        match_size = match[1].rm_eo - match[1].rm_so;
+                        char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                        if (decoded_buffer) {
+                            const int decoded_length = match_size / 2;
+                            os_malloc(decoded_length + 1, path2);
+                            snprintf (path2, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                            os_free(decoded_buffer);
+                        } else {
+                            merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                        }
                     }
+
                     // path3
                     if(regexec(&regexCompiled_path3, buffer, 2, match, 0) == 0) {
                         match_size = match[1].rm_eo - match[1].rm_so;
                         os_malloc(match_size + 1, path3);
                         snprintf (path3, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+                    } else if (regexec(&regexCompiled_path3_hex, buffer, 2, match, 0) == 0) {
+                        match_size = match[1].rm_eo - match[1].rm_so;
+                        char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                        if (decoded_buffer) {
+                            const int decoded_length = match_size / 2;
+                            os_malloc(decoded_length + 1, path3);
+                            snprintf (path3, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                            os_free(decoded_buffer);
+                        } else {
+                            merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                        }
                     }
+
                     if (cwd && path0 && path1 && path2 && path3) {
                         // Send event 1/2
                         char *file_path1;
@@ -843,8 +992,20 @@ void audit_parse(char *buffer) {
                     if(regexec(&regexCompiled_path4, buffer, 2, match, 0) == 0) {
                         match_size = match[1].rm_eo - match[1].rm_so;
                         os_malloc(match_size + 1, path4);
-                        snprintf (path4, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+                        snprintf (path4, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
+                    }  else if (regexec(&regexCompiled_path4_hex, buffer, 2, match, 0) == 0) {
+                        match_size = match[1].rm_eo - match[1].rm_so;
+                        char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
+                        if (decoded_buffer) {
+                            const int decoded_length = match_size / 2;
+                            os_malloc(decoded_length + 1, path4);
+                            snprintf (path4, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                            os_free(decoded_buffer);
+                        } else {
+                            merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
+                        }
                     }
+
                     if (cwd && path1 && path4) {
                         char *file_path;
                         if (file_path = gen_audit_path(cwd, path1, path4), file_path) {
@@ -881,6 +1042,7 @@ void audit_parse(char *buffer) {
     case 3:
         if(regexec(&regexCompiled_syscall, buffer, 2, match, 0) == 0) {
             match_size = match[1].rm_eo - match[1].rm_so;
+            char *syscall = NULL;
             os_malloc(match_size + 1, syscall);
             snprintf (syscall, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
             if(!strcmp(syscall, "2") || !strcmp(syscall, "257")
@@ -902,7 +1064,7 @@ void audit_parse(char *buffer) {
             } else {
                 mdebug2(FIM_HEALTHCHECK_UNRECOGNIZED_EVENT, syscall);
             }
-            free(syscall);
+            os_free(syscall);
         }
     }
 }
@@ -985,6 +1147,15 @@ void * audit_main(int *audit_sock) {
     regfree(&regexCompiled_pname);
     regfree(&regexCompiled_items);
     regfree(&regexCompiled_inode);
+
+    regfree(&regexCompiled_cwd_hex);
+    regfree(&regexCompiled_pname_hex);
+    regfree(&regexCompiled_path0_hex);
+    regfree(&regexCompiled_path1_hex);
+    regfree(&regexCompiled_path2_hex);
+    regfree(&regexCompiled_path3_hex);
+    regfree(&regexCompiled_path4_hex);
+
     // Change Audit monitored folders to Inotify.
     int i;
     w_mutex_lock(&audit_rules_mutex);


### PR DESCRIPTION
|Related issue|
|---|
|#2866|

## Description
Audit encondes paths, and other fields whenever they contain special characters, such as whitespaces. This PR adds support for handling those cases by decoding them to plain text.


## Logs/Alerts example
#### Path with spaces
```
ossec-syscheckd[23525] syscheck_audit.c:833 at audit_parse(): DEBUG: (6247): audit_event: uid=user_name, auid=user_name, euid=user_name, gid=user_name, pid=23546, ppid=10273, inode=10503229, path=/tmp/folder/ddddd xxxxxx, pname=/bin/mkdir
ossec-syscheckd[23525] run_realtime.c:280 at realtime_adddir(): DEBUG: (6230): Monitoring with Audit: '/tmp/folder/ddddd xxxxxx'.
```

#### Process name with spaces
```
ossec-syscheckd[23525] syscheck_audit.c:833 at audit_parse(): DEBUG: (6247): audit_event: uid=some_user, auid=some_user, euid=some_user, gid=some_user, pid=23659, ppid=10273, inode=10503223, path=/tmp/folder/file.asd, pname=/tmp/with space
ossec-syscheckd[23525] run_check.c:48 at send_syscheck_msg(): DEBUG: (6310): Sending msg to the server: '0:33204:1001:1001:d41d8cd98f00b204e9800998ecf8427e:da39a3ee5e6b4b0d3255bfef95601890afd80709:some_user:some_user:1567514109:10503223:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:0!1001:some_user:1001:some_user:/tmp/with\ space:1001:some_user:1001:some_user:10273:23659::: /tmp/folder/file.asd'.
```


## Tests
### Scan-build
```
scan-build: Removing directory '/tmp/scan-build-2019-09-03-141248-5407-1' because it contains no reports.
scan-build: No bugs found.
```
### Valgrind
```
==27737== HEAP SUMMARY:
==27737==     in use at exit: 528,802 bytes in 2,532 blocks
==27737==   total heap usage: 12,085 allocs, 9,553 frees, 6,659,641 bytes allocated
==27737== 
==27737== LEAK SUMMARY:
==27737==    definitely lost: 0 bytes in 0 blocks
==27737==    indirectly lost: 0 bytes in 0 blocks
==27737==      possibly lost: 1,088 bytes in 4 blocks
==27737==    still reachable: 527,714 bytes in 2,528 blocks
==27737==         suppressed: 0 bytes in 0 blocks
==27737== Rerun with --leak-check=full to see details of leaked memory
==27737== 
==27737== For counts of detected and suppressed errors, rerun with: -v
==27737== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
### AddressSanitizer
Clean
### Stress test

#### Scripts

```python
import tempfile
import subprocess
import time
while True:
    f = tempfile.NamedTemporaryFile(prefix="file with spaces.", dir="/tmp/monitored_folder", delete=False)
    d = tempfile.TemporaryDirectory(prefix="directory with spaces.", dir="/tmp/monitored_folder")
    subprocess.run(["/tmp/monitored_folder/process with spaces", "/tmp/monitored_folder"])
    time.sleep(5)
```
Code of "process with spaces"
```C
#include <stdlib.h>
#include <unistd.h>
#include <stdio.h>

int main(int argc, char **argv)
{
    char filename[200];
    sprintf(filename, "%s/file with spaces.XXXXXX", argv[1]);
    int file = mkstemp(filename);
    close(file);
    unlink(filename);
}

```

#### Adress sanitizer
Clean. see file.
[addrsanitizer.log](https://github.com/wazuh/wazuh/files/3574241/addrsanitizer.log)

#### Valgrind
Clean. See file.
[valgrind.log](https://github.com/wazuh/wazuh/files/3574306/valgrind.log)

### Other tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck)
  - [x] AddressSanitizer
