### PR TITLE
Fix for getting rootcheck last scan

### DIFF
--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -276,13 +276,12 @@ def last_scan(agent_id):
     # end time
     query = "SELECT max(date_last) FROM pm_event WHERE log = 'Ending rootcheck scan.'"
     conn.execute(query)
-    for tup in conn:
-        data['end'] = datetime.utcfromtimestamp(tup[0]).strftime("%Y-%m-%d %H:%M:%S") if tup[0] is not None else "ND"
-
+    time = conn.fetch()
+    data['end'] = datetime.utcfromtimestamp(time).strftime("%Y-%m-%d %H:%M:%S") if time is not None else "ND"
     # start time
     query = "SELECT max(date_last) FROM pm_event WHERE log = 'Starting rootcheck scan.'"
     conn.execute(query)
-    for tup in conn:
-        data['start'] = datetime.utcfromtimestamp(tup[0]).strftime("%Y-%m-%d %H:%M:%S") if tup[0] is not None else "ND"
+    time = conn.fetch()
+    data['start'] = datetime.utcfromtimestamp(time).strftime("%Y-%m-%d %H:%M:%S") if time is not None else "ND"
 
     return data


### PR DESCRIPTION
Hi team,

This PR fixes #4070. Mocha tests are OK after applying this fix:

```javascript
# mocha test/test_rootcheck.js 


  Rootcheck
    GET/rootcheck/:agent_id/last_scan
      ✓ Request (455ms)
      ✓ Params: Bad agent id (102ms)
      ✓ Errors: No agent (411ms)
    DELETE/rootcheck/:agent_id
      ✓ Request (446ms)
      ✓ Params: Bad agent id (101ms)
      ✓ Errors: No agent (411ms)
    DELETE/rootcheck
      ✓ Request (587ms)
    PUT/rootcheck/:agent_id
      ✓ Request (421ms)
      ✓ Params: Bad agent id (100ms)
      ✓ Errors: No agent (416ms)
    PUT/rootcheck
      ✓ Request (465ms)


  11 passing (4s)
```

Best regards,

Demetrio.