### PR TITLE
Add sca condition field to new API spec and controller

### DIFF
--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -67,7 +67,8 @@ def get_sca_agent(agent_id=None, pretty=False, wait_for_complete=False, name=Non
 @exception_handler
 def get_sca_checks(agent_id=None, pretty=False, wait_for_complete=False, policy_id=None, title=None, description=None,
                    rationale=None, remediation=None, file=None, process=None, directory=None, registry=None,
-                   references=None, result=None, offset=0, limit=database_limit, sort=None, search=None, q=None):
+                   references=None, result=None, condition=None, offset=0, limit=database_limit, sort=None, search=None,
+                   q=None):
     """Get policy monitoring alerts for a given policy
 
     :param agent_id: Agent ID. All possible values since 000 onwards
@@ -84,6 +85,7 @@ def get_sca_checks(agent_id=None, pretty=False, wait_for_complete=False, policy_
     :param registry: Filters by registry
     :param references: Filters by references
     :param result: Filters by result
+    :param condition: Filters by condition
     :param offset:First element to return in the collection
     :param limit: Maximum number of elements to return
     :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
@@ -101,7 +103,8 @@ def get_sca_checks(agent_id=None, pretty=False, wait_for_complete=False, policy_
                'directory': directory,
                'registry': registry,
                'references': references,
-               'result': result}
+               'result': result,
+               'condition': condition}
 
     f_kwargs = {'policy_id': policy_id,
                 'agent_list': [agent_id],

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1816,7 +1816,13 @@ components:
         title:
           type: string
           description: A brief description of what is being checked.
-
+        condition:
+          type: string
+          description: Specifies how rule results are aggregated in order to calculate the final value of a check.
+          enum:
+            - all
+            - any
+            - none
     SCADatabase:
       type: object
       properties:
@@ -3119,6 +3125,12 @@ components:
       schema:
         type: string
         format: alphanumeric
+    condition:
+      in: query
+      name: condition
+      description: Filters by condition.
+      schema:
+        type: string
     role_id:
       in: path
       name: role_id
@@ -8608,6 +8620,7 @@ paths:
         - $ref: '#/components/parameters/registry'
         - $ref: '#/components/parameters/references'
         - $ref: '#/components/parameters/result'
+        - $ref: '#/components/parameters/condition'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -270,6 +270,7 @@ stages:
               result: !anystr
               compliance: !anything
               rules: !anything
+              condition: !anything
           failed_items: []
           total_failed_items: 0
 
@@ -709,6 +710,7 @@ stages:
               result: !anystr
               compliance: !anything
               rules: !anything
+              condition: !anything
           failed_items: []
           total_failed_items: 0
 
@@ -1148,6 +1150,7 @@ stages:
               result: !anystr
               compliance: !anything
               rules: !anything
+              condition: !anything
           failed_items: []
           total_failed_items: 0
 


### PR DESCRIPTION
|Related issue|
|---|
|#4107|

## Description

Hello team, this PR adds sca condition field to new API spec and controller filters.

## Tests

```
curl -X GET "http://localhost:55000/sca/000/checks/cis_debian9_L2?pretty=false&wait_for_complete=false&condition=any&offset=0&limit=1"

{
  "data": {
    "affected_items": [
      {
        "command": "dpkg -s selinux-basics,dpkg -s apparmor",
        "compliance": [
          {
            "key": "cis",
            "value": "1.6.3"
          }
        ],
        "condition": "any",
        "description": "SELinux and AppArmor provide Mandatory Access Controls.",
        "id": 3506,
        "policy_id": "cis_debian9_L2",
        "rationale": "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available.",
        "reason": "",
        "remediation": "Run one of the following commands to install SELinux or apparmor: # apt-get install selinux-basics Or: # apt-get install apparmor apparmor-profiles apparmor-utils",
        "result": "failed",
        "rules": [
          {
            "rule": "c:dpkg -s apparmor -> r:install ok installed",
            "type": "command"
          }
        ],
        "status": "",
        "title": "Ensure SELinux or AppArmor are installed"
      }
    ],
    "failed_items": [],
    "total_affected_items": 1,
    "total_failed_items": 0
  },
  "message": "All selected sca/policy information is shown"
}
```