### PR TITLE
Osquery module - Modify Windows installation path

### DIFF
--- a/src/config/wmodules-osquery-monitor.c
+++ b/src/config/wmodules-osquery-monitor.c
@@ -40,9 +40,9 @@ int wm_osquery_monitor_read(xml_node **nodes, wmodule *module)
     module->data = osquery_monitor;
 
 #ifdef WIN32
-    os_strdup("C:\\ProgramData\\osquery\\osqueryd", osquery_monitor->bin_path);
-    os_strdup("C:\\ProgramData\\osquery\\log\\osqueryd.results.log", osquery_monitor->log_path);
-    os_strdup("C:\\ProgramData\\osquery\\osquery.conf", osquery_monitor->config_path);
+    os_strdup("C:\\Program Files\\osquery\\osqueryd", osquery_monitor->bin_path);
+    os_strdup("C:\\Program Files\\osquery\\log\\osqueryd.results.log", osquery_monitor->log_path);
+    os_strdup("C:\\Program Files\\osquery\\osquery.conf", osquery_monitor->config_path);
 
 #else
     os_strdup("/var/log/osquery/osqueryd.results.log", osquery_monitor->log_path);

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -268,7 +268,12 @@ void *Execute_Osquery(wm_osquery_monitor_t *osquery)
     }
 
     mdebug1("Launching '%s' with config file '%s'", osqueryd_path, osquery->config_path);
+
+#ifdef WIN32
+    snprintf(config_path, sizeof(config_path), "--config_path=\"%s\"", osquery->config_path);
+#else
     snprintf(config_path, sizeof(config_path), "--config_path=%s", osquery->config_path);
+#endif
 
     // We check that the osquery demon is not down, in which case we run it again.
 

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -188,9 +188,9 @@
   <wodle name="osquery">
     <disabled>yes</disabled>
     <run_daemon>yes</run_daemon>
-    <bin_path>C:\ProgramData\osquery\osqueryd</bin_path>
-    <log_path>C:\ProgramData\osquery\log\osqueryd.results.log</log_path>
-    <config_path>C:\ProgramData\osquery\osquery.conf</config_path>
+    <bin_path>C:\Program Files\osquery\osqueryd</bin_path>
+    <log_path>C:\Program Files\osquery\log\osqueryd.results.log</log_path>
+    <config_path>C:\Program Files\osquery\osquery.conf</config_path>
     <add_labels>yes</add_labels>
   </wodle>
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -204,9 +204,9 @@
   <wodle name="osquery">
     <disabled>yes</disabled>
     <run_daemon>yes</run_daemon>
-    <bin_path>C:\ProgramData\osquery\osqueryd</bin_path>
-    <log_path>C:\ProgramData\osquery\log\osqueryd.results.log</log_path>
-    <config_path>C:\ProgramData\osquery\osquery.conf</config_path>
+    <bin_path>C:\Program Files\osquery\osqueryd</bin_path>
+    <log_path>C:\Program Files\osquery\log\osqueryd.results.log</log_path>
+    <config_path>C:\Program Files\osquery\osquery.conf</config_path>
     <add_labels>yes</add_labels>
   </wodle>
 


### PR DESCRIPTION

## Description

Hello team,

The Osquery new version is installed in `C:\Program File\osquery` directory instead of `C:\ProgramData\osquery`. This PR modifies the `bin_path`, `log_path`, and `config_path` to support this version.

It is reported in following QA Issue: [201](https://github.com/wazuh/wazuh-qa/issues/201)

Best regards,
Eva
