### PR TITLE
Add new security endpoint to revoke tokens and adapt framework/api

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10316,6 +10316,19 @@ paths:
         default:
           $ref: '#/components/responses/ResponseError'
 
+  /security/user/revoke:
+    put:
+      tags:
+      - security
+      summary: 'Revoke all active JWT tokens'
+      description: 'This method should be called to revoke all JWT tokens.'
+      operationId: api.controllers.security_controller.revoke_all_tokens
+      responses:
+        '200':
+          description: 'Tokens revoked succesfully'
+        default:
+          $ref: '#/components/responses/ResponseError'
+
   /security/roles:
     get:
       tags:

--- a/api/test/integration/env/configurations/rbac/security/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/security/black_config.txt
@@ -19,3 +19,4 @@
 | security:delete      | policy:id | *     |                                   |
 | security:create      | *         |       | *                                 |
 | security:create_user | *         | *     |                                   |
+| security:revoke      | *         | *     |                                   |

--- a/api/test/integration/env/configurations/rbac/security/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/security/white_config.txt
@@ -19,3 +19,4 @@
 | security:delete      | policy:id |                                   | *    |
 | security:create      | *         | *                                 |      |
 | security:create_user | *         |                                   | *    |
+| security:revoke      | *         |                                   | *    |

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -1172,3 +1172,26 @@ stages:
       status_code: 400
       body:
         <<: *permission_denied
+
+---
+test_name: REVOKE TOKENS RBAC
+
+stages:
+
+  - name: Revoke all tokens (Allowed)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+    response:
+      status_code: 200
+
+  - name: Revoke all tokens (Invalid token after previous call)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+    response:
+      status_code: 401

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -1005,3 +1005,19 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
         message: Policy created correctly
+
+---
+test_name: REVOKE TOKENS RBAC
+
+stages:
+
+  - name: Revoke all tokens (Denied)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+    response:
+      status_code: 400
+      body:
+        <<: *permission_denied

--- a/api/test/integration/test_security_PUT_endpoint.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoint.tavern.yaml
@@ -4,9 +4,9 @@ test_name: PUT /security/roles
 includes:
   - !include common.yaml
 
-marks:
-  - usefixtures:
-    - security_tests
+#marks:
+#  - usefixtures:
+#    - security_tests
 
 stages:
 
@@ -276,3 +276,26 @@ stages:
             - "agent:id:003"
     response:
       status_code: 400
+
+---
+test_name: PUT /security/user/revoke
+
+stages:
+
+  - name: Revoke all tokens
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+    response:
+      status_code: 200
+
+  - name: Revoke all tokens (Invalid token after previous call)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+    response:
+      status_code: 401

--- a/api/test/integration/test_security_PUT_endpoint.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoint.tavern.yaml
@@ -4,9 +4,9 @@ test_name: PUT /security/roles
 includes:
   - !include common.yaml
 
-#marks:
-#  - usefixtures:
-#    - security_tests
+marks:
+ - usefixtures:
+   - security_tests
 
 stages:
 

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -4,14 +4,15 @@
 
 import re
 
-from api.authentication import AuthenticationManager
+from api.authentication import AuthenticationManager, validation
 from wazuh import common
 from wazuh.exception import WazuhError
 from wazuh.rbac import orm
 from wazuh.rbac.decorators import expose_resources
 from wazuh.rbac.orm import SecurityError
-from wazuh.results import AffectedItemsWazuhResult
+from wazuh.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.utils import process_array
+from time import time
 
 # Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character:
 _user_password = re.compile(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[_@$!%*?&-])[A-Za-z\d@$!%*?&-_]{8,}$')
@@ -420,3 +421,11 @@ def remove_role_policy(role_id, policy_ids):
                 result.total_affected_items += 1
 
     return result
+
+
+@expose_resources(actions=['security:revoke'], resources=['*:*:*'])
+def revoke_tokens():
+    """ Revoke all tokens """
+    validation.key = int(time())
+
+    return WazuhResult({'msg': 'Tokens revoked succesfully'})


### PR DESCRIPTION
|Related issue|
|---|
|#4266|

## Description

This PR adds a new endpoint to revoke all active JWT tokens.

## Tests

```
test_security_PUT_endpoint.tavern.yaml::PUT /security/user/revoke PASSED [100%]
```

**Denied**
```
curl -X PUT "http://localhost:55000/security/user/revoke" -H  "accept: application/json" -H  "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImlhdCI6MTU3NTQ3MzE5NSwiZXhwIjoxNTc1NTA5MTk1LCJzdWIiOiJ3YXp1aCIsInJiYWNfcG9saWNpZXMiOnt9LCJ2YWxpZCI6MTU3NTQ3MzE3Mn0.GaMrbhjwPclXdVmoJjCuWEhOcYAoYM0gjtgezUtHomk"
{
  "code": 4000,
  "dapi_errors": {
    "master-node": {
      "error": "Permission denied: Resource type: *:*"
    }
  },
  "detail": "Permission denied: Resource type: *:*",
  "remediation": "Please, make sure you have permissions to execute current request, for more information on setting up permissions please visit XXXX",
  "status": 400,
  "title": "Wazuh Error",
  "type": "about:blank"
}
```
**Allowed**
```
curl -X PUT "http://localhost:55000/security/user/revoke" -H  "accept: application/json" -H  "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImlhdCI6MTU3NTQ3MzQxNSwiZXhwIjoxNTc1NTA5NDE1LCJzdWIiOiJ3YXp1aCIsInJiYWNfcG9saWNpZXMiOnt9LCJ2YWxpZCI6MTU3NTQ3MzM4Nn0.JOSGQcrpQTdN6AVjnu3Ft0jEE5ITlAcsxFrovhyA-KM"
{
  "msg": "Tokens revoked succesfully"
}
```
**Invalid token following revokation**
```
curl -X PUT "http://localhost:55000/security/user/revoke" -H  "accept: application/json" -H  "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImlhdCI6MTU3NTQ3MzQxNSwiZXhwIjoxNTc1NTA5NDE1LCJzdWIiOiJ3YXp1aCIsInJiYWNfcG9saWNpZXMiOnt9LCJ2YWxpZCI6MTU3NTQ3MzM4Nn0.JOSGQcrpQTdN6AVjnu3Ft0jEE5ITlAcsxFrovhyA-KM"
{
  "detail": "The server could not verify that you are authorized to access the URL requested. You either supplied the wrong credentials (e.g. a bad password), or your browser doesn't understand how to supply the credentials required.",
  "status": 401,
  "title": "Unauthorized",
  "type": "about:blank"
}
```