### PR TITLE
Fix coverity report for 3.10

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1636,7 +1636,9 @@ static void FillCheckEventInfo(Eventinfo *lf,cJSON *scan_id,cJSON *id,cJSON *nam
         fillData(lf, "sca.check.result", result->valuestring);
     } else {
         fillData(lf, "sca.check.status", status->valuestring);
-        fillData(lf, "sca.check.reason", reason->valuestring);
+        if (reason) {
+            fillData(lf, "sca.check.reason", reason->valuestring);
+        }
     }
 
     if(old_result) {
@@ -1865,7 +1867,7 @@ int pm_send_db(char *msg, char *response, int *sock)
         goto end;
 
     default:
-        response[length] = '\0';
+        response[length >= 0 ? length : 0] = '\0';
 
         mdebug1("Got wazuh-db response: %s", response);
         if (strncmp(response, "ok", 2))

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1079,8 +1079,15 @@ int fim_get_scantime (long *ts, Eventinfo *lf, _sdb *sdb) {
     }
 
     output = strchr(response, ' ');
-    *(output++) = '\0';
 
+    if (!output) {
+        merror("FIM decoder: Bad formatted response '%s'", response);
+        os_free(wazuhdb_query);
+        os_free(response);
+        return (-1);
+    }
+
+    *(output++) = '\0';
     *ts = atol(output);
 
     mdebug2("Agent '%s' FIM end_scan '%ld'", lf->agent_id, *ts);

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1634,7 +1634,7 @@ int sc_send_db(char *msg, int *sock) {
             goto end;
 
         default:
-            response[length] = '\0';
+            response[length >= 0 ? length : 0] = '\0';
 
             if (strcmp(response, "ok")) {
                 merror("at sc_send_db(): received: '%s'", response);


### PR DESCRIPTION
## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes the following potential bugs reported by Coverity:

- Negative array index write

```
** CID 204075:  Memory - corruptions  (NEGATIVE_RETURNS)
/analysisd/decoders/syscollector.c: 1637 in sc_send_db()


________________________________________________________________________________________________________
*** CID 204075:  Memory - corruptions  (NEGATIVE_RETURNS)
/analysisd/decoders/syscollector.c: 1637 in sc_send_db()
1631     
1632             case -1:
1633                 merror("at sc_send_db(): at OS_RecvSecureTCP(): %s (%d)", strerror(errno), errno);
1634                 goto end;
1635     
1636             default:
>>>     CID 204075:  Memory - corruptions  (NEGATIVE_RETURNS)
>>>     Using variable "length" as an index to array "response".
1637                 response[length] = '\0';
1638     
1639                 if (strcmp(response, "ok")) {
1640                     merror("at sc_send_db(): received: '%s'", response);
1641                     goto end;
1642                 }

** CID 204074:    (FORWARD_NULL)
```

Fixed at the Syscollector and SCA decoders.

- Dereference after `null` check at SCA decoder

```
>>>     CID 204074:    (FORWARD_NULL)
>>>     Passing null pointer "reason" to "FillCheckEventInfo", which dereferences it.
780                             FillCheckEventInfo(lf,scan_id,id,name,title,description,rationale,remediation,compliance,reference,file,directory,process,registry,result,status,reason,NULL,command);
```

- Dereference `null` return value

```
*** CID 204073:  Null pointer dereferences  (NULL_RETURNS)
/analysisd/decoders/syscheck.c: 1082 in fim_get_scantime()
1076             os_free(wazuhdb_query);
1077             os_free(response);
1078             return (-1);
1079         }
1080     
1081         output = strchr(response, ' ');
>>>     CID 204073:  Null pointer dereferences  (NULL_RETURNS)
>>>     Incrementing a pointer which might be null: "output".
1082         *(output++) = '\0';
1083     
1084         *ts = atol(output);
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Coverity