### PR TITLE
Prevent FIM from producing false negatives due to wrong checksum comparison

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -95,7 +95,7 @@
 #define FIM_REALTIME_MONITORING             "(6225): The '%s' directory starts to be monitored in real-time mode"
 #define FIM_REALTIME_NEWPATH                "(6226): Scanning new file '%s' with options for directory '%s'."
 #define FIM_REALTIME_NEWDIRECTORY           "(6227): Directory added for real time monitoring: '%s'."
-#define FIM_REALTIME_DISCARD_EVENT          "(6228): Inotify event with same checksum for file: '%s'. Ignoring it."
+#define FIM_REALTIME_DISCARD_EVENT          "(6228): Real-time event with same checksum for file: '%s'. Ignoring it."
 
 #define FIM_WHODATA_HANDLE_UPDATE           "(6229): The handler ('%s') will be updated."
 #define FIM_WHODATA_NEWDIRECTORY            "(6230): Monitoring with Audit: '%s'."

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -99,4 +99,13 @@ const char *find_string_in_array(char * const string_array[], size_t array_len, 
 
 char *decode_hex_buffer_2_ascii_buffer(const char * const encoded_buffer, const size_t buffer_size);
 
+/**
+ * @brief Length of the initial segment of s which consists entirely of non-escaped bytes different from reject
+ *
+ * @param s String.
+ * @param reject String delimiter.
+ * @return size_t Number of bytes in s that are not reject.
+ */
+size_t strcspn_escaped(const char * s, char reject);
+
 #endif

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -643,3 +643,24 @@ char* decode_hex_buffer_2_ascii_buffer(const char * const encoded_buffer, const 
 
     return decoded_buffer;
 }
+
+// Length of the initial segment of s which consists entirely of non-escaped bytes different from reject
+
+size_t strcspn_escaped(const char * s, char reject) {
+    char charset[3] = { '\\', reject };
+
+    size_t len = strlen(s);
+    size_t spn_len = 0;
+
+    do {
+        spn_len += strcspn(s + spn_len, charset);
+
+        if (s[spn_len] == '\\') {
+            spn_len += 2;
+        } else {
+            return spn_len;
+        }
+    } while (spn_len < len);
+
+    return len;
+}

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -585,7 +585,7 @@ static int read_file(const char *file_name, const char *linked_file, int dir_pos
                     merror(FIM_ERROR_WHODATA_SUM_MAX, linked_file && *linked_file ? linked_file : file_name);
                 }
                 // Update database
-                snprintf(alert_msg, OS_MAXSTR, "%.*s%.*s", SK_DB_NATTR, buf, (int)strcspn(c_sum, " "), c_sum);
+                snprintf(alert_msg, OS_MAXSTR, "%.*s%.*s", SK_DB_NATTR, buf, (int)strcspn_escaped(c_sum, ' '), c_sum);
                 s_node->checksum = strdup(alert_msg);
 
                 /* Send the new checksum to the analysis server */

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -98,7 +98,7 @@ int realtime_checksumfile(const char *file_name, whodata_evt *evt)
             }
 
             // Update database
-            snprintf(alert_msg, sizeof(alert_msg), "%.*s%.*s", SK_DB_NATTR, buf, (int)strcspn(c_sum, " "), c_sum);
+            snprintf(alert_msg, sizeof(alert_msg), "%.*s%.*s", SK_DB_NATTR, buf, (int)strcspn_escaped(c_sum, ' '), c_sum);
             s_node->checksum = strdup(alert_msg);
 
             alert_msg[OS_MAXSTR] = '\0';

--- a/src/tests/tap_shared.c
+++ b/src/tests/tap_shared.c
@@ -50,6 +50,17 @@ int test_utf8_random(bool replacement) {
     return r;
 }
 
+int test_strnspn_escaped() {
+    w_assert_uint_eq(strcspn_escaped("ABC\\D ", ' '), 5);
+    w_assert_uint_eq(strcspn_escaped("ABC\\ D", ' '), 6);
+    w_assert_uint_eq(strcspn_escaped("ABCD\\", ' '), 5);
+    w_assert_uint_eq(strcspn_escaped("ABCDE \\ ", ' '), 5);
+    w_assert_uint_eq(strcspn_escaped("ABCDE\\\\ F", ' '), 7);
+    w_assert_uint_eq(strcspn_escaped("ABCDE\\\\", ' '), 7);
+    w_assert_uint_eq(strcspn_escaped("ABC\\ D E", ' '), 6);
+    w_assert_uint_eq(strcspn_escaped("ABCDE", ' '), 5);
+}
+
 int main(void) {
     printf("\n\n   STARTING TEST - OS_SHARED   \n\n");
 
@@ -61,6 +72,9 @@ int main(void) {
 
     /* Test UTF-8 string operations */
     TAP_TEST_MSG(test_utf8_random(false), "Filter a random string into UTF-8 without character replacement.");
+
+    /* Test strnspn_escaped function */
+    TAP_TEST_MSG(test_strnspn_escaped(), "Check return values for stnspn_escaped.");
 
     TAP_PLAN;
     TAP_SUMMARY;


### PR DESCRIPTION
## Symptom

File integrity monitoring was not reporting changes in files if these two conditions were met:

a) The file size remains constant.
b) Check permissions is enabled, and the file permissions matrix contains any user with whitespaces.

## Rationale

This version of Syscheck compares every file checksum with the previous checksum string that the agent sent to the manager. If both checksums match, the agent skips that event as it has been already reported.

The checksum and the file name are separated by a whitespace. That is because user names with spaces are escaped. But we were using `strcspn` to find the first whitespace in the string, no matter if it was escaped.

Due to this, the checksum was truncated.

Example:

Original checksum:

```
24:|SYSTEM,0,2032127|Administrators,0,2032127|Users,0,1179817|ALL\ APPLICATION\ PACKAGES,0,1179817|ALL\ RESTRICTED\ APPLICATION\ PACKAGES,0,1179817:S-1-5-18::16c3b094f88e9867ab3309dc857e62a4:88c9f7599d47e244604cdd2e95d89c2d6064ac0c:SYSTEM:::0:2122e5c80c081abe875363f758041716b65da4a0936326bf1da7feeab63339fa:32
```

Truncated checksum:
```
824:|SYSTEM,0,2032127|Administrators,0,2032127|Users,0,1179817|ALL\
```

So, the next time that a change in the file produces an event, the previous checksum will match (substring comparison) the new one, and the event will te discarded.

## Fix

Implement and use a custom function `strcspn_escaped()` to truncate a string by a legal (unescaped) whitespace.

## Logs/Alerts example

This is a sample of an alert that is missing before this change:

```json
{
  "timestamp": "2019-10-10T15:35:51.075+0000",
  "rule": {
    "level": 7,
    "description": "Integrity checksum changed.",
    "id": "550",
    "firedtimes": 7,
    "groups": [
      "ossec",
      "syscheck"
    ]
  },
  "id": "1570721751.2593033",
  "full_log": "File 'c:\\windows\\sysnative\\drivers\\etc\\hosts' checksum changed.\nOld md5sum was: '2c204c50411c0f2d82ec4473cb2aefcc'\nNew md5sum is : 'bc85ebd774419605782381cbede2c261'\nOld sha1sum was: '4b63ac34af3b09e2822e95ecbc9abeafae763c7d'\nNew sha1sum is : '0df7345fd9645207f5f28da57a983cdaba73efda'\nOld sha256sum was: '2b5ba8e3fc32b800768aafa231ab4e02ab1053dfdc4af37de64962a650e4c0a0'\nNew sha256sum is : '20dba7975849735642321871b89dfe4013e65b3799e2157878c656843ae123fc'\n(Audit) User: 'Administrator (S-1-5-21-71058402-408323440-2673923426-500)'\n(Audit) Process id: '4536'\n(Audit) Process name: 'C:\\Program Files (x86)\\Notepad++\\notepad++.exe'\n< # Copyright (c) 1993-2009 Microsoft Corp8.\n< \n---\n> # Copyright (c) 1993-2009 Microsoft Corp9.\n> \n",
  "syscheck": {
    "path": "c:\\windows\\sysnative\\drivers\\etc\\hosts",
    "size_after": "824",
    "win_perm_after": [
      {
        "name": "SYSTEM",
        "allowed": [
          "DELETE",
          "READ_CONTROL",
          "WRITE_DAC",
          "WRITE_OWNER",
          "SYNCHRONIZE",
          "FILE_READ_DATA",
          "FILE_WRITE_DATA",
          "FILE_APPEND_DATA",
          "FILE_READ_EA",
          "FILE_WRITE_EA",
          "FILE_EXECUTE",
          "FILE_READ_ATTRIBUTES",
          "FILE_WRITE_ATTRIBUTES"
        ]
      },
      {
        "name": "Administrators",
        "allowed": [
          "DELETE",
          "READ_CONTROL",
          "WRITE_DAC",
          "WRITE_OWNER",
          "SYNCHRONIZE",
          "FILE_READ_DATA",
          "FILE_WRITE_DATA",
          "FILE_APPEND_DATA",
          "FILE_READ_EA",
          "FILE_WRITE_EA",
          "FILE_EXECUTE",
          "FILE_READ_ATTRIBUTES",
          "FILE_WRITE_ATTRIBUTES"
        ]
      },
      {
        "name": "Users",
        "allowed": [
          "READ_CONTROL",
          "SYNCHRONIZE",
          "FILE_READ_DATA",
          "FILE_READ_EA",
          "FILE_EXECUTE",
          "FILE_READ_ATTRIBUTES"
        ]
      },
      {
        "name": "ALL APPLICATION PACKAGES",
        "allowed": [
          "READ_CONTROL",
          "SYNCHRONIZE",
          "FILE_READ_DATA",
          "FILE_READ_EA",
          "FILE_EXECUTE",
          "FILE_READ_ATTRIBUTES"
        ]
      },
      {
        "name": "ALL RESTRICTED APPLICATION PACKAGES",
        "allowed": [
          "READ_CONTROL",
          "SYNCHRONIZE",
          "FILE_READ_DATA",
          "FILE_READ_EA",
          "FILE_EXECUTE",
          "FILE_READ_ATTRIBUTES"
        ]
      }
    ],
    "uid_after": "S-1-5-18",
    "md5_before": "2c204c50411c0f2d82ec4473cb2aefcc",
    "md5_after": "bc85ebd774419605782381cbede2c261",
    "sha1_before": "4b63ac34af3b09e2822e95ecbc9abeafae763c7d",
    "sha1_after": "0df7345fd9645207f5f28da57a983cdaba73efda",
    "sha256_before": "2b5ba8e3fc32b800768aafa231ab4e02ab1053dfdc4af37de64962a650e4c0a0",
    "sha256_after": "20dba7975849735642321871b89dfe4013e65b3799e2157878c656843ae123fc",
    "attrs_after": [
      "ARCHIVE"
    ],
    "uname_after": "SYSTEM",
    "diff": "< # Copyright (c) 1993-2009 Microsoft Corp8.\n< \n---\n> # Copyright (c) 1993-2009 Microsoft Corp9.\n> \n",
    "event": "modified",
    "audit": {
      "user": {
        "id": "S-1-5-21-71058402-408323440-2673923426-500",
        "name": "Administrator"
      },
      "process": {
        "id": "4536",
        "name": "C:\\Program Files (x86)\\Notepad++\\notepad++.exe"
      }
    }
  },
  "decoder": {
    "name": "syscheck_integrity_changed"
  },
  "location": "syscheck"
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] MAC OS X
- [X] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [X] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [X] Added unit tests (for new features)
- [ ] Stress test for affected components

### Valgrind report on Linux

```
==9993== LEAK SUMMARY:
==9993==    definitely lost: 0 bytes in 0 blocks
==9993==    indirectly lost: 0 bytes in 0 blocks
==9993==      possibly lost: 1,088 bytes in 4 blocks
==9993==    still reachable: 242,141 bytes in 3,206 blocks
==9993==         suppressed: 0 bytes in 0 blocks
```

No invalid read/write issues.

### Unit tests report for _shared library_

```
ok  1 - Search and replace strings test.
ok  2 - Filter a random string into UTF-8 with character replacement.
ok  3 - Filter a random string into UTF-8 without character replacement.
ok  4 - Check return values for stnspn_escaped.
```
