### PR TITLE
Fix defects reported by Coverity

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -103,6 +103,7 @@ void LogCollectorStart()
     w_set_file_mutexes();
 #else
     BY_HANDLE_FILE_INFORMATION lpFileInformation;
+    memset(&lpFileInformation, 0, sizeof(BY_HANDLE_FILE_INFORMATION));
     int r;
     const char *m_uname;
 
@@ -807,6 +808,7 @@ int handle_file(int i, int j, int do_fseek, int do_log)
 
 #else
     BY_HANDLE_FILE_INFORMATION lpFileInformation;
+    memset(&lpFileInformation, 0, sizeof(BY_HANDLE_FILE_INFORMATION));
 
     lf->fp = NULL;
     lf->h = CreateFile(lf->file, GENERIC_READ,
@@ -1820,6 +1822,7 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
     struct stat tmp_stat;
 #else
     BY_HANDLE_FILE_INFORMATION lpFileInformation;
+    memset(&lpFileInformation, 0, sizeof(BY_HANDLE_FILE_INFORMATION));
 #endif
 
     /* Daemon loop */

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -771,7 +771,7 @@ int _unsign(const char * source, char dest[PATH_MAX + 1]) {
         }
     } else {
 #else
-    if (!_mktemp(dest)) {
+    if (_mktemp_s(dest, strlen(dest) + 1)) {
 #endif
         merror("At unsign(): Couldn't create temporary compressed file");
         output = -1;

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1225,21 +1225,11 @@ int mkstemp_ex(char *tmp_path)
     PSID pSystemGroupSID = NULL;
     SID_IDENTIFIER_AUTHORITY SIDAuthNT = {SECURITY_NT_AUTHORITY};
 
-#if defined(_MSC_VER) && _MSC_VER >= 1500
-    result = _mktemp_s(tmp_path, strlen(tmp_path) + 1);
 
-    if (result != 0) {
-        mferror("Could not create temporary file (%s) which returned (%d)", tmp_path, result);
-
+    if (result = _mktemp_s(tmp_path, strlen(tmp_path) + 1), result) {
+        mferror("Could not create temporary file (%s) which returned %d [(%d)-(%s)].", tmp_path, result, errno, strerror(errno));
         return (-1);
     }
-#else
-    if (_mktemp(tmp_path) == NULL) {
-        mferror("Could not create temporary file (%s) which returned [(%d)-(%s)]", tmp_path, errno, strerror(errno));
-
-        return (-1);
-    }
-#endif
 
     /* Create SID for the BUILTIN\Administrators group */
     result = AllocateAndInitializeSid(

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -974,6 +974,7 @@ time_t get_agent_date_added(int agent_id) {
             if (sscanf(date, "%d-%d-%d %d:%d:%d",&t.tm_year, &t.tm_mon, &t.tm_mday, &t.tm_hour, &t.tm_min, &t.tm_sec)<6) {
                 merror("Invalid date format in file '%s' for agent '%d'", TIMESTAMP_FILE, agent_id);
                 free(date);
+                free_strarray(data);
                 fclose(fp);
                 return 0;
             }


### PR DESCRIPTION
|Related issue|
|---|
|#3925|


## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] Usage test on a Windows Server 2003 and Windows XP agents to verify that we can use the safe function `_mktemp_s`. Also check for WPK updates.