### PR TITLE
Solve scan-build warnings reported

### DIFF
--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -196,7 +196,7 @@ int k_extract(const char *cmdextract, int json_output)
         json_root = cJSON_CreateObject();
 
     if (cmdextract) {
-        user_input = strdup(cmdextract);
+        os_strdup(cmdextract, user_input);
         FormatID(user_input);
 
         if (!IDExist(user_input, 1)) {

--- a/src/agentlessd/lessdcom.c
+++ b/src/agentlessd/lessdcom.c
@@ -27,14 +27,14 @@ size_t lessdcom_dispatch(char * command, char ** output) {
         // getconfig section
         if (!rcv_args){
             mdebug1("LESSDCOM getconfig needs arguments.");
-            *output = strdup("err LESSDCOM getconfig needs arguments");
+            os_strdup("err LESSDCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return lessdcom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("LESSDCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -46,7 +46,7 @@ size_t lessdcom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "agentless") == 0){
         if (cfg = getAgentlessConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -60,7 +60,7 @@ size_t lessdcom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At LESSDCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 

--- a/src/analysisd/asyscom.c
+++ b/src/analysisd/asyscom.c
@@ -28,14 +28,14 @@ size_t asyscom_dispatch(char * command, char ** output) {
         // getconfig section
         if (!rcv_args){
             mdebug1("ASYSCOM getconfig needs arguments.");
-            *output = strdup("err ASYSCOM getconfig needs arguments");
+            os_strdup("err ASYSCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return asyscom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("ASYSCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -47,7 +47,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "global") == 0){
         if (cfg = getGlobalConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -59,7 +59,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
     }
     else if (strcmp(section, "active_response") == 0){
         if (cfg = getARManagerConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -71,7 +71,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
     }
     else if (strcmp(section, "alerts") == 0){
         if (cfg = getAlertsConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -83,7 +83,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
     }
     else if (strcmp(section, "decoders") == 0){
         if (cfg = getDecodersConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -95,7 +95,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
     }
     else if (strcmp(section, "rules") == 0){
         if (cfg = getRulesConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -107,7 +107,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
     }
     else if (strcmp(section, "internal") == 0){
         if (cfg = getAnalysisInternalOptions(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -119,7 +119,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
     }
     else if (strcmp(section, "command") == 0){
         if (cfg = getARCommandsConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -131,7 +131,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
     }
     else if (strcmp(section, "labels") == 0){
         if (cfg = getManagerLabelsConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -145,7 +145,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At ASYSCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -99,7 +99,7 @@ static int os_setdecoderids(const char *p_name)
 
                 /* Set parent name */
                 free(nnode->name);
-                nnode->name = strdup(tmp_name);
+                os_strdup(tmp_name, nnode->name);
             }
 
             /* Id cannot be 0 */
@@ -280,7 +280,7 @@ int ReadDecodeXML(const char *file)
         /* Default values to the list */
         pi->parent = NULL;
         pi->id = 0;
-        pi->name = strdup(node[i]->values[0]);
+        os_strdup(node[i]->values[0], pi->name);
         pi->order = NULL;
         pi->plugindecoder = NULL;
         pi->fts = 0;
@@ -475,7 +475,7 @@ int ReadDecodeXML(const char *file)
 
                 norder = OS_StrBreak(',', elements[j]->content, Config.decoder_order_size);
                 s_norder = norder;
-                os_calloc(Config.decoder_order_size, sizeof(void *), pi->order);
+                os_calloc(Config.decoder_order_size, sizeof(void *(*)(struct _Eventinfo *, char *, const char *)), pi->order);
                 os_calloc(Config.decoder_order_size, sizeof(char *), pi->fields);
 
                 /* Check the values from the order */
@@ -522,7 +522,7 @@ int ReadDecodeXML(const char *file)
                         pi->order[order_int] = SystemName_FP;
                     } else {
                         pi->order[order_int] = DynamicField_FP;
-                        pi->fields[order_int] = strdup(word);
+                        os_strdup(word, pi->fields[order_int]);
                     }
 
                     free(*norder);

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -69,16 +69,16 @@ char *GetGeoInfobyIP(char *ip_addr)
         {
             snprintf(geobuffer, 255, "%s / %s", geoiprecord->country_code, regionname);
             geobuffer[255] = '\0';
-            geodata = strdup(geobuffer);
+            os_strdup(geobuffer, geodata);
         }
         else
         {
-            geodata = strdup(geoiprecord->country_code);
+            os_strdup(geoiprecord->country_code, geodata);
         }
     }
     else
     {
-        geodata = strdup(geoiprecord->country_code);
+        os_strdup(geoiprecord->country_code, geodata);
     }
 
     GeoIPRecord_delete(geoiprecord);

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -22,7 +22,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
         return;
 
     if (strcmp(key, "srcip") == 0){
-        lf->srcip = strdup(value);
+        os_strdup(value, lf->srcip);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       srcip: '%s'", lf->srcip);
@@ -42,7 +42,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "dstip") == 0){
-        lf->dstip = strdup(value);
+        os_strdup(value, lf->dstip);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       dstip: '%s'", lf->dstip);
@@ -62,7 +62,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "dstport") == 0){
-        lf->dstport = strdup(value);
+        os_strdup(value, lf->dstport);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       dstport: '%s'", lf->dstport);
@@ -72,7 +72,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "srcport") == 0){
-        lf->srcport = strdup(value);
+        os_strdup(value, lf->srcport);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       srcport: '%s'", lf->srcport);
@@ -82,7 +82,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "protocol") == 0){
-        lf->protocol = strdup(value);
+        os_strdup(value, lf->protocol);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       protocol: '%s'", lf->protocol);
@@ -92,7 +92,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "action") == 0){
-        lf->action = strdup(value);
+        os_strdup(value, lf->action);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       action: '%s'", lf->action);
@@ -102,7 +102,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "srcuser") == 0){
-        lf->srcuser = strdup(value);
+        os_strdup(value, lf->srcuser);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       srcuser: '%s'", lf->srcuser);
@@ -112,7 +112,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "dstuser") == 0){
-        lf->dstuser = strdup(value);
+        os_strdup(value, lf->dstuser);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       dstuser: '%s'", lf->dstuser);
@@ -122,7 +122,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "id") == 0){
-        lf->id = strdup(value);
+        os_strdup(value, lf->id);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       id: '%s'", lf->id);
@@ -132,7 +132,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "status") == 0){
-        lf->status = strdup(value);
+        os_strdup(value, lf->status);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       status: '%s'", lf->status);
@@ -142,7 +142,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "command") == 0){
-        lf->command = strdup(value);
+        os_strdup(value, lf->command);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       command: '%s'", lf->command);
@@ -152,7 +152,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "url") == 0){
-        lf->url = strdup(value);
+        os_strdup(value, lf->url);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       url: '%s'", lf->url);
@@ -182,7 +182,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "systemname") == 0){
-        lf->systemname = strdup(value);
+        os_strdup(value, lf->systemname);
 #ifdef TESTRULE
         if (!alert_only) {
             print_out("       systemname: '%s'", lf->systemname);
@@ -201,8 +201,8 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
         print_out("       %s: '%s'", key, value);
     }
 #endif
-    lf->fields[lf->nfields].key = strdup(key);
-    lf->fields[lf->nfields].value = strdup(value);
+    os_strdup(key, lf->fields[lf->nfields].key);
+    os_strdup(value, lf->fields[lf->nfields].value);
     lf->nfields++;
 
 }
@@ -231,7 +231,7 @@ static void readJSON (cJSON *logJSON, char *parent, Eventinfo *lf)
                 strcpy(key + n, logJSON->string);
             }
             else {
-                key = strdup(logJSON->string);
+                os_strdup(logJSON->string, key);
             }
         }
 

--- a/src/client-agent/agcom.c
+++ b/src/client-agent/agcom.c
@@ -28,14 +28,14 @@ size_t agcom_dispatch(char * command, char ** output){
         // getconfig section
         if (!rcv_args){
             mdebug1("AGCOM getconfig needs arguments.");
-            *output = strdup("err AGCOM getconfig needs arguments");
+            os_strdup("err AGCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return agcom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("AGCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -94,6 +94,6 @@ size_t agcom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At AGCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -28,14 +28,14 @@ size_t lccom_dispatch(char * command, char ** output){
         // getconfig section
         if (!rcv_args){
             mdebug1("LCCOM getconfig needs arguments.");
-            *output = strdup("err LCCOM getconfig needs arguments");
+            os_strdup("err LCCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return lccom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("LCCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -47,7 +47,7 @@ size_t lccom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "localfile") == 0){
         if (cfg = getLocalfileConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -58,7 +58,7 @@ size_t lccom_getconfig(const char * section, char ** output) {
         }
     } else if (strcmp(section, "socket") == 0){
         if (cfg = getSocketConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -69,7 +69,7 @@ size_t lccom_getconfig(const char * section, char ** output) {
         }
     } else if (strcmp(section, "internal") == 0){
         if (cfg = getLogcollectorInternalOptions(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -83,7 +83,7 @@ size_t lccom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At LCCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 

--- a/src/monitord/moncom.c
+++ b/src/monitord/moncom.c
@@ -27,14 +27,14 @@ size_t moncom_dispatch(char * command, char ** output) {
         // getconfig section
         if (!rcv_args){
             mdebug1("MONCOM getconfig needs arguments.");
-            *output = strdup("err MONCOM getconfig needs arguments");
+            os_strdup("err MONCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return moncom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("MONCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -46,7 +46,7 @@ size_t moncom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "internal") == 0){
         if (cfg = getMonitorInternalOptions(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -58,7 +58,7 @@ size_t moncom_getconfig(const char * section, char ** output) {
     }
     else if (strcmp(section, "reports") == 0){
         if (cfg = getReportsOptions(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -72,7 +72,7 @@ size_t moncom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At MONCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 

--- a/src/os_auth/authcom.c
+++ b/src/os_auth/authcom.c
@@ -27,14 +27,14 @@ size_t authcom_dispatch(const char * command, char ** output){
         // getconfig section
         if (!rcv_args){
             mdebug1("AUTHCOM getconfig needs arguments.");
-            *output = strdup("err AUTHCOM getconfig needs arguments");
+            os_strdup("err AUTHCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return authcom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("AUTHCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -60,6 +60,6 @@ size_t authcom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At AUTHCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }

--- a/src/os_csyslogd/csyscom.c
+++ b/src/os_csyslogd/csyscom.c
@@ -27,14 +27,14 @@ size_t csyscom_dispatch(const char * command, char ** output){
         // getconfig section
         if (!rcv_args){
             mdebug1("CSYSCOM getconfig needs arguments.");
-            *output = strdup("err CSYSCOM getconfig needs arguments");
+            os_strdup("err CSYSCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return csyscom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("CSYSCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -46,7 +46,7 @@ size_t csyscom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "csyslog") == 0){
         if (cfg = getCsyslogConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -60,7 +60,7 @@ size_t csyscom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At CSYSCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 

--- a/src/os_integrator/intgcom.c
+++ b/src/os_integrator/intgcom.c
@@ -27,14 +27,14 @@ size_t intgcom_dispatch(char * command, char ** output) {
         // getconfig section
         if (!rcv_args){
             mdebug1("INTGCOM getconfig needs arguments.");
-            *output = strdup("err INTGCOM getconfig needs arguments");
+            os_strdup("err INTGCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return intgcom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("INTGCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -46,7 +46,7 @@ size_t intgcom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "integration") == 0){
         if (cfg = getIntegratorConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -60,7 +60,7 @@ size_t intgcom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At INTGCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 

--- a/src/os_maild/mailcom.c
+++ b/src/os_maild/mailcom.c
@@ -27,14 +27,14 @@ size_t mailcom_dispatch(char * command, char ** output) {
         // getconfig section
         if (!rcv_args){
             mdebug1("MAILCOM getconfig needs arguments.");
-            *output = strdup("err MAILCOM getconfig needs arguments");
+            os_strdup("err MAILCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return mailcom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("MAILCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -46,7 +46,7 @@ size_t mailcom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "global") == 0){
         if (cfg = getMailConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -57,7 +57,7 @@ size_t mailcom_getconfig(const char * section, char ** output) {
         }
     } else if (strcmp(section, "alerts") == 0){
         if (cfg = getMailAlertsConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -68,7 +68,7 @@ size_t mailcom_getconfig(const char * section, char ** output) {
         }
     } else if (strcmp(section, "internal") == 0){
         if (cfg = getMailInternalOptions(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -83,7 +83,7 @@ size_t mailcom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At MAILCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -49,7 +49,15 @@ static int _xml_fgetc(FILE *fp, OS_XML *_lxml)
 int _xml_sgetc(OS_XML *_lxml){
     int c;
 
-    c = (_lxml->stash_i > 0) ? _lxml->stash[--_lxml->stash_i] : *(_lxml->string++);
+    if (_lxml->stash_i > 0) {
+        c = _lxml->stash[--_lxml->stash_i];
+    }
+    else if (_lxml->string) {
+        c = *(_lxml->string++);
+    }
+    else {
+        c = -1;
+    }
 
     if (c == '\n') { /* add newline */
         _lxml->line++;

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -442,6 +442,6 @@ size_t rem_getconfig(const char * section, char ** output) {
     }
 error:
     merror("At request getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }

--- a/src/syscheckd/syscom.c
+++ b/src/syscheckd/syscom.c
@@ -29,14 +29,14 @@ size_t syscom_dispatch(char * command, char ** output){
         // getconfig section
         if (!rcv_args){
             mdebug1(FIM_SYSCOM_ARGUMENTS);
-            *output = strdup("err SYSCOM getconfig needs arguments");
+            os_strdup("err SYSCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return syscom_getconfig(rcv_args, output);
 
     } else {
         mdebug1(FIM_SYSCOM_UNRECOGNIZED_COMMAND, rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -48,7 +48,7 @@ size_t syscom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "syscheck") == 0){
         if (cfg = getSyscheckConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -59,7 +59,7 @@ size_t syscom_getconfig(const char * section, char ** output) {
         }
     } else if (strcmp(section, "rootcheck") == 0){
         if (cfg = getRootcheckConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -70,7 +70,7 @@ size_t syscom_getconfig(const char * section, char ** output) {
         }
     } else if (strcmp(section, "internal") == 0){
         if (cfg = getSyscheckInternalOptions(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -84,7 +84,7 @@ size_t syscom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1(FIM_SYSCOM_FAIL_GETCONFIG, section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4780,7 +4780,7 @@ char *wm_vuldet_cpe_str(cpe *cpe_s) {
     os_calloc(OS_SIZE_256 + 1, sizeof(char), generated_cpe);
 
     snprintf(generated_cpe, OS_SIZE_256, "%c:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
-        cpe_s->part ? *cpe_s->part : "",
+        cpe_s->part ? *cpe_s->part : ' ',
         cpe_s->vendor,
         cpe_s->product,
         cpe_s->version ? cpe_s->version : "",

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4780,7 +4780,7 @@ char *wm_vuldet_cpe_str(cpe *cpe_s) {
     os_calloc(OS_SIZE_256 + 1, sizeof(char), generated_cpe);
 
     snprintf(generated_cpe, OS_SIZE_256, "%c:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
-        *cpe_s->part,
+        cpe_s->part ? *cpe_s->part : "",
         cpe_s->vendor,
         cpe_s->product,
         cpe_s->version ? cpe_s->version : "",

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2016,7 +2016,7 @@ static int wm_sca_check_dir(const char * const dir, const char * const file, cha
 
         if (S_ISDIR(statbuf_local.st_mode)) {
             result = wm_sca_check_dir(f_name, file, pattern, reason);
-        } else if (((strncasecmp(file, "r:", 2) == 0) && OS_Regex(file + 2, entry->d_name))
+        } else if (((file && strncasecmp(file, "r:", 2) == 0) && OS_Regex(file + 2, entry->d_name))
                 || OS_Match2(file, entry->d_name))
         {
             result = wm_sca_check_file_list(f_name, pattern, reason);

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -27,14 +27,14 @@ size_t wmcom_dispatch(char * command, char ** output){
         // getconfig section
         if (!rcv_args){
             mdebug1("WMCOM getconfig needs arguments.");
-            *output = strdup("err WMCOM getconfig needs arguments");
+            os_strdup("err WMCOM getconfig needs arguments", *output);
             return strlen(*output);
         }
         return wmcom_getconfig(rcv_args, output);
 
     } else {
         mdebug1("WMCOM Unrecognized command '%s'.", rcv_comm);
-        *output = strdup("err Unrecognized command");
+        os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
 }
@@ -46,7 +46,7 @@ size_t wmcom_getconfig(const char * section, char ** output) {
 
     if (strcmp(section, "wmodules") == 0){
         if (cfg = getModulesConfig(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -57,7 +57,7 @@ size_t wmcom_getconfig(const char * section, char ** output) {
         }
     } else if (strcmp(section, "internal_options") == 0){
         if (cfg = getModulesInternalOptions(), cfg) {
-            *output = strdup("ok");
+            os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
             free(json_str);
@@ -71,7 +71,7 @@ size_t wmcom_getconfig(const char * section, char ** output) {
     }
 error:
     mdebug1("At WMCOM getconfig: Could not get '%s' section", section);
-    *output = strdup("err Could not get requested section");
+    os_strdup("err Could not get requested section", *output);
     return strlen(*output);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|[4179](https://github.com/wazuh/wazuh/issues/4179)|

## Description

Fix bug reported by Scan-build in CentOS 7. These bugs are:

1. Doesn't check if the variable is null in vulnerability detector
2. Allocate memory for `void *` when variable type is `void *(*)(struct _Eventinfo *, char *, const char *)`
3. Use `strdup` instead of `os_strdup`
4. Doesn't check if the variable is null in `os_xml.c`

## Test
- [x] Scan-build in CentOS 7 (clang version 3.4.2, and gcc versión 4.8.5)
- [x] Scan-build in Ubuntu 19.04 (clang version 8.0.0-3  and gcc version 8.3.0)
- [x] Eventchannel alerts generated
- [x] Wazuh manager installation and execution
- [x] Wazuh agent installation and execution