### PR TITLE
Fix memory leak in Syscheckd on startup when FIM is disabled

### DIFF
--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -119,12 +119,12 @@ int main(int argc, char **argv)
             }
         }
 
-        syscheck.dir[0] = NULL;
+        os_free(syscheck.dir[0]);
 
         if (!syscheck.ignore) {
             os_calloc(1, sizeof(char *), syscheck.ignore);
         } else {
-            syscheck.ignore[0] = NULL;
+            os_free(syscheck.ignore[0]);
         }
 
         if (!test_config) {

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -137,18 +137,18 @@ int Start_win32_Syscheck()
             minfo(FIM_DIRECTORY_NOPROVIDED);
         }
 
-        syscheck.dir[0] = NULL;
+        os_free(syscheck.dir[0]);
 
         if (!syscheck.ignore) {
             os_calloc(1, sizeof(char *), syscheck.ignore);
         } else {
-            syscheck.ignore[0] = NULL;
+            os_free(syscheck.ignore[0]);
         }
 
         if (!syscheck.registry) {
             dump_syscheck_entry(&syscheck, "", 0, 1, NULL, 0, NULL, NULL);
         }
-        syscheck.registry[0].entry = NULL;
+        os_free(syscheck.registry[0].entry);
 
         minfo(FIM_DISABLED);
     }


### PR DESCRIPTION
|Related issue|
|---|
|#4445|

This PR applies the fix proposed in #4445.

## Critical configuration

```xml
<syscheck>
  <disabled>yes</disabled>
  <!-- (...) -->
</syscheck>
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

### Linux

- [X] Compilation.
- [X] Source installation.
- [X] Run on Valgrind.

#### Valgrind report

##### Before

```
==29431== HEAP SUMMARY:
==29431==     in use at exit: 10,948 bytes in 23 blocks
==29431==   total heap usage: 7,367 allocs, 7,344 frees, 2,762,396 bytes allocated
==29431==
==29431== 6 bytes in 1 blocks are definitely lost in loss record 1 of 20
==29431==    at 0x4C3319A: calloc (vg_replace_malloc.c:762)
==29431==    by 0x432BBF: dump_syscheck_entry (syscheck-config.c:69)
==29431==    by 0x434C32: read_attr (syscheck-config.c:762)
==29431==    by 0x435716: Read_Syscheck (syscheck-config.c:969)
==29431==    by 0x41FB84: read_main_elements (config.c:100)
==29431==    by 0x42074C: ReadConfig (config.c:254)
==29431==    by 0x40B970: Read_Syscheck_Config (config.c:70)
==29431==    by 0x410333: main (main.c:108)
==29431==
==29431== 10 bytes in 1 blocks are definitely lost in loss record 3 of 20
==29431==    at 0x4C30E8B: malloc (vg_replace_malloc.c:309)
==29431==    by 0x60F8A0D: strdup (in /usr/lib64/libc-2.28.so)
==29431==    by 0x4367C8: Read_Syscheck (syscheck-config.c:1224)
==29431==    by 0x41FB84: read_main_elements (config.c:100)
==29431==    by 0x42074C: ReadConfig (config.c:254)
==29431==    by 0x40B970: Read_Syscheck_Config (config.c:70)
==29431==    by 0x410333: main (main.c:108)
```

##### After

```
==10832== LEAK SUMMARY:
==10832==    definitely lost: 0 bytes in 0 blocks
==10832==    indirectly lost: 0 bytes in 0 blocks
==10832==      possibly lost: 272 bytes in 1 blocks
==10832==    still reachable: 10,660 bytes in 20 blocks
==10832==         suppressed: 0 bytes in 0 blocks
```

### Windows

- [X] Compilation.