### PR TITLE
Fix for the distributed call /agents/groups/:group/restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - Fix `previous_output` count for alerts when matching by group. ([#4097](https://github.com/wazuh/wazuh/pull/4097))
 - Fix event iteration when evaluating contextual rules. ([#4106](https://github.com/wazuh/wazuh/pull/4106))
 - Fix the use of `prefilter_cmd` remotely by a new local option `allow_remote_prefilter_cmd`. ([#4178](https://github.com/wazuh/wazuh/pull/4178) & [4194](https://github.com/wazuh/wazuh/pull/4194))
+- Fix restarting agents by group using the API when some of them are in a worker node. ([#4226](https://github.com/wazuh/wazuh/pull/4226))
 
 
 ## [v3.10.2] - 2019-09-23

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -865,21 +865,6 @@ class Agent:
             return final_dict
 
     @staticmethod
-    def restart_agents_by_group(group_id: str) -> Dict:
-        """Restart all the agents which belong to a group.
-
-        :param group_id: Name of the group
-        :return: Confirmation message
-        """
-        # list with agent IDs to restart. Contains key-value pairs.
-        agent_list = Agent.get_agent_group(group_id=group_id,
-                                           select={'fields': ['id']}).get('items')
-        # format agent_list as a list with strings of agent IDs
-        agent_list = [elem.get('id') for elem in agent_list]
-
-        return Agent.restart_agents(agent_id=agent_list)
-
-    @staticmethod
     def get_agent_by_name(agent_name, select=None):
         """
         Gets an existing agent called agent_name.

--- a/framework/wazuh/cluster/dapi/requests_list.py
+++ b/framework/wazuh/cluster/dapi/requests_list.py
@@ -102,8 +102,8 @@ functions = {
         'is_async': False
     },
     'PUT/agents/groups/:group_id/restart': {
-        'function': Agent.restart_agents_by_group,
-        'type': 'local_master',
+        'function': Agent.restart_agents,
+        'type': 'distributed_master',
         'is_async': False
     },
     'PUT/agents/:agent_name': {

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -150,6 +150,7 @@ class WazuhException(Exception):
         1747: "Could not remove agent group assigment from database",
         1748: "Could not remove agent files",
         1749: "Downgrading an agent requires the force flag. Use force=1 parameter the downgrade",
+        1750: 'The group does not exist or it is empty',
 
         # CDB List: 1800 - 1899
         1800: 'Bad format in CDB list {path}',


### PR DESCRIPTION
|Related issue|
|---|
|#4224|

Hi team,

This PR closes #4224. We fix the distributed call PUT /agents/groups/:group/restart. When an agent was in a worker node, the call failed and the agent was not restart.