### PR TITLE
Add ciscat module unit tests

### DIFF
--- a/framework/wazuh/tests/test_ciscat.py
+++ b/framework/wazuh/tests/test_ciscat.py
@@ -1,26 +1,67 @@
-#!/usr/bin/env python
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+import sys
+from functools import wraps
+from unittest.mock import patch, MagicMock
 
+import pytest
 
-from unittest.mock import patch
+from wazuh.tests.util import InitWDBSocketMock
+
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        from wazuh import ciscat
+        sys.modules['api'] = MagicMock()
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.decorators
+
+        del sys.modules['wazuh.rbac.orm']
+        del sys.modules['api']
+
+        def RBAC_bypasser(**kwargs):
+            def decorator(f):
+                @wraps(f)
+                def wrapper(*args, **kwargs):
+                    return f(*args, **kwargs)
+
+                return wrapper
+            return decorator
+
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+        from wazuh.ciscat import get_ciscat_results
+        from wazuh.results import AffectedItemsWazuhResult
 
 
-@patch("wazuh.ciscat.get_item_agent", return_value=None)
-def test_get_ciscat_agent(mock_response):
-    """
-        Tests get_netiface_agent method
-    """
-    ciscat.get_results_agent('001')
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 
-@patch("wazuh.ciscat._get_agent_items", return_value=None)
-def test_get_ciscat_result(mock_response):
+@pytest.mark.parametrize('agent_id, exception', [
+    (['001'], False),
+    (['003'], True)
+])
+@patch('wazuh.common.wdb_path', new=test_data_path)
+@patch('socket.socket.connect')
+@patch('wazuh.ciscat.get_agents_info', return_value=['001'])
+def test_get_ciscat_results(agents_info_mock, socket_mock, agent_id, exception):
+    """Test function `get_ciscat_results` from ciscat module.
+
+    Parameters
+    ----------
+    agent_id :  list
+        List of agent IDs.
+    exception : bool
+        True if the code will go through an exception. False otherwise.
     """
-        Tests get_packages method
-    """
-    ciscat.get_ciscat_results()
+    with patch('wazuh.utils.WazuhDBConnection') as mock_wdb:
+        mock_wdb.return_value = InitWDBSocketMock(sql_schema_file='schema_ciscat_test.sql')
+        result = get_ciscat_results(agent_id)
+        assert isinstance(result, AffectedItemsWazuhResult)
+        if not exception:
+            assert result.affected_items
+            assert result.total_affected_items == 2
+            assert result.total_failed_items == 0
+        else:
+            assert not result.affected_items
+            assert result.total_failed_items == 1
+            assert result. total_affected_items == 0


### PR DESCRIPTION
Hi team, this closes #4299 .

## Tests performed
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: tavern-0.30.3, cov-2.8.1
collected 2 items                                                                                                                                                                                                 

wazuh/tests/test_ciscat.py ..                                                                                                                                                                               [100%]

================================================================================================ warnings summary =================================================================================================
wazuh/results.py:19
  /home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/results.py:19: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    class AbstractWazuhResult(collections.MutableMapping):

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform linux, python 3.7.5-final-0 -----------
Name                                            Stmts   Miss  Cover
-------------------------------------------------------------------
wazuh/InputValidator.py                            18     11    39%
wazuh/__init__.py                                  75     53    29%
wazuh/__main__.py                                   2      2     0%
wazuh/active_response.py                           20     20     0%
wazuh/agent.py                                    405    405     0%
wazuh/cdb_list.py                                  24     24     0%
wazuh/ciscat.py                                    26      0   100%
wazuh/cluster.py                                   43     43     0%
wazuh/common.py                                    99     13    87%
wazuh/configuration.py                            382    343    10%
wazuh/core/__init__.py                              0      0   100%
wazuh/core/active_response.py                      34     34     0%
wazuh/core/cdb_list.py                             50     38    24%
wazuh/core/cluster/__init__.py                      5      0   100%
wazuh/core/cluster/client.py                      145    145     0%
wazuh/core/cluster/cluster.py                     212    212     0%
wazuh/core/cluster/common.py                      329    329     0%
wazuh/core/cluster/control.py                      51     51     0%
wazuh/core/cluster/dapi/__init__.py                 0      0   100%
wazuh/core/cluster/dapi/dapi.py                   244    244     0%
wazuh/core/cluster/dapi/requests_list.py           19     19     0%
wazuh/core/cluster/local_client.py                 76     76     0%
wazuh/core/cluster/local_server.py                128    128     0%
wazuh/core/cluster/master.py                      357    357     0%
wazuh/core/cluster/server.py                      150    150     0%
wazuh/core/cluster/tests/__init__.py                0      0   100%
wazuh/core/cluster/tests/test_cluster.py           55     55     0%
wazuh/core/cluster/tests/test_common.py            21     21     0%
wazuh/core/cluster/tests/test_local_client.py      15     15     0%
wazuh/core/cluster/tests/test_worker.py            45     45     0%
wazuh/core/cluster/utils.py                       112     81    28%
wazuh/core/cluster/worker.py                      304    304     0%
wazuh/core/core_agent.py                          924    843     9%
wazuh/core/core_utils.py                           45     34    24%
wazuh/core/decoder.py                              64     64     0%
wazuh/core/manager.py                             116    116     0%
wazuh/core/rule.py                                122    101    17%
wazuh/core/sca.py                                  28     28     0%
wazuh/core/syscheck.py                             19     19     0%
wazuh/core/syscollector.py                         37     11    70%
wazuh/database.py                                  55     36    35%
wazuh/decoder.py                                   69     69     0%
wazuh/exception.py                                 82     39    52%
wazuh/manager.py                                  235    235     0%
wazuh/ossec_queue.py                               70     56    20%
wazuh/ossec_socket.py                              46     29    37%
wazuh/pyDaemonModule.py                            45     45     0%
wazuh/rbac/__init__.py                              0      0   100%
wazuh/rbac/auth_context.py                        169    169     0%
wazuh/rbac/decorators.py                          228    200    12%
wazuh/rbac/orm.py                                 661    661     0%
wazuh/rbac/preprocessor.py                         55     55     0%
wazuh/rbac/tests/__init__.py                        0      0   100%
wazuh/rbac/tests/test_auth_context.py              65     65     0%
wazuh/rbac/tests/test_decorators.py                69     69     0%
wazuh/rbac/tests/test_orm.py                      213    213     0%
wazuh/rbac/tests/test_preprocessor.py              18     18     0%
wazuh/results.py                                  301    157    48%
wazuh/rootcheck.py                                132    132     0%
wazuh/rule.py                                      94     94     0%
wazuh/security.py                                 255    255     0%
wazuh/security_configuration_assessment.py         46     46     0%
wazuh/stats.py                                    118    118     0%
wazuh/syscheck.py                                  92     92     0%
wazuh/syscollector.py                              24     24     0%
wazuh/tests/test_ciscat.py                         38      0   100%
wazuh/tests/util.py                                24      1    96%
wazuh/utils.py                                    596    395    34%
wazuh/wdb.py                                      110     93    15%
wazuh/wlogging.py                                  66     50    24%
-------------------------------------------------------------------
TOTAL                                            8777   7850    11%

====================================================================================== 2 passed, 1 warnings in 0.72 seconds =======================================================================================

```