### PR TITLE
Let Logcollector queue file rotation and keepalive messages

### DIFF
--- a/src/headers/wait_op.h
+++ b/src/headers/wait_op.h
@@ -15,4 +15,12 @@ void os_setwait(void);
 void os_delwait(void);
 void os_wait(void);
 
+/**
+ * @brief Check whether the agent wait mark is on (manager is disconnected)
+ *
+ * @retval true The agent is blocked.
+ * @retval false The agent is not blocked.
+ */
+bool os_iswait();
+
 #endif /* WAIT_OP_H */

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -47,6 +47,7 @@ static int _cday = 0;
 int N_INPUT_THREADS = N_MIN_INPUT_THREADS;
 int OUTPUT_QUEUE_SIZE = OUTPUT_MIN_QUEUE_SIZE;
 logsocket default_agent = { .name = "agent" };
+logtarget default_target[2] = { { .log_socket = &default_agent } };
 
 /* Output thread variables */
 static pthread_mutex_t mutex;
@@ -558,8 +559,7 @@ void LogCollectorStart()
                                  current->file);
 
                         /* Send message about log rotated */
-                        SendMSG(logr_queue, msg_alert,
-                                "ossec-logcollector", LOCALFILE_MQ);
+                        w_msg_hash_queues_push(msg_alert, "ossec-logcollector", strlen(msg_alert) + 1, default_target, LOCALFILE_MQ);
 
                         mdebug1("File inode changed. %s",
                                current->file);
@@ -589,8 +589,7 @@ void LogCollectorStart()
                                  current->file);
 
                         /* Send message about log rotated */
-                        SendMSG(logr_queue, msg_alert,
-                                "ossec-logcollector", LOCALFILE_MQ);
+                        w_msg_hash_queues_push(msg_alert, "ossec-logcollector", strlen(msg_alert) + 1, default_target, LOCALFILE_MQ);
 
                         mdebug1("File size reduced. %s",
                                 current->file);
@@ -738,8 +737,11 @@ void LogCollectorStart()
             f_check = 0;
         }
 
-        rand_keepalive_str(keepalive, KEEPALIVE_SIZE);
-        SendMSG(logr_queue, keepalive, "ossec-keepalive", LOCALFILE_MQ);
+        if (!os_iswait()) {
+            rand_keepalive_str(keepalive, KEEPALIVE_SIZE);
+            w_msg_hash_queues_push(keepalive, "ossec-keepalive", strlen(keepalive) + 1, default_target, LOCALFILE_MQ);
+        }
+
         sleep(1);
 
         f_check++;

--- a/src/shared/wait_op.c
+++ b/src/shared/wait_op.c
@@ -146,3 +146,14 @@ void os_wait()
 }
 
 #endif /* !WIN32 */
+
+// Check whether the agent wait mark is on (manager is disconnected)
+
+bool os_iswait() {
+#ifndef WIN32
+    return IsFile(isChroot() ? WAIT_FILE : WAIT_FILE_PATH) == 0;
+#else
+    return __wait_lock;
+#endif
+
+}


### PR DESCRIPTION
Logcollector runs a thread per each configured output: default agent output, and external sockets.

The agent output thread may get blocked if the agent loses the connection with the manager. This is the expectable behavior.

However, the file check thread will also block when trying to send a keepalive or a file truncation message. In the latter case, this will also prevent input threads from reading logs since the internal mutex remains blocked.

## Fix

This PR aims to get rid of this problem, simply queuing the logs mentioned into the agent's output queue, like any other log.

## Logs/Alerts example

In this case, we configured Logcollector to report a log file to another application: Fluentd.

```xml
<ossec_config>
  <socket>
    <name>fluent</name>
    <location>/var/run/fluent.sock</location>
    <mode>udp</mode>
  </socket>

  <localfile>
    <location>/root/demo.log</location>
    <log_format>syslog</log_format>
    <target>fluent</target>
  </localfile>

  <fluent-forward>
    <enabled>yes</enabled>
    <tag>demo</tag>
    <socket_path>/var/run/fluent.sock</socket_path>
    <address>192.168.33.10</address>
    <port>24224</port>
    <shared_key>secret_string</shared_key>
    <user>foo</user>
    <password>bar</password>
    <timeout>60</timeout>
  </fluent-forward>

</ossec_config>
```

This is a sample log:

```
2019/11/11 17:16:49 ossec-logcollector[15438] logcollector.c:348 at LogCollectorStart(): DEBUG: Performing file check.
2019/11/11 17:16:49 ossec-logcollector[15438] wait_op.c:117 at os_wait(): WARNING: Process locked due to agent is offline. Waiting for connection...
2019/11/11 17:17:49 ossec-logcollector[15438] wait_op.c:138 at os_wait(): INFO: Agent is now online. Process unlocked, continuing...
2019/11/11 17:17:53 ossec-logcollector[15438] logcollector.c:348 at LogCollectorStart(): DEBUG: Performing file check.
2019/11/11 17:17:53 ossec-logcollector[15438] logcollector.c:565 at LogCollectorStart(): DEBUG: File inode changed. /root/demo.log
2019/11/11 17:17:57 ossec-logcollector[15438] logcollector.c:348 at LogCollectorStart(): DEBUG: Performing file check.
```

This log proves that Logcollector still performs file check event when the agent is disconnected. The external receiver (Fluentd) was receiving logs.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [x] Windows
  - [x] MAC OS X
- [X] Source installation
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)


