### PR TITLE
Fix segmentation fault in Logcollector

### DIFF
--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -48,6 +48,7 @@ typedef struct _logtarget {
 typedef struct _logreader {
     off_t size;
     int ign;
+    dev_t dev;
 
 #ifdef WIN32
     HANDLE h;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -448,7 +448,7 @@ void LogCollectorStart()
 
                     /* Variable file name */
                     else if (!current->fp && open_file_attempts - current->ign > 0) {
-                        handle_file(i, j, 0, 1);
+                        handle_file(i, j, 1, 1);
                         continue;
                     }
                 }
@@ -696,14 +696,14 @@ void LogCollectorStart()
                         continue;
                     } else {
                         /* Try for a few times to open the file */
-                        handle_file(i, j, 0, 1);
+                        handle_file(i, j, 1, 1);
                         continue;
                     }
                 }
             }
 
             // Check for new files to be expanded
-            if (check_pattern_expand(0)) {
+            if (check_pattern_expand(1)) {
                 /* Remove duplicate entries */
                 for (i = 0, j = -1;; i++) {
                     if (f_control = update_current(&current, &i, &j), f_control) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -21,6 +21,7 @@ static int update_fname(int i, int j);
 static int update_current(logreader **current, int *i, int *j);
 static void set_read(logreader *current, int i, int j);
 static IT_control remove_duplicates(logreader *current, int i, int j);
+static int find_duplicate_inode(logreader * lf);
 static void set_sockets();
 static void files_lock_init(void);
 static void check_text_only();
@@ -343,6 +344,8 @@ void LogCollectorStart()
             int i;
             int j = -1;
             f_reload += f_check;
+
+            mdebug1("Performing file check.");
 
             // Force reload, if enabled
 
@@ -824,6 +827,7 @@ int handle_file(int i, int j, int do_fseek, int do_log)
 
     lf->fd = stat_fd.st_ino;
     lf->size =  stat_fd.st_size;
+    lf->dev =  stat_fd.st_dev;
 
 #else
     BY_HANDLE_FILE_INFORMATION lpFileInformation;
@@ -869,6 +873,12 @@ int handle_file(int i, int j, int do_fseek, int do_log)
     lf->size = (lpFileInformation.nFileSizeHigh + lpFileInformation.nFileSizeLow);
 
 #endif
+
+    if (find_duplicate_inode(lf)) {
+        mdebug1(DUP_FILE_INODE, lf->file);
+        close_file(lf);
+        return 0;
+    }
 
     /* Only seek the end of the file if set to */
     if (do_fseek == 1 && S_ISREG(stat_fd.st_mode)) {
@@ -1472,13 +1482,10 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
     IT_control d_control = CONTINUE_IT;
     IT_control f_control;
     int r, k;
-    int same_inode = 0;
     logreader *dup;
 
     if (current->file && !current->command) {
         for (r = 0, k = -1;; r++) {
-            same_inode = 0;
-
             if (f_control = update_current(&dup, &r, &k), f_control) {
                 if (f_control == NEXT_IT) {
                     continue;
@@ -1487,39 +1494,10 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
                 }
             }
 
-            if (!dup->file || dup->command) {
-                continue;
-            }
-
-#ifndef WIN32
-            struct stat statCurrent, statDup;
-
-            if (strcmp(current->logformat, "eventchannel") && strcmp(current->logformat, "eventlog") &&
-                strcmp(dup->logformat, "eventchannel") && strcmp(dup->logformat, "eventlog")) {
-
-                if (stat(current->file, &statCurrent) < 0){
-                    merror("Couldn't stat file '%s'", current->file);
-                    d_control = LEAVE_IT;
-                    break;
-                }
-
-                if (stat(dup->file, &statDup) < 0){
-                    merror("Couldn't stat file '%s'", dup->file);
-                    d_control = LEAVE_IT;
-                    break;
-                }
-
-                same_inode = (statCurrent.st_ino == statDup.st_ino && statCurrent.st_dev == statDup.st_dev) ? 1 : 0;
-            }
-#endif
-            if (current != dup && (!strcmp(current->file, dup->file) || same_inode)) {
-                if (same_inode) {
-                    mdebug1(DUP_FILE_INODE, current->file);
-                } else {
-                    mwarn(DUP_FILE, current->file);
-                }
-
+            if (current != dup && dup->file && !strcmp(current->file, dup->file)) {
+                mwarn(DUP_FILE, current->file);
                 int result;
+
                 if (j < 0) {
                     result = Remove_Localfile(&logff, i, 0, 1,NULL);
                 } else {
@@ -1539,6 +1517,37 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
     return d_control;
 }
 
+int find_duplicate_inode(logreader * lf) {
+    if (lf->file == NULL && lf->command != NULL) {
+        return 0;
+    }
+
+    int r;
+    int k;
+    logreader * dup;
+    IT_control f_control;
+
+    for (r = 0, k = -1;; r++) {
+        if (f_control = update_current(&dup, &r, &k), f_control) {
+            if (f_control == NEXT_IT) {
+                continue;
+            } else {
+                break;
+            }
+        }
+
+        /* If the entry is different, the file is open,
+         * and both inode and device match,
+         * then the link is a duplicate.
+         */
+
+        if (lf != dup && dup->fp != NULL && lf->fd == dup->fd && lf->dev == dup->dev) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
 
 static void set_sockets() {
     int i, j, k, t;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -168,8 +168,6 @@ void LogCollectorStart()
         if (duplicates_removed == NEXT_IT) {
             i--;
             continue;
-        } else if (duplicates_removed == LEAVE_IT){
-            continue;
         }
 
         if (!current->file) {
@@ -716,8 +714,6 @@ void LogCollectorStart()
                     duplicates_removed = remove_duplicates(current, i, j);
                     if (duplicates_removed == NEXT_IT) {
                         i--;
-                        continue;
-                    } else if (duplicates_removed == LEAVE_IT){
                         continue;
                     }
                 }


### PR DESCRIPTION
|Related issue|
|---|
|#3992|

## Description

We changed the method to prevent Logcollector from monitoring multiple hard links to the same file.

Instead of finding duplicate files on startup and removing one of the entries, now Logcollector searches for duplicate files on file checking. This stage is performed every `logcollector.vcheck_files` seconds.

Since two different devices may have the same inode, Logcollector finds duplicate "device:inode" pairs.

## Tests

We tested file creation and deletion, including soft and hard links, on these setting combinations:

1. A wildcarded `<location>`.
2. Multiple hardcoded `<location>` stanzas.
3. Combining wildcarded and time pattern-based `<location>` stanzas.

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] MAC OS X
- [X] Source installation
- [ ] Package installation
- [X] Source upgrade
- [ ] Package upgrade
- [X] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [X] Stress test for affected components
