### PR TITLE
Fix Coverity reporting

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -594,7 +594,7 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
     vu_os_feed *os_list = NULL;
     int result;
     char multi_provider;
-    provider_options p_options;
+    provider_options p_options = { .multi_path = 0 };
     int retval = OS_INVALID;
 
     wm_vuldet_init_provider_options(&p_options);
@@ -1011,6 +1011,7 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
                 os_realloc(options->multi_allowed_os_name, (elements + 2) * sizeof(char *), options->multi_allowed_os_name);
                 os_realloc(options->multi_allowed_os_ver, (elements + 2) * sizeof(char *), options->multi_allowed_os_ver);
                 os_strdup(node[i]->content, options->multi_allowed_os_name[elements]);
+                os_strdup(*node[i]->values, options->multi_allowed_os_ver[elements]);
                 options->multi_allowed_os_name[elements + 1] = NULL;
                 options->multi_allowed_os_ver[elements + 1] = NULL;
 
@@ -1018,7 +1019,6 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
                     merror("Invalid use of '%s' option: it need to be used with the %s attribute.", node[i]->element, XML_REPLACED_OS);
                     return OS_INVALID;
                 }
-                os_strdup(*node[i]->values, options->multi_allowed_os_ver[elements]);
             } else {
                 mwarn("'%s' option can only be used in a multi-provider.", node[i]->element);
             }

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -170,6 +170,12 @@ typedef uint8_t u_int8_t;
 #define MSG_DONTWAIT MSG_NONBLOCK
 #endif
 
+#if defined(__GNUC__) && __GNUC__ >= 7
+#define fallthrough __attribute__ ((fallthrough))
+#else
+#define fallthrough ((void) 0)
+#endif
+
 extern const char *__local_name;
 /*** Global prototypes ***/
 /*** These functions will exit on error. No need to check return code ***/

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -362,6 +362,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
             os_calloc(1, sizeof(file_sum), f_sum[f_size]);
             strncpy(f_sum[f_size]->sum, md5sum, 32);
             os_strdup(DEFAULTAR_FILE, f_sum[f_size]->name);
+            f_sum[f_size + 1] = NULL;
 
             if (!logr.nocmerged) {
                 MergeAppendFile(merged_tmp, DEFAULTAR, NULL, -1);
@@ -1070,7 +1071,7 @@ static void read_controlmsg(const char *agent_id, char *msg)
             }
 
             // Copy sum before unlock mutex
-            if (f_sum[0]->sum && *(f_sum[0]->sum)) {
+            if (f_sum[0] && *(f_sum[0]->sum)) {
                 memcpy(tmp_sum, f_sum[0]->sum, sizeof(tmp_sum));
             }
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -203,9 +203,7 @@ void HandleSecure()
                         default:
                             merror("TCP peer [%d] at %s: %s (%d)", sock_client, inet_ntoa(peer_info.sin_addr), strerror(errno), errno);
                         }
-
-                        // Fallthrough
-
+                        fallthrough;
                     case 0:
                         _close_sock(&keys, sock_client);
                         continue;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4259,7 +4259,7 @@ int wm_vuldet_insert_cpe_dic_array(sqlite3 *db, vu_query query, int id, vu_cpe_d
 
                 if (query == VU_INSERT_CPE_TRANSLATION) {
                     char *exact_term;
-                    if (wm_vuldet_get_term_condition(term, &exact_term, &comp_field, &condition)) {
+                    if (!wm_vuldet_get_term_condition(term, &exact_term, &comp_field, &condition)) {
                         free(term);
                         term = exact_term;
                         sqlite3_bind_text(stmt, 5, comp_field, -1, NULL);
@@ -4978,7 +4978,7 @@ int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, c
     regmatch_t matches[5];
 
     if (!i_term) {
-        return 0;
+        return 1;
     }
 
     if (!regex) {
@@ -4990,6 +4990,7 @@ int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, c
         }
     }
 
+    int retval = 1;
     if (!regexec(regex, i_term, 5, matches, 0)) {
         int i;
         char **target;
@@ -4998,7 +4999,6 @@ int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, c
         char *check = NULL;
         char *op_value = NULL;
         size_t size;
-        char success = 0;
 
         for (i = 1; i < 5; i++) {
             int start = (&matches[i])->rm_so;
@@ -5029,22 +5029,26 @@ int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, c
             (*target)[end - start] = '\0';
         }
 
+        // Unnecessary check to remove a false positive reported by Coverity
+        if (!part || !op || !check || !op_value) {
+            goto free_mem;
+        }
+
         size = strlen(check) + strlen(op_value) + 3;
         os_calloc(size, sizeof(char), *condition);
         snprintf(*condition, size, "%s %s", check, op_value);
         os_strdup(part, *term);
         os_strdup(op, *comp_field);
 
-        success = 1;
+        retval = 0;
 free_mem:
         free(part);
         free(op);
         free(check);
         free(op_value);
-        return success;
     }
 
-    return 0;
+    return retval;
 }
 
 cpe *wm_vuldet_generate_cpe(const char *part, const char *vendor, const char *product, const char *version, const char *update, const char *edition, const char *language, const char *sw_edition, const char *target_sw, const char *target_hw, const char *other, const int id, const char *msu_name) {


### PR DESCRIPTION
This PR solves some defects reported by Coverity (not dangerous), as well as a compilation warning due to an intentional fall through. 

We uses the `fallthrough` attribute to indicate to the compiler that the fall through is intentional when using `-Wimplicit-fallthrough`. It is available from GCC 7.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- Static analysis
  - [x] Scan-build report
  - [ ] Coverity