### PR TITLE
Update changes.md (new API) of overview endpoint.

### DIFF
--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -320,3 +320,8 @@ in `dapi_errors` key
 ## Version
 ### GET /version 
 * Removed endpoint
+
+## Summary
+### GET /summary/agents
+* Endpoint **/summary/agents** renamed to **/overview/agents**
+

--- a/api/test/integration/test_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_overview_endpoints.tavern.yaml
@@ -1,4 +1,4 @@
-test_name: GET /summary/agents
+test_name: GET /overview/agents
 
 includes:
  - !include common.yaml
@@ -8,9 +8,9 @@ stages:
  - type: ref
    id: login_get_token
 
- - name: Get full summary of agents
+ - name: Get overview of agents
    request:
-     url: "{protocol:s}://{host:s}:{port:d}/summary/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/overview/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"


### PR DESCRIPTION
Hi team,

This PR is for updating the `tavern` tests for `overview` endpoint (in `3.x` versions, this endpoint was named as `summary`).

Below there is an example of  this endpoint:

```bash
# curl localhost:55000/overview/agents
{
  "data": {
    "agent_os": {
      "items": [
        {
          "count": 2,
          "os": {
            "name": "Ubuntu",
            "platform": "ubuntu",
            "version": "18.04.3 LTS"
          }
        }
      ],
      "totalItems": 2
    },
    "agent_status": {
      "Active": 2,
      "Disconnected": 0,
      "Never connected": 0,
      "Pending": 0,
      "Total": 2
    },
    "agent_version": {
      "items": [
        {
          "count": 1,
          "version": "Wazuh v3.11.0"
        },
        {
          "count": 1,
          "version": "Wazuh v3.9.5"
        }
      ],
      "totalItems": 2
    },
    "groups": {
      "items": [
        {
          "configSum": "ab73af41699f13fdd81903b5f23d8d00",
          "count": 1,
          "mergedSum": "ddda4e15b99efad1d3be7ae9d7ff14ff",
          "name": "default"
        }
      ],
      "totalItems": 1
    },
    "last_registered_agent": {
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "dateAdd": "2019-09-06T11:41:02Z",
      "group": [
        "default"
      ],
      "id": "001",
      "ip": "172.31.0.5",
      "lastKeepAlive": "2019-09-06T11:46:45Z",
      "manager": "f30af2e560d5",
      "mergedSum": "ddda4e15b99efad1d3be7ae9d7ff14ff",
      "name": "e7c0927add7a",
      "node_name": "master",
      "os": {
        "arch": "x86_64",
        "codename": "Bionic Beaver",
        "major": "18",
        "minor": "04",
        "name": "Ubuntu",
        "platform": "ubuntu",
        "uname": "Linux |e7c0927add7a |5.2.9-200.fc30.x86_64 |#1 SMP Fri Aug 16 21:37:45 UTC 2019 |x86_64",
        "version": "18.04.3 LTS"
      },
      "registerIP": "172.31.0.5",
      "status": "active",
      "version": "Wazuh v3.9.5"
    },
    "nodes": {
      "items": [
        {
          "count": 2,
          "node_name": "master"
        }
      ],
      "totalItems": 2
    }
  }
}
```

`tavern` test for this endpoint is OK:
```bash
# /var/ossec/framework/python/bin/pytest /wazuh/api/test/integration/test_overview_endpoints.tavern.yaml 
================================================ test session starts ================================================
platform linux -- Python 3.7.2, pytest-4.5.0, py-1.8.0, pluggy-0.12.0
rootdir: /wazuh/api
plugins: tavern-0.30.0
collected 1 item                                                                                                    

wazuh/api/test/integration/test_overview_endpoints.tavern.yaml .                                              [100%]

================================================= warnings summary ==================================================
var/ossec/framework/python/lib/python3.7/site-packages/yaml/constructor.py:126
  /var/ossec/framework/python/lib/python3.7/site-packages/yaml/constructor.py:126: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if not isinstance(key, collections.Hashable):

test/integration/test_overview_endpoints.tavern.yaml::GET /overview/agents
  /var/ossec/framework/python/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================= 1 passed, 2 warnings in 0.65 seconds ========================================

```

Best regards,

Demetrio.