### PR TITLE
TCP keepalive support for Fluent Forwarder

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -114,6 +114,8 @@ ifeq (${uname_S},SunOS)
 		DEFINES+=-D_REENTRANT
 ifneq (${uname_P},sparc)
 		OSSEC_LDFLAGS+=-z relax=secadj
+else
+		OSSEC_CFLAGS+=-DMSGPACK_ZONE_ALIGN=8
 endif
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 		OSSEC_LIBS+=-lsocket -lnsl -lresolv -lrt -lpthread

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -265,7 +265,7 @@ int Read_Fluent_Forwarder(const OS_XML *xml, xml_node *node, void *d1)
 
     // Fluent Forwarder Module
     if (!strcmp(node->element, WM_FLUENT_CONTEXT.name)) {
-        if (wm_fluent_read(children, cur_wmodule) < 0) {
+        if (wm_fluent_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }

--- a/src/config/wmodules-fluent.c
+++ b/src/config/wmodules-fluent.c
@@ -22,6 +22,7 @@ static const char *XML_CA_FILE= "ca_file";
 static const char *XML_USER = "user";
 static const char *XML_PASSWORD = "password";
 static const char *XML_TIMEOUT = "timeout";
+static const char *XML_POLL_INTERVAL = "poll_interval";
 static const char *XML_KEEPALIVE = "keepalive";
 static const char *XML_COUNT = "count";
 static const char *XML_IDLE = "idle";
@@ -105,6 +106,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         fluent->certificate = NULL;
         fluent->user_name = NULL;
         fluent->user_pass = NULL;
+        fluent->poll_interval = 60;
         module->context = &WM_FLUENT_CONTEXT;
         module->tag = strdup(module->context->name);
         module->data = fluent;
@@ -245,6 +247,15 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             if (fluent->timeout < 0 || fluent->timeout > MAX_TIMEOUT_VALUE) {
                 merror("Invalid timeout at module '%s'", WM_FLUENT_CONTEXT.name);
                 return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_POLL_INTERVAL)) {
+            char * end;
+            int value = strtol(nodes[i]->content, &end, 10);
+
+            if (*end == '\0' && value > 0 && value < 7200) {
+                fluent->poll_interval = value;
+            } else {
+                mwarn("Invalid value '%s' for option '%s' at module '%s", nodes[i]->content, nodes[i]->element, WM_FLUENT_CONTEXT.name);
             }
         } else if (strcmp(nodes[i]->element, XML_KEEPALIVE) == 0) {
             XML_NODE children = OS_GetElementsbyNode(xml, nodes[i]);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -17,6 +17,10 @@
 #include "os_net.h"
 #include "wazuh_modules/wmodules.h"
 
+#ifdef __MACH__
+#define TCP_KEEPIDLE TCP_KEEPALIVE
+#endif
+
 /* Prototypes */
 static int OS_Bindport(u_int16_t _port, unsigned int _proto, const char *_ip, int ipv6);
 static int OS_Connect(u_int16_t _port, unsigned int protocol, const char *_ip, int ipv6);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -548,20 +548,27 @@ int OS_SetKeepalive(int socket)
     return setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, (void *)&keepalive, sizeof(keepalive));
 }
 
-#ifndef CLIENT
+// Set keepalive parameters for a socket
 void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
 {
-    if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {
-        merror("OS_SetKeepalive_Options(TCP_KEEPCNT) failed with error '%s'", strerror(errno));
+    if (cnt > 0) {
+        if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {
+            merror("OS_SetKeepalive_Options(TCP_KEEPCNT) failed with error '%s'", strerror(errno));
+        }
     }
-    if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPIDLE, (void *)&idle, sizeof(idle)) < 0) {
-        merror("OS_SetKeepalive_Options(SO_KEEPIDLE) failed with error '%s'", strerror(errno));
+
+    if (idle > 0) {
+        if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPIDLE, (void *)&idle, sizeof(idle)) < 0) {
+            merror("OS_SetKeepalive_Options(SO_KEEPIDLE) failed with error '%s'", strerror(errno));
+        }
     }
-    if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPINTVL, (void *)&intvl, sizeof(intvl)) < 0) {
-        merror("OS_SetKeepalive_Options(TCP_KEEPINTVL) failed with error '%s'", strerror(errno));
+
+    if (intvl > 0) {
+        if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPINTVL, (void *)&intvl, sizeof(intvl)) < 0) {
+            merror("OS_SetKeepalive_Options(TCP_KEEPINTVL) failed with error '%s'", strerror(errno));
+        }
     }
 }
-#endif
 
 int OS_SetRecvTimeout(int socket, long seconds, long useconds)
 {

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -556,21 +556,53 @@ int OS_SetKeepalive(int socket)
 void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
 {
     if (cnt > 0) {
+#if !defined(sun) && !defined(WIN32)
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {
             merror("OS_SetKeepalive_Options(TCP_KEEPCNT) failed with error '%s'", strerror(errno));
         }
+#else
+        mwarn("Cannot set up keepalive count parameter: unsupported platform.");
+#endif
     }
 
     if (idle > 0) {
+#ifdef sun
+#ifdef TCP_KEEPALIVE_THRESHOLD
+        idle *= 1000;
+
+        if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPALIVE_THRESHOLD, (void *)&idle, sizeof(idle)) < 0) {
+            merror("OS_SetKeepalive_Options(TCP_KEEPALIVE_THRESHOLD) failed with error '%s'", strerror(errno));
+        }
+#else
+        mwarn("Cannot set up keepalive idle parameter: unsupported platform.");
+#endif
+#elif !defined(WIN32)
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPIDLE, (void *)&idle, sizeof(idle)) < 0) {
             merror("OS_SetKeepalive_Options(SO_KEEPIDLE) failed with error '%s'", strerror(errno));
         }
+#else
+        mwarn("Cannot set up keepalive idle parameter: unsupported platform.");
+#endif
     }
 
     if (intvl > 0) {
+#ifdef sun
+#ifdef TCP_KEEPALIVE_ABORT_THRESHOLD
+        intvl *= 1000;
+
+        if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPALIVE_ABORT_THRESHOLD, (void *)&intvl, sizeof(intvl)) < 0) {
+            merror("OS_SetKeepalive_Options(TCP_KEEPALIVE_ABORT_THRESHOLD) failed with error '%s'", strerror(errno));
+        }
+#else
+        mwarn("Cannot set up keepalive interval parameter: unsupported platform.");
+#endif
+#elif !defined(WIN32)
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPINTVL, (void *)&intvl, sizeof(intvl)) < 0) {
             merror("OS_SetKeepalive_Options(TCP_KEEPINTVL) failed with error '%s'", strerror(errno));
         }
+#else
+        mwarn("Cannot set up keepalive interval parameter: unsupported platform.");
+#endif
     }
 }
 

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -85,17 +85,18 @@ int OS_SetRecvTimeout(int socket, long seconds, long useconds);
  */
 int OS_SetKeepalive(int socket);
 
-/*
- * Enable SO_KEEPALIVE options for TCP
+/**
+ * @brief Set keepalive parameters for a socket
+ *
+ * Options with a value 0 will not be changed.
+ *
+ * @param socket Socket descriptor.
+ * @param idle Idle time, in seconds, to start sending probes.
+ * @param intvl Interval between probes, in seconds.
+ * @param cnt Number of probes sent before closing the connection.
  */
-#ifndef CLIENT
-
-#ifdef __MACH__
-#define TCP_KEEPIDLE TCP_KEEPALIVE
-#endif
-
 void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt);
-#endif
+
 /* Set the delivery timeout for a socket
  * Returns 0 on success, else -1
  */

--- a/src/wazuh_modules/wm_fluent.h
+++ b/src/wazuh_modules/wm_fluent.h
@@ -31,6 +31,7 @@ typedef struct wm_fluent_t {
     SSL_CTX * ctx;
     SSL * ssl;
     BIO * bio;
+    int poll_interval;
 
     struct keepalive {
         bool enabled;

--- a/src/wazuh_modules/wm_fluent.h
+++ b/src/wazuh_modules/wm_fluent.h
@@ -31,6 +31,13 @@ typedef struct wm_fluent_t {
     SSL_CTX * ctx;
     SSL * ssl;
     BIO * bio;
+
+    struct keepalive {
+        bool enabled;
+        int count;
+        int idle;
+        int interval;
+    } keepalive;
 } wm_fluent_t;
 
 typedef struct wm_fluent_helo_t {
@@ -51,7 +58,7 @@ typedef struct wm_fluent_pong_t {
 extern const wm_context WM_FLUENT_CONTEXT;
 
 // Read configuration and return a module (if enabled) or NULL (if disabled)
-int wm_fluent_read(xml_node **nodes, wmodule *module);
+int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module);
 
 
 #endif // WM_FLUENT_H


### PR DESCRIPTION
|Related issue|
|---|
|#4197|

## Description

## Configuration options

Described in #4197.

## Logs/Alerts example

This log is expected to appear on keepalive timeout:
```
2019/11/13 00:30:41 fluent-forward: INFO: Fluent server is down or timed-out. Reconnecting.
```

## Tests

### Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows (feature not available)
  - [X] MAC OS X
  - [X] Solaris 10@ i386
  - [X] Solaris 11.3 @ i386
  - [X] Solaris 10 @ SPARC
  - [X] Solaris 11.3 @ SPARC
- [X] Source installation (Debian)
- [X] Package installation (Solaris 10 and 11 on i386 and SPARC)
- [X] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

### Memory tests for Linux
  - [X] Scan-build report
  - [X] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)

### Feature tests

- [X] Configuration on-demand reports new parameters
- [X] The data flow works as expected (agent - Fluentd)
