### PR TITLE
Avoid warnings with the default configuration of syscheck in Windows

### DIFF
--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -282,7 +282,7 @@ void os_winreg_open_key(char *subkey, char *fullkey_name, int pos)
     HKEY oshkey;
 
     if (RegOpenKeyEx(sub_tree, subkey, 0, KEY_READ | (syscheck.registry[pos].arch == ARCH_32BIT ? KEY_WOW64_32KEY : KEY_WOW64_64KEY), &oshkey) != ERROR_SUCCESS) {
-        mwarn(FIM_REG_OPEN, subkey, syscheck.registry[pos].arch == ARCH_32BIT ? "[x32]" : "[x64]");
+        mdebug1(FIM_REG_OPEN, subkey, syscheck.registry[pos].arch == ARCH_32BIT ? "[x32]" : "[x64]");
         return;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4325|

## Description

This PR changes the warnings of the default configuration to debug messages.

## Logs/Alerts example

```
2019/12/05 12:08:23 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\ADOVMPPackage\Final' arch: '[x32]'.
2019/12/05 12:08:23 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\CPK1HWU\Final' arch: '[x32]'.
2019/12/05 12:08:23 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\CPK2HWU\Final' arch: '[x32]'.
2019/12/05 12:08:24 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\mpssvc\Parameters\AppCs' arch: '[x32]'.
2019/12/05 12:08:24 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\mpssvc\Parameters\PortKeywords\DHCP' arch: '[x32]'.
2019/12/05 12:08:24 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\mpssvc\Parameters\PortKeywords\IPTLSIn' arch: '[x32]'.
2019/12/05 12:08:24 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\mpssvc\Parameters\PortKeywords\IPTLSOut' arch: '[x32]'.
2019/12/05 12:08:24 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\mpssvc\Parameters\PortKeywords\RPC-EPMap' arch: '[x32]'.
2019/12/05 12:08:24 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\mpssvc\Parameters\PortKeywords\Teredo' arch: '[x32]'.
2019/12/05 12:08:24 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'System\CurrentControlSet\Services\PolicyAgent\Parameters\Cache' arch: '[x32]'.
2019/12/05 12:08:24 ossec-agent[1268] win-registry.c:285 at os_winreg_open_key(): DEBUG: (6920): Unable to open registry key: 'Software\Microsoft\Windows\CurrentVersion\RunOnceEx' arch: '[x32]'.
```
