### PR TITLE
Let Fluent Forward nest the output log into an object

### DIFF
--- a/src/config/labels-config.c
+++ b/src/config/labels-config.c
@@ -93,6 +93,7 @@ int Read_Labels(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
 
 error:
     labels_free(*labels);
+    *labels = NULL;
     return OS_INVALID;
 }
 

--- a/src/config/wmodules-fluent.c
+++ b/src/config/wmodules-fluent.c
@@ -14,6 +14,7 @@
 
 static const char *XML_ENABLED = "enabled";
 static const char *XML_TAG = "tag";
+static const char *XML_OBJECT_KEY = "object_key";
 static const char *XML_SOCKET_PATH = "socket_path";
 static const char *XML_ADDRESS = "address";
 static const char *XML_PORT = "port";
@@ -147,6 +148,15 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
 
             os_strdup(nodes[i]->content,fluent->tag);
         }
+        else if (!strcmp(nodes[i]->element, XML_OBJECT_KEY))
+        {
+            if (strlen(nodes[i]->content) == 0) {
+                mwarn("Empty value for option <%s> at %s.", nodes[i]->element, WM_FLUENT_CONTEXT.name);
+            } else {
+                free(fluent->object_key);
+                os_strdup(nodes[i]->content, fluent->object_key);
+            }
+        }
         else if (!strcmp(nodes[i]->element, XML_SOCKET_PATH))
         {
             if(strlen(nodes[i]->content) >= PATH_MAX) {
@@ -274,6 +284,10 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
 
     if (!fluent->user_pass) {
         os_strdup("", fluent->user_pass);
+    }
+
+    if (!fluent->object_key) {
+        os_strdup("message", fluent->object_key);
     }
 
     return 0;

--- a/src/config/wmodules-fluent.c
+++ b/src/config/wmodules-fluent.c
@@ -101,7 +101,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         fluent->enabled = 1;
         fluent->tag = NULL;
         fluent->sock_path = NULL;
-        fluent->address = "localhost";
+        fluent->address = strdup("localhost");
         fluent->port = 24224;
         fluent->shared_key = NULL;
         fluent->certificate = NULL;
@@ -146,6 +146,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 return OS_INVALID;
             }
 
+            free(fluent->tag);
             os_strdup(nodes[i]->content,fluent->tag);
         }
         else if (!strcmp(nodes[i]->element, XML_OBJECT_KEY))
@@ -167,6 +168,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 return OS_INVALID;
             }
 
+            free(fluent->sock_path);
             os_strdup(nodes[i]->content,fluent->sock_path);
         }
         else if (!strcmp(nodes[i]->element, XML_ADDRESS))
@@ -179,6 +181,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 return OS_INVALID;
             }
 
+            free(fluent->address);
             os_strdup(nodes[i]->content,fluent->address);
         }
         else if (!strcmp(nodes[i]->element, XML_PORT))
@@ -204,6 +207,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 return OS_INVALID;
             }
 
+            free(fluent->shared_key);
             os_strdup(nodes[i]->content,fluent->shared_key);
         }
         else if (!strcmp(nodes[i]->element, XML_CA_FILE))
@@ -216,6 +220,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 return OS_INVALID;
             }
 
+            free(fluent->certificate);
             os_strdup(nodes[i]->content,fluent->certificate);
         }
         else if (!strcmp(nodes[i]->element, XML_USER))
@@ -227,6 +232,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 mwarn("Empty user value at '%s'.", WM_FLUENT_CONTEXT.name);
             }
 
+            free(fluent->user_name);
             os_strdup(nodes[i]->content,fluent->user_name);
         }
         else if (!strcmp(nodes[i]->element, XML_PASSWORD))
@@ -238,6 +244,7 @@ int wm_fluent_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 mwarn("Empty pass value at '%s'.", WM_FLUENT_CONTEXT.name);
             }
 
+            free(fluent->user_pass);
             os_strdup(nodes[i]->content,fluent->user_pass);
         }
         else if (!strcmp(nodes[i]->element, XML_TIMEOUT))

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -148,6 +148,7 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
 
 // Destroy data
 void wm_fluent_destroy(wm_fluent_t * fluent) {
+    free(fluent->object_key);
     os_free(fluent);
 }
 
@@ -683,6 +684,9 @@ static int wm_fluent_send(wm_fluent_t * fluent, const char * str, size_t size) {
     msgpack_pack_str(&pk, taglen);
     msgpack_pack_str_body(&pk, fluent->tag, taglen);
     msgpack_pack_unsigned_int(&pk, time(NULL));
+    msgpack_pack_map(&pk, 1);
+    msgpack_pack_str(&pk, strlen(fluent->object_key));
+    msgpack_pack_str_body(&pk, fluent->object_key, strlen(fluent->object_key));
     msgpack_pack_str(&pk, size);
     msgpack_pack_str_body(&pk, str, size);
     msgpack_pack_map(&pk, 1);
@@ -805,6 +809,7 @@ cJSON *wm_fluent_dump(const wm_fluent_t *fluent) {
 
     cJSON_AddStringToObject(wm_wd, "enabled", fluent->enabled ? "yes" : "no");
     if (fluent->tag) cJSON_AddStringToObject(wm_wd, "tag", fluent->tag);
+    if (fluent->object_key) cJSON_AddStringToObject(wm_wd, "object_key", fluent->object_key);
     if (fluent->sock_path)cJSON_AddStringToObject(wm_wd, "socket_path", fluent->sock_path);
     if (fluent->address) cJSON_AddStringToObject(wm_wd, "address", fluent->address);
     if (fluent->port) cJSON_AddNumberToObject(wm_wd, "port", fluent->port);

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -148,7 +148,14 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
 
 // Destroy data
 void wm_fluent_destroy(wm_fluent_t * fluent) {
+    free(fluent->tag);
     free(fluent->object_key);
+    free(fluent->sock_path);
+    free(fluent->address);
+    free(fluent->shared_key);
+    free(fluent->certificate);
+    free(fluent->user_name);
+    free(fluent->user_pass);
     os_free(fluent);
 }
 

--- a/src/wazuh_modules/wm_fluent.h
+++ b/src/wazuh_modules/wm_fluent.h
@@ -19,6 +19,7 @@
 typedef struct wm_fluent_t {
     unsigned int enabled:1;
     char * tag;
+    char * object_key;
     char * sock_path;
     char * address;
     unsigned short port;


### PR DESCRIPTION
The [Fluent Forward Protocol Specification](https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#message-modes) states that a record must be a map instead of a string.

## Implemented changes

1. Nest the record of the payload towards Fluent into a map.
2. Add an option `<object_key>` to define the key of the value in the record.
3. Fix memory leaks in the configuration when parsing duplicate or invalid options.

## Configuration options

New option:

```xml
<fluent-forward>
  <object_key>message</object_key>
</fluent-forward>
```

|Option|Allowed|Default|Description|
|---|---|---|---|
|**object_key**|String of 1 to 65.535 bytes.|"message"|Key of the message in the record.|

## Logs/Alerts example

### Sample configuration

```xml
<fluent-forward>
  <tag>demo</tag>
  <object_key>message</object_key>
</fluent-forward>
```

### Input string

```
This is a demo.
```

### Fluentd output

```
2019-12-04 14:31:10.000000000 -0800 demo: {"message":"This is a demo."}
```

## Affected artifacts

- _wazuh-modulesd_ binary.

## Tests

### Basic tests

- [x] Compile on Linux.
- [x] Compile for Windows.
- [x] Compile on macOS.
- [x] Compile on Solaris.
- [x] Source installation on Linux.
- [x] Review logs syntax and correct language.
- [ ] QA templates contemplate the added capabilities.
- [x] Configuration on-demand reports the new parameters.

### Code tests

- [x] Scan-Build for Linux.
- [x] Coverity.
- [x] Valgrind on Linux.

### Feature tests

- [x] Send logs to Fluentd from a Linux host.
- [x] Send logs to Fluentd from a Solaris host.
- [x] Missing option `<object_key>`.
- [x] Empty value for option `<object_key>`.
