### PR TITLE
Add unit test of active_response module

### DIFF
--- a/framework/wazuh/core/tests/data/etc/shared/ar.conf
+++ b/framework/wazuh/core/tests/data/etc/shared/ar.conf
@@ -1,0 +1,2 @@
+restart-ossec0 - restart-ossec.sh - 0
+restart-ossec0 - restart-ossec.cmd - 0

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -3,7 +3,8 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import os, sys
+import os
+import sys
 from unittest.mock import patch, MagicMock
 
 import pytest

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os, sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', '..', 'api'))
+
+with patch('wazuh.common.ossec_uid'):
+    with patch('wazuh.common.ossec_gid'):
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        from wazuh.exception import WazuhError
+        from wazuh.core import active_response
+        del sys.modules['wazuh.rbac.orm']
+
+
+# Functions
+
+def agent_info(expected_exception):
+    """Returns dict to cause or not a exception code 1651 on active_response.send_command()."""
+    if expected_exception == 1651:
+        return {'status': 'random'}
+    else:
+        return {'status': 'active'}
+
+
+def agent_config(expected_exception):
+    """Returns dict to cause or not a exception code 1750 on active_response.send_command()."""
+    if expected_exception == 1750:
+        return {'active-response': {'disabled': 'yes'}}
+    else:
+        return {'active-response': {'disabled': 'no'}}
+
+
+# Tests
+
+@pytest.mark.parametrize('expected_exception, command, arguments, custom', [
+    (1650, None, [], False),
+    (1652, 'random', [], False),
+    (1652, 'invalid_cmd', [], False),
+    (None, 'restart-ossec0', [], False),
+    (None, 'restart-ossec0', [], True),
+    (None, 'restart-ossec0', ["arg1", "arg2"], False)
+])
+@patch('wazuh.common.ossec_path', new='wazuh/core/tests/data')
+def test_create_message(expected_exception, command, arguments, custom):
+    """Checks message returned is correct
+
+    Checks if message returned by create_message(...) contains the command, arguments and '!' symbol
+    when it is needed.
+
+    Parameters
+    ----------
+    expected_exception : str
+        Exception code expected when calling create_message.
+    command : str
+        Command to be introduced in the message.
+    arguments : list
+        Arguments for the command/script.
+    custom : boolean
+        True if command is a script.
+    """
+    if expected_exception:
+        with pytest.raises(WazuhError, match=f'.* {expected_exception} .*'):
+            active_response.create_message(command=command, arguments=arguments, custom=custom)
+    else:
+        ret = active_response.create_message(command=command, arguments=arguments, custom=custom)
+        assert command in ret, f'Command not being returned'
+        if arguments:
+            assert (arg in ret for arg in arguments), f'Arguments not being added'
+        if custom:
+            assert '!' in ret, f'! symbol not being added when custom command'
+
+
+@patch('wazuh.common.ossec_path', new='wazuh/core/tests/data')
+def test_get_commands():
+    """
+    Checks if get_commands method returns a list
+    """
+    ret = active_response.get_commands()
+    assert type(ret) is list, f'Expected type not match'
+
+
+@pytest.mark.parametrize('command, expected_escape', [
+    ('random <arg1> {arg2}', 4),
+    ('" \' \t ; ` > < | # * [ ] { } & $ ! : ( )', 20)
+])
+def test_shell_escape(command, expected_escape):
+    """Checks if shell_escape method is escaping every symbol
+
+    Parameters
+    ----------
+    command : str
+        Symbols to be escaped
+    expected_escape : int
+        Expected number of escaped symbols
+    """
+    ret = active_response.shell_escape(command)
+    assert ret.count('\\') == expected_escape, f'Number of escaped symbols do not match'
+
+
+@pytest.mark.parametrize('expected_exception, command, agent_id', [
+    (1651, 'random', 0),
+    (1750, 'random', 0),
+    (None, 'random', 5)
+])
+def test_send_command(expected_exception, command, agent_id):
+    """Checks if send_command method is correct
+
+    Verify that send_command raise specific exceptions in some cases and that arguments are correct.
+
+    Parameters
+    ----------
+    expected_exception : int
+        Exception code expected when calling send_command.
+    command : str
+        Command to be introduced in the message.
+    agent_id : int
+        ID number to be set on the agent.
+    """
+    with patch('wazuh.core.core_agent.Agent.get_basic_information', return_value=agent_info(expected_exception)):
+        with patch('wazuh.core.core_agent.Agent.getconfig', return_value=agent_config(expected_exception)):
+            if expected_exception:
+                with pytest.raises(WazuhError, match=f'.* {expected_exception} .*'):
+                    active_response.send_command(command, MagicMock(), agent_id)
+            else:
+                mock_oq = MagicMock()
+                active_response.send_command(command, mock_oq, agent_id)
+                mock_oq.send_msg_to_agent.assert_called_with(agent_id=agent_id, msg=command, msg_type='ar-message')

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -4,56 +4,98 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-from unittest.mock import patch
+import sys
+from functools import wraps
+from unittest.mock import patch, MagicMock
+
+from wazuh.exception import WazuhError
 
 import pytest
 
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'api'))
+
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        from wazuh.exception import WazuhError
-        from wazuh import active_response
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.decorators
+        del sys.modules['wazuh.rbac.orm']
 
-# all necessary params
+        def RBAC_bypasser(**kwargs):
+            def decorator(f):
+                @wraps(f)
+                def wrapper(*args, **kwargs):
+                    return f(*args, **kwargs)
+                return wrapper
+            return decorator
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+        from wazuh.active_response import run_command
+
+# All necessary params
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 
-@pytest.mark.parametrize('expected_exception, agent_id, command, arguments, custom', [
-    (1650, '000', None, [], False),
-    (1652, '000', 'random', [], False),
-    (1652, '000', 'invalid_cmd', [], False),
-    (1651, '001', 'restart-ossec0', [], False),
-    (None, '001', 'restart-ossec0', [], False),
-    (None, '001', 'restart-ossec0', [], True),
-    (None, '001', 'restart-ossec0', ["arg1", "arg2"], False),
-    (None, '000', 'restart-ossec0', [], False),
-])
-def test_run_command(expected_exception, agent_id, command, arguments, custom):
-    """
-    Tests run_command function
-    """
-    if expected_exception is not None:
-        with pytest.raises(WazuhError, match=f'.* {expected_exception} .*'):
-            active_response.run_command(agent_id=agent_id, command=command, arguments=arguments, custom=custom)
+# Functions
+
+def agent_info(expected_exception):
+    """Returns dict to cause or not a exception code 1651 on active_response.send_command()."""
+    if expected_exception == 1651:
+        return {'status': 'random'}
     else:
-        ret = active_response.run_command(agent_id=agent_id, command=command, arguments=arguments, custom=custom)
-        assert ret == {'message': 'Command sent.'}
+        return {'status': 'active'}
 
 
-@pytest.mark.parametrize('expected_exception, command, arguments, custom', [
-    (1650, None, [], False),
-    (1652, 'random', [], False),
-    (1652, 'invalid_cmd', [], False),
-    (None, 'restart-ossec0', [], False),
-    (None, 'restart-ossec0', ["arg1", "arg2"], False)
-])
-def test_run_command_all(expected_exception, command, arguments, custom):
-    """
-    Tests run_command function
-    """
-
-    if expected_exception is not None:
-        with pytest.raises(WazuhError, match=f'.* {expected_exception} .*'):
-            active_response.run_command(command=command, arguments=arguments, custom=custom)
+def agent_config(expected_exception):
+    """Returns dict to cause or not an exception code 1750 on active_response.send_command()."""
+    if expected_exception == 1750:
+        return {'active-response': {'disabled': 'yes'}}
     else:
-        ret = active_response.run_command(command=command, arguments=arguments, custom=custom)
-        assert ret == {'message': 'Command sent.'}
+        return {'active-response': {'disabled': 'no'}}
+
+
+# Tests
+
+@pytest.mark.parametrize('message_exception, send_exception, agent_id, command, arguments, custom', [
+    (1650, None, [0], None, [], False),
+    (1652, None, [0], 'random', [], False),
+    (None, 1651, [1], 'restart-ossec0', [], False),
+    (None, 1750, [1], 'restart-ossec0', [], False),
+    (None, None, [1], 'restart-ossec0', [], False),
+    (None, None, [1], 'restart-ossec0', [], True),
+    (None, None, [1], 'restart-ossec0', ["arg1", "arg2"], False),
+    (None, None, [0], 'restart-ossec0', [], False),
+    (None, None, [0, 1, 2, 3, 4, 5, 6], 'restart-ossec0', [], False),
+])
+@patch("wazuh.ossec_queue.OssecQueue._connect")
+@patch("wazuh.syscheck.OssecQueue._send", return_value='1')
+@patch("wazuh.ossec_queue.OssecQueue.close")
+@patch('wazuh.common.ossec_path', new='wazuh/tests/data')
+def test_run_command(mock_conn,  mock_send, mock_close, message_exception, send_exception, agent_id, command,
+                     arguments, custom):
+    """Verify the proper operation of active_response module.
+
+    Parameters
+    ----------
+    message_exception : int
+        Exception code expected when calling create_message.
+    send_exception : int
+        Exception code expected when calling send_command.
+    agent_id : list
+        Agents on which to execute the Active response command.
+    command : string
+        Command to be executed on the agent.
+    arguments : list, optional
+        Arguments of the command.
+    custom : boolean
+        True if command is a script.
+    """
+    with patch('wazuh.core.core_agent.Agent.get_basic_information', return_value=agent_info(send_exception)):
+        with patch('wazuh.core.core_agent.Agent.getconfig', return_value=agent_config(send_exception)):
+            if message_exception:
+                with pytest.raises(WazuhError, match=f'.* {message_exception} .*'):
+                    run_command(agent_list=agent_id, command=command, arguments=arguments, custom=custom)
+            else:
+                ret = run_command(agent_list=agent_id, command=command, arguments=arguments, custom=custom)
+                if send_exception:
+                    assert ret.render()['message'] == 'Could not send command to any agent'
+                else:
+                    assert ret.render()['message'] == 'Command sent to all agents'


### PR DESCRIPTION
|Related issue|
|---|
|[4297](https://github.com/wazuh/wazuh/issues/4297)|

## Description
This PR adds/modifies unit tests to verify the correct working of `active_response.py` and `/core/active_response.py`. Each function is tested individually and without the need to use a wazuh server,

## Tests performed and coverage
The percentage of the covered module by the test is as follows:
### active_response.py
```
================================================= test session starts ==================================================
platform linux -- Python 3.7.4, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /home/selu/miniconda3/bin/python3
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/framework
plugins: cov-2.8.1
collected 9 items                                                                                                      

wazuh/tests/test_active_response.py::test_run_command[1650-None-agent_id0-None-arguments0-False] PASSED          [ 11%]
wazuh/tests/test_active_response.py::test_run_command[1652-None-agent_id1-random-arguments1-False] PASSED        [ 22%]
wazuh/tests/test_active_response.py::test_run_command[None-1651-agent_id2-restart-ossec0-arguments2-False] PASSED [ 33%]
wazuh/tests/test_active_response.py::test_run_command[None-1750-agent_id3-restart-ossec0-arguments3-False] PASSED [ 44%]
wazuh/tests/test_active_response.py::test_run_command[None-None-agent_id4-restart-ossec0-arguments4-False] PASSED [ 55%]
wazuh/tests/test_active_response.py::test_run_command[None-None-agent_id5-restart-ossec0-arguments5-True] PASSED [ 66%]
wazuh/tests/test_active_response.py::test_run_command[None-None-agent_id6-restart-ossec0-arguments6-False] PASSED [ 77%]
wazuh/tests/test_active_response.py::test_run_command[None-None-agent_id7-restart-ossec0-arguments7-False] PASSED [ 88%]
wazuh/tests/test_active_response.py::test_run_command[None-None-agent_id8-restart-ossec0-arguments8-False] PASSED [100%]

=================================================== warnings summary ===================================================
```

```
----------- coverage: platform linux, python 3.7.4-final-0 -----------
Name                                            Stmts   Miss  Cover
-------------------------------------------------------------------
/home/selu/Git/wazuh/api/api/__init__.py            0      0   100%
/home/selu/Git/wazuh/api/api/api_exception.py      10      5    50%
/home/selu/Git/wazuh/api/api/configuration.py      35     17    51%
/home/selu/Git/wazuh/api/api/constants.py           9      0   100%
/home/selu/Git/wazuh/api/api/util.py              116     88    24%
wazuh/InputValidator.py                            18     11    39%
wazuh/__init__.py                                  75     53    29%
wazuh/active_response.py                           20      0   100%
wazuh/agent.py                                    405    334    18%
wazuh/common.py                                    99     13    87%
wazuh/configuration.py                            382    343    10%
wazuh/core/__init__.py                              0      0   100%
wazuh/core/active_response.py                      34      0   100%
wazuh/core/cdb_list.py                             50     38    24%
wazuh/core/cluster/__init__.py                      5      0   100%
wazuh/core/cluster/utils.py                       112     81    28%
wazuh/core/core_agent.py                          924    826    11%
wazuh/core/core_utils.py                           45     34    24%
wazuh/core/rule.py                                122    101    17%
wazuh/core/syscheck.py                             19     12    37%
wazuh/database.py                                  55     36    35%
wazuh/exception.py                                 82     34    59%
wazuh/ossec_queue.py                               70     37    47%
wazuh/ossec_socket.py                              46     29    37%
wazuh/rbac/__init__.py                              0      0   100%
wazuh/rbac/decorators.py                          228    200    12%
wazuh/results.py                                  301    189    37%
wazuh/syscheck.py                                  92     73    21%
wazuh/tests/test_active_response.py                43      0   100%
wazuh/utils.py                                    596    474    20%
wazuh/wdb.py                                      110     93    15%
wazuh/wlogging.py                                  66     50    24%
-------------------------------------------------------------------
TOTAL                                            4169   3171    24%
```

### core/active_response.py
```
$ python3 -m pytest wazuh/core/tests/test_active_response.py -vv
================================================= test session starts ==================================================
platform linux -- Python 3.7.4, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /home/selu/miniconda3/bin/python3
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/framework
plugins: cov-2.8.1
collected 12 items                                                                                                     

wazuh/core/tests/test_active_response.py::test_create_message[1650-None-arguments0-False] PASSED                 [  8%]
wazuh/core/tests/test_active_response.py::test_create_message[1652-random-arguments1-False] PASSED               [ 16%]
wazuh/core/tests/test_active_response.py::test_create_message[1652-invalid_cmd-arguments2-False] PASSED          [ 25%]
wazuh/core/tests/test_active_response.py::test_create_message[None-restart-ossec0-arguments3-False] PASSED       [ 33%]
wazuh/core/tests/test_active_response.py::test_create_message[None-restart-ossec0-arguments4-True] PASSED        [ 41%]
wazuh/core/tests/test_active_response.py::test_create_message[None-restart-ossec0-arguments5-False] PASSED       [ 50%]
wazuh/core/tests/test_active_response.py::test_get_commands PASSED                                               [ 58%]
wazuh/core/tests/test_active_response.py::test_shell_escape[random <arg1> {arg2}-4] PASSED                       [ 66%]
wazuh/core/tests/test_active_response.py::test_shell_escape[" ' \t ; ` > < | # * [ ] { } & $ ! : ( )-20] PASSED  [ 75%]
wazuh/core/tests/test_active_response.py::test_send_command[1651-random-0] PASSED                                [ 83%]
wazuh/core/tests/test_active_response.py::test_send_command[1750-random-0] PASSED                                [ 91%]
wazuh/core/tests/test_active_response.py::test_send_command[None-random-5] PASSED                                [100%]

=================================================== warnings summary ===================================================
```

```
----------- coverage: platform linux, python 3.7.4-final-0 -----------
Name                                            Stmts   Miss  Cover
-------------------------------------------------------------------
/home/selu/Git/wazuh/api/api/__init__.py            0      0   100%
/home/selu/Git/wazuh/api/api/api_exception.py      10      5    50%
/home/selu/Git/wazuh/api/api/configuration.py      35     17    51%
/home/selu/Git/wazuh/api/api/constants.py           9      0   100%
/home/selu/Git/wazuh/api/api/util.py              116     88    24%
wazuh/InputValidator.py                            18     11    39%
wazuh/__init__.py                                  75     53    29%
wazuh/agent.py                                    405    334    18%
wazuh/common.py                                    99     13    87%
wazuh/configuration.py                            382    343    10%
wazuh/core/__init__.py                              0      0   100%
wazuh/core/active_response.py                      34      0   100%
wazuh/core/cdb_list.py                             50     38    24%
wazuh/core/cluster/__init__.py                      5      0   100%
wazuh/core/cluster/utils.py                       112     81    28%
wazuh/core/core_agent.py                          924    826    11%
wazuh/core/core_utils.py                           45     34    24%
wazuh/core/rule.py                                122    101    17%
wazuh/core/tests/test_active_response.py           44      0   100%
wazuh/database.py                                  55     36    35%
wazuh/exception.py                                 82     38    54%
wazuh/ossec_queue.py                               70     56    20%
wazuh/ossec_socket.py                              46     29    37%
wazuh/rbac/__init__.py                              0      0   100%
wazuh/rbac/decorators.py                          228    194    15%
wazuh/results.py                                  301    229    24%
wazuh/utils.py                                    596    474    20%
wazuh/wdb.py                                      110     93    15%
wazuh/wlogging.py                                  66     50    24%
-------------------------------------------------------------------
TOTAL                                            4039   3143    22%
```
