### PR TITLE
Substitute cJSON_Parse function with cJSON_ParseWithOpts for FIM

### DIFF
--- a/src/analysisd/decoders/dbsync.c
+++ b/src/analysisd/decoders/dbsync.c
@@ -225,9 +225,10 @@ end:
 }
 
 void DispatchDBSync(dbsync_context_t * ctx, Eventinfo * lf) {
+    const char *jsonErrPtr;
     ctx->agent_id = lf->agent_id;
 
-    cJSON * root = cJSON_Parse(lf->log);
+    cJSON * root = cJSON_ParseWithOpts(lf->log, &jsonErrPtr, 0);
 
     if (root == NULL) {
         merror("dbsync: Cannot parse JSON: %s", lf->log);

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1120,8 +1120,9 @@ int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
 
     cJSON *root_json = NULL;
     int retval = 0;
+    const char *jsonErrPtr;
 
-    if (root_json = cJSON_Parse(lf->log), !root_json) {
+    if (root_json = cJSON_ParseWithOpts(lf->log, &jsonErrPtr, 0), !root_json) {
         merror("Malformed FIM JSON event");
         return retval;
     }

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -197,6 +197,7 @@ void fim_sync_send_list(const char * start, const char * top) {
 void fim_sync_dispatch(char * payload) {
     assert(payload != NULL);
 
+    const char *jsonErrPtr;
     char * command = payload;
     char * json_arg = strchr(payload, ' ');
 
@@ -206,7 +207,7 @@ void fim_sync_dispatch(char * payload) {
     }
 
     *json_arg++ = '\0';
-    cJSON * root = cJSON_Parse(json_arg);
+    cJSON * root = cJSON_ParseWithOpts(json_arg, &jsonErrPtr, 0);
 
     if (root == NULL) {
         mdebug1(FIM_DBSYNC_INVALID_ARGUMENT, json_arg);

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -366,7 +366,9 @@ end:
 }
 int wdb_syscheck_save2(wdb_t * wdb, const char * payload) {
     int retval = -1;
-    cJSON * data = cJSON_Parse(payload);
+    const char *jsonErrPtr;
+
+    cJSON * data = cJSON_ParseWithOpts(payload, &jsonErrPtr, 0);
 
     if (data == NULL) {
         mdebug1("DB(%s): cannot parse FIM payload: '%s'", wdb->agent_id, payload);

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -182,7 +182,8 @@ static void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long 
 // Query the checksum of a data range
 int wdbi_query_checksum(wdb_t * wdb, wdb_component_t component, const char * command, const char * payload) {
     int retval = -1;
-    cJSON * data = cJSON_Parse(payload);
+    const char *jsonErrPtr;
+    cJSON * data = cJSON_ParseWithOpts(payload, &jsonErrPtr, 0);
 
     if (data == NULL) {
         mdebug1("DB(%s): cannot parse checksum range payload: '%s'", wdb->agent_id, payload);
@@ -272,7 +273,8 @@ int wdbi_query_clear(wdb_t * wdb, wdb_component_t component, const char * payloa
     assert(component < sizeof(INDEXES) / sizeof(int));
 
     int retval = -1;
-    cJSON * data = cJSON_Parse(payload);
+    const char *jsonErrPtr;
+    cJSON * data = cJSON_ParseWithOpts(payload, &jsonErrPtr, 0);
 
     if (data == NULL) {
         mdebug1("DB(%s): cannot parse checksum range payload: '%s'", wdb->agent_id, payload);


### PR DESCRIPTION
|Related issue|
|---|
|#4351|

## Description

This PR substitutes the occurrences of `cJSON_Parse`  with `cJSON_ParseWithOpts` for FIM.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
