### PR TITLE
Add default directory to syscheck socket path

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -570,7 +570,7 @@ const char *get_group(int gid) {
 
 /* Send a one-way message to Syscheck */
 void ag_send_syscheck(char * message) {
-    int sock = OS_ConnectUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
+    int sock = OS_ConnectUnixDomain(DEFAULTDIR SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
 
     if (sock < 0) {
         merror("dbsync: cannot connect to syscheck: %s (%d)", strerror(errno), errno);


### PR DESCRIPTION
| Related issue  |
|---------------|
| #4495             |

## Description

Syscheck database wasn't synchronising because the path passed to `OS_ConnectUnixDomain` inside the `ag_send_syscheck` function, wasn't complete.
https://github.com/wazuh/wazuh/blob/87ad1cee52b91b44f4f35140d6c643b3d77a6f78/src/shared/syscheck_op.c#L573
Adding `DEFAULTDIR` fixed this issue.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation