### PR TITLE
Fim rework monitoring new directory

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -764,7 +764,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile, recursion_limit, clean_tag, real_path);
                 }
             } else {
-                mdebug1("Could not check the real path of '%s' due to [(%d)-(%s)].", real_path, errno, strerror(errno));
+                dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile, recursion_limit, clean_tag, NULL);
             }
             os_free(resolved_path);
         }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4516|

## Description

According to the expected behavior, when we add a new directory to be monitored as shown here:
```XML
<directories realtime="yes">/home/user/TestFim/NULL</directories>
```
it should generate events for every change in files that are inside. These changes should begin to be monitored after restarting Wazuh **or after the next scheduled scan.** 

However, although it does work after restarting, no event appears in the `/home/user/TestFim/NULL` directory when we create / modify / delete files inside if we have only waited for the next scan to begin.

## Configuration options
``` xml
<syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>30</frequency>

    <scan_on_start>yes</scan_on_start>

    <!-- Generate alert when new file detected -->
    <alert_new_files>yes</alert_new_files>

    <!-- Don't ignore files that change more than 'frequency' times -->
    <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories check_all="yes" realtime="yes">/home/user/TestFim/NULL</directories>
```

## Logs/Alerts example
When the `<frequency>` time passes and we create that directory, alerts should be observed:
```
** Alert 1580287148.35791: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Jan 29 09:39:08 Wazuh-Machine->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/home/cabrera/TestFim/NULL/t.txt' added
Mode: scheduled

Attributes:
 - Size: 1
 - Permissions: rw-r--r--
 - Date: Wed Jan 29 09:38:59 2020
 - Inode: 4982041
 - User: root (0)
 - Group: root (0)
 - MD5: 68b329da9893e34099c7d8ad5cb9c940
 - SHA1: adc83b19e793491b1c6ea0fd8b46cd9f32e592fc
 - SHA256: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b

** Alert 1580287149.36394: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Jan 29 09:39:09 Wazuh-Machine->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/home/user/TestFim/NULL/t.txt' modified
Mode: real-time
Changed attributes: size,mtime,md5,sha1,sha256
Size changed from '1' to '8'
Old modification time was: '1580287139', now it is '1580287149'
Old md5sum was: '68b329da9893e34099c7d8ad5cb9c940'
New md5sum is : 'a2b2b47c54bbdb8a2748618995265b9b'
Old sha1sum was: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
New sha1sum is : '1fcd31ec6c048ad320b5b0d4c9da465082e4d4d8'
Old sha256sum was: '01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b'
New sha256sum is : '22add9347a868090ff185c841a894d36b67f17a08d3ffd68dac27b86a5054d16'

Attributes:
 - Size: 8
 - Permissions: rw-r--r--
 - Date: Wed Jan 29 09:39:09 2020
 - Inode: 4982041
 - User: root (0)
 - Group: root (0)
 - MD5: a2b2b47c54bbdb8a2748618995265b9b
 - SHA1: 1fcd31ec6c048ad320b5b0d4c9da465082e4d4d8
 - SHA256: 22add9347a868090ff185c841a894d36b67f17a08d3ffd68dac27b86a5054d16

** Alert 1580287337.37536: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Jan 29 09:42:17 Wazuh-Machine->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/home/user/TestFim/NULL/t.txt' deleted
Mode: real-time

Attributes:
 - Size: 8
 - Permissions: rw-r--r--
 - Date: Wed Jan 29 09:39:09 2020
 - Inode: 4982041
 - User: root (0)
 - Group: root (0)
 - MD5: a2b2b47c54bbdb8a2748618995265b9b
 - SHA1: 1fcd31ec6c048ad320b5b0d4c9da465082e4d4d8
 - SHA256: 22add9347a868090ff185c841a894d36b67f17a08d3ffd68dac27b86a5054d16 
```
