### PR TITLE
Including <info> field content in alerts.log alerts

### DIFF
--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -315,7 +315,7 @@ void OS_Log(Eventinfo *lf)
     fprintf(_aflog,
             "** Alert %ld.%ld:%s - %s\n"
             "%d %s %02d %s %s%s%s\n%sRule: %d (level %d) -> '%s'"
-            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
+            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
             (long int)lf->time.tv_sec,
             __crt_ftell,
             lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
@@ -365,6 +365,9 @@ void OS_Log(Eventinfo *lf)
 
             lf->dstuser == NULL ? "" : "\nUser: ",
             lf->dstuser == NULL ? "" : lf->dstuser,
+
+            lf->generated_rule->info == NULL ? "" : "\nInfo: ",
+            lf->generated_rule->info == NULL ? "" : lf->generated_rule->info,
             "\n",
             lf->full_log);
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4026|


## Description

When `<info>` field is specified on any rule, the corresponding alert in `alerts.log` file will now contain the correct `<info>` content.

Before this fix, the `<info>` content was shown on alerts.json and `ossec-logtest` output but was missing on `alerts.log`


## Logs/Alerts example

- Example rule with <info> field:

```XML
<rule id="100010" level="4">
  <program_name>example</program_name>
  <description>User logged </description>
  <info type="link">https://www.google.es</info>
</rule>
```

- Incomplete `alerts.log` output(before the fix):

```
** Alert 1569847128.390380: - local,syslog,sshd,
2019 Sep 30 14:38:48 MyHost->/var/log/auth.log
Rule: 100010 (level 4) -> 'User logged '
```

- `alerts.log` correct output(after the fix):

```
** Alert 1569847128.390380: - local,syslog,sshd,
2019 Sep 30 14:38:48 MyHost->/var/log/auth.log
Rule: 100010 (level 4) -> 'User logged '
Info: https://www.google.es
```


## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
