### PR TITLE
Add new DB version

### DIFF
--- a/src/wazuh_db/wdb_metadata.c
+++ b/src/wazuh_db/wdb_metadata.c
@@ -27,7 +27,7 @@ static const char *SQL_METADATA_STMT[] = {
 int wdb_metadata_initialize (wdb_t *wdb) {
     int result = 0;
 
-    if (wdb_metadata_insert_entry(wdb, "db_version", "2") < 0) {
+    if (wdb_metadata_insert_entry(wdb, "db_version", "3") < 0) {
         merror("Couldn't fill metadata into database '%s'", wdb->agent_id);
         result = -1;
     }


### PR DESCRIPTION

## Description

Following warnings appears when Wazuh-manager start:
``` 
2019/10/11 14:57:52 wazuh-db: INFO: Started (pid: 7024).
2019/10/11 14:57:52 wazuh-db: WARNING: DB(002) wdb_sql_exec returned error: 'duplicate column name: condition'
2019/10/11 14:57:52 wazuh-db: WARNING: Creating DB backup and create clear DB for agent: '002'
2019/10/11 14:57:54 wazuh-db: WARNING: DB(000) wdb_sql_exec returned error: 'duplicate column name: condition'
2019/10/11 14:57:54 wazuh-db: WARNING: Creating DB backup and create clear DB for agent: '000'
```  
It is due to the database version is not correct. This PR solves it.

