### PR TITLE
Make Windows agents to send the keep-alive independently

### DIFF
--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -86,6 +86,9 @@ int send_msg(const char *msg, ssize_t msg_length);
 /* Extract the shared files */
 char *getsharedfiles(void);
 
+/* Get agent IP */
+char *get_agent_ip();
+
 /* Initialize handshake to server */
 void start_agent(int is_startup);
 

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -79,14 +79,12 @@ char *get_agent_ip()
 /* Periodically send notification to server */
 void run_notify()
 {
-    char tmp_msg[OS_MAXSTR - OS_HEADER_SIZE];
+    char tmp_msg[OS_MAXSTR - OS_HEADER_SIZE + 2];
     static char tmp_labels[OS_MAXSTR - OS_HEADER_SIZE] = { '\0' };
     char *shared_files;
     os_md5 md5sum;
     time_t curr_time;
     char *agent_ip;
-
-    agent_ip = get_agent_ip();
 
     tmp_msg[OS_MAXSTR - OS_HEADER_SIZE + 1] = '\0';
     curr_time = time(0);
@@ -141,6 +139,8 @@ void run_notify()
             return;
         }
     }
+
+    agent_ip = get_agent_ip();
 
     /* Create message */
     if(agent_ip && strcmp(agent_ip, "Err")) {

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -80,7 +80,7 @@ char *get_agent_ip()
 void run_notify()
 {
     char tmp_msg[OS_MAXSTR - OS_HEADER_SIZE + 2];
-    static char tmp_labels[OS_MAXSTR - OS_HEADER_SIZE] = { '\0' };
+    static char tmp_labels[OS_MAXSTR - OS_SIZE_2048] = { '\0' };
     char *shared_files;
     os_md5 md5sum;
     time_t curr_time;
@@ -123,11 +123,11 @@ void run_notify()
         merror(MEM_ERROR, errno, strerror(errno));
     }
 
-    /* Format labeled data */
-
-    if (!tmp_labels[0] && labels_format(agt->labels, tmp_labels, OS_MAXSTR - OS_HEADER_SIZE) < 0) {
-        merror("Too large labeled data.");
-        tmp_labels[0] = '\0';
+    /* Format labeled data
+     * Limit maximum size of the labels to avoid truncation of the keep-alive message
+     */
+    if (!tmp_labels[0] && labels_format(agt->labels, tmp_labels, OS_MAXSTR - OS_SIZE_2048) < 0) {
+        mwarn("Too large labeled data. Not all labels will be shown in the keep-alive messages.");
     }
 
     /* Get shared files */

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -61,6 +61,8 @@ void *receiver_thread(__attribute__((unused)) void *none)
             continue;
         }
 
+        run_notify();
+
         FD_ZERO(&fdset);
         FD_SET(agt->sock, &fdset);
 

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -56,7 +56,6 @@
 #define MAX_TAG_COUNTER 256             /* Max retrying counter         */
 #define SOCK_RECV_TIME0 300             /* Socket receiving timeout (s) */
 #define MIN_ORDER_SIZE  10              /* Minimum size of orders array */
-#define KEEPALIVE_SIZE  700             /* Random keepalive string size */
 #define MAX_DYN_STR     4194304         /* Max message size received 4MiB */
 
 /* Some global names */

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -62,26 +62,6 @@ static pthread_rwlock_t files_update_rwlock;
 static OSHash *excluded_files = NULL;
 static OSHash *excluded_binaries = NULL;
 
-static char *rand_keepalive_str(char *dst, int size)
-{
-    static const char text[] = "abcdefghijklmnopqrstuvwxyz"
-                               "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                               "0123456789"
-                               "!@#$%^&*()_+-=;'[],./?";
-    int i;
-    int len;
-    srandom_init();
-    len = os_random() % (size - 10);
-    len = len >= 0 ? len : -len;
-
-    strncpy(dst, "--MARK--: ", 12);
-    for ( i = 10; i < len; ++i ) {
-        dst[i] = text[(unsigned int)os_random() % (sizeof text - 1)];
-    }
-    dst[i] = '\0';
-    return dst;
-}
-
 /* Handle file management */
 void LogCollectorStart()
 {
@@ -735,11 +715,6 @@ void LogCollectorStart()
             }
 
             f_check = 0;
-        }
-
-        if (!os_iswait()) {
-            rand_keepalive_str(keepalive, KEEPALIVE_SIZE);
-            w_msg_hash_queues_push(keepalive, "ossec-keepalive", strlen(keepalive) + 1, default_target, LOCALFILE_MQ);
         }
 
         sleep(1);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -71,7 +71,6 @@ void LogCollectorStart()
     int f_free_excluded = 0;
     IT_control f_control = 0;
     IT_control duplicates_removed = 0;
-    char keepalive[1024];
     logreader *current;
 
     /* Create store data */

--- a/src/shared/labels_op.c
+++ b/src/shared/labels_op.c
@@ -73,17 +73,22 @@ void labels_free(wlabel_t *labels) {
 /* Format label array into string. Return 0 on success or -1 on error. */
 int labels_format(const wlabel_t *labels, char *str, size_t size) {
     int i;
-    size_t z = 0;
+    size_t z = 0, l = 0;
 
     for (i = 0; labels[i].key != NULL; i++) {
-        z += (size_t)snprintf(str + z, size - z, "%s%s\"%s\":%s\n",
+        l = (size_t)snprintf(str + z, size - z, "%s%s\"%s\":%s\n",
             labels[i].flags.system ? "#" : "",
             labels[i].flags.hidden ? "!" : "",
             labels[i].key,
             labels[i].value);
 
-        if (z >= size)
+        if (z + l >= size) {
+            snprintf(str + z, 50, "%s\n", "Not all labels are being shown in this message");
             return -1;
+        }
+
+        z += l;
+        l = 0;
     }
 
     return 0;

--- a/src/shared/randombytes.c
+++ b/src/shared/randombytes.c
@@ -78,11 +78,9 @@ void randombytes(void *ptr, size_t length)
 
 void srandom_init(void)
 {
-#ifndef WIN32
     unsigned int seed;
     randombytes(&seed, sizeof seed);
     srandom(seed);
-#endif /* !WIN32 */
 }
 
 int os_random(void) {


### PR DESCRIPTION
|Related issue|
|--|
|#3963|

The purpose of this PR is to solve a problem with the keep-alive message sent by a Windows agent. Because the agent checks if the notify time was reached (to send the keep-alive) when sending a new message to the manager, it is not sending a keep-alive when there is no data to report.

The solution proposed in this PR is to check and send the keep-alive message inside the **receiver_thread** of Windows agent, which results to be a behavior quite similar to Linux agents.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
  - [x] Dr. Memory