### PR TITLE
Fix service's installation path for CentOS 8

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -30,7 +30,7 @@ runInit()
             type=agent
         fi
         # RHEL 8 services must to be installed in /usr/lib/systemd/system/
-        if [ "${DIST_NAME}" = "rhel" -a "${DIST_VER}" = "8" ]; then
+        if [ "${DIST_NAME}" = "rhel" -a "${DIST_VER}" = "8" ] || [ "${DIST_NAME}" = "centos" -a "${DIST_VER}" = "8" ]; then
             cp -p ./src/systemd/wazuh-$type.service /usr/lib/systemd/system/
             chown root:ossec /usr/lib/systemd/system/"wazuh-"$type.service
             systemctl daemon-reload


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/323|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

This PR closes https://github.com/wazuh/wazuh-packages/issues/323 by installing the services files in /usr/lib/systemd/system/. This allows using systemd to manage the service of the manager and the agent in CentOS 8.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

Not needed.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

- Agent:
```
[root@centos8 wazuh]# systemctl start wazuh-agent          
[root@centos8 wazuh]# systemctl status wazuh-agent      
● wazuh-agent.service - Wazuh agent
   Loaded: loaded (/usr/lib/systemd/system/wazuh-agent.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2019-10-08 09:11:48 UTC; 2s ago
  Process: 12620 ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-control start (code=exited, status=0/SUCCESS)
    Tasks: 22 (limit: 24014)
   Memory: 12.1M
   CGroup: /system.slice/wazuh-agent.service
           ├─12647 /var/ossec/bin/ossec-execd
           ├─12652 /var/ossec/bin/ossec-agentd
           ├─12659 /var/ossec/bin/ossec-syscheckd
           ├─12664 /var/ossec/bin/ossec-logcollector
           └─12674 /var/ossec/bin/wazuh-modulesd

```
- Manager
```
[root@centos8 vagrant]# systemctl status wazuh-manager
● wazuh-manager.service - Wazuh manager
   Loaded: loaded (/usr/lib/systemd/system/wazuh-manager.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2019-10-08 09:21:26 UTC; 10s ago
  Process: 4948 ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-control start (code=exited, status=0/SUCCESS)
    Tasks: 85 (limit: 24014)
   Memory: 47.5M
   CGroup: /system.slice/wazuh-manager.service
           ├─5013 /var/ossec/bin/ossec-authd
           ├─5022 /var/ossec/bin/wazuh-db
           ├─5039 /var/ossec/bin/ossec-execd
           ├─5047 /var/ossec/bin/ossec-analysisd
           ├─5054 /var/ossec/bin/ossec-syscheckd
           ├─5062 /var/ossec/bin/ossec-remoted
           ├─5087 /var/ossec/bin/ossec-logcollector
           ├─5092 /var/ossec/bin/ossec-monitord
           └─5098 /var/ossec/bin/wazuh-modulesd

Oct 08 09:21:24 centos8 env[4948]: Started wazuh-db...
Oct 08 09:21:24 centos8 env[4948]: Started ossec-execd...
Oct 08 09:21:24 centos8 env[4948]: Started ossec-analysisd...
Oct 08 09:21:24 centos8 env[4948]: Started ossec-syscheckd...
Oct 08 09:21:24 centos8 env[4948]: Started ossec-remoted...
Oct 08 09:21:24 centos8 env[4948]: Started ossec-logcollector...
Oct 08 09:21:24 centos8 env[4948]: Started ossec-monitord...
Oct 08 09:21:24 centos8 env[4948]: Started wazuh-modulesd...
Oct 08 09:21:26 centos8 env[4948]: Completed.
Oct 08 09:21:26 centos8 systemd[1]: Started Wazuh manager.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language