### PR TITLE
Adapt internal options

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -35,7 +35,7 @@ analysisd.label_cache_maxage=1
 # Show hidden labels on alerts
 analysisd.show_hidden_labels=0
 # Maximum number of file descriptor that Analysisd can open [1024..1048576]
-analysisd.rlimit_nofile=65536
+analysisd.rlimit_nofile=458752
 # Minimum output rotate interval. This limits rotation by time and size. [10..86400]
 analysisd.min_rotate_interval=600
 # Number of event decoder threads
@@ -172,7 +172,7 @@ remoted.max_attempts=4
 remoted.shared_reload=10
 
 # Maximum number of file descriptor that Remoted can open [1024..1048576]
-remoted.rlimit_nofile=65536
+remoted.rlimit_nofile=458752
 
 # Maximum time waiting for a client response in TCP (seconds) [1..60]
 remoted.recv_timeout=1
@@ -381,7 +381,7 @@ wazuh_db.commit_time=60
 wazuh_db.open_db_limit=64
 
 # Maximum number of file descriptor that WazuhDB can open [1024..1048576]
-wazuh_db.rlimit_nofile=65536
+wazuh_db.rlimit_nofile=458752
 
 
 # Wazuh Command Module - If it should accept remote commands from the manager


### PR DESCRIPTION
## Description

<!--
Add a clear description of how the problem has been solved.
-->
Hello Team,

This PR goes accordingly with the new value of allowed agents https://github.com/wazuh/wazuh/commit/989ffd9e2b1a6434c2dba3786d3f0a42c5adff0d in 3.11 version to avoid crashing **remoted** when having more than 65536 agents.

Note that I have increased other file descriptor values for **analysisd** and **wazuh_db** that may go through the same behaviour.


## POC 

<!--
Paste here related logs and alerts
-->
![Crashremoted](https://user-images.githubusercontent.com/16334770/70157158-60f85300-16b5-11ea-9191-f79ad9ba4c1c.gif)


**NOTE** : 

- Increasing the file descriptor values fixed it.
- The new value added according to the new rate number of agents allowed [ `(100000/14000) * 65536` ]
- Tested on Centos7
