### PR TITLE
Revision in test_wdb_fim.c

### DIFF
--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -88,10 +88,8 @@ list(APPEND tests_flags "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,_mde
                          -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP")
 
 list(APPEND tests_names "test_wdb_fim")
-list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,cJSON_Parse -Wl,--wrap,wdb_begin2 \
-                         -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,cJSON_IsNumber \
-                         -Wl,--wrap,cJSON_IsObject -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_text \
-                         -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_step")
+list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_begin2 \
+                         -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_step")
 
 list(APPEND tests_names "test_wdb_parser")
 list(APPEND tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \


### PR DESCRIPTION
|Related issue|
|--|
| #4354          |

# Tasks:
- Fixed test and added checks in wdb_fim methods to validate incoming parameters. 
- Also removed unnecesary wraps to cJSON library that would invalidate the unit test if there are small inner changes.

### wdb_syscheck_save2


TEST|STATUS
|--|--|
Test_wdb_syscheck_save2_wbs_null|**Passed**
Test_wdb_syscheck_save2_payload_null|**Passed**
Test_wdb_syscheck_save2_data_null|**Passed**
Test_wdb_syscheck_save2_fail_transaction|**Passed**
Test_wdb_syscheck_save2_fail_file_entry|**Passed**
Test_wdb_syscheck_save2_success|**Passed**


### wdb_fim_insert_entry2


TEST|STATUS
|--|--|
test_wdb_fim_insert_entry2_wdb_null|**Failed**. The function does not check whether parameter `wbs` is null, causing a segmentation fault.
test_wdb_fim_insert_entry2_data_null|**Passed**
test_wdb_fim_insert_entry2_path_null|**Passed**
test_wdb_fim_insert_entry2_timestamp_null|**Passed**
test_wdb_fim_insert_entry2_attributes_null|**Passed**
test_wdb_fim_insert_entry2_fail_cache|**Passed**
test_wdb_fim_insert_entry2_fail_element_string|**Passed**
test_wdb_fim_insert_entry2_fail_sqlite3_stmt|**Passed**
test_wdb_fim_insert_entry2_success|**Passed**
