### PR TITLE
Increase the maximum size of the forwarded messages

### DIFF
--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -22,10 +22,10 @@ void *AR_Forward(__attribute__((unused)) void *arg)
     int key_id = 0;
     int ar_location = 0;
     const char * path = isChroot() ? ARQUEUE : DEFAULTDIR ARQUEUE;
-
-    char msg_to_send[OS_SIZE_20480];
-
-    char msg[OS_SIZE_20480];
+    char *msg_to_send;
+    os_calloc(OS_MAXSTR, sizeof(char), msg_to_send);
+    char *msg;
+    os_calloc(OS_MAXSTR, sizeof(char), msg);
     char *location = NULL;
     char *ar_location_str = NULL;
     char *ar_agent_id = NULL;
@@ -37,11 +37,9 @@ void *AR_Forward(__attribute__((unused)) void *arg)
         merror_exit(QUEUE_ERROR, path, strerror(errno));
     }
 
-    memset(msg, '\0', OS_SIZE_20480 + 1);
-
     /* Daemon loop */
     while (1) {
-        if (OS_RecvUnix(arq, OS_SIZE_20480, msg)) {
+        if (OS_RecvUnix(arq, OS_MAXSTR, msg)) {
 
             mdebug2("Active response request received: %s", msg);
 
@@ -108,11 +106,11 @@ void *AR_Forward(__attribute__((unused)) void *arg)
 
             /* Create the new message */
             if (ar_location & NO_AR_MSG) {
-                snprintf(msg_to_send, OS_SIZE_20480, "%s%s",
+                snprintf(msg_to_send, OS_MAXSTR, "%s%s",
                          CONTROL_HEADER,
                          tmp_str);
             } else {
-                snprintf(msg_to_send, OS_SIZE_20480, "%s%s%s",
+                snprintf(msg_to_send, OS_MAXSTR, "%s%s%s",
                          CONTROL_HEADER,
                          EXECD_HEADER,
                          tmp_str);

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -39,7 +39,7 @@ void *AR_Forward(__attribute__((unused)) void *arg)
 
     /* Daemon loop */
     while (1) {
-        if (OS_RecvUnix(arq, OS_MAXSTR, msg)) {
+        if (OS_RecvUnix(arq, OS_MAXSTR - 1, msg)) {
 
             mdebug2("Active response request received: %s", msg);
 

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -23,9 +23,9 @@ void *AR_Forward(__attribute__((unused)) void *arg)
     int ar_location = 0;
     const char * path = isChroot() ? ARQUEUE : DEFAULTDIR ARQUEUE;
 
-    char msg_to_send[OS_SIZE_1024 + 1];
+    char msg_to_send[OS_SIZE_20480];
 
-    char msg[OS_SIZE_1024 + 1];
+    char msg[OS_SIZE_20480];
     char *location = NULL;
     char *ar_location_str = NULL;
     char *ar_agent_id = NULL;
@@ -37,11 +37,11 @@ void *AR_Forward(__attribute__((unused)) void *arg)
         merror_exit(QUEUE_ERROR, path, strerror(errno));
     }
 
-    memset(msg, '\0', OS_SIZE_1024 + 1);
+    memset(msg, '\0', OS_SIZE_20480 + 1);
 
     /* Daemon loop */
     while (1) {
-        if (OS_RecvUnix(arq, OS_SIZE_1024, msg)) {
+        if (OS_RecvUnix(arq, OS_SIZE_20480, msg)) {
 
             mdebug2("Active response request received: %s", msg);
 
@@ -108,11 +108,11 @@ void *AR_Forward(__attribute__((unused)) void *arg)
 
             /* Create the new message */
             if (ar_location & NO_AR_MSG) {
-                snprintf(msg_to_send, OS_SIZE_1024, "%s%s",
+                snprintf(msg_to_send, OS_SIZE_20480, "%s%s",
                          CONTROL_HEADER,
                          tmp_str);
             } else {
-                snprintf(msg_to_send, OS_SIZE_1024, "%s%s%s",
+                snprintf(msg_to_send, OS_SIZE_20480, "%s%s%s",
                          CONTROL_HEADER,
                          EXECD_HEADER,
                          tmp_str);

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -897,12 +897,10 @@ const char *print_agent_status(agent_status_t status)
 int send_msg_to_agent(int msocket, const char *msg, const char *agt_id, const char *exec)
 {
     int rc;
-    char agt_msg[OS_SIZE_1024 + 1];
-
-    agt_msg[OS_SIZE_1024] = '\0';
+    char agt_msg[OS_SIZE_20480];
 
     if (!exec) {
-        snprintf(agt_msg, OS_SIZE_1024,
+        snprintf(agt_msg, OS_SIZE_20480,
                  "%s %c%c%c %s %s",
                  "(msg_to_agent) []",
                  (agt_id == NULL) ? ALL_AGENTS_C : NONE_C,
@@ -911,7 +909,7 @@ int send_msg_to_agent(int msocket, const char *msg, const char *agt_id, const ch
                  agt_id != NULL ? agt_id : "(null)",
                  msg);
     } else {
-        snprintf(agt_msg, OS_SIZE_1024,
+        snprintf(agt_msg, OS_SIZE_20480,
                  "%s %c%c%c %s %s - %s (from_the_server) (no_rule_id)",
                  "(msg_to_agent) []",
                  (agt_id == NULL) ? ALL_AGENTS_C : NONE_C,

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -897,10 +897,11 @@ const char *print_agent_status(agent_status_t status)
 int send_msg_to_agent(int msocket, const char *msg, const char *agt_id, const char *exec)
 {
     int rc;
-    char agt_msg[OS_SIZE_20480];
+    char *agt_msg;
+    os_malloc(OS_MAXSTR * sizeof(char), agt_msg);
 
     if (!exec) {
-        snprintf(agt_msg, OS_SIZE_20480,
+        snprintf(agt_msg, OS_MAXSTR,
                  "%s %c%c%c %s %s",
                  "(msg_to_agent) []",
                  (agt_id == NULL) ? ALL_AGENTS_C : NONE_C,
@@ -927,10 +928,11 @@ int send_msg_to_agent(int msocket, const char *msg, const char *agt_id, const ch
             merror("Remoted socket error.");
         }
         merror("Error communicating with remoted queue (%d).", rc);
-
+        free(agt_msg);
         return (-1);
     }
 
+    free(agt_msg);
     return (0);
 }
 

--- a/src/tests/tap_os_net.c
+++ b/src/tests/tap_os_net.c
@@ -231,13 +231,13 @@ int test_unix() {
 
     w_assert_int_eq(OS_SendUnix(client_socket, SENDSTRING, 5), 0);
 
-    w_assert_int_eq(OS_RecvUnix(server_socket, BUFFERSIZE, buffer), 5);
+    w_assert_int_eq(OS_RecvUnix(server_socket, BUFFERSIZE - 1, buffer), 5);
 
     w_assert_str_eq(buffer, "Hello");
 
     w_assert_int_eq(OS_SendUnix(client_socket, SENDSTRING, 0), 0);
 
-    w_assert_int_eq(OS_RecvUnix(server_socket, BUFFERSIZE, buffer), strlen(SENDSTRING) + 1);
+    w_assert_int_eq(OS_RecvUnix(server_socket, BUFFERSIZE - 1, buffer), strlen(SENDSTRING) + 1);
 
     w_assert_str_eq(buffer, SENDSTRING);
 
@@ -254,7 +254,7 @@ int test_unix_invalid_sockets() {
 
     w_assert_int_eq(OS_SendUnix(-1, SENDSTRING, strlen(SENDSTRING)), OS_SOCKTERR);
 
-    w_assert_int_eq(OS_RecvUnix(-1, BUFFERSIZE, buffer), 0);
+    w_assert_int_eq(OS_RecvUnix(-1, BUFFERSIZE - 1, buffer), 0);
 
     return 1;
 }


### PR DESCRIPTION
|Related issue|
|---|
|#4324|

This PR solves the problem described in the linked issue. The reason for the bug was a string truncation in two parts of the manager code from Analysisd and Remoted.

I have decided to increase the string size of the sync message from 1KB to 20KB because this size is enough to store it. 

The maximum size message that this function can receive has the following format:

``` BASH
syscheck dbsync checksum_fail {"id":<NUMERIC ID>, "begin":<PATH>, "end":<path>}
```

We can verify that the increase is enough by taking into account that the maximum path that Syscheck process has 4096 bytes.

https://github.com/wazuh/wazuh/blob/e17fe55e6fdef51cd586e8353b5e89790ba3d6e1/src/shared/read-agents.c#L903-L910
