### PR TITLE
Fix a memory leak in Vulnerability Detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4744,11 +4744,7 @@ int wm_vuldet_index_nvd(sqlite3 *db, update_node *upd, nvd_vulnerability *nvd_it
 
     return 0;
 error:
-    while (nvd_it) {
-        nvd_vulnerability *r_node = nvd_it;
-        nvd_it = nvd_it->next;
-        wm_vuldet_free_nvd_node(r_node);
-    }
+    wm_vuldet_free_nvd_list(nvd_it);
 
     return OS_INVALID;
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -698,6 +698,7 @@ int wm_vuldet_json_nvd_parser(char *json_feed, wm_vuldet_db *parsed_vulnerabilit
 int wm_vuldet_clean_nvd_metadata(sqlite3 *db, int year);
 int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year);
 void wm_vuldet_free_nvd_node(nvd_vulnerability *data);
+void wm_vuldet_free_nvd_list(nvd_vulnerability *nvd_it);
 int wm_vuldet_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, wm_vuldet_flags *flags);
 int wm_checks_package_vulnerability(char *version, const char *operation, const char *operation_value);
 int wm_vuldet_send_agent_report(vu_report *report);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -922,6 +922,7 @@ int wm_vuldet_json_nvd_parser(char *json_feed, wm_vuldet_db *parsed_vulnerabilit
         cJSON * cve_list;
 
         if (cve_list = cJSON_ParseWithOpts(cve, &next_cve, 0), !cve_list) {
+            wm_vuldet_free_nvd_list(nvd_first);
             return OS_INVALID;
         }
 
@@ -1508,6 +1509,14 @@ void wm_vuldet_free_nvd_node(nvd_vulnerability *data) {
     os_free(data->published);
     os_free(data->last_modified);
     os_free(data);
+}
+
+void wm_vuldet_free_nvd_list(nvd_vulnerability *nvd_it) {
+    while (nvd_it) {
+        nvd_vulnerability *r_node = nvd_it;
+        nvd_it = nvd_it->next;
+        wm_vuldet_free_nvd_node(r_node);
+    }
 }
 
 int wm_vuldet_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, wm_vuldet_flags *flags) {


### PR DESCRIPTION
|Related issue|
|---|
|#4479|

This PR aims to fix a memory leak in Vulnerability Detector that happens when an NVD database (in JSON format) fails to parse partially.

## Fix

Implement an NVD vulnerability list destructor and make `wm_vuldet_json_nvd_parser()` call it on parsing error.

The logic to free a list has been copied from `wm_vuldet_index_nvd()`.

## Affected artifacts

- wazuh_modulesd.

## Tests

- [X] Manager compilation on Linux.
- [X] Source upgrade.
- [X] _Scan build_ for Linux.
- [X] Run on Valgrind and force an error in the NVD parser (try to reproduce the failing path).
- [x] Run Coverity.