### PR TITLE
Latch remote FIM prefilter command setting

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -829,7 +829,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_whodata_options = "whodata";
     const char *xml_audit_key = "audit_key";
     const char *xml_audit_hc = "startup_healthcheck";
-    const char *xml_allow_prefilter_cmd = "allow_prefilter_cmd";
+    const char *xml_allow_remote_prefilter_cmd = "allow_remote_prefilter_cmd";
 
     /* Configuration example
     <directories check_all="yes">/etc,/usr/bin</directories>
@@ -840,6 +840,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     syscheck_config *syscheck;
     syscheck = (syscheck_config *)configp;
     unsigned int nodiff_size = 0;
+    char prefilter_cmd[OS_MAXSTR] = "";
 
     if (syscheck->disabled == SK_CONF_UNPARSED) {
         syscheck->disabled = SK_CONF_UNDEFINED;
@@ -1233,31 +1234,28 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         } else if (strcmp(node[i]->element, xml_alert_new_files) == 0) {
             /* alert_new_files option is not read here */
         } else if (strcmp(node[i]->element, xml_prefilter_cmd) == 0) {
-            char cmd[OS_MAXSTR];
             struct stat statbuf;
 
 #ifdef WIN32
-            if(!ExpandEnvironmentStrings(node[i]->content, cmd, sizeof(cmd) - 1)){
+            if(!ExpandEnvironmentStrings(node[i]->content, prefilter_cmd, sizeof(prefilter_cmd) - 1)){
                 merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
                 continue;
             }
-            str_lowercase(cmd);
+            str_lowercase(prefilter_cmd);
 #else
-            strncpy(cmd, node[i]->content, sizeof(cmd) - 1);
+            strncpy(prefilter_cmd, node[i]->content, sizeof(prefilter_cmd) - 1);
+            prefilter_cmd[sizeof(prefilter_cmd) - 1] = '\0';
 #endif
 
-            if (strlen(cmd) > 0) {
+            if (strlen(prefilter_cmd) > 0) {
                 char statcmd[OS_MAXSTR];
                 char *ix;
-                strncpy(statcmd, cmd, sizeof(statcmd) - 1);
+                strncpy(statcmd, prefilter_cmd, sizeof(statcmd) - 1);
+                statcmd[sizeof(statcmd) - 1] = '\0';
                 if (NULL != (ix = strchr(statcmd, ' '))) {
                     *ix = '\0';
                 }
-                if (stat(statcmd, &statbuf) == 0) {
-                    /* More checks needed (perms, owner, etc.) */
-                    os_calloc(1, strlen(cmd) + 1, syscheck->prefilter_cmd);
-                    strncpy(syscheck->prefilter_cmd, cmd, strlen(cmd));
-                } else {
+                if (stat(statcmd, &statbuf) != 0) {
                     merror(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 }
@@ -1331,16 +1329,16 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             }
             OS_ClearNode(children);
         } /* Allow prefilter cmd */
-        else if (strcmp(node[i]->element, xml_allow_prefilter_cmd) == 0) {
+        else if (strcmp(node[i]->element, xml_allow_remote_prefilter_cmd) == 0) {
             if (modules & CAGENT_CONFIG) {
-                mwarn("'%s' option can't be changed using centralized configuration (agent.conf).", xml_allow_prefilter_cmd);
+                mwarn("'%s' option can't be changed using centralized configuration (agent.conf).", xml_allow_remote_prefilter_cmd);
                 i++;
                 continue;
             }
             if(strcmp(node[i]->content, "yes") == 0)
-                syscheck->allow_prefilter_cmd = 1;
+                syscheck->allow_remote_prefilter_cmd = 1;
             else if(strcmp(node[i]->content, "no") == 0)
-                syscheck->allow_prefilter_cmd = 0;
+                syscheck->allow_remote_prefilter_cmd = 0;
             else {
                 merror(XML_VALUEERR,node[i]->element,node[i]->content);
                 return(OS_INVALID);
@@ -1350,6 +1348,17 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             return (OS_INVALID);
         }
         i++;
+    }
+
+    // Set prefilter only if it's expressly allowed (ossec.conf in agent side).
+
+    if (prefilter_cmd[0]) {
+        if (!(modules & CAGENT_CONFIG) || syscheck->allow_remote_prefilter_cmd) {
+            free(syscheck->prefilter_cmd);
+            os_strdup(prefilter_cmd, syscheck->prefilter_cmd);
+        } else if (!syscheck->allow_remote_prefilter_cmd) {
+            mwarn(FIM_WARN_ALLOW_PREFILTER, prefilter_cmd, xml_allow_remote_prefilter_cmd);
+        }
     }
 
     return (0);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -233,7 +233,7 @@ typedef struct _config {
     rtfim *realtime;
 
     char *prefilter_cmd;
-    int allow_prefilter_cmd;
+    bool allow_remote_prefilter_cmd;
 
 } syscheck_config;
 

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -34,6 +34,6 @@
 #define FIM_WARN_WHODATA_AUTOCONF               "Audit policies could not be auto-configured due to the Windows version. Check if they are correct for whodata mode."
 #define FIM_WARN_WHODATA_LOCALPOLICIES          "Local audit policies could not be configured."
 #define FIM_WARN_WHODATA_EVENT_OVERFLOW         "Real-time Whodata events queue for Windows has more than %d elements."
-#define FIM_WARN_ALLOW_PREFILTER                "Ignoring prefilter option '%s'. Enable <allow_prefilter_option> to use it."
+#define FIM_WARN_ALLOW_PREFILTER                "Ignoring prefilter option '%s'. Enable <%s> to use it."
 
 #endif /* WARN_MESSAGES_H */

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -51,7 +51,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.max_fd_win_rt  = 0;
 #endif
     syscheck.prefilter_cmd  = NULL;
-    syscheck.allow_prefilter_cmd  = 0;
+    syscheck.allow_remote_prefilter_cmd  = false;
 
     mdebug1(FIM_CONFIGURATION_FILE, cfgfile);
 
@@ -302,11 +302,8 @@ cJSON *getSyscheckConfig(void) {
         cJSON_AddItemToObject(syscfg,"registry_ignore_sregex",rgi);
     }
 #endif
-    if (syscheck.allow_prefilter_cmd) {
-        cJSON_AddStringToObject(syscfg, "allow_prefilter_cmd", "yes");
-    } else {
-        cJSON_AddStringToObject(syscfg, "allow_prefilter_cmd", "no");
-    }
+
+    cJSON_AddStringToObject(syscfg, "allow_remote_prefilter_cmd", syscheck.allow_remote_prefilter_cmd ? "yes" : "no");
 
     if (syscheck.prefilter_cmd) {
         cJSON_AddStringToObject(syscfg,"prefilter_cmd",syscheck.prefilter_cmd);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -98,14 +98,6 @@ int fim_initialize() {
     }
     OSHash_SetFreeDataPointer(syscheck.fp, (void (*)(void *))free_syscheck_node_data);
 
-    // Set prefilter to NULL if it's not expressly allowed (ossec.conf in agent side).
-    if (!syscheck.allow_prefilter_cmd) {
-        if (syscheck.prefilter_cmd != NULL) {
-            mwarn(FIM_WARN_ALLOW_PREFILTER, syscheck.prefilter_cmd);
-        }
-        os_free(syscheck.prefilter_cmd);
-    }
-
     return 0;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#4193|

## Description

This PR aims to refactor new FIM option `<allow_prefilter_cmd`> to `<allow_remote_prefilter_cmd>` so that `<prefilter_cmd>` is always available locally (_ossec.conf_), and the setting above allow _agent.conf_ overwrite the latter's value.

## Configuration options

### Removed

```xml
<syscheck>
  <allow_prefilter_cmd>
</syscheck>
```

### Added

```xml
<syscheck>
  <allow_remote_prefilter_cmd>
</syscheck>
```

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] MAC OS X
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)

### Custom test

- _ossec.conf_:
```xml
<ossec_config>
  </syscheck>
    <allow_remote_prefilter_cmd>yes</allow_remote_prefilter_cmd>

    <prefilter_cmd>/usr/bin/ls</prefilter_cmd>
    <prefilter_cmd>/usr/bin/ls</prefilter_cmd>
    <prefilter_cmd>/usr/bin/ls</prefilter_cmd>
    <prefilter_cmd>/usr/bin/ls -1</prefilter_cmd>
  </syscheck>
</ossec_config>
```

- _agent.conf_:
```xml
<agent_config>

  <syscheck>
    <allow_remote_prefilter_cmd>no</allow_remote_prefilter_cmd>
    <prefilter_cmd>/usr/bin/cat</prefilter_cmd>
    <prefilter_cmd>/usr/bin/cat</prefilter_cmd>
    <prefilter_cmd>/usr/bin/cat</prefilter_cmd>
  </syscheck>

</agent_config>
```

1. The definite value of `<prefilter_cmd>` must be `ls` or `cat` depending on `<allow_remote_prefilter_cmd>` at _ossec.conf_, not _agent.conf_.
2. `<allow_remote_prefilter_cmd>` on _agent.conf_ must produce a warning and FIM must discard its value.
3. No memory leaks must appear though `<prefilter_cmd>` is defined multiple times.

### Example

```shell
# curl -sk -XGET -ufoo:bar https://localhost:55000/agents/015/config/syscheck/syscheck?pretty | grep prefilter_cmd
         "allow_remote_prefilter_cmd": "no",
         "prefilter_cmd": "/usr/bin/ls -1"
```

### Valgrind report

```
==12263== LEAK SUMMARY:
==12263==    definitely lost: 0 bytes in 0 blocks
==12263==    indirectly lost: 0 bytes in 0 blocks
==12263==      possibly lost: 272 bytes in 1 blocks
==12263==    still reachable: 19,560 bytes in 53 blocks
==12263==         suppressed: 0 bytes in 0 blocks
```

### Scan-build report

No related issues.