### PR TITLE
Fix agent_upgrade binary downloaded file permissions

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1,11 +1,11 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import errno
+import fcntl
 import hashlib
 import operator
-
+import os
 import socket
 from base64 import b64encode
 from datetime import date, datetime, timedelta, timezone
@@ -18,7 +18,6 @@ from shutil import copyfile, rmtree
 from time import time, sleep
 from typing import Dict
 
-import fcntl
 import requests
 
 from wazuh import common, configuration
@@ -28,10 +27,9 @@ from wazuh.database import Connection
 from wazuh.exception import WazuhException
 from wazuh.ossec_queue import OssecQueue
 from wazuh.ossec_socket import OssecSocket, OssecSocketJSON
-from wazuh.utils import cut_array, sort_array, search_array, chmod_r, chown_r, WazuhVersion, plain_dict_to_nested_dict, \
-                        get_fields_to_nest, get_hash, WazuhDBQuery, WazuhDBQueryDistinct, WazuhDBQueryGroupBy, mkdir_with_mode, \
-                        md5, SQLiteBackend, WazuhDBBackend, filter_array_by_query, safe_move
-from wazuh.wdb import WazuhDBConnection
+from wazuh.utils import cut_array, sort_array, search_array, chmod_r, chown_r, WazuhVersion, \
+    plain_dict_to_nested_dict, get_fields_to_nest, get_hash, WazuhDBQuery, WazuhDBQueryDistinct, WazuhDBQueryGroupBy, \
+    mkdir_with_mode, md5, SQLiteBackend, WazuhDBBackend, filter_array_by_query, safe_move
 
 
 def create_exception_dic(id, e):
@@ -1962,6 +1960,8 @@ class Agent:
             with open(wpk_file_path, 'wb') as fd:
                 for chunk in result.iter_content(chunk_size=128):
                     fd.write(chunk)
+                os.chown(wpk_file_path, common.ossec_gid(), common.ossec_gid())
+                os.chmod(wpk_file_path, 0o660)
         else:
             raise WazuhException(1714,
                                  WazuhException.ERRORS[1714] + ". Can't access to the WPK file in {}".format(wpk_url),


### PR DESCRIPTION
|Related issue|
|---|
|#4453|

## Description

This fix ensures WPK upgrade file always gets downloaded with read/write permissions for Wazuh API.

## Tests

Now, after using `agent_upgrade`:
```
root@41485b114ad5:/var/ossec/var/upgrade# /var/ossec/bin/agent_upgrade -a 001 -F -v v3.11.0
```

The wpk file has right `ossec:ossec` permissions and the API is able to use the file.
```
-rw-rw---- 1 ossec ossec 5.1M Feb  3 08:50 wazuh_agent_v3.11.0_linux_x86_64.wpk
```