### PR TITLE
Remove useless select() calls in Analysisd decoders

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1783,8 +1783,6 @@ int pm_send_db(char *msg, char *response, int *sock)
     assert(response);
 
     ssize_t length;
-    fd_set fdset;
-    struct timeval timeout = {0, 1000};
     int size = strlen(msg);
     int retval = -1;
     int attempts;
@@ -1851,16 +1849,6 @@ int pm_send_db(char *msg, char *response, int *sock)
             merror("at OS_SendSecureTCP(): %s (%d)", strerror(errno), errno);
             goto end;
         }
-    }
-
-    // Wait for socket
-    FD_ZERO(&fdset);
-    FD_SET(*sock, &fdset);
-
-    if (select(*sock + 1, &fdset, NULL, NULL, &timeout) < 0)
-    {
-        merror("at select(): %s (%d)", strerror(errno), errno);
-        goto end;
     }
 
     // Receive response from socket

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1782,8 +1782,6 @@ int pm_send_db(char *msg, char *response, int *sock)
     assert(msg);
     assert(response);
 
-    ssize_t length;
-    int size = strlen(msg);
     int retval = -1;
     int attempts;
 
@@ -1811,6 +1809,8 @@ int pm_send_db(char *msg, char *response, int *sock)
             goto end;
         }
     }
+
+    int size = strlen(msg);
 
     // Send msg to Wazuh DB
     if (OS_SendSecureTCP(*sock, size + 1, msg) != 0)
@@ -1850,6 +1850,8 @@ int pm_send_db(char *msg, char *response, int *sock)
             goto end;
         }
     }
+
+    ssize_t length;
 
     // Receive response from socket
     length = OS_RecvSecureTCP(*sock, response, OS_SIZE_6144);

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -434,8 +434,6 @@ exit_fail:
 
 int send_query_wazuhdb(char *wazuhdb_query, char **output, _sdb *sdb) {
     char response[OS_SIZE_6144];
-    fd_set fdset;
-    struct timeval timeout = {0, 1000};
     int size = strlen(wazuhdb_query);
     int retval = -2;
     int attempts;
@@ -488,14 +486,6 @@ int send_query_wazuhdb(char *wazuhdb_query, char **output, _sdb *sdb) {
         }
     }
 
-    // Wait for socket
-    FD_ZERO(&fdset);
-    FD_SET(sdb->socket, &fdset);
-
-    if (select(sdb->socket + 1, &fdset, NULL, NULL, &timeout) < 0) {
-        mterror(ARGV0, "FIM decoder: in select (%d) '%s'.", errno, strerror(errno));
-        return retval;
-    }
     retval = -1;
 
     // Receive response from socket

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -433,8 +433,7 @@ exit_fail:
 
 
 int send_query_wazuhdb(char *wazuhdb_query, char **output, _sdb *sdb) {
-    char response[OS_SIZE_6144];
-    int size = strlen(wazuhdb_query);
+
     int retval = -2;
     int attempts;
 
@@ -456,6 +455,8 @@ int send_query_wazuhdb(char *wazuhdb_query, char **output, _sdb *sdb) {
             return retval;
         }
     }
+
+    int size = strlen(wazuhdb_query);
 
     // Send query to Wazuh DB
     if (OS_SendSecureTCP(sdb->socket, size + 1, wazuhdb_query) != 0) {
@@ -487,6 +488,8 @@ int send_query_wazuhdb(char *wazuhdb_query, char **output, _sdb *sdb) {
     }
 
     retval = -1;
+
+    char response[OS_SIZE_6144];
 
     // Receive response from socket
     if (OS_RecvSecureTCP(sdb->socket, response, OS_SIZE_6144 - 1) > 0) {

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1566,8 +1566,6 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
 int sc_send_db(char *msg, int *sock) {
     char response[OS_SIZE_128 + 1];
     ssize_t length;
-    fd_set fdset;
-    struct timeval timeout = {0, 1000};
     int size = strlen(msg);
     int retval = -1;
     int attempts;
@@ -1619,15 +1617,6 @@ int sc_send_db(char *msg, int *sock) {
             merror("at sc_send_db(): at OS_SendSecureTCP(): %s (%d)", strerror(errno), errno);
             goto end;
         }
-    }
-
-    // Wait for socket
-    FD_ZERO(&fdset);
-    FD_SET(*sock, &fdset);
-
-    if (select(*sock + 1, &fdset, NULL, NULL, &timeout) < 0) {
-        merror("at sc_send_db(): at select(): %s (%d)", strerror(errno), errno);
-        goto end;
     }
 
     // Receive response from socket

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1564,9 +1564,7 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
 }
 
 int sc_send_db(char *msg, int *sock) {
-    char response[OS_SIZE_128 + 1];
-    ssize_t length;
-    int size = strlen(msg);
+
     int retval = -1;
     int attempts;
 
@@ -1588,6 +1586,8 @@ int sc_send_db(char *msg, int *sock) {
             goto end;
         }
     }
+
+    int size = strlen(msg);
 
     // Send msg to Wazuh DB
     if (OS_SendSecureTCP(*sock, size + 1, msg) != 0) {
@@ -1618,6 +1618,9 @@ int sc_send_db(char *msg, int *sock) {
             goto end;
         }
     }
+
+    char response[OS_SIZE_128 + 1];
+    ssize_t length;
 
     // Receive response from socket
     length = OS_RecvSecureTCP(*sock, response, OS_SIZE_128);


### PR DESCRIPTION
##  Description

As @vikman90 states [here](https://github.com/wazuh/wazuh/issues/3675#issuecomment-526945027). There exists a known bug with the `select()` call when handling file descriptors higher than 1024.

We noticed the `select()` calls in the SCA, Syscollector, and Syscheck decoders are not needed since `OS_RecvSecureTCP()` waits for the response from Wazuh DB.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language
- [X] Tested queries from the three issued decoders.

Analysisd stats after restarting:

```
# Syscheck events decoded
syscheck_events_decoded='431'
syscheck_edps='86'

# Syscollector events decoded
syscollector_events_decoded='472'
syscollector_edps='94'

# Security configuration assessment events decoded
sca_events_decoded='101'
sca_edps='20'
```

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)

**Valgrind report** of `ossec-analysisd` stressed with Syscheck, Syscollector and SCA events:

```
==46889== LEAK SUMMARY:
==46889==    definitely lost: 100 bytes in 9 blocks
==46889==    indirectly lost: 0 bytes in 0 blocks
==46889==      possibly lost: 7,072 bytes in 26 blocks
==46889==    still reachable: 14,881,769 bytes in 68,750 blocks
==46889==         suppressed: 0 bytes in 0 blocks
==46889== Reachable blocks (those to which a pointer was found) are not shown.
==46889== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

- 100 bytes lost correspond to the rules load fixed at #3887 
- No descriptor leaks

**Scan-build report**

```
Done building server

scan-build: Removing directory '/tmp/scan-build-2019-09-12-103908-47512-1' because it contains no reports.
scan-build: No bugs found.
```