### PR TITLE
Change Synchronization configuration

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -108,7 +108,7 @@
     <inventory>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>
 

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -106,6 +106,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -106,7 +106,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>
     </inventory>

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -105,11 +105,11 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
-    </inventory>
+    </synchronization>
   </syscheck>
 
   <!-- Log analysis -->

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -120,11 +120,11 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
-    </inventory>
+    </synchronization>
   </syscheck>
 
   <!-- Active response -->

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -121,7 +121,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>
     </inventory>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -121,6 +121,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -123,7 +123,7 @@
     <inventory>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -120,11 +120,11 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
-    </inventory>
+    </synchronization>
   </syscheck>
 
   <!-- Active response -->

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -121,7 +121,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>
     </inventory>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -121,6 +121,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -123,7 +123,7 @@
     <inventory>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>
 

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -142,6 +142,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -142,7 +142,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>
   </syscheck>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -141,7 +141,7 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -144,7 +144,7 @@
     <inventory>
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
   </syscheck>
 
   <!-- Active response -->

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -46,7 +46,6 @@
     <inventory>
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
-      <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -44,7 +44,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -47,6 +47,6 @@
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -43,8 +43,8 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
-    </inventory>
+    </synchronization>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -45,7 +45,6 @@
     <!-- Database synchronization settings -->
     <inventory>
       <interval>5m</interval>
-      <max_sync_interval>1h</max_sync_interval>
-      <queue_size>16384</queue_size>
+      <max_interval>1h</max_interval>
     </inventory>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -44,6 +44,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
     </synchronization>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -52,7 +52,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -55,6 +55,6 @@
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -53,7 +53,6 @@
     <!-- Database synchronization settings -->
     <inventory>
       <interval>5m</interval>
-      <max_sync_interval>1h</max_sync_interval>
-      <queue_size>16384</queue_size>
+      <max_interval>1h</max_interval>
     </inventory>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -52,6 +52,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
     </synchronization>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -54,7 +54,6 @@
     <inventory>
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
-      <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -51,8 +51,8 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
-    </inventory>
+    </synchronization>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -46,7 +46,6 @@
     <inventory>
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
-      <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -44,7 +44,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -47,6 +47,6 @@
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -43,8 +43,8 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
-    </inventory>
+    </synchronization>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -45,7 +45,6 @@
     <!-- Database synchronization settings -->
     <inventory>
       <interval>5m</interval>
-      <max_sync_interval>1h</max_sync_interval>
-      <queue_size>16384</queue_size>
+      <max_interval>1h</max_interval>
     </inventory>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -44,6 +44,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
     </synchronization>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -50,7 +50,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -50,6 +50,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
     </synchronization>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -52,7 +52,6 @@
     <inventory>
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
-      <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -53,6 +53,6 @@
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -49,8 +49,8 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
-    </inventory>
+    </synchronization>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -51,7 +51,6 @@
     <!-- Database synchronization settings -->
     <inventory>
       <interval>5m</interval>
-      <max_sync_interval>1h</max_sync_interval>
-      <queue_size>16384</queue_size>
+      <max_interval>1h</max_interval>
     </inventory>
   </syscheck>

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -812,7 +812,7 @@ out_free:
 
 static void parse_inventory(syscheck_config * syscheck, XML_NODE node) {
     const char *xml_enabled = "enabled";
-    const char *xml_sync_interval = "sync_interval";
+    const char *xml_sync_interval = "interval";
     const char *xml_max_sync_interval = "max_sync_interval";
     const char *xml_response_timeout = "response_timeout";
     const char *xml_sync_queue_size = "sync_queue_size";

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -815,7 +815,7 @@ static void parse_inventory(syscheck_config * syscheck, XML_NODE node) {
     const char *xml_sync_interval = "interval";
     const char *xml_max_sync_interval = "max_sync_interval";
     const char *xml_response_timeout = "response_timeout";
-    const char *xml_sync_queue_size = "sync_queue_size";
+    const char *xml_sync_queue_size = "queue_size";
 
     for (int i = 0; node[i]; i++) {
         if (strcmp(node[i]->element, xml_enabled) == 0) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -813,7 +813,7 @@ out_free:
 static void parse_inventory(syscheck_config * syscheck, XML_NODE node) {
     const char *xml_enabled = "enabled";
     const char *xml_sync_interval = "interval";
-    const char *xml_max_sync_interval = "max_sync_interval";
+    const char *xml_max_sync_interval = "max_interval";
     const char *xml_response_timeout = "response_timeout";
     const char *xml_sync_queue_size = "queue_size";
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -810,7 +810,7 @@ out_free:
     return ret;
 }
 
-static void parse_inventory(syscheck_config * syscheck, XML_NODE node) {
+static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
     const char *xml_enabled = "enabled";
     const char *xml_sync_interval = "interval";
     const char *xml_max_sync_interval = "max_interval";
@@ -824,7 +824,7 @@ static void parse_inventory(syscheck_config * syscheck, XML_NODE node) {
             if (r < 0) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
-                syscheck->enable_inventory = r;
+                syscheck->enable_synchronization = r;
             }
         } else if (strcmp(node[i]->element, xml_sync_interval) == 0) {
             long t = w_parse_time(node[i]->content);
@@ -903,7 +903,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_audit_key = "audit_key";
     const char *xml_audit_hc = "startup_healthcheck";
     const char *xml_process_priority = "process_priority";
-    const char *xml_inventory = "inventory";
+    const char *xml_synchronization = "synchronization";
     const char *xml_max_eps = "max_eps";
     const char *xml_allow_remote_prefilter_cmd = "allow_remote_prefilter_cmd";
 
@@ -1456,14 +1456,14 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             } else {
                 syscheck->process_priority = value;
             }
-        } else if (strcmp(node[i]->element, xml_inventory) == 0) {
+        } else if (strcmp(node[i]->element, xml_synchronization) == 0) {
             children = OS_GetElementsbyNode(xml, node[i]);
 
             if (children == NULL) {
                 continue;
             }
 
-            parse_inventory(syscheck, children);
+            parse_synchronization(syscheck, children);
             OS_ClearNode(children);
         } else if (strcmp(node[i]->element, xml_max_eps) == 0) {
             char * end;

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -224,7 +224,7 @@ typedef struct _config {
     int queue;                      /* file descriptor of socket to write to queue */
     unsigned int restart_audit:1;   /* Allow Syscheck restart Auditd */
     unsigned int enable_whodata:1;  /* At less one directory configured with whodata */
-    unsigned int enable_inventory:1;    /* Enable database synchronization */
+    unsigned int enable_synchronization:1;    /* Enable database synchronization */
 
     int *opts;                      /* attributes set in the <directories> tag element */
 

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -40,7 +40,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.scan_time      = NULL;
     syscheck.dir            = NULL;
     syscheck.opts           = NULL;
-    syscheck.enable_inventory = 1;
+    syscheck.enable_synchronization = 1;
     syscheck.restart_audit  = 1;
     syscheck.enable_whodata = 0;
     syscheck.realtime       = NULL;
@@ -57,6 +57,7 @@ int Read_Syscheck_Config(const char *cfgfile)
 #endif
     syscheck.prefilter_cmd  = NULL;
     syscheck.sync_interval  = 300;
+    syscheck.max_sync_interval = 3600;
     syscheck.sync_response_timeout = 30;
     syscheck.sync_queue_size = 16384;
     syscheck.max_eps        = 200;
@@ -306,13 +307,13 @@ cJSON *getSyscheckConfig(void) {
         cJSON_AddStringToObject(syscfg,"prefilter_cmd",syscheck.prefilter_cmd);
     }
 
-    cJSON * inventory = cJSON_CreateObject();
-    cJSON_AddStringToObject(inventory, "enabled", syscheck.enable_inventory ? "yes" : "no");
-    cJSON_AddNumberToObject(inventory, "max_interval", syscheck.max_sync_interval);
-    cJSON_AddNumberToObject(inventory, "interval", syscheck.sync_interval);
-    cJSON_AddNumberToObject(inventory, "response_timeout", syscheck.sync_response_timeout);
-    cJSON_AddNumberToObject(inventory, "queue_size", syscheck.sync_queue_size);
-    cJSON_AddItemToObject(syscfg, "inventory", inventory);
+    cJSON * synchronization = cJSON_CreateObject();
+    cJSON_AddStringToObject(synchronization, "enabled", syscheck.enable_synchronization ? "yes" : "no");
+    cJSON_AddNumberToObject(synchronization, "max_interval", syscheck.max_sync_interval);
+    cJSON_AddNumberToObject(synchronization, "interval", syscheck.sync_interval);
+    cJSON_AddNumberToObject(synchronization, "response_timeout", syscheck.sync_response_timeout);
+    cJSON_AddNumberToObject(synchronization, "queue_size", syscheck.sync_queue_size);
+    cJSON_AddItemToObject(syscfg, "synchronization", synchronization);
 
     cJSON_AddNumberToObject(syscfg, "max_eps", syscheck.max_eps);
     cJSON_AddNumberToObject(syscfg, "process_priority", syscheck.process_priority);

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -308,7 +308,7 @@ cJSON *getSyscheckConfig(void) {
 
     cJSON * inventory = cJSON_CreateObject();
     cJSON_AddStringToObject(inventory, "enabled", syscheck.enable_inventory ? "yes" : "no");
-    cJSON_AddNumberToObject(inventory, "max_sync_interval", syscheck.max_sync_interval);
+    cJSON_AddNumberToObject(inventory, "max_interval", syscheck.max_sync_interval);
     cJSON_AddNumberToObject(inventory, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(inventory, "response_timeout", syscheck.sync_response_timeout);
     cJSON_AddNumberToObject(inventory, "queue_size", syscheck.sync_queue_size);

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -309,7 +309,7 @@ cJSON *getSyscheckConfig(void) {
     cJSON * inventory = cJSON_CreateObject();
     cJSON_AddStringToObject(inventory, "enabled", syscheck.enable_inventory ? "yes" : "no");
     cJSON_AddNumberToObject(inventory, "max_sync_interval", syscheck.max_sync_interval);
-    cJSON_AddNumberToObject(inventory, "sync_interval", syscheck.sync_interval);
+    cJSON_AddNumberToObject(inventory, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(inventory, "response_timeout", syscheck.sync_response_timeout);
     cJSON_AddNumberToObject(inventory, "sync_queue_size", syscheck.sync_queue_size);
     cJSON_AddItemToObject(syscfg, "inventory", inventory);

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -311,7 +311,7 @@ cJSON *getSyscheckConfig(void) {
     cJSON_AddNumberToObject(inventory, "max_sync_interval", syscheck.max_sync_interval);
     cJSON_AddNumberToObject(inventory, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(inventory, "response_timeout", syscheck.sync_response_timeout);
-    cJSON_AddNumberToObject(inventory, "sync_queue_size", syscheck.sync_queue_size);
+    cJSON_AddNumberToObject(inventory, "queue_size", syscheck.sync_queue_size);
     cJSON_AddItemToObject(syscfg, "inventory", inventory);
 
     cJSON_AddNumberToObject(syscfg, "max_eps", syscheck.max_eps);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -165,7 +165,7 @@ void start_daemon()
     w_create_thread(fim_run_realtime, &syscheck);
 
     // Launch inventory synchronization thread, if enabled
-    if (syscheck.enable_inventory) {
+    if (syscheck.enable_synchronization) {
         w_create_thread(fim_run_integrity, &syscheck);
     }
 

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -61,7 +61,7 @@
     <!-- Database synchronization settings -->
     <inventory>
       <interval>10m</interval>
-      <max_sync_interval>1h</max_sync_interval>
+      <max_interval>1h</max_interval>
       <queue_size>64</queue_size>
     </inventory>
   </syscheck>

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -62,7 +62,6 @@
     <inventory>
       <interval>10m</interval>
       <max_sync_interval>1h</max_sync_interval>
-      <response_timeout>1m</response_timeout>
       <queue_size>64</queue_size>
     </inventory>
   </syscheck>

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -59,10 +59,10 @@
     </whodata>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>10m</interval>
       <max_interval>1h</max_interval>
       <queue_size>64</queue_size>
-    </inventory>
+    </synchronization>
   </syscheck>
 </ossec_config>

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -63,7 +63,7 @@
       <interval>10m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>1m</response_timeout>
-      <sync_queue_size>64</sync_queue_size>
+      <queue_size>64</queue_size>
     </inventory>
   </syscheck>
 </ossec_config>

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -60,6 +60,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>10m</interval>
       <max_interval>1h</max_interval>
       <queue_size>64</queue_size>

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -60,7 +60,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>10m</sync_interval>
+      <interval>10m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>1m</response_timeout>
       <sync_queue_size>64</sync_queue_size>

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -132,7 +132,7 @@
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>
 

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -129,7 +129,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -128,10 +128,10 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
-    </inventory>
+    </synchronization>
   </syscheck>
 
   <!-- System inventory -->

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -129,6 +129,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
     </synchronization>

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -130,8 +130,7 @@
     <!-- Database synchronization settings -->
     <inventory>
       <interval>5m</interval>
-      <max_sync_interval>1h</max_sync_interval>
-      <queue_size>16384</queue_size>
+      <max_interval>1h</max_interval>
     </inventory>
   </syscheck>
 

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -131,7 +131,6 @@
     <inventory>
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
-      <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -148,6 +148,7 @@
 
     <!-- Database synchronization settings -->
     <synchronization>
+      <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
     </synchronization>

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -150,7 +150,6 @@
     <inventory>
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
-      <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
     </inventory>
   </syscheck>

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -149,8 +149,7 @@
     <!-- Database synchronization settings -->
     <inventory>
       <interval>5m</interval>
-      <max_sync_interval>1h</max_sync_interval>
-      <queue_size>16384</queue_size>
+      <max_interval>1h</max_interval>
     </inventory>
   </syscheck>
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -151,7 +151,7 @@
       <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
     </inventory>
   </syscheck>
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -147,10 +147,10 @@
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
+    <synchronization>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
-    </inventory>
+    </synchronization>
   </syscheck>
 
   <!-- System inventory -->

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -148,7 +148,7 @@
 
     <!-- Database synchronization settings -->
     <inventory>
-      <sync_interval>5m</sync_interval>
+      <interval>5m</interval>
       <max_sync_interval>1h</max_sync_interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>


### PR DESCRIPTION
|Related issue|
|---|
| #4364 |

## Description
Following changes are treated in this pull request;

>  **sync_interval**
>
>  - [x] Change its name from `sync_interval` to `interval`
>
>
>  **response_timeout**
>
> - [x] Do not add it to the default configuration
>
> **sync_queue_size**
>
> - [x] Change its name from `sync_queue_size` to `queue_size`
> - [x] Do not add it to the default configuration
>
>
> **max_sync_interval**
>
> - [x] Change its name from `max_sync_interval` to `max_interval`
> - [x] Add this option to the documentation
>
> **synchronization**
>
> - [x] Change the stanza title: from `inventory` to `synchronization`

## Configuration options

Configuration proposal matches the one proposed on #4364 

```xml
<syscheck>
  ...
  <synchronization>
    <enabled>yes</enabled>
    <interval>5m</interval>
    <max_interval>2h</max_interval>
    <response_timeout>30</response_timeout>
    <queue_size>16384</queue_size>
  </synchronization>
</syscheck>
```
