### PR TITLE
Fix race condition with modulesd in temp files

### DIFF
--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -359,8 +359,9 @@ def safe_move(source, target, ownership=(common.ossec_uid(), common.ossec_gid())
     :param time: tuple in the form (addition_timestamp, modified_timestamp)
     :param permissions: string mask in octal notation. I.e.: '0o640'
     """
-    # Create temp file. Move between 
-    tmp_target = f"{target}.tmp"
+    # Create temp file. Move between
+    tmp_path, tmp_filename = path.split(target)
+    tmp_target = path.join(tmp_path, f".{tmp_filename}.tmp")
     shutil.move(source, tmp_target, copy_function=shutil.copyfile)
 
     # Overwrite the file atomically


### PR DESCRIPTION
|Related issue|
|---|
|#4007|

## Description

`wazuh-modulesd` deletes the tmp file created by the `safe_move` function only if the beginning of the filename matches an agent-info file name.

To avoid that, the temporary file will start by a '.' character, so `wazuh-modulesd` won't try to delete it. 

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

No errors in `cluster.log`.

```
root@f86f0a14fd00:/# tail -f /var/ossec/logs/cluster.log 
2019/09/30 06:59:51 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Analyzing worker integrity: Files checked. There are no KO files.
2019/09/30 06:59:51 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Finished integrity synchronization.
2019/09/30 06:59:53 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Waiting to receive zip file from worker
2019/09/30 06:59:53 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Analyzing worker integrity: Received 12 files to check.
2019/09/30 06:59:53 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Analyzing worker integrity: Files checked. There are no KO files.
2019/09/30 06:59:53 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Finished integrity synchronization.
2019/09/30 06:59:53 wazuh-clusterd: INFO: [Worker worker2] [Agent info] Waiting to receive zip file from worker
2019/09/30 06:59:53 wazuh-clusterd: INFO: [Worker worker2] [Agent info] Analyzing worker files: Received 1 files to check.
2019/09/30 06:59:54 wazuh-clusterd: INFO: [Worker worker1] [Agent info] Waiting to receive zip file from worker
2019/09/30 06:59:54 wazuh-clusterd: INFO: [Worker worker1] [Agent info] Analyzing worker files: Received 0 files to check.
2019/09/30 07:00:00 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Waiting to receive zip file from worker
2019/09/30 07:00:00 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Analyzing worker integrity: Received 12 files to check.
2019/09/30 07:00:00 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Analyzing worker integrity: Files checked. There are no KO files.
2019/09/30 07:00:00 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Finished integrity synchronization.
2019/09/30 07:00:02 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Waiting to receive zip file from worker
2019/09/30 07:00:02 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Analyzing worker integrity: Received 12 files to check.
2019/09/30 07:00:02 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Analyzing worker integrity: Files checked. There are no KO files.
2019/09/30 07:00:02 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Finished integrity synchronization.
2019/09/30 07:00:03 wazuh-clusterd: INFO: [Worker worker2] [Agent info] Waiting to receive zip file from worker
2019/09/30 07:00:03 wazuh-clusterd: INFO: [Worker worker2] [Agent info] Analyzing worker files: Received 1 files to check.
2019/09/30 07:00:04 wazuh-clusterd: INFO: [Worker worker1] [Agent info] Waiting to receive zip file from worker
2019/09/30 07:00:04 wazuh-clusterd: INFO: [Worker worker1] [Agent info] Analyzing worker files: Received 0 files to check.
2019/09/30 07:00:09 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Waiting to receive zip file from worker
2019/09/30 07:00:09 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Analyzing worker integrity: Received 12 files to check.
2019/09/30 07:00:09 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Analyzing worker integrity: Files checked. There are no KO files.
2019/09/30 07:00:09 wazuh-clusterd: INFO: [Worker worker2] [Integrity] Finished integrity synchronization.
2019/09/30 07:00:11 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Waiting to receive zip file from worker
2019/09/30 07:00:11 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Analyzing worker integrity: Received 12 files to check.
2019/09/30 07:00:11 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Analyzing worker integrity: Files checked. There are no KO files.
2019/09/30 07:00:11 wazuh-clusterd: INFO: [Worker worker1] [Integrity] Finished integrity synchronization.
2019/09/30 07:00:13 wazuh-clusterd: INFO: [Worker worker2] [Agent info] Waiting to receive zip file from worker
2019/09/30 07:00:13 wazuh-clusterd: INFO: [Worker worker2] [Agent info] Analyzing worker files: Received 1 files to check.

root@f86f0a14fd00:/# grep -i error /var/ossec/logs/cluster.log 
root@f86f0a14fd00:/# 
```

## Tests

Unit tests pass and don't need to get updated:
```
platform linux -- Python 3.7.3, pytest-4.6.2, py-1.8.0, pluggy-0.12.0
rootdir: /home/danielruiz/git/wazuh/framework
collected 181 items                                                                                                                                                                                                                          

tests/test_utils.py .....................................................................................................................................................................................                              [100%]

========================================================================================================= 181 passed in 0.52 seconds =========================================================================================================


