### PR TITLE
Allow JSON escaping for logs on Logcollector's output format

### DIFF
--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -133,4 +133,14 @@ char *decode_hex_buffer_2_ascii_buffer(const char * const encoded_buffer, const 
  */
 size_t strcspn_escaped(const char * s, char reject);
 
+/**
+ * @brief Escape JSON reserved characters
+ *
+ * Add an escape to the following bytes: \b \t \n \f \r " \
+ *
+ * @param string Input string
+ * @return Pointer to a new string containg an escaped copy of "string"
+ */
+char * wstr_escape_json(const char * string);
+
 #endif

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -226,6 +226,7 @@ char * msgsubst(const char * pattern, const char * logmsg, const char * location
     const char * field;
     char _timestamp[64];
     char hostname[512];
+    char * escaped_log = NULL;
     size_t n = 0;
     size_t z;
 
@@ -302,6 +303,8 @@ char * msgsubst(const char * pattern, const char * logmsg, const char * location
 
             hostname[sizeof(hostname) - 1] = '\0';
             field = hostname;
+        } else if (strcmp(param, "json_escaped_log") == 0) {
+            field = escaped_log = wstr_escape_json(logmsg);
         } else {
             mdebug1("Invalid parameter '%s' for log format.", param);
             continue;
@@ -317,6 +320,8 @@ char * msgsubst(const char * pattern, const char * logmsg, const char * location
             strncpy(final + n, field, OS_MAXSTR - n);
             n += z;
         }
+
+        os_free(escaped_log);
     }
 
     // Copy rest of the pattern
@@ -338,5 +343,6 @@ fail:
     strncpy(final, logmsg ? logmsg : "Too long message format", OS_MAXSTR - 1);
     final[OS_MAXSTR - 1] = '\0';
     free(_pattern);
+    free(escaped_log);
     return final;
 }

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -741,3 +741,48 @@ size_t strcspn_escaped(const char * s, char reject) {
 
     return len;
 }
+
+// Escape JSON reserved characters
+
+char * wstr_escape_json(const char * string) {
+    const char escape_map[] = {
+        ['\b'] = 'b',
+        ['\t'] = 't',
+        ['\n'] = 'n',
+        ['\f'] = 'f',
+        ['\r'] = 'r',
+        ['\"'] = '\"',
+        ['\\'] = '\\'
+    };
+
+    size_t i = 0;   // Read position
+    size_t j = 0;   // Write position
+    size_t z;       // Span length
+
+    char * output;
+    os_malloc(1, output);
+
+    do {
+        z = strcspn(string + i, "\b\t\n\f\r\"\\");
+
+        if (string[i + z] == '\0') {
+            // End of string
+            os_realloc(output, j + z + 1, output);
+            strncpy(output + j, string + i, z);
+        } else {
+            // Reserved character
+            os_realloc(output, j + z + 3, output);
+            strncpy(output + j, string + i, z);
+            output[j + z] = '\\';
+            output[j + z + 1] = escape_map[(int)string[i + z]];
+            z++;
+            j++;
+        }
+
+        j += z;
+        i += z;
+    } while (string[i] != '\0');
+
+    output[j] = '\0';
+    return output;
+}

--- a/src/tests/tap_shared.c
+++ b/src/tests/tap_shared.c
@@ -29,7 +29,7 @@ int test_search_and_replace(){
 }
 
 int test_utf8_random(bool replacement) {
-    int i;
+    size_t i;
     const size_t LENGTH = 4096;
     char buffer[LENGTH];
 
@@ -61,6 +61,24 @@ int test_strnspn_escaped() {
     w_assert_uint_eq(strcspn_escaped("ABCDE", ' '), 5);
 }
 
+int test_json_escape() {
+    const char * INPUTS[] = { "\b\tHello \n\f\r \"World\".\\", "Hello\b\t \n\f\r \"World\"\\.", NULL };
+    const char * EXPECTED_OUTPUTS[] = { "\\b\\tHello \\n\\f\\r \\\"World\\\".\\\\", "Hello\\b\\t \\n\\f\\r \\\"World\\\"\\\\.", NULL };
+    int i;
+
+    for (i = 0; INPUTS[i] != NULL; i++) {
+        char * output = wstr_escape_json(INPUTS[i]);
+        int cmp = strcmp(output, EXPECTED_OUTPUTS[i]);
+        free(output);
+
+        if (cmp != 0) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 int main(void) {
     printf("\n\n   STARTING TEST - OS_SHARED   \n\n");
 
@@ -75,6 +93,9 @@ int main(void) {
 
     /* Test strnspn_escaped function */
     TAP_TEST_MSG(test_strnspn_escaped(), "Check return values for stnspn_escaped.");
+
+    /* Test reserved JSON character escaping */
+    TAP_TEST_MSG(test_json_escape(), "Escape reserved JSON characters.");
 
     TAP_PLAN;
     TAP_SUMMARY;


### PR DESCRIPTION
|Related issue|
|---|
|#4268|

## Description

As explained at @4268, this PR aims to implement a new output format parameter `$(json_escaped_log)` that will replace the described characters with their corresponding escape.

## Configuration options

Described at @4268.

Configuration sample:

```xml
<ossec_config>
   <localfile>
     <location>/root/demo.txt</location>
     <log_format>syslog</log_format>
     <target>agent</target>
     <out_format>{"timestamp":"$(timestamp)","hostname":"$(hostname)","log":"$(json_escaped_log)"}</out_format>
   </localfile>
</ossec_config>
```

Testing rule:
```xml
<group name="local,">
  <rule id="100001" level="5">
    <decoded_as>json</decoded_as>
    <description>JSON decoded event.</description>
  </rule>
</group>
```

## Logs/Alerts example

Input log:
```
Hello "World"
```

Alert:
```
** Alert 1574465132.2515: - local,
2019 Nov 22 15:25:32 buster->/root/demo.txt
Rule: 100001 (level 5) -> 'JSON decoded event.'
{"timestamp":"Nov 22 15:25:32","hostname":"buster","log":"Hello \"World\""}
timestamp: Nov 22 15:25:32
hostname: buster
log: Hello "World"
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source upgrade
- [x] QA templates contemplate the added capabilities

- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

- [x] Retrocompatibility with older Wazuh versions (*)
- [x] Configuration on-demand reports new parameters
- [x] Added unit tests (for new features)

(*) Old agents parse an output string containing the new `$(json_escaped_log)` parameter. However, they won't substitute that field. They will print a log like this:
```
ossec-logcollector: DEBUG: Invalid parameter 'json_escaped_log' for log format.
```