### PR TITLE
Fix descriptor leak in Rootcheck's system scan

### DIFF
--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -237,12 +237,12 @@ static int read_sys_dir(const char *dir_name, int depth)
             * /dev/fd5, /dev/fd6, etc.. weird
             */
             if (strstr(f_name, "/dev/fd") != NULL) {
-                return (0);
+                continue;
             }
 #ifndef WIN32
             /* Ignore the /proc directory (it has size 0) */
             if (statbuf_local.st_size == 0) {
-                return (0);
+                continue;
             }
 #endif
             if(rootcheck.readall) {
@@ -273,7 +273,7 @@ static int read_sys_dir(const char *dir_name, int depth)
 
         }
 
-        
+
     }
 
     /* skip further test because the FS cant deliver the stats (btrfs link count always is 1) */


### PR DESCRIPTION
|Related issue|
|---|
|#4473|

This PR aims to fix a descriptor leak produced by `opendir()` in the Rootcheck system scan.

## Rationale

Until version 3.11.1, `read_sys_file()` checked for directories that should not be scanned and used `return 0` to stop the recursivity. From #4415 on, `read_sys_dir()` scans the directories recursively, so the `while` loop should use `continue` instead of `return 0`.

Anyway, every path exiting from the function must call `closedir()` before returning.

## Descriptor sample

File descriptor list after 16 Rootcheck scans:

```
lrwx------ 1 root root 64 Jan 20 12:12 0 -> /dev/pts/0
l-wx------ 1 root root 64 Jan 20 12:12 1 -> pipe:[2271107]
l-wx------ 1 root root 64 Jan 20 12:12 2 -> pipe:[2271107]
lrwx------ 1 root root 64 Jan 20 12:12 3 -> socket:[2272299]
lrwx------ 1 root root 64 Jan 20 12:12 4 -> socket:[2271109]
lrwx------ 1 root root 64 Jan 20 12:12 5 -> socket:[2272300]
lr-x------ 1 root root 64 Jan 20 12:12 6 -> /dev/urandom
```

## Changed artifacts

- `ossec-syscheckd` on UNIX.
- `ossec-agent.exe` on Windows.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [X] Manager compilation on Linux.
- [X] Agent compilation on macOS.
- [X] Agent compilation for Windows.
- [X] Run _ossec-syscheckd_ from sources.
- [X] Run _scan-build_ for Linux.
- [x] Run _scan-build_ for Windows.
- [X] Run Valgrind with file descriptor checking.
- [x] Run Coverity.
- [x] Run agent on Windows and check for handles periodically over multiple Rootcheck scans.