### PR TITLE
static field dstport is now parsed for its output in alerts description

### DIFF
--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1146,6 +1146,8 @@ char* ParseRuleComment(Eventinfo *lf) {
 #endif
         } else if (strcmp(var, "srcport") == 0) {
             field = lf->srcport;
+        } else if (strcmp(var, "dstport") == 0) {
+            field = lf->dstport;
         } else if (strcmp(var, "protocol") == 0) {
             field = lf->protocol;
         } else if (strcmp(var, "action") == 0) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4352|

## Description
After including the `dstport` field parsing on the `eventinfo.c` file for its use as output in `<description>` rules option, it is correctly displayed through `Analysisd` and `ossec-logtest`

## Logs/Alerts example
```
date=2016-06-15 time=11:44:46 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=2 sessionid=1563645 user="" srcip=1.2.3.11 srcport=52414 srcintf="internal2" dstip=1.5.5.92 dstport=443 dstintf="wan2" proto=6 service=HTTPS hostname="4-edge-chat.facebook.com" profile="default" action=blocked reqtype=referral url="/p?partition=-2&cb=lz1k&failure=5&sticky_token=274&sticky_pool=atn2c06_chat-proxy" sentbyte=932 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high


  <rule id="111111" level="6">
    <if_sid>81620</if_sid>
    <description>The dstport value is '$(dstport)'</description>
  </rule>
```

## Tests

*Analysisd alert*
```
** Alert 1576073466.361093: - local,syslog,sshd,
2019 Dec 11 15:11:06 nanoPill->/var/log/syslog
Rule: 111111 (level 6) -> 'The dstport value is '443''
Src IP: 1.2.3.11
Src Port: 52414
Dst IP: 1.5.5.92
Dst Port: 443
date=2016-06-15 time=11:44:46 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=2 sessionid=1563645 user="" srcip=1.2.3.11 srcport=52414 srcintf="internal2" dstip=1.5.5.92 dstport=443 dstintf="wan2" proto=6 service=HTTPS hostname="4-edge-chat.facebook.com" profile="default" action=blocked reqtype=referral url="/p?partition=-2&cb=lz1k&failure=5&sticky_token=274&sticky_pool=atn2c06_chat-proxy" sentbyte=932 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high
```
*ossec-logtest alert*
```
**Phase 2: Completed decoding.
       decoder: 'fortigate-firewall-v5'
       status: 'warning'
       srcuser: ''
       srcip: '1.2.3.11'
       srcport: '52414'
       dstip: '1.5.5.92'
       dstport: '443'
       url: '4-edge-chat.facebook.com'
       action: 'blocked'

**Phase 3: Completed filtering (rules).
       Rule id: '111111'
       Level: '6'
       Description: 'The dstport value is '443''
**Alert to be generated.
```

The destination port is now properly displayed as the examples above shown.

Greetings, JP Sáez