### PR TITLE
Fixed CLANG analyzer (scan-build) for Windows agents building

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -254,7 +254,9 @@ endif
 MING_BASE:=
 ifeq (${TARGET}, winagent)
 # Avoid passing environment variables such CFLAGS to external Makefiles
-MAKEOVERRIDES=
+ifeq (${CC}, gcc)
+	MAKEOVERRIDES=
+endif
 
 CC=gcc
 ifneq (,$(shell which amd64-mingw32msvc-gcc))
@@ -266,7 +268,11 @@ ifneq (,$(shell which i686-pc-mingw32-gcc))
 	MINGW_HOST="i686-pc-mingw32"
 else
 ifneq (,$(shell which i686-w64-mingw32-gcc))
-	MING_BASE:=i686-w64-mingw32-
+	ifeq (${CC}, gcc)
+		MING_BASE:=i686-w64-mingw32-
+	else
+		MING_BASE:=
+	endif
 	MINGW_HOST="i686-w64-mingw32"
 else
 $(error No windows cross-compiler found!) #MING_BASE:=unknown-

--- a/src/Makefile
+++ b/src/Makefile
@@ -260,11 +260,19 @@ endif
 
 CC=gcc
 ifneq (,$(shell which amd64-mingw32msvc-gcc))
-	MING_BASE:=amd64-mingw32msvc-
+	ifeq (${CC}, gcc)
+		MING_BASE:=amd64-mingw32msvc-
+	else
+		MING_BASE:=
+	endif
 	MINGW_HOST="amd64-mingw32msvc"
 else
 ifneq (,$(shell which i686-pc-mingw32-gcc))
-	MING_BASE:=i686-pc-mingw32-
+	ifeq (${CC}, gcc)
+		MING_BASE:=i686-pc-mingw32-
+	else
+		MING_BASE:=
+	endif
 	MINGW_HOST="i686-pc-mingw32"
 else
 ifneq (,$(shell which i686-w64-mingw32-gcc))


### PR DESCRIPTION
|Related issue|
|---|
|#4239|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As it is explained in the issue, an error is generated when scan-build for Windows agent is running. Scan-build overrides the CC and CXX environment variables to (hopefully) change the build to use a "fake" compiler instead of the one that would normally build your project.

So, the CC variable in Makefile (CC=gcc) is overwritten by CC=/usr/share/clang/scan-build-8/bin/../libexec/ccc-analyzer. For that reason, it appears the **error**: 

/bin/sh: 1: i686-w64-mingw32-/usr/share/clang/scan-build-8/bin/../libexec/ccc-analyzer: not found 

In order to solve that, it is necessary to modify MING_BASE in the Makefile when CC environment is not equal to "gcc": 

`MING_BASE:=`

## Configuration options

The command to run scan-build correctly is:

`# /usr/share/clang/scan-build-8/bin/scan-build --use-cc=/usr/bin/i686-w64-mingw32-gcc --analyzer-target=i686-w64-mingw32 --force-analyze-debug-code make TARGET=winagent`

According to this [site](http://blog.canyonbliss.net/static-code-analysis-with-scan-build-while-cross-compiling/), it is necessary to use the following scan-build options: _--use-cc_ and _--analyzer-target_ flags. 

In addition, _--force-analyze-debug-code_ is an optional flag in order to get more assertions. An alternative is to use: 

`# /usr/share/clang/scan-build-8/bin/scan-build --use-cc=/usr/bin/i686-w64-mingw32-gcc --analyzer-target=i686-w64-mingw32 make TARGET=winagent DEBUG=yes 
`
## Logs/Alerts example

Scan-build result:

![image](https://user-images.githubusercontent.com/24528466/69966675-307ab280-1517-11ea-8a22-b0b5e0080dca.png)
