### PR TITLE
Prevent Remoted from exiting when a client closes a connection prematurely

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -167,7 +167,15 @@ void HandleSecure()
                 if (fd == logr.sock) {
                     sock_client = accept(logr.sock, (struct sockaddr *)&peer_info, &logr.peer_size);
                     if (sock_client < 0) {
-                        merror_exit(ACCEPT_ERROR, strerror(errno), errno);
+                        switch (errno) {
+                        case ECONNABORTED:
+                            mdebug1(ACCEPT_ERROR, strerror(errno), errno);
+                            break;
+                        default:
+                            merror(ACCEPT_ERROR, strerror(errno), errno);
+                        }
+
+                        continue;
                     }
 
                     nb_open(&netbuffer, sock_client, &peer_info);


### PR DESCRIPTION
|Related issue|
|---|
|#3816|

## Description

Remoted may exit abruptly if a client (an agent) closes a connection before Remoted accepts it. This PR aims to let Remoted:

- Report a debugging message on this condition.
- Report a non-critical error on any other `accept()` call error.

## Logs/Alerts example

```
2019/12/23 05:18:54 ossec-remoted[3961] secure.c:172 at HandleSecure(): DEBUG: (1242): Couldn't accept TCP connections: Software caused connection abort (103)
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [X] Compilation on Linux.
- [x] Scan Build on Linux.