### PR TITLE
Rootcheck - Fix false positive on Windows

### DIFF
--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -239,12 +239,12 @@ static int read_sys_dir(const char *dir_name, int depth)
             if (strstr(f_name, "/dev/fd") != NULL) {
                 return (0);
             }
-#ifndef WIN32
+
             /* Ignore the /proc directory (it has size 0) */
             if (statbuf_local.st_size == 0) {
                 return (0);
             }
-#endif
+ 
             if(rootcheck.readall) {
                 read_sys_dir(f_name, depth + 1);
             }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -237,12 +237,12 @@ static int read_sys_dir(const char *dir_name, int depth)
             * /dev/fd5, /dev/fd6, etc.. weird
             */
             if (strstr(f_name, "/dev/fd") != NULL) {
-                continue;
+                return (0);
             }
 #ifndef WIN32
             /* Ignore the /proc directory (it has size 0) */
             if (statbuf_local.st_size == 0) {
-                continue;
+                return (0);
             }
 #endif
             if(rootcheck.readall) {
@@ -273,7 +273,7 @@ static int read_sys_dir(const char *dir_name, int depth)
 
         }
 
-
+        
     }
 
     /* skip further test because the FS cant deliver the stats (btrfs link count always is 1) */

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -12,8 +12,8 @@
 #include "rootcheck.h"
 
 /* Prototypes */
-static int read_sys_file(const char *file_name, int do_read, int depth);
-static int read_sys_dir(const char *dir_name, int do_read, int depth);
+static int read_sys_file(const char *file_name, int do_read);
+static int read_sys_dir(const char *dir_name, int do_read);
 
 /* Global variables */
 static int   _sys_errors;
@@ -24,7 +24,7 @@ static FILE *_ww;
 static FILE *_suid;
 
 
-static int read_sys_file(const char *file_name, int do_read, int depth)
+static int read_sys_file(const char *file_name, int do_read)
 {
     struct stat statbuf;
 
@@ -62,7 +62,7 @@ static int read_sys_file(const char *file_name, int do_read, int depth)
             return (0);
         }
 
-        return (read_sys_dir(file_name, do_read, depth + 1));
+        return (read_sys_dir(file_name, do_read));
     }
 
     /* Check if the size from stats is the same as when we read the file */
@@ -140,7 +140,7 @@ static int read_sys_file(const char *file_name, int do_read, int depth)
     return (0);
 }
 
-static int read_sys_dir(const char *dir_name, int do_read, int depth)
+static int read_sys_dir(const char *dir_name, int do_read)
 {
     int i = 0;
     unsigned int entry_count = 0;
@@ -150,6 +150,13 @@ static int read_sys_dir(const char *dir_name, int do_read, int depth)
     struct stat statbuf;
     short is_nfs;
     short skip_fs;
+
+#ifndef WIN32
+    const char *(dirs_to_doread[]) = { "/bin", "/sbin", "/usr/bin",
+                                       "/usr/sbin", "/dev", "/etc",
+                                       "/boot", NULL
+                                     };
+#endif
 
     if ((dir_name == NULL) || (strlen(dir_name) > PATH_MAX)) {
         mterror(ARGV0, "Invalid directory given.");
@@ -188,9 +195,13 @@ static int read_sys_dir(const char *dir_name, int do_read, int depth)
     }
 
 #ifndef WIN32
-    /* Only the root files will be read */
-    if (!depth) {
-        do_read = 1;
+    /* Check if the do_read is valid for this directory */
+    while (dirs_to_doread[i]) {
+        if (strcmp(dir_name, dirs_to_doread[i]) == 0) {
+            do_read = 1;
+            break;
+        }
+        i++;
     }
 #else
     do_read = 0;
@@ -270,7 +281,7 @@ static int read_sys_dir(const char *dir_name, int do_read, int depth)
             }
         }
 
-        read_sys_file(f_name, do_read, depth);
+        read_sys_file(f_name, do_read);
     }
 
     /* skip further test because the FS cant deliver the stats (btrfs link count always is 1) */
@@ -298,7 +309,7 @@ static int read_sys_dir(const char *dir_name, int do_read, int depth)
                      "(%d,%d).",
                      dir_name, entry_count, (int)statbuf.st_nlink);
 
-            /* Solaris /boot is terrible, as is /dev! */
+            /* Solaris /boot is terrible :), as is /dev! */
 #ifdef SOLARIS
             if ((strncmp(dir_name, "/boot", strlen("/boot")) != 0) && (strncmp(dir_name, "/dev", strlen("/dev")) != 0)) {
                 notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
@@ -357,7 +368,7 @@ void check_rc_sys(const char *basedir)
 #else
         snprintf(file_path, 5, "%s", "C:\\");
 #endif
-        read_sys_dir(file_path, rootcheck.readall, 0);
+        read_sys_dir(file_path, rootcheck.readall);
     } else {
         /* Scan only specific directories */
         int _i;
@@ -378,7 +389,7 @@ void check_rc_sys(const char *basedir)
         _i = 0;
         while (dirs_to_scan[_i] != NULL) {
             snprintf(dir_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, dirs_to_scan[_i]);
-            read_sys_dir(dir_path, rootcheck.readall, 0);
+            read_sys_dir(dir_path, rootcheck.readall);
             _i++;
         }
     }

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -77,7 +77,7 @@ void run_rk_check()
         free(rootcheck.basedir);
         rootcheck.basedir = strdup(basedir);
     } else {
-        if (rootcheck.basedir[strlen(rootcheck.basedir)-1] == PATH_SEP) {
+        if (rootcheck.basedir[strlen(rootcheck.basedir)-1] == '/') {
             rootcheck.basedir[strlen(rootcheck.basedir)-1] = '\0';
         }
     }


### PR DESCRIPTION
All changes regarding `readall` have been reversed. The `readall` option was misunderstood, and these commits do not solve anything.  There are 4 commits among versions 3.9 - 3.11

## Test
+ CPU use
+ FD and memory leak
+ Rootcheck options
+ False positive non-reporting
+ Scan-build