### PR TITLE
Fix Scan-build report

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -319,7 +319,7 @@ void fim_whodata_event(whodata_evt * w_evt) {
 
 void fim_audit_inode_event(char *file, fim_event_mode mode, whodata_evt * w_evt) {
     struct fim_element *item;
-    char **paths;
+    char **paths = NULL;
 
     w_mutex_lock(&syscheck.fim_entry_mutex);
 

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -752,21 +752,22 @@ int fim_db_data_checksum_range(fdb_t *fim_sql, const char *start, const char *to
     OS_SHA1_Hexdigest(digest, hexdigest);
     plain = dbsync_check_msg("syscheck", INTEGRITY_CHECK_LEFT, id, start, str_pathlh, str_pathuh, hexdigest);
     fim_send_sync_msg(plain);
-    free(plain);
+    os_free(plain);
 
     // Send message with checksum of second half
     EVP_DigestFinal_ex(ctx_right, digest, &digest_size);
     OS_SHA1_Hexdigest(digest, hexdigest);
     plain = dbsync_check_msg("syscheck", INTEGRITY_CHECK_RIGHT, id, str_pathuh, top, "", hexdigest);
     fim_send_sync_msg(plain);
-    free(plain);
-    os_free(str_pathuh);
+    os_free(plain);
 
     retval = FIMDB_OK;
 
     end1:
         EVP_MD_CTX_destroy(ctx_right);
         os_free(str_pathlh);
+        os_free(str_pathuh);
+
     end:
         EVP_MD_CTX_destroy(ctx_left);
         return retval;

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -721,7 +721,7 @@ int fim_db_data_checksum_range(fdb_t *fim_sql, const char *start, const char *to
             goto end;
         }
         entry = fim_db_decode_full_row(fim_sql->stmt[FIMDB_STMT_GET_PATH_RANGE]);
-        if (i == (m - 1)) {
+        if (i == (m - 1) && entry->path) {
             os_strdup(entry->path, str_pathlh);
         }
         fim_db_callback_calculate_checksum(fim_sql, entry, (void *)ctx_left);
@@ -735,7 +735,7 @@ int fim_db_data_checksum_range(fdb_t *fim_sql, const char *start, const char *to
             goto end1;
         }
         entry = fim_db_decode_full_row(fim_sql->stmt[FIMDB_STMT_GET_PATH_RANGE]);
-        if (i == m) {
+        if (i == m && entry->path) {
             os_strdup(entry->path, str_pathuh);
         }
         fim_db_callback_calculate_checksum(fim_sql, entry, (void *)ctx_right);

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -90,7 +90,8 @@ void * fim_run_integrity(void * args) {
 // LCOV_EXCL_STOP
 
 void fim_sync_checksum() {
-    char *start, *top;
+    char *start = NULL;
+    char *top = NULL;
     EVP_MD_CTX * ctx = EVP_MD_CTX_create();
     EVP_DigestInit(ctx, EVP_sha1());
 
@@ -130,8 +131,6 @@ void fim_sync_checksum() {
         char * plain = dbsync_check_msg("syscheck", INTEGRITY_CHECK_GLOBAL, fim_sync_cur_id, start, top, NULL, hexdigest);
         fim_send_sync_msg(plain);
 
-        os_free(start);
-        os_free(top);
         os_free(plain);
 
     } else { // If database is empty
@@ -141,6 +140,8 @@ void fim_sync_checksum() {
     }
 
     end:
+        os_free(start);
+        os_free(top);
         EVP_MD_CTX_destroy(ctx);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|[4530](https://github.com/wazuh/wazuh/issues/4530)|


**FIXED:**

1. Memory leak on `fim_db_init`
2. Memory leak on `fim_db_data_checksum_range`
3. Prevent arguments with 'nonnull' attribute passed null on `fim_db_data_checksum_range`
