### PR TITLE
OpenBSD 6.6 TCP related building errors fix

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -556,7 +556,7 @@ int OS_SetKeepalive(int socket)
 void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
 {
     if (cnt > 0) {
-#if !defined(sun) && !defined(WIN32)
+#if !defined(sun) && !defined(WIN32) && !defined(OpenBSD)
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {
             merror("OS_SetKeepalive_Options(TCP_KEEPCNT) failed with error '%s'", strerror(errno));
         }
@@ -576,7 +576,7 @@ void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
 #else
         mwarn("Cannot set up keepalive idle parameter: unsupported platform.");
 #endif
-#elif !defined(WIN32)
+#elif !defined(WIN32) && !defined(OpenBSD)
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPIDLE, (void *)&idle, sizeof(idle)) < 0) {
             merror("OS_SetKeepalive_Options(SO_KEEPIDLE) failed with error '%s'", strerror(errno));
         }
@@ -596,7 +596,7 @@ void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
 #else
         mwarn("Cannot set up keepalive interval parameter: unsupported platform.");
 #endif
-#elif !defined(WIN32)
+#elif !defined(WIN32) && !defined(OpenBSD)
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPINTVL, (void *)&intvl, sizeof(intvl)) < 0) {
             merror("OS_SetKeepalive_Options(TCP_KEEPINTVL) failed with error '%s'", strerror(errno));
         }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4440|

Hi team, OpenBSD seems not to support TCP keepalive options. These definitions are now under `ifndef` directives and the building process is successful.

## Tests

- [X] Compilation on Linux: manager local and agent.
- [X] Agent compilation for Windows.
- [X] Agent compilation on OpenBSD.
- [X] Agent compilation on macOS.
- [X] Source installation on Linux. 