### PR TITLE
Add Catalina to the list of Mac OS Versions

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -285,8 +285,9 @@ char *OSX_ReleaseName(const int version) {
     /* 15 */ "El Capitan",
     /* 16 */ "Sierra",
     /* 17 */ "High Sierra",
-    /* 18 */ "Mojave"};
-    if (version >= 10 && version <= 18)
+    /* 18 */ "Mojave",
+    /* 19 */ "Catalina"};
+    if (version >= 10 && version <= 19)
         return r_names[version%10];
     else
         return "Unknown";


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3987|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds Catalina to the list of Mac OS versions in order to extract the name of the OS with the numeric version (19)

## Logs/Alerts example

Agent info:
```
Darwin |vagrants-iMac.local |19.0.0 |Darwin Kernel Version 19.0.0: Thu Jun 27 20:18:24 PDT 2019; root:xnu-6153.0.13.131.3~1/RELEASE_X86_64 |x86_64 [Mac OS X|darwin: 10.15 (Catalina)] - Wazuh v3.10.3
f52e38c75fdf1ba71ab6abc1d94a33c6 merged.mg
```

Output from Wazuh DB. (Syscollector scan)
```
sqlite> select * from sys_osinfo ;
1398797652|2019/10/08 06:56:06|vagrants-iMac.local|x86_64|Mac OS X|10.15 (Catalina)|Catalina|10|15|19A501i|darwin|Darwin|19.0.0|Darwin Kernel Version 19.0.0: Thu Jun 27 20:18:24 PDT 2019; root:xnu-6153.0.13.131.3~1/RELEASE_X86_64
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [x] Compilation in MAC OS X
- [x] Source installation