### PR TITLE
Fix critical error and invalid read in Remoted

### DIFF
--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -629,7 +629,7 @@ keyentry * OS_DupKeyEntry(const keyentry * key) {
     }
 
     copy->sock = key->sock;
-    copy->mutex = key->mutex;
+    w_mutex_init(&copy->mutex, NULL);
     copy->peer_info = key->peer_info;
 
     return copy;

--- a/src/remoted/netcounter.c
+++ b/src/remoted/netcounter.c
@@ -32,7 +32,7 @@ void rem_setCounter(int fd, size_t counter) {
     w_mutex_lock(&lock);
     while (fd >= connections.size) {
         os_realloc(connections.list, sizeof(int) * (connections.size + SIZE_BLOCK), connections.list);
-        memset(&connections.list[connections.size], 0, SIZE_BLOCK);
+        memset(&connections.list[connections.size], 0, sizeof(int) * SIZE_BLOCK);
         connections.size = connections.size + SIZE_BLOCK;
     }
     connections.list[fd] = counter;
@@ -42,7 +42,7 @@ void rem_setCounter(int fd, size_t counter) {
 
 size_t rem_getCounter(int fd) {
     w_mutex_lock(&lock);
-    size_t counter = connections.list[fd];
+    size_t counter = (fd >= connections.size) ? 0 : connections.list[fd];
     w_mutex_unlock(&lock);
     return counter;
 }


### PR DESCRIPTION
|Related issues|
|---|
|#3988 #3989|

This PR aims to fix the issues above.

## Fix busy resource critical error

Remoted copies agent key entries when reloading _client.keys_ and while handling a control message. This copy includes the entry mutex state. When Remoted frees the key entry, it crashes if the mutex copy is in a locked state, even when it's not being actually used.

Fix: a mutex should never be copied, let Remoted create a new mutex.

## Fix invalid read in the network counter library

The network counter library checked the counter array size when writing but not when reading.

Fixes:

1. Check the array size in `rem_getCounter()`.
2. Add a missing `sizeof(int)` operator when zeroing an array chunk after expanding.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [X] Stress test for affected components