### PR TITLE
Filebeat module: Remove on_failure: drop()

### DIFF
--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -61,8 +61,5 @@
     { "remove": { "field": "event", "ignore_missing": true, "ignore_failure": true } },
     { "remove": { "field": "fileset", "ignore_missing": true, "ignore_failure": true } },
     { "remove": { "field": "service", "ignore_missing": true, "ignore_failure": true } }
-  ],
-  "on_failure" : [{
-    "drop" : { }
-  }]
+  ]
 }

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -61,8 +61,5 @@
     { "remove": { "field": "event", "ignore_missing": true, "ignore_failure": true } },
     { "remove": { "field": "fileset", "ignore_missing": true, "ignore_failure": true } },
     { "remove": { "field": "service", "ignore_missing": true, "ignore_failure": true } }
-  ],
-  "on_failure" : [{
-    "drop" : { }
-  }]
+  ]
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4101|

## Description

This PR removes the on_failure: drop() section from the ingestion pipeline of the Filebeat module, for both alerts and archives.