### PR TITLE
Fix core dump in Crypto library

### DIFF
--- a/src/os_crypto/md5/md5_op.c
+++ b/src/os_crypto/md5/md5_op.c
@@ -27,7 +27,7 @@ int OS_MD5_File(const char *fname, os_md5 output, int mode)
     unsigned char digest[16];
     size_t n;
 
-    memset(output, 0, 33);
+    memset(output, 0, sizeof(os_md5));
     buf[1024] = '\0';
 
     fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -35,7 +35,7 @@ int OS_SHA1_File(const char *fname, os_sha1 output, int mode)
     unsigned char md[SHA_DIGEST_LENGTH];
     size_t n;
 
-    memset(output, 0, 65);
+    memset(output, 0, sizeof(os_sha1));
     buf[2049] = '\0';
 
     fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");

--- a/src/os_crypto/sha256/sha256_op.c
+++ b/src/os_crypto/sha256/sha256_op.c
@@ -24,7 +24,7 @@ int OS_SHA256_File(const char *fname, os_sha256 output, int mode)
     unsigned char md[SHA256_DIGEST_LENGTH];
     size_t n;
 
-    memset(output, 0, 65);
+    memset(output, 0, sizeof(os_sha256));
     buf[2049] = '\0';
 
     fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");


### PR DESCRIPTION
|Related issue|
|---|
|[4521](https://github.com/wazuh/wazuh/issues/4521)|

Hello,

`os_sha1` size has changed on FIM rework. The os_sha1 size will be 41.

In `OS_SHA1_File` function the parameter output is filled with 0 using the old size (65). It causes a core dump.

## Test

TAP unit test output:
```
   STARTING TEST - OS_CRYPTO   

    ok  1 - Blowfish encryption test.
    ok  2 - MD5 encryption test.
    ok  3 - MD5 file reading encryption test.
    ok  4 - MD5 non-existing file to read from.
    ok  5 - SHA1 encryption test.
    ok  6 - SHA1 file reading encryption test.
    ok  7 - SHA1 non-existing file to read from.
    ok  8 - MD5+SHA1 file reading encryption test.
    ok  9 - MD5+SHA1 reading from file using command encryption test.
    ok 10 - MD5+SHA1 non-existing file to read from using command.
1..10

      [ ALL TESTS PASSED ]

    ENDING TEST  - OS_CRYPTO   
```

Execute test using Valgrind:
```
lopezziur@lopezziur:~/wazuh/wazuh/src$ valgrind --track-origins=yes --leak-check=full --keep-stacktraces=alloc-and-free --track-fds=yes --num-callers=20 --show-leak-kinds=definite,indirect ./tap_os_crypto
==24370== Memcheck, a memory error detector
==24370== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==24370== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==24370== Command: ./tap_os_crypto
==24370== 


   STARTING TEST - OS_CRYPTO   

    ok  1 - Blowfish encryption test.
    ok  2 - MD5 encryption test.
    ok  3 - MD5 file reading encryption test.
    ok  4 - MD5 non-existing file to read from.
    ok  5 - SHA1 encryption test.
    ok  6 - SHA1 file reading encryption test.
    ok  7 - SHA1 non-existing file to read from.
    ok  8 - MD5+SHA1 file reading encryption test.
    ok  9 - MD5+SHA1 reading from file using command encryption test.
    ok 10 - MD5+SHA1 non-existing file to read from using command.
1..10

      [ ALL TESTS PASSED ]

    ENDING TEST  - OS_CRYPTO   

==24370== 
==24370== FILE DESCRIPTORS: 3 open at exit.
==24370== Open file descriptor 2: /dev/pts/1
==24370==    <inherited from parent>
==24370== 
==24370== Open file descriptor 1: /dev/pts/1
==24370==    <inherited from parent>
==24370== 
==24370== Open file descriptor 0: /dev/pts/1
==24370==    <inherited from parent>
==24370== 
==24370== 
==24370== HEAP SUMMARY:
==24370==     in use at exit: 0 bytes in 0 blocks
==24370==   total heap usage: 157 allocs, 157 frees, 103,808 bytes allocated
==24370== 
==24370== All heap blocks were freed -- no leaks are possible
==24370== 
==24370== For counts of detected and suppressed errors, rerun with: -v
==24370== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
lopezziur@lopezziur:~/wazuh/wazuh/src$ 
```