### PR TITLE
SCA -  First scan does not generate alerts

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -803,22 +803,6 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
                         event
                 );
 
-                if (result) {
-                    if(strcmp(wdb_response,result->valuestring)) {
-                        FillCheckEventInfo(lf, scan_id, id, name, title, description, rationale, remediation,
-                                compliance, reference, file, directory, process, registry, result,
-                                status, reason, NULL, command
-                        );
-                    }
-                } else if (status && status->valuestring) {
-                    if(strcmp(wdb_response, status->valuestring)) {
-                        FillCheckEventInfo(lf, scan_id, id, name, title, description, rationale,
-                                remediation, compliance, reference, file, directory,
-                                process, registry, result, status, reason, NULL, command
-                        );
-                    }
-                }
-
                 if (result_event < 0)
                 {
                     merror("Error storing policy monitoring information for agent '%s'", lf->agent_id);

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1180,8 +1180,6 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
                     policy_id->valuestring);
             if (!first_scan) {
                 PushDumpRequest(lf->agent_id,policy_id->valuestring,0);
-            } else {
-                PushDumpRequest(lf->agent_id,policy_id->valuestring,1);
             }
 
             break;


### PR DESCRIPTION
|Related issue|
|---|
| [3941](https://github.com/wazuh/wazuh/issues/3941) |

## Description

SCA generates `checks` and `summary` alerts in the first scan.

Also, if DB is empty, Analysisd creates two alerts reporting the policy summary.  That's because the function `HandleScanInfo` requests the scan result two times.

![imagen](https://user-images.githubusercontent.com/17710550/67766211-32e87900-fa4e-11e9-8ba3-b878134aeb31.png)

This PR only generates summary alerts and it does once:

![imagen](https://user-images.githubusercontent.com/17710550/67766065-e309b200-fa4d-11e9-8657-16a3bb1c1f4d.png)


## Test

- Linux compilation
   - [x] Source installation
   - [x] Source upgrade

- Custom test
  - [x] Alerts don't generate
  - [x] When check status change alert is generated
  - [x] Scan is show in Wazuh APP
  - [x] Policies checks and status are saved correctly in DB