### PR TITLE
userID field extraction

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -181,11 +181,11 @@ int DecodeWinevt(Eventinfo *lf){
                                 }
                             } else if (!strcmp(child_attr[p]->element, "Channel")) {
                                 cJSON_AddStringToObject(json_system_in, "channel", child_attr[p]->content);
-                                if(child_attr[p]->attributes && child_attr[p]->values && !strcmp(child_attr[p]->values[0], "UserID")){
+                                if(child_attr[p]->attributes && child_attr[p]->values && !strcmp(child_attr[p]->attributes[0], "UserID")){
                                     cJSON_AddStringToObject(json_system_in, "userID", child_attr[p]->values[0]);
                                 }
                             } else if (!strcmp(child_attr[p]->element, "Security")) {
-                                if(child_attr[p]->attributes && child_attr[p]->values && !strcmp(child_attr[p]->values[0], "UserID")){
+                                if(child_attr[p]->attributes && child_attr[p]->values && !strcmp(child_attr[p]->attributes[0], "UserID")){
                                     cJSON_AddStringToObject(json_system_in, "securityUserID", child_attr[p]->values[0]);
                                 }
                             } else if (!strcmp(child_attr[p]->element, "Level")) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4439|


## Description

The `userID` field regarding Eventchannel events wasn't correctly extracted. Attribute names were referenced as values instead of attributes so they were never extracted.

After referencing the attributes correctly the field value is the expected one.

## Logs/Alerts example
Incorrect userID extraction:
```JSON
{"win":{"system":{"providerName":"MsiInstaller","eventID":"1034","level":"4","task":"0","keywords":"0x80000000000000","systemTime":"2020-01-13T15:51:57.098919900Z","eventRecordID":"3250","channel":"Application","computer":"DESKTOP-D33AN6I","severityValue":"INFORMATION","message":"\"Windows Installer quitó el producto. Nombre del producto: osquery. Versión del producto: 4.1.1. Idioma del producto: 1033. Fabricante: osquery. Resultado de la eliminación: 0.\""},"eventdata":{"binary":"7B31394335354339452D333937442D343338312D413746412D3435444343303343324131387D3030303035623833336130666361336265643236313630643764633434383461666334613030303030393034","data":"osquery, 4.1.1, 1033, 0, osquery"}}}
```

Correct `userID` extraction after referencing the right structure members:
```JSON
{"win":{"system":{"providerName":"MsiInstaller","eventID":"1034","level":"4","task":"0","keywords":"0x80000000000000","systemTime":"2020-01-13T16:34:50.122596100Z","eventRecordID":"3266","channel":"Application","computer":"DESKTOP-D33AN6I","securityUserID":"S-1-5-21-2635242741-4024004514-10403589-1001","severityValue":"INFORMATION","message":"\"Windows Installer quitó el producto. Nombre del producto: osquery. Versión del producto: 4.1.1. Idioma del producto: 1033. Fabricante: osquery. Resultado de la eliminación: 0.\""},"eventdata":{"binary":"7B31394335354339452D333937442D343338312D413746412D3435444343303343324131387D3030303035623833336130666361336265643236313630643764633434383461666334613030303030393034","data":"osquery, 4.1.1, 1033, 0, osquery"}}}
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows


