### PR TITLE
Fix invalid use of <global_frequency> option

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -961,7 +961,7 @@ int Rules_OP_ReadRules(const char *rulefile)
                         config_ruleinfo->context_opts &= NOT_SAME_AGENT;
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_global_frequency) == 0) {
-                        config_ruleinfo->context_opts &= GLOBAL_FREQUENCY;
+                        config_ruleinfo->context_opts |= GLOBAL_FREQUENCY;
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_field) == 0) {
 
@@ -987,7 +987,6 @@ int Rules_OP_ReadRules(const char *rulefile)
                                           xml_notsame_field) == 0) {
 
                         if (config_ruleinfo->context_opts & NOT_SAME_FIELD) {
-
                             int size;
                             for (size = 0; config_ruleinfo->not_same_fields[size] != NULL; size++);
 

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -557,7 +557,7 @@ int OS_ReadXMLRules(const char *rulefile,
                     config_ruleinfo->context_opts &= NOT_SAME_AGENT;
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_global_frequency) == 0) {
-                    config_ruleinfo->context_opts &= GLOBAL_FREQUENCY;
+                    config_ruleinfo->context_opts |= GLOBAL_FREQUENCY;
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_same_field) == 0) {
 


### PR DESCRIPTION
|Related issue|
--|
|3865|

## Description

A new label has been added for the contextual rules don't check the ID of the agent or manager that generates the event. . This label is <global_frequency/>.

## Configuration options

`local_rules.xml`
```xml
<group name="local,syslog,sshd,">
<!--
    Dec 10 01:02:02 my_host my_program[1234]: ruleset test
    -->
    <rule id="999999" level="9">
        <match>ruleset test</match>
        <description>test</description>
    </rule>

    <rule id="999998" level="10" frequency="4" timeframe="30" ignore="60">
	<global_frequency/>
	<if_matched_sid>999999</if_matched_sid>
        <description>TEST GLOBAL FREQUENCY</description>
    </rule>
</group>
```

## Logs/Alerts example

```
** Alert 1571229805.2711453: - local,syslog,sshd,
2019 Oct 16 12:43:25 my_host->/home/vagrant/test.log
Rule: 999999 (level 9) -> 'test'
Dec 10 01:02:02 my_host my_program[1234]: ruleset test

** Alert 1571229807.2711645: - local,syslog,sshd,
2019 Oct 16 12:43:27 my_host->/home/vagrant/test.log
Rule: 999999 (level 9) -> 'test'
Dec 10 01:02:02 my_host my_program[1234]: ruleset test

** Alert 1571229809.2712861: - local,syslog,sshd,
2019 Oct 16 12:43:29 (vm-ubuntu-agent) 10.0.0.2->/home/vagrant/logs/test.log
Rule: 999999 (level 9) -> 'test'
Dec 10 01:02:02 my_host my_program[1234]: ruleset test

** Alert 1571229811.2713077: - local,syslog,sshd,
2019 Oct 16 12:43:31 (vm-ubuntu-agent) 10.0.0.2->/home/vagrant/logs/test.log
Rule: 999998 (level 10) -> 'TEST GLOBAL FREQUENCY'
Dec 10 01:02:02 my_host my_progrma[1234]: ruleset test
Dec 10 01:02:02 my_host my_progrma[1234]: ruleset test
Dec 10 01:02:02 my_host my_progrma[1234]: ruleset test
Dec 10 01:02:02 my_host my_progrma[1234]: ruleset test
```

## Tests

To test this solution, we will use a server and an agent. In the `ossec.conf` file of both, the next block is configured:
```xml
<localfile>
    <location>path/test.log</location>
    <log_format>syslog</log_format>
  </localfile>
```

Once connected and with the `local_rules.xml` file above, two alerts are generated from the agent and another two from the manager,  because the frequency that executed the rule is four. For this, the following instruction is executed
```
echo "Dec 10 01:02:02 my_host my_program[1234]: ruleset test" >> test.log
```

And we can see how the fourth instruction has generated the alert:
```
** Alert 1571229805.2711453: - local,syslog,sshd,
2019 Oct 16 12:43:25 my_host->/home/vagrant/test.log
Rule: 999999 (level 9) -> 'test'
Dec 10 01:02:02 my_host my_program[1234]: ruleset test

** Alert 1571229807.2711645: - local,syslog,sshd,
2019 Oct 16 12:43:27 my_host->/home/vagrant/test.log
Rule: 999999 (level 9) -> 'test'
Dec 10 01:02:02 my_host my_program[1234]: ruleset test

** Alert 1571229809.2712861: - local,syslog,sshd,
2019 Oct 16 12:43:29 (vm-ubuntu-agent) 10.0.0.2->/home/vagrant/logs/test.log
Rule: 999999 (level 9) -> 'test'
Dec 10 01:02:02 my_host my_program[1234]: ruleset test

** Alert 1571229811.2713077: - local,syslog,sshd,
2019 Oct 16 12:43:31 (vm-ubuntu-agent) 10.0.0.2->/home/vagrant/logs/test.log
Rule: 999998 (level 10) -> 'TEST GLOBAL FREQUENCY'
Dec 10 01:02:02 my_host my_progrma[1234]: ruleset test
Dec 10 01:02:02 my_host my_progrma[1234]: ruleset test
Dec 10 01:02:02 my_host my_progrma[1234]: ruleset test
Dec 10 01:02:02 my_host my_progrma[1234]: ruleset test
```