### PR TITLE
Fix mutex initialization in the rule parser

### DIFF
--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -111,7 +111,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
     regex.prts_closure = NULL;
     regex.d_prts_str = NULL;
     regex.d_sub_strings = NULL;
-    regex.mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
+    w_mutex_init(&regex.mutex, NULL);
 
     if (node) {
         while (node[i]) {


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 3.11.3 | ossec-dbd | Local |Sources | OpenBSD 6.6 |

|Related mailing list thread|
|---|
|[Compile Wazuh 3.10.2 as TARGET=local fails under OpenBSD 6.6](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/wazuh/QDFXv2JlqIk/OBCVO97BBwAJ)|

This was preventing ossec-dbd from starting on OpenBSD.

## Debugging log

```shell
# /var/ossec/bin/ossec-dbd -d

2020/01/18 13:04:27 ossec-dbd[91378] main.c:132 at main(): DEBUG: Starting ...
2020/01/18 13:04:27 ossec-dbd[91378] rules-config.c:189 at Read_Rules(): DEBUG: Adding decoder dir: ruleset/decoders
2020/01/18 13:04:27 ossec-dbd[91378] rules-config.c:219 at Read_Rules(): DEBUG: Adding rules dir: ruleset/rules
2020/01/18 13:04:27 ossec-dbd[91378] rules-config.c:173 at Read_Rules(): DEBUG: Excluding rule: 0215-policy_rules.xml
2020/01/18 13:04:27 ossec-dbd[91378] rules-config.c:189 at Read_Rules(): DEBUG: Adding decoder dir: etc/decoders
2020/01/18 13:04:27 ossec-dbd[91378] rules-config.c:219 at Read_Rules(): DEBUG: Adding rules dir: etc/rules
2020/01/18 13:04:27 ossec-dbd[91378] rules-config.c:274 at Read_Rules(): DEBUG: Reading decoders folder: ruleset/decoders
2020/01/18 13:04:27 ossec-dbd[91378] os_regex_free_pattern.c:70 at OSRegex_FreePattern(): CRITICAL: At pthread_mutex_destroy(): Invalid argument
```

## Reason

Function `Read_Rules()` was creating a mutex using a static initializer:

```c
pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
```

Which is correct, according to the documentation of Pthreads on Linux: [pthread_mutex_init(3)](https://linux.die.net/man/3/pthread_mutex_init). However, this method is known to cause race conditions on Windows. In addition, it is causing problems on `pthread_mutex_destroy()` on OpenBSD.

## Fix

Simply replace the mutex initialization with a call to `pthread_mutex_init()`.

## Affected systems

This change affects those binaries on the manager and local installation that parse rules:

- _ossec-analysisd_.
- _ossec-dbd_.

## Tests

- [X] Compile local on OpenBSD 6.5.
- [X] Compile manager on Debian Buster.
- [X] Compile agent for Windows.
- [X] Compile agent on macOS.
- [X] Source installation on OpenBSD.
- [X] Source installation on Debian.
- [X] Run _ossec-dbd_  on Valgrind.

### Valgrind on ossec-dbd

No defects reported on the mutex. However, Valgrind reports many memory leaks in the rule parser (like _ossec-analysisd_):

```
==5645== HEAP SUMMARY:
==5645==     in use at exit: 11,233 bytes in 243 blocks
==5645==   total heap usage: 5,511 allocs, 5,268 frees, 2,338,803 bytes allocated
==5645==
==5645== 12 bytes in 2 blocks are definitely lost in loss record 1 of 11
==5645==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==5645==    by 0x4F62DB9: strdup (strdup.c:42)
==5645==    by 0x11C47A: Read_Rules (rules-config.c:202)
==5645==    by 0x117301: read_main_elements (config.c:96)
==5645==    by 0x117F6C: ReadConfig (config.c:254)
==5645==    by 0x1146C5: OS_ReadDBConf (config.c:42)
==5645==    by 0x115719: main (main.c:145)
==5645==
==5645== 12 bytes in 2 blocks are definitely lost in loss record 2 of 11
==5645==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==5645==    by 0x4F62DB9: strdup (strdup.c:42)
==5645==    by 0x11C90B: Read_Rules (rules-config.c:232)
==5645==    by 0x117301: read_main_elements (config.c:96)
==5645==    by 0x117F6C: ReadConfig (config.c:254)
==5645==    by 0x1146C5: OS_ReadDBConf (config.c:42)
==5645==    by 0x115719: main (main.c:145)
==5645==
==5645== 22 bytes in 1 blocks are definitely lost in loss record 3 of 11
==5645==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==5645==    by 0x4F62DB9: strdup (strdup.c:42)
==5645==    by 0x11BE44: Read_Rules (rules-config.c:171)
==5645==    by 0x117301: read_main_elements (config.c:96)
==5645==    by 0x117F6C: ReadConfig (config.c:254)
==5645==    by 0x1146C5: OS_ReadDBConf (config.c:42)
==5645==    by 0x115719: main (main.c:145)
==5645==
==5645== 24 bytes in 2 blocks are definitely lost in loss record 4 of 11
==5645==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==5645==    by 0x4F62DB9: strdup (strdup.c:42)
==5645==    by 0x11C668: Read_Rules (rules-config.c:216)
==5645==    by 0x117301: read_main_elements (config.c:96)
==5645==    by 0x117F6C: ReadConfig (config.c:254)
==5645==    by 0x1146C5: OS_ReadDBConf (config.c:42)
==5645==    by 0x115719: main (main.c:145)
==5645==
==5645== 30 bytes in 2 blocks are definitely lost in loss record 5 of 11
==5645==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==5645==    by 0x4F62DB9: strdup (strdup.c:42)
==5645==    by 0x11C1D7: Read_Rules (rules-config.c:186)
==5645==    by 0x117301: read_main_elements (config.c:96)
==5645==    by 0x117F6C: ReadConfig (config.c:254)
==5645==    by 0x1146C5: OS_ReadDBConf (config.c:42)
==5645==    by 0x115719: main (main.c:145)
==5645==
==5645== 117 (32 direct, 85 indirect) bytes in 1 blocks are definitely lost in loss record 7 of 11
==5645==    at 0x4837D7B: realloc (vg_replace_malloc.c:826)
==5645==    by 0x11BC43: Read_Rules (rules-config.c:164)
==5645==    by 0x117301: read_main_elements (config.c:96)
==5645==    by 0x117F6C: ReadConfig (config.c:254)
==5645==    by 0x1146C5: OS_ReadDBConf (config.c:42)
==5645==    by 0x115719: main (main.c:145)
==5645==
==5645== 5,180 (816 direct, 4,364 indirect) bytes in 1 blocks are definitely lost in loss record 11 of 11
==5645==    at 0x4837D7B: realloc (vg_replace_malloc.c:826)
==5645==    by 0x11D118: Read_Rules (rules-config.c:315)
==5645==    by 0x117301: read_main_elements (config.c:96)
==5645==    by 0x117F6C: ReadConfig (config.c:254)
==5645==    by 0x1146C5: OS_ReadDBConf (config.c:42)
==5645==    by 0x115719: main (main.c:145)
```