### PR TITLE
Add 'mitre' field for rules

### DIFF
--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -516,6 +516,11 @@ functions = {
         'type': 'local_any',
         'is_async': False
     },
+    '/rules/mitre': {
+        'function': Rule.get_mitre,
+        'type': 'local_any',
+        'is_async': False
+    },
     '/rules/files': {
         'function': Rule.get_rules_files,
         'type': 'local_any',

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -260,7 +260,7 @@ class Rule:
         :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
         :param search: Looks for items with the specified string.
         :param filters: Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}.
-            This filter is used for filtering by 'status', 'group', 'pci', 'gpg13', 'gdpr', 'hipaa', 'nist_800_53',
+            This filter is used for filtering by 'status', 'group', 'pci', 'gpg13', 'gdpr', 'hipaa', 'nist-800-53',
             'mitre', 'file', 'path', 'id' and 'level'.
         :param q: Defines query to filter.
 
@@ -273,7 +273,7 @@ class Rule:
         gpg13 = filters.get('gpg13', None)
         gdpr = filters.get('gdpr', None)
         hipaa = filters.get('hipaa', None)
-        nist_800_53 = filters.get('nist_800_53', None)
+        nist_800_53 = filters.get('nist-800-53', None)
         mitre = filters.get('mitre', None)
         path = filters.get('path', None)
         file_ = filters.get('file', None)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -35,6 +35,7 @@ class Rule:
         self.gdpr = []
         self.hipaa = []
         self.nist_800_53 = []
+        self.mitre = []
         self.details = {}
 
     def __str__(self):
@@ -67,7 +68,8 @@ class Rule:
     def to_dict(self):
         return {'file': self.file, 'path': self.path, 'id': self.id, 'description': self.description,
                 'level': self.level, 'status': self.status, 'groups': self.groups, 'pci': self.pci, 'gdpr': self.gdpr,
-                'hipaa': self.hipaa, 'nist-800-53': self.nist_800_53, 'gpg13': self.gpg13, 'details': self.details}
+                'hipaa': self.hipaa, 'nist-800-53': self.nist_800_53, 'gpg13': self.gpg13, 'mitre': self.mitre,
+                'details': self.details}
 
 
     def set_group(self, group):
@@ -114,6 +116,13 @@ class Rule:
         :param nist_800_53: Requirement to add (string or list).
         """
         Rule.__add_unique_element(self.nist_800_53, nist_800_53)
+
+    def set_mitre(self, mitre):
+        """
+        Adds a mitre requirement to the mitre list.
+        :param mitre: Requirement to add (string or list).
+        """
+        Rule.__add_unique_element(self.mitre, mitre)
 
     def add_detail(self, detail, value):
         """
@@ -251,8 +260,8 @@ class Rule:
         :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
         :param search: Looks for items with the specified string.
         :param filters: Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}.
-            This filter is used for filtering by 'status', 'group', 'pci', 'gpg13', 'gdpr', 'hipaa', 'nist-800-53',
-            'file', 'path', 'id' and 'level'.
+            This filter is used for filtering by 'status', 'group', 'pci', 'gpg13', 'gdpr', 'hipaa', 'nist_800_53',
+            'mitre', 'file', 'path', 'id' and 'level'.
         :param q: Defines query to filter.
 
         :return: Dictionary: {'items': array of items, 'totalItems': Number of items (without applying the limit)}
@@ -264,7 +273,8 @@ class Rule:
         gpg13 = filters.get('gpg13', None)
         gdpr = filters.get('gdpr', None)
         hipaa = filters.get('hipaa', None)
-        nist_800_53 = filters.get('nist-800-53', None)
+        nist_800_53 = filters.get('nist_800_53', None)
+        mitre = filters.get('mitre', None)
         path = filters.get('path', None)
         file_ = filters.get('file', None)
         id_ = filters.get('id', None)
@@ -300,6 +310,9 @@ class Rule:
             elif nist_800_53 and nist_800_53 not in r.nist_800_53:
                 rules.remove(r)
                 continue
+            elif mitre and mitre not in r.mitre:
+                rules.remove(r)
+                continue
             elif path and path != r.path:
                 rules.remove(r)
                 continue
@@ -315,8 +328,8 @@ class Rule:
                         rules.remove(r)
                         continue
                 elif not (int(levels[0]) <= r.level <= int(levels[1])):
-                        rules.remove(r)
-                        continue
+                    rules.remove(r)
+                    continue
 
         if search:
             rules = search_array(rules, search['value'], search['negation'])
@@ -371,7 +384,7 @@ class Rule:
         :param requirement: requirement to get (pci, gpg13 or dgpr)
         :return: Dictionary: {'items': array of items, 'totalItems': Number of items (without applying the limit)}
         """
-        valid_requirements = ['pci', 'gdpr', 'gpg13', 'hipaa', 'nist-800-53']
+        valid_requirements = ['pci', 'gdpr', 'gpg13', 'hipaa', 'nist-800-53', 'mitre']
 
         if requirement not in valid_requirements:
             raise WazuhException(1205, requirement)
@@ -455,6 +468,19 @@ class Rule:
         return Rule._get_requirement('nist-800-53', offset=offset, limit=limit, sort=sort, search=search)
 
     @staticmethod
+    def get_mitre(offset=0, limit=common.database_limit, sort=None, search=None):
+        """
+        Get all the Mitre requirements used in the rules.
+
+        :param offset: First item to return.
+        :param limit: Maximum number of items to return.
+        :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
+        :param search: Looks for items with the specified string.
+        :return: Dictionary: {'items': array of items, 'totalItems': Number of items (without applying the limit)}
+        """
+        return Rule._get_requirement('mitre', offset=offset, limit=limit, sort=sort, search=search)
+
+    @staticmethod
     def __load_rules_from_file(rule_file, rule_path, rule_status):
         try:
             rules = []
@@ -468,6 +494,7 @@ class Rule:
                         # New rule
                         if xml_rule.tag.lower() == "rule":
                             groups = []
+                            mitre = []
                             rule = Rule()
                             rule.file = rule_file
                             rule.path = rule_path
@@ -486,6 +513,9 @@ class Rule:
                                     value = ''
                                 if tag == "group":
                                     groups.extend(value.split(","))
+                                if tag == "mitre":
+                                    for mitre_attack in xml_rule_tags.getchildren():
+                                        mitre.append(mitre_attack.text)
                                 elif tag == "description":
                                     rule.description += value
                                 elif tag == "field":
@@ -501,6 +531,9 @@ class Rule:
                                         rule.add_detail(tag, variable.text)
                                 else:
                                     rule.add_detail(tag, value)
+
+                            # set mitre
+                            rule.set_mitre(mitre)
 
                             # Set groups
                             groups.extend(general_groups)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -514,7 +514,7 @@ class Rule:
                                 if tag == "group":
                                     groups.extend(value.split(","))
                                 if tag == "mitre":
-                                    for mitre_attack in xml_rule_tags.getchildren():
+                                    for mitre_attack in list(xml_rule_tags):
                                         mitre.append(mitre_attack.text)
                                 elif tag == "description":
                                     rule.description += value

--- a/framework/wazuh/tests/test_rules.py
+++ b/framework/wazuh/tests/test_rules.py
@@ -33,6 +33,10 @@ rule_contents = '''
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3</group>
     <list field="user" lookup="match_key">etc/lists/list-user</list>
     <field name="netinfo.iface.name">ens33</field>
+    <mitre>
+      <id>T1210</id>
+      <id>T1021</id>
+    </mitre>
     <regex>$(\\d+.\\d+.\\d+.\\d+)</regex>
   </rule>
 </group>
@@ -64,6 +68,7 @@ def test_rule__init__():
     assert isinstance(rule.gdpr, list)
     assert isinstance(rule.hipaa, list)
     assert isinstance(rule.nist_800_53, list)
+    assert isinstance(rule.mitre, list)
     assert isinstance(rule.details, dict)
 
 
@@ -135,6 +140,10 @@ def test_set_hippa():
 
 def test_nist_800_53():
     Rule().set_nist_800_53('test')
+
+
+def test_mitre():
+    Rule().set_mitre('test')
 
 
 @pytest.mark.parametrize('detail, value, details', [
@@ -346,7 +355,9 @@ def test_failed_get_rules_file(mock_config):
     {'filters': {'nist_800_53': 'AU.1'}},
     {'filters': {'id': '510'}},
     {'filters': {'level': '2'}},
-    {'filters':{'level': '2-2'}}
+    {'filters': {'level': '2-2'}},
+    {'filters': {'mitre': 'T1210'}},
+    {'filters': {'mitre': 'T1021'}}
 ])
 @patch('wazuh.rule.glob', side_effect=rules_files)
 @patch('wazuh.configuration.get_ossec_conf', return_value=other_rule_ossec_conf)
@@ -432,6 +443,16 @@ def test_get_nist_800_53(mocked_config, mocked_glob):
         assert 'AU.3' in result['items'][0]
 
 
+@patch('wazuh.rule.glob', side_effect=rules_files)
+@patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)
+def test_get_mitre(mocked_config, mocked_glob):
+    m = mock_open(read_data=rule_contents)
+    with patch('builtins.open', m):
+        result = Rule.get_mitre()
+        assert isinstance(result, dict)
+        assert 'T1021' in result['items'][0]
+
+
 @pytest.mark.parametrize('sort', [
     None,
     {
@@ -451,7 +472,8 @@ def test_get_nist_800_53(mocked_config, mocked_glob):
     'gpg13',
     'wrong',
     'hipaa',
-    'nist-800-53'
+    'nist-800-53',
+    'mitre'
 ])
 @patch('wazuh.rule.glob', side_effect=rules_files)
 @patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)


### PR DESCRIPTION
Hi team,

This PR closes #4212 and it gives support for filtering by `mitre` attack IDs.

## Test performed

### Unit tests

```python
% python3 -m pytest test_rules.py -vv
============================================================================ test session starts ============================================================================
platform linux -- Python 3.7.5, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/druizz/Git/wazuh/framework, inifile:
plugins: tavern-0.26.3
collected 112 items                                                                                                                                                         

test_rules.py::test_rule__init__ PASSED                                                                                                                               [  0%]
test_rules.py::test_rule__str__ PASSED                                                                                                                                [  1%]
test_rules.py::test_rule__compare__ PASSED                                                                                                                            [  2%]
test_rules.py::test_failed_rule__compare__ PASSED                                                                                                                     [  3%]
test_rules.py::test_rule_to_dict PASSED                                                                                                                               [  4%]
test_rules.py::test_set_group PASSED                                                                                                                                  [  5%]
test_rules.py::test_set_pci PASSED                                                                                                                                    [  6%]
test_rules.py::test_set_gpg13 PASSED                                                                                                                                  [  7%]
test_rules.py::test_set_gdpr PASSED                                                                                                                                   [  8%]
test_rules.py::test_set_hippa PASSED                                                                                                                                  [  8%]
test_rules.py::test_nist_800_53 PASSED                                                                                                                                [  9%]
test_rules.py::test_mitre PASSED                                                                                                                                      [ 10%]
test_rules.py::test_add_details[if_sid-400-details0] PASSED                                                                                                           [ 11%]
test_rules.py::test_add_details[if_sid-400-details1] PASSED                                                                                                           [ 12%]
test_rules.py::test_get_rules_file_status_include[None-get_rules_files] PASSED                                                                                        [ 13%]
test_rules.py::test_get_rules_file_status_include[None-get_rules] PASSED                                                                                              [ 14%]
test_rules.py::test_get_rules_file_status_include[all-get_rules_files] PASSED                                                                                         [ 15%]
test_rules.py::test_get_rules_file_status_include[all-get_rules] PASSED                                                                                               [ 16%]
test_rules.py::test_get_rules_file_status_include[enabled-get_rules_files] PASSED                                                                                     [ 16%]
test_rules.py::test_get_rules_file_status_include[enabled-get_rules] PASSED                                                                                           [ 17%]
test_rules.py::test_get_rules_file_status_include[disabled-get_rules_files] PASSED                                                                                    [ 18%]
test_rules.py::test_get_rules_file_status_include[disabled-get_rules] PASSED                                                                                          [ 19%]
test_rules.py::test_get_rules_file_status_include[random-get_rules_files] PASSED                                                                                      [ 20%]
test_rules.py::test_get_rules_file_status_include[random-get_rules] PASSED                                                                                            [ 21%]
test_rules.py::test_get_rules_file_path[None-get_rules_files] PASSED                                                                                                  [ 22%]
test_rules.py::test_get_rules_file_path[None-get_rules] PASSED                                                                                                        [ 23%]
test_rules.py::test_get_rules_file_path[ruleset/rules-get_rules_files] PASSED                                                                                         [ 24%]
test_rules.py::test_get_rules_file_path[ruleset/rules-get_rules] PASSED                                                                                               [ 25%]
test_rules.py::test_get_rules_file_path[random-get_rules_files] PASSED                                                                                                [ 25%]
test_rules.py::test_get_rules_file_path[random-get_rules] PASSED                                                                                                      [ 26%]
test_rules.py::test_get_rules_file_file_param[rules0.xml-get_rules_files] PASSED                                                                                      [ 27%]
test_rules.py::test_get_rules_file_file_param[rules0.xml-get_rules] PASSED                                                                                            [ 28%]
test_rules.py::test_get_rules_file_file_param[rules1.xml-get_rules_files] PASSED                                                                                      [ 29%]
test_rules.py::test_get_rules_file_file_param[rules1.xml-get_rules] PASSED                                                                                            [ 30%]
test_rules.py::test_get_rules_file_file_param[rules2.xml-get_rules_files] PASSED                                                                                      [ 31%]
test_rules.py::test_get_rules_file_file_param[rules2.xml-get_rules] PASSED                                                                                            [ 32%]
test_rules.py::test_get_rules_file_pagination[0-0-get_rules_files] PASSED                                                                                             [ 33%]
test_rules.py::test_get_rules_file_pagination[0-0-get_rules] PASSED                                                                                                   [ 33%]
test_rules.py::test_get_rules_file_pagination[0-1-get_rules_files] PASSED                                                                                             [ 34%]
test_rules.py::test_get_rules_file_pagination[0-1-get_rules] PASSED                                                                                                   [ 35%]
test_rules.py::test_get_rules_file_pagination[0-500-get_rules_files] PASSED                                                                                           [ 36%]
test_rules.py::test_get_rules_file_pagination[0-500-get_rules] PASSED                                                                                                 [ 37%]
test_rules.py::test_get_rules_file_pagination[1-500-get_rules_files] PASSED                                                                                           [ 38%]
test_rules.py::test_get_rules_file_pagination[1-500-get_rules] PASSED                                                                                                 [ 39%]
test_rules.py::test_get_rules_file_pagination[2-500-get_rules_files] PASSED                                                                                           [ 40%]
test_rules.py::test_get_rules_file_pagination[2-500-get_rules] PASSED                                                                                                 [ 41%]
test_rules.py::test_get_rules_file_pagination[3-500-get_rules_files] PASSED                                                                                           [ 41%]
test_rules.py::test_get_rules_file_pagination[3-500-get_rules] PASSED                                                                                                 [ 42%]
test_rules.py::test_get_rules_file_sort[None-get_rules_files] PASSED                                                                                                  [ 43%]
test_rules.py::test_get_rules_file_sort[None-get_rules] PASSED                                                                                                        [ 44%]
test_rules.py::test_get_rules_file_sort[sort1-get_rules_files] PASSED                                                                                                 [ 45%]
test_rules.py::test_get_rules_file_sort[sort1-get_rules] PASSED                                                                                                       [ 46%]
test_rules.py::test_get_rules_file_sort[sort2-get_rules_files] PASSED                                                                                                 [ 47%]
test_rules.py::test_get_rules_file_sort[sort2-get_rules] PASSED                                                                                                       [ 48%]
test_rules.py::test_get_rules_file_search[None-get_rules_files] PASSED                                                                                                [ 49%]
test_rules.py::test_get_rules_file_search[None-get_rules] PASSED                                                                                                      [ 50%]
test_rules.py::test_get_rules_file_search[search1-get_rules_files] PASSED                                                                                             [ 50%]
test_rules.py::test_get_rules_file_search[search1-get_rules] PASSED                                                                                                   [ 51%]
test_rules.py::test_get_rules_file_search[search2-get_rules_files] PASSED                                                                                             [ 52%]
test_rules.py::test_get_rules_file_search[search2-get_rules] PASSED                                                                                                   [ 53%]
test_rules.py::test_failed_get_rules_file PASSED                                                                                                                      [ 54%]
test_rules.py::test_get_rules[arg0] PASSED                                                                                                                            [ 55%]
test_rules.py::test_get_rules[arg1] PASSED                                                                                                                            [ 56%]
test_rules.py::test_get_rules[arg2] PASSED                                                                                                                            [ 57%]
test_rules.py::test_get_rules[arg3] PASSED                                                                                                                            [ 58%]
test_rules.py::test_get_rules[arg4] PASSED                                                                                                                            [ 58%]
test_rules.py::test_get_rules[arg5] PASSED                                                                                                                            [ 59%]
test_rules.py::test_get_rules[arg6] PASSED                                                                                                                            [ 60%]
test_rules.py::test_get_rules[arg7] PASSED                                                                                                                            [ 61%]
test_rules.py::test_get_rules[arg8] PASSED                                                                                                                            [ 62%]
test_rules.py::test_get_rules[arg9] PASSED                                                                                                                            [ 63%]
test_rules.py::test_get_rules[arg10] PASSED                                                                                                                           [ 64%]
test_rules.py::test_failed_get_rules PASSED                                                                                                                           [ 65%]
test_rules.py::test_get_groups[arg0] PASSED                                                                                                                           [ 66%]
test_rules.py::test_get_groups[arg1] PASSED                                                                                                                           [ 66%]
test_rules.py::test_get_groups[arg2] PASSED                                                                                                                           [ 67%]
test_rules.py::test_get_groups[arg3] PASSED                                                                                                                           [ 68%]
test_rules.py::test_get_pci PASSED                                                                                                                                    [ 69%]
test_rules.py::test_get_gpg13 PASSED                                                                                                                                  [ 70%]
test_rules.py::test_get_gdpr PASSED                                                                                                                                   [ 71%]
test_rules.py::test_get_hipaa PASSED                                                                                                                                  [ 72%]
test_rules.py::test_get_nist_800_53 PASSED                                                                                                                            [ 73%]
test_rules.py::test_get_mitre PASSED                                                                                                                                  [ 74%]
test_rules.py::test_protected_get_requirement[pci-None-None] PASSED                                                                                                   [ 75%]
test_rules.py::test_protected_get_requirement[pci-None-sort1] PASSED                                                                                                  [ 75%]
test_rules.py::test_protected_get_requirement[pci-search1-None] PASSED                                                                                                [ 76%]
test_rules.py::test_protected_get_requirement[pci-search1-sort1] PASSED                                                                                               [ 77%]
test_rules.py::test_protected_get_requirement[gdpr-None-None] PASSED                                                                                                  [ 78%]
test_rules.py::test_protected_get_requirement[gdpr-None-sort1] PASSED                                                                                                 [ 79%]
test_rules.py::test_protected_get_requirement[gdpr-search1-None] PASSED                                                                                               [ 80%]
test_rules.py::test_protected_get_requirement[gdpr-search1-sort1] PASSED                                                                                              [ 81%]
test_rules.py::test_protected_get_requirement[gpg13-None-None] PASSED                                                                                                 [ 82%]
test_rules.py::test_protected_get_requirement[gpg13-None-sort1] PASSED                                                                                                [ 83%]
test_rules.py::test_protected_get_requirement[gpg13-search1-None] PASSED                                                                                              [ 83%]
test_rules.py::test_protected_get_requirement[gpg13-search1-sort1] PASSED                                                                                             [ 84%]
test_rules.py::test_protected_get_requirement[wrong-None-None] PASSED                                                                                                 [ 85%]
test_rules.py::test_protected_get_requirement[wrong-None-sort1] PASSED                                                                                                [ 86%]
test_rules.py::test_protected_get_requirement[wrong-search1-None] PASSED                                                                                              [ 87%]
test_rules.py::test_protected_get_requirement[wrong-search1-sort1] PASSED                                                                                             [ 88%]
test_rules.py::test_protected_get_requirement[hipaa-None-None] PASSED                                                                                                 [ 89%]
test_rules.py::test_protected_get_requirement[hipaa-None-sort1] PASSED                                                                                                [ 90%]
test_rules.py::test_protected_get_requirement[hipaa-search1-None] PASSED                                                                                              [ 91%]
test_rules.py::test_protected_get_requirement[hipaa-search1-sort1] PASSED                                                                                             [ 91%]
test_rules.py::test_protected_get_requirement[nist-800-53-None-None] PASSED                                                                                           [ 92%]
test_rules.py::test_protected_get_requirement[nist-800-53-None-sort1] PASSED                                                                                          [ 93%]
test_rules.py::test_protected_get_requirement[nist-800-53-search1-None] PASSED                                                                                        [ 94%]
test_rules.py::test_protected_get_requirement[nist-800-53-search1-sort1] PASSED                                                                                       [ 95%]
test_rules.py::test_protected_get_requirement[mitre-None-None] PASSED                                                                                                 [ 96%]
test_rules.py::test_protected_get_requirement[mitre-None-sort1] PASSED                                                                                                [ 97%]
test_rules.py::test_protected_get_requirement[mitre-search1-None] PASSED                                                                                              [ 98%]
test_rules.py::test_protected_get_requirement[mitre-search1-sort1] PASSED                                                                                             [ 99%]
test_rules.py::test_failed_load_rules_from_file PASSED                                                                                                                [100%]

======================================================================== 112 passed in 0.97 seconds =========================================================================
```

### Mocha tests
```javascript
# mocha /wazuh-api/test/test_rules.js 


  Rules
    GET/rules
      ✓ Request (610ms)
      ✓ Pagination (568ms)
      ✓ Retrieve all elements with limit=0 (560ms)
      ✓ Sort (580ms)
      ✓ Search (705ms)
      ✓ Filters: Invalid filter (99ms)
      ✓ Filters: Invalid filter - Extra field (97ms)
      ✓ Filters: status (576ms)
      ✓ Filters: group (601ms)
      ✓ Filters: level (1) (574ms)
      ✓ Filters: level (2) (728ms)
      ✓ Filters: path (576ms)
      ✓ Filters: file (562ms)
      ✓ Filters: pci (674ms)
      ✓ Filters: gdpr (565ms)
      ✓ Filters: hipaa (816ms)
      ✓ Filters: nist-800-53 (565ms)
      ✓ Filters: gpg13 (569ms)
      ✓ Filters: mitre (590ms)
      ✓ Filters: query 1 (572ms)
      ✓ Filters: query 2 (601ms)
    GET/rules/groups
      ✓ Request (555ms)
      ✓ Pagination (620ms)
      ✓ Retrieve all elements with limit=0 (555ms)
      ✓ Sort (559ms)
      ✓ Search (558ms)
      ✓ Filters: Invalid filter (98ms)
    GET/rules/pci
      ✓ Request (564ms)
      ✓ Pagination (559ms)
      ✓ Retrieve all elements with limit=0 (565ms)
      ✓ Sort (571ms)
      ✓ Search (561ms)
      ✓ Filters: Invalid filter (98ms)
    GET/rules/gdpr
      ✓ Request (569ms)
      ✓ Pagination (564ms)
      ✓ Retrieve all elements with limit=0 (563ms)
      ✓ Sort (562ms)
      ✓ Search (569ms)
      ✓ Filters: Invalid filter (97ms)
    GET/rules/gpg13
      ✓ Request (650ms)
      ✓ Pagination (596ms)
      ✓ Retrieve all elements with limit=0 (562ms)
      ✓ Sort (575ms)
      ✓ Search (582ms)
      ✓ Filters: Invalid filter (99ms)
    GET/rules/hipaa
      ✓ Request (562ms)
      ✓ Pagination (563ms)
      ✓ Retrieve all elements with limit=0 (564ms)
      ✓ Sort (578ms)
      ✓ Search (567ms)
      ✓ Filters: Invalid filter (97ms)
    GET/rules/nist-800-53
      ✓ Request (571ms)
      ✓ Pagination (558ms)
      ✓ Retrieve all elements with limit=0 (565ms)
      ✓ Sort (562ms)
      ✓ Search (564ms)
      ✓ Filters: Invalid filter (98ms)
    GET/rules/mitre
      ✓ Request (563ms)
      ✓ Pagination (558ms)
      ✓ Retrieve all elements with limit=0 (565ms)
      ✓ Sort (564ms)
      ✓ Search (561ms)
      ✓ Filters: Invalid filter (98ms)
    GET/rules/files
      ✓ Request (401ms)
      ✓ Pagination (387ms)
      ✓ Retrieve all elements with limit=0 (393ms)
      ✓ Sort (402ms)
      ✓ Search (403ms)
      ✓ Filters: Invalid filter (99ms)
      ✓ Filters: Invalid filter - Extra field (98ms)
      ✓ Filters: status (410ms)
      ✓ Filters: download (406ms)
    GET/rules/:rule_id
      ✓ Request (584ms)
      ✓ Pagination (554ms)
      ✓ Retrieve all elements with limit=0 (646ms)
      ✓ Sort (574ms)
      ✓ Search (614ms)
      ✓ Filters: Invalid filter (100ms)
      ✓ Params: Bad rule id (98ms)
      ✓ Params: No rule (574ms)


  80 passing (39s)
```

Best regards,

Demetrio.