### PR TITLE
Fixed logcollector to ignore existing lines of files when restarting

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2914,7 +2914,7 @@ int64_t w_ftell (FILE *x) {
 #ifndef WIN32
     int64_t z = ftell(x);
 #else
-    int64_t z = _ftelli64(x);
+    int64_t z = ftello64(x);
 #endif
 
     if (z < 0)  {


### PR DESCRIPTION
|Related issue|Related issue|
|---|---|
|#4030|#3546|

## Description

Logcollector should send only the lines that appear after the agent starts. However, it is sending the complete content of the files with each restart. 
To see more details, please, go to the related issues.

## Logs/Alerts example

Before this change, using `_ftelli64` function, files' content was reading after restarting the agent.
~~~
2019 Nov 15 09:21:13 (vela-b5e7a638c2) 10.0.0.1->\Test\mytest2.txt a
2019 Nov 15 09:21:13 (vela-b5e7a638c2) 10.0.0.1->\Test\mytest2.txt a
2019 Nov 15 09:21:13 (vela-b5e7a638c2) 10.0.0.1->\Test\mytest2.txt a
2019 Nov 15 09:21:13 (vela-b5e7a638c2) 10.0.0.1->\Test\mytest2.txt a
2019 Nov 15 09:21:13 (vela-b5e7a638c2) 10.0.0.1->\Test\mytest2.txt aa
2019 Nov 15 09:21:13 (vela-b5e7a638c2) 10.0.0.1->\Test\mytest2.txt a
2019 Nov 15 09:21:13 (vela-b5e7a638c2) 10.0.0.1->\Test\mytest2.txt a
~~~

It has been solved after this changes.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
-  Platform: Windows agent

- [x] Compilation without warnings
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Windows
  - [x] Scan-build report
~~~
Done building winagent

scan-build: Removing directory '/tmp/scan-build-2019-11-15-13-02-38-997405-p8qbNV' because it contains no report.
~~~
