### PR TITLE
Fix memory leak in Syscheck for Windows

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -184,5 +184,6 @@
 #define FIM_WHODATA_FOLDER_REMOVED          "(6308): File '%s' was inside the removed directory '%s'. It will be notified."
 #define FIM_WHODATA_IGNORE_FILEEVENT        "(6309): Ignoring remove event for file '%s' because it has already been reported."
 #define FIM_CHECKSUM_MSG                    "(6310): Sending msg to the server: '%s'."
+#define FIM_MONITORING_FILES_COUNT          "(6311): Number of indexed files %s scanning: %u."
 
 #endif

--- a/src/headers/hash_op.h
+++ b/src/headers/hash_op.h
@@ -28,6 +28,7 @@ typedef struct _OSHash {
     unsigned int initial_seed;
     unsigned int constant;
     pthread_rwlock_t mutex;
+    unsigned int elements;
 
     void (*free_data_function)(void *data);
     OSHashNode **table;
@@ -68,6 +69,8 @@ void *OSHash_Get(const OSHash *self, const char *key) __attribute__((nonnull));
 void *OSHash_Numeric_Get_ex(const OSHash *self, int key) __attribute__((nonnull(1)));
 void *OSHash_Get_ex(const OSHash *self, const char *key) __attribute__((nonnull));
 void *OSHash_Get_ins(const OSHash *self, const char *key) __attribute__((nonnull));
+
+unsigned int OSHash_Get_Elem_ex(OSHash *self) __attribute__((nonnull));
 
 int OSHash_setSize(OSHash *self, unsigned int new_size) __attribute__((nonnull));
 int OSHash_setSize_ex(OSHash *self, unsigned int new_size) __attribute__((nonnull));

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -780,10 +780,9 @@ static void c_files()
     }
 
     OSHashNode *my_node;
-    unsigned int *i;
-    os_calloc(1, sizeof(unsigned int), i);
+    unsigned int i;
 
-    for (my_node = OSHash_Begin(m_hash, i); my_node; my_node = OSHash_Next(m_hash, i, my_node)) {
+    for (my_node = OSHash_Begin(m_hash, &i); my_node; my_node = OSHash_Next(m_hash, &i, my_node)) {
         os_free(key);
         os_free(data);
         os_strdup(my_node->key, key);
@@ -791,7 +790,6 @@ static void c_files()
             os_strdup(my_node->data, data);
         }
         else {
-            os_free(i);
             os_free(key);
             os_free(data);
             closedir(dp);
@@ -836,7 +834,6 @@ static void c_files()
         p_size++;
     }
 
-    os_free(i);
     os_free(key);
     os_free(data);
     /* Unlock mutex */

--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -294,6 +294,8 @@ int _OSHash_Add(OSHash *self, const char *key, void *data, int update)
         self->table[index] = new_node;
     }
 
+    self->elements = self->elements + 1;
+
     return (2);
 }
 
@@ -443,6 +445,16 @@ void *OSHash_Get_ins(const OSHash *self, const char *key)
     return result;
 }
 
+/* Return the number of elements in the hash table */
+unsigned int OSHash_Get_Elem_ex(OSHash *self) {
+    unsigned int ret;
+    w_rwlock_rdlock((pthread_rwlock_t *)&self->mutex);
+    ret = self->elements;
+    w_rwlock_unlock((pthread_rwlock_t *)&self->mutex);
+
+    return ret;
+}
+
 /* Return a pointer to a hash node if found, that hash node is removed from the table */
 void *OSHash_Delete(OSHash *self, const char *key)
 {
@@ -472,6 +484,7 @@ void *OSHash_Delete(OSHash *self, const char *key)
             free(curr_node->key);
             data = curr_node->data;
             free(curr_node);
+            self->elements = self->elements - 1;
             return data;
         }
         prev_node = curr_node;

--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -590,15 +590,14 @@ OSHashNode *OSHash_Next(const OSHash *self, unsigned int *i, OSHashNode *current
 }
 
 void *OSHash_Clean(OSHash *self, void (*cleaner)(void*)){
-    unsigned int *i;
-    os_calloc(1, sizeof(unsigned int), i);
+    unsigned int i;
     OSHashNode *curr_node;
     OSHashNode *next_node;
 
-    curr_node = OSHash_Begin(self, i);
+    curr_node = OSHash_Begin(self, &i);
     if(curr_node){
         do {
-            next_node = OSHash_Next(self, i, curr_node);
+            next_node = OSHash_Next(self, &i, curr_node);
             if(curr_node->key){
                 free(curr_node->key);
             }
@@ -609,8 +608,6 @@ void *OSHash_Clean(OSHash *self, void (*cleaner)(void*)){
             curr_node = next_node;
         } while (curr_node);
     }
-
-    os_free(i);
 
     /* Free the hash table */
     free(self->table);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -233,15 +233,8 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
 
             snprintf(alert_msg, OS_SIZE_6144, "-1!:::::::::::%s:%s:%c %s", syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", esc_linked_file ? esc_linked_file : "", silent, file_name);
             send_syscheck_msg(alert_msg);
-#ifndef WIN32
             fim_delete_hashes(strdup(file_name));
-#else
-            // Delete from hash table
-            if (s_node = OSHash_Delete_ex(syscheck.fp, file_name), s_node) {
-                os_free(s_node->checksum);
-                os_free(s_node);
-            }
-#endif
+
             os_free(alert_msg);
             os_free(wd_sum);
             free(esc_linked_file);
@@ -861,11 +854,9 @@ int run_dbcheck()
 
         // Send messages for deleted files
         OSHashNode *curr_node;
-        unsigned int *i;
+        unsigned int i;
 
-        os_calloc(1, sizeof(unsigned int), i);
-
-        for (curr_node = OSHash_Begin(last_backup, i); curr_node && curr_node->data; curr_node = OSHash_Next(last_backup, i, curr_node)) {
+        for (curr_node = OSHash_Begin(last_backup, &i); curr_node && curr_node->data; curr_node = OSHash_Next(last_backup, &i, curr_node)) {
             char *esc_linked_file = NULL;
             if (pos = find_dir_pos(curr_node->key, 1, 0, 0), pos >= 0) {
                 *linked_file = '\0';
@@ -883,12 +874,10 @@ int run_dbcheck()
                 send_syscheck_msg(alert_msg);
             }
 
-#ifndef WIN32
-            fim_delete_hashes(strdup(curr_node->key));
-#endif
+            fim_delete_hashes(curr_node->key);
+
             OSHash_Delete_ex(syscheck.last_check, curr_node->key);
         }
-        os_free(i);
 
         last_backup->free_data_function = NULL;
         OSHash_Free(last_backup);
@@ -1140,19 +1129,19 @@ int read_links(const char *dir_name, int dir_position, int max_depth, unsigned i
     return 0;
 }
 
+#endif
+
 int fim_delete_hashes(char *file_name) {
-    char *checksum_inode;
-    char *inode_str;
-    char *w_inode;
-    OSHashNode *s_inode;
-    char * inode_path;
     syscheck_node *data;
 
     if (data = OSHash_Delete_ex(syscheck.fp, file_name), data) {
-        os_strdup(data->checksum, checksum_inode);
+#ifndef WIN32
+        char *inode_str;
 
-        if(inode_str = get_attr_from_checksum(checksum_inode, SK_INODE), !inode_str || *inode_str == '\0') {
+        if(inode_str = get_attr_from_checksum(data->checksum, SK_INODE), !inode_str || *inode_str == '\0') {
             unsigned int *inode_it;
+            OSHashNode *s_inode;
+
             os_calloc(1, sizeof(unsigned int), inode_it);
 
             //Looking for inode if check_inode = no
@@ -1165,26 +1154,25 @@ int fim_delete_hashes(char *file_name) {
             os_free(inode_it);
         }
 
+        char * inode_path;
+
         if(inode_str) {
             if (inode_path = OSHash_Get_ex(syscheck.inode_hash, inode_str), inode_path) {
                 if(!strcmp(inode_path, file_name)) {
+                    char *w_inode;
                     if (w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str), w_inode) {
                         os_free(w_inode);
                     }
                 }
             }
         }
-
-        os_free(checksum_inode);
+#endif
         os_free(data->checksum);
         os_free(data);
     }
-    os_free(file_name);
 
     return 0;
 }
-
-#endif
 
 void replace_linked_path(const char *file_name, int dir_position, char *linked_file) {
     char *dir_path;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1139,19 +1139,16 @@ int fim_delete_hashes(char *file_name) {
         char *inode_str;
 
         if(inode_str = get_attr_from_checksum(data->checksum, SK_INODE), !inode_str || *inode_str == '\0') {
-            unsigned int *inode_it;
+            unsigned int inode_it;
             OSHashNode *s_inode;
 
-            os_calloc(1, sizeof(unsigned int), inode_it);
-
             //Looking for inode if check_inode = no
-            for (s_inode = OSHash_Begin(syscheck.inode_hash, inode_it); s_inode && s_inode->data; s_inode = OSHash_Next(syscheck.inode_hash, inode_it, s_inode)) {
+            for (s_inode = OSHash_Begin(syscheck.inode_hash, &inode_it); s_inode && s_inode->data; s_inode = OSHash_Next(syscheck.inode_hash, &inode_it, s_inode)) {
                 if(!strcmp(s_inode->data, file_name)){
                     inode_str = s_inode->key;
                     break;
                 }
             }
-            os_free(inode_it);
         }
 
         char * inode_path;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -233,7 +233,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
 
             snprintf(alert_msg, OS_SIZE_6144, "-1!:::::::::::%s:%s:%c %s", syscheck.tag[dir_position] ? syscheck.tag[dir_position] : "", esc_linked_file ? esc_linked_file : "", silent, file_name);
             send_syscheck_msg(alert_msg);
-            fim_delete_hashes(strdup(file_name));
+            fim_delete_hashes(file_name);
 
             os_free(alert_msg);
             os_free(wd_sum);
@@ -1134,7 +1134,7 @@ int read_links(const char *dir_name, int dir_position, int max_depth, unsigned i
 
 #endif
 
-int fim_delete_hashes(char *file_name) {
+int fim_delete_hashes(const char * const file_name) {
     syscheck_node *data;
 
     if (data = OSHash_Delete_ex(syscheck.fp, file_name), data) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -822,6 +822,8 @@ int run_dbcheck()
 
     os_calloc(OS_SIZE_6144, sizeof(char), alert_msg);
 
+    mdebug2(FIM_MONITORING_FILES_COUNT, "before", OSHash_Get_Elem_ex(syscheck.fp));
+
     __counter = 0;
     while (syscheck.dir[i] != NULL) {
         char *clink;
@@ -887,6 +889,7 @@ int run_dbcheck()
     }
 
     free(alert_msg);
+    mdebug2(FIM_MONITORING_FILES_COUNT, "after", OSHash_Get_Elem_ex(syscheck.fp));
 
     return (0);
 }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -394,10 +394,9 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
                 os_strdup(s_node->checksum, checksum_inode);
                 if(inode_str = get_attr_from_checksum(checksum_inode, SK_INODE), !inode_str || *inode_str == '\0') {
                     OSHashNode *s_inode;
-                    unsigned int *i;
-                    os_calloc(1, sizeof(unsigned int), i);
+                    unsigned int i;
 
-                    for (s_inode = OSHash_Begin(syscheck.inode_hash, i); s_inode; s_inode = OSHash_Next(syscheck.inode_hash, i, s_inode)) {
+                    for (s_inode = OSHash_Begin(syscheck.inode_hash, &i); s_inode; s_inode = OSHash_Next(syscheck.inode_hash, &i, s_inode)) {
                         if(s_inode && s_inode->data){
                             if(!strcmp(s_inode->data, file_name)) {
                                 inode_str = s_inode->key;
@@ -405,7 +404,6 @@ int c_read_file(const char *file_name, const char *linked_file, const char *olds
                             }
                         }
                     }
-                    os_free(i);
                 }
                 if(inode_str){
                     w_inode = OSHash_Delete_ex(syscheck.inode_hash, inode_str);

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -147,7 +147,7 @@ int w_update_sacl(const char *obj_path);
 #endif
 
 int print_hash_table();
-int fim_delete_hashes(char *file_name);
+int fim_delete_hashes(const char * const file_name);
 
 #ifdef WIN32
 #define check_removed_file(x) ({ strstr(x, ":\\$recycle.bin") ? 1 : 0; })


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/134|

This PR solves the issue linked to it. 

The steps to replicate the memory leak:
1) Configure the monitoring on a folder without realtime/whodata.
2) Create several files and let the frequency mode reporting them.
3) Remove all files when the frequency scan ends.
4) The removed files will remain in the hash table.

This could be verified by evaluating the number of indexed files, as well as a memory test replicating the previous use case. Therefore, a debug message has been added before and after the scan to control the size of the hash table (https://github.com/wazuh/wazuh/pull/3919/commits/de8383692665d203d9248ccfe3f16f531dc0abb8).

The following graph displays a memory test of replicating the error case. 

![image](https://user-images.githubusercontent.com/20266121/64272263-4a6c1f80-cf3f-11e9-83ca-37e7e36fbca3.png)


- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [X] Scan-build for Linux
- Memory tests for Windows
  - [x] Coverity (defects found not related https://github.com/wazuh/wazuh/pull/3927)
  - [x] Dr. Memory
  - [x] MTuner

- [x] Stress test for affected components
