### PR TITLE
Implement multi-line collection for indented logs

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -245,6 +245,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             } else if (strcmp(logf[pl].logformat, "command") == 0) {
             } else if (strcmp(logf[pl].logformat, "full_command") == 0) {
             } else if (strcmp(logf[pl].logformat, "audit") == 0) {
+            } else if (strcmp(logf[pl].logformat, "multi-line_indented") == 0) {
             } else if (strncmp(logf[pl].logformat, "multi-line", 10) == 0) {
 
                 char *p_lf = logf[pl].logformat;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1099,6 +1099,8 @@ void set_read(logreader *current, int i, int j) {
         current->read = read_multiline;
     } else if (strcmp("audit", current->logformat) == 0) {
         current->read = read_audit;
+    } else if (strcmp("multi-line_indented", current->logformat) == 0) {
+        current->read = read_multiline_indented;
     } else {
 #ifdef WIN32
         if (current->filter_binary) {

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -78,6 +78,9 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it);
 /* read multi line logs */
 void *read_multiline(logreader *lf, int *rc, int drop_it);
 
+/* read indented multi line logs */
+void *read_multiline_indented(logreader *lf, int *rc, int drop_it);
+
 /* Read DJB multilog format */
 /* Initializes multilog */
 int init_djbmultilog(logreader *lf);

--- a/src/logcollector/read_multiline_indented.c
+++ b/src/logcollector/read_multiline_indented.c
@@ -1,0 +1,112 @@
+/* Copyright (C) 2019, Semper Victus LLC
+ * Copyright (C) 2015-2019, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+/* Read indentend multi line logs */
+
+#include "shared.h"
+#include "logcollector.h"
+
+
+/* Read multi line indented log files */
+void *read_multiline_indented(logreader *lf, int *rc, int drop_it) {
+    size_t str_len = 0;
+    char *p;
+    char str[OS_MAXSTR + 1];
+    char buffer[OS_MAXSTR + 1];
+    int lines = 0;
+
+    /* Zero buffer and str */
+    buffer[0] = '\0';
+    buffer[OS_MAXSTR] = '\0';
+    str[OS_MAXSTR] = '\0';
+    *rc = 0;
+
+    /* Get new entry */
+    while (fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+
+        lines++;
+        /* Get buffer size */
+        str_len = strlen(str);
+
+        /* Check str_len size. Very useless, but just to make sure.. */
+        if (str_len >= sizeof(buffer) - 2) {
+            str_len = sizeof(buffer) - 10;
+        }
+
+        /* Get the last occurrence of \n */
+        if ((p = strrchr(str, '\n')) != NULL) {
+            *p = '\0';
+        }
+
+#ifdef WIN32
+        if ((p = strrchr(str, '\r')) != NULL) {
+            *p = '\0';
+        }
+#endif
+        /* Look for empty string */
+        if ((str_len <= 1) || (str[0] == '\r')) {
+            /* Send existing data if any in buffer */
+            if (buffer[0] != '\0') {
+                w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
+                buffer[0] = '\0';
+                lines = 0;
+            }
+            continue;
+        }
+
+        /* Look for lines starting with indents */
+        if ((str_len > 2) && (buffer[0] != '\0') &&
+                 ((str[0] == ' ') || (str[0] == '\t'))) {
+            /* Size of the buffer */
+            size_t buffer_len = strlen(buffer);
+
+            p = str + 1;
+
+            /* Remove extra spaces and tabs */
+            while (*p == ' ' || *p == '\t') {
+                p++;
+            }
+
+            /* Add additional message to the saved buffer */
+            if (sizeof(buffer) - buffer_len > str_len + 256) {
+                /* Here we make sure that the size of the buffer
+                 * minus what was used (strlen) is greater than
+                 * the length of the received message.
+                 */
+                buffer[buffer_len] = ' ';
+                buffer[buffer_len + 1] = '\0';
+                strncat(buffer, str, str_len + 3);
+            }
+        /* Look for lines not starting with indents */
+        } else if ((str[0] != ' ') || (str[0] != '\t')) {
+            /* Flush previous messages */
+            if (buffer[0] != '\0') {
+                w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
+                buffer[0] = '\0';
+                lines = 0;
+            }
+            strncpy(buffer, str, str_len + 2);
+            continue;
+       /* Error handling for buffer[0] being '\0' when indents are present */
+       } else {
+           // messages or retries
+       }
+
+    }
+
+    /* Send whatever is stored */
+    if (buffer[0] != '\0') {
+        w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
+    }
+
+    mdebug2("Read %d lines from %s", lines, lf->file);
+    return (NULL);
+}


### PR DESCRIPTION
|Related issue|
|---|
|4092|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Multiple logging implementations utilize tabs or spaces to prefix
lines following the top, unindented line starting the entry. The
existing multi-line approach does not deal well with variable log
lengths using these indented sub-entries as it extracts lines by
count, not content.

This commit implements a modified postgresql log reader as a
generic multi-line parser sending the current buffer downstream
when it starts a new log entry (line does not start with ' ' or
'\t'), or encounters an empty line.


## Configuration options

N/A

## Logs/Alerts example

Not generated yet, need to build a manager and agent with this PR - currently untested.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
