### PR TITLE
vulnerability_detector: add debian 10 buster support

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -164,7 +164,12 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
         }
         upd->dist_ref = FEED_UBUNTU;
     } else  if (strcasestr(feed, vu_feed_tag[FEED_DEBIAN]) && version) {
-        if (!strcmp(version, "9") || strcasestr(version, vu_feed_tag[FEED_STRETCH])) {
+        if (!strcmp(version, "10") || strcasestr(version, vu_feed_tag[FEED_BUSTER])) {
+            os_index = CVE_BUSTER;
+            os_strdup(vu_feed_tag[FEED_BUSTER], upd->version);
+            upd->dist_tag_ref = FEED_BUSTER;
+            upd->dist_ext = vu_feed_ext[FEED_BUSTER];
+        } else if (!strcmp(version, "9") || strcasestr(version, vu_feed_tag[FEED_STRETCH])) {
             os_index = CVE_STRETCH;
             os_strdup(vu_feed_tag[FEED_STRETCH], upd->version);
             upd->dist_tag_ref = FEED_STRETCH;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -141,6 +141,7 @@ const char *vu_feed_tag[] = {
     // Debian versions
     "JESSIE",
     "STRETCH",
+    "BUSTER",
     "WHEEZY",
     // RedHat versions
     "RHEL5",
@@ -186,6 +187,7 @@ const char *vu_feed_ext[] = {
     // Debian versions
     "Debian Jessie",
     "Debian Stretch",
+    "Debian Buster",
     "Debian Wheezy",
     // RedHat versions
     "Red Hat Enterprise Linux 5",
@@ -2559,6 +2561,7 @@ int wm_vuldet_run_update(update_node **updates) {
         wm_vuldet_check_feed(updates[CVE_TRUSTY], &error_code)   ||
         wm_vuldet_check_feed(updates[CVE_PRECISE], &error_code)  ||
         // Debian
+        wm_vuldet_check_feed(updates[CVE_BUSTER], &error_code)  ||
         wm_vuldet_check_feed(updates[CVE_STRETCH], &error_code)  ||
         wm_vuldet_check_feed(updates[CVE_JESSIE], &error_code)   ||
         wm_vuldet_check_feed(updates[CVE_WHEEZY], &error_code)   ||
@@ -3076,6 +3079,8 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
                 agent_dist_ver = FEED_JESSIE;
             } else if (strstr(os_version, "9")) {
                 agent_dist_ver = FEED_STRETCH;
+            } else if (strstr(os_version, "10")) {
+                agent_dist_ver = FEED_BUSTER;
             } else {
                 dist_error = FEED_DEBIAN;
             }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -183,6 +183,7 @@ typedef enum vu_feed {
     // Debian versions
     FEED_JESSIE,
     FEED_STRETCH,
+    FEED_BUSTER,
     FEED_WHEEZY,
     // RedHat versions
     FEED_RHEL5,
@@ -267,6 +268,7 @@ typedef enum cve_db{
     CVE_BIONIC,
     CVE_JESSIE,
     CVE_STRETCH,
+    CVE_BUSTER,
     CVE_WHEEZY,
     CVE_REDHAT,
     CVE_NVD,


### PR DESCRIPTION
This is adding debian 10 buster support for vulnerability detector.

Schema don't have change vs debian9, I have tested it, it's working fine.

|Related issue|
https://github.com/wazuh/wazuh/issues/3802


