### PR TITLE
Adjust 'queue/vulnerabilities' permissions

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -967,9 +967,9 @@ InstallLocal()
     fi
 
     # Install Vulnerability Detector files
-    ${INSTALL} -d -m 0760 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/vulnerabilities
-    ${INSTALL} -d -m 0760 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/vulnerabilities/dictionaries
-    ${INSTALL} -m 0660 -o ossec -g ${OSSEC_GROUP} wazuh_modules/vulnerability_detector/*.json ${PREFIX}/queue/vulnerabilities/dictionaries
+    ${INSTALL} -d -m 0660 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/vulnerabilities
+    ${INSTALL} -d -m 0440 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/vulnerabilities/dictionaries
+    ${INSTALL} -m 0440 -o root -g ${OSSEC_GROUP} wazuh_modules/vulnerability_detector/*.json ${PREFIX}/queue/vulnerabilities/dictionaries
 
     ### Install Python
     ${MAKEBIN} wpython PREFIX=${PREFIX} TARGET=${INSTYPE}

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -936,6 +936,10 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
             cwe = (char *)sqlite3_column_text(stmt, 17);
             advisories = (char *)sqlite3_column_text(stmt, 18);
 
+            if (!cve || !package || !version || !arch) {
+                continue;
+            }
+
             *condition = '\0';
             *state = '\0';
             if (pending) {
@@ -960,7 +964,7 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
             // Fill the report data
             os_calloc(1, sizeof(vu_report), report);
 
-            w_strdup(cve, report->cve);
+            os_strdup(cve, report->cve);
             w_strdup(title, report->title);
             w_strdup(rationale, report->rationale);
             w_strdup(severity, report->severity);
@@ -986,9 +990,9 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
             w_strdup(advisories, report->advisories);
             w_strdup(bugzilla_reference, report->bugzilla_reference);
             w_strdup(reference, report->reference);
-            w_strdup(package, report->software);
-            w_strdup(version, report->version);
-            w_strdup(arch, report->arch);
+            os_strdup(package, report->software);
+            os_strdup(version, report->version);
+            os_strdup(arch, report->arch);
             w_strdup(operation, report->operation);
             w_strdup(operation_value, report->operation_value);
             w_strdup(agents_it->agent_id, report->agent_id);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -1091,8 +1091,8 @@ int wm_vuldet_parse_nvd_configuration_node(cJSON *config, const char *cve, nvd_c
                     for(cpe_match_element = cpe_match_item->child; json_tagged_obj(cpe_match_element); cpe_match_element = cpe_match_element->next) {
                         if (!strcmp(cpe_match_element->string, JSON_VULNERABLE)) {
                             cpe_match_node->vulnerable = cpe_match_element->valueint;
-                        } else if (!strcmp(cpe_match_element->string, JSON_CPE23URI)) {
-                            w_strdup(cpe_match_element->valuestring, cpe_match_node->cpe_uri23);
+                        } else if (!strcmp(cpe_match_element->string, JSON_CPE23URI) && cpe_match_element->valuestring) {
+                            os_strdup(cpe_match_element->valuestring, cpe_match_node->cpe_uri23);
                             cpe_match_node->cpe_node = wm_vuldet_decode_cpe(cpe_match_node->cpe_uri23 + strlen(CPE_VER_TAG));
                         } else if (!strcmp(cpe_match_element->string, JSON_START_INC)) {
                             w_strdup(cpe_match_element->valuestring, cpe_match_node->version_start_including);


### PR DESCRIPTION
This PR adjusts the permissions for this folder. They are:

- **queue/vulnerabilities**: 0660 root:ossec (adds write permissions for the database, but we don't need execution)
- **queue/vulnerabilities/dictionaries**: 0440 root:ossec (we don't need write permissions here)

To test it, I have deployed a vulnerability detector scan and update. Because there are no errors in this process, we can confirm that these permissions are correct.

The solution also includes the silence of a false positive reported by `scan-build`. The tool says that we can call to `strdup` with a nullable variable (`cve`) at this point:

https://github.com/wazuh/wazuh/blob/8ec9d48d7ea4cdf0860ab2acf92a55c8a9bc7b02/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c#L3459

That variable is extracted from:

https://github.com/wazuh/wazuh/blob/8ec9d48d7ea4cdf0860ab2acf92a55c8a9bc7b02/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c#L919

This field cannot be null.

https://github.com/wazuh/wazuh/blob/8ec9d48d7ea4cdf0860ab2acf92a55c8a9bc7b02/src/wazuh_db/schema_vuln_detector.sql#L73