### PR TITLE
Logtest - Allows ossec-logtest decodes SCA events

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.h
+++ b/src/analysisd/decoders/security_configuration_assessment.h
@@ -1,0 +1,72 @@
+/*
+* Copyright (C) 2015-2019, Wazuh Inc.
+* November, 2019.
+*
+* This program is free software; you can redistribute it
+* and/or modify it under the terms of the GNU General Public
+* License (version 2) as published by the FSF - Free Software
+* Foundation.
+*/
+
+/* Security configuration assessment decoder */
+
+#include "config.h"
+#include "eventinfo.h"
+#include "alerts/alerts.h"
+#include "decoder.h"
+#include "external/cJSON/cJSON.h"
+#include "plugin_decoders.h"
+#include "wazuh_modules/wmodules.h"
+#include "os_net/os_net.h"
+#include "os_crypto/sha256/sha256_op.h"
+#include "string_op.h"
+#include "../../remoted/remoted.h"
+#include <time.h>
+
+/** SCA decoder */
+OSDecoderInfo *sca_json_dec;
+
+int FindEventcheck(Eventinfo *lf, int pm_id, int *socket, char *wdb_response);
+int FindScanInfo(Eventinfo *lf, char *policy_id, int *socket, char *wdb_response);
+int FindPolicyInfo(Eventinfo *lf, char *policy, int *socket);
+int FindPolicySHA256(Eventinfo *lf, char *policy, int *socket, char *wdb_response);
+int FindCheckResults(Eventinfo *lf, char *policy_id, int *socket, char *wdb_response);
+int FindPoliciesIds(Eventinfo *lf, int *socket, char *wdb_response);
+
+int DeletePolicy(Eventinfo *lf, char *policy, int *socket);
+int DeletePolicyCheck(Eventinfo *lf, char *policy, int *socket);
+int DeletePolicyCheckDistinct(Eventinfo *lf, char *policy_id,int scan_id, int *socket);
+
+int SaveEventcheck(Eventinfo *lf, int exists, int *socket, int id , int scan_id, char * result, char *status,
+    char *reason, cJSON *event);
+int SaveScanInfo(Eventinfo *lf,int *socket, char * policy_id,int scan_id, int pm_start_scan, int pm_end_scan,
+    int pass,int failed, int invalid, int total_checks, int score,char * hash,int update);
+int SaveCompliance(Eventinfo *lf,int *socket, int id_check, char *key, char *value);
+int SaveRules(Eventinfo *lf,int *socket, int id_check, char *type, char *rule);
+int SavePolicyInfo(Eventinfo *lf, int *socket, char *name, char *file, char * id, char *description, char *references,
+    char *hash_file);
+
+void HandleCheckEvent(Eventinfo *lf, int *socket, cJSON *event);
+void HandleScanInfo(Eventinfo *lf, int *socket, cJSON *event);
+void HandlePoliciesInfo(Eventinfo *lf, int *socket, cJSON *event);
+void HandleDumpEvent(Eventinfo *lf, int *socket, cJSON *event);
+
+int CheckEventJSON(cJSON *event, cJSON **scan_id, cJSON **id, cJSON **name, cJSON **title, cJSON **description,
+    cJSON **rationale, cJSON **remediation, cJSON **compliance, cJSON **condition, cJSON **check, cJSON **reference,
+    cJSON **file, cJSON **directory, cJSON **process, cJSON **registry, cJSON **result, cJSON **status, cJSON **reason,
+    cJSON **policy_id, cJSON **command, cJSON **rules);
+int CheckPoliciesJSON(cJSON *event, cJSON **policies);
+int CheckDumpJSON(cJSON *event, cJSON **elements_sent, cJSON **policy_id, cJSON **scan_id);
+
+void FillCheckEventInfo(Eventinfo *lf, cJSON *scan_id, cJSON *id, cJSON *name, cJSON *title, cJSON *description,
+    cJSON *rationale, cJSON *remediation, cJSON *compliance, cJSON *reference, cJSON *file,
+    cJSON *directory, cJSON *process, cJSON *registry, cJSON *result, cJSON *status, cJSON *reason, char *old_result,
+    cJSON *command);
+void FillScanInfo(Eventinfo *lf, cJSON *scan_id, cJSON *name, cJSON *description, cJSON *pass, cJSON *failed,
+    cJSON *invalid, cJSON *total_checks, cJSON *score, cJSON *file, cJSON *policy_id);
+
+void PushDumpRequest(char *agent_id, char *policy_id, int first_scan);
+int pm_send_db(char *msg, char *response, int *sock);
+void *RequestDBThread();
+int ConnectToSecurityConfigurationAssessmentSocket();
+int ConnectToSecurityConfigurationAssessmentSocketRemoted();


### PR DESCRIPTION
|Related issue|
|---|
|[2765](https://github.com/wazuh/wazuh/issues/2765)|

## Description

This PR is due to an enhancement `ossec-logtest`. The new Logtest must allow testing all events processed by Analysisd.

An `ossec-logtest` output:
```
root@lopezziur:/var/ossec# bin/ossec-logtest -e sca
2019/11/19 15:12:55 ossec-testrule: INFO: Started (pid: 5805).
ossec-testrule: Type one log per line.

{"type":"summary","scan_id":2016198709,"name":"CIS benchmark for Debian/Linux 9 L1","policy_id":"cis_debian9_L1","file":"cis_debian9_L1.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":32,"failed":64,"invalid":3,"total_checks":99,"score":33.333335876464844,"start_time":1571055389,"end_time":1571055390,"hash":"ec017f9235c74e261c3e4706e2015a2cae1e3b6057abc9e67c452456a563578e","hash_file":"050662edd03c302de6d9f7f68757ece85ebb274ef023cfcd2bba37cc5554eb4d"}


**Phase 1: Completed pre-decoding.
       full event: '{"type":"summary","scan_id":2016198709,"name":"CIS benchmark for Debian/Linux 9 L1","policy_id":"cis_debian9_L1","file":"cis_debian9_L1.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":32,"failed":64,"invalid":3,"total_checks":99,"score":33.333335876464844,"start_time":1571055389,"end_time":1571055390,"hash":"ec017f9235c74e261c3e4706e2015a2cae1e3b6057abc9e67c452456a563578e","hash_file":"050662edd03c302de6d9f7f68757ece85ebb274ef023cfcd2bba37cc5554eb4d"}'
       timestamp: '(null)'
       hostname: 'lopezziur'
       program_name: '(null)'
       log: '{"type":"summary","scan_id":2016198709,"name":"CIS benchmark for Debian/Linux 9 L1","policy_id":"cis_debian9_L1","file":"cis_debian9_L1.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":32,"failed":64,"invalid":3,"total_checks":99,"score":33.333335876464844,"start_time":1571055389,"end_time":1571055390,"hash":"ec017f9235c74e261c3e4706e2015a2cae1e3b6057abc9e67c452456a563578e","hash_file":"050662edd03c302de6d9f7f68757ece85ebb274ef023cfcd2bba37cc5554eb4d"}'

**Phase 2: Completed decoding.

       decoder: 'sca'
       sca.type: 'summary'
       sca.scan_id: '2016198709'
       sca.policy: 'CIS benchmark for Debian/Linux 9 L1'
       sca.description: 'This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.'
       sca.policy_id: 'cis_debian9_L1'
       sca.passed: '32'
       sca.failed: '64'
       sca.invalid: '3'
       sca.total_checks: '99'
       sca.score: '33'
       sca.file: 'cis_debian9_L1.yml'

**Phase 3: Completed filtering (rules).
       Rule id: '19004'
       Level: '7'
       Description: 'SCA summary: CIS benchmark for Debian/Linux 9 L1: Score less than 50% (33)'
**Alert to be generated.
```

## Tests

- [x] Compilation without warnings
- [x] Review logs syntax and correct language
- [x] Analysisd processes SCA events correctly
- [x] Logtest processes SCA events correctly
- Memory tests for manager
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

