### PR TITLE
agent_control agentless hosts JSON output fix

### DIFF
--- a/framework/wazuh/wazuh.json
+++ b/framework/wazuh/wazuh.json
@@ -1,0 +1,1 @@
+{"install_type": "server", "wazuh_version": "v3.10.2", "installation_date": "Fri Oct 18 07:54:40 UTC 2019"}

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -615,6 +615,17 @@ int print_agents(int print_status, int active_only, int inactive_only, int csv_o
 
                 if (csv_output) {
                     printf("na,%s,%s,agentless,\n", dp->d_name, aip);
+                } else if(json_output) {
+                    cJSON *json_agent = cJSON_CreateObject();
+                    if (!json_agent) {
+                        fclose(fp);
+                        return 0;
+                    }
+                    cJSON_AddStringToObject(json_agent, "id", "<na>");
+                    cJSON_AddStringToObject(json_agent, "name", dp->d_name);
+                    cJSON_AddStringToObject(json_agent, "ip", aip);
+                    cJSON_AddStringToObject(json_agent, "status", "agentless");
+                    cJSON_AddItemToArray(json_output, json_agent);
                 } else {
                     printf("   ID: na, Name: %s, IP: %s, agentless\n",
                            dp->d_name, aip);

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
- * This program is a free software; you can redistribute it
+ * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation
@@ -999,7 +999,7 @@ static int _get_time_rkscan(const char *agent_name, const char *agent_ip, agent_
     } else {
         os_strdup(ctime(&fim_start), agt_info->syscheck_time);
 
-        /* Remove newline */
+        /* Remove syscheck_time newline */
         tmp_str = strchr(agt_info->syscheck_time, '\n');
         if (tmp_str) {
             *tmp_str = '\0';
@@ -1009,6 +1009,12 @@ static int _get_time_rkscan(const char *agent_name, const char *agent_ip, agent_
         os_strdup("Unknown", agt_info->syscheck_endtime);
     } else {
         os_strdup(ctime(&fim_end), agt_info->syscheck_endtime);
+        
+        /* Remove syscheck_endtime newline */
+        tmp_str = strchr(agt_info->syscheck_endtime, '\n');
+        if (tmp_str) {
+            *tmp_str = '\0';
+        }
     }
 
     /* Agent name of null, means it is the server info */


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3918|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
`agent_control` binary includes output to JSON feature:
```
	-s                Changes the output to CSV (comma delimited).
	-j                Changes the output to JSON .
	-m                Show the limit of agents that can be added.
``` 
However, agentless hosts are not listed using JSON output when this option is specified. i.e:
```
root@vagrantWorker /home/vagrant/wazuh/wazuh/src/util $ agent_control -l -j
   ID: na, Name: (ssh_integrity_check_linux) vagrant@192.168.33.32, IP: 192.168.33.32, agentless
   ID: na, Name: (ssh_generic_diff) vagrant@192.168.33.32, IP: 192.168.33.32, agentless
{"error":0,"data":[{"id":"000","name":"vagrantWorker","ip":"127.0.0.1","status":"Active"},{"id":"003","name":"SERV2016","ip":"192.168.75.131","status":"Disconnected"}]}
```



<!--
Add a clear description of how the problem has been solved.
-->

After an in-depth review, the agentless hosts section on [print_agents](https://github.com/wazuh/wazuh/blob/6f47eb206f65ecef6053ff77921639161e1a8db6/src/addagent/validate.c#L509-L633) function doesn't cover the JSON output case, so here lies the bug.

A new if-else case has been added covering the agentless hosts JSON output.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
 - [x] Linux
 - [x] Source installation

