### PR TITLE
[Logcollector] Fix SIGSEGV when using force_reload and the eventchannel format in UNIX systems

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -183,6 +183,7 @@ void LogCollectorStart()
             /* Mutexes are not previously initialized under Windows*/
             w_mutex_init(&current->mutex, &win_el_mutex_attr);
 #endif
+            free(current->file);
             current->file = NULL;
             current->command = NULL;
             current->fp = NULL;
@@ -199,6 +200,7 @@ void LogCollectorStart()
             /* Mutexes are not previously initialized under Windows*/
             w_mutex_init(&current->mutex, &win_el_mutex_attr);
 #endif
+            free(current->file);
             current->file = NULL;
             current->command = NULL;
             current->fp = NULL;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -199,7 +199,9 @@ void LogCollectorStart()
             /* Mutexes are not previously initialized under Windows*/
             w_mutex_init(&current->mutex, &win_el_mutex_attr);
 #endif
-
+            current->file = NULL;
+            current->command = NULL;
+            current->fp = NULL;
         } else if (strcmp(current->logformat, "command") == 0) {
             current->file = NULL;
             current->fp = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4288|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Eventchannel only works for Windows systems, whenever we have a configuration block with this log format in an UNIX system, we shouldn't give it any importance. Then, this data structure, `logreader`, has to change its main fields, name, file descriptor and size, to NULL, as it is done for `eventlog` as well.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
```
scan-build: Removing directory '/tmp/scan-build-2019-12-03-092702-11428-1' because it contains no reports.
scan-build: No bugs found.
```
  - [x] Valgrind (memcheck and descriptor leaks check)
The next memory leak which is present in eventlog and eventchannel in Linux has been fixed.
```
==29445== 31 bytes in 1 blocks are definitely lost in loss record 5 of 28
==29445==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==29445==    by 0x5BAD9B9: strdup (strdup.c:42)
==29445==    by 0x122B43: Read_Localfile (localfile-config.c:226)
==29445==    by 0x1258B4: read_main_elements (config.c:115)
==29445==    by 0x1263CD: ReadConfig (config.c:254)
==29445==    by 0x11B642: LogCollectorConfig (config.c:81)
==29445==    by 0x11E8E9: main (main.c:123)
```
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Dr. Memory
