### PR TITLE
Fix event iteration when evaluating a contextual rule

### DIFF
--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -31,7 +31,7 @@ time_t current_time = 0;
 Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unused)) regex_matching *rule_match)
 {
     Eventinfo *lf = NULL;
-    Eventinfo *first_lf;
+    Eventinfo *first_matched = NULL;
     OSListNode *lf_node;
     int frequency_count = 0;
     int i;
@@ -61,8 +61,6 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
         lf = NULL;
         goto end;
     }
-
-    first_lf = (Eventinfo *)lf_node->data;
 
     do {
         lf = (Eventinfo *)lf_node->data;
@@ -233,13 +231,17 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unus
 
         if (frequency_count < rule->frequency) {
             frequency_count++;
+            if (!first_matched) {
+               first_matched = lf;
+            }
             continue;
         }
         frequency_count++;
         /* If reached here, we matched */
         my_lf->matched = rule->level;
-        lf->matched = rule->level;
-        first_lf->matched = rule->level;
+        if (first_matched) { // To protect from a possible frequency 0
+            first_matched->matched = rule->level;
+        }
         goto end;
     } while ((lf_node = lf_node->prev) != NULL);
 
@@ -258,7 +260,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
 {
     Eventinfo *lf = NULL;
     OSListNode *lf_node;
-    Eventinfo *first_lf;
+    Eventinfo *first_matched = NULL;
     int frequency_count = 0;
     int i;
     int found;
@@ -291,8 +293,6 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
         lf = NULL;
         goto end;
     }
-
-    first_lf = (Eventinfo *)lf_node->data;
 
     do {
         lf = (Eventinfo *)lf_node->data;
@@ -464,13 +464,17 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((un
             }
 
             frequency_count++;
+            if (!first_matched) {
+               first_matched = lf;
+            }
             continue;
         }
 
         /* If reached here, we matched */
         my_lf->matched = rule->level;
-        lf->matched = rule->level;
-        first_lf->matched = rule->level;
+        if (first_matched) { // To protect from a possible frequency 0
+            first_matched->matched = rule->level;
+        }
         goto end;
     } while ((lf_node = lf_node->prev) != NULL);
 
@@ -491,6 +495,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
 {
     EventNode *eventnode_pt = NULL;
     EventNode *first_pt;
+    Eventinfo *first_matched = NULL;
     Eventinfo *lf = NULL;
     int frequency_count = 0;
     int i;
@@ -661,13 +666,17 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
             }
 
             frequency_count++;
+            if (!first_matched) {
+               first_matched = lf;
+            }
             goto next_it;
         }
 
         /* If reached here, we matched */
         my_lf->matched = rule->level;
-        lf->matched = rule->level;
-
+        if (first_matched) { // To protect from a possible frequency 0
+            first_matched->matched = rule->level;
+        }
         goto end;
 next_it:
         w_mutex_lock(&eventnode_pt->mutex);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/185#issuecomment-543101833|

# How contextual rules work

When Analysisd analyzes an event to check if it matches with a contextual rule (those who use the `frequency` tag) iterates a list of old events evaluating each one to see if they can be used to increase the counter of the rule. 

If an old event matches the requirements of the context rule, in combination with the input event, a final check is performed before increasing the counter. 

These are the 3 alert level checks, one for each function to analyze contextual rules:

https://github.com/wazuh/wazuh/blob/7aa4d46661f8b0f97b0969634482626f30866731/src/analysisd/eventinfo.c#L214-L217

https://github.com/wazuh/wazuh/blob/7aa4d46661f8b0f97b0969634482626f30866731/src/analysisd/eventinfo.c#L434-L437

https://github.com/wazuh/wazuh/blob/7aa4d46661f8b0f97b0969634482626f30866731/src/analysisd/eventinfo.c#L622-L625

This check discards the event if it was marked with a rule of a level lower than or equal to the evaluated rule. After this, no event is iterated again and the rule is discarded.

## Where and when are these events marked?

An event is marked when it is the last one to be counted to reach the `frequency` value and/or if it was inserted just before the event that triggers a contextual rule.

https://github.com/wazuh/wazuh/blob/7aa4d46661f8b0f97b0969634482626f30866731/src/analysisd/eventinfo.c#L232

https://github.com/wazuh/wazuh/blob/7aa4d46661f8b0f97b0969634482626f30866731/src/analysisd/eventinfo.c#L452-L453

https://github.com/wazuh/wazuh/blob/7aa4d46661f8b0f97b0969634482626f30866731/src/analysisd/eventinfo.c#L639

To simplify the explanation of this behaviour, we will use the following scheme. The rule should trigger if 4 events with the same letter appear (equivalent to using `<same_field>` or another filter).

![contextual rules](https://user-images.githubusercontent.com/20266121/67077268-297a2980-f18f-11e9-84b9-d288e6a435d9.png)

- **T0**: First event is inserted.
- **T2**: The thirst `A` event is inserted. We need one more report the contextual rule.
- **T5**: Three more events are inserted. Due to they are of `B` type, the contextual rule has not been triggered.
- **T6**: The fourth `A` event has appeared, which skips the contextual rule because there are three more events that match the conditions. The events have been iterated in the following order: `B3` (discarded), `B2` (discarded), `B1` (discarded), `A3`, `A2`, `A1`. In addition, the event `A1` (last to be taken into account) and `B3` (first to be iterated) have been marked with the rule level. Finally, `A4` is not inserted because it is the trigger event.
- **T7**: `B4` is inserted. The first strange behaviour we found is that the contextual rule is not triggered by 4 `B` events. This is because, after inserting `B4`, `B3` is evaluated and the iteration is broken because it was marked with the same level of the rule that is iterating (7). If `B3` had not been a candidate to increase the frequency, its mark would not have been evaluated and the event iteration would continue.
- **T8**: The contextual rule cannot trigger after insert `B5` due to only `B4` can be counted.
- **T9**: `A5` is inserted. After this, the range of `B1-B5` is iterated without break the iteration in `B3`. This happens because `B3` is not a candidate to match with `A5`, so the break condition (level evaluation) is not reached. The contextual rule does not trigger because we have 3/4 events (`A5`, `A3`, `A2`).
- **T10**: The rule is triggered after insert `A6` because the engine has counted 4 valid events, so `A2` (last to be taken into account) and `A5` (first to be iterated) are marked.
- **T11**: `B6` is inserted, but the contextual rule needs one more event.
- **T12**: The rule can be triggered because it has four iterable candidate events: `B7`, `B6`, `B5`, and `B4`.

## Proposed solution

Understanding that it is intended to maintain a system of marked events to prevent the same rule being triggered several times, and at the same time allow events subsequent to those that trigger the event to be taken into account, the solution of this PR has been developed.

First of all, we have not found sense to mark the last event taken into account, so we have removed this step. In addition, it was only done in 2/3 of the functions to check contextual alerts.

To achieve the purpose of this solution, the last event inserted, which matches the rule at the time it is triggered, will be marked.

If we use the same sequence of inputs with this solution:

![contextual rules2](https://user-images.githubusercontent.com/20266121/67080335-503b5e80-f195-11e9-8d69-d5cb6bc0361c.png)

## Stress test

Add the following rules to the `local_rules.xml` file:

``` XML
    <rule id="100114" level="3">
      <field name="key1">value1</field>
      <description>Test</description>
    </rule>

    <rule id="100116" level="7" frequency="4" timeframe="9999">
      <if_matched_sid>100114</if_matched_sid>
      <same_field>key2.key21</same_field>
      <description>Test2</description>
   </rule>
```

Execute 2 instances of `queue.py` script, which inserts directly to the Analysisd queue.

``` BASH
queue.py '1:/file.log:{"key1":"value1", "key2":{"key21":"A","ID":"X"}}'
queue.py '1:/file.log:{"key1":"value1", "key2":{"key21":"B","ID":"X"}}'
```

With this test, the memory never exceeds 182MB. The queue of cached events grows to a maximum size of 8000.

![mem-graph](https://user-images.githubusercontent.com/20266121/67086942-37857580-f1a2-11e9-8c1b-7ddb3f4db19e.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade

- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Stress test for affected components
