### PR TITLE
Reduce memory usage when parsing NVD

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -324,6 +324,7 @@
 #define VU_REPORT_ERROR             "(5436): The agent %s vulnerabilities could not be reported. Error: %s."
 #define VU_UPDATE_RETRY             "(5437): Failed when updating '%s %s' database. Retrying in %lu seconds."
 #define VU_API_REQ_INV              "(5489): There was no valid response to '%s' after %d attempts."
+#define VU_CONTENT_FEED_ERROR       "(5491): Couldn't get the content of the %s feed from '%s' file."
 #define VU_PARSED_FEED_ERROR        "(5491): The %s feed couldn't be parsed from '%s' file."
 #define VU_VER_EXTRACT_ERROR        "(5493): The version of '%s' could not be extracted."
 #define VU_GLOBALDB_ERROR           "(5496): Could not connect to global DB."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -324,7 +324,7 @@
 #define VU_REPORT_ERROR             "(5436): The agent %s vulnerabilities could not be reported. Error: %s."
 #define VU_UPDATE_RETRY             "(5437): Failed when updating '%s %s' database. Retrying in %lu seconds."
 #define VU_API_REQ_INV              "(5489): There was no valid response to '%s' after %d attempts."
-#define VU_CONTENT_FEED_ERROR       "(5491): Couldn't get the content of the %s feed from '%s' file."
+#define VU_CONTENT_FEED_ERROR       "(5490): Couldn't get the content of the %s feed from '%s' file."
 #define VU_PARSED_FEED_ERROR        "(5491): The %s feed couldn't be parsed from '%s' file."
 #define VU_VER_EXTRACT_ERROR        "(5493): The version of '%s' could not be extracted."
 #define VU_GLOBALDB_ERROR           "(5496): Could not connect to global DB."

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -154,4 +154,7 @@ void w_file_cloexec(FILE * fp);
 /* Prevent children processes from inheriting a file descriptor */
 void w_descriptor_cloexec(int fd);
 
+/* Return the content of a file */
+char * get_file_content(const char * path, int max_size);
+
 #endif /* FILE_OP_H */

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -154,7 +154,14 @@ void w_file_cloexec(FILE * fp);
 /* Prevent children processes from inheriting a file descriptor */
 void w_descriptor_cloexec(int fd);
 
-/* Return the content of a file */
+/**
+ * @brief Get the content of a given file
+ *
+ * @param path File location
+ * @param max_size Maximum allowed file size
+ * @return The content of the file
+ * @retval NULL The file doesn't exist or its size exceeds the maximum allowed
+ */
 char * w_get_file_content(const char * path, int max_size);
 
 #endif /* FILE_OP_H */

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -155,6 +155,6 @@ void w_file_cloexec(FILE * fp);
 void w_descriptor_cloexec(int fd);
 
 /* Return the content of a file */
-char * get_file_content(const char * path, int max_size);
+char * w_get_file_content(const char * path, int max_size);
 
 #endif /* FILE_OP_H */

--- a/src/headers/json_op.h
+++ b/src/headers/json_op.h
@@ -13,7 +13,6 @@
 #define JSON_OP_H
 
 #define JSON_MAX_FSIZE 536870912
-#define JSON_MAX_FSIZE_TEXT "512 MiB"
 
 #include <external/cJSON/cJSON.h>
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2940,3 +2940,54 @@ void w_descriptor_cloexec(__attribute__((unused)) int fd){
     }
 #endif
 }
+
+/* Return the content of a file from a given path*/
+char * get_file_content(const char * path, int max_size) {
+    FILE * fp = NULL;
+    char * buffer = NULL;
+    long size;
+    size_t read;
+
+    // Check if path is NULL
+    if (path == NULL) {
+        mdebug1("Cannot open NULL path");
+        goto end;
+    }
+
+    // Load file
+    if (fp = fopen(path, "r"), !fp) {
+        mdebug1(FOPEN_ERROR, path, errno, strerror(errno));
+        goto end;
+    }
+
+    // Get file size
+    if (size = get_fp_size(fp), size < 0) {
+        mdebug1(FSEEK_ERROR, path, errno, strerror(errno));
+        goto end;
+    }
+
+    // Check file size limit
+    if (size > max_size) {
+        mdebug1("Cannot load file '%s': it exceeds %i MiB", path, (max_size / (1024 * 1024)));
+        goto end;
+    }
+
+    // Allocate memory
+    os_malloc(size + 1, buffer);
+
+    // Get file and parse into JSON
+    if (read = fread(buffer, 1, size, fp), read != (size_t)size && !feof(fp)) {
+        mdebug1(FREAD_ERROR, path, errno, strerror(errno));
+        os_free(buffer);
+        goto end;
+    }
+
+    buffer[size] = '\0';
+
+end:
+    if (fp) {
+        fclose(fp);
+    }
+
+    return buffer;
+}

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2942,7 +2942,7 @@ void w_descriptor_cloexec(__attribute__((unused)) int fd){
 }
 
 /* Return the content of a file from a given path*/
-char * get_file_content(const char * path, int max_size) {
+char * w_get_file_content(const char * path, int max_size) {
     FILE * fp = NULL;
     char * buffer = NULL;
     long size;
@@ -2975,7 +2975,7 @@ char * get_file_content(const char * path, int max_size) {
     // Allocate memory
     os_malloc(size + 1, buffer);
 
-    // Get file and parse into JSON
+    // Get file content
     if (read = fread(buffer, 1, size, fp), read != (size_t)size && !feof(fp)) {
         mdebug1(FREAD_ERROR, path, errno, strerror(errno));
         os_free(buffer);

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2941,7 +2941,7 @@ void w_descriptor_cloexec(__attribute__((unused)) int fd){
 #endif
 }
 
-/* Return the content of a file from a given path*/
+/* Return the content of a file from a given path */
 char * w_get_file_content(const char * path, int max_size) {
     FILE * fp = NULL;
     char * buffer = NULL;

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -16,7 +16,7 @@ cJSON * json_fread(const char * path, char retry) {
     char * buffer = NULL;
     const char *jsonErrPtr;
 
-    if (buffer = get_file_content(path, JSON_MAX_FSIZE), !buffer) {
+    if (buffer = w_get_file_content(path, JSON_MAX_FSIZE), !buffer) {
         mdebug1("Cannot get the content of the file: %s", path);
         return NULL;
     }

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -12,44 +12,14 @@
 #include <shared.h>
 
 cJSON * json_fread(const char * path, char retry) {
-    FILE * fp = NULL;
     cJSON * item = NULL;
     char * buffer = NULL;
-    long size;
-    size_t read;
+    const char *jsonErrPtr;
 
-    // Load file
-
-    if (fp = fopen(path, "r"), !fp) {
-        mdebug1(FOPEN_ERROR, path, errno, strerror(errno));
+    if (buffer = get_file_content(path, JSON_MAX_FSIZE), !buffer) {
+        mdebug1("Cannot get the content of the file: %s", path);
         return NULL;
     }
-
-    // Get file size
-
-    if (size = get_fp_size(fp), size < 0) {
-        mdebug1(FSEEK_ERROR, path, errno, strerror(errno));
-        goto end;
-    }
-
-    // Check file size limit
-
-    if (size > JSON_MAX_FSIZE) {
-        mdebug1("Cannot load JSON file '%s': it exceeds %s", path, JSON_MAX_FSIZE_TEXT);
-        goto end;
-    }
-
-    // Allocate memory
-    os_malloc(size + 1, buffer);
-
-    // Get file and parse into JSON
-    if (read = fread(buffer, 1, size, fp), read != (size_t)size && !feof(fp)) {
-        mdebug1(FREAD_ERROR, path, errno, strerror(errno));
-        goto end;
-    }
-
-    buffer[size] = '\0';
-    const char *jsonErrPtr;
 
     if (item = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0), !item) {
         if (retry) {
@@ -62,9 +32,6 @@ cJSON * json_fread(const char * path, char retry) {
         }
     }
 
-end:
-
-    fclose(fp);
     free(buffer);
     return item;
 }

--- a/src/tests/tap_shared.c
+++ b/src/tests/tap_shared.c
@@ -123,6 +123,53 @@ int test_log_builder() {
     return retval;
 }
 
+int test_get_file_content() {
+    int max_size = 100;
+    const char * expected = "{\n"
+                            "    \"test\":[\n"
+                            "        {\n"
+                            "            \"test_name\":\"Test1\",\n"
+                            "            \"test_number\":1\n"
+                            "        }, {\n"
+                            "            \"test_name\":\"Test2\",\n"
+                            "            \"test_number\":2\n"
+                            "        }, {\n"
+                            "            \"test_name\":\"Test3\",\n"
+                            "            \"test_number\":3\n"
+                            "        }\n"
+                            "    ]\n"
+                            "}\n";
+
+    char * content;
+
+    // Test NULL path
+    if (content = w_get_file_content(NULL, max_size), content != NULL) {
+        return 0;
+    }
+
+    // Test invalid path
+    if (content = w_get_file_content("./tests/invalid_path", max_size), content != NULL) {
+        return 0;
+    }
+
+    // Test file size exceeds max size allowed
+    if (content = w_get_file_content("./tests/test_file.json", max_size), content != NULL) {
+        return 0;
+    }
+
+    max_size = 300;
+
+    // Test file content
+    if (content = w_get_file_content("./tests/test_file.json", max_size), content == NULL) {
+        return 0;
+    }
+
+    w_assert_str_eq(content, expected);
+    free(content);
+
+    return 1;
+}
+
 int main(void) {
     printf("\n\n   STARTING TEST - OS_SHARED   \n\n");
 
@@ -146,6 +193,9 @@ int main(void) {
 
     /* Test log builder */
     TAP_TEST_MSG(test_log_builder(), "Test log builder.");
+
+    /* Test get_file_content function */
+    TAP_TEST_MSG(test_get_file_content(), "Get the content of a file.");
 
     TAP_PLAN;
     TAP_SUMMARY;

--- a/src/tests/test_file.json
+++ b/src/tests/test_file.json
@@ -1,0 +1,14 @@
+{
+    "test":[
+        {
+            "test_name":"Test1",
+            "test_number":1
+        }, {
+            "test_name":"Test2",
+            "test_number":2
+        }, {
+            "test_name":"Test3",
+            "test_number":3
+        }
+    ]
+}

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2762,31 +2762,45 @@ int wm_vuldet_json_rh_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilit
 }
 
 int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities, update_node *update) {
-    cJSON *json_feed;
     int retval = OS_INVALID;
 
-    if (json_feed = wm_vuldet_json_fread(json_path), !json_feed) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_PARSED_FEED_ERROR, update->dist_ext, json_path);
-        goto end;
+    if (update->dist_ref == FEED_NVD) {
+        char *json_feed;
+
+        if (json_feed = get_file_content(json_path, JSON_MAX_FSIZE), !json_feed) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
+            return retval;
+        }
+
+        if (retval = wm_vuldet_json_nvd_parser(json_feed, parsed_vulnerabilities), retval == OS_INVALID) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_PARSED_FEED_ERROR, update->dist_ext, json_path);
+        }
+        free(json_feed);
+    }
+    else {
+        cJSON *json_feed;
+
+        if (json_feed = wm_vuldet_json_fread(json_path), !json_feed) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_PARSED_FEED_ERROR, update->dist_ext, json_path);
+            return retval;
+        }
+
+        switch ((int) update->dist_ref) {
+            case FEED_REDHAT:
+                retval = wm_vuldet_json_rh_parser(json_feed, parsed_vulnerabilities);
+                break;
+            case FEED_CPEW:
+                retval = wm_vuldet_json_wcpe_parser(json_feed, parsed_vulnerabilities);
+                break;
+            case FEED_MSU:
+                retval = wm_vuldet_json_msu_parser(json_feed, parsed_vulnerabilities);
+                break;
+            default:
+                break;
+        }
+        cJSON_Delete(json_feed);
     }
 
-    switch ((int) update->dist_ref) {
-        case FEED_REDHAT:
-            retval = wm_vuldet_json_rh_parser(json_feed, parsed_vulnerabilities);
-        break;
-        case FEED_NVD:
-            retval = wm_vuldet_json_nvd_parser(json_feed, parsed_vulnerabilities);
-        break;
-        case FEED_CPEW:
-            retval = wm_vuldet_json_wcpe_parser(json_feed, parsed_vulnerabilities);
-        break;
-        case FEED_MSU:
-            retval = wm_vuldet_json_msu_parser(json_feed, parsed_vulnerabilities);
-        break;
-    }
-
-end:
-    cJSON_Delete(json_feed);
     return retval;
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2767,7 +2767,7 @@ int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities,
     if (update->dist_ref == FEED_NVD) {
         char *json_feed;
 
-        if (json_feed = get_file_content(json_path, JSON_MAX_FSIZE), !json_feed) {
+        if (json_feed = w_get_file_content(json_path, JSON_MAX_FSIZE), !json_feed) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
             return retval;
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -694,7 +694,7 @@ int wm_vuldet_add_cpe(cpe *ncpe, char *cpe_raw, cpe_list *node_list, int index);
 int wm_vuldet_generate_agent_cpes(sqlite3 *db, agent_software *agent, char dic);
 int wm_vuldet_fetch_nvd_cve(update_node *update);
 int wm_vuldet_fetch_nvd_cpe(char *repo);
-int wm_vuldet_json_nvd_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities);
+int wm_vuldet_json_nvd_parser(char *json_feed, wm_vuldet_db *parsed_vulnerabilities);
 int wm_vuldet_clean_nvd_metadata(sqlite3 *db, int year);
 int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year);
 void wm_vuldet_free_nvd_node(nvd_vulnerability *data);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -913,16 +913,15 @@ int wm_vuldet_json_nvd_parser(char *json_feed, wm_vuldet_db *parsed_vulnerabilit
     static char *JSON_DATA_FORMAT = "data_format";
     static char *JSON_DATA_VERSION = "data_version";
 
+    const char * cve;
+    const char * next_cve;
     const char * match_cve = " {\r\n    \"cve\" : {\r\n";
-    const size_t match_size = strlen(match_cve);
 
-    char * cve;
-
-    for (cve = json_feed; (cve = strstr(cve, match_cve)) != NULL; cve += match_size) {
+    for (cve = strstr(json_feed, match_cve); cve != NULL; cve = strstr(next_cve, match_cve)) {
 
         cJSON * cve_list;
 
-        if (cve_list = cJSON_Parse(cve), !cve_list) {
+        if (cve_list = cJSON_ParseWithOpts(cve, &next_cve, 0), !cve_list) {
             return OS_INVALID;
         }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -900,12 +900,10 @@ int wm_vuldet_clean_nvd_metadata(sqlite3 *db, int year) {
     return 0;
 }
 
-int wm_vuldet_json_nvd_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities) {
-    cJSON *cve_list;
+int wm_vuldet_json_nvd_parser(char *json_feed, wm_vuldet_db *parsed_vulnerabilities) {
     cJSON *cve_content;
     nvd_vulnerability *nvd_it = NULL;
     nvd_vulnerability *nvd_first = NULL;
-    static char *JSON_CVE_ITEMS = "CVE_Items";
     static char *JSON_CVE = "cve";
     static char *JSON_CONFIGURATIONS = "configurations";
     static char *JSON_IMPACT = "impact";
@@ -915,37 +913,47 @@ int wm_vuldet_json_nvd_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabili
     static char *JSON_DATA_FORMAT = "data_format";
     static char *JSON_DATA_VERSION = "data_version";
 
-    for (json_feed = json_feed->child; json_tagged_obj(json_feed); json_feed = json_feed->next) {
-        if (!strcmp(json_feed->string, JSON_CVE_ITEMS)) {
-            for (cve_list = json_feed->child; cve_list; cve_list = cve_list->next) {
-                if (nvd_it) {
-                    os_calloc(1, sizeof(nvd_vulnerability), nvd_it->next);
-                    nvd_it = nvd_it->next;
-                } else {
-                    os_calloc(1, sizeof(nvd_vulnerability), nvd_it);
-                    nvd_first = nvd_it;
-                }
-                for (cve_content = cve_list->child; json_tagged_obj(cve_content); cve_content = cve_content->next) {
-                    if (!strcmp(cve_content->string, JSON_CVE)) {
-                        wm_vuldet_parse_nvd_cve(cve_content, nvd_it);
-                    } else if (!strcmp(cve_content->string, JSON_CONFIGURATIONS)) {
-                        wm_vuldet_parse_nvd_configuration(cve_content, nvd_it);
-                    } else if (!strcmp(cve_content->string, JSON_IMPACT)) {
-                        wm_vuldet_parse_nvd_impact(cve_content, nvd_it);
-                    } else if (!strcmp(cve_content->string, JSON_PUBLISHED)) {
-                        w_strdup(cve_content->valuestring, nvd_it->published);
-                    } else if (!strcmp(cve_content->string, JSON_LAST_MOD)) {
-                        w_strdup(cve_content->valuestring, nvd_it->last_modified);
-                    } else if (strcmp(cve_content->string, JSON_DATA_TYPE) &&
-                               strcmp(cve_content->string, JSON_DATA_FORMAT) &&
-                               strcmp(cve_content->string, JSON_DATA_VERSION)) {
-                        mtwarn(WM_VULNDETECTOR_LOGTAG, VU_UNKNOWN_NVD_CVE_TAG, cve_content->string);
-                    } else {
-                        mtwarn(WM_VULNDETECTOR_LOGTAG, VU_UNKNOWN_NVD_TAG, cve_content->string);
-                    }
-                }
+    const char * match_cve = " {\r\n    \"cve\" : {\r\n";
+    const size_t match_size = strlen(match_cve);
+
+    char * cve;
+
+    for (cve = json_feed; (cve = strstr(cve, match_cve)) != NULL; cve += match_size) {
+
+        cJSON * cve_list;
+
+        if (cve_list = cJSON_Parse(cve), !cve_list) {
+            return OS_INVALID;
+        }
+
+        if (nvd_it) {
+            os_calloc(1, sizeof(nvd_vulnerability), nvd_it->next);
+            nvd_it = nvd_it->next;
+        } else {
+            os_calloc(1, sizeof(nvd_vulnerability), nvd_it);
+            nvd_first = nvd_it;
+        }
+        for (cve_content = cve_list->child; json_tagged_obj(cve_content); cve_content = cve_content->next) {
+            if (!strcmp(cve_content->string, JSON_CVE)) {
+                wm_vuldet_parse_nvd_cve(cve_content, nvd_it);
+            } else if (!strcmp(cve_content->string, JSON_CONFIGURATIONS)) {
+                wm_vuldet_parse_nvd_configuration(cve_content, nvd_it);
+            } else if (!strcmp(cve_content->string, JSON_IMPACT)) {
+                wm_vuldet_parse_nvd_impact(cve_content, nvd_it);
+            } else if (!strcmp(cve_content->string, JSON_PUBLISHED)) {
+                w_strdup(cve_content->valuestring, nvd_it->published);
+            } else if (!strcmp(cve_content->string, JSON_LAST_MOD)) {
+                w_strdup(cve_content->valuestring, nvd_it->last_modified);
+            } else if (strcmp(cve_content->string, JSON_DATA_TYPE) &&
+                        strcmp(cve_content->string, JSON_DATA_FORMAT) &&
+                        strcmp(cve_content->string, JSON_DATA_VERSION)) {
+                mtwarn(WM_VULNDETECTOR_LOGTAG, VU_UNKNOWN_NVD_CVE_TAG, cve_content->string);
+            } else {
+                mtwarn(WM_VULNDETECTOR_LOGTAG, VU_UNKNOWN_NVD_TAG, cve_content->string);
             }
         }
+
+        cJSON_Delete(cve_list);
     }
 
     if (nvd_it) {


### PR DESCRIPTION
|Related issue|
|---|
|#4398|

## Description

The purpose of this PR is to reduce the memory usage when parsing the NVD feeds.

The size of some of these feeds exceeds 200MB. When analyzing them, we were loading the entire content of the file in memory and the json tree generated by calling the parse function of the cJSON library, whose size is over than four times the size of the file.
As an example, if the file size was 200MB, in memory we were allocating:

- 200MB for the file content string.
- <800MB for the json tree.

So, just to analyze one of these files, we were allocating more than 1GB of memory. On resource limited systems, this could lead the kernel to kill the _wazuh-modulesd_ process because it fills all the system memory.

The proposed solution consists in analyzing the content of the file in chunks, where each chunk corresponds to a cve object. This is done by looking for the start of a new cve object within the content string and increasing a pointer until no more cve objects are found. This way, the memory usage will be just the size of the file being analyzed.
Following the last example, if the file size is 200MB, in memory we are allocating:

- 200MB for the file content string.
- ~1MB for the current cve object.

This solution allows a large amount of memory usage to be reduced at the cost of increasing the processing time approximately 2.5 times. Since this operation occurs only when changes are detected, this shouldn't be a big limitation.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)