### PR TITLE
The contextual rules check the agent ID

### DIFF
--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -71,7 +71,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
         time(&current_time);
  #endif
         /* If time is outside the timeframe, return */
-        if ((current_time - lf->generate_time) > rule->timeframe) {
+        if (((current_time - lf->generate_time) > rule->timeframe) && (strcmp(lf->agent_id, my_lf->agent_id))) {
             lf = NULL;
             goto end;
         }
@@ -291,7 +291,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         time(&current_time);
 #endif
         /* If time is outside the timeframe, return */
-        if ((current_time - lf->generate_time) > rule->timeframe) {
+        if (((current_time - lf->generate_time) > rule->timeframe)  && (strcmp(lf->agent_id, my_lf->agent_id))) {
             lf = NULL;
             goto end;
         }
@@ -500,7 +500,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
         time(&current_time);
 #endif
         /* If time is outside the timeframe, return */
-        if ((current_time - lf->generate_time) > rule->timeframe) {
+        if (((current_time - lf->generate_time) > rule->timeframe) && (strcmp(lf->agent_id, my_lf->agent_id))) {
             lf = NULL;
             goto end;
         }

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -71,9 +71,13 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
         time(&current_time);
  #endif
         /* If time is outside the timeframe, return */
-        if (((current_time - lf->generate_time) > rule->timeframe) && (strcmp(lf->agent_id, my_lf->agent_id))) {
+        if ((current_time - lf->generate_time) > rule->timeframe) {
             lf = NULL;
             goto end;
+        }
+
+        if (strcmp(lf->agent_id, my_lf->agent_id)){
+            continue;
         }
 
         /* Check for same ID */
@@ -291,9 +295,13 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         time(&current_time);
 #endif
         /* If time is outside the timeframe, return */
-        if (((current_time - lf->generate_time) > rule->timeframe)  && (strcmp(lf->agent_id, my_lf->agent_id))) {
+        if ((current_time - lf->generate_time) > rule->timeframe) {
             lf = NULL;
             goto end;
+        }
+
+        if (strcmp(lf->agent_id, my_lf->agent_id)){
+            continue;
         }
 
         /* Check for same ID */
@@ -500,13 +508,17 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
         time(&current_time);
 #endif
         /* If time is outside the timeframe, return */
-        if (((current_time - lf->generate_time) > rule->timeframe) && (strcmp(lf->agent_id, my_lf->agent_id))) {
+        if ((current_time - lf->generate_time) > rule->timeframe) {
             lf = NULL;
             goto end;
         }
 
+        if (strcmp(lf->agent_id, my_lf->agent_id)){
+            continue;
+        }
+
         /* The category must be the same */
-        else if (lf->decoder_info->type != my_lf->decoder_info->type) {
+        if (lf->decoder_info->type != my_lf->decoder_info->type) {
             goto next_it;
         }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -76,8 +76,14 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
             goto end;
         }
 
-        if (!(rule->context_opts & GLOBAL_FREQUENCY) && (strcmp(lf->agent_id, my_lf->agent_id))){
-            continue;
+        if (!(rule->context_opts & GLOBAL_FREQUENCY)) {
+            if ((!lf->agent_id) || (!my_lf->agent_id)) {
+                continue;
+            }
+
+            if (strcmp(lf->agent_id, my_lf->agent_id) != 0) {
+                continue;
+            }
         }
 
         /* Check for same ID */
@@ -300,8 +306,14 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             goto end;
         }
 
-        if (!(rule->context_opts & GLOBAL_FREQUENCY) && (strcmp(lf->agent_id, my_lf->agent_id))){
-            continue;
+        if (!(rule->context_opts & GLOBAL_FREQUENCY)) {
+            if ((!lf->agent_id) || (!my_lf->agent_id)) {
+                continue;
+            }
+
+            if (strcmp(lf->agent_id, my_lf->agent_id) != 0) {
+                continue;
+            }
         }
 
         /* Check for same ID */
@@ -512,9 +524,15 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
             lf = NULL;
             goto end;
         }
-        
-        if (!(rule->context_opts & GLOBAL_FREQUENCY) && (strcmp(lf->agent_id, my_lf->agent_id))){
-            continue;
+
+        if (!(rule->context_opts & GLOBAL_FREQUENCY)) {
+            if ((!lf->agent_id) || (!my_lf->agent_id)) {
+                continue;
+            }
+
+            if (strcmp(lf->agent_id, my_lf->agent_id) != 0) {
+                continue;
+            }
         }
 
         /* The category must be the same */

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -76,7 +76,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
             goto end;
         }
 
-        if (!(rule->context_opts & NOT_SAME_AGENT_ID) && (strcmp(lf->agent_id, my_lf->agent_id))){
+        if (!(rule->context_opts & GLOBAL_FREQUENCY) && (strcmp(lf->agent_id, my_lf->agent_id))){
             continue;
         }
 
@@ -300,7 +300,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             goto end;
         }
 
-        if (!(rule->context_opts & NOT_SAME_AGENT_ID) && (strcmp(lf->agent_id, my_lf->agent_id))){
+        if (!(rule->context_opts & GLOBAL_FREQUENCY) && (strcmp(lf->agent_id, my_lf->agent_id))){
             continue;
         }
 
@@ -513,7 +513,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
             goto end;
         }
         
-        if (!(rule->context_opts & NOT_SAME_AGENT_ID) && (strcmp(lf->agent_id, my_lf->agent_id))){
+        if (!(rule->context_opts & GLOBAL_FREQUENCY) && (strcmp(lf->agent_id, my_lf->agent_id))){
             continue;
         }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -76,7 +76,8 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
             goto end;
         }
 
-        if (strcmp(lf->agent_id, my_lf->agent_id)){
+        if (rule->context_opts & NOT_SAME_AGENT_ID) {
+        } else if (strcmp(lf->agent_id, my_lf->agent_id)){
             continue;
         }
 
@@ -300,7 +301,8 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             goto end;
         }
 
-        if (strcmp(lf->agent_id, my_lf->agent_id)){
+        if (rule->context_opts & NOT_SAME_AGENT_ID) {
+        } else if (strcmp(lf->agent_id, my_lf->agent_id)){
             continue;
         }
 
@@ -512,8 +514,9 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
             lf = NULL;
             goto end;
         }
-
-        if (strcmp(lf->agent_id, my_lf->agent_id)){
+        
+        if (rule->context_opts & NOT_SAME_AGENT_ID) {
+        } else if (strcmp(lf->agent_id, my_lf->agent_id)){
             continue;
         }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -76,8 +76,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
             goto end;
         }
 
-        if (rule->context_opts & NOT_SAME_AGENT_ID) {
-        } else if (strcmp(lf->agent_id, my_lf->agent_id)){
+        if (!(rule->context_opts & NOT_SAME_AGENT_ID) && (strcmp(lf->agent_id, my_lf->agent_id))){
             continue;
         }
 
@@ -301,8 +300,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             goto end;
         }
 
-        if (rule->context_opts & NOT_SAME_AGENT_ID) {
-        } else if (strcmp(lf->agent_id, my_lf->agent_id)){
+        if (!(rule->context_opts & NOT_SAME_AGENT_ID) && (strcmp(lf->agent_id, my_lf->agent_id))){
             continue;
         }
 
@@ -515,8 +513,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
             goto end;
         }
         
-        if (rule->context_opts & NOT_SAME_AGENT_ID) {
-        } else if (strcmp(lf->agent_id, my_lf->agent_id)){
+        if (!(rule->context_opts & NOT_SAME_AGENT_ID) && (strcmp(lf->agent_id, my_lf->agent_id))){
             continue;
         }
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -127,10 +127,6 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_different_srcip = "different_srcip";
     const char *xml_different_srcgeoip = "different_srcgeoip";
 
-    const char *xml_notsame_source_ip = "not_same_source_ip";
-    const char *xml_notsame_user = "not_same_user";
-    const char *xml_notsame_agent = "not_same_agent";
-    const char *xml_notsame_id = "not_same_id";
     const char *xml_notsame_field = "not_same_field";
     const char *xml_global_frequency = "global_frequency";
 
@@ -876,9 +872,6 @@ int Rules_OP_ReadRules(const char *rulefile)
                         if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                         }
-                    } else if (strcasecmp(rule_opt[k]->element,
-                                          xml_notsame_source_ip) == 0) {
-                        config_ruleinfo->context_opts &= NOT_SAME_SRCIP;
                     } else if (strcmp(rule_opt[k]->element, xml_same_id) == 0) {
                         config_ruleinfo->context_opts |= SAME_ID;
                     } else if (strcmp(rule_opt[k]->element,
@@ -900,8 +893,6 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         if(!(config_ruleinfo->alert_opts & SAME_EXTRAINFO))
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
-                    } else if (strcmp(rule_opt[k]->element, xml_notsame_id) == 0) {
-                        config_ruleinfo->context_opts &= NOT_SAME_ID;
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_fts) == 0) {
                         config_ruleinfo->alert_opts |= DO_FTS;
@@ -913,20 +904,14 @@ int Rules_OP_ReadRules(const char *rulefile)
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
-                                          xml_notsame_user) == 0) {
-                        config_ruleinfo->context_opts &= NOT_SAME_USER;
-                    } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_location) == 0) {
                         config_ruleinfo->context_opts |= SAME_LOCATION;
                         if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
-                                          xml_notsame_agent) == 0) {
-                        config_ruleinfo->context_opts &= NOT_SAME_AGENT;
-                    } else if (strcasecmp(rule_opt[k]->element,
                                           xml_global_frequency) == 0) {
-                        config_ruleinfo->context_opts &= NOT_SAME_AGENT_ID;
+                        config_ruleinfo->context_opts &= GLOBAL_FREQUENCY;
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_field) == 0) {
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -127,6 +127,10 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_different_srcip = "different_srcip";
     const char *xml_different_srcgeoip = "different_srcgeoip";
 
+    const char *xml_notsame_source_ip = "not_same_source_ip";
+    const char *xml_notsame_user = "not_same_user";
+    const char *xml_notsame_agent = "not_same_agent";
+    const char *xml_notsame_id = "not_same_id";
     const char *xml_notsame_field = "not_same_field";
     const char *xml_global_frequency = "global_frequency";
 
@@ -872,6 +876,9 @@ int Rules_OP_ReadRules(const char *rulefile)
                         if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                         }
+                    } else if (strcasecmp(rule_opt[k]->element,
+                                          xml_notsame_source_ip) == 0) {
+                        config_ruleinfo->context_opts &= NOT_SAME_SRCIP;
                     } else if (strcmp(rule_opt[k]->element, xml_same_id) == 0) {
                         config_ruleinfo->context_opts |= SAME_ID;
                     } else if (strcmp(rule_opt[k]->element,
@@ -893,6 +900,8 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         if(!(config_ruleinfo->alert_opts & SAME_EXTRAINFO))
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
+                    } else if (strcmp(rule_opt[k]->element, xml_notsame_id) == 0) {
+                        config_ruleinfo->context_opts &= NOT_SAME_ID;
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_fts) == 0) {
                         config_ruleinfo->alert_opts |= DO_FTS;
@@ -904,11 +913,17 @@ int Rules_OP_ReadRules(const char *rulefile)
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
+                                          xml_notsame_user) == 0) {
+                        config_ruleinfo->context_opts &= NOT_SAME_USER;
+                    } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_location) == 0) {
                         config_ruleinfo->context_opts |= SAME_LOCATION;
                         if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                         }
+                    } else if (strcasecmp(rule_opt[k]->element,
+                                          xml_notsame_agent) == 0) {
+                        config_ruleinfo->context_opts &= NOT_SAME_AGENT;
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_global_frequency) == 0) {
                         config_ruleinfo->context_opts &= GLOBAL_FREQUENCY;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -132,6 +132,7 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_notsame_agent = "not_same_agent";
     const char *xml_notsame_id = "not_same_id";
     const char *xml_notsame_field = "not_same_field";
+    const char *xml_global_frequency = "global_frequency";
 
     const char *xml_options = "options";
 
@@ -923,6 +924,9 @@ int Rules_OP_ReadRules(const char *rulefile)
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_notsame_agent) == 0) {
                         config_ruleinfo->context_opts &= NOT_SAME_AGENT;
+                    } else if (strcasecmp(rule_opt[k]->element,
+                                          xml_global_frequency) == 0) {
+                        config_ruleinfo->context_opts &= NOT_SAME_AGENT_ID;
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_field) == 0) {
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -30,11 +30,7 @@
 #define SAME_DODIFF         0x100
 #define SAME_FIELD          0x080
 #define NOT_SAME_FIELD      0x800
-#define NOT_SAME_USER       0xffe /* 0xfff - 0x001  */
-#define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002  */
-#define NOT_SAME_ID         0xffb /* 0xfff - 0x004  */
-#define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
-#define NOT_SAME_AGENT_ID   0xff3
+#define GLOBAL_FREQUENCY    0x1000
 
 /* Alert options  - store on a uint16 */
 #define DO_FTS          0x0001

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -30,6 +30,10 @@
 #define SAME_DODIFF         0x100
 #define SAME_FIELD          0x080
 #define NOT_SAME_FIELD      0x800
+#define NOT_SAME_USER       0xffe /* 0xfff - 0x001  */
+#define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002  */
+#define NOT_SAME_ID         0xffb /* 0xfff - 0x004  */
+#define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
 #define GLOBAL_FREQUENCY    0x1000
 
 /* Alert options  - store on a uint16 */

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -34,6 +34,7 @@
 #define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002  */
 #define NOT_SAME_ID         0xffb /* 0xfff - 0x004  */
 #define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
+#define NOT_SAME_AGENT_ID   0xff3
 
 /* Alert options  - store on a uint16 */
 #define DO_FTS          0x0001

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -32,6 +32,7 @@
 #define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002 */
 #define NOT_SAME_ID         0xffb /* 0xfff - 0x004 */
 #define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
+#define NOT_SAME_AGENT_ID   0xff3 
 
 /* Alert options - stored in a uint8 */
 #define DO_FTS          0x0001

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -28,11 +28,7 @@
 #define SAME_DODIFF         0x100
 #define SAME_FIELD          0x200
 #define NOT_SAME_FIELD      0x400
-#define NOT_SAME_USER       0xffe /* 0xfff - 0x001 */
-#define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002 */
-#define NOT_SAME_ID         0xffb /* 0xfff - 0x004 */
-#define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
-#define NOT_SAME_AGENT_ID   0xff3 
+#define GLOBAL_FREQUENCY    0x1000
 
 /* Alert options - stored in a uint8 */
 #define DO_FTS          0x0001

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -28,6 +28,10 @@
 #define SAME_DODIFF         0x100
 #define SAME_FIELD          0x200
 #define NOT_SAME_FIELD      0x400
+#define NOT_SAME_USER       0xffe /* 0xfff - 0x001 */
+#define NOT_SAME_SRCIP      0xffd /* 0xfff - 0x002 */
+#define NOT_SAME_ID         0xffb /* 0xfff - 0x004 */
+#define NOT_SAME_AGENT      0xff7 /* 0xfff - 0x008 */
 #define GLOBAL_FREQUENCY    0x1000
 
 /* Alert options - stored in a uint8 */

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -95,10 +95,6 @@ int OS_ReadXMLRules(const char *rulefile,
 
     const char *xml_different_url = "different_url";
 
-    const char *xml_notsame_source_ip = "not_same_source_ip";
-    const char *xml_notsame_user = "not_same_user";
-    const char *xml_notsame_agent = "not_same_agent";
-    const char *xml_notsame_id = "not_same_id";
     const char *xml_notsame_field = "not_same_field";
     const char *xml_global_frequency = "global_frequency";
 
@@ -516,9 +512,6 @@ int OS_ReadXMLRules(const char *rulefile,
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
-                } else if (strcasecmp(rule_opt[k]->element,
-                                      xml_notsame_source_ip) == 0) {
-                    config_ruleinfo->context_opts &= NOT_SAME_SRCIP;
                 } else if (strcmp(rule_opt[k]->element, xml_same_id) == 0) {
                     config_ruleinfo->context_opts |= SAME_ID;
                 } else if (strcmp(rule_opt[k]->element,
@@ -528,8 +521,6 @@ int OS_ReadXMLRules(const char *rulefile,
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
-                } else if (strcmp(rule_opt[k]->element, xml_notsame_id) == 0) {
-                    config_ruleinfo->context_opts &= NOT_SAME_ID;
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_fts) == 0) {
                     config_ruleinfo->alert_opts |= DO_FTS;
@@ -541,9 +532,6 @@ int OS_ReadXMLRules(const char *rulefile,
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
                 } else if (strcasecmp(rule_opt[k]->element,
-                                      xml_notsame_user) == 0) {
-                    config_ruleinfo->context_opts &= NOT_SAME_USER;
-                } else if (strcasecmp(rule_opt[k]->element,
                                       xml_same_location) == 0) {
                     config_ruleinfo->context_opts |= SAME_LOCATION;
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
@@ -551,10 +539,7 @@ int OS_ReadXMLRules(const char *rulefile,
                     }
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_global_frequency) == 0) {
-                    config_ruleinfo->context_opts &= NOT_SAME_AGENT_ID;
-                } else if (strcasecmp(rule_opt[k]->element,
-                                      xml_notsame_agent) == 0) {
-                    config_ruleinfo->context_opts &= NOT_SAME_AGENT;
+                    config_ruleinfo->context_opts &= GLOBAL_FREQUENCY;
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_same_field) == 0) {
 

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -100,6 +100,7 @@ int OS_ReadXMLRules(const char *rulefile,
     const char *xml_notsame_agent = "not_same_agent";
     const char *xml_notsame_id = "not_same_id";
     const char *xml_notsame_field = "not_same_field";
+    const char *xml_global_frequency = "global_frequency";
 
     const char *xml_options = "options";
 
@@ -548,6 +549,9 @@ int OS_ReadXMLRules(const char *rulefile,
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
+                } else if (strcasecmp(rule_opt[k]->element,
+                                      xml_global_frequency) == 0) {
+                    config_ruleinfo->context_opts &= NOT_SAME_AGENT_ID;
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_notsame_agent) == 0) {
                     config_ruleinfo->context_opts &= NOT_SAME_AGENT;

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -95,6 +95,10 @@ int OS_ReadXMLRules(const char *rulefile,
 
     const char *xml_different_url = "different_url";
 
+    const char *xml_notsame_source_ip = "not_same_source_ip";	
+    const char *xml_notsame_user = "not_same_user";	
+    const char *xml_notsame_agent = "not_same_agent";	
+    const char *xml_notsame_id = "not_same_id";
     const char *xml_notsame_field = "not_same_field";
     const char *xml_global_frequency = "global_frequency";
 
@@ -512,6 +516,9 @@ int OS_ReadXMLRules(const char *rulefile,
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
+                } else if (strcasecmp(rule_opt[k]->element,
+                                      xml_notsame_source_ip) == 0) {
+                    config_ruleinfo->context_opts &= NOT_SAME_SRCIP;
                 } else if (strcmp(rule_opt[k]->element, xml_same_id) == 0) {
                     config_ruleinfo->context_opts |= SAME_ID;
                 } else if (strcmp(rule_opt[k]->element,
@@ -521,6 +528,8 @@ int OS_ReadXMLRules(const char *rulefile,
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
+                } else if (strcmp(rule_opt[k]->element, xml_notsame_id) == 0) {
+                    config_ruleinfo->context_opts &= NOT_SAME_ID;
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_fts) == 0) {
                     config_ruleinfo->alert_opts |= DO_FTS;
@@ -532,11 +541,17 @@ int OS_ReadXMLRules(const char *rulefile,
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
                 } else if (strcasecmp(rule_opt[k]->element,
+                                      xml_notsame_user) == 0) {
+                    config_ruleinfo->context_opts &= NOT_SAME_USER;
+                } else if (strcasecmp(rule_opt[k]->element,
                                       xml_same_location) == 0) {
                     config_ruleinfo->context_opts |= SAME_LOCATION;
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
+                } else if (strcasecmp(rule_opt[k]->element,
+                                      xml_notsame_agent) == 0) {
+                    config_ruleinfo->context_opts &= NOT_SAME_AGENT;
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_global_frequency) == 0) {
                     config_ruleinfo->context_opts &= GLOBAL_FREQUENCY;

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -95,9 +95,9 @@ int OS_ReadXMLRules(const char *rulefile,
 
     const char *xml_different_url = "different_url";
 
-    const char *xml_notsame_source_ip = "not_same_source_ip";	
-    const char *xml_notsame_user = "not_same_user";	
-    const char *xml_notsame_agent = "not_same_agent";	
+    const char *xml_notsame_source_ip = "not_same_source_ip";
+    const char *xml_notsame_user = "not_same_user";
+    const char *xml_notsame_agent = "not_same_agent";
     const char *xml_notsame_id = "not_same_id";
     const char *xml_notsame_field = "not_same_field";
     const char *xml_global_frequency = "global_frequency";


### PR DESCRIPTION
|Related issue|
|---------|
[3865](https://github.com/wazuh/wazuh/issues/3865)

## Description

The contextual rules don't check the ID of the agent or manager that generates the event. This results in that some rules are fired when multiples agents send an event when these rules should only be fired when the same agent sends the event. To remediate this issue, I introduced a condition when we check the timeframe of the alerts. The condition is that the agent ID has to be the same that fired the event in the first place. 
In addition, a new label has been added to preserve the previous behavior.  This label is `<global_frequency/>`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Custom test
   - [x] Fired an alert of an SSH attack. Check if the alerts 5712 is fired when we introduced the wrong user eight times in a row. 

```
** Alert 1567770100.745521: - syslog,sshd,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,
2019 Sep 06 13:41:40 (centos7) 172.16.1.13->/var/log/secure
Rule: 5712 (level 10) -> 'sshd: brute force trying to get access to the system.'
Src IP: 172.16.1.14
Src Port: 58150
Sep  6 11:41:40 localhost sshd[7260]: Invalid user centos7 from 172.16.1.14 port 58150
Sep  6 11:41:39 localhost sshd[7258]: Invalid user centos7 from 172.16.1.14 port 58148
Sep  6 11:41:38 localhost sshd[7256]: Invalid user centos7 from 172.16.1.14 port 58146
Sep  6 11:41:38 localhost sshd[7254]: Invalid user centos7 from 172.16.1.14 port 58144
Sep  6 11:41:37 localhost sshd[7252]: Invalid user centos7 from 172.16.1.14 port 58142
Sep  6 11:41:36 localhost sshd[7250]: Invalid user centos7 from 172.16.1.14 port 58140
Sep  6 11:41:36 localhost sshd[7248]: Invalid user centos7 from 172.16.1.14 port 58138
Sep  6 11:41:32 localhost sshd[7246]: Invalid user centos7 from 172.16.1.14 port 58136
```
   - [x] Fired an alert of an SSH attack from two different agents. Check if the alerts 5712 is fired only when an agent reaches eight users wrong.
```
** Alert 1568110751.279076: - syslog,sshd,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,
2019 Sep 10 12:19:11 (centos7) 172.16.1.13->/var/log/secure
Rule: 5712 (level 10) -> 'sshd: brute force trying to get access to the system.'
Src IP: 172.16.1.14
Src Port: 42264
Sep 10 10:19:10 centos7 sshd[6584]: Invalid user centos7-cliente from 172.16.1.14 port 42264
Sep 10 10:19:09 centos7 sshd[6582]: Invalid user centos7-cliente from 172.16.1.14 port 42262
Sep 10 10:19:04 centos7 sshd[6579]: Invalid user centos7-cliente from 172.16.1.14 port 42260
Sep 10 10:19:04 centos7 sshd[6577]: Invalid user centos7-cliente from 172.16.1.14 port 42258
Sep 10 10:18:59 centos7 sshd[6573]: Invalid user centos7-cliente from 172.16.1.14 port 42256
Sep 10 10:18:58 centos7 sshd[6571]: Invalid user centos7-cliente from 172.16.1.14 port 42254
Sep 10 10:18:57 centos7 sshd[6569]: Invalid user centos7-cliente from 172.16.1.14 port 42252
Sep 10 10:18:56 centos7 sshd[6567]: Invalid user centos7-cliente from 172.16.1.14 port 42250

** Alert 1568110755.280136: - syslog,sshd,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,
2019 Sep 10 12:19:15 (centos7-cliente) 172.16.1.14->/var/log/secure
Rule: 5712 (level 10) -> 'sshd: brute force trying to get access to the system.'
Src IP: 172.16.1.13
Src Port: 51236
Sep 10 10:19:14 centos7-cliente sshd[6314]: Invalid user centos7 from 172.16.1.13 port 51236
Sep 10 10:19:07 centos7-cliente sshd[6310]: Invalid user centos7 from 172.16.1.13 port 51234
Sep 10 10:19:02 centos7-cliente sshd[6306]: Invalid user centos7 from 172.16.1.13 port 51232
Sep 10 10:19:01 centos7-cliente sshd[6304]: Invalid user centos7 from 172.16.1.13 port 51230
Sep 10 10:18:53 centos7-cliente sshd[6298]: Invalid user centos7 from 172.16.1.13 port 51228
Sep 10 10:18:52 centos7-cliente sshd[6296]: Invalid user centos7 from 172.16.1.13 port 51226
Sep 10 10:18:51 centos7-cliente sshd[6294]: Invalid user centos7 from 172.16.1.13 port 51224
Sep 10 10:18:49 centos7-cliente sshd[6292]: Invalid user centos7 from 172.16.1.13 port 51222
```

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
