### PR TITLE
Add remote syslog configuration on install

### DIFF
--- a/etc/templates/config/generic/remote-syslog.template
+++ b/etc/templates/config/generic/remote-syslog.template
@@ -1,0 +1,5 @@
+  <remote>
+    <connection>syslog</connection>
+    <port>514</port>
+    <protocol>udp</protocol>
+  </remote>

--- a/install.sh
+++ b/install.sh
@@ -557,7 +557,7 @@ ConfigureServer()
     if [ "X$INSTYPE" = "Xserver" ]; then
       # Configuring remote syslog
       echo ""
-      $ECHO "  3.6- ${syslog} ($yes/$no) [$yes]: "
+      $ECHO "  3.6- ${syslog} ($yes/$no) [$no]: "
 
       if [ "X${USER_ENABLE_SYSLOG}" = "X" ]; then
         read ANSWER
@@ -567,12 +567,12 @@ ConfigureServer()
 
       echo ""
       case $ANSWER in
-        $nomatch)
-            echo "   --- ${nosyslog}."
+        $yesmatch)
+            echo "   --- ${yessyslog}."
+            RLOG="yes"
             ;;
         *)
-            echo "   - ${yessyslog}."
-            RLOG="yes"
+            echo "   --- ${nosyslog}."
             ;;
       esac
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -25,6 +25,7 @@ AR_DEFINITIONS_TEMPLATE="./etc/templates/config/generic/ar-definitions.template"
 ALERTS_TEMPLATE="./etc/templates/config/generic/alerts.template"
 LOGGING_TEMPLATE="./etc/templates/config/generic/logging.template"
 REMOTE_SEC_TEMPLATE="./etc/templates/config/generic/remote-secure.template"
+REMOTE_SYS_TEMPLATE="./etc/templates/config/generic/remote-syslog.template"
 
 LOCALFILES_TEMPLATE="./etc/templates/config/generic/localfile-logs/*.template"
 
@@ -509,6 +510,12 @@ WriteManager()
     # Logging format
     cat ${LOGGING_TEMPLATE} >> $NEWCONFIG
     echo "" >> $NEWCONFIG
+
+    # Remote connection syslog
+        if [ "X$RLOG" = "Xyes" ]; then
+      cat ${REMOTE_SYS_TEMPLATE} >> $NEWCONFIG
+      echo "" >> $NEWCONFIG
+    fi
 
     # Remote connection secure
     if [ "X$SLOG" = "Xyes" ]; then


### PR DESCRIPTION
This PR reverts the commit a87074149bfc6942dd40e2a6f524aec940285d11

## Description

Using the sources installation script, when the remote syslog is set to yes, the configuration block was not added to the `ossec.conf` file.

Now this option is set to `no` by default in the installation procedure, but setting it to `yes` will add the remote syslog configuration block.

## Logs example

```
  3.6- Do you want to enable remote syslog (port 514 udp)? (y/n) [n]:

   --- Remote syslog disabled.
```

```
  3.6- Do you want to enable remote syslog (port 514 udp)? (y/n) [n]: y

   --- Remote syslog enabled.
```




