### PR TITLE
Create 'queue/fim/db' folder in agent's installation

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -796,6 +796,8 @@ InstallCommon()
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/ossec
   ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/diff
   ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/db
+  ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/fim
+  ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/fim/db
 
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/ruleset
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/ruleset/sca

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -17,7 +17,7 @@
 #define FIM_DB_MEMORY_PATH  ":memory:"
 
 #ifndef WIN32
-#define FIM_DB_DISK_PATH    DEFAULTDIR "/queue/db/fim.db"
+#define FIM_DB_DISK_PATH    DEFAULTDIR "/queue/fim/db/fim.db"
 #else
 #define FIM_DB_DISK_PATH    "queue/fim/db/fim.db"
 #endif


### PR DESCRIPTION
| Related issue  |
|---------------|
| #4525             |

## Description

Create `queue/fim/db` folder in agent's installation and  `fim.db` file on agent's start on Linux.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
