### PR TITLE
Fim rework empty directories tag

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -177,11 +177,12 @@ def _read_option(section_name, opt):
         for a in opt.attrib:
             json_attribs[a] = opt.attrib[a]
 
-        for path in opt.text.split(','):
-            json_path = {}
-            json_path = json_attribs.copy()
-            json_path['path'] = path.strip()
-            opt_value.append(json_path)
+        if opt.text:
+            for path in opt.text.split(','):
+                json_path = {}
+                json_path = json_attribs.copy()
+                json_path['path'] = path.strip()
+                opt_value.append(json_path)
     elif (section_name == 'cluster' and opt_name == 'nodes') or \
         (section_name == 'sca' and opt_name == 'policies'):
         opt_value = [child.text for child in opt]

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -730,14 +730,14 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 
             if (glob(tmp_dir, 0, NULL, &g) != 0) {
                 merror(GLOB_ERROR, real_path);
-                ret = 1;
-                goto out_free;
+                dir++;
+                continue;
             }
 
             if (g.gl_pathv[0] == NULL) {
                 merror(GLOB_NFOUND, real_path);
-                ret = 1;
-                goto out_free;
+                dir++;
+                continue;
             }
 
             while (g.gl_pathv[gindex]) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -376,6 +376,11 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 #endif
 
+        if (!strcmp(tmp_dir,"")) {
+            dir++;
+            continue;
+        }
+
         attrs = g_attrs;
         values = g_values;
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -336,7 +336,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
     dir = OS_StrBreak(',', dirs, MAX_DIR_SIZE); /* Max number */
     char **dir_org = dir;
 
-    int ret = 0, i;
+    int i;
 
     /* Dir can not be null */
     if (dir == NULL) {
@@ -423,8 +423,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     opts &= ~ CHECK_ATTRS;
 #endif
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);       
                     goto out_free;
                 }
             }
@@ -437,8 +436,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ (CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM);
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -449,8 +447,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_MD5SUM;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -461,8 +458,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_SHA1SUM;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -473,8 +469,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_SHA256SUM;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -487,8 +482,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ WHODATA_ACTIVE;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -499,8 +493,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_PERM;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -511,8 +504,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_SIZE;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -523,8 +515,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_OWNER;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -535,8 +526,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_GROUP;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -547,8 +537,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_MTIME;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -559,8 +548,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_INODE;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -572,8 +560,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_ATTRS;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
 #else
@@ -588,8 +575,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ REALTIME_ACTIVE;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -600,8 +586,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~ CHECK_SEECHANGES;
                 } else {
-                    merror(FIM_INVALID_OPTION, *values, *attrs);
-                    ret = 0;
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -644,8 +629,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                } else if (strcmp(*values, "no") == 0) {
                    opts &= ~ CHECK_FOLLOW;
                } else {
-                   merror(FIM_INVALID_OPTION, *values, *attrs);
-                   ret = 0;
+                   mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                    goto out_free;
                }
             } else {
@@ -658,7 +642,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         /* You must have something set */
         if (opts == 0) {
             mwarn(FIM_NO_OPTIONS, dirs);
-            ret = 0;
             goto out_free;
         }
 
@@ -794,8 +777,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         dir++;
     }
 
-    ret = 1;
-
 out_free:
 
     i = 0;
@@ -812,7 +793,7 @@ out_free:
         free(clean_tag);
     }
 
-    return ret;
+    return 1;
 }
 
 static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -37,5 +37,6 @@
 #define FIM_PATH_NOT_OPEN                       "(6922): Cannot open '%s': %s"
 #define FIM_WARN_SKIP_EVENT                     "(6923): Unable to process file '%s'"
 #define FIM_AUDIT_NORUNNING                     "(6224): Who-data engine cannot start because Auditd is not running."
+#define FIM_INVALID_OPTION_SKIP                 "(6225): Invalid option '%s' for attribute '%s'. The paths '%s' not be monitored."
 
 #endif /* WARN_MESSAGES_H */


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4517|

## Description

According to the expected behavior, when we add no directory to be monitored in `/var/ossec/etc/ossec.conf` as shown here:
```XML
<directories realtime="yes"></directories>
```
and we restart Wazuh, a log should appear in `ossec.log`, not an error. There should be no problems in the restart.

However, currently when we try to restart Wazuh, a message like this appears in ossec.log:
`2020/02/14 00:08:19 ossec-syscheckd[5145] syscheck-config.c:767 at read_attr(): DEBUG: Could not check the real path of '' due to [(2)-(No such file or directory)].`

## Configuration options
``` xml
<syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>30</frequency>

    <scan_on_start>yes</scan_on_start>

    <!-- Generate alert when new file detected -->
    <alert_new_files>yes</alert_new_files>

    <!-- Don't ignore files that change more than 'frequency' times -->
    <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories check_all="yes" realtime="yes"></directories>
```