### PR TITLE
Fix FTS data length bound mishandling in Analysisd

### DIFF
--- a/src/analysisd/fts.c
+++ b/src/analysisd/fts.c
@@ -109,7 +109,7 @@ int FTS_Init(int threads)
 
     /* Add content from the files to memory */
     fseek(fp_list, 0, SEEK_SET);
-    while (fgets(_line, OS_FLSIZE , fp_list) != NULL) {
+    while (fgets(_line, sizeof(_line), fp_list) != NULL) {
         char *tmp_s;
 
         /* Remove newlines */


### PR DESCRIPTION
|Related issue|
|---|
|#4277|

## Description

FTS uses a queue file (_/var/ossec/queue/fts/fts-queue_) to store the log event fields that produced an FTS-driven alert.

As explained in issue #4277, FTS writes up to 256 bytes per event. However, it's reading up to 255 bytes per line. This produces a data truncation. The next time `fgets()` returns an empty line (`\n`).

According to the [documentation of fgets()](https://www.gnu.org/software/libc/manual/html_node/Line-Input.html#index-getline-993), `fgets()` reads up to `count - 1` bytes from the file. So, since `_line` is _`OS_FLSIZE` + 1_ bytes, we need to give `fgets()` the current size of `_line`.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

Issue #4277 explains how to reproduce the error. This PR aims to get rid of that.

## Tests

### Compilation

- [X] Compile manager on Linux.
- [X] Source installation.

### Feature test

- [X] The error does not appear anymore.

### Memory test

- [X] Valgrind.

### Feature test

- [X] Stress test for affected components.

#### Stress test

Producing a bunch of logs about `sudo` execution:

```shell
while true
do 
    echo "Nov 25 18:48:05 buster sudo:     $(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 226) : TTY=pts/1 ; PWD=/root ; USER=root ; COMMAND=/usr/bin/echo" >> /var/log/auth.log
done
```

Analysisd produces alerts like this one:

```
** Alert 1574737136.63002205: mail  - syslog,sudo,
2019 Nov 25 18:58:56 buster->/var/log/auth.log
Rule: 5403 (level 4) -> 'First time user executed sudo.'
User: root
Nov 25 18:48:05 buster sudo:     HTcypDynPlbRx : TTY=pts/1 ; PWD=/root ; USER=root ; COMMAND=/usr/bin/echo
tty: pts/1
pwd: /root
command: /usr/bin/echo
```

#### Coverity report

- No invalid read/write operations reported.
- Valgrind runs out-of-memory:

```
==28149==     Valgrind's memory management: out of memory:
==28149==        newSuperblock's request for 8704000 bytes failed.
==28149==          531,664,896 bytes have already been mmap-ed ANONYMOUS.
==28149==     Valgrind cannot continue.  Sorry.
==28149==
==28149==     There are several possible reasons for this.
==28149==     - You have some kind of memory limit in place.  Look at the
==28149==       output of 'ulimit -a'.  Is there a limit on the size of
==28149==       virtual memory or address space?
==28149==     - You have run out of swap space.
==28149==     - Valgrind has a bug.  If you think this is the case or you are
==28149==     not sure, please let us know and we'll try to fix it.
==28149==     Please note that programs can take substantially more memory than
==28149==     normal when running under Valgrind tools, eg. up to twice or
==28149==     more, depending on the tool.  On a 64-bit machine, Valgrind
==28149==     should be able to make use of up 32GB memory.  On a 32-bit
==28149==     machine, Valgrind should be able to use all the memory available
==28149==     to a single process, up to 4GB if that's how you have your
==28149==     kernel configured.  Most 32-bit Linux setups allow a maximum of
==28149==     3GB per process.
==28149==
==28149==     Whatever the reason, Valgrind cannot continue.  Sorry.
```