### PR TITLE
Authd: Do not enforce source IP checking by default

### DIFF
--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -82,8 +82,8 @@
 
   <wodle name="key-request">
     <enabled>yes</enabled>
-    <timeout>60</timeout>  
-    <script>my_script.sh</script>  
+    <timeout>60</timeout>
+    <script>my_script.sh</script>
     <threads>4</threads>
     <queue_size>1024</queue_size>
   </wodle>
@@ -244,7 +244,7 @@
   <auth>
     <disabled>no</disabled>
     <port>1515</port>
-    <use_source_ip>yes</use_source_ip>
+    <use_source_ip>no</use_source_ip>
     <force_insert>yes</force_insert>
     <force_time>0</force_time>
     <purge>yes</purge>

--- a/etc/templates/config/generic/auth.template
+++ b/etc/templates/config/generic/auth.template
@@ -2,7 +2,7 @@
   <auth>
     <disabled>no</disabled>
     <port>1515</port>
-    <use_source_ip>yes</use_source_ip>
+    <use_source_ip>no</use_source_ip>
     <force_insert>yes</force_insert>
     <force_time>0</force_time>
     <purge>yes</purge>

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -79,7 +79,7 @@ DisableAuthd()
     echo "  <auth>" >> $NEWCONFIG
     echo "    <disabled>yes</disabled>" >> $NEWCONFIG
     echo "    <port>1515</port>" >> $NEWCONFIG
-    echo "    <use_source_ip>yes</use_source_ip>" >> $NEWCONFIG
+    echo "    <use_source_ip>no</use_source_ip>" >> $NEWCONFIG
     echo "    <force_insert>yes</force_insert>" >> $NEWCONFIG
     echo "    <force_time>0</force_time>" >> $NEWCONFIG
     echo "    <purge>yes</purge>" >> $NEWCONFIG


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3269|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As explained in the related issue, I have seen how this setting makes several users complain about an agent not able to report a few days after the registration. Dynamics environment (boot up and shut down instances) and load balancers make the agent unable to report.

My proposal is to disable use_source_ip by default. I think it will make easier the agent deployment (registering via LB) and connection durability.

## Documentation

Linked documentation PR: TBD

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] MAC OS X

- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
Not required since it is a default configuration change, but does not include any source code changes.


<!-- Checks for huge PRs that affect the product more generally -->
- [X] Retrocompatibility with older Wazuh versions
- [X] Working on cluster environments
- [X] Configuration on demand reports new parameters
- [X] The data flow works as expected (agent-manager-api-app)
