### PR TITLE
[Fluentd] Send messages to server socket in chunks

### DIFF
--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -69,7 +69,6 @@ const wm_context WM_FLUENT_CONTEXT = {
 void * wm_fluent_main(wm_fluent_t * fluent) {
     int server_sock;
     char * buffer = NULL;
-    char * aux_buffer = NULL;
     ssize_t recv_b = -1;
 
     // If module is disabled, exit
@@ -97,32 +96,25 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
     }
 
     int matrix_index = 0;
-    const int MAX_MSG_RECV = 3;
     char **matrix_buffer = NULL;
     int attempts = 0;
+    struct timespec tsec;
+    tsec.tv_sec = 0;
+    tsec.tv_nsec = 1000000;
 
-    os_malloc(MAX_MSG_RECV * sizeof(char *), matrix_buffer);
+    os_malloc(OS_MAXSTR * sizeof(char *), matrix_buffer);
     os_calloc(OS_MAXSTR, sizeof(char), buffer);
 
     while (1) {
-        // Store logs until MAX_MSG_RECV is reached
-        while ((recv_b = recv(server_sock, buffer, OS_MAXSTR - 1, MSG_DONTWAIT)) && matrix_index < MAX_MSG_RECV) {
-            // Check if there is a log that was not being taken into account
+        // Store logs for 1 second
+        while ((recv_b = recv(server_sock, buffer, OS_MAXSTR - 1, MSG_DONTWAIT))) {
             os_calloc(OS_MAXSTR, sizeof(char), matrix_buffer[matrix_index]);
 
-            if (aux_buffer != NULL) {
-                memcpy(matrix_buffer[matrix_index], aux_buffer, strlen(aux_buffer));
-                matrix_buffer[matrix_index][strlen(aux_buffer)] = '\0';
-                matrix_index++;
-                free(aux_buffer);
-                aux_buffer = NULL;
-            }
-
-            // Set a timeout of 30 seconds to send the data accumulated
+            // Set a timeout of 1 second to send the data accumulated
             if (!strcmp(buffer, "") || recv_b == -1) {
+                nanosleep(&tsec, NULL);
                 attempts++;
-                sleep(1);
-                if (attempts >= 10 && strcmp(matrix_buffer[0], "") != 0) {
+                if (attempts >= 1000 && strcmp(matrix_buffer[0], "") != 0) {
                     attempts = 0;
                     break;
                 }
@@ -131,44 +123,19 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
             }
 
             attempts = 0;
-            buffer[recv_b] = '\0';
-
-            if (!matrix_buffer[matrix_index]) {
-                os_calloc(OS_MAXSTR, sizeof(char), matrix_buffer[matrix_index]);
-            }
-
-            memcpy(matrix_buffer[matrix_index], buffer, strlen(buffer));
-            matrix_buffer[matrix_index][strlen(buffer)] = '\0';
+            strncpy(matrix_buffer[matrix_index], buffer, recv_b);
             matrix_index++;
         }
 
-        // When the matrix has MAX_MSG_RECV logs, send them to the fluentd server
         if (wm_fluent_send(fluent, matrix_buffer, matrix_index) < 0) {
             mwarn("Cannot send data to '%s': %s (%d). Reconnecting...", fluent->address, strerror(errno), errno);
         }
 
-        if (recv_b > 0 && buffer != NULL) {
-            buffer[recv_b] = '\0';
-            os_strdup(buffer, aux_buffer);
-        }
-
-        for(int i = 0; i < matrix_index; i++) {
-            free(matrix_buffer[i]);
-            matrix_buffer[i] = '\0';
+        for(int i = 0; i <= matrix_index; i++) {
+            os_free(matrix_buffer[i]);
         }
         matrix_index = 0;
     }
-
-    if (fluent->client_sock >= 0) {
-        close(fluent->client_sock);
-        fluent->client_sock = -1;
-    }
-
-    for(int i = 0; i < MAX_MSG_RECV; i++) {
-        os_free(matrix_buffer[i]);
-    }
-    os_free(matrix_buffer);
-    os_free(buffer);
 
     return NULL;
 }

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -122,7 +122,7 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
             if (!strcmp(buffer, "") || recv_b == -1) {
                 attempts++;
                 sleep(1);
-                if (attempts >= 10 && strcmp(matrix_buffer[0], "") != 0) {
+                if (attempts >= 1 && strcmp(matrix_buffer[0], "") != 0) {
                     attempts = 0;
                     break;
                 }

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -116,6 +116,7 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
                 attempts++;
                 if (attempts >= 1000 && strcmp(matrix_buffer[0], "") != 0) {
                     attempts = 0;
+                    os_free(matrix_buffer[matrix_index]);
                     break;
                 }
                 os_free(matrix_buffer[matrix_index]);
@@ -131,7 +132,7 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
             mwarn("Cannot send data to '%s': %s (%d). Reconnecting...", fluent->address, strerror(errno), errno);
         }
 
-        for(int i = 0; i <= matrix_index; i++) {
+        for(int i = 0; i < matrix_index; i++) {
             os_free(matrix_buffer[i]);
         }
         matrix_index = 0;

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -69,6 +69,7 @@ const wm_context WM_FLUENT_CONTEXT = {
 void * wm_fluent_main(wm_fluent_t * fluent) {
     int server_sock;
     char * buffer = NULL;
+    char * aux_buffer = NULL;
     ssize_t recv_b = -1;
 
     // If module is disabled, exit
@@ -96,27 +97,33 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
     }
 
     int matrix_index = 0;
+    const int MAX_MSG_RECV = 3;
     char **matrix_buffer = NULL;
     int attempts = 0;
-    struct timespec tsec;
-    tsec.tv_sec = 0;
-    tsec.tv_nsec = 1000000;
 
-    os_malloc(OS_MAXSTR * sizeof(char *), matrix_buffer);
+    os_malloc(MAX_MSG_RECV * sizeof(char *), matrix_buffer);
     os_calloc(OS_MAXSTR, sizeof(char), buffer);
 
     while (1) {
-        // Store logs for 1 second
-        while ((recv_b = recv(server_sock, buffer, OS_MAXSTR - 1, MSG_DONTWAIT))) {
+        // Store logs until MAX_MSG_RECV is reached
+        while ((recv_b = recv(server_sock, buffer, OS_MAXSTR - 1, MSG_DONTWAIT)) && matrix_index < MAX_MSG_RECV) {
+            // Check if there is a log that was not being taken into account
             os_calloc(OS_MAXSTR, sizeof(char), matrix_buffer[matrix_index]);
 
-            // Set a timeout of 1 second to send the data accumulated
+            if (aux_buffer != NULL) {
+                memcpy(matrix_buffer[matrix_index], aux_buffer, strlen(aux_buffer));
+                matrix_buffer[matrix_index][strlen(aux_buffer)] = '\0';
+                matrix_index++;
+                free(aux_buffer);
+                aux_buffer = NULL;
+            }
+
+            // Set a timeout of 30 seconds to send the data accumulated
             if (!strcmp(buffer, "") || recv_b == -1) {
-                nanosleep(&tsec, NULL);
                 attempts++;
-                if (attempts >= 1000 && strcmp(matrix_buffer[0], "") != 0) {
+                sleep(1);
+                if (attempts >= 10 && strcmp(matrix_buffer[0], "") != 0) {
                     attempts = 0;
-                    os_free(matrix_buffer[matrix_index]);
                     break;
                 }
                 os_free(matrix_buffer[matrix_index]);
@@ -124,19 +131,44 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
             }
 
             attempts = 0;
-            strncpy(matrix_buffer[matrix_index], buffer, recv_b);
+            buffer[recv_b] = '\0';
+
+            if (!matrix_buffer[matrix_index]) {
+                os_calloc(OS_MAXSTR, sizeof(char), matrix_buffer[matrix_index]);
+            }
+
+            memcpy(matrix_buffer[matrix_index], buffer, strlen(buffer));
+            matrix_buffer[matrix_index][strlen(buffer)] = '\0';
             matrix_index++;
         }
 
+        // When the matrix has MAX_MSG_RECV logs, send them to the fluentd server
         if (wm_fluent_send(fluent, matrix_buffer, matrix_index) < 0) {
             mwarn("Cannot send data to '%s': %s (%d). Reconnecting...", fluent->address, strerror(errno), errno);
         }
 
+        if (recv_b > 0 && buffer != NULL) {
+            buffer[recv_b] = '\0';
+            os_strdup(buffer, aux_buffer);
+        }
+
         for(int i = 0; i < matrix_index; i++) {
-            os_free(matrix_buffer[i]);
+            free(matrix_buffer[i]);
+            matrix_buffer[i] = '\0';
         }
         matrix_index = 0;
     }
+
+    if (fluent->client_sock >= 0) {
+        close(fluent->client_sock);
+        fluent->client_sock = -1;
+    }
+
+    for(int i = 0; i < MAX_MSG_RECV; i++) {
+        os_free(matrix_buffer[i]);
+    }
+    os_free(matrix_buffer);
+    os_free(buffer);
 
     return NULL;
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3901|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR redesigns the `fluentd` module in order to connect directly to the Fluent socket when necessary to send messages. These messages will be stored until there are 3 messages to send, then, they will be forwarded to the server socket.

## Logs example

<!--
Paste here related logs and alerts
-->
This is the way 300 messages are being sent.
```
2019-10-03 10:25:43.000000000 -0700 debug.test: ["0","1","2"]
2019-10-03 10:25:43.000000000 -0700 debug.test: ["3","4","5"]
2019-10-03 10:25:43.000000000 -0700 debug.test: ["6","7","8"]
2019-10-03 10:25:43.000000000 -0700 debug.test: ["9","10","11"]
2019-10-03 10:25:44.000000000 -0700 debug.test: ["12","13","14"]
2019-10-03 10:25:44.000000000 -0700 debug.test: ["15","16","17"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["18"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["19","20","21"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["22","23","24"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["25","26","27"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["28","29","30"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["31","32","33"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["34","35","36"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["37","38","39"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["40","41","42"]
2019-10-03 10:25:45.000000000 -0700 debug.test: ["43","44","45"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["46","47","48"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["49","50","51"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["52","53","54"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["55","56","57"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["58","59","60"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["61","62","63"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["64","65","66"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["67","68","69"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["70","71","72"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["73","74","75"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["76","77","78"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["79","80","81"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["82","83","84"]
2019-10-03 10:25:46.000000000 -0700 debug.test: ["85","86","87"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["88","89","90"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["91","92","93"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["94","95","96"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["97","98","99"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["100","101","102"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["103","104","105"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["106","107","108"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["109","110","111"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["112","113","114"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["115","116","117"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["118","119","120"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["121","122","123"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["124","125","126"]
2019-10-03 10:25:47.000000000 -0700 debug.test: ["127","128","129"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["130","131","132"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["133","134","135"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["136","137","138"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["139","140","141"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["142","143","144"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["145","146","147"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["148","149","150"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["151","152","153"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["154","155","156"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["157","158","159"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["160","161","162"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["163","164","165"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["166","167","168"]
2019-10-03 10:25:48.000000000 -0700 debug.test: ["169","170","171"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["172","173","174"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["175","176","177"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["178","179","180"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["181","182","183"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["184","185","186"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["187","188","189"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["190","191","192"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["193","194","195"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["196","197","198"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["199","200","201"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["202","203","204"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["205","206","207"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["208","209","210"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["211","212","213"]
2019-10-03 10:25:49.000000000 -0700 debug.test: ["214","215","216"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["217","218","219"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["220","221","222"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["223","224","225"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["226","227","228"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["229","230","231"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["232","233","234"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["235","236","237"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["238","239","240"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["241","242","243"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["244","245","246"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["247","248","249"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["250","251","252"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["253","254","255"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["256","257","258"]
2019-10-03 10:25:50.000000000 -0700 debug.test: ["259","260","261"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["262","263","264"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["265","266","267"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["268","269","270"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["271","272","273"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["274","275","276"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["277","278","279"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["280","281","282"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["283","284","285"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["286","287","288"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["289","290","291"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["292","293","294"]
2019-10-03 10:25:51.000000000 -0700 debug.test: ["295","296","297"]
2019-10-03 10:25:52.000000000 -0700 debug.test: ["298","299"]
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer


Memory monitoring
-------------------------

- Scan build

This tool reported the following: 
```
scan-build: 3 bugs found.
scan-build: Run 'scan-view /tmp/scan-build-2019-10-01-120548-6380-1' to examine bug reports.
```

Which, apparently have nothing to do with the branch, as they are related to `remoted` and rules reading.
![image](https://user-images.githubusercontent.com/14914658/65992783-c1b0a880-e444-11e9-905d-9fc4a3abd4fd.png)

- Address sanitizer
No reports from this tool

- Valgrind
```
==516== LEAK SUMMARY:
==516==    definitely lost: 0 bytes in 0 blocks
==516==    indirectly lost: 0 bytes in 0 blocks
==516==      possibly lost: 5,736 bytes in 7 blocks
==516==    still reachable: 619,336 bytes in 382 blocks
==516==                       of which reachable via heuristic:
==516==                         length64           : 223,856 bytes in 121 blocks
==516==         suppressed: 0 bytes in 0 blocks
==516== Reachable blocks (those to which a pointer was found) are not shown.
==516== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

Performance 
------------------
_Environment_
Using a localfile to send packets of logs of different sizes to the `fluentd` module's UDP socket.

- 1024 bytes

| Total messages sent to UDP socket | Messages sent to fluentd | Time |
| :---: | :---: | :---: |
| 6560 | 2171 | 2 minutes |


- 32768 bytes

| Total messages sent to UDP socket | Messages sent to fluentd | Time |
| :---: | :---: | :---: |
| 5804 | 1935 | 2 minutes |

- Sending ten thousand 32768 messages

| Total messages sent | Time spent in UDP socket | Time spent in TCP socket |
| :---: | :---: | :---: |
| 10000 | 2 min 47 sec | 3 min 17 sec |