### PR TITLE
Adds tests for sdb_clean, sdb_init, fim_init and fim_alert

### DIFF
--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -101,7 +101,8 @@ list(APPEND tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_mer
                          -Wl,--wrap,wdbi_query_checksum -Wl,--wrap,wdbi_query_clear")
 
 list(APPEND tests_names "test_analysisd_syscheck")
-list(APPEND tests_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
+list(APPEND tests_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,_merror -Wl,--wrap,_mdebug1 \
+                         -Wl,--wrap,getDecoderfromlist -Wl,--wrap,OSHash_Create")
 
 list(APPEND tests_names "test_wdb_integrity")
 list(APPEND tests_flags "-Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_errmsg \


### PR DESCRIPTION
Tests on fim_alert are not completed.

|Related issue|
|---|
|#4344|

## Description

Add unit tests for Analysisd.

The tests to be added correspond to tier 2 of the related issue.

## Tests
### sdb_clean
|Test|Status|
|---|---|
|test_sdb_clean_success|**Pass**|
|test_sdb_clean_null_sdb|**Fail** - sdb_clean segfaults on a null input sdb|

### sdb_init
|Test|Status|
|---|---|
|test_sdb_init_success|**Pass**|
|test_sdb_init_null_sdb|**Fail** - sdb_init segfaults on a null sdb input parameter|
|test_sdb_init_null_fim_decoder|**Fail** - sdb_init segfaults on a null fim_decoder input parameter|

### fim_init
|Test|Status|
|---|---|
|test_fim_init_success|**Pass**|
|test_fim_init_no_hash_created|**Pass**|

### fim_alert
|Test|Status|
|---|---|
|test_fim_alert_deleted|**Pass**|
|test_fim_alert_added|**Pass**|
|test_fim_alert_modified|**Pass**|
|test_fim_alert_invalid_event_type|**Pass**|
|test_fim_alert_modified_no_changes|**Pass**|