### PR TITLE
Add AWS fields to Elasticsearch template

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -86,6 +86,8 @@
       "data.aws.errorMessage",
       "data.aws.eventID",
       "data.aws.eventName",
+      "data.aws.eventTime",
+      "data.aws.created-at",
       "data.aws.eventSource",
       "data.aws.eventType",
       "data.aws.id",
@@ -149,6 +151,7 @@
       "data.aws.userIdentity.accessKeyId",
       "data.aws.userIdentity.accountId",
       "data.aws.userIdentity.userName",
+      "data.aws.userIdentity.sessionContext.attributes.creationDate",
       "data.aws.vpcEndpointId",
       "data.command",
       "data.data",
@@ -1745,8 +1748,21 @@
               "createdAt": {
                 "type": "date"
               },
+              "created-at": {
+                "type": "date"
+              },
+              "eventTime": {
+                "type": "date"
+              },
               "updatedAt": {
                 "type": "date"
+              },
+              "userIdentity.sessionContext.attributes": {
+                "properties": {
+                  "creationDate": {
+                    "type": "date"
+                  }
+                }
               },
               "resource.instanceDetails": {
                 "properties": {


### PR DESCRIPTION
Hi team,

As requested in [#1951](https://github.com/wazuh/wazuh-kibana-app/issues/1951.). The Elasticsearch template has been updated to include these 3 new fields of AWS of `date` type:
- `data.aws.eventTime`
- `data.aws.userIdentity.sessionContext.attributes.creationDate`
- `data.aws.created-at`

--------

I have applied this new template to my Elasticsearch cluster and generated some alerts with these specific fields to check that everything is working correctly:

- Here we can see the applied mappings in our `wazuh-alerts*` index pattern:
![image](https://user-images.githubusercontent.com/35685689/70629202-e5a11f00-1c29-11ea-997c-0b35596b5d77.png)

- Discover section also shows these 3 fields with the correct mapping (`date` instead of `string`)
![image](https://user-images.githubusercontent.com/35685689/70629086-a672ce00-1c29-11ea-8438-df6a4a36fd84.png)


Best regards,
Pablo Torres