### PR TITLE
SCA - Update database when switching between managers

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1605,6 +1605,7 @@ static void HandleIntegrityCheck(Eventinfo *lf, int *socket, cJSON *event){
     }
 
     if (!policy_id) {
+        merror("Malformed JSON: field 'policy_id' not found.");
         return;
     }
 
@@ -1626,7 +1627,7 @@ static void HandleIntegrityCheck(Eventinfo *lf, int *socket, cJSON *event){
 
                 PushDumpRequest(lf->agent_id, policy_id->valuestring, 0);
             }
-            
+
             break;
         case 1: /* Empty DB */
             mdebug1("Check results DB empty for policy '%s'. Requesting DB dump.",

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1625,7 +1625,7 @@ static void HandleIntegrityCheck(Eventinfo *lf, int *socket, cJSON *event){
                 mdebug1("Scan result integrity failed for policy '%s'. Hash from DB: '%s', hash from summary: '%s'. Requesting DB dump.",
                         policy_id->valuestring, wdb_response, integrity_hash->valuestring);
 
-                PushDumpRequest(lf->agent_id, policy_id->valuestring, 0);
+                PushDumpRequest(lf->agent_id, policy_id->valuestring, 1);
             }
 
             break;

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -243,7 +243,7 @@ int DecodeSCA(Eventinfo *lf, int *socket)
                 os_free(msg_unformatted);
             }
 
-            HandleIntegrityCheck(lf,socket,json_event);
+            HandleIntegrityCheck(lf, socket, json_event);
 
             lf->decoder_info = sca_json_dec;
 
@@ -251,7 +251,7 @@ int DecodeSCA(Eventinfo *lf, int *socket)
             ret_val = 1;
             return ret_val;
         }
-        else if (strcmp(type->valuestring,"dump_end") == 0) {
+        else if (strcmp(type->valuestring, "dump_end") == 0) {
             char *msg_unformatted = cJSON_PrintUnformatted(json_event);
 
             if (msg_unformatted) {

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -70,7 +70,7 @@ static void wm_sca_send_policies_scanned(wm_sca_t * data);
 static int wm_sca_send_dump_end(wm_sca_t * data, unsigned int elements_sent,char * policy_id,int scan_id);  // Send dump end event
 static int append_msg_to_vm_scat (wm_sca_t * const data, const char * const msg);
 static int compare_cis_db_info_t_entry(const void * const a, const void * const  b);
-static void *wm_sca_check_integrity_periodically (wm_sca_t * data); // Send integrity to manager
+static void *wm_sca_check_integrity_periodically(wm_sca_t * data); // Send integrity to manager
 
 #ifndef WIN32
 static void * wm_sca_request_thread(wm_sca_t * data);
@@ -3231,9 +3231,21 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
                 
                 mdebug1("Calculating hash for scanned results.");
                 char *integrity_hash = wm_sca_hash_integrity(cis_db_index);
+
+                // If there is no hash in the local db, it will send an empty one
+                if (!integrity_hash) {
+                    integrity_hash = "";
+                }
                 
                 cJSON_AddStringToObject(json_integrity, "hash", integrity_hash);
-                cJSON_AddStringToObject(json_integrity, "policy_id", data->policies[cis_db_index]->policy_id);
+
+                // If there is no policy id in the local db, it will send an empty one
+                if(!data->policies[cis_db_index]->policy_id){
+                    cJSON_AddStringToObject(json_integrity, "policy_id", "");
+                }
+                else{
+                    cJSON_AddStringToObject(json_integrity, "policy_id", data->policies[cis_db_index]->policy_id);
+                }
 
                 /* Send integrity hash to the manager */
                 mdebug2("Sending integrity hash: %s", integrity_hash);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -3238,7 +3238,6 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
 
             /* If there is no hash in the local db, it will send an empty one */
             if (!integrity_hash) {
-                os_free(integrity_hash);
                 os_malloc(sizeof(""), integrity_hash);
                 strncpy(integrity_hash, "", sizeof(""));
             }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -3224,7 +3224,7 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
 
         /* Send hash for every policy file */
         for (i = 0; data->policies[i]; i++) {
-            if (!data->policies[i]->enabled) {
+            if (!data->policies[i]->enabled || !data->policies[i]->policy_id) {
                 continue;
             }
 
@@ -3243,17 +3243,7 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
             }
             
             cJSON_AddStringToObject(json_integrity, "hash", integrity_hash);
-
-            /* If there is no policy id in the local db, it will send nothing */
-            if(!data->policies[cis_db_index]->policy_id){
-                os_free(integrity_hash);
-                cJSON_Delete(json_integrity);
-                
-                continue;
-            }
-            else{
-                cJSON_AddStringToObject(json_integrity, "policy_id", data->policies[cis_db_index]->policy_id);
-            }
+            cJSON_AddStringToObject(json_integrity, "policy_id", data->policies[cis_db_index]->policy_id);
 
             /* Send integrity hash to the manager */
             mdebug2("Sending integrity hash: %s", integrity_hash);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -70,6 +70,7 @@ static void wm_sca_send_policies_scanned(wm_sca_t * data);
 static int wm_sca_send_dump_end(wm_sca_t * data, unsigned int elements_sent,char * policy_id,int scan_id);  // Send dump end event
 static int append_msg_to_vm_scat (wm_sca_t * const data, const char * const msg);
 static int compare_cis_db_info_t_entry(const void * const a, const void * const  b);
+static void *wm_sca_check_integrity_periodically (wm_sca_t * data); // Send integrity to manager
 
 #ifndef WIN32
 static void * wm_sca_request_thread(wm_sca_t * data);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -3238,7 +3238,7 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
 
             /* If there is no hash in the local db, it will send an empty one */
             if (!integrity_hash) {
-                os_malloc(sizeof(""), integrity_hash);
+                os_realloc(integrity_hash, sizeof(""), integrity_hash);
                 strncpy(integrity_hash, "", sizeof(""));
             }
             

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -128,6 +128,9 @@ static wm_sca_t * data_win;
 
 cJSON **last_summary_json = NULL;
 
+// Mutexes
+static pthread_mutex_t control_msg_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 /* Multiple readers / one write mutex */
 static pthread_rwlock_t dump_rwlock;
 
@@ -3232,9 +3235,13 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
             int cis_db_index = i;
 
             cJSON_AddStringToObject(json_integrity, "type", "integrity_check");
-            
+
             mdebug1("Calculating hash for scanned results.");
+            
+            /* Mutex for global varible cis_db_for_hash */
+            w_mutex_lock(&control_msg_mutex);
             char *integrity_hash = wm_sca_hash_integrity(cis_db_index);
+            w_mutex_unlock(&control_msg_mutex);
 
             /* If there is no hash in the local db, it will send an empty one */
             if (!integrity_hash) {

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -235,6 +235,12 @@ void * wm_sca_main(wm_sca_t * data) {
                     data,
                     0,
                     NULL);
+    w_create_thread(NULL,
+                    0,
+                    (LPTHREAD_START_ROUTINE)wm_sca_check_integrity_periodically,
+                    data,
+                    0,
+                    NULL);
 #endif
 
     wm_sca_start(data);
@@ -3201,7 +3207,7 @@ static int append_msg_to_vm_scat (wm_sca_t * const data, const char * const msg)
     sca scan and integrity hash.
  */
 static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
-    unsigned int time_sleep = 300;
+    unsigned int time_sleep = data->integrity_interval;
 
     while (1) {
         /* Thread sleeps for 5 minutes until the next time it sends the hash */
@@ -3211,7 +3217,6 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
         /* Send hash for every policy file */
         if (data->policies) {
             int i;
-            OSHash *check_list = OSHash_Create();
 
             for (i = 0; data->policies[i]; i++) {
                 if (!data->policies[i]->enabled) {

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -3208,7 +3208,6 @@ static int append_msg_to_vm_scat (wm_sca_t * const data, const char * const msg)
     sca scan and integrity hash.
  */
 static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
-    int i;
     unsigned int time_sleep = data->integrity_interval;
 
     while (1) {
@@ -3220,6 +3219,8 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
         if (!data->policies) {
             continue;
         }
+
+        int i;
 
         /* Send hash for every policy file */
         for (i = 0; data->policies[i]; i++) {
@@ -3237,7 +3238,7 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
 
             /* If there is no hash in the local db, it will send an empty one */
             if (!integrity_hash) {
-                free(integrity_hash);
+                os_free(integrity_hash);
                 os_malloc(sizeof(""), integrity_hash);
                 strncpy(integrity_hash, "", sizeof(""));
             }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -3232,14 +3232,14 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
                 mdebug1("Calculating hash for scanned results.");
                 char *integrity_hash = wm_sca_hash_integrity(cis_db_index);
 
-                // If there is no hash in the local db, it will send an empty one
+                /* If there is no hash in the local db, it will send an empty one */
                 if (!integrity_hash) {
                     integrity_hash = "";
                 }
                 
                 cJSON_AddStringToObject(json_integrity, "hash", integrity_hash);
 
-                // If there is no policy id in the local db, it will send an empty one
+                /* If there is no policy id in the local db, it will send an empty one */
                 if(!data->policies[cis_db_index]->policy_id){
                     cJSON_AddStringToObject(json_integrity, "policy_id", "");
                 }
@@ -3249,10 +3249,9 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
 
                 /* Send integrity hash to the manager */
                 mdebug2("Sending integrity hash: %s", integrity_hash);
-
                 wm_sca_send_alert(data, json_integrity);
 
-                os_free(integrity_hash);
+                /* Free memory */
                 cJSON_Delete(json_integrity);
             }
         }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -3244,9 +3244,12 @@ static void *wm_sca_check_integrity_periodically (wm_sca_t * data) {
             
             cJSON_AddStringToObject(json_integrity, "hash", integrity_hash);
 
-            /* If there is no policy id in the local db, it will send an empty one */
+            /* If there is no policy id in the local db, it will send nothing */
             if(!data->policies[cis_db_index]->policy_id){
-                cJSON_AddStringToObject(json_integrity, "policy_id", "");
+                os_free(integrity_hash);
+                cJSON_Delete(json_integrity);
+                
+                continue;
             }
             else{
                 cJSON_AddStringToObject(json_integrity, "policy_id", data->policies[cis_db_index]->policy_id);

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -47,6 +47,7 @@ typedef struct wm_sca_t {
     unsigned int interval;
     int scan_day;
     int scan_wday;
+    int integrity_interval;
     int msg_delay;
     unsigned int summary_delay;
     time_t next_time;

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -47,7 +47,7 @@ typedef struct wm_sca_t {
     unsigned int interval;
     int scan_day;
     int scan_wday;
-    int integrity_interval;
+    unsigned int integrity_interval;
     int msg_delay;
     unsigned int summary_delay;
     time_t next_time;


### PR DESCRIPTION
| Related issue | Documentation pull request              |
|--------------|-------------------------------------|
| #3943           | wazuh/wazuh-documentation#2045 |

## Description

In a cluster environment, when switching between managers, the SCA DB of the new manager keeps empty until the next scan.
To solve this, I have added two new functions, one is a thread in the agent sending the integrity hash of the policy every configurable number of seconds, the other is in charge of checking this hash with the one stored, if the hash doesn't match the manager will request a new scan.

## Configuration options

In the `sca` section in the agent, the new option is `integrity_interval`. For example:

```xml
<integrity_interval>5m</integrity_interval>
```

## Logs/Alerts example

Not needed.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Dr. Memory
- Memory tests for macOS
  - [x] Scan-build report
  - [ ] Leaks
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)

