### PR TITLE
Add the host's primary IP to Logcollector's output format

### DIFF
--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -85,7 +85,7 @@ int auth_add_agent(int sock, char *id, const char *name, const char *ip, const c
 char * get_agent_id_from_name(const char *agent_name);
 
 /* Check control module availability */
-#if defined (__linux__) || defined (__MACH__)
+#if defined (__linux__) || defined (__MACH__) || defined (sun)
 int control_check_connection();
 #endif
 

--- a/src/headers/log_builder.h
+++ b/src/headers/log_builder.h
@@ -1,0 +1,77 @@
+/**
+ * @file log_builder.h
+ * @author Vikman Fernandez-Castro (victor@wazuh.com)
+ * @brief Declaration of the shared log builder library
+ * @version 0.1
+ * @date 2019-12-06
+ *
+ * @copyright Copyright (c) 2019 Wazuh, Inc.
+ */
+
+/*
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef LOG_BUILDER_H
+#define LOG_BUILDER_H
+
+#define LOG_BUILDER_HOSTNAME_LEN 512
+
+/**
+ * @brief Log builder type
+ *
+ * This structure holds the pattern values that change rarely.
+ *
+ */
+typedef struct {
+    char host_name[LOG_BUILDER_HOSTNAME_LEN];   ///< Host name
+    pthread_rwlock_t rwlock;                    ///< Mutex
+} log_builder_t;
+
+/**
+ * @brief Initialize a log builder structure
+ *
+ * @param update Selects if the initializer should populate the data.
+ * @return Pointer to an initialized log builder structure.
+ */
+log_builder_t * log_builder_init(bool update);
+
+/**
+ * @brief Free a log builder structure.
+ *
+ * @param builder Pointer to a log builder structure.
+ */
+void log_builder_destroy(log_builder_t * builder);
+
+/**
+ * @brief Update the pattern values
+ *
+ * @param builder Pointer to a log builder structure.
+ * @retval 0 All the values were updated successfully.
+ * @retval -1 Any of the values failed to update.
+ */
+int log_builder_update(log_builder_t * builder);
+
+/**
+ * @brief Build a log string
+ *
+ * Supported patterns:
+ * - $(log) or $(output): Message from the log.
+ * - $(json_escaped_log): Message from the log, with JSON string escapes applied.
+ * - $(location) or $(command): Source of the message.
+ * - $(timestamp): Current timestamp in RFC3164 format.
+ * - $(timestamp <format>): Current timestamp, in strftime string format.
+ * - $(hostname): System's host name.
+ *
+ * @param builder Pointer to a log builder structure.
+ * @param pattern String holding the log format.
+ * @param logmsg String containing the input log.
+ * @param location String representing the log location.
+ * @return Pointer to a new string holding the output log. It will never be NULL.
+ */
+char * log_builder_build(log_builder_t * builder, const char * pattern, const char * logmsg, const char * location);
+
+#endif // LOG_BUILDER_H

--- a/src/headers/log_builder.h
+++ b/src/headers/log_builder.h
@@ -28,6 +28,7 @@
  */
 typedef struct {
     char host_name[LOG_BUILDER_HOSTNAME_LEN];   ///< Host name
+    char host_ip[INET6_ADDRSTRLEN];             ///< Host's primary IP
     pthread_rwlock_t rwlock;                    ///< Mutex
 } log_builder_t;
 
@@ -65,6 +66,7 @@ int log_builder_update(log_builder_t * builder);
  * - $(timestamp): Current timestamp in RFC3164 format.
  * - $(timestamp <format>): Current timestamp, in strftime string format.
  * - $(hostname): System's host name.
+ * - $(host_ip): Host's primary IP.
  *
  * @param builder Pointer to a log builder structure.
  * @param pattern String holding the log format.

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -42,4 +42,8 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attr
 
 int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logtarget * target) __attribute__((nonnull (2, 3, 5)));
 
+void mq_log_builder_init();
+
+int mq_log_builder_update();
+
 #endif /* MQ_H */

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -240,6 +240,7 @@ extern const char *__local_name;
 #include "notify_op.h"
 #include "version_op.h"
 #include "utf8_op.h"
+#include "log_builder.h"
 
 #include "os_xml/os_xml.h"
 #include "os_regex/os_regex.h"

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -297,6 +297,9 @@ void LogCollectorStart()
         }
     }
 
+    // Initialize message queue's log builder
+    mq_log_builder_init();
+
     /* Create the output threads */
     w_create_output_threads();
 
@@ -740,6 +743,10 @@ void LogCollectorStart()
         if (!os_iswait()) {
             rand_keepalive_str(keepalive, KEEPALIVE_SIZE);
             w_msg_hash_queues_push(keepalive, "ossec-keepalive", strlen(keepalive) + 1, default_target, LOCALFILE_MQ);
+        }
+
+        if (mq_log_builder_update() == -1) {
+            mdebug1("Output log pattern data could not be updated.");
         }
 
         sleep(1);

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -769,7 +769,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 /* Connect to the control socket if available */
 #if defined (__linux__) || defined (__MACH__)
 int control_check_connection() {
-    int sock = OS_ConnectUnixDomain(CONTROL_SOCK, SOCK_STREAM, OS_SIZE_128);
+    int sock = OS_ConnectUnixDomain(isChroot() ? CONTROL_SOCK : DEFAULTDIR CONTROL_SOCK, SOCK_STREAM, OS_SIZE_128);
 
     if (sock < 0) {
         return -1;

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -767,7 +767,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 }
 
 /* Connect to the control socket if available */
-#if defined (__linux__) || defined (__MACH__)
+#if defined (__linux__) || defined (__MACH__) || defined(sun)
 int control_check_connection() {
     int sock = OS_ConnectUnixDomain(isChroot() ? CONTROL_SOCK : DEFAULTDIR CONTROL_SOCK, SOCK_STREAM, OS_SIZE_128);
 

--- a/src/shared/log_builder.c
+++ b/src/shared/log_builder.c
@@ -245,7 +245,7 @@ int log_builder_update_host_ip(log_builder_t * builder) {
         mdebug1("Cannot update host IP.");
     }
 
-#elif defined __linux__ || defined __MACH__
+#elif defined __linux__ || defined __MACH__ || defined sun
     const char * REQUEST = "host_ip";
     int sock = control_check_connection();
 

--- a/src/shared/log_builder.c
+++ b/src/shared/log_builder.c
@@ -1,0 +1,221 @@
+/**
+ * @file log_builder.c
+ * @author Vikman Fernandez-Castro (victor@wazuh.com)
+ * @brief Definition of the shared log builder library
+ * @version 0.1
+ * @date 2019-12-06
+ *
+ * @copyright Copyright (c) 2019 Wazuh, Inc.
+ */
+
+/*
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "shared.h"
+
+/**
+ * @brief Update the hostname value
+ *
+ * @param builder Pointer to a log builder structure.
+ * @post If the hostname cannot be updated, it's replaced by "localhost".
+ * @retval 0 If the hostname was updated successfully.
+ * @retval 1 If the hostname failed to be updated.
+ */
+static int log_builder_update_hostname(log_builder_t * builder);
+
+// Initialize a log builder structure
+log_builder_t * log_builder_init(bool update) {
+    log_builder_t * builder;
+    os_calloc(1, sizeof(log_builder_t), builder);
+
+    {
+        pthread_rwlockattr_t attr;
+        pthread_rwlockattr_init(&attr);
+
+#ifdef __linux__
+        /* PTHREAD_RWLOCK_PREFER_WRITER_NP is ignored.
+        * Do not use recursive locking.
+        */
+        pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+#endif
+
+        w_rwlock_init(&builder->rwlock, &attr);
+        pthread_rwlockattr_destroy(&attr);
+    }
+
+    if (update) {
+        log_builder_update(builder);
+    } else {
+        strncpy(builder->host_name, "localhost", LOG_BUILDER_HOSTNAME_LEN - 1);
+    }
+
+    return builder;
+}
+
+// Free a log builder structure.
+void log_builder_destroy(log_builder_t * builder) {
+    pthread_rwlock_destroy(&builder->rwlock);
+    free(builder);
+}
+
+// Update the pattern values
+int log_builder_update(log_builder_t * builder) {
+    int result = 0;
+
+    result = log_builder_update_hostname(builder) == 0 ? result : -1;
+
+    return result;
+}
+
+// Build a log string
+char * log_builder_build(log_builder_t * builder, const char * pattern, const char * logmsg, const char * location) {
+    char * final;
+    char * _pattern;
+    char * cur;
+    char * tok;
+    char * end;
+    char * param;
+    const char * field;
+    char _timestamp[64];
+    char * escaped_log = NULL;
+    size_t n = 0;
+    size_t z;
+    time_t timestamp = time(NULL);
+
+    if (!pattern) {
+        return strdup(logmsg);
+    }
+
+    os_malloc(OS_MAXSTR, final);
+    os_strdup(pattern, _pattern);
+
+    w_rwlock_rdlock(&builder->rwlock);
+
+    for (cur = _pattern; tok = strstr(cur, "$("), tok; cur = end) {
+        field = NULL;
+        *tok = '\0';
+
+        // Skip $(
+        param = tok + 2;
+
+        // Copy anything before the token
+        z = strlen(cur);
+
+        if (n + z >= OS_MAXSTR) {
+            goto fail;
+        }
+
+        strncpy(final + n, cur, OS_MAXSTR - n);
+        n += z;
+
+        if (end = strchr(param, ')'), !end) {
+            // Token not closed: break
+            *tok = '$';
+            cur = tok;
+            break;
+        }
+
+        *end++ = '\0';
+
+        // Find parameter
+
+        if (strcmp(param, "log") == 0 || strcmp(param, "output") == 0) {
+            field = logmsg;
+        } else if (strcmp(param, "location") == 0 || strcmp(param, "command") == 0) {
+            field = location;
+        } else if (strncmp(param, "timestamp", 9) == 0) {
+            struct tm tm;
+            char * format;
+
+            localtime_r(&timestamp, &tm);
+
+            if (format = strchr(param, ' '), format) {
+                if (strftime(_timestamp, sizeof(_timestamp), format + 1, &tm)) {
+                    field = _timestamp;
+                } else {
+                    mdebug1("Cannot format time '%s': %s (%d)", format, strerror(errno), errno);
+                }
+            } else {
+                // If format is not speficied, use RFC3164
+#ifdef WIN32
+                // strfrime() does not allow %e in Windows
+                const char * MONTHS[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+
+                if (snprintf(_timestamp, sizeof(_timestamp), "%s %s%d %02d:%02d:%02d", MONTHS[tm.tm_mon], tm.tm_mday < 10 ? " " : "", tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec) < (int)sizeof(_timestamp)) {
+                    field = _timestamp;
+                }
+#else
+                if (strftime(_timestamp, sizeof(_timestamp), "%b %e %T", &tm)) {
+                    field = _timestamp;
+                }
+#endif // WIN32
+            }
+        } else if (strcmp(param, "hostname") == 0) {
+            field = builder->host_name;
+        } else if (strcmp(param, "json_escaped_log") == 0) {
+            field = escaped_log = wstr_escape_json(logmsg);
+        } else {
+            mdebug1("Invalid parameter '%s' for log format.", param);
+            continue;
+        }
+
+        if (field) {
+            z = strlen(field);
+
+            if (n + z >= OS_MAXSTR) {
+                goto fail;
+            }
+
+            strncpy(final + n, field, OS_MAXSTR - n);
+            n += z;
+        }
+
+        os_free(escaped_log);
+    }
+
+    // Copy rest of the pattern
+
+    z = strlen(cur);
+
+    if (n + z >= OS_MAXSTR) {
+        goto fail;
+    }
+
+    w_rwlock_unlock(&builder->rwlock);
+
+    strncpy(final + n, cur, OS_MAXSTR - n);
+    final[n + z] = '\0';
+
+    free(_pattern);
+    return final;
+
+fail:
+    w_rwlock_unlock(&builder->rwlock);
+
+    mdebug1("Too long message format");
+    strncpy(final, logmsg ? logmsg : "Too long message format", OS_MAXSTR - 1);
+    final[OS_MAXSTR - 1] = '\0';
+    free(_pattern);
+    free(escaped_log);
+    return final;
+}
+
+// Update the hostname value
+int log_builder_update_hostname(log_builder_t * builder) {
+    int retval = 0;
+
+    w_rwlock_wrlock(&builder->rwlock);
+
+    if (gethostname(builder->host_name, LOG_BUILDER_HOSTNAME_LEN) != 0) {
+        strncpy(builder->host_name, "localhost", LOG_BUILDER_HOSTNAME_LEN - 1);
+        builder->host_name[LOG_BUILDER_HOSTNAME_LEN - 1] = '\0';
+        retval = -1;
+    }
+
+    w_rwlock_unlock(&builder->rwlock);
+    return retval;
+}

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -109,7 +109,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
 {
     int __mq_rcode;
     char tmpstr[OS_MAXSTR + 1];
-    time_t mtime = time(NULL);
+    time_t mtime;
     char * _message = NULL;
 
     _message = log_builder_build(mq_log_builder, target->format, message, locmsg);

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -12,8 +12,7 @@
 #include "config/config.h"
 #include "os_net/os_net.h"
 
-static char * msgsubst(const char * pattern, const char * logmsg, const char * location, time_t timestamp);
-
+static log_builder_t * mq_log_builder;
 int sock_fail_time;
 
 #ifndef WIN32
@@ -113,7 +112,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
     time_t mtime = time(NULL);
     char * _message = NULL;
 
-    _message = msgsubst(target->format, message, locmsg, mtime);
+    _message = log_builder_build(mq_log_builder, target->format, message, locmsg);
 
     if (strcmp(target->log_socket->name, "agent") == 0) {
         SendMSG(queue, _message, locmsg, loc);
@@ -208,7 +207,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
         return -1;
     }
 
-    _message = msgsubst(targets[0].format, message, locmsg, time(NULL));
+    _message = log_builder_build(mq_log_builder, targets[0].format, message, locmsg);
     retval = SendMSG(queue, _message, locmsg, loc);
     free(_message);
     return retval;
@@ -216,133 +215,12 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, l
 
 #endif /* !WIN32 */
 
-char * msgsubst(const char * pattern, const char * logmsg, const char * location, time_t timestamp) {
-    char * final;
-    char * _pattern;
-    char * cur;
-    char * tok;
-    char * end;
-    char * param;
-    const char * field;
-    char _timestamp[64];
-    char hostname[512];
-    char * escaped_log = NULL;
-    size_t n = 0;
-    size_t z;
+void mq_log_builder_init() {
+    assert(mq_log_builder == NULL);
+    mq_log_builder = log_builder_init(true);
+}
 
-    if (!pattern) {
-        return strdup(logmsg);
-    }
-
-    os_malloc(OS_MAXSTR, final);
-    os_strdup(pattern, _pattern);
-
-    for (cur = _pattern; tok = strstr(cur, "$("), tok; cur = end) {
-        field = NULL;
-        *tok = '\0';
-
-        // Skip $(
-        param = tok + 2;
-
-        // Copy anything before the token
-        z = strlen(cur);
-
-        if (n + z >= OS_MAXSTR) {
-            goto fail;
-        }
-
-        strncpy(final + n, cur, OS_MAXSTR - n);
-        n += z;
-
-        if (end = strchr(param, ')'), !end) {
-            // Token not closed: break
-            *tok = '$';
-            cur = tok;
-            break;
-        }
-
-        *end++ = '\0';
-
-        // Find parameter
-
-        if (strcmp(param, "log") == 0 || strcmp(param, "output") == 0) {
-            field = logmsg;
-        } else if (strcmp(param, "location") == 0 || strcmp(param, "command") == 0) {
-            field = location;
-        } else if (strncmp(param, "timestamp", 9) == 0) {
-            struct tm tm;
-            char * format;
-
-            localtime_r(&timestamp, &tm);
-
-            if (format = strchr(param, ' '), format) {
-                if (strftime(_timestamp, sizeof(_timestamp), format + 1, &tm)) {
-                    field = _timestamp;
-                } else {
-                    mdebug1("Cannot format time '%s': %s (%d)", format, strerror(errno), errno);
-                }
-            } else {
-                // If format is not speficied, use RFC3164
-#ifdef WIN32
-                // strfrime() does not allow %e in Windows
-                const char * MONTHS[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
-
-                if (snprintf(_timestamp, sizeof(_timestamp), "%s %s%d %02d:%02d:%02d", MONTHS[tm.tm_mon], tm.tm_mday < 10 ? " " : "", tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec) < (int)sizeof(_timestamp)) {
-                    field = _timestamp;
-                }
-#else
-                if (strftime(_timestamp, sizeof(_timestamp), "%b %e %T", &tm)) {
-                    field = _timestamp;
-                }
-#endif // WIN32
-            }
-        } else if (strcmp(param, "hostname") == 0) {
-            if (gethostname(hostname, sizeof(hostname)) != 0) {
-                strncpy(hostname, "localhost", sizeof(hostname));
-            }
-
-            hostname[sizeof(hostname) - 1] = '\0';
-            field = hostname;
-        } else if (strcmp(param, "json_escaped_log") == 0) {
-            field = escaped_log = wstr_escape_json(logmsg);
-        } else {
-            mdebug1("Invalid parameter '%s' for log format.", param);
-            continue;
-        }
-
-        if (field) {
-            z = strlen(field);
-
-            if (n + z >= OS_MAXSTR) {
-                goto fail;
-            }
-
-            strncpy(final + n, field, OS_MAXSTR - n);
-            n += z;
-        }
-
-        os_free(escaped_log);
-    }
-
-    // Copy rest of the pattern
-
-    z = strlen(cur);
-
-    if (n + z >= OS_MAXSTR) {
-        goto fail;
-    }
-
-    strncpy(final + n, cur, OS_MAXSTR - n);
-    final[n + z] = '\0';
-
-    free(_pattern);
-    return final;
-
-fail:
-    mdebug1("Too long message format");
-    strncpy(final, logmsg ? logmsg : "Too long message format", OS_MAXSTR - 1);
-    final[OS_MAXSTR - 1] = '\0';
-    free(_pattern);
-    free(escaped_log);
-    return final;
+int mq_log_builder_update() {
+    assert(mq_log_builder != NULL);
+    return log_builder_update(mq_log_builder);
 }

--- a/src/tests/tap_os_net.c
+++ b/src/tests/tap_os_net.c
@@ -16,6 +16,8 @@
 #define SENDSTRING "Hello World!\n"
 #define BUFFERSIZE 1024
 
+char * getPrimaryIP();
+
 int test_tcpv4_local() {
     int server_root_socket, server_client_socket, client_socket;
     char buffer[BUFFERSIZE];
@@ -280,6 +282,13 @@ int test_gethost_not_exists() {
     return 1;
 }
 
+int test_get_ip() {
+    char * ip = getPrimaryIP();
+    int retval = OS_IsValidIP(ip, NULL);
+    free(ip);
+    return retval == 1;
+}
+
 int main(void) {
     printf("\n\n    STARTING TEST - OS_NET   \n\n");
 
@@ -318,6 +327,9 @@ int main(void) {
 
     // Try to get host by name with non-existent host name
     TAP_TEST_MSG(test_gethost_not_exists(), "Get host by name: non-existent host test.");
+
+    // Get IP address
+    TAP_TEST_MSG(test_get_ip(), "Get primary IP address collection.");
 
     TAP_PLAN;
     TAP_SUMMARY;

--- a/src/tests/tap_shared.c
+++ b/src/tests/tap_shared.c
@@ -59,6 +59,8 @@ int test_strnspn_escaped() {
     w_assert_uint_eq(strcspn_escaped("ABCDE\\\\", ' '), 7);
     w_assert_uint_eq(strcspn_escaped("ABC\\ D E", ' '), 6);
     w_assert_uint_eq(strcspn_escaped("ABCDE", ' '), 5);
+
+    return 1;
 }
 
 int test_json_escape() {
@@ -79,6 +81,30 @@ int test_json_escape() {
     return 1;
 }
 
+int test_log_builder() {
+    const char * PATTERN = "location: $(location), log: $(log), escaped: $(json_escaped_log)";
+    const char * LOG = "Hello \"World\"";
+    const char * LOCATION = "test";
+    const char * EXPECTED_OUTPUT = "location: test, log: Hello \"World\", escaped: Hello \\\"World\\\"";
+
+    int retval = 1;
+    log_builder_t * builder = log_builder_init(false);
+
+    if (builder == NULL) {
+        return 0;
+    }
+
+    char * output = log_builder_build(builder, PATTERN, LOG, LOCATION);
+
+    if (strcmp(output, EXPECTED_OUTPUT) != 0) {
+        retval = 0;
+    }
+
+    free(output);
+    log_builder_destroy(builder);
+    return retval;
+}
+
 int main(void) {
     printf("\n\n   STARTING TEST - OS_SHARED   \n\n");
 
@@ -96,6 +122,9 @@ int main(void) {
 
     /* Test reserved JSON character escaping */
     TAP_TEST_MSG(test_json_escape(), "Escape reserved JSON characters.");
+
+    /* Test log builder */
+    TAP_TEST_MSG(test_log_builder(), "Test log builder.");
 
     TAP_PLAN;
     TAP_SUMMARY;

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -9,7 +9,6 @@
  * Foundation.
  */
 
-#ifdef CLIENT
 #if defined (__linux__) || defined (__MACH__)
 #include "wm_control.h"
 #include "syscollector/syscollector.h"
@@ -243,5 +242,5 @@ void *send_ip(){
     close(sock);
     return NULL;
 }
-#endif
+
 #endif

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -9,13 +9,12 @@
  * Foundation.
  */
 
-#if defined (__linux__) || defined (__MACH__)
+#if defined (__linux__) || defined (__MACH__) || defined (sun)
 #include "wm_control.h"
 #include "syscollector/syscollector.h"
 #include "external/cJSON/cJSON.h"
 #include "file_op.h"
 #include "../os_net/os_net.h"
-#include <ifaddrs.h>
 
 static void *wm_control_main();
 static void wm_control_destroy();
@@ -28,9 +27,52 @@ const wm_context WM_CONTROL_CONTEXT = {
     (cJSON * (*)(const void *))wm_control_dump
 };
 
+#if defined (__linux__) || defined (__MACH__)
+#include <ifaddrs.h>
+#elif defined sun
+#include <net/if.h>
+#include <sys/sockio.h>
+
+/**
+ * @brief Get the number of available network interfaces
+ *
+ * @return Number of network interfaces in the system.
+ */
+static int get_if_num() {
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+
+    if (fd == -1) {
+        return -1;
+    }
+
+    struct lifnum ifn = { .lifn_family = AF_INET };
+
+    int retval = ioctl(fd, SIOCGLIFNUM, &ifn);
+    close(fd);
+
+    if (retval == -1) {
+        return -1;
+    }
+
+    return ifn.lifn_count;
+}
+
+#endif
+
+/**
+ * @brief Get the Primary IP address
+ *
+ * Resolve the host's IP as the IP address of the default route interface,
+ * or the first non-loopback available interface.
+ *
+ * @return Pointer to a string holding the host's IP.
+ * @post The user must free the returned pointer.
+ */
 char* getPrimaryIP(){
      /* Get Primary IP */
     char * agent_ip = NULL;
+
+#if defined __linux__ || defined __MACH__
     char **ifaces_list;
     struct ifaddrs *ifaddr = NULL, *ifa;
     int size;
@@ -136,6 +178,73 @@ char* getPrimaryIP(){
     }
 
     free(ifaces_list);
+
+#elif defined sun
+
+    // Get number of interfaces
+
+    int if_count = get_if_num();
+
+    if (if_count == -1) {
+        return NULL;
+    }
+
+    // Initialize configuration structure
+
+    struct lifconf if_conf = { .lifc_family = AF_INET, .lifc_len = if_count * sizeof(struct lifreq) };
+    if_conf.lifc_buf = malloc(if_conf.lifc_len);
+    assert(if_conf.lifc_buf != NULL);
+
+    // Create helper socket
+
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+
+    if (fd == -1) {
+        goto end;
+    }
+
+    // Get interfaces
+
+    if (ioctl(fd, SIOCGLIFCONF, &if_conf) == -1) {
+        goto end;
+    }
+
+    // Scan interfaces
+
+    int i;
+    for (i = 0; i < if_count; i++) {
+        struct lifreq * if_req = if_conf.lifc_req + i;
+
+        // Get flags
+
+        if (ioctl(fd, SIOCGLIFFLAGS, if_req) == -1) {
+            goto end;
+        }
+
+        // Get the first interface that is up and is not loopback
+
+        int flags = if_req->lifr_flags;
+
+        if ((flags & IFF_UP) && (flags & IFF_LOOPBACK) == 0) {
+            // Get IP address
+
+            if (ioctl(fd, SIOCGLIFADDR, if_req) == -1) {
+                goto end;
+            }
+
+            struct sockaddr_in * addr = (struct sockaddr_in *)&if_req->lifr_addr;
+            agent_ip = strdup(inet_ntoa(addr->sin_addr));
+            break;
+        }
+    }
+
+end:
+    if (fd != -1) {
+        close(fd);
+    }
+
+    free(if_conf.lifc_buf);
+#endif
 
     return agent_ip;
 }

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -56,7 +56,7 @@ int wm_config() {
 
 #endif
 
-#if defined (__linux__) || (__MACH__)
+#if defined (__linux__) || (__MACH__) || defined (sun)
     wmodule * control_module;
     control_module = wm_control_read();
     wm_add(control_module);

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -38,17 +38,10 @@ int wm_config() {
         return -1;
     }
 
-
-
 #ifdef CLIENT
     // Read configuration: agent.conf
     agent_cfg = 1;
     ReadConfig(CWMODULE | CAGENT_CONFIG, AGENTCONFIG, &wmodules, &agent_cfg);
-#if defined (__linux__) || (__MACH__)
-    wmodule *module;
-    module = wm_control_read();
-    wm_add(module);
-#endif
 #else
     wmodule *module;
     // The database module won't be available on agents
@@ -61,6 +54,12 @@ int wm_config() {
     if ((module = wm_download_read()))
         wm_add(module);
 
+#endif
+
+#if defined (__linux__) || (__MACH__)
+    wmodule * control_module;
+    control_module = wm_control_read();
+    wm_add(control_module);
 #endif
 
     return 0;


### PR DESCRIPTION
|Related issue|
|---|
|#4341|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to implement a new parameter into `<out_format>` option in Logcollector to include the host's primary IP:

```xml
<localfile>
  <out_format>$(host_ip)</out_format>
</localfile>
```

## Configuration options

As described in #4341.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

- [X] Compilation on Linux.
- [X] Compilation on Windows.
- [X] Compilation on macOS.
- [X] Compilation on Solaris x86.
- [X] Source installation.
- [X] Unit tests.
- [X] Valgrind on Logcollector.
- [X] Stress test on log builder reload.
- [X] On-demand configuration.