### PR TITLE
Stop directory recursion when readall is 0

### DIFF
--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -239,12 +239,12 @@ static int read_sys_dir(const char *dir_name, int depth)
             if (strstr(f_name, "/dev/fd") != NULL) {
                 return (0);
             }
-
+#ifndef WIN32
             /* Ignore the /proc directory (it has size 0) */
             if (statbuf_local.st_size == 0) {
                 return (0);
             }
- 
+#endif
             if(rootcheck.readall) {
                 read_sys_dir(f_name, depth + 1);
             }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -12,8 +12,8 @@
 #include "rootcheck.h"
 
 /* Prototypes */
-static int read_sys_file(const char *file_name, int do_read, int depth);
-static int read_sys_dir(const char *dir_name, int do_read, int depth);
+static int read_sys_file(const char *file_name, int depth);
+static int read_sys_dir(const char *dir_name, int depth);
 
 /* Global variables */
 static int   _sys_errors;
@@ -24,8 +24,10 @@ static FILE *_ww;
 static FILE *_suid;
 
 
-static int read_sys_file(const char *file_name, int do_read, int depth)
+static int read_sys_file(const char *file_name, int depth)
 {
+    mtdebug2(ARGV0, "Reading file %s, with depth=%d", file_name, depth);
+
     struct stat statbuf;
 
     _sys_total++;
@@ -47,26 +49,8 @@ static int read_sys_file(const char *file_name, int do_read, int depth)
         return (-1);
     }
 
-    /* If directory, read the directory */
-    else if (S_ISDIR(statbuf.st_mode)) {
-        /* Make Darwin happy. For some reason,
-         * when I read /dev/fd, it goes forever on
-         * /dev/fd5, /dev/fd6, etc.. weird
-         */
-        if (strstr(file_name, "/dev/fd") != NULL) {
-            return (0);
-        }
-
-        /* Ignore the /proc directory (it has size 0) */
-        if (statbuf.st_size == 0) {
-            return (0);
-        }
-
-        return (read_sys_dir(file_name, do_read, depth + 1));
-    }
-
     /* Check if the size from stats is the same as when we read the file */
-    if (S_ISREG(statbuf.st_mode) && do_read) {
+    if (S_ISREG(statbuf.st_mode)) {
         char buf[OS_SIZE_1024];
         int fd;
         ssize_t nr;
@@ -140,8 +124,9 @@ static int read_sys_file(const char *file_name, int do_read, int depth)
     return (0);
 }
 
-static int read_sys_dir(const char *dir_name, int do_read, int depth)
+static int read_sys_dir(const char *dir_name, int depth)
 {
+
     int i = 0;
     unsigned int entry_count = 0;
     int did_changed = 0;
@@ -150,6 +135,8 @@ static int read_sys_dir(const char *dir_name, int do_read, int depth)
     struct stat statbuf;
     short is_nfs;
     short skip_fs;
+
+    mtdebug2(ARGV0, "Reading dir %s, with depth=%d", dir_name, depth);
 
     if ((dir_name == NULL) || (strlen(dir_name) > PATH_MAX)) {
         mterror(ARGV0, "Invalid directory given.");
@@ -186,15 +173,6 @@ static int read_sys_dir(const char *dir_name, int do_read, int depth)
     if (!S_ISDIR(statbuf.st_mode)) {
         return (-1);
     }
-
-#ifndef WIN32
-    /* Only the root files will be read */
-    if (!depth) {
-        do_read = 1;
-    }
-#else
-    do_read = 0;
-#endif
 
     /* Open the directory */
     dp = opendir(dir_name);
@@ -252,25 +230,50 @@ static int read_sys_dir(const char *dir_name, int do_read, int depth)
             }
         }
 
-        /* Check every file against the rootkit database */
-        for (i = 0; i <= rk_sys_count; i++) {
-            if (!rk_sys_file[i]) {
-                break;
+        /* If  directory, read the directory */
+        if (S_ISDIR(statbuf_local.st_mode)) {
+            /* Make Darwin happy. For some reason,
+            * when I read /dev/fd, it goes forever on
+            * /dev/fd5, /dev/fd6, etc.. weird
+            */
+            if (strstr(f_name, "/dev/fd") != NULL) {
+                return (0);
             }
 
-            if (strcmp(rk_sys_file[i], entry->d_name) == 0) {
-                char op_msg[OS_SIZE_1024 + 1];
-
-                _sys_errors++;
-                snprintf(op_msg, OS_SIZE_1024, "Rootkit '%s' detected "
-                         "by the presence of file '%s/%s'.",
-                         rk_sys_name[i], dir_name, rk_sys_file[i]);
-
-                notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+            /* Ignore the /proc directory (it has size 0) */
+            if (statbuf_local.st_size == 0) {
+                return (0);
+            }
+ 
+            if(rootcheck.readall) {
+                read_sys_dir(f_name, depth + 1);
             }
         }
 
-        read_sys_file(f_name, do_read, depth);
+        else {
+            /* Check every file against the rootkit database */
+            for (i = 0; i <= rk_sys_count; i++) {
+                if (!rk_sys_file[i]) {
+                    break;
+                }
+
+                if (strcmp(rk_sys_file[i], entry->d_name) == 0) {
+                    char op_msg[OS_SIZE_1024 + 1];
+
+                    _sys_errors++;
+                    snprintf(op_msg, OS_SIZE_1024, "Rootkit '%s' detected "
+                            "by the presence of file '%s/%s'.",
+                            rk_sys_name[i], dir_name, rk_sys_file[i]);
+
+                    notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+                }
+            }
+
+            read_sys_file(f_name, depth);
+
+        }
+
+        
     }
 
     /* skip further test because the FS cant deliver the stats (btrfs link count always is 1) */
@@ -357,7 +360,7 @@ void check_rc_sys(const char *basedir)
 #else
         snprintf(file_path, 5, "%s", "C:\\");
 #endif
-        read_sys_dir(file_path, rootcheck.readall, 0);
+        read_sys_dir(file_path, 0);
     } else {
         /* Scan only specific directories */
         int _i;
@@ -378,7 +381,7 @@ void check_rc_sys(const char *basedir)
         _i = 0;
         while (dirs_to_scan[_i] != NULL) {
             snprintf(dir_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, dirs_to_scan[_i]);
-            read_sys_dir(dir_path, rootcheck.readall, 0);
+            read_sys_dir(dir_path, 0);
             _i++;
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
| #4335  |

## Description

Rootcheck expected behaviour is to only check the first level of files on system directories. However, there was a problem that avoided this from happening which caused the module to always work recursively. This can cause a high CPU utilization for a considerable amount of time. 

## Configuration options

Rootcheck: 
``` xml
<!-- Policy monitoring -->
  <rootcheck>
    <disabled>no</disabled>
    <check_files>yes</check_files>
    <check_trojans>yes</check_trojans>
    <check_dev>yes</check_dev>
    <check_sys>yes</check_sys>
    <check_pids>yes</check_pids>
    <check_ports>yes</check_ports>
    <check_if>yes</check_if>
    <!-- Frequency that rootcheck is executed - every 12 hours -->
    <frequency>43200</frequency>
    <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
    <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
    <skip_nfs>yes</skip_nfs>
  </rootcheck>
```
 We will test cases for :
``` xml
<readall>yes/no</readall>
```
Configurations


## Logs/Alerts example

Before changes we could see the rootcheck module was searching in depth with the readall flag set to 0:

```
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/dvd, with do_read=1 and depth=0
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/cdrom, with do_read=1 and depth=0
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/i2c-0, with do_read=1 and depth=0
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/vboxuser, with do_read=1 and depth=0
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/vboxguest, with do_read=1 and depth=0
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd, with do_read=1 and depth=0
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:156 at read_sys_dir(): DEBUG: Reading dir /dev/snd, with do_read=1 and depth=1
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd/by-path, with do_read=1 and depth=1
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:156 at read_sys_dir(): DEBUG: Reading dir /dev/snd/by-path, with do_read=1 and depth=2
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd/by-path/pci-0000:00:05.0, with do_read=1 and depth=2
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd/pcmC0D1c, with do_read=1 and depth=1
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd/pcmC0D0c, with do_read=1 and depth=1
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd/pcmC0D0p, with do_read=1 and depth=1
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd/controlC0, with do_read=1 and depth=1
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd/seq, with do_read=1 and depth=1
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/snd/timer, with do_read=1 and depth=1
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/vhost-vsock, with do_read=1 and depth=0
2020/01/06 14:47:15 rootcheck[8865] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/vhost-net, with do_read=1 and depth=0
```

After changes we can see that when readall is not recursively entering directories again:

```
2020/01/06 16:10:29 rootcheck[17063] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/dvd, with depth=0
2020/01/06 16:10:29 rootcheck[17063] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/cdrom, with depth=0
2020/01/06 16:10:29 rootcheck[17063] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/i2c-0, with depth=0
2020/01/06 16:10:29 rootcheck[17063] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/vboxuser, with depth=0
2020/01/06 16:10:29 rootcheck[17063] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/vboxguest, with depth=0
2020/01/06 16:10:29 rootcheck[17063] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/vhost-vsock, with depth=0
2020/01/06 16:10:29 rootcheck[17063] check_rc_sys.c:29 at read_sys_file(): DEBUG: Reading file /dev/vhost-net, with depth=0
```

## Results

I´m attaching a few images, the CPU utilization spike is shorter when `readall=0` . The red box represents the amount of time rootcheck module is reading system directories


![image](https://user-images.githubusercontent.com/11711684/71845376-f2892500-30a6-11ea-8a40-9090d2a22849.png)
![image](https://user-images.githubusercontent.com/11711684/71845401-046ac800-30a7-11ea-8a70-eab8ed60932c.png)

