### PR TITLE
Fix for filtering rules by 'nist'

### DIFF
--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -251,7 +251,7 @@ class Rule:
         :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
         :param search: Looks for items with the specified string.
         :param filters: Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}.
-            This filter is used for filtering by 'status', 'group', 'pci', 'gpg13', 'gdpr', 'hipaa', 'nist_800_53',
+            This filter is used for filtering by 'status', 'group', 'pci', 'gpg13', 'gdpr', 'hipaa', 'nist-800-53',
             'file', 'path', 'id' and 'level'.
         :param q: Defines query to filter.
 
@@ -264,7 +264,7 @@ class Rule:
         gpg13 = filters.get('gpg13', None)
         gdpr = filters.get('gdpr', None)
         hipaa = filters.get('hipaa', None)
-        nist_800_53 = filters.get('nist_800_53', None)
+        nist_800_53 = filters.get('nist-800-53', None)
         path = filters.get('path', None)
         file_ = filters.get('file', None)
         id_ = filters.get('id', None)


### PR DESCRIPTION
Hi team,

This PR fixes #4144. We received `nist-800-53` parameter instead  `nist_800_53` from the API and this PR fixes it.

Best regards,

Demetrio.