### PR TITLE
Change nested field format from "_" to "." in new API and framework

### DIFF
--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 
 import connexion
-from connexion.lifecycle import ConnexionResponse
 
 import wazuh.configuration as config
 from api import configuration
@@ -59,8 +58,8 @@ def delete_agents(pretty=False, wait_for_complete=False, list_agents='all', purg
 
 @exception_handler
 def get_all_agents(pretty=False, wait_for_complete=False, offset=0, limit=None, select=None, sort=None, search=None,
-                   status=None, q='', older_than=None, os_platform=None, os_version=None, os_name=None, manager=None,
-                   version=None, group=None, node_name=None, name=None, ip=None, registerIP=None):
+                   status=None, q='', older_than=None, manager=None, version=None, group=None, node_name=None,
+                   name=None, ip=None, registerip=None):
     """Get all agents
 
     Returns a list with the available agents.
@@ -89,28 +88,31 @@ def get_all_agents(pretty=False, wait_for_complete=False, offset=0, limit=None, 
     :param registerIP: Filters by agent register IP
     :return: AllAgents
     """
-
     f_kwargs = {'offset': offset,
                 'limit': limit,
-                'sort': parse_api_param(sort.replace('os_', 'os.') if sort else sort, 'sort'),
+                'sort': parse_api_param(sort, 'sort'),
                 'search': parse_api_param(search, 'search'),
-                'select': [x.replace('os_', 'os.') for x in select] if select else select,
+                'select': select,
                 'filters': {
                     'status': status,
                     'older_than': older_than,
-                    'os.platform': os_platform,
-                    'os.version': os_version,
-                    'os.name': os_name,
                     'manager': manager,
                     'version': version,
                     'group': group,
                     'node_name': node_name,
                     'name': name,
                     'ip': ip,
-                    'registerIP': registerIP
+                    'registerIP': registerip
                 },
                 'q': q
                 }
+    # Add nested fields to kwargs filters
+    nested = ['os.version', 'os.name', 'os.platform']
+    for field in nested:
+        try:
+            f_kwargs['filters'][field] = connexion.request.args[field]
+        except KeyError:
+            f_kwargs['filters'][field] = None
 
     dapi = DistributedAPI(f=Agent.get_agents_overview,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -956,7 +958,7 @@ def get_group_file_xml(group_id, file_name, pretty=False, wait_for_complete=Fals
                           logger=logger
                           )
     data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
-    response = ConnexionResponse(body=data["message"], mimetype='application/xml')
+    response = connexion.lifecycle.ConnexionResponse(body=data["message"], mimetype='application/xml')
 
     return response
 

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -59,7 +59,7 @@ def delete_agents(pretty=False, wait_for_complete=False, list_agents='all', purg
 @exception_handler
 def get_all_agents(pretty=False, wait_for_complete=False, offset=0, limit=None, select=None, sort=None, search=None,
                    status=None, q='', older_than=None, manager=None, version=None, group=None, node_name=None,
-                   name=None, ip=None, registerip=None):
+                   name=None, ip=None):
     """Get all agents
 
     Returns a list with the available agents.
@@ -76,16 +76,12 @@ def get_all_agents(pretty=False, wait_for_complete=False, offset=0, limit=None, 
     :param q: Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;Active&amp;quot;
     :param older_than: Filters out disconnected agents for longer than specified. Time in seconds, ‘[n_days]d’,
     ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never connected agents, uses the register date.
-    :param os_platform: Filters by OS platform.
-    :param os_version: Filters by OS version.
-    :param os_name: Filters by OS name.
     :param manager: Filters by manager hostname to which agents are connected.
     :param version: Filters by agents version.
     :param group: Filters by group of agents.
     :param node_name: Filters by node name.
     :param name: Filters by agent name.
     :param ip: Filters by agent IP
-    :param registerIP: Filters by agent register IP
     :return: AllAgents
     """
     f_kwargs = {'offset': offset,
@@ -102,17 +98,14 @@ def get_all_agents(pretty=False, wait_for_complete=False, offset=0, limit=None, 
                     'node_name': node_name,
                     'name': name,
                     'ip': ip,
-                    'registerIP': registerip
+                    'registerIP': connexion.request.args.get('registerIP', None)
                 },
                 'q': q
                 }
     # Add nested fields to kwargs filters
     nested = ['os.version', 'os.name', 'os.platform']
     for field in nested:
-        try:
-            f_kwargs['filters'][field] = connexion.request.args[field]
-        except KeyError:
-            f_kwargs['filters'][field] = None
+        f_kwargs['filters'][field] = connexion.request.args.get(field, None)
 
     dapi = DistributedAPI(f=Agent.get_agents_overview,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/ciscat_controller.py
+++ b/api/api/controllers/ciscat_controller.py
@@ -37,26 +37,34 @@ def get_agents_ciscat_results(agent_id: str, pretty: bool = False, wait_for_comp
     :param search: Looks for elements with the specified string
     :param benchmark: Filters by benchmark type.
     :param profile: Filters by evaluated profile.
-    :param pass: Filters by passed checks
     :param fail: Filters by failed checks
     :param error: Filters by encountered errors
     :param notchecked: Filters by not checked
     :param unknown: Filters by unknown results.
     :param score: Filters by final score
     """
-
-    # We get pass param using connexion as pass is a python reserved keyword
+    # We get param using connexion as it is a python reserved keyword
     try:
         pass_ = connexion.request.args['pass']
     except KeyError:
         pass_ = None
 
     f_kwargs = {
-        'offset': offset, 'limit': limit, 'sort': parse_api_param(sort, 'sort'),
-        'search': parse_api_param(search, 'search'), 'select': select, 'agent_id': agent_id,
+        'offset': offset,
+        'limit': limit,
+        'sort': parse_api_param(sort, 'sort'),
+        'search': parse_api_param(search, 'search'),
+        'select': select,
+        'agent_id': agent_id,
         'filters': {
-            'benchmark': benchmark, 'profile': profile, 'pass': pass_, 'fail': fail, 'error': error,
-            'notchecked': notchecked, 'unknown': unknown, 'score': score
+            'benchmark': benchmark,
+            'profile': profile,
+            'pass': pass_,
+            'fail': fail,
+            'error': error,
+            'notchecked': notchecked,
+            'unknown': unknown,
+            'score': score
                 }
             }
 

--- a/api/api/controllers/syscollector_controller.py
+++ b/api/api/controllers/syscollector_controller.py
@@ -5,32 +5,29 @@
 import asyncio
 import logging
 
-from api.util import remove_nones_to_dict, exception_handler, parse_api_param
-from wazuh.cluster.dapi.dapi import DistributedAPI
-import wazuh.syscollector as syscollector
-from ..util import raise_if_exc
-from ..models.base_model_ import Data
+import connexion
 
+import wazuh.syscollector as syscollector
+from api.models.base_model_ import Data
+from api.util import remove_nones_to_dict, exception_handler, parse_api_param, raise_if_exc
+from wazuh.cluster.dapi.dapi import DistributedAPI
 
 loop = asyncio.get_event_loop()
 logger = logging.getLogger('wazuh')
 
 
 @exception_handler
-def get_hardware_info(agent_id, pretty=False, wait_for_complete=False,
-    select=None):
-    """
-    :param agent_id: Agent ID
-    :type agent_id: str
-    :param pretty: Show results in human-readable format
-    :type pretty: bool
-    :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :param select: Select which fields to return (separated by comma)
-    :type select: List[str]
-    """
+def get_hardware_info(agent_id, pretty=False, wait_for_complete=False, select=None):
+    """ Get hardware info of an agent
 
-    f_kwargs = {'agent_id': agent_id, 'select': select}
+    :param agent_id: Agent ID
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param select: Select which fields to return (separated by comma)
+    :return: Data
+    """
+    f_kwargs = {'agent_id': agent_id,
+                'select': select}
 
     dapi = DistributedAPI(f=syscollector.get_hardware_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -47,41 +44,39 @@ def get_hardware_info(agent_id, pretty=False, wait_for_complete=False,
 
 
 @exception_handler
-def get_network_address_info(agent_id, pretty=False, wait_for_complete=False,
-    offset=0, limit=None, select=None, sort=None, search=None, iface=None,
-    proto=None, address=None, broadcast=None, netmask=None):
-    """
-    :param agent_id: Agent ID
-    :type agent_id: str
-    :param pretty: Show results in human-readable format
-    :type pretty: bool
-    :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :type offset: int
-    :param limit: Maximum number of elements to return
-    :type limit: int
-    :param select: Select which fields to return (separated by comma)
-    :type select: List[str]
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
-    :type sort: str
-    :param search: Looks for elements with the specified string
-    :type search: str
-    :param iface: Filters by interface name
-    :type iface: str
-    :param proto: Filters by IP protocol
-    :type proto: str
-    :param address: IP address associated with the network interface
-    :type address: str
-    :param broadcast: Filters by broadcast direction
-    :type broadcast: str
-    :param netmask: Filters by netmask
-    :type netmask: str
-    """
-    filters = {'iface': iface, 'proto': proto, 'address': address,
-                'broadcast': broadcast, 'netmask': netmask}
+def get_network_address_info(agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, select=None,
+                             sort=None, search=None, iface=None, proto=None, address=None, broadcast=None,
+                             netmask=None):
+    """ Get network address info of an agent
 
-    f_kwargs = {'agent_id': agent_id, 'offset': offset, 'limit': limit,
-                'select': select, 'sort': parse_api_param(sort, 'sort'), 'search': parse_api_param(search, 'search'),
+    :param agent_id: Agent ID
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param offset: First element to return in the collection
+    :param limit: Maximum number of elements to return
+    :param select: Select which fields to return (separated by comma)
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
+    ascending or descending order.
+    :param search: Looks for elements with the specified string
+    :param iface: Filters by interface name
+    :param proto: Filters by IP protocol
+    :param address: IP address associated with the network interface
+    :param broadcast: Filters by broadcast direction
+    :param netmask: Filters by netmask
+    :return: Data
+    """
+    filters = {'iface': iface,
+               'proto': proto,
+               'address': address,
+               'broadcast': broadcast,
+               'netmask': netmask}
+
+    f_kwargs = {'agent_id': agent_id,
+                'offset': offset,
+                'limit': limit,
+                'select': select,
+                'sort': parse_api_param(sort, 'sort'),
+                'search': parse_api_param(search, 'search'),
                 'filters': filters}
 
     dapi = DistributedAPI(f=syscollector.get_netaddr_agent,
@@ -99,62 +94,50 @@ def get_network_address_info(agent_id, pretty=False, wait_for_complete=False,
 
 
 @exception_handler
-def get_network_interface_info(agent_id, pretty=False, wait_for_complete=False,
-    offset=0, limit=None, select=None, sort=None, search=None, name=None,
-    adapter=None, type=None, state=None, mtu=None, tx_packets=None, rx_packets=None,
-    tx_bytes=None, rx_bytes=None, tx_errors=None, rx_errors=None,
-    tx_dropped=None, rx_dropped=None):
-    """
-    :param agent_id: Agent ID
-    :type agent_id: str
-    :param pretty: Show results in human-readable format
-    :type pretty: bool
-    :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :type offset: int
-    :param limit: Maximum number of elements to return
-    :type limit: int
-    :param select: Select which fields to return (separated by comma)
-    :type select: List[str]
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
-    :type sort: str
-    :param search: Looks for elements with the specified string
-    :type search: str
-    :param name: Name of the network interface
-    :type name: str
-    :param adapter: Filters by adapter
-    :type adapter: str
-    :param type: Filters by type
-    :type type: str
-    :params state: Filters by state
-    :type state: str
-    :params mtu: Filters by mtu
-    :type mtu: str
-    :params tx_packets: Filters by tx_packets
-    :type tx_packets: str
-    :param rx_packets: Filters by rx_packets
-    :type rx_packets: str
-    :param tx_bytes: Filters by tx_bytes
-    :type tx_bytes: str
-    :param rx_bytes: Filters by rx_bytes
-    :type rx_bytes: str
-    :params tx_errors: Filters by tx_errors
-    :type tx_errors: str
-    :params rx_errors: Filters by rx_errors
-    :type rx_errors: str
-    :params tx_dropped: Filters by tx_dropped
-    :type tx_dropped: str
-    :params rx_dropped: Filters by rx_dropped
-    :type rx_dropped: str
-    """
-    filters = {'adapter': adapter, 'type': type, 'state': state, 'name': name,
-               'mtu': mtu, 'tx_packets': tx_packets, 'rx_packets': rx_packets,
-               'tx_bytes': tx_bytes, 'rx_bytes': rx_bytes,
-               'tx_errors': tx_errors, 'rx_errors': rx_errors,
-               'tx_dropped': tx_dropped, 'rx_dropped': rx_dropped}
+def get_network_interface_info(agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, select=None,
+                               sort=None, search=None, name=None, adapter=None, state=None, mtu=None):
+    """ Get network interface info of an agent
 
-    f_kwargs = {'agent_id': agent_id, 'offset': offset, 'limit': limit,
-                'select': select, 'sort': parse_api_param(sort, 'sort'), 'search': parse_api_param(search, 'search'),
+    :param agent_id: Agent ID
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param offset: First element to return in the collection
+    :param limit: Maximum number of elements to return
+    :param select: Select which fields to return (separated by comma)
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
+    ascending or descending order.
+    :param search: Looks for elements with the specified string
+    :param name: Name of the network interface
+    :param adapter: Filters by adapter
+    :param state: Filters by state
+    :param mtu: Filters by mtu
+    :return: Data
+    """
+    # We get param using connexion as it is a python reserved keyword
+    try:
+        type_ = connexion.request.args['type']
+    except KeyError:
+        type_ = None
+
+    filters = {'adapter': adapter,
+               'type': type_,
+               'state': state,
+               'name': name,
+               'mtu': mtu}
+    # Add nested fields to kwargs filters
+    nested = ['tx.packets', 'rx.packets', 'tx.bytes', 'rx.bytes', 'tx.errors', 'rx.errors', 'tx.dropped', 'rx.dropped']
+    for field in nested:
+        try:
+            filters[field] = connexion.request.args[field]
+        except KeyError:
+            filters[field] = None
+
+    f_kwargs = {'agent_id': agent_id,
+                'offset': offset,
+                'limit': limit,
+                'select': select,
+                'sort': parse_api_param(sort, 'sort'),
+                'search': parse_api_param(search, 'search'),
                 'filters': filters}
 
     dapi = DistributedAPI(f=syscollector.get_netiface_agent,
@@ -172,38 +155,41 @@ def get_network_interface_info(agent_id, pretty=False, wait_for_complete=False,
 
 
 @exception_handler
-def get_network_protocol_info(agent_id, pretty=False, wait_for_complete=False,
-    offset=0, limit=None, select=None, sort=None, search=None, iface=None,
-    type=None, gateway=None, dhcp=None):
-    """
-    :param agent_id: Agent ID
-    :type agent_id: str
-    :param pretty: Show results in human-readable format
-    :type pretty: bool
-    :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :type offset: int
-    :param limit: Maximum number of elements to return
-    :type limit: int
-    :param select: Select which fields to return (separated by comma)
-    :type select: List[str]
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
-    :type sort: str
-    :param search: Looks for elements with the specified string
-    :type search: str
-    :param iface: Filters by iface
-    :type iface: str
-    :param type: Filters by type
-    :type type: str
-    :param gateway: Filters by gateway
-    :type gateway: str
-    :param dhcp: Filters by dhcp
-    :type dhcp: str
-    """
-    filters = {'iface': iface, 'type': type, 'gateway': gateway, 'dhcp': dhcp}
+def get_network_protocol_info(agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, select=None,
+                              sort=None, search=None, iface=None, gateway=None, dhcp=None):
+    """ Get network protocol info of an agent
 
-    f_kwargs = {'agent_id': agent_id, 'offset': offset, 'limit': limit,
-                'select': select, 'sort': parse_api_param(sort, 'sort'), 'search': parse_api_param(search, 'search'),
+    :param agent_id: Agent ID
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param offset: First element to return in the collection
+    :param limit: Maximum number of elements to return
+    :param select: Select which fields to return (separated by comma)
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
+    ascending or descending order.
+    :param search: Looks for elements with the specified string
+    :param iface: Filters by iface
+    :param gateway: Filters by gateway
+    :param dhcp: Filters by dhcp
+    :return: Data
+    """
+    # We get param using connexion as it is a python reserved keyword
+    try:
+        type_ = connexion.request.args['type']
+    except KeyError:
+        type_ = None
+
+    filters = {'iface': iface,
+               'type': type_,
+               'gateway': gateway,
+               'dhcp': dhcp}
+
+    f_kwargs = {'agent_id': agent_id,
+                'offset': offset,
+                'limit': limit,
+                'select': select,
+                'sort': parse_api_param(sort, 'sort'),
+                'search': parse_api_param(search, 'search'),
                 'filters': filters}
 
     dapi = DistributedAPI(f=syscollector.get_netproto_agent,
@@ -221,20 +207,17 @@ def get_network_protocol_info(agent_id, pretty=False, wait_for_complete=False,
 
 
 @exception_handler
-def get_os_info(agent_id, pretty=False, wait_for_complete=False,
-    select=None):
-    """
-    :param agent_id: Agent ID
-    :type agent_id: str
-    :param pretty: Show results in human-readable format
-    :type pretty: bool
-    :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :param select: Select which fields to return (separated by comma)
-    :type select: List[str]
-    """
+def get_os_info(agent_id, pretty=False, wait_for_complete=False, select=None):
+    """ Get OS info of an agent
 
-    f_kwargs = {'agent_id': agent_id, 'select': select}
+    :param agent_id: Agent ID
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param select: Select which fields to return (separated by comma)
+    :return: Data
+    """
+    f_kwargs = {'agent_id': agent_id,
+                'select': select}
 
     dapi = DistributedAPI(f=syscollector.get_os_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -251,41 +234,43 @@ def get_os_info(agent_id, pretty=False, wait_for_complete=False,
 
 
 @exception_handler
-def get_packages_info(agent_id, pretty=False, wait_for_complete=False,
-    offset=0, limit=None, select=None, sort=None, search=None, vendor=None,
-    name=None, architecture=None, format=None, version=None):
-    """
-    :param agent_id: Agent ID
-    :type agent_id: str
-    :param pretty: Show results in human-readable format
-    :type pretty: bool
-    :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :type offset: int
-    :param limit: Maximum number of elements to return
-    :type limit: int
-    :param select: Select which fields to return (separated by comma)
-    :type select: List[str]
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
-    :type sort: str
-    :param search: Looks for elements with the specified string
-    :type search: str
-    :param vendor: Filters by vendor
-    :type vendor: str
-    :param name: Filters by name
-    :type name: str
-    :param architecture: Filters by architecture
-    :type architecture: str
-    :param format: Filters by format
-    :type format: str
-    :param version: Filters by version
-    :type version: str
-    """
-    filters = {'vendor': vendor, 'name': name, 'architecture': architecture,
-               'format': format, 'version': version}
+def get_packages_info(agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, select=None, sort=None,
+                      search=None, vendor=None, name=None, architecture=None, version=None):
+    """ Get packages info of an agent
 
-    f_kwargs = {'agent_id': agent_id, 'offset': offset, 'limit': limit,
-                'select': select, 'sort': parse_api_param(sort, 'sort'), 'search': parse_api_param(search, 'search'),
+    :param agent_id: Agent ID
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param offset: First element to return in the collection
+    :param limit: Maximum number of elements to return
+    :param select: Select which fields to return (separated by comma)
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
+    ascending or descending order.
+    :param search: Looks for elements with the specified string
+    :param vendor: Filters by vendor
+    :param name: Filters by name
+    :param architecture: Filters by architecture
+    :param version: Filters by version
+    :return: Data
+    """
+    # We get param using connexion as it is a python reserved keyword
+    try:
+        format_ = connexion.request.args['format']
+    except KeyError:
+        format_ = None
+
+    filters = {'vendor': vendor,
+               'name': name,
+               'architecture': architecture,
+               'format': format_,
+               'version': version}
+
+    f_kwargs = {'agent_id': agent_id,
+                'offset': offset,
+                'limit': limit,
+                'select': select,
+                'sort': parse_api_param(sort, 'sort'),
+                'search': parse_api_param(search, 'search'),
                 'filters': filters}
 
     dapi = DistributedAPI(f=syscollector.get_packages_agent,
@@ -303,46 +288,43 @@ def get_packages_info(agent_id, pretty=False, wait_for_complete=False,
 
 
 @exception_handler
-def get_ports_info(agent_id, pretty=False, wait_for_complete=False,
-    offset=0, limit=None, select=None, sort=None, search=None, pid=None,
-    protocol=None, local_ip=None, local_port=None, remote_ip=None,
-    tx_queue=None, state=None):
-    """
-    :param agent_id: Agent ID
-    :type agent_id: str
-    :param pretty: Show results in human-readable format
-    :type pretty: bool
-    :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :type offset: int
-    :param limit: Maximum number of elements to return
-    :type limit: int
-    :param select: Select which fields to return (separated by comma)
-    :type select: List[str]
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
-    :type sort: str
-    :param search: Looks for elements with the specified string
-    :type search: str
-    :param pid: Filters by pid
-    :type pid: str
-    :param protocol: Filters by protocol
-    :type protocol: str
-    :param local_ip: Filters by local IP
-    :type local_ip: str
-    :param local_port: Filters by local port
-    :type local_port: str
-    :param remote_ip Filters by remote IP
-    :type remote_ip: str
-    :param tx_queue: Filters by tx_queue
-    :type tx_queue: str
-    :param state: Filters by state
-    :type state: str
-    """
-    filters = {'pid': pid, 'protocol': protocol, 'local_ip': local_ip, 'local_port': local_port,
-               'remote_ip': remote_ip, 'tx_queue': tx_queue, 'state': state}
+def get_ports_info(agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, select=None, sort=None,
+                   search=None, pid=None, protocol=None, tx_queue=None, state=None):
+    """ Get ports info of an agent
 
-    f_kwargs = {'agent_id': agent_id, 'offset': offset, 'limit': limit,
-                'select': select, 'sort': parse_api_param(sort, 'sort'), 'search': parse_api_param(search, 'search'),
+    :param agent_id: Agent ID
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param offset: First element to return in the collection
+    :param limit: Maximum number of elements to return
+    :param select: Select which fields to return (separated by comma)
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
+    ascending or descending order.
+    :param search: Looks for elements with the specified string
+    :param pid: Filters by pid
+    :param protocol: Filters by protocol
+    :param tx_queue: Filters by tx_queue
+    :param state: Filters by state
+    :return: Data
+    """
+    filters = {'pid': pid,
+               'protocol': protocol,
+               'tx_queue': tx_queue,
+               'state': state}
+    # Add nested fields to kwargs filters
+    nested = ['local.ip', 'local.port', 'remote.ip']
+    for field in nested:
+        try:
+            filters[field] = connexion.request.args[field]
+        except KeyError:
+            filters[field] = None
+
+    f_kwargs = {'agent_id': agent_id,
+                'offset': offset,
+                'limit': limit,
+                'select': select,
+                'sort': parse_api_param(sort, 'sort'),
+                'search': parse_api_param(search, 'search'),
                 'filters': filters}
 
     dapi = DistributedAPI(f=syscollector.get_ports_agent,
@@ -360,64 +342,57 @@ def get_ports_info(agent_id, pretty=False, wait_for_complete=False,
 
 
 @exception_handler
-def get_processes_info(agent_id, pretty=False, wait_for_complete=False,
-    offset=0, limit=None, select=None, sort=None, search=None, pid=None,
-    state=None, ppid=None, egroup=None, euser=None, fgroup=None,
-    name=None, nlwp=None, pgrp=None, priority=None, rgroup=None,
-    ruser=None, sgroup=None, suser=None):
-    """
-    :param agent_id: Agent ID
-    :type agent_id: str
-    :param pretty: Show results in human-readable format
-    :type pretty: bool
-    :param wait_for_complete: Disable timeout response
-    :type wait_for_complete: bool
-    :type offset: int
-    :param limit: Maximum number of elements to return
-    :type limit: int
-    :param select: Select which fields to return (separated by comma)
-    :type select: List[str]
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
-    :type sort: str
-    :param search: Looks for elements with the specified string
-    :type search: str
-    :param pid: Filters by process pid
-    :type pid: str
-    :param state: Filters by process state
-    :type state: str
-    :param ppid: Filters by process parent pid
-    :type ppid: str
-    :param egroup: Filters by process egroup
-    :type egroup: str
-    :param euser Filters by process euser
-    :type euser: str
-    :param fgroup: Filters by process fgroup
-    :type fgroup: str
-    :param name: Filters by process name
-    :type name: str
-    :param nlwp: Filters by process nlwp
-    :type nlwp: str
-    :param pgrp: Filters by process pgrp
-    :type pgrp: str
-    :param priority: Filters by process priority
-    :type priority: str
-    :param rgroup: Filters by process rgroup
-    :type rgroup: str
-    :param ruser: Filters by process ruser
-    :type ruser: str
-    :param sgroup: Filters by process sgroup
-    :type sgroup: str
-    :param suser: Filters by process suser
-    :type suser: str
-    """
-    filters = {'state': state, 'pid': pid,
-              'ppid': ppid,'egroup': egroup, 'euser': euser, 'fgroup': fgroup,
-              'name': name, 'nlwp': nlwp, 'pgrp': pgrp,
-              'priority': priority, 'rgroup': rgroup, 'ruser': ruser,
-              'sgroup': sgroup, 'suser': suser}
+def get_processes_info(agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, select=None, sort=None,
+                       search=None, pid=None, state=None, ppid=None, egroup=None, euser=None, fgroup=None, name=None,
+                       nlwp=None, pgrp=None, priority=None, rgroup=None, ruser=None, sgroup=None, suser=None):
+    """ Get processes info an agent
 
-    f_kwargs = {'agent_id': agent_id, 'offset': offset, 'limit': limit,
-                'select': select, 'sort': parse_api_param(sort, 'sort'), 'search': parse_api_param(search, 'search'),
+    :param agent_id: Agent ID
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param offset: First element to return in the collection
+    :param limit: Maximum number of elements to return
+    :param select: Select which fields to return (separated by comma)
+    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
+    ascending or descending order.
+    :param search: Looks for elements with the specified string
+    :param pid: Filters by process pid
+    :param state: Filters by process state
+    :param ppid: Filters by process parent pid
+    :param egroup: Filters by process egroup
+    :param euser Filters by process euser
+    :param fgroup: Filters by process fgroup
+    :param name: Filters by process name
+    :param nlwp: Filters by process nlwp
+    :param pgrp: Filters by process pgrp
+    :param priority: Filters by process priority
+    :param rgroup: Filters by process rgroup
+    :param ruser: Filters by process ruser
+    :param sgroup: Filters by process sgroup
+    :param suser: Filters by process suser
+    :return: Data
+    """
+    filters = {'state': state,
+               'pid': pid,
+               'ppid': ppid,
+               'egroup': egroup,
+               'euser': euser,
+               'fgroup': fgroup,
+               'name': name,
+               'nlwp': nlwp,
+               'pgrp': pgrp,
+               'priority': priority,
+               'rgroup': rgroup,
+               'ruser': ruser,
+               'sgroup': sgroup,
+               'suser': suser}
+
+    f_kwargs = {'agent_id': agent_id,
+                'offset': offset,
+                'limit': limit,
+                'select': select,
+                'sort': parse_api_param(sort, 'sort'),
+                'search': parse_api_param(search, 'search'),
                 'filters': filters}
 
     dapi = DistributedAPI(f=syscollector.get_processes_agent,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3567,8 +3567,8 @@ tags:
   - name: security
     description: 'Roles administration and user authentication'
 
-#security:
-  #- jwt: []
+security:
+  - jwt: []
 
 paths:
   /:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3271,10 +3271,7 @@ components:
       name: dhcp
       description: Filters by network dhcp (enabled or disabled).
       schema:
-        type: string
-        enum:
-          - enabled
-          - disabled
+          $ref: '#/components/schemas/DHCPStatus'
     os.name:
       in: query
       name: os.name
@@ -3316,7 +3313,6 @@ components:
       description: Filters by vendor.
       schema:
         type: string
-        format: alphanumeric
     pid:
       in: query
       name: pid
@@ -3471,7 +3467,6 @@ components:
       description: Filters by version name.
       schema:
         type: string
-        format: alphanumeric
     older_than:
       in: query
       name: older_than

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2712,8 +2712,7 @@ components:
       in: query
       name: select
       description: |
-        Select which fields to return (separated by comma). Use '_' for nested fields. For example, "{field1: field2}"
-        may be selected with "field1_field2".
+        Select which fields to return (separated by comma). Use '.' for nested fields. For example, "{field1: field2}" may be selected with "field1.field2".
       schema:
         type: array
         items:
@@ -2725,8 +2724,7 @@ components:
       name: sort
       description: |
         Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
-        Use '_' for nested fields. For example, "{field1: field2}"
-            may be selected with "field1_field2".
+        Use '.' for nested fields. For example, "{field1: field2}" may be selected with "field1.field2".
       schema:
         type: string
         format: sort
@@ -3190,66 +3188,66 @@ components:
         type: integer
         format: int32
         minimum: 0
-    tx_packets:
+    tx.packets:
       in: query
-      name: tx_packets
-      description: Filters by tx_packets.
+      name: tx.packets
+      description: Filters by tx.packets.
       schema:
         type: integer
         format: int32
         minimum: 0
-    rx_packets:
+    rx.packets:
       in: query
-      name: rx_packets
-      description: Filters by rx_packets.
+      name: rx.packets
+      description: Filters by rx.packets.
       schema:
         type: integer
         format: int32
         minimum: 0
-    tx_bytes:
+    tx.bytes:
       in: query
-      name: tx_bytes
-      description: Filters by tx_bytes.
+      name: tx.bytes
+      description: Filters by tx.bytes.
       schema:
         type: integer
         format: int32
         minimum: 0
-    rx_bytes:
+    rx.bytes:
       in: query
-      name: rx_bytes
-      description: Filters by rx_bytes.
+      name: rx.bytes
+      description: Filters by rx.bytes.
       schema:
         type: integer
         format: int32
         minimum: 0
-    tx_errors:
+    tx.errors:
       in: query
-      name: tx_errors
-      description: Filters by tx_errors.
+      name: tx.errors
+      description: Filters by tx.errors.
       schema:
         type: integer
         format: int32
         minimum: 0
-    rx_errors:
+    rx.errors:
       in: query
-      name: rx_errors
-      description: Filters by rx_errors.
+      name: rx.errors
+      description: Filters by rx.errors.
       schema:
         type: integer
         format: int32
         minimum: 0
-    tx_dropped:
+    tx.dropped:
       in: query
-      name: tx_dropped
-      description: Filters by tx_dropped.
+      name: tx.dropped
+      description: Filters by tx.dropped.
       schema:
         type: integer
         format: int32
         minimum: 0
-    rx_dropped:
+    rx.dropped:
       in: query
-      name: rx_dropped
-      description: Filters by rx_dropped.
+      name: rx.dropped
+      description: Filters by rx.dropped.
       schema:
         type: integer
         format: int32
@@ -3277,16 +3275,16 @@ components:
         enum:
           - enabled
           - disabled
-    os_name:
+    os.name:
       in: query
-      name: os_name
-      description: "Filters by os_name. Example: Ubuntu, Windows..."
+      name: os.name
+      description: Filters by OS name.
       schema:
         type: string
         format: alphanumeric
-    os_platform:
+    os.platform:
       in: query
-      name: os_platform
+      name: os.platform
       description: Filters by OS platform.
       schema:
         type: string
@@ -3298,10 +3296,10 @@ components:
       schema:
         type: string
         format: alphanumeric
-    os_version:
+    os.version:
       in: query
-      name: os_version
-      description: Filters by os_version.
+      name: os.version
+      description: Filters by OS version.
       schema:
         type: string
         format: alphanumeric
@@ -3341,23 +3339,23 @@ components:
       schema:
         type: string
         format: etc_path
-    local_ip:
+    local.ip:
       in: query
-      name: local_ip
+      name: local.ip
       description: Filters by Local IP.
       schema:
         type: string
         format: alphanumeric
-    local_port:
+    local.port:
       in: query
-      name: local_port
+      name: local.port
       description: Filters by Local Port.
       schema:
         type: string
         format: numbers
-    remote_ip:
+    remote.ip:
       in: query
-      name: remote_ip
+      name: remote.ip
       description: Filters by Remote IP.
       schema:
         type: string
@@ -3706,9 +3704,9 @@ paths:
         - $ref: '#/components/parameters/statusAgentParam'
         - $ref: '#/components/parameters/query'
         - $ref: '#/components/parameters/olderThanParam'
-        - $ref: '#/components/parameters/os_platform'
-        - $ref: '#/components/parameters/os_version'
-        - $ref: '#/components/parameters/os_name'
+        - $ref: '#/components/parameters/os.platform'
+        - $ref: '#/components/parameters/os.version'
+        - $ref: '#/components/parameters/os.name'
         - $ref: '#/components/parameters/manager_host'
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/agent_group'
@@ -9142,14 +9140,14 @@ paths:
         - $ref: '#/components/parameters/type_syscollector'
         - $ref: '#/components/parameters/state'
         - $ref: '#/components/parameters/mtu'
-        - $ref: '#/components/parameters/tx_packets'
-        - $ref: '#/components/parameters/rx_packets'
-        - $ref: '#/components/parameters/tx_bytes'
-        - $ref: '#/components/parameters/rx_bytes'
-        - $ref: '#/components/parameters/tx_errors'
-        - $ref: '#/components/parameters/rx_errors'
-        - $ref: '#/components/parameters/tx_dropped'
-        - $ref: '#/components/parameters/rx_dropped'
+        - $ref: '#/components/parameters/tx.packets'
+        - $ref: '#/components/parameters/rx.packets'
+        - $ref: '#/components/parameters/tx.bytes'
+        - $ref: '#/components/parameters/rx.bytes'
+        - $ref: '#/components/parameters/tx.errors'
+        - $ref: '#/components/parameters/rx.errors'
+        - $ref: '#/components/parameters/tx.dropped'
+        - $ref: '#/components/parameters/rx.dropped'
       responses:
         '200':
           description: "Return a list of agent's network interfaces results"
@@ -9284,9 +9282,9 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/select'
-        - $ref: '#/components/parameters/os_name'
+        - $ref: '#/components/parameters/os.name'
         - $ref: '#/components/parameters/architecture'
-        - $ref: '#/components/parameters/os_version'
+        - $ref: '#/components/parameters/os.version'
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/release'
       responses:
@@ -9438,9 +9436,9 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/pid'
         - $ref: '#/components/parameters/protocol'
-        - $ref: '#/components/parameters/local_ip'
-        - $ref: '#/components/parameters/local_port'
-        - $ref: '#/components/parameters/remote_ip'
+        - $ref: '#/components/parameters/local.ip'
+        - $ref: '#/components/parameters/local.port'
+        - $ref: '#/components/parameters/remote.ip'
         - $ref: '#/components/parameters/tx_queue'
         - $ref: '#/components/parameters/state'
         - $ref: '#/components/parameters/process'
@@ -9715,7 +9713,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: 'Get network interface info of an agents'
+      summary: 'Get network interface info of an agent'
       description: "Returns the agent's network interface info. This information include rx, scan, tx info and some network information among others."
       operationId: api.controllers.syscollector_controller.get_network_interface_info
       parameters:
@@ -9732,14 +9730,14 @@ paths:
         - $ref: '#/components/parameters/typesys'
         - $ref: '#/components/parameters/state'
         - $ref: '#/components/parameters/mtu'
-        - $ref: '#/components/parameters/tx_packets'
-        - $ref: '#/components/parameters/rx_packets'
-        - $ref: '#/components/parameters/tx_bytes'
-        - $ref: '#/components/parameters/rx_bytes'
-        - $ref: '#/components/parameters/tx_errors'
-        - $ref: '#/components/parameters/rx_errors'
-        - $ref: '#/components/parameters/tx_dropped'
-        - $ref: '#/components/parameters/rx_dropped'
+        - $ref: '#/components/parameters/tx.packets'
+        - $ref: '#/components/parameters/rx.packets'
+        - $ref: '#/components/parameters/tx.bytes'
+        - $ref: '#/components/parameters/rx.bytes'
+        - $ref: '#/components/parameters/tx.errors'
+        - $ref: '#/components/parameters/rx.errors'
+        - $ref: '#/components/parameters/tx.dropped'
+        - $ref: '#/components/parameters/rx.dropped'
       responses:
         '200':
           description: "Return a list of agent's network interfaces results"
@@ -9860,7 +9858,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: 'Get OS info'
+      summary: 'Get OS info of an agent'
       description: "Returns the agent's OS info. This information include os information, architecture information among others of all agents."
       operationId: api.controllers.syscollector_controller.get_os_info
       parameters:
@@ -9904,7 +9902,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: 'Get packages info'
+      summary: 'Get packages info of an agent'
       description: "Returns the agent's packages info. This information include name, section, size, priority information of all packages among others."
       operationId: api.controllers.syscollector_controller.get_packages_info
       parameters:
@@ -9977,7 +9975,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: 'Get ports info of an agents'
+      summary: 'Get ports info of an agent'
       description: "Returns the agent's ports info. This information include local IP, Remote IP, protocol information among others."
       operationId: api.controllers.syscollector_controller.get_ports_info
       parameters:
@@ -9991,9 +9989,9 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/pid'
         - $ref: '#/components/parameters/protocol'
-        - $ref: '#/components/parameters/local_ip'
-        - $ref: '#/components/parameters/local_port'
-        - $ref: '#/components/parameters/remote_ip'
+        - $ref: '#/components/parameters/local.ip'
+        - $ref: '#/components/parameters/local.port'
+        - $ref: '#/components/parameters/remote.ip'
         - $ref: '#/components/parameters/tx_queue'
         - $ref: '#/components/parameters/state'
       responses:
@@ -10054,7 +10052,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: 'Get processes info'
+      summary: 'Get processes info an agent'
       description: "Returns the agent's processes info."
       operationId: api.controllers.syscollector_controller.get_processes_info
       parameters:

--- a/api/api/util.py
+++ b/api/api/util.py
@@ -320,7 +320,7 @@ def _parse_sort_param(sort: str) -> [typing.Dict, None]:
     :param sort: Sort parameter coming from the API query
     :return: A dictionary like {"fields":["field1", "field1"], "order": "desc"}
     """
-    sort_fields = sort[(1 if sort[0] == '-' or sort[0] == ' ' else 0):]
+    sort_fields = sort[(1 if sort[0] == '-' or sort[0] == '+' else 0):]
     return {'fields': sort_fields.split(','), 'order': 'desc' if sort[0] == '-' else 'asc'}
 
 

--- a/framework/wazuh/ciscat.py
+++ b/framework/wazuh/ciscat.py
@@ -20,7 +20,7 @@ def get_ciscat_results(agent_id=None, offset=0, limit=common.database_limit, sel
     :param q: Defines query to filter in DB.
     :return: Dictionary: {'items': array of items, 'totalItems': Number of items (without applying the limit)}
     """
-    valid_select_fields = {'scan_id': 'scan_id', 'scan_time': 'scan_time', 'benchmark': 'benchmark',
+    valid_select_fields = {'scan.id': 'scan_id', 'scan.time': 'scan_time', 'benchmark': 'benchmark',
                            'profile': 'profile', 'pass': 'pass', 'fail': 'fail', 'error': 'error',
                            'notchecked': 'notchecked', 'unknown': 'unknown', 'score': 'score'}
     table = 'ciscat_results'

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -11,7 +11,7 @@ from operator import itemgetter
 
 class WazuhDBQuerySyscollector(WazuhDBQuery):
 
-    nested_fields = ['scan', 'os', 'ram', 'cpu', 'local', 'remote']
+    nested_fields = ['scan', 'os', 'ram', 'cpu', 'local', 'remote', 'tx', 'rx']
 
     def __init__(self, array, nested, agent_id, *args, **kwargs):
         super().__init__(backend=WazuhDBBackend(agent_id), default_sort_field='scan_id', get_data=True, count=True,
@@ -21,8 +21,8 @@ class WazuhDBQuerySyscollector(WazuhDBQuery):
 
     def _format_data_into_dictionary(self):
         if self.nested:
-            fields_to_nest, non_nested = get_fields_to_nest(self.fields.keys(), self.nested_fields, '_')
-            self._data = [plain_dict_to_nested_dict(d, fields_to_nest, non_nested, self.nested_fields, '_') for d in self._data]
+            fields_to_nest, non_nested = get_fields_to_nest(self.fields.keys(), self.nested_fields, '.')
+            self._data = [plain_dict_to_nested_dict(d, fields_to_nest, non_nested, self.nested_fields, '.') for d in self._data]
 
         return super()._format_data_into_dictionary() if self.array else next(iter(self._data), {})
 
@@ -45,11 +45,11 @@ def get_os_agent(agent_id, offset=0, limit=common.database_limit, select={}, sea
 
     # The osinfo fields in database are different in Windows and Linux
     os_name = agent_obj.get_agent_attr('os_name')
-    windows_fields = {'hostname': 'hostname', 'os_version': 'os_version', 'os_name': 'os_name',
-                      'architecture': 'architecture', 'os_major': 'os_major', 'os_minor': 'os_minor',
-                      'os_build': 'os_build', 'version': 'version', 'scan_time': 'scan_time',
-                      'scan_id': 'scan_id'}
-    linux_fields = {**windows_fields, **{'os_codename': 'os_codename', 'os_platform': 'os_platform',
+    windows_fields = {'hostname': 'hostname', 'os.version': 'os_version', 'os.name': 'os_name',
+                      'architecture': 'architecture', 'os.major': 'os_major', 'os.minor': 'os_minor',
+                      'os.build': 'os_build', 'version': 'version', 'scan.time': 'scan_time',
+                      'scan.id': 'scan_id'}
+    linux_fields = {**windows_fields, **{'os.codename': 'os_codename', 'os.platform': 'os_platform',
                                          'sysname': 'sysname', 'release': 'release'}}
 
     valid_select_fields = windows_fields if 'Windows' in os_name else linux_fields
@@ -64,9 +64,9 @@ def get_hardware_agent(agent_id, offset=0, limit=common.database_limit, select={
     """
     Get info about an agent's OS
     """
-    valid_select_fields = {'board_serial': 'board_serial', 'cpu_name': 'cpu_name', 'cpu_cores': 'cpu_cores',
-                           'cpu_mhz': 'cpu_mhz', 'ram_total': 'ram_total', 'ram_free': 'ram_free',
-                           'ram_usage': 'ram_usage', 'scan_id': 'scan_id', 'scan_time': 'scan_time'}
+    valid_select_fields = {'board_serial': 'board_serial', 'cpu.name': 'cpu_name', 'cpu.cores': 'cpu_cores',
+                           'cpu.mhz': 'cpu_mhz', 'ram.total': 'ram_total', 'ram.free': 'ram_free',
+                           'ram.usage': 'ram_usage', 'scan.id': 'scan_id', 'scan.time': 'scan_time'}
 
     return get_item_agent(agent_id=agent_id, offset=offset, limit=limit, select=select, nested=nested,
                           search=search, sort=sort, filters=filters, valid_select_fields=valid_select_fields,
@@ -78,7 +78,7 @@ def get_packages_agent(agent_id, offset=0, limit=common.database_limit, select={
     """
     Get info about an agent's programs
     """
-    valid_select_fields = {'scan_id': 'scan_id', 'scan_time': 'scan_time', 'format': 'format', 'name': 'name',
+    valid_select_fields = {'scan.id': 'scan_id', 'scan.time': 'scan_time', 'format': 'format', 'name': 'name',
                            'priority': 'priority', 'section': 'section', 'size': 'size', 'vendor': 'vendor',
                            'install_time': 'install_time', 'version': 'version', 'architecture': 'architecture',
                            'multiarch': 'multiarch', 'source': 'source', 'description': 'description',
@@ -94,7 +94,7 @@ def get_processes_agent(agent_id, offset=0, limit=common.database_limit, select=
     """
     Get info about an agent's processes
     """
-    valid_select_fields = {'scan_id': 'scan_id', 'scan_time': 'scan_time', 'pid': 'pid', 'name': 'name',
+    valid_select_fields = {'scan.id': 'scan_id', 'scan.time': 'scan_time', 'pid': 'pid', 'name': 'name',
                            'state': 'state', 'ppid': 'ppid', 'utime': 'utime', 'stime': 'stime', 'cmd': 'cmd',
                            'argvs': 'argvs', 'euser': 'euser', 'ruser': 'ruser', 'suser': 'suser',
                            'egroup': 'egroup', 'rgroup': 'rgroup', 'sgroup': 'sgroup', 'fgroup': 'fgroup',
@@ -112,10 +112,10 @@ def get_ports_agent(agent_id, offset=0, limit=common.database_limit, select={}, 
     """
     Get info about an agent's ports
     """
-    valid_select_fields = {'scan_id': 'scan_id', 'scan_time': 'scan_time', 'protocol': 'protocol',
-                           'local_port': 'local_port', 'remote_ip': 'remote_ip', 'remote_port': 'remote_port',
+    valid_select_fields = {'scan.id': 'scan_id', 'scan.time': 'scan_time', 'protocol': 'protocol',
+                           'local.port': 'local_port', 'remote.ip': 'remote_ip', 'remote.port': 'remote_port',
                            'tx_queue': 'tx_queue', 'rx_queue': 'rx_queue', 'inode': 'inode', 'state': 'state',
-                           'pid': 'pid', 'process': 'process', 'local_ip': 'local_ip'}
+                           'pid': 'pid', 'process': 'process', 'local.ip': 'local_ip'}
 
     return get_item_agent(agent_id=agent_id, offset=offset, limit=limit, select=select, search=search, sort=sort,
                           filters=filters, valid_select_fields=valid_select_fields, table='sys_ports', array=True,
@@ -127,7 +127,7 @@ def get_netaddr_agent(agent_id, offset=0, limit=common.database_limit, select={}
     """
     Get info about an agent's network address
     """
-    valid_select_fields = {'scan_id': 'scan_id', 'iface': 'iface', 'proto': 'proto', 'address': 'address',
+    valid_select_fields = {'scan.id': 'scan_id', 'iface': 'iface', 'proto': 'proto', 'address': 'address',
                            'netmask': 'netmask', 'broadcast': 'broadcast'}
 
     return get_item_agent(agent_id=agent_id, offset=offset, limit=limit, select=select, search=search, sort=sort,
@@ -140,7 +140,7 @@ def get_netproto_agent(agent_id, offset=0, limit=common.database_limit, select={
     """
     Get info about an agent's network protocol
     """
-    valid_select_fields = {'scan_id': 'scan_id', 'iface': 'iface', 'type': 'type', 'gateway': 'gateway', 'dhcp': 'dhcp'}
+    valid_select_fields = {'scan.id': 'scan_id', 'iface': 'iface', 'type': 'type', 'gateway': 'gateway', 'dhcp': 'dhcp'}
 
     return get_item_agent(agent_id=agent_id, offset=offset, limit=limit, select=select, search=search, sort=sort,
                           filters=filters, valid_select_fields=valid_select_fields, table='sys_netproto', array=True,
@@ -152,11 +152,11 @@ def get_netiface_agent(agent_id, offset=0, limit=common.database_limit, select={
     """
     Get info about an agent's network interface
     """
-    valid_select_fields = {'scan_id': 'scan_id', 'scan_time': 'scan_time', 'name': 'name', 'adapter': 'adapter',
-                           'type': 'type', 'state': 'state', 'mtu': 'mtu', 'mac': 'mac', 'tx_packets': 'tx_packets',
-                           'rx_packets': 'rx_packets', 'tx_bytes': 'tx_bytes', 'rx_bytes': 'rx_bytes',
-                           'tx_errors': 'tx_errors', 'rx_errors': 'rx_errors', 'tx_dropped': 'tx_dropped',
-                           'rx_dropped': 'rx_dropped'}
+    valid_select_fields = {'scan.id': 'scan_id', 'scan.time': 'scan_time', 'name': 'name', 'adapter': 'adapter',
+                           'type': 'type', 'state': 'state', 'mtu': 'mtu', 'mac': 'mac', 'tx.packets': 'tx_packets',
+                           'rx.packets': 'rx_packets', 'tx.bytes': 'tx_bytes', 'rx.bytes': 'rx_bytes',
+                           'tx.errors': 'tx_errors', 'rx.errors': 'rx_errors', 'tx.dropped': 'tx_dropped',
+                           'rx.dropped': 'rx_dropped'}
 
     return get_item_agent(agent_id=agent_id, offset=offset, limit=limit, select=select, search=search, sort=sort,
                           filters=filters, valid_select_fields=valid_select_fields, table='sys_netiface', array=True,
@@ -188,12 +188,12 @@ def _get_agent_items(func, offset, limit, select, filters, search, sort, array=F
             result = sorted(result, key=itemgetter(sort['fields'][0]),
                             reverse=True if sort['order'] == "desc" else False)
 
-        fields_to_nest, non_nested = get_fields_to_nest(result[0].keys(), '_')
+        fields_to_nest, non_nested = get_fields_to_nest(result[0].keys(), '.')
     else:
         fields_to_nest, non_nested = None, None
 
     return {'items': list(map(lambda x: plain_dict_to_nested_dict(x, fields_to_nest, non_nested,
-                                                                  WazuhDBQuerySyscollector.nested_fields, '_'),
+                                                                  WazuhDBQuerySyscollector.nested_fields, '.'),
                               result)),
             'totalItems': total}
 


### PR DESCRIPTION
Hello team, 

This PR closes #3503, including changes in nested fields processing from API to Database.

Best regards,

David J. Iglesias

### **Integration test results:**

**SYSCOLLECTOR**
```
============================================== test session starts ===============================================
platform linux -- Python 3.6.7, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.26.4
collected 160 items                                                                                              

test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED                            [  0%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[architecture] PASSED     [  1%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[hostname] PASSED         [  1%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.codename] PASSED      [  2%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.major] PASSED         [  3%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.minor] PASSED         [  3%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.name] PASSED          [  4%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.platform] PASSED      [  5%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.version] PASSED       [  5%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[release] PASSED          [  6%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.id] PASSED          [  6%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.time] PASSED        [  7%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[sysname] PASSED          [  8%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[version] PASSED          [  8%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED                      [  9%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[board_serial] PASSED [ 10%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.cores] PASSED  [ 10%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.mhz] PASSED    [ 11%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.name] PASSED   [ 11%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.free] PASSED   [ 12%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.total] PASSED  [ 13%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.usage] PASSED  [ 13%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.id] PASSED    [ 14%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.time] PASSED  [ 15%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages PASSED                      [ 15%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[architecture] PASSED [ 16%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[description] PASSED [ 16%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[format] PASSED     [ 17%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[name] PASSED       [ 18%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[priority] PASSED   [ 18%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[scan.id] PASSED    [ 19%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[scan.time] PASSED  [ 20%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[section] PASSED    [ 20%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[size] PASSED       [ 21%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[vendor] PASSED     [ 21%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[version] PASSED    [ 22%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes PASSED                     [ 23%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[argvs] PASSED [ 23%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[cmd] PASSED  [ 24%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[egroup] PASSED [ 25%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[euser] PASSED [ 25%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[fgroup] PASSED [ 26%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[name] PASSED [ 26%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[nice] PASSED [ 27%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[nlwp] PASSED [ 28%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[pgrp] PASSED [ 28%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[pid] PASSED  [ 29%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[ppid] PASSED [ 30%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[priority] PASSED [ 30%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[processor] PASSED [ 31%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[resident] PASSED [ 31%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[rgroup] PASSED [ 32%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[ruser] PASSED [ 33%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[scan.id] PASSED [ 33%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[session] PASSED [ 34%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[sgroup] PASSED [ 35%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[share] PASSED [ 35%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[size] PASSED [ 36%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[start_time] PASSED [ 36%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[state] PASSED [ 37%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[stime] PASSED [ 38%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[suser] PASSED [ 38%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[tgid] PASSED [ 39%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[tty] PASSED  [ 40%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[utime] PASSED [ 40%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[vm_size] PASSED [ 41%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/ports PASSED                         [ 41%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[inode] PASSED     [ 42%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[local.ip] PASSED  [ 43%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[local.port] PASSED [ 43%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[protocol] PASSED  [ 44%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[remote.ip] PASSED [ 45%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[remote.port] PASSED [ 45%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[rx_queue] PASSED  [ 46%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[scan.id] PASSED   [ 46%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[scan.time] PASSED [ 47%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[state] PASSED     [ 48%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[tx_queue] PASSED  [ 48%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED                       [ 49%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[address] PASSED [ 50%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[broadcast] PASSED [ 50%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[iface] PASSED  [ 51%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[netmask] PASSED [ 51%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[proto] PASSED  [ 52%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[scan.id] PASSED [ 53%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED                      [ 53%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[dhcp] PASSED  [ 54%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[gateway] PASSED [ 55%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[iface] PASSED [ 55%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[scan.id] PASSED [ 56%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[type] PASSED  [ 56%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED                      [ 57%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mac] PASSED   [ 58%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mtu] PASSED   [ 58%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[name] PASSED  [ 59%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.bytes] PASSED [ 60%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.dropped] PASSED [ 60%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.errors] PASSED [ 61%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.packets] PASSED [ 61%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.id] PASSED [ 62%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.time] PASSED [ 63%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[state] PASSED [ 63%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.bytes] PASSED [ 64%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.dropped] PASSED [ 65%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.errors] PASSED [ 65%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.packets] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[type] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED                            [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[architecture] PASSED     [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[hostname] PASSED         [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.codename] PASSED      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.major] PASSED         [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.minor] PASSED         [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.name] PASSED          [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.platform] PASSED      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.version] PASSED       [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[release] PASSED          [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.id] PASSED          [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.time] PASSED        [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[sysname] PASSED          [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[version] PASSED          [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED                      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[board_serial] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.cores] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.mhz] PASSED    [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.name] PASSED   [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.free] PASSED   [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.total] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.usage] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.id] PASSED    [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.time] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED                       [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[address] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[broadcast] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[iface] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[netmask] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[proto] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[scan.id] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED                      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[dhcp] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[gateway] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[iface] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[scan.id] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[type] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED                      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mac] PASSED   [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mtu] PASSED   [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[name] PASSED  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.bytes] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.dropped] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.errors] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.packets] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.id] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.time] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[state] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.bytes] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.dropped] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.errors] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.packets] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[type] PASSED  [ 66%]

================================================ warnings summary ================================================
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================================== 160 passed, 1 warnings in 12.41 seconds =====================================
```
**CISCAT**
```
============================================== test session starts ===============================================
platform linux -- Python 3.6.7, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.26.4
collected 11 items                                                                                               

test_ciscat_endpoints.tavern.yaml::GET /ciscat/001/results PASSED                                          [  9%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/002/results PASSED                                          [ 18%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/003/results PASSED                                          [ 27%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results[profile] PASSED                          [ 36%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results[score] PASSED                            [ 45%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results[error] PASSED                            [ 54%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results[fail] PASSED                             [ 63%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results[benchmark] PASSED                        [ 72%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results[pass] PASSED                             [ 81%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results[notchecked] PASSED                       [ 90%]
test_ciscat_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results[unknown] PASSED                          [100%]

================================================ warnings summary ================================================
test/integration/test_ciscat_endpoints.tavern.yaml::GET /ciscat/001/results
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================================== 11 passed, 1 warnings in 1.91 seconds ======================================
```
**AGENTS**
```
============================================== test session starts ===============================================
platform linux -- Python 3.6.7, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.26.4
collected 114 items                                                                                              

test_agentsGET_endpoints.tavern.yaml::GET /agents PASSED                                                   [  0%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/:agent_id PASSED                                         [  1%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/:agent/config/:component/:configuration PASSED           [  2%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/:agent_id/group/is_sync PASSED                           [  3%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/:agent_id/key PASSED                                     [  4%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups PASSED                                            [  5%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[md5] PASSED                           [  6%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha1] PASSED                          [  7%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha224] PASSED                        [  7%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha256] PASSED                        [  8%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha384] PASSED                        [  9%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha512] PASSED                        [ 10%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[blake2b] PASSED                       [ 11%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[blake2s] PASSED                       [ 12%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha3_224] PASSED                      [ 13%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha3_256] PASSED                      [ 14%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha3_384] PASSED                      [ 14%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups filter hash[sha3_512] PASSED                      [ 15%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} PASSED                                 [ 16%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[configSum] PASSED        [ 17%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[dateAdd] PASSED          [ 18%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[group] PASSED            [ 19%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[id] PASSED               [ 20%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[ip] PASSED               [ 21%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[lastKeepAlive] PASSED    [ 21%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[manager] PASSED          [ 22%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[mergedSum] PASSED        [ 23%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[name] PASSED             [ 24%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[node_name] PASSED        [ 25%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.arch] PASSED          [ 26%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.build] PASSED         [ 27%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.codename] PASSED      [ 28%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.major] PASSED         [ 28%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.minor] PASSED         [ 29%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.name] PASSED          [ 30%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.platform] PASSED      [ 31%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.uname] PASSED         [ 32%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[os.version] PASSED       [ 33%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[registerIP] PASSED       [ 34%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[status] PASSED           [ 35%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id} {sort,select}[version] PASSED          [ 35%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/configuration PASSED                   [ 36%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files PASSED                           [ 37%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[md5] PASSED          [ 38%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha1] PASSED         [ 39%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha224] PASSED       [ 40%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha256] PASSED       [ 41%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha384] PASSED       [ 42%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha512] PASSED       [ 42%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[blake2b] PASSED      [ 43%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[blake2s] PASSED      [ 44%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha3_224] PASSED     [ 45%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha3_256] PASSED     [ 46%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha3_384] PASSED     [ 47%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files filter hash[sha3_512] PASSED     [ 48%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files/{filename}/json PASSED           [ 49%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/groups/{group_id}/files/{filename}/xml PASSED            [ 50%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/name/:agent_name PASSED                                  [ 50%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                          [ 51%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                   [ 52%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                        [ 53%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                        [ 54%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                      [ 55%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                 [ 56%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                [ 57%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                    [ 57%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                          [ 58%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/outdated {sort}[id] PASSED                               [ 59%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/outdated {sort}[name] PASSED                             [ 60%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/outdated {sort}[version] PASSED                          [ 61%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                    [ 62%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[dateAdd] PASSED             [ 63%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[id] PASSED                  [ 64%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[ip] PASSED                  [ 64%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[lastKeepAlive] PASSED       [ 65%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[manager] PASSED             [ 66%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[name] PASSED                [ 67%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[node_name] PASSED           [ 68%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.arch] PASSED             [ 69%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.build] PASSED            [ 70%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.codename] PASSED         [ 71%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.major] PASSED            [ 71%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.minor] PASSED            [ 72%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.name] PASSED             [ 73%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.platform] PASSED         [ 74%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.uname] PASSED            [ 75%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[os.version] PASSED          [ 76%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[registerIP] PASSED          [ 77%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[status] PASSED              [ 78%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {sort,select}[version] PASSED             [ 78%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary PASSED                                           [ 79%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                        [ 80%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[configSum] PASSED                      [ 81%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[dateAdd] PASSED                        [ 82%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[group] PASSED                          [ 83%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[id] PASSED                             [ 84%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[ip] PASSED                             [ 85%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[lastKeepAlive] PASSED                  [ 85%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[manager] PASSED                        [ 86%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[mergedSum] PASSED                      [ 87%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[name] PASSED                           [ 88%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[node_name] PASSED                      [ 89%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[os.name] PASSED                        [ 90%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[os.version] PASSED                     [ 91%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[os.codename] PASSED                    [ 92%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[os.major] PASSED                       [ 92%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[os.minor] PASSED                       [ 93%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[os.uname] PASSED                       [ 94%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[os.arch] PASSED                        [ 95%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[os.build] PASSED                       [ 96%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[registerIP] PASSED                     [ 97%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[status] PASSED                         [ 98%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os {sort}[version] PASSED                        [ 99%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/:agent_id/upgrade_result SKIPPED                         [100%]

================================================ warnings summary ================================================
test/integration/test_agentsGET_endpoints.tavern.yaml::GET /agents
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================== 113 passed, 1 skipped, 1 warnings in 6.16 seconds ================================

============================================== test session starts ===============================================
platform linux -- Python 3.6.7, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.26.4
collected 5 items                                                                                                

test_agentsPOST_endpoints.tavern.yaml::POST /agents PASSED                                                 [ 20%]
test_agentsPOST_endpoints.tavern.yaml::POST /agents/groups/:group_id PASSED                                [ 40%]
test_agentsPOST_endpoints.tavern.yaml::POST /agents/insert PASSED                                          [ 60%]
test_agentsPOST_endpoints.tavern.yaml::POST /agents/{agent_name} PASSED                                    [ 80%]
test_agentsPOST_endpoints.tavern.yaml::POST /agents/restart PASSED                                         [100%]

================================================ warnings summary ================================================
test/integration/test_agentsPOST_endpoints.tavern.yaml::POST /agents
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================================== 5 passed, 1 warnings in 0.69 seconds ======================================

============================================== test session starts ===============================================
platform linux -- Python 3.6.7, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.26.4
collected 8 items                                                                                                

test_agentsPUT_endpoints.tavern.yaml::PUT /agents/group/:group_id PASSED                                   [ 12%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/groups/{group_id}/configuration PASSED                   [ 25%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/groups/{group_id}/files/agent.conf PASSED                [ 37%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/restart PASSED                                           [ 50%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/:agent_id/group/:group_id PASSED                         [ 62%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/:agent_id/restart PASSED                                 [ 75%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/:agent_id/upgrade SKIPPED                                [ 87%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/:agent_id/upgrade_custom PASSED                          [100%]

================================================ warnings summary ================================================
test/integration/test_agentsPUT_endpoints.tavern.yaml::PUT /agents/group/:group_id
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================ 7 passed, 1 skipped, 1 warnings in 10.93 seconds ================================

============================================== test session starts ===============================================
platform linux -- Python 3.6.7, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.26.4
collected 7 items                                                                                                

test_agentsDELETE_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                 [ 14%]
test_agentsDELETE_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                            [ 28%]
test_agentsDELETE_endpoints.tavern.yaml::DELETE /agents/group/{group_id} PASSED                            [ 42%]
test_agentsDELETE_endpoints.tavern.yaml::DELETE /agents/groups/{group_id} PASSED                           [ 57%]
test_agentsDELETE_endpoints.tavern.yaml::DELETE /agents/groups PASSED                                      [ 71%]
test_agentsDELETE_endpoints.tavern.yaml::DELETE /agents PASSED                                             [ 85%]
test_agentsDELETE_endpoints.tavern.yaml::DELETE /agents/{agent_id} PASSED                                  [100%]

================================================ warnings summary ================================================
test/integration/test_agentsDELETE_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id}
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================================== 7 passed, 1 warnings in 1.29 seconds ======================================
```