### PR TITLE
Fix infinite loop in Windows Eventchannel decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.11.0]
 
+### Fixed
+
+- The Windows Eventchannel log decoder in Analysisd maxed out CPU usage due to an infinite loop. ([#4412](https://github.com/wazuh/wazuh/pull/4412))
+
+
+## [v3.11.0]
+
 ### Added
 
 - Add support to Windows agents for vulnerability detector. ([#2787](https://github.com/wazuh/wazuh/pull/2787))

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -47,81 +47,17 @@ void WinevtInit(){
     mdebug1("WinevtInit completed.");
 }
 
-char *replace_formatting_bytes(const char * string, const char * search, const char * replace) {
-    char * result;
-    const char * scur;
-    const char * snext;
-    const char * prev_char;
-    const char * snext_search;
-    size_t wi = 0;
-    size_t zcur;
-    size_t znext_search;
-
-    if (!(string && search && replace)) {
-        return NULL;
-    }
-
-    const size_t ZSEARCH = strlen(search);
-    const size_t ZREPLACE = strlen(replace);
-
-    os_malloc(sizeof(char), result);
-
-    scur = string;
-
-    while (snext = strstr(scur, search), snext) {
-        // Check if the previous character is not a backslash, which would mean it is not a formatting character
-        prev_char = snext - 1;
-
-        if (*prev_char != '\\') {
-            zcur = snext - scur;
-            os_realloc(result, wi + zcur + ZREPLACE + 1, result);
-            memcpy(result + wi, scur, zcur);
-            wi += zcur;
-            memcpy(result + wi, replace, ZREPLACE);
-            wi += ZREPLACE;
-            scur = snext + ZSEARCH;
-        } else {
-            if (snext_search = strstr(snext + ZSEARCH, search), snext_search) {
-                znext_search = snext_search - scur;
-                os_realloc(result, wi + znext_search + 1, result);
-                memcpy(result + wi, scur, znext_search);
-                wi += znext_search;
-                scur = snext_search;
-            }
-        }
-    }
-
-    zcur = strlen(scur);
-    os_realloc(result, wi + zcur + 1, result);
-    memcpy(result + wi, scur, zcur);
-    wi += zcur;
-    result[wi] = '\0';
-
-    return result;
-}
-
 char *replace_win_format(char *str, int message){
-    char *ret1 = NULL;
-    char *ret2 = NULL;
     char *result = NULL;
     char *end = NULL;
     int spaces = 0;
 
     // Remove undesired characters from the string
     if (message) {
-        ret1 = replace_formatting_bytes(str, "\\n", "\n");
-        ret2 = replace_formatting_bytes(ret1, "\\r", "\r");
-        result = replace_formatting_bytes(ret2, "\\t", "\t");
-        os_free(ret1);
-        os_free(ret2);
+        result = wstr_unescape_json(str);
     } else {
         os_strdup(str, result);
     }
-
-    ret1 = wstr_replace(result, "\\\"", "\"");
-    os_free(result);
-    result = wstr_replace(ret1, "\\\\", "\\");
-    os_free(ret1);
 
     // Remove trailing spaces at the end of the string
     end = result + strlen(result) - 1;

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -143,4 +143,15 @@ size_t strcspn_escaped(const char * s, char reject);
  */
 char * wstr_escape_json(const char * string);
 
+/**
+ * @brief Unescape JSON reserved characters
+ *
+ * Unescape sets '\b', '\t', '\n', '\f', '\r', '\"' and '\\'.
+ * Bypass any other escape attempt.
+ *
+ * @param string Input string
+ * @return Pointer to a new string containg an unescaped copy of "string"
+ */
+char * wstr_unescape_json(const char * string);
+
 #endif

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -786,3 +786,64 @@ char * wstr_escape_json(const char * string) {
     output[j] = '\0';
     return output;
 }
+
+// Unescape JSON reserved characters
+
+char * wstr_unescape_json(const char * string) {
+    const char UNESCAPE_MAP[] = {
+        ['b'] = '\b',
+        ['t'] = '\t',
+        ['n'] = '\n',
+        ['f'] = '\f',
+        ['r'] = '\r',
+        ['\"'] = '\"',
+        ['\\'] = '\\'
+    };
+
+    size_t i = 0;   // Read position
+    size_t j = 0;   // Write position
+    size_t z;       // Span length
+
+    char * output;
+    os_malloc(1, output);
+
+    do {
+        z = strcspn(string + i, "\\");
+
+        // Extend output and copy
+        os_realloc(output, j + z + 3, output);
+        strncpy(output + j, string + i, z);
+
+        i += z;
+        j += z;
+
+        if (string[i] != '\0') {
+            // Peek byte following '\'
+            switch (string[++i]) {
+            case '\0':
+                // End of string
+                output[j++] = '\\';
+                break;
+
+            case 'b':
+            case 't':
+            case 'n':
+            case 'f':
+            case 'r':
+            case '\"':
+            case '\\':
+                // Escaped character
+                output[j++] = UNESCAPE_MAP[(int)string[i++]];
+                break;
+
+            default:
+                // Bad escape
+                output[j++] = '\\';
+                output[j++] = string[i++];
+            }
+        }
+    } while (string[i] != '\0');
+
+    output[j] = '\0';
+    return output;
+}

--- a/src/tests/tap_shared.c
+++ b/src/tests/tap_shared.c
@@ -81,6 +81,24 @@ int test_json_escape() {
     return 1;
 }
 
+int test_json_unescape() {
+    const char * INPUTS[] = { "\\b\\tHello \\n\\f\\r \\\"World\\\".\\\\", "Hello\\b\\t \\n\\f\\r \\\"World\\\"\\\\.", "Hello \\World", "Hello World\\", NULL };
+    const char * EXPECTED_OUTPUTS[] = { "\b\tHello \n\f\r \"World\".\\", "Hello\b\t \n\f\r \"World\"\\.", "Hello \\World", "Hello World\\", NULL };
+    int i;
+
+    for (i = 0; INPUTS[i] != NULL; i++) {
+        char * output = wstr_unescape_json(INPUTS[i]);
+        int cmp = strcmp(output, EXPECTED_OUTPUTS[i]);
+        free(output);
+
+        if (cmp != 0) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 int test_log_builder() {
     const char * PATTERN = "location: $(location), log: $(log), escaped: $(json_escaped_log)";
     const char * LOG = "Hello \"World\"";
@@ -122,6 +140,9 @@ int main(void) {
 
     /* Test reserved JSON character escaping */
     TAP_TEST_MSG(test_json_escape(), "Escape reserved JSON characters.");
+
+    /* Test reserved JSON character unescaping */
+    TAP_TEST_MSG(test_json_unescape(), "Unescape reserved JSON characters.");
 
     /* Test log builder */
     TAP_TEST_MSG(test_log_builder(), "Test log builder.");


### PR DESCRIPTION
|Related issues|
|---|
|#4400 #4407|

## Description

The related issues report an infinite loop condition in the Windows Eventchannel decoder thread.

The function `replace_formatting_bytes()` misses an `else` sentence that breaks the loop: https://github.com/wazuh/wazuh/blob/v3.11.0/src/analysisd/decoders/winevtchannel.c#L90

There are two extra issues in this function:
1. If the input string starts with an escape (`\t` or `\n`) the function would produce an invalid read on the byte preceding the first one of the string.
2. The function can't detect escapes on backslashes accurately.

## Logs/Alerts example

This is an input string that would produce an infinite loop:

```
"The access history in hive \\??\\C:\\Users\\Administrator\\ntuser.dat was cleared updating 2201 keys and creating 145 modified pages."
```

This is the corresponding archive entry:

```json
{
  "timestamp": "2020-01-02T15:30:48.487+0100",
  "agent": {
    "id": "001",
    "name": "WIN-CPMVB479AP3",
    "ip": "192.168.29.128"
  },
  "manager": {
    "name": "buster"
  },
  "id": "1577975448.5905424",
  "full_log": "{\"win\":{\"system\":{\"providerName\":\"Microsoft-Windows-Kernel-General\",\"providerGuid\":\"{a68ca8b7-004f-d7b6-a698-07e2de0f1f5d}\",\"eventID\":\"16\",\"version\":\"0\",\"level\":\"4\",\"task\":\"0\",\"opcode\":\"0\",\"keywords\":\"0x8000000000000000\",\"systemTime\":\"2019-12-30T17:36:59.916422900Z\",\"eventRecordID\":\"6637\",\"processID\":\"5716\",\"threadID\":\"112\",\"channel\":\"System\",\"computer\":\"WIN-CPMVB479AP3\",\"severityValue\":\"INFORMATION\",\"message\":\"\\\"The access history in hive \\\\SystemRoot\\\\System32\\\\Config\\\\RegBack\\\\SYSTEM was cleared updating 53160 keys and creating 3407 modified pages.\\\"\"},\"eventdata\":{\"hiveNameLength\":\"42\",\"hiveName\":\"\\\\SystemRoot\\\\System32\\\\Config\\\\RegBack\\\\SYSTEM\",\"keysUpdated\":\"53160\",\"dirtyPages\":\"3407\"}}}",
  "decoder": {
    "name": "windows_eventchannel"
  },
  "data": {
    "win": {
      "system": {
        "providerName": "Microsoft-Windows-Kernel-General",
        "providerGuid": "{a68ca8b7-004f-d7b6-a698-07e2de0f1f5d}",
        "eventID": "16",
        "version": "0",
        "level": "4",
        "task": "0",
        "opcode": "0",
        "keywords": "0x8000000000000000",
        "systemTime": "2019-12-30T17:36:59.916422900Z",
        "eventRecordID": "6637",
        "processID": "5716",
        "threadID": "112",
        "channel": "System",
        "computer": "WIN-CPMVB479AP3",
        "severityValue": "INFORMATION",
        "message": "\"The access history in hive \\SystemRoot\\System32\\Config\\RegBack\\SYSTEM was cleared updating 53160 keys and creating 3407 modified pages.\""
      },
      "eventdata": {
        "hiveNameLength": "42",
        "hiveName": "\\SystemRoot\\System32\\Config\\RegBack\\SYSTEM",
        "keysUpdated": "53160",
        "dirtyPages": "3407"
      }
    }
  },
  "location": "EventChannel"
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [X] Compilation on Linux.
- [X] Compilation of an agent for Windows.
- [X] Compilation of an agent for macOS.
- [X] Run Analysisd from sources.
- [X] Run Analysisd on Valgrind.
- [X] Make Analysisd parse the critical input event.
- [X] Unit tests for the new function `wstr_unescape_json`.
- [X] Run _scan-build_: no related issues.