### PR TITLE
Add test for 'context_cached' function in common module

### DIFF
--- a/framework/wazuh/tests/test_common.py
+++ b/framework/wazuh/tests/test_common.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 import pytest
 from os import path, remove
 import os
-from wazuh.common import find_wazuh_path, ossec_uid, ossec_gid
+from wazuh.common import find_wazuh_path, ossec_uid, ossec_gid, context_cached, reset_context_cache
 from grp import getgrnam
 from pwd import getpwnam
 from sys import modules
@@ -31,3 +31,16 @@ def test_ossec_uid():
 def test_ossec_gid():
     with patch('wazuh.common.getgrnam', return_value=getgrnam("root")):
         ossec_gid()
+
+
+def test_context_cached():
+    """Verify that context_cached decorator correctly saves and returns saved value when called again"""
+    @context_cached('foobar')
+    def foo(arg='bar'):
+        return arg
+
+    assert foo() == 'bar', '"bar" should be returned.'
+    assert foo('other_arg') != 'other_arg', '"bar" should be returned.'
+    reset_context_cache()
+    assert foo('other_arg_2') == 'other_arg_2', '"other_arg_2" should be returned.'
+    assert foo() == 'other_arg_2', '"other_arg_2" should be returned.'


### PR DESCRIPTION
|Related issue|
|---|
|[4301](https://github.com/wazuh/wazuh/issues/4301)|

## Description
This PR adds a unit test for the functions `context_cached` and `reset_context_cache` of the module `common`. It checks that functions decorated with context_cached return the same result that was produced in the first call, even if the arguments are different in the following calls. This shows that the function is not rerun unless the cache is reset with `reset_context_cache`.

## Tests performed and coverage
The results and percentage of coverage of the module after executing the test is:
```
$ python3 -m pytest wazuh/tests/test_common.py
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: cov-2.8.1
collected 7 items                                                              

wazuh/tests/test_common.py .......                                       [100%]

============================== 7 passed in 0.02s ===============================
```

```
----------- coverage: platform linux, python 3.7.5-final-0 -----------
Name                                            Stmts   Miss  Cover
-------------------------------------------------------------------
wazuh/InputValidator.py                            18     18     0%
wazuh/__init__.py                                  75     53    29%
wazuh/__main__.py                                   2      2     0%
wazuh/active_response.py                           20     20     0%
wazuh/agent.py                                    405    405     0%
wazuh/cdb_list.py                                  24     24     0%
wazuh/ciscat.py                                    26     26     0%
wazuh/cluster.py                                   43     43     0%
wazuh/common.py                                    99      1    99%
wazuh/configuration.py                            382    382     0%
wazuh/core/__init__.py                              0      0   100%
wazuh/core/active_response.py                      34     34     0%
wazuh/core/cdb_list.py                             50     50     0%
wazuh/core/cluster/__init__.py                      5      5     0%
wazuh/core/cluster/client.py                      145    145     0%
wazuh/core/cluster/cluster.py                     212    212     0%
wazuh/core/cluster/common.py                      329    329     0%
wazuh/core/cluster/control.py                      51     51     0%
wazuh/core/cluster/dapi/__init__.py                 0      0   100%
wazuh/core/cluster/dapi/dapi.py                   244    244     0%
wazuh/core/cluster/dapi/requests_list.py           19     19     0%
wazuh/core/cluster/local_client.py                 76     76     0%
wazuh/core/cluster/local_server.py                128    128     0%
wazuh/core/cluster/master.py                      357    357     0%
wazuh/core/cluster/server.py                      150    150     0%
wazuh/core/cluster/tests/__init__.py                0      0   100%
wazuh/core/cluster/tests/test_cluster.py           55     55     0%
wazuh/core/cluster/tests/test_common.py            21     21     0%
wazuh/core/cluster/tests/test_local_client.py      15     15     0%
wazuh/core/cluster/tests/test_worker.py            45     45     0%
wazuh/core/cluster/utils.py                       112    112     0%
wazuh/core/cluster/worker.py                      304    304     0%
wazuh/core/core_agent.py                          924    924     0%
wazuh/core/core_utils.py                           45     45     0%
wazuh/core/decoder.py                              64     64     0%
wazuh/core/manager.py                             116    116     0%
wazuh/core/rule.py                                122    122     0%
wazuh/core/sca.py                                  28     28     0%
wazuh/core/syscheck.py                             19     19     0%
wazuh/core/syscollector.py                         37     37     0%
wazuh/database.py                                  55     36    35%
wazuh/decoder.py                                   69     69     0%
wazuh/exception.py                                 82     54    34%
wazuh/manager.py                                  235    235     0%
wazuh/ossec_queue.py                               70     70     0%
wazuh/ossec_socket.py                              46     46     0%
wazuh/pyDaemonModule.py                            45     45     0%
wazuh/rbac/__init__.py                              0      0   100%
wazuh/rbac/auth_context.py                        169    169     0%
wazuh/rbac/decorators.py                          228    228     0%
wazuh/rbac/orm.py                                 661    661     0%
wazuh/rbac/preprocessor.py                         55     55     0%
wazuh/rbac/tests/__init__.py                        0      0   100%
wazuh/rbac/tests/test_auth_context.py              65     65     0%
wazuh/rbac/tests/test_decorators.py                69     69     0%
wazuh/rbac/tests/test_orm.py                      213    213     0%
wazuh/rbac/tests/test_preprocessor.py              18     18     0%
wazuh/results.py                                  301    301     0%
wazuh/rootcheck.py                                132    132     0%
wazuh/rule.py                                      94     94     0%
wazuh/security.py                                 255    255     0%
wazuh/security_configuration_assessment.py         46     46     0%
wazuh/stats.py                                    118    118     0%
wazuh/syscheck.py                                  92     92     0%
wazuh/syscollector.py                              24     24     0%
wazuh/tests/test_common.py                         30      0   100%
wazuh/utils.py                                    596    596     0%
wazuh/wdb.py                                      110    110     0%
wazuh/wlogging.py                                  66     66     0%
-------------------------------------------------------------------
TOTAL                                            8745   8548     2%

TOTAL                                            8807   7801    11%
```

Gets 99% coverage. It does not reach 100% because the following `metadata = json.load(f)` is not executed.
```
try:
    here = os.path.abspath(os.path.dirname(__file__))
    with open(os.path.join(here, 'wazuh.json'), 'r') as f:
        metadata = json.load(f)
``