### PR TITLE
Fix decode error when loading 'ossec.conf'

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -148,7 +148,7 @@ def ossec_log_summary(months=3):
 
     first_date = previous_month(months)
 
-    with open(common.ossec_log) as f:
+    with open(common.ossec_log, errors='ignore') as f:
         lines_count = 0
         for line in f:
             if lines_count > 50000:


### PR DESCRIPTION
Hi team,

This PR closes #4108. After applying this fix, it is possible to perform the call `cluster/:node_id/logs/summary` although a non UTF character is in `ossec.conf`.

Best regards,

Demetrio.