### PR TITLE
Deprecate Agentd option -D

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -15,7 +15,7 @@
 int rotate_log;
 
 /* Start the agent daemon */
-void AgentdStart(const char *dir, int uid, int gid, const char *user, const char *group)
+void AgentdStart(int uid, int gid, const char *user, const char *group)
 {
     int rc = 0;
     int maxfd = 0;

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -54,7 +54,7 @@ cJSON *getLabelsConfig(void);
 cJSON *getAgentInternalOptions(void);
 
 /* Agentd init function */
-void AgentdStart(const char *dir, int uid, int gid, const char *user, const char *group) __attribute__((noreturn));
+void AgentdStart(int uid, int gid, const char *user, const char *group) __attribute__((noreturn));
 
 /* Event Forwarder */
 void *EventForward(void);

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -27,7 +27,7 @@ static void help_agentd(void) __attribute((noreturn));
 static void help_agentd()
 {
     print_header();
-    print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config] [-D dir]", ARGV0);
+    print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config]", ARGV0);
     print_out("    -V          Version and license message");
     print_out("    -h          This help message");
     print_out("    -d          Execute in debug mode. This parameter");
@@ -38,7 +38,6 @@ static void help_agentd()
     print_out("    -u <user>   User to run as (default: %s)", USER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
     print_out("    -c <config> Configuration file to use (default: %s)", DEFAULTCPATH);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", DEFAULTDIR);
     print_out(" ");
     exit(1);
 }
@@ -51,7 +50,6 @@ int main(int argc, char **argv)
     int debug_level = 0;
     agent_debug_level = getDefine_Int("agent", "debug", 0, 2);
 
-    const char *dir = DEFAULTDIR;
     const char *user = USER;
     const char *group = GROUPGLOBAL;
     const char *cfg = DEFAULTCPATH;
@@ -98,7 +96,7 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                dir = optarg;
+                mwarn("-D is deprecated.");
                 break;
             case 'c':
                 if (!optarg) {
@@ -181,7 +179,7 @@ int main(int argc, char **argv)
     StartSIG(ARGV0);
 
     /* Agentd Start */
-    AgentdStart(dir, uid, gid, user, group);
+    AgentdStart(uid, gid, user, group);
 
     return (0);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#4508|

## Description

This PR aims to deprecate option `-D` in Agentd.

- Using option `-D` is still parsed:

```
# ossec-agentd -D
ossec-agentd: option requires an argument -- 'D'
```

- Calling Agentd with a valid argument for `-D` prints that it's now deprecated:
```
# ossec-agentd -D /something
2020/01/28 02:57:55 ossec-agentd: WARNING: -D is deprecated.
```

- The program help does not show option `-D` anymore:
```
# ossec-agentd -h
Wazuh v3.12.0 - Wazuh Inc. (info@wazuh.com)
http://www.wazuh.com
  ossec-agentd: -[Vhdtf] [-u user] [-g group] [-c config]
    -V          Version and license message
    -h          This help message
    -d          Execute in debug mode. This parameter
                can be specified multiple times
                to increase the debug level.
    -t          Test configuration
    -f          Run in foreground
    -u <user>   User to run as (default: ossec)
    -g <group>  Group to run as (default: ossec)
    -c <config> Configuration file to use (default: /var/ossec/etc/ossec.conf)
```

## Tests

- [X] Compile agent on Linux.
- [X] Compile manager on Linux.
- [X] Compile agent for Windows.
- [X] Compile agent on macOS.
- [X] Source installation.
- [X] Run _ossec-agentd_ with the options shown above.