### PR TITLE
Connect the fluentd forwarder to the Fluentd server through TLS without user and password

### DIFF
--- a/src/config/wmodules-fluent.c
+++ b/src/config/wmodules-fluent.c
@@ -152,8 +152,7 @@ int wm_fluent_read(xml_node **nodes, wmodule *module)
                 merror("User is too long at module '%s'. Max user length is %d", WM_FLUENT_CONTEXT.name,PATH_MAX);
                 return OS_INVALID;
             } else if (strlen(nodes[i]->content) == 0) {
-                merror("Empty user value at '%s'.", WM_FLUENT_CONTEXT.name);
-                return OS_INVALID;
+                mwarn("Empty user value at '%s'.", WM_FLUENT_CONTEXT.name);
             }
 
             os_strdup(nodes[i]->content,fluent->user_name);
@@ -164,8 +163,7 @@ int wm_fluent_read(xml_node **nodes, wmodule *module)
                 merror("Password is too long at module '%s'. Max password length is %d", WM_FLUENT_CONTEXT.name,PATH_MAX);
                 return OS_INVALID;
             } else if (strlen(nodes[i]->content) == 0) {
-                merror("Empty user value at '%s'.", WM_FLUENT_CONTEXT.name);
-                return OS_INVALID;
+                mwarn("Empty pass value at '%s'.", WM_FLUENT_CONTEXT.name);
             }
 
             os_strdup(nodes[i]->content,fluent->user_pass);
@@ -193,6 +191,14 @@ int wm_fluent_read(xml_node **nodes, wmodule *module)
         {
             mwarn("No such tag <%s> at module '%s'.", nodes[i]->element, WM_FLUENT_CONTEXT.name);
         }
+    }
+
+    if (!fluent->user_name) {
+        os_strdup("",fluent->user_name);
+    }
+
+    if (!fluent->user_pass) {
+        os_strdup("",fluent->user_pass);
     }
 
     return 0;

--- a/src/config/wmodules-fluent.c
+++ b/src/config/wmodules-fluent.c
@@ -194,11 +194,11 @@ int wm_fluent_read(xml_node **nodes, wmodule *module)
     }
 
     if (!fluent->user_name) {
-        os_strdup("",fluent->user_name);
+        os_strdup("", fluent->user_name);
     }
 
     if (!fluent->user_pass) {
-        os_strdup("",fluent->user_pass);
+        os_strdup("", fluent->user_pass);
     }
 
     return 0;

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -607,9 +607,8 @@ static int wm_fluent_handshake(wm_fluent_t * fluent) {
         }
 
         if (helo->auth_size > 0) {
-            if (!strcmp(fluent->user_name,"") && !strcmp(fluent->user_pass,"")) {
+            if (!strcmp(fluent->user_name, "") && !strcmp(fluent->user_pass, "")) {
                 mdebug1("Fluent server requires user name and password, but they are undefined.");
-                goto end;
             }
         } else if (fluent->user_name || fluent->user_pass) {
             mdebug1("The Fluent server does not require user authentication. Ignoring user name and pass.");

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -607,8 +607,8 @@ static int wm_fluent_handshake(wm_fluent_t * fluent) {
         }
 
         if (helo->auth_size > 0) {
-            if (!(fluent->user_name && fluent->user_pass)) {
-                mwarn("Authentication error: the Fluent server requires user name and password.");
+            if (!strcmp(fluent->user_name,"") && !strcmp(fluent->user_pass,"")) {
+                mdebug1("Fluent server requires user name and password, but they are undefined.");
                 goto end;
             }
         } else if (fluent->user_name || fluent->user_pass) {

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -477,8 +477,6 @@ static int wm_fluent_send_ping(wm_fluent_t * fluent, const wm_fluent_helo_t * he
         unsigned char md[SHA512_DIGEST_LENGTH];
         SHA512_CTX ctx;
 
-        assert(fluent->user_name && fluent->user_pass);
-
         /* Compute password hex digest */
 
         SHA512_Init(&ctx);
@@ -604,14 +602,6 @@ static int wm_fluent_handshake(wm_fluent_t * fluent) {
         if (!helo) {
             merror("Cannot receive HELO message from server");
             return -1;
-        }
-
-        if (helo->auth_size > 0) {
-            if (!strcmp(fluent->user_name, "") && !strcmp(fluent->user_pass, "")) {
-                mdebug1("Fluent server requires user name and password, but they are undefined.");
-            }
-        } else if (fluent->user_name || fluent->user_pass) {
-            mdebug1("The Fluent server does not require user authentication. Ignoring user name and pass.");
         }
 
         if (wm_fluent_send_ping(fluent, helo) < 0) {
@@ -742,8 +732,8 @@ cJSON *wm_fluent_dump(const wm_fluent_t *fluent) {
     if (fluent->port) cJSON_AddNumberToObject(wm_wd, "port", fluent->port);
     if (fluent->shared_key) cJSON_AddStringToObject(wm_wd, "shared_key", fluent->shared_key);
     if (fluent->certificate) cJSON_AddStringToObject(wm_wd, "ca_file", fluent->certificate);
-    if (fluent->user_name) cJSON_AddStringToObject(wm_wd, "user", fluent->user_name);
-    if (fluent->user_pass) cJSON_AddStringToObject(wm_wd, "password", fluent->user_pass);
+    cJSON_AddStringToObject(wm_wd, "user", fluent->user_name);
+    cJSON_AddStringToObject(wm_wd, "password", fluent->user_pass);
     cJSON_AddNumberToObject(wm_wd, "timeout", fluent->timeout);
 
     cJSON_AddItemToObject(root,"fluent-forward",wm_wd);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3900|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The fluent forwarder was requiring a username and password to complete the handshake with the fluent server. This isn't necessary when the forwarder is connected through TLS.

This PR sets the username and the password to an empty string when the variables are NULL and remove the restriction of requiring them to do the handshake.


## Logs/Alerts example

When the username and the password are empty the agent will log a debug message:
```
2019/09/03 13:50:58 fluent-forward[19385] wm_fluent.c:599 at wm_fluent_handshake(): DEBUG: Connection with localhost:24224 established
2019/09/03 13:50:58 fluent-forward[19385] wm_fluent.c:610 at wm_fluent_handshake(): DEBUG: Fluent server requires user name and password, but they are undefined.
2019/09/03 13:50:58 fluent-forward[19385] wm_fluent.c:633 at wm_fluent_handshake(): INFO: Connected to host 'demo' (localhost:24224)
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
