### PR TITLE
Fix DISABLE_SHARED flag filter in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -54,6 +54,10 @@ USE_FRAMEWORK_LIB=no
 MINGW_HOST=unknown
 USE_MSGPACK_OPT=yes
 
+DISABLE_SHARED?=no
+DISABLE_SYSC?=no
+DISABLE_CISCAT?=no
+
 ifneq ($(HAS_CHECKMODULE),)
 ifneq ($(HAS_SEMODULE_PACKAGE),)
 USE_SELINUX=yes
@@ -504,6 +508,9 @@ settings:
 	@echo "    USE_SELINUX:        ${USE_SELINUX}"
 	@echo "    USE_AUDIT:          ${USE_AUDIT}"
 	@echo "    USE_FRAMEWORK_LIB:  ${USE_FRAMEWORK_LIB}"
+	@echo "    DISABLE_SHARED:     ${DISABLE_SHARED}"
+	@echo "    DISABLE_SYSC:       ${DISABLE_SYSC}"
+	@echo "    DISABLE_CISCAT:     ${DISABLE_CISCAT}"
 	@echo "Mysql settings:"
 	@echo "    includes:           ${MI}"
 	@echo "    libs:               ${ML}"
@@ -880,10 +887,9 @@ external/%.tar.gz:
 #### OSSEC Libs ####
 ####################
 
-ifeq (,$(filter ${DISABLE_SHARED},YES yes y Y 1))
+ifneq (,$(filter ${DISABLE_SHARED},YES yes y Y 1))
 BUILD_LIBS = libwazuh.a $(EXTERNAL_LIBS)
-endif
-ifeq (,$(filter ${DISABLE_SHARED},YES yes y Y 1))
+else
 WAZUHEXT_LIB = libwazuhext.$(SHARED)
 BUILD_LIBS = libwazuh.a $(WAZUHEXT_LIB)
 endif


### PR DESCRIPTION
## Description

The `DISABLE_SHARED` flag used to not to build the Wazuh shared library was not filtered correctly when it is used.

That provoked to fail the agent compilation for agents in AIX, where this flag is needed.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] AIX
