### PR TITLE
Fix file descriptor leak on Windows

### DIFF
--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -584,6 +584,9 @@ int del_plist(OSList *p_list)
         p_node = NULL;
     }
 
+    pthread_mutex_destroy(&(p_list->mutex));
+    pthread_rwlock_destroy(&(p_list->wr_mutex));
+
     free(p_list);
 
     return (1);

--- a/src/rootcheck/win-process.c
+++ b/src/rootcheck/win-process.c
@@ -94,7 +94,11 @@ OSList *os_get_process_list()
     /* Enable debug privilege */
     if (!os_win32_setdebugpriv(hpriv, 1)) {
         mterror(ARGV0, "os_win32_setdebugpriv");
-        CloseHandle(hpriv);
+
+        if(CloseHandle(hpriv) == 0) {
+            mdebug2("Can't close handle");
+        }
+
         return (NULL);
     }
 
@@ -102,20 +106,41 @@ OSList *os_get_process_list()
     hsnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (hsnap == INVALID_HANDLE_VALUE) {
         mterror(ARGV0, "CreateToolhelp32Snapshot");
+
+        if (CloseHandle(hpriv) == 0) {
+            mdebug2("Can't close handle");
+        }
+
         return (NULL);
     }
 
     /* Get first and second processes -- system entries */
     if (!Process32First(hsnap, &p_entry) && !Process32Next(hsnap, &p_entry )) {
         mterror(ARGV0, "Process32First");
-        CloseHandle(hsnap);
+
+        if (CloseHandle(hsnap) == 0) {
+            mdebug2("Can't close handle");
+        }
+
+        if (CloseHandle(hpriv) == 0) {
+            mdebug2("Can't close handle");
+        }
+
         return (NULL);
     }
 
     /* Create process list */
     p_list = OSList_Create();
     if (!p_list) {
-        CloseHandle(hsnap);
+
+        if (CloseHandle(hsnap) == 0) {
+            mdebug2("Can't close handle");
+        }
+
+        if (CloseHandle(hpriv) == 0) {
+            mdebug2("Can't close handle");
+        }
+
         mterror(ARGV0, LIST_ERROR);
         return (0);
     }
@@ -141,11 +166,19 @@ OSList *os_get_process_list()
             os_strdup(p_name, p_path);
         } else if (!Module32First(hmod, &m_entry)) {
             /* Get executable path (first entry in the module list) */
-            CloseHandle(hmod);
+
+            if (CloseHandle(hmod) == 0){
+                mdebug2("Can't close handle");
+            }
+
             os_strdup(p_name, p_path);
-        } else {
+        }
+        else {
             os_strdup(m_entry.szExePath, p_path);
-            CloseHandle(hmod);
+
+            if (CloseHandle(hmod) == 0) {
+                mdebug2("Can't close handle");
+            }
         }
 
         os_calloc(1, sizeof(Proc_Info), p_info);
@@ -157,7 +190,14 @@ OSList *os_get_process_list()
     /* Remove debug privileges */
     os_win32_setdebugpriv(hpriv, 0);
 
-    CloseHandle(hsnap);
+    if (CloseHandle(hsnap) == 0) {
+        mdebug2("Can't close handle");
+    }
+
+    if (CloseHandle(hpriv) == 0) {
+        mdebug2("Can't close handle");
+    }
+
     return (p_list);
 }
 

--- a/src/shared/os_utils.c
+++ b/src/shared/os_utils.c
@@ -169,6 +169,9 @@ int w_del_plist(OSList *p_list)
         p_node = NULL;
     }
 
+    pthread_mutex_destroy(&(p_list->mutex));
+    pthread_rwlock_destroy(&(p_list->wr_mutex));
+
     free(p_list);
 
     return (1);


### PR DESCRIPTION
|Related issue|
|---|
|[4388](https://github.com/wazuh/wazuh/issues/4388)|

Exist three file descriptor leaks on Windows. I list them below:

+ SCA file descriptor leak. It's due the function [w_del_plist](https://github.com/wazuh/wazuh/blob/971b1acbb881c86b20c0d364ce12f004ec43419d/src/shared/os_utils.c#L133) remove an `OS_List` but doesn't destroy the mutex used in the `OS_List`.
+ Rootcheck file descriptor leak. It's similar to previously FD leak but it happens in [del_plist](https://github.com/wazuh/wazuh/blob/971b1acbb881c86b20c0d364ce12f004ec43419d/src/rootcheck/common.c#L548) function.
+ Rootcheck file descriptor leak. Function [os_get_process_list](https://github.com/wazuh/wazuh/blob/971b1acbb881c86b20c0d364ce12f004ec43419d/src/rootcheck/win-process.c#L65) doesn't close handle `hpriv`.

This PR solves it.

## Configuration options

To test it, enable only the module to test and add a scan's interval of 60 seconds.

## Artifacts affected

### Primarily

- Wazuh Agent binary for Windows.

### Secondarily

- Analysisd
- Syscheckd (Rootcheck)
- Execd
- Modulesd (SCA)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [X] Compile on Linux.
- [x] Compile for Windows.
- [X] Compile on macOS.
- [x] Source installation on Linux.
- [X] NSIS package installation on Windows.
- [X] _scan-build_ for Windows.
