### PR TITLE
Extract hexadecimal fields from audit logs with case insensitive.

### DIFF
--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -352,49 +352,49 @@ int init_regex(void) {
     }
 
     static const char *pattern_pname_hex = " exe=([A-F0-9]*)";
-    if (regcomp(&regexCompiled_pname_hex, pattern_pname_hex, REG_EXTENDED)) {
+    if (regcomp(&regexCompiled_pname_hex, pattern_pname_hex, REG_EXTENDED | REG_ICASE)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "pname_hex");
         return -1;
     }
 
     static const char *pattern_cwd_hex = " cwd=([A-F0-9]*)";
-    if (regcomp(&regexCompiled_cwd_hex, pattern_cwd_hex, REG_EXTENDED)) {
+    if (regcomp(&regexCompiled_cwd_hex, pattern_cwd_hex, REG_EXTENDED | REG_ICASE)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "cwd_hex");
         return -1;
     }
 
     static const char *pattern_dir_hex = " dir=([A-F0-9]*)";
-    if (regcomp(&regexCompiled_dir_hex, pattern_dir_hex, REG_EXTENDED)) {
+    if (regcomp(&regexCompiled_dir_hex, pattern_dir_hex, REG_EXTENDED | REG_ICASE)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "dir_hex");
         return -1;
     }
 
     static const char *pattern_path0_hex = " item=0 name=([A-F0-9]*)";
-    if (regcomp(&regexCompiled_path0_hex, pattern_path0_hex, REG_EXTENDED)) {
+    if (regcomp(&regexCompiled_path0_hex, pattern_path0_hex, REG_EXTENDED | REG_ICASE)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path0_hex");
         return -1;
     }
 
     static const char *pattern_path1_hex = " item=1 name=([A-F0-9]*)";
-    if (regcomp(&regexCompiled_path1_hex, pattern_path1_hex, REG_EXTENDED)) {
+    if (regcomp(&regexCompiled_path1_hex, pattern_path1_hex, REG_EXTENDED | REG_ICASE)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path1_hex");
         return -1;
     }
 
     static const char *pattern_path2_hex = " item=2 name=([A-F0-9]*)";
-    if (regcomp(&regexCompiled_path2_hex, pattern_path2_hex, REG_EXTENDED)) {
+    if (regcomp(&regexCompiled_path2_hex, pattern_path2_hex, REG_EXTENDED | REG_ICASE)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path2_hex");
         return -1;
     }
 
     static const char *pattern_path3_hex = " item=3 name=([A-F0-9]*)";
-    if (regcomp(&regexCompiled_path3_hex, pattern_path3_hex, REG_EXTENDED)) {
+    if (regcomp(&regexCompiled_path3_hex, pattern_path3_hex, REG_EXTENDED | REG_ICASE)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path3_hex");
         return -1;
     }
 
     static const char *pattern_path4_hex = " item=4 name=([A-F0-9]*)";
-    if (regcomp(&regexCompiled_path4_hex, pattern_path4_hex, REG_EXTENDED)) {
+    if (regcomp(&regexCompiled_path4_hex, pattern_path4_hex, REG_EXTENDED | REG_ICASE)) {
         merror(FIM_ERROR_WHODATA_COMPILE_REGEX, "path4_hex");
         return -1;
     }


### PR DESCRIPTION
|Related issue / PR|
|---|
|Issue: Whodata events name encoded when using extended ASCII characters https://github.com/wazuh/wazuh/issues/2866|
|Pull request: Decode audit logs hex fields https://github.com/wazuh/wazuh/pull/3909|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
To complement this one #3909.

It's possible to extract hexadecimal fields from the audit log without distinguishing between upper and lower case.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
