### PR TITLE
Replace non-reentrant function cJSON_Parse for vulnerability-detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4466,6 +4466,7 @@ int wm_vuldet_request_hotfixes(sqlite3 *db, char *agent_id) {
     cJSON *obj_it;
     sqlite3_stmt *stmt = NULL;
     char *last_id;
+    const char *jsonErrPtr;
 
     if (last_id = wm_vuldet_get_hotfix_scan(agent_id), !last_id) {
         retval = 1;
@@ -4491,7 +4492,7 @@ int wm_vuldet_request_hotfixes(sqlite3 *db, char *agent_id) {
 
     request[0] = request[1] = ' ';
 
-    if (obj = cJSON_Parse(request), !obj) {
+    if (obj = cJSON_ParseWithOpts(request, &jsonErrPtr, 0), !obj) {
         goto end;
     }
 
@@ -4541,6 +4542,7 @@ int wm_vuldet_get_oswindows_info(agent_software *agent) {
     char request[OS_SIZE_128];
     cJSON *obj = NULL;
     cJSON *obj_it;
+    const char *jsonErrPtr;
 
     snprintf(request, OS_SIZE_128, vu_queries[VU_SYSC_OSWIN_INFO], agent->agent_id);
 
@@ -4561,7 +4563,7 @@ int wm_vuldet_get_oswindows_info(agent_software *agent) {
 
     request[0] = request[1] = ' ';
 
-    if (obj = cJSON_Parse(request), !obj) {
+    if (obj = cJSON_ParseWithOpts(request, &jsonErrPtr, 0), !obj) {
         goto end;
     }
 
@@ -5248,6 +5250,7 @@ int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time, char *hotfix_
     char request[OS_SIZE_6144];
     cJSON *obj = NULL;
     cJSON *obj_it;
+    const char *jsonErrPtr;
 
     snprintf(request, OS_SIZE_128, vu_queries[VU_LAST_SCAN_REQUEST], agent_id);
 
@@ -5267,7 +5270,7 @@ int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time, char *hotfix_
 
     request[0] = request[1] = ' ';
 
-    if (obj = cJSON_Parse(request), !obj) {
+    if (obj = cJSON_ParseWithOpts(request, &jsonErrPtr, 0), !obj) {
         goto end;
     }
 
@@ -5358,6 +5361,7 @@ char *wm_vuldet_get_hotfix_scan(char *agent_id) {
     char request[OS_SIZE_128];
     char *scan_id = NULL;
     cJSON *obj = NULL;
+    const char *jsonErrPtr;
 
     // Get the last scan ID
     snprintf(request, OS_SIZE_128, vu_queries[VU_HOTF_SCAN_REQUEST], agent_id);
@@ -5378,7 +5382,7 @@ char *wm_vuldet_get_hotfix_scan(char *agent_id) {
 
     request[0] = request[1] = ' ';
 
-    if (obj = cJSON_Parse(request), !obj || !obj->child || !obj->child->child) {
+    if (obj = cJSON_ParseWithOpts(request, &jsonErrPtr, 0), !obj || !obj->child || !obj->child->child) {
         goto end;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|None|

## Description

This PR substitutes the occurrences of `cJSON_Parse` with `cJSON_ParseWithOpts` for vulnerability detector.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
