### PR TITLE
Display a warning message when registering to manager without -v option

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -366,6 +366,9 @@ int main(int argc, char **argv)
             exit(1);
         }
     }
+    else {
+        mwarn("Registering agent to unverified manager.");
+    }
 
     minfo("Using agent name as: %s", agentname);
 


### PR DESCRIPTION
|Related issue|
|---|
|#4190|

Regarding the registration method with manager verification, when the agent runs without the -v option, a warning message will be displayed.

In this way, the connection will be stablished but the agent will display a log message indicating that the connection may be insecure.

This solution was agreed with @elwali10 regarding the issue #4164.