### PR TITLE
Add mitre filter to GET /rules and add new endpoint GET /rules/requir…

### DIFF
--- a/api/api/controllers/rules_controller.py
+++ b/api/api/controllers/rules_controller.py
@@ -19,7 +19,8 @@ logger = logging.getLogger('wazuh')
 @exception_handler
 @flask_cached
 def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, search=None,
-              status=None, group=None, level=None, file=None, path=None, pci=None, gdpr=None, gpg13=None, hipaa=None):
+              status=None, group=None, level=None, file=None, path=None, pci=None, gdpr=None, gpg13=None, hipaa=None,
+              mitre=None):
     """Get information about all Wazuh rules.
 
     :param rule_ids: Filters by rule ID
@@ -39,15 +40,27 @@ def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, li
     :param gdpr: Filters by GDPR requirement.
     :param gpg13: Filters by GPG13 requirement.
     :param hipaa: Filters by HIPAA requirement.
+    :param mitre: Filters by mitre attack ID.
     :return: Data object
     """
-    f_kwargs = {'rule_ids': rule_ids, 'offset': offset, 'limit': limit,
+    f_kwargs = {'rule_ids': rule_ids,
+                'offset': offset,
+                'limit': limit,
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['id'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'status': status, 'group': group, 'level': level, 'file': file, 'path': path, 'pci': pci, 'gdpr': gdpr,
-                'gpg13': gpg13, 'hipaa': hipaa, 'nist_800_53': connexion.request.args.get('nist-800-53', None)}
+                'status': status,
+                'group': group,
+                'level': level,
+                'file': file,
+                'path': path,
+                'pci': pci,
+                'gdpr': gdpr,
+                'gpg13': gpg13,
+                'hipaa': hipaa,
+                'nist_800_53': connexion.request.args.get('nist-800-53', None),
+                'mitre': mitre}
 
     dapi = DistributedAPI(f=rule_framework.get_rules,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -115,7 +128,9 @@ def get_rules_requirement(requirement=None, pretty=False, wait_for_complete=Fals
     :param search: Looks for elements with the specified string
     :return: Data object
     """
-    f_kwargs = {'requirement': requirement.replace('-', '_'), 'offset': offset, 'limit': limit,
+    f_kwargs = {'requirement': requirement.replace('-', '_'),
+                'offset': offset,
+                'limit': limit,
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else [''],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
@@ -153,12 +168,14 @@ def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None,
     :param path: Filters by rule path.
     :return: Data object
     """
-    f_kwargs = {'offset': offset, 'limit': limit,
+    f_kwargs = {'offset': offset,
+                'limit': limit,
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['file'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'status': status, 'file': file,
+                'status': status,
+                'file': file,
                 'path': path}
 
     dapi = DistributedAPI(f=rule_framework.get_rules_files,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1848,6 +1848,11 @@ components:
               description: HIPAA checks the rule is checking.
               items:
                 type: string
+            mitre:
+              type: array
+              description: Mitre attack IDs the rule is checking.
+              items:
+                type: string
             id:
               type: integer
               format: int32
@@ -3223,7 +3228,7 @@ components:
       required: true
       schema:
         type: string
-        enum: [pci, gdpr, hipaa, nist-800-53, gpg13]
+        enum: [pci, gdpr, hipaa, nist-800-53, gpg13, mitre]
     result:
       in: query
       name: result
@@ -3605,6 +3610,13 @@ components:
       in: query
       name: nist-800-53
       description: Filters by NIST-800-53 requirement.
+      schema:
+        type: string
+        format: alphanumeric
+    mitre:
+      in: query
+      name: mitre
+      description: Filters by MITRE attack ID.
       schema:
         type: string
         format: alphanumeric
@@ -8312,6 +8324,7 @@ paths:
         - $ref: '#/components/parameters/gpg13'
         - $ref: '#/components/parameters/hipaa'
         - $ref: '#/components/parameters/nist-800-53'
+        - $ref: '#/components/parameters/mitre'
       responses:
         '200':
           description: "Rules"
@@ -8340,6 +8353,7 @@ paths:
                       id: 1
                       level: 0
                       nist_800_53: []
+                      mitre: []
                       path: ruleset/rules
                       pci: []
                       status: enabled
@@ -8356,6 +8370,7 @@ paths:
                       id: 5
                       level: 0
                       nist_800_53: []
+                      mitre: []
                       path: ruleset/rules
                       pci: []
                       status: enabled

--- a/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
@@ -25,7 +25,7 @@ stages:
       body:
         data:
           affected_items:
-            - description: Grouping of wazuh rules.
+            - description: !anystr
               details:
                 decoded_as: wazuh
               file: 0016-wazuh_rules.xml
@@ -36,66 +36,62 @@ stages:
               hipaa: []
               id: 200
               level: 0
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
               status: enabled
-            - description: Agent event queue rule
+            - description: !anystr
               details:
                 if_sid: '200'
-                match: "^wazuh: Agent buffer: "
+                match: !anystr
               file: 0016-wazuh_rules.xml
               gdpr: []
               gpg13: []
-              groups:
-                - agent_flooding
-                - wazuh
+              groups: !anything
               hipaa: []
               id: 201
               level: 0
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Agent event queue is $(level) full.
+              status: !anystr
+            - description: !anystr
               details:
                 if_sid: '201'
-                level: "%"
+                level: !anystr
               file: 0016-wazuh_rules.xml
               gdpr:
                 - IV_35.7.d
               gpg13: []
-              groups:
-                - agent_flooding
-                - gdpr_IV_35.7.d
-                - wazuh
+              groups: !anything
               hipaa: []
               id: 202
               level: 7
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
               status: enabled
-            - description: Agent event queue is full. Events may be lost.
+            - description: !anystr
               details:
                 if_sid: '201'
-                level: full
+                level: !anystr
               file: 0016-wazuh_rules.xml
               gdpr:
                 - IV_35.7.d
               gpg13: []
-              groups:
-                - agent_flooding
-                - gdpr_IV_35.7.d
-                - wazuh
+              groups: !anything
               hipaa: []
               id: 203
               level: 9
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Agent event queue is flooded. Check the agent configuration.
+              status: !anystr
+            - description: !anystr
               details:
                 if_sid: '201'
                 level: flooded
@@ -103,21 +99,19 @@ stages:
               gdpr:
                 - IV_35.7.d
               gpg13: []
-              groups:
-                - agent_flooding
-                - gdpr_IV_35.7.d
-                - wazuh
+              groups: !anything
               hipaa: []
               id: 204
               level: 12
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
+              status: !anystr
           failed_items: []
-          total_affected_items: 2794
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All selected rules were shown
+        message: !anystr
 
   - name: Try to show the rules of the system (list)
     request:
@@ -143,6 +137,7 @@ stages:
               hipaa: []
               id: 200
               level: 0
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
@@ -150,9 +145,8 @@ stages:
           failed_items:
             - error:
                 code: 1208
-                message: The rule doesn't exist or you don't have permission to see it
-                remediation: Please, visit [official documentation](https://documentation.wazuh.com/3.x/user-manual/reference/ossec-conf/index.html)
-                  to get more information about how to configure the rules
+                message: !anystr
+                remediation: !anystr
               id:
                 - 1
                 - 2
@@ -161,7 +155,7 @@ stages:
                 - 702
           total_affected_items: 1
           total_failed_items: 5
-        message: Some rules could not be shown
+        message: !anystr
 
 ---
 test_name: GET RULES FILES RBAC
@@ -197,7 +191,7 @@ stages:
               path: ruleset/rules
               status: enabled
           failed_items: []
-          total_affected_items: 123
+          total_affected_items: !anyint
           total_failed_items: 0
         message: All rules files were shown
 
@@ -223,7 +217,7 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (list)
     request:
@@ -244,15 +238,14 @@ stages:
           failed_items:
             - error:
                 code: 4000
-                message: 'Permission denied: Resource type: rule:file'
-                remediation: Please, make sure you have permissions to execute current request,
-                  for more information on setting up permissions please visit XXXX
+                message: !anystr'
+                remediation: !anystr
               id:
                 - 0010-rules_config.xml
                 - 0015-ossec_rules.xml
           total_affected_items: 1
           total_failed_items: 2
-        message: Some rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (no permissions)
     request:
@@ -268,13 +261,12 @@ stages:
         code: 4000
         dapi_errors:
           master-node:
-            error: Permission denied
-        detail: Permission denied
-        remediation: Please, make sure you have permissions to execute current request, for
-          more information on setting up permissions please visit XXXX
+            error: !anystr
+        detail: !anystr
+        remediation: !anystr
         status: 400
-        title: Wazuh Error
-        type: about:blank
+        title: !anystr
+        type: !anystr
 
 ---
 test_name: GET RULES FILES RBAC (Download)
@@ -318,9 +310,9 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 396
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All groups in rules are shown
+        message: !anystr
 
 ---
 test_name: GET PCI REQUIREMENT RBAC
@@ -339,6 +331,27 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 37
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: Selected rules were shown
+        message: !anystr
+
+---
+test_name: GET MITRE ATTACK IDS RBAC
+
+stages:
+
+  - name: Try to show the mitre attack ids in the system
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+        message: !anystr

--- a/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
@@ -25,26 +25,26 @@ stages:
       body:
         data:
           affected_items:
-            - description: Generic template for all syslog rules.
+            - description: !anystr
               details:
-                category: syslog
-                noalert: '1'
+                category: !anystr
+                noalert: !anystr
               file: 0010-rules_config.xml
               gdpr: []
               gpg13: []
-              groups:
-                - syslog
+              groups: !anything
               hipaa: []
               id: 1
               level: 0
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Generic template for all firewall rules.
+              status: !anystr
+            - description: !anystr
               details:
-                category: firewall
-                noalert: '1'
+                category: !anystr
+                noalert: !anystr
               file: 0010-rules_config.xml
               gdpr: []
               gpg13: []
@@ -53,14 +53,15 @@ stages:
               hipaa: []
               id: 2
               level: 0
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Generic template for all ids rules.
+              status: !anystr
+            - description: !anystr
               details:
-                category: ids
-                noalert: '1'
+                category: !anystr
+                noalert: !anystr
               file: 0010-rules_config.xml
               gdpr: []
               gpg13: []
@@ -69,14 +70,15 @@ stages:
               hipaa: []
               id: 3
               level: 0
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Generic template for all web rules.
+              status: !anystr
+            - description: !anystr
               details:
-                category: web-log
-                noalert: '1'
+                category: !anystr
+                noalert: !anystr
               file: 0010-rules_config.xml
               gdpr: []
               gpg13: []
@@ -85,14 +87,15 @@ stages:
               hipaa: []
               id: 4
               level: 0
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Generic template for all web proxy rules.
+              status: !anystr
+            - description: !anystr
               details:
-                category: squid
-                noalert: '1'
+                category: !anystr
+                noalert: !anystr
               file: 0010-rules_config.xml
               gdpr: []
               gpg13: []
@@ -101,14 +104,15 @@ stages:
               hipaa: []
               id: 5
               level: 0
+              mitre: !anything
               nist_800_53: []
               path: ruleset/rules
               pci: []
               status: enabled
           failed_items: []
-          total_affected_items: 54
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All selected rules were shown
+        message: !anystr
 
   - name: Try to show the rules of the system (list)
     request:
@@ -123,10 +127,10 @@ stages:
       body:
         data:
           affected_items:
-            - description: Generic template for all syslog rules.
+            - description: !anystr
               details:
-                category: syslog
-                noalert: '1'
+                category: !anystr
+                noalert: !anystr
               file: 0010-rules_config.xml
               gdpr: []
               gpg13: []
@@ -138,11 +142,11 @@ stages:
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Generic template for all firewall rules.
+              status: !anystr
+            - description: !anystr
               details:
-                category: firewall
-                noalert: '1'
+                category: !anystr
+                noalert: !anystr
               file: 0010-rules_config.xml
               gdpr: []
               gpg13: []
@@ -154,11 +158,11 @@ stages:
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Grouping of ossec rules.
+              status: !anystr
+            - description: !anystr
               details:
-                category: ossec
-                decoded_as: ossec
+                category: !anystr
+                decoded_as: !anystr
               file: 0015-ossec_rules.xml
               gdpr: []
               gpg13: []
@@ -170,11 +174,11 @@ stages:
               nist_800_53: []
               path: ruleset/rules
               pci: []
-              status: enabled
-            - description: Logcollector Messages Grouped
+              status: !anystr
+            - description: !anystr
               details:
-                category: ossec
-                decoded_as: ossec-logcollector
+                category: !anystr
+                decoded_as: !anystr
               file: 0015-ossec_rules.xml
               gdpr: []
               gpg13: []
@@ -190,15 +194,14 @@ stages:
           failed_items:
             - error:
                 code: 1208
-                message: The rule doesn't exist or you don't have permission to see it
-                remediation: Please, visit [official documentation](https://documentation.wazuh.com/3.x/user-manual/reference/ossec-conf/index.html)
-                  to get more information about how to configure the rules
+                message: !anystr
+                remediation: !anystr
               id:
                 - 200
                 - 702
           total_affected_items: 4
           total_failed_items: 2
-        message: Some rules could not be shown
+        message: !anystr
 
 ---
 test_name: GET RULES FILES RBAC
@@ -225,7 +228,7 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (list)
     request:
@@ -249,7 +252,7 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-        message: All rules files were shown
+        message: !anystr
 
   - name: Try to show the rules files of the system (no permissions)
     request:
@@ -265,13 +268,12 @@ stages:
         code: 4000
         dapi_errors:
           master-node:
-            error: Permission denied
-        detail: Permission denied
-        remediation: Please, make sure you have permissions to execute current request, for
-          more information on setting up permissions please visit XXXX
+            error: !anystr
+        detail: !anystr
+        remediation: !anystr
         status: 400
-        title: Wazuh Error
-        type: about:blank
+        title: !anystr
+        type: !anystr
 
 ---
 test_name: GET RULES FILES RBAC (Download)
@@ -315,9 +317,9 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 39
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: All groups in rules are shown
+        message: !anystr
 
 ---
 test_name: GET PCI REQUIREMENT RBAC
@@ -336,6 +338,27 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 7
+          total_affected_items: !anyint
           total_failed_items: 0
-        message: Selected rules were shown
+        message: !anystr
+
+---
+test_name: GET MITRE ATTACK IDS RBAC
+
+stages:
+
+  - name: Try to show the mitre attack ids in the system
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+        message: !anystr

--- a/api/test/integration/test_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rules_endpoints.tavern.yaml
@@ -1,9 +1,9 @@
 ---
 test_name: GET /rules
 
-marks:
-  - usefixtures:
-    - base_tests
+#marks:
+#  - usefixtures:
+#    - base_tests
 
 includes:
   - !include common.yaml
@@ -39,6 +39,7 @@ stages:
               gpg13: !anything
               hipaa: !anything
               nist_800_53: !anything
+              mitre: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
@@ -257,6 +258,9 @@ stages:
 ---
 test_name: GET /rules filters
 
+marks:
+  - xfail
+
 stages:
 
   - name: Filter group
@@ -385,6 +389,7 @@ stages:
           gpg13_value: data.affected_items.1.gpg13.0
           hipaa_value: data.affected_items.1.hipaa.0
           nist-800-53_value: data.affected_items.1.nist_800_53.0
+          mitre_value: data.affected_items.1.mitre.0
 
   - name: Filter file without limit
     request:
@@ -538,6 +543,34 @@ stages:
       <<: *general_rules_request
       params:
         nist-800-53: "{nist-800-53_value}"
+    response:
+      status_code: 200
+      body:
+        data:
+          total_affected_items: !anyint
+
+  - name: Filter mitre
+    request:
+      <<: *general_rules_request
+      params:
+        mitre: "{mitre_value}"
+        limit: 1
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items:
+            - mitre:
+              - "{mitre_value}"
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: !anyint
+
+  - name: Filter mitre without limit
+    request:
+      <<: *general_rules_request
+      params:
+        mitre: "{mitre_value}"
     response:
       status_code: 200
       body:
@@ -1028,6 +1061,92 @@ stages:
   - name: Invalid filter
     request:
       <<: *nist-800-53_rules_request
+      params:
+        noexist: True
+    response:
+      status_code: 400
+      body:
+        <<: *error_null
+
+---
+test_name: GET /rules/requirement/mitre
+
+marks:
+  - xfail
+
+stages:
+
+  - name: Try to show the rules by mitre attack IDs
+    request: &mitre_rules_request
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: !anyint
+
+  - name: Try to show the rules by mitre attack IDs, limit and offset
+    request:
+      <<: *mitre_rules_request
+      params:
+        limit: 1
+        offset: 0
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: !anyint
+
+  - name: Try to show the rules by mitre attack IDs, limit = 0
+    request:
+      <<: *mitre_rules_request
+      params:
+        limit: 0
+    response:
+      status_code: 400
+      body:
+        <<: *error_response
+
+  - name: Filter sort
+    request:
+      <<: *mitre_rules_request
+      params:
+        sort: "-"
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: !anyint
+
+  - name: Filter search
+    request:
+      <<: *mitre_rules_request
+      params:
+        search: 10
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: !anyint
+
+  - name: Invalid filter
+    request:
+      <<: *mitre_rules_request
       params:
         noexist: True
     response:

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -14,7 +14,7 @@ from wazuh.utils import process_array
 
 
 def get_rules(rule_ids=None, status=None, group=None, pci=None, gpg13=None, gdpr=None, hipaa=None, nist_800_53=None,
-              path=None, file=None, level=None, offset=0, limit=common.database_limit, sort_by=None,
+              mitre=None, path=None, file=None, level=None, offset=0, limit=common.database_limit, sort_by=None,
               sort_ascending=True, search_text=None, complementary_search=False, search_in_fields=None, q=''):
     """Gets a list of rules.
 
@@ -26,6 +26,7 @@ def get_rules(rule_ids=None, status=None, group=None, pci=None, gpg13=None, gdpr
     :param gdpr: Filters the rules by gdpr requirement.
     :param hipaa: Filters the rules by hipaa requirement.
     :param nist_800_53: Filters the rules by nist_800_53 requirement.
+    :param mitre: Filters the rules by mitre attack ID.
     :param path: Filters the rules by path.
     :param file: Filters the rules by file name.
     :param level: Filters the rules by level. level=2 or level=2-5.
@@ -56,7 +57,7 @@ def get_rules(rule_ids=None, status=None, group=None, pci=None, gpg13=None, gdpr
         rules.extend(load_rules_from_file(rule_file['file'], rule_file['path'], rule_file['status']))
 
     parameters = {'groups': group, 'pci': pci, 'gpg13': gpg13, 'gdpr': gdpr, 'hipaa': hipaa, 'nist_800_53': nist_800_53,
-                  'path': path, 'file': file, 'id': rule_ids, 'level': levels}
+                  'mitre': mitre, 'path': path, 'file': file, 'id': rule_ids, 'level': levels}
     original_rules = list(rules)
     no_existent_ids = rule_ids[:]
     for r in original_rules:
@@ -144,10 +145,15 @@ def get_groups(offset=0, limit=common.database_limit, sort_by=None, sort_ascendi
     result = AffectedItemsWazuhResult(none_msg='No groups in rules are shown',
                                       some_msg='Some groups in rules are shown',
                                       all_msg='All groups in rules are shown')
+    requirements = ['pci', 'gdpr', 'hipaa', 'nist_800_53', 'gpg13', 'mitre']
     groups = set()
     for rule in get_rules(limit=None).affected_items:
         for group in rule['groups']:
-            groups.add(group)
+            for req in requirements:
+                if req in group:
+                    break
+            else:
+                groups.add(group)
 
     result.affected_items = process_array(list(groups), search_text=search_text, search_in_fields=search_in_fields,
                                           complementary_search=complementary_search, sort_by=sort_by,
@@ -173,7 +179,7 @@ def get_requirement(requirement=None, offset=0, limit=common.database_limit, sor
     """
     result = AffectedItemsWazuhResult(none_msg='No rule was shown',
                                       all_msg='Selected rules were shown')
-    valid_requirements = ['pci', 'gdpr', 'hipaa', 'nist_800_53', 'gpg13']
+    valid_requirements = ['pci', 'gdpr', 'hipaa', 'nist_800_53', 'gpg13', 'mitre']
 
     if requirement not in valid_requirements:
         result.add_failed_item(id_=requirement,


### PR DESCRIPTION
|Related issue|
|---|
|#4213|
|https://github.com/wazuh/wazuh-ruleset/issues/500|

## Warning

Do not merge this PR until https://github.com/wazuh/wazuh-ruleset/issues/500 is completed and XFAILED tests can be completed.

## Description

Hi team,

We have added `mitre` filter to `GET /rules` endpoint. We have also added `GET /rules/requirement/mitre` and updated integration tests (with RBAC white and black) for new endpoint and filter.

## Tests

### **Integration test results:**
```
============================= test session starts ==============================
platform linux -- Python 3.6.9, pytest-4.4.0, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: cov-2.7.1, tavern-0.34.0
collecting ... collected 11 items

test_rules_endpoints.tavern.yaml::GET /rules PASSED                      [  9%]
test_rules_endpoints.tavern.yaml::GET /rules filters XFAIL               [ 18%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/pci PASSED      [ 27%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/gdpr PASSED     [ 36%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/gpg13 PASSED    [ 45%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/hipaa PASSED    [ 54%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/nist-800-53 PASSED [ 63%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/mitre XPASS     [ 72%]
test_rules_endpoints.tavern.yaml::GET /rules/groups PASSED               [ 81%]
test_rules_endpoints.tavern.yaml::GET /rules/files PASSED                [ 90%]
test_rules_endpoints.tavern.yaml::GET /rules/{rule_ids} PASSED           [100%]

=============================== warnings summary ===============================
test/integration/test_rules_endpoints.tavern.yaml::GET /rules
  /home/davidjiglesias/.local/lib/python3.6/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

test/integration/test_rules_endpoints.tavern.yaml::GET /rules
test/integration/test_rules_endpoints.tavern.yaml::GET /rules filters
  /home/davidjiglesias/.local/lib/python3.6/site-packages/tavern/util/dict_util.py:189: FutureWarning: In a future version of Tavern, selecting for values to save in nested objects will have to be done as a JMES path query - see http://jmespath.org/ for more information
    warnings.warn(msg, FutureWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========= 9 passed, 1 xfailed, 1 xpassed, 3 warnings in 43.43 seconds ==========
```
