### PR TITLE
Add q to `GET /rules` and `GET  /decoders`

### DIFF
--- a/api/api/controllers/decoders_controller.py
+++ b/api/api/controllers/decoders_controller.py
@@ -18,7 +18,8 @@ logger = logging.getLogger('wazuh')
 
 @exception_handler
 def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
-                 limit: int = None, sort: str = None, search: str = None, file: str = None, path: str = None, status: str = None):
+                 limit: int = None, sort: str = None, search: str = None, q: str = None, file: str = None,
+                 path: str = None, status: str = None):
     """Get all decoders
 
     Returns information about all decoders included in ossec.conf. This information include decoder's route,
@@ -32,16 +33,23 @@ def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_comp
     :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
     ascending or descending order.
     :param search: Looks for elements with the specified string
+    :param q: Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
     :param file: Filters by filename.
     :param path: Filters by path
     :param status: Filters by list status.
     :return: Data object
     """
-    f_kwargs = {'names': decoder_names, 'offset': offset, 'limit': limit, 'file': file, 'status': status, 'path': path,
+    f_kwargs = {'names': decoder_names,
+                'offset': offset,
+                'limit': limit,
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['file', 'position'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
-                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None}
+                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
+                'q': q,
+                'file': file,
+                'status': status,
+                'path': path}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoders,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -124,7 +132,7 @@ def get_download_file(pretty: bool = False, wait_for_complete: bool = False, fil
     data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
     response = connexion.lifecycle.ConnexionResponse(body=data["message"], mimetype='application/xml')
 
-    return data
+    return response
 
 
 @exception_handler

--- a/api/api/controllers/rules_controller.py
+++ b/api/api/controllers/rules_controller.py
@@ -19,7 +19,8 @@ logger = logging.getLogger('wazuh')
 @exception_handler
 @flask_cached
 def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, search=None,
-              status=None, group=None, level=None, file=None, path=None, pci=None, gdpr=None, gpg13=None, hipaa=None):
+              q=None, status=None, group=None, level=None, file=None, path=None, pci=None, gdpr=None, gpg13=None,
+              hipaa=None):
     """Get information about all Wazuh rules.
 
     :param rule_ids: Filters by rule ID
@@ -30,6 +31,7 @@ def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, li
     :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
     ascending or descending order.
     :param search: Looks for elements with the specified string
+    :param q: Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
     :param status: Filters by rules status.
     :param group: Filters by rule group.
     :param level: Filters by rule level. Can be a single level (4) or an interval (2-4)
@@ -46,8 +48,17 @@ def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, li
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'status': status, 'group': group, 'level': level, 'file': file, 'path': path, 'pci': pci, 'gdpr': gdpr,
-                'gpg13': gpg13, 'hipaa': hipaa, 'nist_800_53': connexion.request.args.get('nist-800-53', None)}
+                'q': q,
+                'status': status,
+                'group': group,
+                'level': level,
+                'file': file,
+                'path': path,
+                'pci': pci,
+                'gdpr': gdpr,
+                'gpg13': gpg13,
+                'hipaa': hipaa,
+                'nist_800_53': connexion.request.args.get('nist-800-53', None)}
 
     dapi = DistributedAPI(f=rule_framework.get_rules,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3190,7 +3190,7 @@ components:
       description: Query to filter results by. For example q=&quot;status=active&quot;
       schema:
         type: string
-#        format: query
+        format: query
     rationale:
       in: query
       name: rationale
@@ -8302,6 +8302,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/query'
         - $ref: '#/components/parameters/statusRLDParam'
         - $ref: '#/components/parameters/group'
         - $ref: '#/components/parameters/level'
@@ -8869,10 +8870,10 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/query'
         - $ref: '#/components/parameters/file'
         - $ref: '#/components/parameters/etc_and_ruleset_path'
         - $ref: '#/components/parameters/statusRLDParam'
-
       responses:
         '200':
           description: 'List of decoders included in ossec.conf'

--- a/api/test/integration/test_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoders_endpoints.tavern.yaml
@@ -193,6 +193,24 @@ stages:
       body:
         code: 1403
 
+    # GET /decoders?q=name=agent-upgrade;position=2
+  - name: Get decoders using query parameter
+    request:
+      <<: *get_decoders
+      params:
+        q: 'name=agent-upgrade;position=2'
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items:
+            - <<: *full_items_array
+              name: 'agent-upgrade'
+              position: 2
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: !anyint
+
 ---
 test_name: GET /decoders
 

--- a/api/test/integration/test_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoders_endpoints.tavern.yaml
@@ -816,7 +816,7 @@ test_name: GET /decoders/files/{file}/download
 stages:
 
     # GET /decoders/files/{file}/download
-  - name: Try to download a decoders file
+  - name: Download a decoders file
     request:
       method: GET
       url: "{protocol:s}://{host:s}:{port:d}/decoders/files/{returned_file:s}/download"
@@ -824,6 +824,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
+      headers:
+        content-type: application/xml
 
     # GET /decoders/files/{wrong_file}/download
   - name: Try to download a decoders file using a wrong filename

--- a/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
@@ -78,6 +78,24 @@ stages:
           total_failed_items: 0
         message: All selected decoders were shown
 
+  - name: Try to show the decoders of the system (try q parameter to bypass a denied resource)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        q: 'file=0005-wazuh_decoders.xml'
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+        message: !anystr
+
   - name: Try to show the decoders of the system (list)
     request:
       url: "{protocol:s}://{host:s}:{port:d}/decoders"
@@ -211,6 +229,8 @@ stages:
       method: GET
     response:
       status_code: 200
+      headers:
+        content-type: application/xml
 
   - name: Try get one decoder file (no permissions)
     request:

--- a/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
@@ -25,58 +25,25 @@ stages:
       body:
         data:
           affected_items:
-            - details:
-                plugin_decoder: JSON_Decoder
-                prematch: !anystr
+            - &full_item_decoders
+              details: !anything
               file: 0006-json_decoders.xml
-              name: json
-              path: ruleset/decoders
-              position: 0
-              status: enabled
-            - details:
-                prematch: ^\w\w\w \w+\s+\d+ \d\d:\d\d:\d\d \p*\w+ \d+ /\S+/active-response/bin/|^\w\w\w
-                  \d\d/\d\d/\d\d\d\d \.+"active-response/bin/|^\d\d/\d\d/\d\d\d\d \.+"active-response/bin/
+              name: !anystr
+              path: !anystr
+              position: !anyint
+              status: !anystr
+            - <<: *full_item_decoders
               file: 0010-active-response_decoders.xml
-              name: ar_log
-              path: ruleset/decoders
-              position: 0
-              status: enabled
-            - details:
-                order: script, type, srcip, id
-                parent: ar_log
-                regex:
-                  - '^(\S+) (\S+) - (\S+) (\.+) |^(\S+)" (\S+) "-" "(\S+)" "(\.+) '
+            - <<: *full_item_decoders
               file: 0010-active-response_decoders.xml
-              name: ar_log_fields
-              path: ruleset/decoders
-              position: 1
-              status: enabled
-            - details:
-                order: extra_data
-                parent: ar_log
-                regex:
-                  - "^(\\d+)|(\\.+\\))"
+            - <<: *full_item_decoders
               file: 0010-active-response_decoders.xml
-              name: ar_log_fields
-              path: ruleset/decoders
-              position: 2
-              status: enabled
-            - details:
-                order: action,srcip,dstip,protocol,srcport,dstport
-                program_name: "^ipsec_logd"
-                regex:
-                  - " R:(\\w)  \\w:\\S+ S:(\\S+) "
-                  - 'D:(\S+) P:(\S+) SP:(\d+) DP:(\d+) '
-                type: firewall
+            - <<: *full_item_decoders
               file: 0015-aix-ipsec_decoders.xml
-              name: aix-ipsec
-              path: ruleset/decoders
-              position: 0
-              status: enabled
           failed_items: []
-          total_affected_items: 806
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All selected decoders were shown
+        message: !anystr
 
   - name: Try to show the decoders of the system (try q parameter to bypass a denied resource)
     request:
@@ -112,9 +79,6 @@ stages:
           failed_items:
             - error:
                 code: 1504
-                message: The decoder doesn't exist or you don't have permission to see it
-                remediation: Please, visit [official documentation](https://documentation.wazuh.com/3.x/user-manual/reference/ossec-conf/index.html)
-                  to get more information about the decoders
               id:
                 - agent-buffer
                 - agent-upgrade
@@ -123,7 +87,7 @@ stages:
                 - wazuh
           total_affected_items: 0
           total_failed_items: 5
-        message: No decoder was shown
+        message: !anystr
 
 ---
 test_name: GET DECODERS FILES RBAC
@@ -159,9 +123,9 @@ stages:
               path: ruleset/decoders
               status: enabled
           failed_items: []
-          total_affected_items: 98
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the decoders files of the system (list)
     request:
@@ -185,14 +149,11 @@ stages:
           failed_items:
             - error:
                 code: 4000
-                message: 'Permission denied: Resource type: decoder:file'
-                remediation: Please, make sure you have permissions to execute current request,
-                  for more information on setting up permissions please visit XXXX
               id:
                 - 0005-wazuh_decoders.xml
           total_affected_items: 2
           total_failed_items: 1
-        message: Some rules files were shown
+        message: !anystr
 
   - name: Try to show the decoders files of the system (no permissions)
     request:
@@ -208,13 +169,12 @@ stages:
         code: 4000
         dapi_errors:
           master-node:
-            error: Permission denied
-        detail: Permission denied
-        remediation: Please, make sure you have permissions to execute current request, for
-          more information on setting up permissions please visit XXXX
+            error: !anystr
+        detail: !anystr
+        remediation: !anystr
         status: 400
-        title: Wazuh Error
-        type: about:blank
+        title: !anystr
+        type: !anystr
 
 ---
 test_name: GET DECODERS FILES RBAC (Download)
@@ -248,7 +208,7 @@ test_name: GET DECODERS PARENTS RBAC
 
 stages:
 
-  - name: Try to show the groups of rules in the system
+  - name: Try to show the decoder parents in the system
     request:
       url: "{protocol:s}://{host:s}:{port:d}/decoders/parents"
       headers:
@@ -261,49 +221,22 @@ stages:
       body:
         data:
           affected_items:
-            - details:
-                plugin_decoder: JSON_Decoder
-                prematch: !anystr
+            - &full_item_decoders_parent
+              details: !anything
               file: 0006-json_decoders.xml
-              name: json
-              path: ruleset/decoders
-              position: 0
-              status: enabled
-            - details:
-                prematch: ^\w\w\w \w+\s+\d+ \d\d:\d\d:\d\d \p*\w+ \d+ /\S+/active-response/bin/|^\w\w\w
-                  \d\d/\d\d/\d\d\d\d \.+"active-response/bin/|^\d\d/\d\d/\d\d\d\d \.+"active-response/bin/
+              name: !anystr
+              path: !anystr
+              position: !anyint
+              status: !anystr
+            - <<: *full_item_decoders_parent
               file: 0010-active-response_decoders.xml
-              name: ar_log
-              path: ruleset/decoders
-              position: 0
-              status: enabled
-            - details:
-                order: action,srcip,dstip,protocol,srcport,dstport
-                program_name: "^ipsec_logd"
-                regex:
-                  - " R:(\\w)  \\w:\\S+ S:(\\S+) "
-                  - 'D:(\S+) P:(\S+) SP:(\d+) DP:(\d+) '
-                type: firewall
+            - <<: *full_item_decoders_parent
               file: 0015-aix-ipsec_decoders.xml
-              name: aix-ipsec
-              path: ruleset/decoders
-              position: 0
-              status: enabled
-            - details:
-                program_name: "^apache2|^httpd"
+            - <<: *full_item_decoders_parent
               file: 0025-apache_decoders.xml
-              name: apache-errorlog
-              path: ruleset/decoders
-              position: 0
-              status: enabled
-            - details:
-                prematch: "^[warn] |^[notice] |^[error] "
+            - <<: *full_item_decoders_parent
               file: 0025-apache_decoders.xml
-              name: apache-errorlog
-              path: ruleset/decoders
-              position: 1
-              status: enabled
           failed_items: []
-          total_affected_items: 157
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All selected decoders were shown
+        message: !anystr

--- a/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
@@ -119,6 +119,24 @@ stages:
           total_failed_items: 0
         message: All selected rules were shown
 
+  - name: Try to show the rules of the system (try q parameter to bypass a denied resource)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        q: 'file=0010-rules_config.xml'
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+        message: !anystr
+
   - name: Try to show the rules of the system (list)
     request:
       url: "{protocol:s}://{host:s}:{port:d}/rules"
@@ -289,6 +307,8 @@ stages:
       method: GET
     response:
       status_code: 200
+      headers:
+        content-type: application/xml
 
   - name: Try get one rule file (no permissions)
     request:

--- a/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
@@ -25,99 +25,28 @@ stages:
       body:
         data:
           affected_items:
-            - description: Grouping of wazuh rules.
-              details:
-                decoded_as: wazuh
+            - &full_item_rules
+              description: !anystr
+              details: !anything
               file: 0016-wazuh_rules.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - wazuh
-              hipaa: []
-              id: 200
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Agent event queue rule
-              details:
-                if_sid: '200'
-                match: "^wazuh: Agent buffer: "
-              file: 0016-wazuh_rules.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - agent_flooding
-                - wazuh
-              hipaa: []
-              id: 201
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Agent event queue is $(level) full.
-              details:
-                if_sid: '201'
-                level: "%"
-              file: 0016-wazuh_rules.xml
-              gdpr:
-                - IV_35.7.d
-              gpg13: []
-              groups:
-                - agent_flooding
-                - gdpr_IV_35.7.d
-                - wazuh
-              hipaa: []
-              id: 202
-              level: 7
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Agent event queue is full. Events may be lost.
-              details:
-                if_sid: '201'
-                level: full
-              file: 0016-wazuh_rules.xml
-              gdpr:
-                - IV_35.7.d
-              gpg13: []
-              groups:
-                - agent_flooding
-                - gdpr_IV_35.7.d
-                - wazuh
-              hipaa: []
-              id: 203
-              level: 9
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Agent event queue is flooded. Check the agent configuration.
-              details:
-                if_sid: '201'
-                level: flooded
-              file: 0016-wazuh_rules.xml
-              gdpr:
-                - IV_35.7.d
-              gpg13: []
-              groups:
-                - agent_flooding
-                - gdpr_IV_35.7.d
-                - wazuh
-              hipaa: []
-              id: 204
-              level: 12
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
+              gdpr: !anything
+              gpg13: !anything
+              groups: !anything
+              hipaa: !anything
+              id: !anyint
+              level: !anyint
+              nist_800_53: !anything
+              path: !anystr
+              pci: !anything
+              status: !anystr
+            - <<: *full_item_rules
+            - <<: *full_item_rules
+            - <<: *full_item_rules
+            - <<: *full_item_rules
           failed_items: []
-          total_affected_items: 2794
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All selected rules were shown
+        message: !anystr
 
   - name: Try to show the rules of the system (try q parameter to bypass a denied resource)
     request:
@@ -150,27 +79,11 @@ stages:
       body:
         data:
           affected_items:
-            - description: Grouping of wazuh rules.
-              details:
-                decoded_as: wazuh
-              file: 0016-wazuh_rules.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - wazuh
-              hipaa: []
+            - <<: *full_item_rules
               id: 200
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
           failed_items:
             - error:
                 code: 1208
-                message: The rule doesn't exist or you don't have permission to see it
-                remediation: Please, visit [official documentation](https://documentation.wazuh.com/3.x/user-manual/reference/ossec-conf/index.html)
-                  to get more information about how to configure the rules
               id:
                 - 1
                 - 2
@@ -179,7 +92,7 @@ stages:
                 - 702
           total_affected_items: 1
           total_failed_items: 5
-        message: Some rules could not be shown
+        message: !anystr
 
 ---
 test_name: GET RULES FILES RBAC
@@ -199,25 +112,22 @@ stages:
       body:
         data:
           affected_items:
-            - file: 0016-wazuh_rules.xml
+            - &full_item_rules_files
+              file: 0016-wazuh_rules.xml
               path: ruleset/rules
               status: enabled
-            - file: 0020-syslog_rules.xml
-              path: ruleset/rules
-              status: enabled
-            - file: 0025-sendmail_rules.xml
-              path: ruleset/rules
-              status: enabled
-            - file: 0030-postfix_rules.xml
-              path: ruleset/rules
-              status: enabled
-            - file: 0035-spamd_rules.xml
-              path: ruleset/rules
-              status: enabled
+            - <<: *full_item_rules_files
+              file: 0020-syslog_rules.xml
+            - <<: *full_item_rules_files
+              file: 0025-sendmail_rules.xml
+            - <<: *full_item_rules_files
+              file: 0030-postfix_rules.xml
+            - <<: *full_item_rules_files
+              file: 0035-spamd_rules.xml
           failed_items: []
-          total_affected_items: 123
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (list)
     request:
@@ -232,16 +142,15 @@ stages:
       body:
         data:
           affected_items:
-            - file: 0620-win-generic_rules.xml
-              path: ruleset/rules
-              status: enabled
-            - file: local_rules.xml
+            - <<: *full_item_rules_files
+              file: 0620-win-generic_rules.xml
+            - <<: *full_item_rules_files
+              file: local_rules.xml
               path: etc/rules
-              status: enabled
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (list)
     request:
@@ -256,21 +165,18 @@ stages:
       body:
         data:
           affected_items:
-            - file: local_rules.xml
+            - <<: *full_item_rules_files
+              file: local_rules.xml
               path: etc/rules
-              status: enabled
           failed_items:
             - error:
                 code: 4000
-                message: 'Permission denied: Resource type: rule:file'
-                remediation: Please, make sure you have permissions to execute current request,
-                  for more information on setting up permissions please visit XXXX
               id:
                 - 0010-rules_config.xml
                 - 0015-ossec_rules.xml
           total_affected_items: 1
           total_failed_items: 2
-        message: Some rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (no permissions)
     request:
@@ -286,13 +192,12 @@ stages:
         code: 4000
         dapi_errors:
           master-node:
-            error: Permission denied
-        detail: Permission denied
-        remediation: Please, make sure you have permissions to execute current request, for
-          more information on setting up permissions please visit XXXX
+            error: !anystr
+        detail: !anystr
+        remediation: !anystr
         status: 400
-        title: Wazuh Error
-        type: about:blank
+        title: !anystr
+        type: !anystr
 
 ---
 test_name: GET RULES FILES RBAC (Download)
@@ -338,9 +243,9 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 396
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All groups in rules are shown
+        message: !anystr
 
 ---
 test_name: GET PCI REQUIREMENT RBAC
@@ -359,6 +264,6 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 37
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: Selected rules were shown
+        message: !anystr

--- a/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
@@ -25,59 +25,21 @@ stages:
       body:
         data:
           affected_items:
-            - details:
-                prematch: "^wazuh: "
+            - &full_item_decoders
+              details: !anything
               file: 0005-wazuh_decoders.xml
-              name: wazuh
-              path: ruleset/decoders
-              position: 0
-              status: enabled
-            - details:
-                order: level
-                parent: wazuh
-                prematch: "^Agent buffer:"
-                regex:
-                  - "^ '(\\S+)'."
-              file: 0005-wazuh_decoders.xml
-              name: agent-buffer
-              path: ruleset/decoders
-              position: 1
-              status: enabled
-            - details:
-                order: agent.id, agent.name, status
-                parent: wazuh
-                prematch: "^Upgrade procedure |^Custom installation "
-                regex:
-                  - on agent (\d\d\d)\s\((\S+)\):\s(\w+)
-              file: 0005-wazuh_decoders.xml
-              name: agent-upgrade
-              path: ruleset/decoders
-              position: 2
-              status: enabled
-            - details:
-                order: error
-                parent: wazuh
-                regex:
-                  - aborted:\s(\.+)$|failed:\s(\.+)$|lost:\s(\.+)$
-              file: 0005-wazuh_decoders.xml
-              name: agent-upgrade
-              path: ruleset/decoders
-              position: 3
-              status: enabled
-            - details:
-                order: agent.cur_version
-                parent: wazuh
-                regex:
-                  - started.\sCurrent\sversion:\sWazuh\s(\.+)$
-              file: 0005-wazuh_decoders.xml
-              name: agent-upgrade
-              path: ruleset/decoders
-              position: 4
-              status: enabled
+              name: !anystr
+              path: !anystr
+              position: !anyint
+              status: !anystr
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
           failed_items: []
-          total_affected_items: 21
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All selected decoders were shown
+        message: !anystr
 
   - name: Try to show the decoders of the system (try q parameter to bypass a denied resource)
     request:
@@ -110,72 +72,14 @@ stages:
       body:
         data:
           affected_items:
-            - details:
-                prematch: "^wazuh: "
-              file: 0005-wazuh_decoders.xml
-              name: wazuh
-              path: ruleset/decoders
-              position: 0
-              status: enabled
-            - details:
-                order: level
-                parent: wazuh
-                prematch: "^Agent buffer:"
-                regex:
-                  - "^ '(\\S+)'."
-              file: 0005-wazuh_decoders.xml
-              name: agent-buffer
-              path: ruleset/decoders
-              position: 1
-              status: enabled
-            - details:
-                order: agent.id, agent.name, status
-                parent: wazuh
-                prematch: "^Upgrade procedure |^Custom installation "
-                regex:
-                  - on agent (\d\d\d)\s\((\S+)\):\s(\w+)
-              file: 0005-wazuh_decoders.xml
-              name: agent-upgrade
-              path: ruleset/decoders
-              position: 2
-              status: enabled
-            - details:
-                order: error
-                parent: wazuh
-                regex:
-                  - aborted:\s(\.+)$|failed:\s(\.+)$|lost:\s(\.+)$
-              file: 0005-wazuh_decoders.xml
-              name: agent-upgrade
-              path: ruleset/decoders
-              position: 3
-              status: enabled
-            - details:
-                order: agent.cur_version
-                parent: wazuh
-                regex:
-                  - started.\sCurrent\sversion:\sWazuh\s(\.+)$
-              file: 0005-wazuh_decoders.xml
-              name: agent-upgrade
-              path: ruleset/decoders
-              position: 4
-              status: enabled
-            - details:
-                order: agent.new_version
-                parent: wazuh
-                regex:
-                  - succeeded.\sNew\sversion:\sWazuh\s(\.+)$
-              file: 0005-wazuh_decoders.xml
-              name: agent-upgrade
-              path: ruleset/decoders
-              position: 5
-              status: enabled
-            - details:
-                prematch: "\\d\\d/\\d\\d/\\d\\d\\d\\d:\\s*\\d\\d:\\d\\d:\\d\\d\\s+GMT\\s+\\S+\\.+PPE\\.+:\\s|\\d\\d/\\d\\d/\\d\\d\\d\\d:\\s*\\d\\d:\\d\\d:\\d\\d\\s+GMT\\s+ns\\.+:\\s"
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
+            - <<: *full_item_decoders
               file: 0160-netscaler_decoders.xml
-              name: netscaler
-              path: ruleset/decoders
-              position: 0
-              status: enabled
           failed_items:
             - error:
                 code: 1504
@@ -183,9 +87,9 @@ stages:
                 remediation: !anystr
               id:
                 - netinfo
-          total_affected_items: 7
+          total_affected_items: !anyint
           total_failed_items: 1
-        message: Some decoders could not be shown
+        message: !anystr
 
 ---
 test_name: GET DECODERS FILES RBAC
@@ -210,9 +114,9 @@ stages:
               path: ruleset/decoders
               status: enabled
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the decoders files of the system (list)
     request:
@@ -234,9 +138,9 @@ stages:
               path: ruleset/decoders
               status: enabled
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the decoders files of the system (no permissions)
     request:
@@ -252,13 +156,12 @@ stages:
         code: 4000
         dapi_errors:
           master-node:
-            error: Permission denied
-        detail: Permission denied
-        remediation: Please, make sure you have permissions to execute current request, for
-          more information on setting up permissions please visit XXXX
+            error: !anystr
+        detail: !anystr
+        remediation: !anystr
         status: 400
-        title: Wazuh Error
-        type: about:blank
+        title: !anystr
+        type: !anystr
 
 ---
 test_name: GET DECODERS FILES RBAC (Download)
@@ -304,6 +207,6 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All selected decoders were shown
+        message: !anystr

--- a/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
@@ -79,6 +79,24 @@ stages:
           total_failed_items: 0
         message: All selected decoders were shown
 
+  - name: Try to show the decoders of the system (try q parameter to bypass a denied resource)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        q: 'file=0006-json_decoders.xml'
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+        message: !anystr
+
   - name: Try to show the decoders of the system (list)
     request:
       url: "{protocol:s}://{host:s}:{port:d}/decoders"
@@ -255,6 +273,8 @@ stages:
       method: GET
     response:
       status_code: 200
+      headers:
+        content-type: application/xml
 
   - name: Try get one decoder file (no permissions)
     request:

--- a/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
@@ -110,6 +110,24 @@ stages:
           total_failed_items: 0
         message: All selected rules were shown
 
+  - name: Try to show the rules of the system (try q parameter to bypass a denied resource)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        q: 'file=0020-syslog_rules.xml'
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+        message: !anystr
+
   - name: Try to show the rules of the system (list)
     request:
       url: "{protocol:s}://{host:s}:{port:d}/rules"
@@ -286,6 +304,8 @@ stages:
       method: GET
     response:
       status_code: 200
+      headers:
+        content-type: application/xml
 
   - name: Try get one rule file (no permissions)
     request:

--- a/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
@@ -25,90 +25,28 @@ stages:
       body:
         data:
           affected_items:
-            - description: Generic template for all syslog rules.
-              details:
-                category: syslog
-                noalert: '1'
+            - &full_item_rules
+              description: !anystr
+              details: !anything
               file: 0010-rules_config.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - syslog
-              hipaa: []
-              id: 1
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Generic template for all firewall rules.
-              details:
-                category: firewall
-                noalert: '1'
-              file: 0010-rules_config.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - firewall
-              hipaa: []
-              id: 2
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Generic template for all ids rules.
-              details:
-                category: ids
-                noalert: '1'
-              file: 0010-rules_config.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - ids
-              hipaa: []
-              id: 3
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Generic template for all web rules.
-              details:
-                category: web-log
-                noalert: '1'
-              file: 0010-rules_config.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - web-log
-              hipaa: []
-              id: 4
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Generic template for all web proxy rules.
-              details:
-                category: squid
-                noalert: '1'
-              file: 0010-rules_config.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - squid
-              hipaa: []
-              id: 5
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
+              gdpr: !anything
+              gpg13: !anything
+              groups: !anything
+              hipaa: !anything
+              id: !anyint
+              level: !anyint
+              nist_800_53: !anything
+              path: !anystr
+              pci: !anything
+              status: !anystr
+            - <<: *full_item_rules
+            - <<: *full_item_rules
+            - <<: *full_item_rules
+            - <<: *full_item_rules
           failed_items: []
-          total_affected_items: 54
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All selected rules were shown
+        message: !anystr
 
   - name: Try to show the rules of the system (try q parameter to bypass a denied resource)
     request:
@@ -141,82 +79,25 @@ stages:
       body:
         data:
           affected_items:
-            - description: Generic template for all syslog rules.
-              details:
-                category: syslog
-                noalert: '1'
-              file: 0010-rules_config.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - syslog
-              hipaa: []
+            - <<: *full_item_rules
               id: 1
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Generic template for all firewall rules.
-              details:
-                category: firewall
-                noalert: '1'
-              file: 0010-rules_config.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - firewall
-              hipaa: []
+            - <<: *full_item_rules
               id: 2
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Grouping of ossec rules.
-              details:
-                category: ossec
-                decoded_as: ossec
+            - <<: *full_item_rules
               file: 0015-ossec_rules.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - ossec
-              hipaa: []
               id: 500
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
-            - description: Logcollector Messages Grouped
-              details:
-                category: ossec
-                decoded_as: ossec-logcollector
+            - <<: *full_item_rules
               file: 0015-ossec_rules.xml
-              gdpr: []
-              gpg13: []
-              groups:
-                - ossec
-              hipaa: []
               id: 700
-              level: 0
-              nist_800_53: []
-              path: ruleset/rules
-              pci: []
-              status: enabled
           failed_items:
             - error:
                 code: 1208
-                message: The rule doesn't exist or you don't have permission to see it
-                remediation: Please, visit [official documentation](https://documentation.wazuh.com/3.x/user-manual/reference/ossec-conf/index.html)
-                  to get more information about how to configure the rules
               id:
                 - 200
                 - 702
           total_affected_items: 4
           total_failed_items: 2
-        message: Some rules could not be shown
+        message: !anystr
 
 ---
 test_name: GET RULES FILES RBAC
@@ -234,16 +115,16 @@ stages:
       body:
         data:
           affected_items:
-            - file: 0010-rules_config.xml
+            - &full_item_rules_files
+              file: 0010-rules_config.xml
               path: ruleset/rules
               status: enabled
-            - file: 0015-ossec_rules.xml
-              path: ruleset/rules
-              status: enabled
+            - <<: *full_item_rules_files
+              file: 0015-ossec_rules.xml
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (list)
     request:
@@ -258,16 +139,14 @@ stages:
       body:
         data:
           affected_items:
-            - file: 0010-rules_config.xml
-              path: ruleset/rules
-              status: enabled
-            - file: 0015-ossec_rules.xml
-              path: ruleset/rules
-              status: enabled
+            - <<: *full_item_rules_files
+              file: 0010-rules_config.xml
+            - <<: *full_item_rules_files
+              file: 0015-ossec_rules.xml
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (no permissions)
     request:
@@ -283,13 +162,12 @@ stages:
         code: 4000
         dapi_errors:
           master-node:
-            error: Permission denied
-        detail: Permission denied
-        remediation: Please, make sure you have permissions to execute current request, for
-          more information on setting up permissions please visit XXXX
+            error: !anystr
+        detail: !anystr
+        remediation: !anystr
         status: 400
-        title: Wazuh Error
-        type: about:blank
+        title: !anystr
+        type: !anystr
 
 ---
 test_name: GET RULES FILES RBAC (Download)
@@ -335,9 +213,9 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 39
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All groups in rules are shown
+        message: !anystr
 
 ---
 test_name: GET PCI REQUIREMENT RBAC
@@ -356,6 +234,6 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 7
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: Selected rules were shown
+        message: !anystr

--- a/api/test/integration/test_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rules_endpoints.tavern.yaml
@@ -254,6 +254,22 @@ stages:
       body:
         <<: *error_response
 
+  - name: Test q
+    request:
+      <<: *general_rules_request
+      params:
+        q: 'id=200'
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items:
+            - <<: *rules_response
+              id: 200
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: !anyint
+
 ---
 test_name: GET /rules filters
 
@@ -1222,7 +1238,7 @@ stages:
       status_code: 200
 
 ---
-test_name: GET /rules/{rule_ids}
+test_name: GET /rules?rule_ids
 
 stages:
 

--- a/api/test/integration/test_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rules_endpoints.tavern.yaml
@@ -1229,13 +1229,20 @@ stages:
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-  - name: Filter download
+---
+test_name: GET /rules/files/{file}/download
+
+stages:
+
+  - name: Download rule
     request:
       url: "{protocol:s}://{host:s}:{port:d}/rules/files/0350-amazon_rules.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
+      headers:
+        content-type: application/xml
 
 ---
 test_name: GET /rules?rule_ids

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -144,10 +144,15 @@ def get_groups(offset=0, limit=common.database_limit, sort_by=None, sort_ascendi
     result = AffectedItemsWazuhResult(none_msg='No groups in rules are shown',
                                       some_msg='Some groups in rules are shown',
                                       all_msg='All groups in rules are shown')
+    requirements = ['pci', 'gdpr', 'hipaa', 'nist_800_53', 'gpg13']
     groups = set()
     for rule in get_rules(limit=None).affected_items:
         for group in rule['groups']:
-            groups.add(group)
+            for req in requirements:
+                if req in group:
+                    break
+            else:
+                groups.add(group)
 
     result.affected_items = process_array(list(groups), search_text=search_text, search_in_fields=search_in_fields,
                                           complementary_search=complementary_search, sort_by=sort_by,


### PR DESCRIPTION
|Related issue|
|---|
|#4283|

## Description

Hello team,

This PR adds `q` parameter to `GET /rules` and `GET /decoders` endpoints for the new API. We have also updated the integration tests for those 2 endpoints and made sure the `q` filter is not bypassing RBAC protection.

## Tests

### **Rules test results:**
```
============================= test session starts ==============================
platform linux -- Python 3.6.9, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.34.0
collecting ... collected 10 items

test_rules_endpoints.tavern.yaml::GET /rules PASSED                      [ 10%]
test_rules_endpoints.tavern.yaml::GET /rules filters PASSED              [ 20%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/pci PASSED      [ 30%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/gdpr PASSED     [ 40%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/gpg13 PASSED    [ 50%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/hipaa PASSED    [ 60%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/nist-800-53 PASSED [ 70%]
test_rules_endpoints.tavern.yaml::GET /rules/groups PASSED               [ 80%]
test_rules_endpoints.tavern.yaml::GET /rules/files PASSED                [ 90%]
test_rules_endpoints.tavern.yaml::GET /rules?rule_ids PASSED             [100%]

=============================== warnings summary ===============================
test/integration/test_rules_endpoints.tavern.yaml::GET /rules
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

test/integration/test_rules_endpoints.tavern.yaml::GET /rules
test/integration/test_rules_endpoints.tavern.yaml::GET /rules filters
  /home/davidjiglesias/.local/lib/python3.6/site-packages/tavern/util/dict_util.py:189: FutureWarning: In a future version of Tavern, selecting for values to save in nested objects will have to be done as a JMES path query - see http://jmespath.org/ for more information
    warnings.warn(msg, FutureWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 10 passed, 3 warnings in 50.85 seconds ====================
```
### **Decoders test results:**
```
============================= test session starts ==============================
platform linux -- Python 3.6.9, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.34.0
collecting ... collected 23 items

test_decoders_endpoints.tavern.yaml::GET /decoders PASSED                [  4%]
test_decoders_endpoints.tavern.yaml::GET /decoders[file] PASSED          [  8%]
test_decoders_endpoints.tavern.yaml::GET /decoders[path] PASSED          [ 13%]
test_decoders_endpoints.tavern.yaml::GET /decoders[name] PASSED          [ 17%]
test_decoders_endpoints.tavern.yaml::GET /decoders[position] PASSED      [ 21%]
test_decoders_endpoints.tavern.yaml::GET /decoders[status] PASSED        [ 26%]
test_decoders_endpoints.tavern.yaml::GET /decoders/{decoder_name} PASSED [ 30%]
test_decoders_endpoints.tavern.yaml::GET /decoders/{decoder_name}[file] PASSED [ 34%]
test_decoders_endpoints.tavern.yaml::GET /decoders/{decoder_name}[path] PASSED [ 39%]
test_decoders_endpoints.tavern.yaml::GET /decoders/{decoder_name}[name] PASSED [ 43%]
test_decoders_endpoints.tavern.yaml::GET /decoders/{decoder_name}[position] PASSED [ 47%]
test_decoders_endpoints.tavern.yaml::GET /decoders/{decoder_name}[status] PASSED [ 52%]
test_decoders_endpoints.tavern.yaml::GET /decoders/files PASSED          [ 56%]
test_decoders_endpoints.tavern.yaml::GET /decoders/files[file] PASSED    [ 60%]
test_decoders_endpoints.tavern.yaml::GET /decoders/files[path] PASSED    [ 65%]
test_decoders_endpoints.tavern.yaml::GET /decoders/files[status] PASSED  [ 69%]
test_decoders_endpoints.tavern.yaml::GET /decoders/parents PASSED        [ 73%]
test_decoders_endpoints.tavern.yaml::GET /decoders/parents[file] PASSED  [ 78%]
test_decoders_endpoints.tavern.yaml::GET /decoders/parents[name] PASSED  [ 82%]
test_decoders_endpoints.tavern.yaml::GET /decoders/parents[path] PASSED  [ 86%]
test_decoders_endpoints.tavern.yaml::GET /decoders/parents[position] PASSED [ 91%]
test_decoders_endpoints.tavern.yaml::GET /decoders/parents[status] PASSED [ 95%]
test_decoders_endpoints.tavern.yaml::GET /decoders/files/{file}/download PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_decoders_endpoints.tavern.yaml::GET /decoders
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

test/integration/test_decoders_endpoints.tavern.yaml::GET /decoders
test/integration/test_decoders_endpoints.tavern.yaml::GET /decoders/{decoder_name}
test/integration/test_decoders_endpoints.tavern.yaml::GET /decoders/files
test/integration/test_decoders_endpoints.tavern.yaml::GET /decoders/parents
  /home/davidjiglesias/.local/lib/python3.6/site-packages/tavern/util/dict_util.py:189: FutureWarning: In a future version of Tavern, selecting for values to save in nested objects will have to be done as a JMES path query - see http://jmespath.org/ for more information
    warnings.warn(msg, FutureWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 23 passed, 5 warnings in 24.73 seconds ====================
```