### PR TITLE
Fix framework error when empty <directories> tag.

### DIFF
--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -177,11 +177,12 @@ def _read_option(section_name, opt):
         for a in opt.attrib:
             json_attribs[a] = opt.attrib[a]
 
-        for path in opt.text.split(','):
-            json_path = {}
-            json_path = json_attribs.copy()
-            json_path['path'] = path.strip()
-            opt_value.append(json_path)
+        if opt.text:
+            for path in opt.text.split(','):
+                json_path = {}
+                json_path = json_attribs.copy()
+                json_path['path'] = path.strip()
+                opt_value.append(json_path)
     elif (section_name == 'cluster' and opt_name == 'nodes') or \
         (section_name == 'sca' and opt_name == 'policies'):
         opt_value = [child.text for child in opt]


### PR DESCRIPTION
Hello team,

This PR fixes the issue #4517. Now, adding a configuration like this will not cause an error that prevents Wazuh from starting correctly.
```XML
<directories realtime="yes"></directories>
```

The mistake was trying to use the split() method on an empty string, as was the case here:
https://github.com/wazuh/wazuh/blob/71ca38f1787cee394e2ffcf8f964837bc4e53c25/framework/wazuh/configuration.py#L180

Kind regards,
José Luis.
