### PR TITLE
Fixed clearing report_changes database on Solaris

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1958,6 +1958,9 @@ int rmdir_ex(const char *name) {
 #endif
         return unlink(name);
 
+#if EEXIST != ENOTEMPTY
+    case EEXIST:
+#endif
     case ENOTEMPTY: // Directory not empty
         // Erase content and try to erase again
         return cldir_ex(name) || rmdir(name) ? -1 : 0;

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -149,7 +149,10 @@ void start_daemon()
     char diff_dir[PATH_MAX];
 
     snprintf(diff_dir, PATH_MAX, "%s/local/", DIFF_DIR_PATH);
-    cldir_ex(diff_dir);
+
+    if (cldir_ex(diff_dir) == -1) {
+        merror("Unable to clear directory '%s': %s (%d)", diff_dir, strerror(errno), errno);
+    }
 
     if (syscheck.disabled) {
         return;

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -150,7 +150,7 @@ void start_daemon()
 
     snprintf(diff_dir, PATH_MAX, "%s/local/", DIFF_DIR_PATH);
 
-    if (cldir_ex(diff_dir) == -1) {
+    if (cldir_ex(diff_dir) == -1 && errno != ENOENT) {
         merror("Unable to clear directory '%s': %s (%d)", diff_dir, strerror(errno), errno);
     }
 


### PR DESCRIPTION
|Related issue|
|---|
| #4381 |

## Description
Added `EEXIST` case to `rmdir_ex` because, in Solaris, there is no `ENOTEMPTY` error value, which caused the folder not to be cleared.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
  - [x] Solaris
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [x] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components