### PR TITLE
Unify reconnection behaviour of Wazuh daemons when reconnecting with unix sockets

### DIFF
--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -60,7 +60,7 @@ static int send_intcheck_msg(const char *script, const char *host, const char *m
     if (SendMSG(lessdc.queue, msg, sys_location, SYSCHECK_MQ) < 0) {
         merror(QUEUE_SEND);
 
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             merror_exit(QUEUE_FATAL, DEFAULTQPATH);
         }
 
@@ -81,7 +81,7 @@ static int send_log_msg(const char *script, const char *host, const char *msg)
 
     if (SendMSG(lessdc.queue, msg, sys_location, LOCALFILE_MQ) < 0) {
         merror(QUEUE_SEND);
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             merror_exit(QUEUE_FATAL, DEFAULTQPATH);
         }
 
@@ -137,7 +137,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
     if (SendMSG(lessdc.queue, diff_alert, buf, LOCALFILE_MQ) < 0) {
         merror(QUEUE_SEND);
 
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             merror_exit(QUEUE_FATAL, DEFAULTQPATH);
         }
 
@@ -455,7 +455,7 @@ void Agentlessd()
     today = tm_result.tm_mday;
 
     /* Connect to the message queue. Exit if it fails. */
-    if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+    if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 

--- a/src/analysisd/alerts/exec.h
+++ b/src/analysisd/alerts/exec.h
@@ -14,6 +14,6 @@
 #include "eventinfo.h"
 #include "active-response.h"
 
-void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar);
+void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar);
 
 #endif /* EXEC_H */

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -658,7 +658,7 @@ int main_analysisd(int argc, char **argv)
     }
 
     /* Set the queue */
-    if ((m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
+    if ((m_queue = StartMQ(DEFAULTQUEUE, READ, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
     }
 
@@ -768,7 +768,7 @@ void OS_ReadMSG_analysisd(int m_queue)
 
 #ifndef LOCAL
         if (Config.ar & REMOTE_AR) {
-            if ((arq = StartMQ(ARQUEUE, WRITE)) < 0) {
+            if ((arq = StartMQ(ARQUEUE, WRITE, 1)) < 0) {
                 merror(ARQ_ERROR);
 
                 /* If LOCAL_AR is set, keep it there */
@@ -795,7 +795,7 @@ void OS_ReadMSG_analysisd(int m_queue)
 #endif
 
         if (Config.ar & LOCAL_AR) {
-            if ((execdq = StartMQ(EXECQUEUE, WRITE)) < 0) {
+            if ((execdq = StartMQ(EXECQUEUE, WRITE, 1)) < 0) {
                 merror(ARQ_ERROR);
 
                 /* If REMOTE_AR is set, keep it there */
@@ -2539,7 +2539,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
                     }
 
                     if (do_ar && execdq >= 0) {
-                        OS_Exec(execdq, arq, lf, *rule_ar);
+                        OS_Exec(execdq, &arq, lf, *rule_ar);
                     }
                     rule_ar++;
                 }

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -147,7 +147,7 @@ end:
 
 static int ConnectToSecurityConfigurationAssessmentSocket() {
 
-    if ((cfga_socket = StartMQ(CFGAQUEUE, WRITE)) < 0) {
+    if ((cfga_socket = StartMQ(CFGAQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror(QUEUE_ERROR, CFGAQUEUE, strerror(errno));
         return -1;
     }
@@ -157,7 +157,7 @@ static int ConnectToSecurityConfigurationAssessmentSocket() {
 
 static int ConnectToSecurityConfigurationAssessmentSocketRemoted() {
 
-    if ((cfgar_socket = StartMQ(CFGARQUEUE, WRITE)) < 0) {
+    if ((cfgar_socket = StartMQ(CFGARQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror(QUEUE_ERROR, CFGARQUEUE, strerror(errno));
         return -1;
     }

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -80,7 +80,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     os_setwait();
 
     /* Create the queue and read from it. Exit if fails. */
-    if ((agt->m_queue = StartMQ(DEFAULTQPATH, READ)) < 0) {
+    if ((agt->m_queue = StartMQ(DEFAULTQPATH, READ, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_ERROR, DEFAULTQPATH, strerror(errno));
     }
 
@@ -141,7 +141,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 
     /* Connect to the execd queue */
     if (agt->execdq == 0) {
-        if ((agt->execdq = StartMQ(EXECQUEUEPATH, WRITE)) < 0) {
+        if ((agt->execdq = StartMQ(EXECQUEUEPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             minfo("Unable to connect to the active response "
                    "queue (disabled).");
             agt->execdq = -1;

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -151,7 +151,7 @@ int receive_msg()
                         merror("Error communicating with Security configuration assessment");
                         close(agt->cfgadq);
 
-                        if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE)) < 0) {
+                        if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
                             merror("Unable to connect to the Security configuration assessment "
                                     "queue (disabled).");
                             agt->cfgadq = -1;
@@ -162,7 +162,7 @@ int receive_msg()
                         }
                     }
                 } else {
-                    if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE)) < 0) {
+                    if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
                         merror("Unable to connect to the Security configuration assessment "
                             "queue (disabled).");
                         agt->cfgadq = -1;

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -35,13 +35,13 @@
 
 extern int sock_fail_time;
 /**
- *  Starts a Message Queue. 
+ *  Starts a Message Queue.
  *  @param key path where the message queue will be created
- *  @param type WRITE||READ 
- *  @return 
+ *  @param type WRITE||READ
+ *  @return
  *  UNIX -> OS_INVALID if queue failed to start
- *  UNIX -> int(rc) file descriptor of initialized queue  
- *  WIN32 -> 0 
+ *  UNIX -> int(rc) file descriptor of initialized queue
+ *  WIN32 -> 0
  */
 int StartMQ(const char *key, short int type) __attribute__((nonnull));
 
@@ -51,16 +51,19 @@ int StartMQ(const char *key, short int type) __attribute__((nonnull));
  * @param message string containing the message
  * @param locmsg path to the queue file
  * @param loc  queue location (WIN32)
- * @return 
+ * @return
  * UNIX -> 0 if file descriptor is still available
  * UNIX -> -1 if there is an error in the socket. The socket will be closed before returning (StartMQ should be called to restore queue)
  * WIN32 -> 0
  * Notes: (UNIX) If the socket is busy when trying to send a message a DEBUG2 message will be loggeed but the return code will be 0
  */
+
 int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
 
+int StartMQWithRetry(const char *path, short int type, short int retry_times);
+
 /**
- * Sends a message to a socket. If the socket has not been created yet it will be created based on 
+ * Sends a message to a socket. If the socket has not been created yet it will be created based on
  * the target information. If a message fails to be sent the method will not try to send it again until *sock_fail_time* has passed
  * @param queue file descriptor of the queue where the error message will be sent (UNIX)
  * @param message string containing the message that will be sent
@@ -68,11 +71,11 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attr
  * @param loc  queue location (WIN32)
  * @param target logtarget ptr with the socket information
  * @return
- * UNIX -> -1 invalid protocol or cannot create socket 
+ * UNIX -> -1 invalid protocol or cannot create socket
  * UNIX ->  0 message was sent or discarded
  * WIN32 -> -1 invalid target
  * WIN32 -> 0 valid target
- * Notes: (UNIX) If the message is not sent because the socket is busy, the return code will be 0  
+ * Notes: (UNIX) If the message is not sent because the socket is busy, the return code will be 0
  */
 int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logtarget * target) __attribute__((nonnull (2, 3, 5)));
 

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -31,19 +31,20 @@
 #define CISCAT_MQ        'e'
 #define WIN_EVT_MQ       'f'
 
-#define MAX_OPENQ_ATTEMPS 15
+#define MAX_OPENQ_ATTEMPS 0
 
 extern int sock_fail_time;
 /**
  *  Starts a Message Queue.
  *  @param key path where the message queue will be created
  *  @param type WRITE||READ
+ *  @param n_attempts Number of attempts to connect to the queue (0 to attempt until a successful conection).
  *  @return
  *  UNIX -> OS_INVALID if queue failed to start
  *  UNIX -> int(rc) file descriptor of initialized queue
  *  WIN32 -> 0
  */
-int StartMQ(const char *key, short int type) __attribute__((nonnull));
+int StartMQ(const char *key, short int type, short int n_attempts) __attribute__((nonnull));
 
 /**
  * Sends a message string through a message queue
@@ -59,8 +60,6 @@ int StartMQ(const char *key, short int type) __attribute__((nonnull));
  */
 
 int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
-
-int StartMQWithRetry(const char *path, short int type, short int retry_times);
 
 /**
  * Sends a message to a socket. If the socket has not been created yet it will be created based on

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1823,19 +1823,18 @@ void * w_output_thread(void * args){
                 merror("Unable to send message to '%s' (ossec-analysisd might be down). Attempting to reconnect.", DEFAULTQPATH);
                 #endif
 
-                while(1) {
-                    if(logr_queue = StartMQ(DEFAULTQPATH, WRITE), logr_queue >= 0) {
-                        if (SendMSG(logr_queue, message->buffer, message->file, message->queue_mq) == 0) {
-                            minfo("Successfully reconnected to '%s'", DEFAULTQPATH);
-                            break;  //  We sent the message successfully, we can go on.
-                        }
-                    }
+                // Retry to connect infinitely.
+                logr_queue = StartMQWithRetry(DEFAULTQPATH, WRITE, 0);
 
-                    sleep(sleep_time);
+                minfo("Successfully reconnected to '%s'", DEFAULTQPATH);
 
-                    // If we failed, we will wait longer before reattempting to connect
-                    if(sleep_time < 300)
-                        sleep_time += 5;
+                if (SendMSGtoSCK(logr_queue, message->buffer, message->file, message->queue_mq, message->log_target) != 0) {
+                    // We reconnected but are still unable to send the message, notify it and go on.
+                    #ifdef CLIENT
+                    merror("Unable to send message to '%s' after a successfull reconnection...", DEFAULTQPATH);
+                    #else
+                    merror("Unable to send message to '%s' after a successfull reconnection...", DEFAULTQPATH);
+                    #endif
                 }
             }
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1824,7 +1824,7 @@ void * w_output_thread(void * args){
                 #endif
 
                 // Retry to connect infinitely.
-                logr_queue = StartMQWithRetry(DEFAULTQPATH, WRITE, 0);
+                logr_queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
                 minfo("Successfully reconnected to '%s'", DEFAULTQPATH);
 

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
     mdebug1(STARTED_MSG);
 
     /* Start the queue */
-    if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+    if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQPATH);
     }
 

--- a/src/monitord/monitor_agents.c
+++ b/src/monitord/monitor_agents.c
@@ -55,6 +55,7 @@ void monitor_agents()
                     // Agent is no longer in the database
                     snprintf(str, OS_SIZE_1024 - 1, OS_AG_REMOVED, *cr_agents);
                     if (SendMSG(mond.a_queue, str, ARGV0, LOCALFILE_MQ) < 0) {
+                        mond.a_queue = -1;  // set an invalid fd so we can attempt to reconnect later on.
                         mdebug1("Could not generate removed agent alert for '%s'", *cr_agents);
                         merror(QUEUE_SEND);
                     }
@@ -69,6 +70,7 @@ void monitor_agents()
                     snprintf(str, OS_SIZE_1024 - 1, OS_AG_REMOVED, *cr_agents);
                     if (SendMSG(mond.a_queue, str, ARGV0,
                                 LOCALFILE_MQ) < 0) {
+                        mond.a_queue = -1;  // set an invalid fd so we can attempt to reconnect later on.
                         merror(QUEUE_SEND);
                     }
                 }
@@ -91,6 +93,7 @@ void monitor_agents()
                     snprintf(str, OS_SIZE_1024 - 1, OS_AG_REMOVED, *na_agents_p);
                     if (SendMSG(mond.a_queue, str, ARGV0,
                                 LOCALFILE_MQ) < 0) {
+                        mond.a_queue = -1;  // set an invalid fd so we can attempt to reconnect later on.
                         merror(QUEUE_SEND);
                     }
                 }
@@ -159,6 +162,7 @@ int mon_send_agent_msg(char *agent, char *msg) {
     if (ag_id = wdb_find_agent(ag_name, ag_ip), ag_id > 0) {
         snprintf(header, OS_SIZE_256, "[%03d] (%s) %s", ag_id, ag_name, ag_ip);
         if (SendMSG(mond.a_queue, msg, header, SECURE_MQ) < 0) {
+            mond.a_queue = -1;  // set an invalid fd so we can attempt to reconnect later on.
             merror(QUEUE_SEND);
             return 1;
         }

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -82,6 +82,18 @@ void Monitord()
 #ifndef LOCAL
         /* Check for unavailable agents, every two minutes */
         if (mond.monitor_agents && counter >= 120) {
+            if (mond.a_queue < 0) {
+                /* Connect to the message queue */
+                if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE)) > 0) {
+                    /* Send startup message */
+                    snprintf(str, OS_SIZE_1024 - 1, OS_AD_STARTED);
+                    if (SendMSG(mond.a_queue, str, ARGV0,
+                                LOCALFILE_MQ) < 0) {
+                        mond.a_queue = -1;  // We keep trying to reconnect next time.
+                        merror(QUEUE_SEND);
+                    }
+                }
+            }
             monitor_agents();
             counter = 0;
         }

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -59,7 +59,7 @@ void Monitord()
 #endif
 
     /* Connect to the message queue or exit */
-    if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
+    if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
@@ -84,7 +84,7 @@ void Monitord()
         if (mond.monitor_agents && counter >= 120) {
             if (mond.a_queue < 0) {
                 /* Connect to the message queue */
-                if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE)) > 0) {
+                if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE, 1)) > 0) {
                     /* Send startup message */
                     snprintf(str, OS_SIZE_1024 - 1, OS_AD_STARTED);
                     if (SendMSG(mond.a_queue, str, ARGV0,

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
     }
 
     /* Start exec queue */
-    if ((m_queue = StartMQ(EXECQUEUEPATH, READ)) < 0) {
+    if ((m_queue = StartMQ(EXECQUEUEPATH, READ, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_ERROR, EXECQUEUEPATH, strerror(errno));
     }
 
@@ -409,7 +409,7 @@ static void ExecdStart(int q)
             int rc;
             /* Start api socket */
             int api_sock;
-            if ((api_sock = StartMQ(EXECQUEUEPATHAPI, WRITE)) < 0) {
+            if ((api_sock = StartMQ(EXECQUEUEPATHAPI, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
                 merror(QUEUE_ERROR, EXECQUEUEPATHAPI, strerror(errno));
                 os_free(output);
                 continue;

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -33,7 +33,7 @@ void *AR_Forward(__attribute__((unused)) void *arg)
     char agent_id[KEYSIZE + 1] = "";
 
     /* Create the unix queue */
-    if ((arq = StartMQ(path, READ)) < 0) {
+    if ((arq = StartMQ(path, READ, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_ERROR, path, strerror(errno));
     }
 

--- a/src/remoted/cfga-forward.c
+++ b/src/remoted/cfga-forward.c
@@ -25,7 +25,7 @@ void *SCFGA_Forward(__attribute__((unused)) void *arg)
     char msg[OS_SIZE_4096 + 1];
 
     /* Create the unix queue */
-    if ((cfgarq = StartMQ(path, READ)) < 0) {
+    if ((cfgarq = StartMQ(path, READ, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_ERROR, path, strerror(errno));
     }
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -425,8 +425,14 @@ static void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
                 SECURE_MQ) < 0) {
         merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
-        if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
-            merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
+        // Try to reconnect infinitely
+        logr.m_queue = StartMQWithRetry(DEFAULTQUEUE, WRITE, 0);
+
+        minfo("Successfully reconnected to '%s'", DEFAULTQUEUE);
+
+        if (SendMSG(logr.m_queue, tmp_msg, srcmsg, SECURE_MQ) < 0) {
+            // Something went wrong sending a message after an immediate reconnection...
+            merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
         }
     } else {
         rem_inc_evt();

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -118,7 +118,7 @@ void HandleSecure()
     /* Connect to the message queue
      * Exit if it fails.
      */
-    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
+    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
@@ -426,7 +426,7 @@ static void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
         merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
         // Try to reconnect infinitely
-        logr.m_queue = StartMQWithRetry(DEFAULTQUEUE, WRITE, 0);
+        logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS);
 
         minfo("Successfully reconnected to '%s'", DEFAULTQUEUE);
 

--- a/src/remoted/syslog.c
+++ b/src/remoted/syslog.c
@@ -51,10 +51,8 @@ void HandleSyslog()
     memset(buffer, '\0', OS_MAXSTR + 2);
     memset(&peer_info, 0, sizeof(struct sockaddr_in));
 
-    /* Connect to the message queue
-     * Exit if it fails.
-     */
-    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
+    /* Connect to the message queue infinitely */
+    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
@@ -103,7 +101,7 @@ void HandleSyslog()
             merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
             // Try to reconnect infinitely
-            logr.m_queue = StartMQWithRetry(DEFAULTQUEUE, WRITE, 0);
+            logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS);
 
             minfo("Successfully reconnected to '%s'", DEFAULTQUEUE);
 

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -49,7 +49,7 @@ void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
         if (SendMSG(logr.m_queue, data_pt, srcip, SYSLOG_MQ) < 0) {
             merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
-            if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
+            if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
                 merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
             }
         }
@@ -111,7 +111,7 @@ void HandleSyslogTCP()
     /* Connecting to the message queue
      * Exit if it fails.
      */
-    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
+    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -247,7 +247,7 @@ void rootcheck_connect() {
         mtdebug1(ARGV0, "Starting queue ...");
 
         /* Start the queue */
-        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQPATH);
         }
     }

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -43,7 +43,7 @@ int notify_rk(int rk_type, const char *msg)
     if (SendMSG(rootcheck.queue, msg, ROOTCHECK, ROOTCHECK_MQ) < 0) {
         mterror(ARGV0, QUEUE_SEND);
 
-        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQPATH);
         }
 

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -48,6 +48,30 @@ int StartMQ(const char *path, short int type)
     }
 }
 
+/* Continuously attempt to start a queue */
+int StartMQWithRetry(const char *path, short int type, short int retry_times)
+{
+    int socket;
+    int retries = 0;
+    int sleep_time = 5;
+
+    while(socket = StartMQ(path, type), socket < 0) {
+        if(retry_times <= 0 || retries < retry_times) {
+            retries++;
+
+            sleep(sleep_time);
+
+            // If we failed, we will wait longer before reattempting to connect
+            if(sleep_time < 300)
+                sleep_time += 5;
+        } else {
+            // We already failed more than retry_times, return the error to the caller.
+            break;
+        }
+    }
+    return socket;
+}
+
 /* Send a message to the queue */
 int SendMSG(int queue, const char *message, const char *locmsg, char loc)
 {

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -943,7 +943,7 @@ int connect_to_remoted()
 {
     int arq = -1;
 
-    if ((arq = StartMQ(ARQUEUE, WRITE)) < 0) {
+    if ((arq = StartMQ(ARQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
         merror(ARQ_ERROR);
         return (-1);
     }

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -175,22 +175,12 @@ int main(int argc, char **argv)
     }
 
     /* Connect to the queue */
-    if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
-        minfo(FIM_WAITING_QUEUE, DEFAULTQPATH, errno, strerror(errno), 5);
 
-        sleep(5);
-        if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
-            /* more 10 seconds of wait */
-            minfo(FIM_WAITING_QUEUE, DEFAULTQPATH, errno, strerror(errno), 10);
-            sleep(10);
-            if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
-                merror_exit(QUEUE_FATAL, DEFAULTQPATH);
-            }
-        }
+    if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        merror_exit(QUEUE_FATAL, DEFAULTQPATH);
     }
 
     if (!syscheck.disabled) {
-
         /* Start up message */
         minfo(STARTUP_MSG, (int)getpid());
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -80,7 +80,7 @@ STATIC void fim_send_msg(char mq, const char * location, const char * msg) {
     if (SendMSG(syscheck.queue, msg, location, mq) < 0) {
         merror(QUEUE_SEND);
 
-        if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+        if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             merror_exit(QUEUE_FATAL, DEFAULTQPATH);
         }
 

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -38,8 +38,8 @@ list(APPEND shared_tests_names "test_time_op")
 list(APPEND shared_tests_flags " ")
 
 if(${TARGET} STREQUAL "server")
-list(APPEND shared_tests_names "test_bzip2_op")
-list(APPEND shared_tests_flags "-Wl,--wrap=fopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen,--wrap=BZ2_bzWriteClose64,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen,--wrap=BZ2_bzRead,--wrap=BZ2_bzWrite,--wrap=_mdebug2")
+    list(APPEND shared_tests_names "test_bzip2_op")
+    list(APPEND shared_tests_flags "-Wl,--wrap=fopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen,--wrap=BZ2_bzWriteClose64,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen,--wrap=BZ2_bzRead,--wrap=BZ2_bzWrite,--wrap=_mdebug2")
 endif()
 
 set(SYSCHECK_OP_BASE_FLAGS "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \
@@ -56,14 +56,18 @@ else()
 endif()
 
 if(NOT ${TARGET} STREQUAL "winagent")
-list(APPEND shared_tests_names "test_audit_op")
-list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,audit_send -Wl,--wrap,select -Wl,--wrap,audit_get_reply \
+    list(APPEND shared_tests_names "test_audit_op")
+    list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,audit_send -Wl,--wrap,select -Wl,--wrap,audit_get_reply \
                                 -Wl,--wrap,wpopenv -Wl,--wrap,fgets -Wl,--wrap,wpclose -Wl,--wrap,audit_open -Wl,--wrap,audit_add_watch_dir \
                                 -Wl,--wrap,audit_update_watch_perms -Wl,--wrap,audit_errno_to_name -Wl,--wrap,audit_rule_fieldpair_data \
                                 -Wl,--wrap,audit_add_rule_data -Wl,--wrap,audit_delete_rule_data -Wl,--wrap,audit_close")
 
-list(APPEND shared_tests_names "test_privsep_op")
-list(APPEND shared_tests_flags "-Wl,--wrap=sysconf,--wrap=getpwnam_r,--wrap=getgrnam_r")
+    list(APPEND shared_tests_names "test_privsep_op")
+    list(APPEND shared_tests_flags "-Wl,--wrap=sysconf,--wrap=getpwnam_r,--wrap=getgrnam_r")
+
+    list(APPEND shared_tests_names "test_mq_op")
+    list(APPEND shared_tests_flags "-Wl,--wrap,OS_BindUnixDomain -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,sleep \
+                                    -Wl,--wrap,_mdebug1 -Wl,--wrap,OS_getsocketsize -Wl,--wrap,_merror")
 endif()
 
 

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include "../headers/shared.h"
+
+/* Define values may be changed */
+
+#define MAX_ATTEMPTS 100
+#define SOCKET_SIZE 1
+#define ERRNO ENOTSOCK
+
+/* Redefinitons/wrapping */
+
+void __wrap__merror(const char * file, int line, const char * func, const char * msg, ...){
+    char formatted_msg[OS_SIZE_64];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_SIZE_64, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+void __wrap__mdebug1(const char * file, int line, const char * func, const char * msg, ...){
+    char formatted_msg[OS_SIZE_64];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_SIZE_64, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+int __wrap_OS_getsocketsize(int ossock) { 
+    return SOCKET_SIZE; 
+}
+
+void __wrap_sleep(unsigned int seconds){};
+
+int __wrap_OS_BindUnixDomain(const char * path, int type, int max_msg_size){
+    return (int) mock();
+}
+
+int __wrap_OS_ConnectUnixDomain(const char * path, int type, int max_msg_size){
+    return (int) mock();
+}
+
+/* Tests */
+
+void test_start_mq_read_success(void ** state){
+    (void)state; // Unused
+    
+    /* Function parameters */
+    short int n_attempts = 0;
+    short int type = READ;
+    char * path = "/test";
+    
+    int ret = 0;
+
+    will_return(__wrap_OS_BindUnixDomain, 0);
+    
+    ret = StartMQ(path, type, n_attempts);
+    assert_false(ret);
+}
+
+void test_start_mq_read_fail(void ** state){
+    (void)state; // Unused
+    
+    /* Function parameters */
+    short int n_attempts = 0;
+    short int type = READ;
+    char * path = "/test";
+
+    int ret = 0;
+    
+    will_return(__wrap_OS_BindUnixDomain, -1);
+    
+    ret = StartMQ(path, type, n_attempts);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_start_mq_write_simple_success(void ** state){
+    (void)state; // Unused
+    
+    /* Function parameters */
+    short int n_attempts = 1;
+    short int type = WRITE;
+    char * path = "/test";
+    
+    int ret = 0;
+    char messages[2][OS_SIZE_64];
+
+    will_return(__wrap_OS_ConnectUnixDomain, 0);
+    
+    snprintf(messages[0], OS_SIZE_64,"Connected succesfully to %s after %d attempts", path, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, messages[0]);
+
+    snprintf(messages[1], OS_SIZE_64, "(unix_domain) Maximum send buffer set to: '%d'.",SOCKET_SIZE);
+    expect_string(__wrap__mdebug1, formatted_msg, messages[1]);
+
+    ret = StartMQ(path, type, n_attempts);
+    assert_false(ret);
+}
+
+void test_start_mq_write_simple_fail(void ** state){
+    (void)state; // Unused
+    
+    /* Function parameters */
+    short int n_attempts = 1;
+    short int type = WRITE;
+    char * path = "/test";
+
+    int ret = 0;
+    char expected_str[OS_SIZE_64];
+    errno = ERRNO;
+
+    will_return(__wrap_OS_ConnectUnixDomain, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Can't connect to queue. attempt: 1");
+    
+    snprintf(expected_str, OS_SIZE_64, "(1210): Queue '%s' not accessible: '%s'", path,strerror(errno));
+    expect_string(__wrap__merror, formatted_msg, expected_str);
+
+    ret = StartMQ(path, type, n_attempts);
+    assert_int_equal(ret, -1);
+}
+
+void test_start_mq_write_multiple_success(void ** state){
+    (void)state; // Unused
+
+    /* Function parameters */
+    short int n_attempts = 5;
+    short int type = WRITE;
+    char * path = "/test";
+
+    int ret = 0;
+    char messages[n_attempts+1][OS_SIZE_64];
+
+    errno = ERRNO;
+
+    for (int i = 0; i < n_attempts - 1; i++) {
+        will_return(__wrap_OS_ConnectUnixDomain, -1);
+        snprintf(messages[i], OS_SIZE_64, "Can't connect to queue. attempt: %d", i + 1);
+        expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
+    }
+    will_return(__wrap_OS_ConnectUnixDomain, 0);
+
+    snprintf(messages[n_attempts - 1], OS_SIZE_64,"Connected succesfully to %s after %d attempts", path, n_attempts - 1);
+    expect_string(__wrap__mdebug1, formatted_msg, messages[n_attempts - 1]);
+
+    snprintf(messages[n_attempts], OS_SIZE_64,"(unix_domain) Maximum send buffer set to: '%d'.", SOCKET_SIZE);
+    expect_string(__wrap__mdebug1, formatted_msg, messages[n_attempts]);
+
+    ret = StartMQ(path, type, n_attempts);
+    assert_false(ret);
+}
+
+void test_start_mq_write_multiple_fail(void ** state){
+    (void)state; // Unused
+
+    /* Function parameters */
+    short int n_attempts = 10;
+    short int type = WRITE;
+    char * path = "/test";
+
+    int ret = 0;
+    char messages[n_attempts][OS_SIZE_64];
+    char expected_str[OS_SIZE_64];
+
+    for (int i = 0; i <= n_attempts - 1; i++) {
+        will_return(__wrap_OS_ConnectUnixDomain, -1);
+        snprintf(messages[i], OS_SIZE_64, "Can't connect to queue. attempt: %d", i + 1);
+        expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
+    }
+
+    snprintf(expected_str, OS_SIZE_64, "(1210): Queue '%s' not accessible: '%s'", path,strerror(errno));
+    expect_string(__wrap__merror, formatted_msg, expected_str);
+
+    ret = StartMQ(path, type, n_attempts);
+    assert_int_equal(ret, -1);
+}
+
+void test_start_mq_write_inf_success(void ** state){
+    (void)state; // Unused
+
+    /* Function parameters */
+    short int n_attempts = 0;
+    short int type = WRITE;
+    char * path = "/test";
+    
+    int ret = 0;
+    char messages[MAX_ATTEMPTS + 1][OS_SIZE_64];
+
+    for (int i = 0; i < MAX_ATTEMPTS - 1; i++) {
+        will_return(__wrap_OS_ConnectUnixDomain, -1);
+        sprintf(messages[i], "Can't connect to queue. attempt: %d", i + 1);
+        expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
+    }
+    will_return(__wrap_OS_ConnectUnixDomain, 0);
+
+    snprintf(messages[MAX_ATTEMPTS - 1], OS_SIZE_64,"Connected succesfully to %s after %d attempts", path, MAX_ATTEMPTS - 1);
+    expect_string(__wrap__mdebug1, formatted_msg, messages[MAX_ATTEMPTS - 1]);
+
+    snprintf(messages[MAX_ATTEMPTS], OS_SIZE_64,"(unix_domain) Maximum send buffer set to: '%d'.", SOCKET_SIZE);
+    expect_string(__wrap__mdebug1, formatted_msg, messages[MAX_ATTEMPTS]);
+
+    ret = StartMQ(path, type, n_attempts);
+    assert_false(ret);
+}
+
+void test_start_mq_write_inf_fail(void ** state){
+    (void)state; // Unused
+
+    /* Function parameters */
+    short int n_attempts = 0;
+    short int type = WRITE;
+    char * path = "/test";
+
+    int ret = 0;
+    char messages[MAX_ATTEMPTS][OS_SIZE_64];
+
+    for (int i = 0; i <= MAX_ATTEMPTS - 1; i++) {
+        will_return(__wrap_OS_ConnectUnixDomain, -1);
+        snprintf(messages[i], OS_SIZE_64, "Can't connect to queue. attempt: %d", i + 1);
+        expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
+    }
+    /* Breaking the infinite loop */
+    will_return(__wrap_OS_ConnectUnixDomain, 0);
+    /* Ignoring output */
+    expect_any_always(__wrap__mdebug1, formatted_msg);
+    
+    ret = StartMQ(path, type, n_attempts);
+}
+
+// Main test function
+
+int main(void){
+    const struct CMUnitTest tests[] = {
+       cmocka_unit_test(test_start_mq_read_success),
+       cmocka_unit_test(test_start_mq_read_fail),
+       cmocka_unit_test(test_start_mq_write_simple_success),
+       cmocka_unit_test(test_start_mq_write_simple_fail),
+       cmocka_unit_test(test_start_mq_write_multiple_success),
+       cmocka_unit_test(test_start_mq_write_multiple_fail),
+       cmocka_unit_test(test_start_mq_write_inf_success),
+       cmocka_unit_test(test_start_mq_write_inf_fail)
+       };
+    
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -199,12 +199,10 @@ static void wm_sys_setup(wm_sys_t *_sys) {
 
     #ifndef WIN32
 
-    int i;
     // Connect to socket
-    for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        w_time_delay(1000 * WM_MAX_WAIT);
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-    if (i == WM_MAX_ATTEMPTS) {
+    if (queue_fd < 0) {
         mterror(WM_SYS_LOGTAG, "Can't connect to queue.");
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1406,7 +1406,7 @@ int wm_vuldet_send_cve_report(vu_report *report) {
 
     if (wm_sendmsg(usec, *vu_queue, alert_msg, header, send_queue) < 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-        if ((*vu_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
+        if ((*vu_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             mterror_exit(WM_VULNDETECTOR_LOGTAG, QUEUE_FATAL, DEFAULTQUEUE);
         }
     }
@@ -6774,11 +6774,9 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
         pthread_exit(NULL);
     }
 
-    for (i = 0; vuldet->queue_fd = StartMQ(DEFAULTQPATH, WRITE), vuldet->queue_fd < 0 && i < WM_MAX_ATTEMPTS; i++) {
-        sleep(WM_MAX_WAIT);
-    }
+    vuldet->queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-    if (i == WM_MAX_ATTEMPTS) {
+    if (vuldet->queue_fd < 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, "Can't connect to queue.");
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -249,9 +249,9 @@ void wm_aws_setup(wm_aws *_aws_config) {
 
     // Connect to socket
 
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    aws_config->queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-    if (queue_fd < 0) {
+    if (aws_config->queue_fd < 0) {
         mterror(WM_AWS_LOGTAG, "Can't connect to queue.");
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -238,7 +238,6 @@ void wm_aws_destroy(wm_aws *aws_config) {
 // Setup module
 
 void wm_aws_setup(wm_aws *_aws_config) {
-    int i;
 
     aws_config = _aws_config;
     wm_aws_check();
@@ -250,10 +249,9 @@ void wm_aws_setup(wm_aws *_aws_config) {
 
     // Connect to socket
 
-    for (i = 0; (aws_config->queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        w_time_delay(1000 * WM_MAX_WAIT);
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-    if (i == WM_MAX_ATTEMPTS) {
+    if (queue_fd < 0) {
         mterror(WM_AWS_LOGTAG, "Can't connect to queue.");
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -51,7 +51,7 @@ void* wm_azure_main(wm_azure_t *azure_config) {
     wm_azure_setup(azure_config);
     mtinfo(WM_AZURE_LOGTAG, "Module started.");
 
-    
+
 
     // Main loop
 
@@ -333,7 +333,6 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
 
 void wm_azure_setup(wm_azure_t *_azure_config) {
 
-    int i;
     azure_config = _azure_config;
     wm_azure_check();
 
@@ -344,10 +343,9 @@ void wm_azure_setup(wm_azure_t *_azure_config) {
 
     // Connect to socket
 
-    for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        w_time_delay(1000 * WM_MAX_WAIT);
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-    if (i == WM_MAX_ATTEMPTS) {
+    if (queue_fd < 0) {
         mterror(WM_AZURE_LOGTAG, "Can't connect to queue.");
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -230,14 +230,9 @@ void wm_ciscat_setup(wm_ciscat *_ciscat) {
 
 #ifndef WIN32
 
-    int i;
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-    // Connect to socket
-
-    for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        w_time_delay(1000 * WM_MAX_WAIT);
-
-    if (i == WM_MAX_ATTEMPTS) {
+    if (queue_fd < 0) {
         mterror(WM_CISCAT_LOGTAG, "Can't connect to queue.");
         pthread_exit(NULL);
     }
@@ -1456,7 +1451,7 @@ cJSON *wm_ciscat_dump(const wm_ciscat * ciscat) {
 
 
     sched_scan_dump(&(ciscat->scan_config), wm_cscat);
-    
+
     if (ciscat->java_path) cJSON_AddStringToObject(wm_cscat,"java_path",ciscat->java_path);
     if (ciscat->ciscat_path) cJSON_AddStringToObject(wm_cscat,"ciscat_path",ciscat->ciscat_path);
     cJSON_AddNumberToObject(wm_cscat,"timeout",ciscat->timeout);

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -152,13 +152,10 @@ void * wm_command_main(wm_command_t * command) {
 
 #ifndef WIN32
     if (!command->ignore_output) {
-        int i;
 
-        for (i = 0; command->queue_fd = StartMQ(DEFAULTQPATH, WRITE), command->queue_fd < 0 && i < WM_MAX_ATTEMPTS; i++) {
-            w_time_delay(1000 * WM_MAX_WAIT);
-        }
+        command->queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-        if (i == WM_MAX_ATTEMPTS) {
+        if (command->queue_fd < 0) {
             mterror(WM_COMMAND_LOGTAG, "Can't connect to queue.");
             pthread_exit(NULL);
         }
@@ -181,7 +178,7 @@ void * wm_command_main(wm_command_t * command) {
         }
 
         mtinfo(WM_COMMAND_LOGTAG, "Starting command '%s'.", command->tag);
-        
+
         int status = 0;
         char *output = NULL;
         switch (wm_exec(command->full_command, command->ignore_output ? NULL : &output, &status, command->timeout, NULL)) {

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -86,7 +86,7 @@ void * wm_key_request_main(wm_krequest_t * data) {
     /* Init the queue input */
     request_queue = queue_init(data->queue_size);
 
-    if ((sock = StartMQ(WM_KEY_REQUEST_SOCK_PATH, READ)) < 0) {
+    if ((sock = StartMQ(WM_KEY_REQUEST_SOCK_PATH, READ, MAX_OPENQ_ATTEMPS)) < 0) {
         merror(QUEUE_ERROR, WM_KEY_REQUEST_SOCK_PATH, strerror(errno));
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -83,7 +83,6 @@ void* wm_oscap_main(wm_oscap *oscap) {
 // Setup module
 
 void wm_oscap_setup(wm_oscap *_oscap) {
-    int i;
 
     oscap = _oscap;
     wm_oscap_check();
@@ -98,10 +97,9 @@ void wm_oscap_setup(wm_oscap *_oscap) {
 
     // Connect to socket
 
-    for (i = 0; (queue_fd = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++)
-        w_time_delay(1000 * WM_MAX_WAIT);
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-    if (i == WM_MAX_ATTEMPTS) {
+    if (queue_fd < 0) {
         mterror(WM_OSCAP_LOGTAG, "Can't connect to queue.");
         pthread_exit(NULL);
     }
@@ -300,7 +298,7 @@ cJSON *wm_oscap_dump(const wm_oscap *oscap) {
     cJSON *wm_scp = cJSON_CreateObject();
 
     sched_scan_dump(&(oscap->scan_config), wm_scp);
-    
+
     if (oscap->flags.enabled) cJSON_AddStringToObject(wm_scp,"disabled","no"); else cJSON_AddStringToObject(wm_scp,"disabled","yes");
     if (oscap->flags.scan_on_start) cJSON_AddStringToObject(wm_scp,"scan-on-start","yes"); else cJSON_AddStringToObject(wm_scp,"scan-on-start","no");
     cJSON_AddNumberToObject(wm_scp,"timeout",oscap->timeout);

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -585,16 +585,10 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
     osquery->msg_delay = 1000000 / wm_max_eps;
 
 #ifndef WIN32
-    int i;
-
     // Connect to queue
 
-    for (i = 0; i < WM_MAX_ATTEMPTS && (osquery->queue_fd = StartMQ(DEFAULTQPATH, WRITE), osquery->queue_fd < 0); i++) {
-        // Trying to connect to queue
-        sleep(WM_MAX_WAIT);
-    }
-
-    if (i == WM_MAX_ATTEMPTS) {
+    osquery->queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    if (osquery->queue_fd < 0) {
         mterror(WM_OSQUERYMONITOR_LOGTAG, "Can't connect to queue. Closing module.");
         return NULL;
     }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -204,11 +204,9 @@ void * wm_sca_main(wm_sca_t * data) {
 
 #ifndef WIN32
 
-    for (i = 0; (data->queue = StartMQ(DEFAULTQPATH, WRITE)) < 0 && i < WM_MAX_ATTEMPTS; i++){
-        w_time_delay(1000 * WM_MAX_WAIT);
-    }
+    data->queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
 
-    if (i == WM_MAX_ATTEMPTS) {
+    if (data->queue < 0) {
         merror("Can't connect to queue.");
     }
 
@@ -254,7 +252,7 @@ static int wm_sca_send_alert(wm_sca_t * data,cJSON *json_alert)
             close(data->queue);
         }
 
-        if ((data->queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+        if ((data->queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
             mwarn("Can't connect to queue.");
         } else {
             if(wm_sendmsg(data->msg_delay, data->queue, msg,WM_SCA_STAMP, SCA_MQ) < 0) {
@@ -2943,7 +2941,7 @@ static void * wm_sca_request_thread(wm_sca_t * data) {
 
     /* Create request socket */
     int cfga_queue;
-    if ((cfga_queue = StartMQ(CFGASSESSMENTQUEUEPATH, READ)) < 0) {
+    if ((cfga_queue = StartMQ(CFGASSESSMENTQUEUEPATH, READ, MAX_OPENQ_ATTEMPS)) < 0) {
         merror(QUEUE_ERROR, CFGASSESSMENTQUEUEPATH, strerror(errno));
         pthread_exit(NULL);
     }
@@ -3045,7 +3043,7 @@ cJSON *wm_sca_dump(const wm_sca_t *data) {
     cJSON_AddStringToObject(wm_wd, "enabled", data->enabled ? "yes" : "no");
     cJSON_AddStringToObject(wm_wd, "scan_on_start", data->scan_on_start ? "yes" : "no");
     cJSON_AddStringToObject(wm_wd, "skip_nfs", data->skip_nfs ? "yes" : "no");
-    
+
     if (data->policies && *data->policies) {
         cJSON *policies = cJSON_CreateArray();
         int i;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -46,10 +46,10 @@ int local_start()
         nowDebug();
         debug_level--;
     }
-    
+
     /* Initialize logging module*/
     w_logging_init();
-    
+
     /* Start agent */
     os_calloc(1, sizeof(agent), agt);
 
@@ -216,7 +216,7 @@ int local_start()
     start_agent(1);
     os_delwait();
     update_status(GA_STATUS_ACTIVE);
-    
+
     req_init();
 
     /* Start receiver thread */
@@ -317,7 +317,7 @@ int SendMSG(__attribute__((unused)) int queue, const char *message, const char *
 }
 
 /* StartMQ for Windows */
-int StartMQ(__attribute__((unused)) const char *path, __attribute__((unused)) short int type)
+int StartMQ(__attribute__((unused)) const char *path, __attribute__((unused)) short int type, __attribute__((unused)) short int n_tries)
 {
     return (0);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#3876|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR is meant to unify the behaviour of different daemons so that the default behaviour is attempting to reconnect to queues that might be closed when other daemon falls. By doing this we will be able to restore normal operations by restarting the fallen daemons instead of restarting the whole application.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
