### PR TITLE
Rootcheck - Fix duplicate function to remove OS_List

### DIFF
--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -544,53 +544,6 @@ int is_file(char *file_name)
     return (1);
 }
 
-/* Delete the process list */
-int del_plist(OSList *p_list)
-{
-    OSListNode *l_node;
-    OSListNode *p_node = NULL;
-
-    if (p_list == NULL) {
-        return (0);
-    }
-
-    l_node = OSList_GetFirstNode(p_list);
-    while (l_node) {
-        Proc_Info *pinfo;
-
-        pinfo = (Proc_Info *)l_node->data;
-
-        if (pinfo->p_name) {
-            free(pinfo->p_name);
-        }
-
-        if (pinfo->p_path) {
-            free(pinfo->p_path);
-        }
-
-        free(l_node->data);
-
-        if (p_node) {
-            free(p_node);
-            p_node = NULL;
-        }
-        p_node = l_node;
-
-        l_node = OSList_GetNextNode(p_list);
-    }
-
-    if (p_node) {
-        free(p_node);
-        p_node = NULL;
-    }
-
-    pthread_mutex_destroy(&(p_list->mutex));
-    pthread_rwlock_destroy(&(p_list->wr_mutex));
-
-    free(p_list);
-
-    return (1);
-}
 
 /* Check if a process is running */
 int is_process(char *value, OSList *p_list)
@@ -605,9 +558,9 @@ int is_process(char *value, OSList *p_list)
 
     l_node = OSList_GetFirstNode(p_list);
     while (l_node) {
-        Proc_Info *pinfo;
+        W_Proc_Info *pinfo;
 
-        pinfo = (Proc_Info *)l_node->data;
+        pinfo = (W_Proc_Info *)l_node->data;
 
         /* Check if value matches */
         if (pt_matches(pinfo->p_path, value)) {

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -88,9 +88,6 @@ OSList *os_get_process_list(void);
 /* Check if a process is running */
 int is_process(char *value, OSList *p_list);
 
-/*  Delete the process list */
-int del_plist(OSList *p_list);
-
 /* Used to report messages */
 int notify_rk(int rk_type, const char *msg);
 
@@ -139,11 +136,5 @@ extern int rk_sys_count;
 /* All the ports */
 extern char total_ports_udp[65535 + 1];
 extern char total_ports_tcp[65535 + 1];
-
-/* Process struct */
-typedef struct _Proc_Info {
-    char *p_name;
-    char *p_path;
-} Proc_Info;
 
 #endif /* ROOTCHECK_H */

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -194,7 +194,7 @@ void run_rk_check()
     }
 
     /* Free the process list */
-    del_plist((void *)plist);
+    w_del_plist((void *)plist);
 
 #else
     size_t i;
@@ -221,7 +221,7 @@ void run_rk_check()
             }
 
             /* Free list */
-            del_plist(plist);
+            w_del_plist(plist);
         }
     }
 

--- a/src/rootcheck/unix-process.c
+++ b/src/rootcheck/unix-process.c
@@ -94,7 +94,7 @@ OSList *os_get_process_list()
         /* Check if the pid is present */
         if ((!((getsid(i) == -1) && (errno == ESRCH))) &&
                 (!((getpgid(i) == -1) && (errno == ESRCH)))) {
-            Proc_Info *p_info;
+            W_Proc_Info *p_info;
             char *p_name;
 
             p_name = _os_get_runps(ps, (int)i);
@@ -102,7 +102,7 @@ OSList *os_get_process_list()
                 continue;
             }
 
-            os_calloc(1, sizeof(Proc_Info), p_info);
+            os_calloc(1, sizeof(W_Proc_Info), p_info);
             p_info->p_path = p_name;
             p_info->p_name = NULL;
             OSList_AddData(p_list, p_info);

--- a/src/rootcheck/win-process.c
+++ b/src/rootcheck/win-process.c
@@ -149,7 +149,7 @@ OSList *os_get_process_list()
     while (Process32Next( hsnap, &p_entry)) {
         char *p_name;
         char *p_path;
-        Proc_Info *p_info;
+        W_Proc_Info *p_info;
 
         /* Set process name */
         os_strdup(p_entry.szExeFile, p_name);
@@ -181,7 +181,7 @@ OSList *os_get_process_list()
             }
         }
 
-        os_calloc(1, sizeof(Proc_Info), p_info);
+        os_calloc(1, sizeof(W_Proc_Info), p_info);
         p_info->p_name = p_name;
         p_info->p_path = p_path;
         OSList_AddData(p_list, p_info);


### PR DESCRIPTION

## Description

This PR removes function `del_plist` from Rootcheck which is duplicate. Instead of using it, the function `w_del_plist` will be used.

This PR must be tested on Windows and Linux(agent or manager, not relevant). It must be ensured that Rootcheck scan works correctly.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Rootcheck scan works
