### PR TITLE
Add FIM option 'allow_prefilter_cmd'

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -97,7 +97,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
         } else if (strcmp(node[i]->element, ossyscheck) == 0) {
-            if ((modules & CSYSCHECK) && (Read_Syscheck(xml, chld_node, d1, d2) < 0)) {
+            if ((modules & CSYSCHECK) && (Read_Syscheck(xml, chld_node, d1, d2, modules) < 0)) {
                 goto fail;
             }
             if ((modules & CGLOBAL) && (Read_GlobalSK(chld_node, d1, d2) < 0)) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -51,7 +51,7 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2);
 int Read_Global(XML_NODE node, void *d1, void *d2);
 int Read_GlobalSK(XML_NODE node, void *configp, void *mailp);
 int Read_Rules(XML_NODE node, void *d1, void *d2);
-int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
+int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *d1, void *d2, int modules);
 int Read_Rootcheck(XML_NODE node, void *d1, void *d2);
 int Read_Alerts(XML_NODE node, void *d1, void *d2);
 int Read_EmailAlerts(XML_NODE node, void *d1, void *d2);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1333,7 +1333,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         } /* Allow prefilter cmd */
         else if (strcmp(node[i]->element, xml_allow_prefilter_cmd) == 0) {
             if (modules & CAGENT_CONFIG) {
-                mwarn("'%s' option can't be set from the manager.", xml_allow_prefilter_cmd);
+                mwarn("'%s' option can't be changed using centralized configuration (agent.conf).", xml_allow_prefilter_cmd);
                 i++;
                 continue;
             }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -829,6 +829,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_whodata_options = "whodata";
     const char *xml_audit_key = "audit_key";
     const char *xml_audit_hc = "startup_healthcheck";
+    const char *xml_allow_prefilter_cmd = "allow_prefilter_cmd";
 
     /* Configuration example
     <directories check_all="yes">/etc,/usr/bin</directories>
@@ -1329,6 +1330,16 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 }
             }
             OS_ClearNode(children);
+        } /* Allow prefilter cmd */
+        else if (strcmp(node[i]->element, xml_allow_prefilter_cmd) == 0) {
+            if(strcmp(node[i]->content, "yes") == 0)
+                syscheck->allow_prefilter_cmd = 1;
+            else if(strcmp(node[i]->content, "no") == 0)
+                syscheck->allow_prefilter_cmd = 0;
+            else {
+                merror(XML_VALUEERR,node[i]->element,node[i]->content);
+                return(OS_INVALID);
+            }
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -795,7 +795,7 @@ out_free:
     return ret;
 }
 
-int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__((unused)) void *mailp)
+int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__((unused)) void *mailp, int modules)
 {
     int i = 0;
     int j = 0;
@@ -1332,6 +1332,11 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             OS_ClearNode(children);
         } /* Allow prefilter cmd */
         else if (strcmp(node[i]->element, xml_allow_prefilter_cmd) == 0) {
+            if (modules & CAGENT_CONFIG) {
+                mwarn("'%s' option can't be set from the manager.", xml_allow_prefilter_cmd);
+                i++;
+                continue;
+            }
             if(strcmp(node[i]->content, "yes") == 0)
                 syscheck->allow_prefilter_cmd = 1;
             else if(strcmp(node[i]->content, "no") == 0)

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -233,6 +233,7 @@ typedef struct _config {
     rtfim *realtime;
 
     char *prefilter_cmd;
+    int allow_prefilter_cmd;
 
 } syscheck_config;
 

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -34,5 +34,6 @@
 #define FIM_WARN_WHODATA_AUTOCONF               "Audit policies could not be auto-configured due to the Windows version. Check if they are correct for whodata mode."
 #define FIM_WARN_WHODATA_LOCALPOLICIES          "Local audit policies could not be configured."
 #define FIM_WARN_WHODATA_EVENT_OVERFLOW         "Real-time Whodata events queue for Windows has more than %d elements."
+#define FIM_WARN_ALLOW_PREFILTER                "Ignoring prefilter option '%s'. Enable <allow_prefilter_option> to use it."
 
 #endif /* WARN_MESSAGES_H */

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -302,6 +302,12 @@ cJSON *getSyscheckConfig(void) {
         cJSON_AddItemToObject(syscfg,"registry_ignore_sregex",rgi);
     }
 #endif
+    if (syscheck.allow_prefilter_cmd) {
+        cJSON_AddStringToObject(syscfg, "allow_prefilter_cmd", "yes");
+    } else {
+        cJSON_AddStringToObject(syscfg, "allow_prefilter_cmd", "no");
+    }
+
     if (syscheck.prefilter_cmd) {
         cJSON_AddStringToObject(syscfg,"prefilter_cmd",syscheck.prefilter_cmd);
     }

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -51,6 +51,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.max_fd_win_rt  = 0;
 #endif
     syscheck.prefilter_cmd  = NULL;
+    syscheck.allow_prefilter_cmd  = 0;
 
     mdebug1(FIM_CONFIGURATION_FILE, cfgfile);
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -98,6 +98,10 @@ int fim_initialize() {
     }
     OSHash_SetFreeDataPointer(syscheck.fp, (void (*)(void *))free_syscheck_node_data);
 
+    if (!syscheck.allow_prefilter_cmd) {
+        syscheck.prefilter_cmd = NULL;
+    }
+
     return 0;
 }
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -98,8 +98,9 @@ int fim_initialize() {
     }
     OSHash_SetFreeDataPointer(syscheck.fp, (void (*)(void *))free_syscheck_node_data);
 
+    // Set prefilter to NULL if it's not expressly allowed.
     if (!syscheck.allow_prefilter_cmd) {
-        syscheck.prefilter_cmd = NULL;
+        os_free(syscheck.prefilter_cmd);
     }
 
     return 0;

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -98,8 +98,11 @@ int fim_initialize() {
     }
     OSHash_SetFreeDataPointer(syscheck.fp, (void (*)(void *))free_syscheck_node_data);
 
-    // Set prefilter to NULL if it's not expressly allowed.
+    // Set prefilter to NULL if it's not expressly allowed (ossec.conf in agent side).
     if (!syscheck.allow_prefilter_cmd) {
+        if (syscheck.prefilter_cmd != NULL) {
+            mwarn(FIM_WARN_ALLOW_PREFILTER, syscheck.prefilter_cmd);
+        }
         os_free(syscheck.prefilter_cmd);
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|No issue related|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds an option to enable or disable the `prefilter_cmd` option. This option only can be set from _ossec.conf_ on the agent side.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

There are two values allowed, yes and no. By default is set to no.
```xml
# ossec.conf
<syscheck>
    <allow_prefilter_cmd>yes</allow_prefilter_cmd>
    <prefilter_cmd>/bin/cat</prefilter_cmd>
</syscheck>
```

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

If it is configured in _agent.conf_ on the manager side, a warning message is displayed indicating that the value will not be set.
>ossec-syscheckd: WARNING: 'allow_prefilter_cmd' option can't be set from the manager.

Configuration on demand from API request:

>curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/001/config/syscheck/syscheck?pretty"

```json
{
   "error": 0,
   "data": {
      "syscheck": {
         ...
         "allow_prefilter_cmd": "yes",
         "prefilter_cmd": "/bin/cat"
      }
   }
}

```
<!--
Paste here related logs and alerts
-->

## Tests
Valgrind report:
```log
==27885== LEAK SUMMARY:
==27885==    definitely lost: 0 bytes in 0 blocks
==27885==    indirectly lost: 0 bytes in 0 blocks
==27885==      possibly lost: 1,120 bytes in 2 blocks
==27885==    still reachable: 52,955 bytes in 60 blocks
==27885==         suppressed: 0 bytes in 0 blocks
==27885== Reachable blocks (those to which a pointer was found) are not shown.
==27885== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```
scan-build results don't show any bugs in files modified:
>src/config/config.c
>src/config/config.h
>src/config/syscheck-config.c
>src/config/syscheck-config.h
>src/syscheckd/config.c
>src/syscheckd/syscheck.c

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
