### PR TITLE
Fixed issues reported by Coverity

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -319,7 +319,7 @@ void fim_whodata_event(whodata_evt * w_evt) {
 
 void fim_audit_inode_event(char *file, fim_event_mode mode, whodata_evt * w_evt) {
     struct fim_element *item;
-    char **paths;
+    char **paths = NULL;
 
     w_mutex_lock(&syscheck.fim_entry_mutex);
 

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -83,7 +83,8 @@ void * fim_run_integrity(void * args) {
 // LCOV_EXCL_STOP
 
 void fim_sync_checksum() {
-    char *start, *top;
+    char *start = NULL;
+    char *top = NULL;
     EVP_MD_CTX * ctx = EVP_MD_CTX_create();
     EVP_DigestInit(ctx, EVP_sha1());
 
@@ -122,9 +123,6 @@ void fim_sync_checksum() {
 
         char * plain = dbsync_check_msg("syscheck", INTEGRITY_CHECK_GLOBAL, fim_sync_cur_id, start, top, NULL, hexdigest);
         fim_send_sync_msg(plain);
-
-        os_free(start);
-        os_free(top);
         os_free(plain);
 
     } else { // If database is empty
@@ -134,6 +132,8 @@ void fim_sync_checksum() {
     }
 
     end:
+        os_free(start);
+        os_free(top);
         EVP_MD_CTX_destroy(ctx);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#4540|

## Description

Coverity has reported some issues from 3319-fim-rework-sqlite:

- [x] Resource leak

```
/syscheckd/fim_db.c: 162 in fim_db_init()
/syscheckd/fim_db.c: 166 in fim_db_init()
/syscheckd/fim_db.c: 184 in fim_db_init()
/syscheckd/fim_db.c: 175 in fim_db_init()
```

- [ ] Sleep

```
/syscheckd/fim_sync.c: 165 in fim_sync_checksum_split()
```

- [x] Resource leak

```
/syscheckd/fim_sync.c: 138 in fim_sync_checksum()
```

- [x] Illegal access

```
/syscheckd/create_db.c: 347 in fim_audit_inode_event()
```

- [x] Resource leak
```
/syscheckd/fim_db.c: 751 in fim_db_data_checksum_range()
```

- [x] Resource leak

```
/syscheckd/fim_sync.c: 138 in fim_sync_checksum()
```
Two of them have been fixed in 4530-fim-rework-sql-scan-build branch.