### PR TITLE
Fix previous_output count for alerts when matching by group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Fix service's installation path for CentOS 8. ([#4060](https://github.com/wazuh/wazuh/pull/4060))
 - Add macOS Catalina to the list of detected versions. ([#4061](https://github.com/wazuh/wazuh/pull/4061))
 - Prevent FIM from producing false negatives due to wrong checksum comparison. ([#4066](https://github.com/wazuh/wazuh/pull/4066))
+- Fix `previous_output` count for alerts when matching by group. ([#4097](https://github.com/wazuh/wazuh/pull/4097))
 
 
 ## [v3.10.2] - 2019-09-23

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -236,6 +236,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
             continue;
         }
         frequency_count++;
+
         /* If reached here, we matched */
         my_lf->matched = rule->level;
         lf->matched = rule->level;
@@ -270,7 +271,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
 
     /* Check if sid search is valid */
     if (!list) {
-        merror("No group search!");
+        merror("No group search.");
         return NULL;
     }
 
@@ -448,6 +449,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
                 }
             }
         }
+
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
@@ -458,14 +460,15 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
 
 
         /* Check if the number of matches worked */
-        if (frequency_count < rule->frequency) {
-            if (frequency_count <= 10) {
-                add_lastevt(my_lf->last_events, frequency_count, lf->full_log);
-            }
+        if (frequency_count <= 10) {
+            add_lastevt(my_lf->last_events, frequency_count, lf->full_log);
+        }
 
+        if (frequency_count < rule->frequency) {
             frequency_count++;
             continue;
         }
+        frequency_count++;
 
         /* If reached here, we matched */
         my_lf->matched = rule->level;


### PR DESCRIPTION
## Description

There is a bug when frequency rules use `if_matched_group`, the count of previous events added to the list at `Search_LastGroups()` was erroneous, it doesn't take into account the last incoming event.

Now, the last event is added to the list of previous events shown when a frequency rule is fired. Here an example:

_rules_

```xml
<rule id="5716" level="5">
    <if_sid>5700</if_sid>
    <match>^Failed|^error: PAM: Authentication</match>
    <description>sshd: authentication failed. (child rule)</description>
     <group>authentication_failed</group>
  </rule>

<rule id="100001" level="10" frequency="6" timeframe="300">
    <if_matched_group>authentication_failed</if_matched_group>
    <same_source_ip/>
    <description>sshd: frequency rule</description>
    <options>no_full_log</options>
</rule>
```

_event_
```
Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
```

### Before the fix

_frequency alert fired_
```js
{
  "timestamp": "2019-10-16T09:44:44.492-0700",
  "rule": {
    "level": 10,
    "description": "sshd: frequency rule",
    "id": "100001",
    "frequency": 6,
    "firedtimes": 1,
    "mail": true,
    "groups": [
      "local"
    ]
  },
  "agent": {
    "id": "000",
    "name": "ubuntu"
  },
  "manager": {
    "name": "ubuntu"
  },
  "id": "1571244284.859863",
  "previous_output": "Oct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n\nOct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n\nOct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n\nOct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n",
  "decoder": {
    "name": "sshd",
    "parent": "sshd"
  },
  "data": {
    "srcip": "1.1.1.1",
    "srcport": "1066",
    "dstuser": "root"
  },
  "location": "/var/log/syslog",
  "predecoder": {
    "program_name": "sshd",
    "timestamp": "Oct 16 00:00:00",
    "hostname": "host"
  }
}
```

The `previous_output` field shows four events instead of five.

### After the fix

_frequency alert fired_
```js
{
  "timestamp": "2019-10-16T09:50:52.805-0700",
  "rule": {
    "level": 10,
    "description": "sshd: frequency rule",
    "id": "100001",
    "frequency": 6,
    "firedtimes": 1,
    "mail": true,
    "groups": [
      "local"
    ]
  },
  "agent": {
    "id": "000",
    "name": "ubuntu"
  },
  "manager": {
    "name": "ubuntu"
  },
  "id": "1571244652.865261",
  "previous_output": "Oct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n\nOct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n\nOct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n\nOct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n\nOct 16 00:00:00 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n",
  "decoder": {
    "name": "sshd",
    "parent": "sshd"
  },
  "data": {
    "srcip": "1.1.1.1",
    "srcport": "1066",
    "dstuser": "root"
  },
  "location": "/var/log/syslog",
  "predecoder": {
    "program_name": "sshd",
    "timestamp": "Oct 16 00:00:00",
    "hostname": "host"
  }
}
```

Now, the `previous_output` field **contains the five previous events**.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language
- [X] QA templates contemplate the added capabilities https://github.com/wazuh/wazuh-qa/commit/02a10c155aeee11d4f2725c81f3121fab302eb0b

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)