### PR TITLE
API 4.0 Refactor lists, decoders and rules

### DIFF
--- a/api/api/controllers/decoders_controller.py
+++ b/api/api/controllers/decoders_controller.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
@@ -9,8 +9,8 @@ import connexion
 
 from api.authentication import get_permissions
 from api.util import remove_nones_to_dict, exception_handler, parse_api_param, raise_if_exc
-from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh import decoder as decoder_framework
+from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
 loop = asyncio.get_event_loop()
 logger = logging.getLogger('wazuh')
@@ -18,8 +18,8 @@ logger = logging.getLogger('wazuh')
 
 @exception_handler
 def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
-                 limit: int = None, sort: str = None, search: str = None, q: str = None, file: str = None,
-                 path: str = None, status: str = None):
+                 limit: int = None, sort: str = None, search: str = None, q: str = None, filename: str = None,
+                 relative_path: str = None, status: str = None):
     """Get all decoders
 
     Returns information about all decoders included in ossec.conf. This information include decoder's route,
@@ -34,22 +34,22 @@ def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_comp
     ascending or descending order.
     :param search: Looks for elements with the specified string
     :param q: Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
-    :param file: Filters by filename.
-    :param path: Filters by path
+    :param filename: Filters by filename.
+    :param relative_path: Filters by relative path
     :param status: Filters by list status.
     :return: Data object
     """
     f_kwargs = {'names': decoder_names,
                 'offset': offset,
                 'limit': limit,
-                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['file', 'position'],
+                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['filename', 'position'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'q': q,
-                'file': file,
+                'filename': filename,
                 'status': status,
-                'path': path}
+                'relative_path': relative_path}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoders,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -67,7 +67,8 @@ def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_comp
 
 @exception_handler
 def get_decoders_files(pretty: bool = False, wait_for_complete: bool = False, offset: int = 0, limit: int = None,
-                       sort: str = None, search: str = None, file: str = None, path: str = None, status: str = None):
+                       sort: str = None, search: str = None, filename: str = None, relative_path: str = None,
+                       status: str = None):
     """Get all decoders files
 
     Returns information about all decoders files used in Wazuh. This information include decoder's file, decoder's route
@@ -80,19 +81,19 @@ def get_decoders_files(pretty: bool = False, wait_for_complete: bool = False, of
     :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
     ascending or descending order.
     :param search: Looks for elements with the specified string
-    :param file: Filters by filename.
-    :param path: Filters by path
+    :param filename: Filters by filename.
+    :param relative_path: Filters by relative path
     :param status: Filters by list status.
     :return: Data object
     """
     f_kwargs = {'offset': offset,
                 'limit': limit,
-                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['file'],
+                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['filename'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'file': file,
-                'path': path,
+                'filename': filename,
+                'relative_path': relative_path,
                 'status': status}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoders_files,
@@ -110,15 +111,15 @@ def get_decoders_files(pretty: bool = False, wait_for_complete: bool = False, of
 
 
 @exception_handler
-def get_download_file(pretty: bool = False, wait_for_complete: bool = False, file: str = None):
+def get_download_file(pretty: bool = False, wait_for_complete: bool = False, filename: str = None):
     """Download an specified decoder file.
 
     :param pretty: Show results in human-readable format
     :param wait_for_complete: Disable timeout response
-    :param file: File name to download.
+    :param filename: Filename to download.
     :return: Raw xml file
     """
-    f_kwargs = {'file': file}
+    f_kwargs = {'filename': filename}
 
     dapi = DistributedAPI(f=decoder_framework.get_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -153,7 +154,7 @@ def get_decoders_parents(pretty: bool = False, wait_for_complete: bool = False, 
     """
     f_kwargs = {'offset': offset,
                 'limit': limit,
-                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['file', 'position'],
+                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['filename', 'position'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,

--- a/api/api/controllers/decoders_controller.py
+++ b/api/api/controllers/decoders_controller.py
@@ -34,7 +34,7 @@ def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_comp
     ascending or descending order.
     :param search: Looks for elements with the specified string
     :param q: Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
-    :param filename: Filters by filename.
+    :param filename: List of filenames to filter by.
     :param relative_dirname: Filters by relative dirname.
     :param status: Filters by list status.
     :return: Data object
@@ -81,7 +81,7 @@ def get_decoders_files(pretty: bool = False, wait_for_complete: bool = False, of
     :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
     ascending or descending order.
     :param search: Looks for elements with the specified string
-    :param filename: Filters by filename
+    :param filename: List of filenames to filter by.
     :param relative_dirname: Filters by relative dirname
     :param status: Filters by list status
     :return: Data object

--- a/api/api/controllers/decoders_controller.py
+++ b/api/api/controllers/decoders_controller.py
@@ -19,7 +19,7 @@ logger = logging.getLogger('wazuh')
 @exception_handler
 def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                  limit: int = None, sort: str = None, search: str = None, q: str = None, filename: str = None,
-                 relative_path: str = None, status: str = None):
+                 relative_dirname: str = None, status: str = None):
     """Get all decoders
 
     Returns information about all decoders included in ossec.conf. This information include decoder's route,
@@ -35,7 +35,7 @@ def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_comp
     :param search: Looks for elements with the specified string
     :param q: Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
     :param filename: Filters by filename.
-    :param relative_path: Filters by relative path
+    :param relative_dirname: Filters by relative dirname.
     :param status: Filters by list status.
     :return: Data object
     """
@@ -49,7 +49,7 @@ def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_comp
                 'q': q,
                 'filename': filename,
                 'status': status,
-                'relative_path': relative_path}
+                'relative_dirname': relative_dirname}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoders,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -67,7 +67,7 @@ def get_decoders(decoder_names: list = None, pretty: bool = False, wait_for_comp
 
 @exception_handler
 def get_decoders_files(pretty: bool = False, wait_for_complete: bool = False, offset: int = 0, limit: int = None,
-                       sort: str = None, search: str = None, filename: str = None, relative_path: str = None,
+                       sort: str = None, search: str = None, filename: str = None, relative_dirname: str = None,
                        status: str = None):
     """Get all decoders files
 
@@ -81,9 +81,9 @@ def get_decoders_files(pretty: bool = False, wait_for_complete: bool = False, of
     :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
     ascending or descending order.
     :param search: Looks for elements with the specified string
-    :param filename: Filters by filename.
-    :param relative_path: Filters by relative path
-    :param status: Filters by list status.
+    :param filename: Filters by filename
+    :param relative_dirname: Filters by relative dirname
+    :param status: Filters by list status
     :return: Data object
     """
     f_kwargs = {'offset': offset,
@@ -93,7 +93,7 @@ def get_decoders_files(pretty: bool = False, wait_for_complete: bool = False, of
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'filename': filename,
-                'relative_path': relative_path,
+                'relative_dirname': relative_dirname,
                 'status': status}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoders_files,

--- a/api/api/controllers/lists_controller.py
+++ b/api/api/controllers/lists_controller.py
@@ -1,9 +1,10 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
 import logging
+import os
 
 import connexion
 
@@ -32,6 +33,7 @@ def get_lists(pretty: bool = False, wait_for_complete: bool = False, offset: int
     :param relative_dirname: Filters by relative dirname
     :return: Data object
     """
+    path = [os.path.join(relative_dirname, item) for item in filename] if filename and relative_dirname else None
     f_kwargs = {'offset': offset,
                 'limit': limit,
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['relative_dirname',
@@ -40,7 +42,8 @@ def get_lists(pretty: bool = False, wait_for_complete: bool = False, offset: int
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'filename': filename,
-                'relative_dirname': relative_dirname
+                'relative_dirname': relative_dirname,
+                'path': path
                 }
 
     dapi = DistributedAPI(f=cdb_list.get_lists,
@@ -73,15 +76,18 @@ def get_lists_files(pretty: bool = False, wait_for_complete: bool = False, offse
     :param relative_dirname: Filters by relative dirname
     :return: Data object
     """
+    path = [os.path.join(relative_dirname, item) for item in filename] if filename and relative_dirname else None
     f_kwargs = {'offset': offset,
                 'limit': limit,
-                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['filename'],
+                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['relative_dirname',
+                                                                                             'filename'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'search_in_fields': ['filename', 'relative_dirname'],
                 'filename': filename,
-                'relative_dirname': relative_dirname
+                'relative_dirname': relative_dirname,
+                'path': path
                 }
 
     dapi = DistributedAPI(f=cdb_list.get_path_lists,

--- a/api/api/controllers/lists_controller.py
+++ b/api/api/controllers/lists_controller.py
@@ -79,7 +79,7 @@ def get_lists_files(pretty: bool = False, wait_for_complete: bool = False, offse
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'search_in_fields': ['filename', 'relative_path'],
+                'search_in_fields': ['filename', 'relative_dirname'],
                 'filename': filename,
                 'relative_dirname': relative_dirname
                 }

--- a/api/api/controllers/lists_controller.py
+++ b/api/api/controllers/lists_controller.py
@@ -18,7 +18,7 @@ logger = logging.getLogger('wazuh')
 
 @exception_handler
 def get_lists(pretty: bool = False, wait_for_complete: bool = False, offset: int = 0, limit: int = None,
-              sort: str = None, search: str = None, path: str = None):
+              sort: str = None, search: str = None, filename: str = None, relative_dirname: str = None):
     """ Get all CDB lists
 
     :param pretty: Show results in human-readable format.
@@ -28,16 +28,20 @@ def get_lists(pretty: bool = False, wait_for_complete: bool = False, offset: int
     :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
     ascending or descending order.
     :param search: Looks for elements with the specified string.
-    :param path: Filters by list path.
+    :param filename: List of filenames to filter by.
+    :param relative_dirname: Filters by relative dirname
     :return: Data object
     """
     f_kwargs = {'offset': offset,
                 'limit': limit,
-                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['path'],
+                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['relative_dirname',
+                                                                                             'filename'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'path': path}
+                'filename': filename,
+                'relative_dirname': relative_dirname
+                }
 
     dapi = DistributedAPI(f=cdb_list.get_lists,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -55,7 +59,7 @@ def get_lists(pretty: bool = False, wait_for_complete: bool = False, offset: int
 
 @exception_handler
 def get_lists_files(pretty: bool = False, wait_for_complete: bool = False, offset: int = 0, limit: int = None,
-                    sort: str = None, search: str = None):
+                    sort: str = None, search: str = None, filename: str = None, relative_dirname: str = None):
     """ Get paths from all CDB lists
 
     :param pretty: Show results in human-readable format.
@@ -65,15 +69,20 @@ def get_lists_files(pretty: bool = False, wait_for_complete: bool = False, offse
     :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
     ascending or descending order.
     :param search: Looks for elements with the specified string.
+    :param filename: List of filenames to filter by.
+    :param relative_dirname: Filters by relative dirname
     :return: Data object
     """
     f_kwargs = {'offset': offset,
                 'limit': limit,
-                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['path'],
+                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['filename'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'search_in_fields': ['name', 'path']}
+                'search_in_fields': ['filename', 'relative_path'],
+                'filename': filename,
+                'relative_dirname': relative_dirname
+                }
 
     dapi = DistributedAPI(f=cdb_list.get_path_lists,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/rules_controller.py
+++ b/api/api/controllers/rules_controller.py
@@ -35,7 +35,7 @@ def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, li
     :param status: Filters by rules status.
     :param group: Filters by rule group.
     :param level: Filters by rule level. Can be a single level (4) or an interval (2-4)
-    :param filename: Filters by filename.
+    :param filename: List of filenames to filter by.
     :param relative_dirname: Filters by relative dirname.
     :param pci_dss: Filters by PCI_DSS requirement name.
     :param gdpr: Filters by GDPR requirement.
@@ -160,7 +160,7 @@ def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None,
     ascending or descending order.
     :param search: Looks for elements with the specified string
     :param status: Filters by rules status.
-    :param filename: Filters by filename.
+    :param filename: List of filenames to filter by..
     :param relative_dirname: Filters by relative dirname.
     :return: Data object
     """

--- a/api/api/controllers/rules_controller.py
+++ b/api/api/controllers/rules_controller.py
@@ -19,7 +19,7 @@ logger = logging.getLogger('wazuh')
 @exception_handler
 @flask_cached
 def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, search=None,
-              q=None, status=None, group=None, level=None, filename=None, relative_path=None, pci_dss=None, gdpr=None,
+              q=None, status=None, group=None, level=None, filename=None, relative_dirname=None, pci_dss=None, gdpr=None,
               gpg13=None, hipaa=None):
     """Get information about all Wazuh rules.
 
@@ -36,7 +36,7 @@ def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, li
     :param group: Filters by rule group.
     :param level: Filters by rule level. Can be a single level (4) or an interval (2-4)
     :param filename: Filters by filename.
-    :param relative_path: Filters by rule path.
+    :param relative_dirname: Filters by relative dirname.
     :param pci_dss: Filters by PCI_DSS requirement name.
     :param gdpr: Filters by GDPR requirement.
     :param gpg13: Filters by GPG13 requirement.
@@ -53,7 +53,7 @@ def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, li
                 'group': group,
                 'level': level,
                 'filename': filename,
-                'relative_path': relative_path,
+                'relative_dirname': relative_dirname,
                 'pci_dss': pci_dss,
                 'gdpr': gdpr,
                 'gpg13': gpg13,
@@ -149,7 +149,7 @@ def get_rules_requirement(requirement=None, pretty=False, wait_for_complete=Fals
 @exception_handler
 @flask_cached
 def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, search=None,
-                    status=None, filename=None, relative_path=None):
+                    status=None, filename=None, relative_dirname=None):
     """Get all files which defines rules
 
     :param pretty: Show results in human-readable format
@@ -161,7 +161,7 @@ def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None,
     :param search: Looks for elements with the specified string
     :param status: Filters by rules status.
     :param filename: Filters by filename.
-    :param relative_path: Filters by relative_path.
+    :param relative_dirname: Filters by relative dirname.
     :return: Data object
     """
     f_kwargs = {'offset': offset,
@@ -172,7 +172,7 @@ def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'status': status,
                 'filename': filename,
-                'relative_path': relative_path}
+                'relative_dirname': relative_dirname}
 
     dapi = DistributedAPI(f=rule_framework.get_rules_files,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/rules_controller.py
+++ b/api/api/controllers/rules_controller.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
@@ -19,8 +19,8 @@ logger = logging.getLogger('wazuh')
 @exception_handler
 @flask_cached
 def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, search=None,
-              q=None, status=None, group=None, level=None, file=None, path=None, pci=None, gdpr=None, gpg13=None,
-              hipaa=None):
+              q=None, status=None, group=None, level=None, filename=None, relative_path=None, pci_dss=None, gdpr=None,
+              gpg13=None, hipaa=None):
     """Get information about all Wazuh rules.
 
     :param rule_ids: Filters by rule ID
@@ -35,9 +35,9 @@ def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, li
     :param status: Filters by rules status.
     :param group: Filters by rule group.
     :param level: Filters by rule level. Can be a single level (4) or an interval (2-4)
-    :param file: Filters by filename.
-    :param path: Filters by rule path.
-    :param pci: Filters by PCI requirement name.
+    :param filename: Filters by filename.
+    :param relative_path: Filters by rule path.
+    :param pci_dss: Filters by PCI_DSS requirement name.
     :param gdpr: Filters by GDPR requirement.
     :param gpg13: Filters by GPG13 requirement.
     :param hipaa: Filters by HIPAA requirement.
@@ -52,9 +52,9 @@ def get_rules(rule_ids=None, pretty=False, wait_for_complete=False, offset=0, li
                 'status': status,
                 'group': group,
                 'level': level,
-                'file': file,
-                'path': path,
-                'pci': pci,
+                'filename': filename,
+                'relative_path': relative_path,
+                'pci_dss': pci_dss,
                 'gdpr': gdpr,
                 'gpg13': gpg13,
                 'hipaa': hipaa,
@@ -114,7 +114,7 @@ def get_rules_groups(pretty=False, wait_for_complete=False, offset=0, limit=None
 @flask_cached
 def get_rules_requirement(requirement=None, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None,
                           search=None):
-    """Get all PCI requirements
+    """Get all specified requirements
 
     :param requirement: Get the specified requirement in all rules in the system.
     :param pretty: Show results in human-readable format
@@ -149,7 +149,7 @@ def get_rules_requirement(requirement=None, pretty=False, wait_for_complete=Fals
 @exception_handler
 @flask_cached
 def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None, search=None,
-                    status=None, file=None, path=None):
+                    status=None, filename=None, relative_path=None):
     """Get all files which defines rules
 
     :param pretty: Show results in human-readable format
@@ -160,17 +160,19 @@ def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None,
     ascending or descending order.
     :param search: Looks for elements with the specified string
     :param status: Filters by rules status.
-    :param file: Filters by filename.
-    :param path: Filters by rule path.
+    :param filename: Filters by filename.
+    :param relative_path: Filters by relative_path.
     :return: Data object
     """
-    f_kwargs = {'offset': offset, 'limit': limit,
-                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['file'],
+    f_kwargs = {'offset': offset,
+                'limit': limit,
+                'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['filename'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'status': status, 'file': file,
-                'path': path}
+                'status': status,
+                'filename': filename,
+                'relative_path': relative_path}
 
     dapi = DistributedAPI(f=rule_framework.get_rules_files,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -188,15 +190,15 @@ def get_rules_files(pretty=False, wait_for_complete=False, offset=0, limit=None,
 
 @exception_handler
 @flask_cached
-def get_download_file(pretty: bool = False, wait_for_complete: bool = False, file: str = None):
+def get_download_file(pretty: bool = False, wait_for_complete: bool = False, filename: str = None):
     """Download an specified decoder file.
 
     :param pretty: Show results in human-readable format
     :param wait_for_complete: Disable timeout response
-    :param file: File name to download.
+    :param filename: Filename to download.
     :return: Raw XML file
     """
-    f_kwargs = {'filename': file}
+    f_kwargs = {'filename': filename}
 
     dapi = DistributedAPI(f=rule_framework.get_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2546,13 +2546,13 @@ components:
     CDBListFile:
       type: object
       required:
-        - name
-        - path
+        - filename
+        - relative_dirname
       properties:
-        name:
+        filename:
           type: string
           description: Name of the CDB list file.
-        path:
+        relative_dirname:
           type: string
           format: etc_path
           description: Folder path of the CDB list. This path is relative to the Wazuh installation path.
@@ -3556,13 +3556,6 @@ components:
       schema:
         type: string
         format: etc_and_ruleset_path
-    relative_path_filter:
-      in: query
-      name: path
-      description: Filters by path
-      schema:
-        type: string
-        format: etc_file_path
     overwrite:
       in: query
       name: overwrite
@@ -7092,10 +7085,10 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/relative_path_filter'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
-
+        - $ref: '#/components/parameters/etc_and_ruleset_path'
+        - $ref: '#/components/parameters/filename'
       responses:
         '200':
           description: 'Successfully got all CDB lists and the files where they are defined'
@@ -7167,6 +7160,8 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/etc_and_ruleset_path'
+        - $ref: '#/components/parameters/filename'
       responses:
         '200':
           description: 'Successfully got CDB lists'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2922,9 +2922,9 @@ components:
         type: string
     downloadFile:
       in: path
-      name: file
+      name: filename
       required: True
-      description: File name to download.
+      description: Filename to download.
       schema:
         type: string
         format: alphanumeric
@@ -2953,9 +2953,9 @@ components:
         items:
           type: string
           format: names
-    file:
+    filename:
       in: query
-      name: file
+      name: filename
       description: Filters by filename.
       schema:
         type: array
@@ -3225,7 +3225,7 @@ components:
       required: true
       schema:
         type: string
-        enum: [pci, gdpr, hipaa, nist-800-53, gpg13]
+        enum: [pci_dss, gdpr, hipaa, nist-800-53, gpg13]
     result:
       in: query
       name: result
@@ -3551,8 +3551,8 @@ components:
         format: etc_and_ruleset_file_path
     etc_and_ruleset_path:
       in: query
-      name: path
-      description: Path to return.
+      name: relative_path
+      description: Filters by relative path
       schema:
         type: string
         format: etc_and_ruleset_path
@@ -3584,10 +3584,10 @@ components:
       schema:
         type: string
         format: range
-    pci:
+    pci_dss:
       in: query
-      name: pci
-      description: Filters by PCI requirement name.
+      name: pci_dss
+      description: Filters by PCI_DSS requirement name.
       schema:
         type: string
         format: alphanumeric
@@ -8099,7 +8099,7 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
         - $ref: '#/components/parameters/rootcheck_status'
-        - $ref: '#/components/parameters/pci'
+        - $ref: '#/components/parameters/pci_dss'
         - $ref: '#/components/parameters/cis'
       responses:
         '200':
@@ -8131,7 +8131,7 @@ paths:
                     - status: outstanding
                       readDay: "2019-03-08T09:20:05Z"
                       oldDay: "2019-03-08T09:20:05Z"
-                      pci: 2.2.4
+                      pci_dss: 2.2.4
                       event: "System Audit: SSH Hardening - 4: No Public Key authentication {PCI_DSS: 2.2.4}. File: /etc/ssh/sshd_config. Reference: 4 ."
         default:
           $ref: '#/components/responses/ResponseError'
@@ -8314,9 +8314,9 @@ paths:
         - $ref: '#/components/parameters/statusRLDParam'
         - $ref: '#/components/parameters/group'
         - $ref: '#/components/parameters/level'
-        - $ref: '#/components/parameters/file'
+        - $ref: '#/components/parameters/filename'
         - $ref: '#/components/parameters/etc_and_ruleset_path'
-        - $ref: '#/components/parameters/pci'
+        - $ref: '#/components/parameters/pci_dss'
         - $ref: '#/components/parameters/gdpr'
         - $ref: '#/components/parameters/gpg13'
         - $ref: '#/components/parameters/hipaa'
@@ -8350,7 +8350,7 @@ paths:
                       level: 0
                       nist_800_53: []
                       path: ruleset/rules
-                      pci: []
+                      pci_dss: []
                       status: enabled
                     - description: Generic template for all web proxy rules.
                       details:
@@ -8366,7 +8366,7 @@ paths:
                       level: 0
                       nist_800_53: []
                       path: ruleset/rules
-                      pci: []
+                      pci_dss: []
                       status: enabled
                   failed_items: []
                   total_affected_items: 54
@@ -8476,7 +8476,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/etc_and_ruleset_path'
-        - $ref: '#/components/parameters/file'
+        - $ref: '#/components/parameters/filename'
         - $ref: '#/components/parameters/statusRLDParam'
       responses:
         '200':
@@ -8512,7 +8512,7 @@ paths:
         default:
           $ref: '#/components/responses/ResponseError'
 
-  /rules/files/{file}/download:
+  /rules/files/{filename}/download:
     get:
       tags:
         - rules
@@ -8879,7 +8879,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/query'
-        - $ref: '#/components/parameters/file'
+        - $ref: '#/components/parameters/filename'
         - $ref: '#/components/parameters/etc_and_ruleset_path'
         - $ref: '#/components/parameters/statusRLDParam'
       responses:
@@ -8931,7 +8931,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
-        - $ref: '#/components/parameters/file'
+        - $ref: '#/components/parameters/filename'
         - $ref: '#/components/parameters/etc_and_ruleset_path'
         - $ref: '#/components/parameters/statusRLDParam'
       responses:
@@ -8965,7 +8965,7 @@ paths:
         default:
           $ref: '#/components/responses/ResponseError'
 
-  /decoders/files/{file}/download:
+  /decoders/files/{filename}/download:
     get:
       tags:
       - decoders

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -276,6 +276,32 @@ components:
               items:
                 $ref: '#/components/schemas/AgentIdKey'
 
+    AllItemsResponseRules:
+      allOf:
+        - $ref: '#/components/schemas/AllItemsResponse'
+        - type: object
+          required:
+            - affected_items
+          properties:
+            affected_items:
+              type: array
+              description: Items that successfully applied the API call action.
+              items:
+                $ref: '#/components/schemas/Rule'
+
+    AllItemsResponseRulesFiles:
+      allOf:
+        - $ref: '#/components/schemas/AllItemsResponse'
+        - type: object
+          required:
+            - affected_items
+          properties:
+            affected_items:
+              type: array
+              description: Items that successfully applied the API call action.
+              items:
+                $ref: '#/components/schemas/RuleFile'
+
     AllItemsResponseDecoders:
       allOf:
         - $ref: '#/components/schemas/AllItemsResponse'
@@ -313,9 +339,7 @@ components:
               type: array
               description: Items that successfully applied the API call action.
               items:
-                oneOf:
-                  - $ref: '#/components/schemas/CDBList'
-                  - $ref: '#/components/schemas/CDBListPair'
+                $ref: '#/components/schemas/CDBList'
 
     AllItemsResponseListsFiles:
       allOf:
@@ -357,32 +381,6 @@ components:
                 oneOf:
                   - $ref: '#/components/schemas/PoliciesResponse'
                   - type: integer
-
-    AllItemsResponseRules:
-      allOf:
-        - $ref: '#/components/schemas/AllItemsResponse'
-        - type: object
-          required:
-            - affected_items
-          properties:
-            affected_items:
-              type: array
-              description: Items that successfully applied the API call action.
-              items:
-                $ref: '#/components/schemas/Rules'
-
-    AllItemsResponseRulesFiles:
-      allOf:
-        - $ref: '#/components/schemas/AllItemsResponse'
-        - type: object
-          required:
-            - affected_items
-          properties:
-            affected_items:
-              type: array
-              description: Items that successfully applied the API call action.
-              items:
-                $ref: '#/components/schemas/RulesFiles'
 
     AllItemsResponseSyscollectorHardware:
       allOf:
@@ -641,6 +639,34 @@ components:
           description: Server hostname.
         timestamp:
           type: string
+
+    ## Ruleset models
+
+    RulesetFile:
+      type: object
+      required:
+        - filename
+        - relative_dirname
+      properties:
+        filename:
+          type: string
+          description: Name of the file.
+        relative_dirname:
+          type: string
+          format: etc_path
+          description: Folder path where the file is located. This path is relative to the Wazuh installation path.
+
+    RulesetStatus:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          description: Whether the specified rulesetfile is enabled or disabled in Wazuh.
+          enum:
+            - enabled
+            - disabled
 
     ## Active-response models
     ActiveResponseBody:
@@ -1801,25 +1827,14 @@ components:
           description: 'Date when the latest scan started. If no scans have been run, null will be returned.'
 
     # Rules models
-    RulesFiles:
-      type: object
-      properties:
-        filename:
-          type: string
-          description: Filename where the rule is defined.
-        relative_path:
-          type: string
-          description: Path where the file defining the rule is located. The path is relative to the Wazuh install path.
-        status:
-          type: string
-          description: Rule status.
-          enum:
-          - enabled
-          - disabled
-
-    Rules:
+    RuleFile:
       allOf:
-        - $ref: '#/components/schemas/RulesFiles'
+        - $ref: '#/components/schemas/RulesetFile'
+        - $ref: '#/components/schemas/RulesetStatus'
+
+    Rule:
+      allOf:
+        - $ref: '#/components/schemas/RuleFile'
         - type: object
           properties:
             description:
@@ -2055,22 +2070,9 @@ components:
               nullable: true
 
     DecoderFile:
-      type: object
-      required:
-      - filename
-      - status
-      - relative_path
-      properties:
-        filename:
-          type: string
-          description: Filename containing decoder definitions.
-        status:
-          type: string
-          description: Whether the decoders defined in that file are used by Wazuh or not.
-        relative_path:
-          type: string
-          format: ruleset_path
-          description: Decoder file path.
+      allOf:
+        - $ref: '#/components/schemas/RulesetFile'
+        - $ref: '#/components/schemas/RulesetStatus'
 
     # Syscollector models
     SyscollectorHardware:
@@ -2527,35 +2529,14 @@ components:
 
     # Lists models
     CDBList:
-      type: object
-      properties:
-        items:
-          type: array
-          items:
-            type: object
-            properties:
-              key:
-                type: string
-              value:
-                type: string
-        path:
-          type: string
-          format: etc_path
-          description: Filepath that contains the returned CDB definitions.
-
-    CDBListFile:
-      type: object
-      required:
-        - filename
-        - relative_dirname
-      properties:
-        filename:
-          type: string
-          description: Name of the CDB list file.
-        relative_dirname:
-          type: string
-          format: etc_path
-          description: Folder path of the CDB list. This path is relative to the Wazuh installation path.
+      allOf:
+        - $ref: '#/components/schemas/RulesetFile'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/CDBListPair'
 
     CDBListPair:
       type: object
@@ -2569,6 +2550,9 @@ components:
         value:
           type: string
           description: Value of the CDB list item value.
+
+    CDBListFile:
+      $ref: '#/components/schemas/RulesetFile'
 
     # Overview models
     OverviewAgents:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2546,21 +2546,16 @@ components:
     CDBListFile:
       type: object
       required:
-        - folder
         - name
         - path
       properties:
-        folder:
-          type: string
-          format: path
-          description: Folder path where the CDB list file is contained
         name:
           type: string
           description: Name of the CDB list file.
         path:
           type: string
           format: etc_path
-          description: File path of the CDB list. This path is relative to the Wazuh installation path.
+          description: Folder path of the CDB list. This path is relative to the Wazuh installation path.
 
     CDBListPair:
       type: object
@@ -7116,18 +7111,14 @@ paths:
               example:
                 data:
                   affected_items:
-                    - folder: etc/lists/amazon
+                    - path: etc/lists/amazon
                       name: aws-eventnames
-                      path: etc/lists/amazon/aws-eventnames
-                    - folder: etc/lists/amazon
+                    - path: etc/lists/amazon
                       name: aws-sources
-                      path: etc/lists/amazon/aws-sources
-                    - folder: etc/lists
+                    - path: etc/lists
                       name: audit-keys
-                      path: etc/lists/audit-keys
-                    - folder: etc/lists
+                    - path: etc/lists
                       name: security-eventchannel
-                      path: etc/lists/security-eventchannel
                   failed_items: []
                   total_affected_items: 4
                   total_failed_items: 0

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -7098,50 +7098,6 @@ paths:
 
       responses:
         '200':
-          description: 'Successfully got CDB lists'
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponseLists'
-              example:
-                data:
-                  affected_items:
-                    - path: etc/lists/amazon
-                      name: aws-eventnames
-                    - path: etc/lists/amazon
-                      name: aws-sources
-                    - path: etc/lists
-                      name: audit-keys
-                    - path: etc/lists
-                      name: security-eventchannel
-                  failed_items: []
-                  total_affected_items: 4
-                  total_failed_items: 0
-                message: All specified paths were shown
-        default:
-          $ref: '#/components/responses/ResponseError'
-
-  /lists/files:
-    get:
-      tags:
-      - lists
-      summary: 'Get paths from all CDB lists'
-      description: 'Returns the path from all CDB lists. Use this method to know all the CDB lists and their location in the filesystem relative to Wazuh installation folder'
-      operationId: api.controllers.lists_controller.get_lists_files
-      parameters:
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/sort'
-        - $ref: '#/components/parameters/search'
-      responses:
-        '200':
           description: 'Successfully got all CDB lists and the files where they are defined'
           content:
             application/json:
@@ -7151,7 +7107,7 @@ paths:
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/AllItemsResponseListsFiles'
+                        $ref: '#/components/schemas/AllItemsResponseLists'
               example:
                 data:
                   affected_items:
@@ -7193,6 +7149,51 @@ paths:
                   total_affected_items: 4
                   total_failed_items: 0
                 message: All specified lists were shown
+
+        default:
+          $ref: '#/components/responses/ResponseError'
+
+  /lists/files:
+    get:
+      tags:
+      - lists
+      summary: 'Get paths from all CDB lists'
+      description: 'Returns the path from all CDB lists. Use this method to know all the CDB lists and their location in the filesystem relative to Wazuh installation folder'
+      operationId: api.controllers.lists_controller.get_lists_files
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+      responses:
+        '200':
+          description: 'Successfully got CDB lists'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseListsFiles'
+              example:
+                data:
+                  affected_items:
+                    - path: etc/lists/amazon
+                      name: aws-eventnames
+                    - path: etc/lists/amazon
+                      name: aws-sources
+                    - path: etc/lists
+                      name: audit-keys
+                    - path: etc/lists
+                      name: security-eventchannel
+                  failed_items: []
+                  total_affected_items: 4
+                  total_failed_items: 0
+                message: All specified paths were shown
         default:
           $ref: '#/components/responses/ResponseError'
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1804,10 +1804,10 @@ components:
     RulesFiles:
       type: object
       properties:
-        file:
+        filename:
           type: string
           description: Filename where the rule is defined.
-        path:
+        relative_path:
           type: string
           description: Path where the file defining the rule is located. The path is relative to the Wazuh install path.
         status:
@@ -2057,17 +2057,17 @@ components:
     DecoderFile:
       type: object
       required:
-      - file
+      - filename
       - status
-      - path
+      - relative_path
       properties:
-        file:
+        filename:
           type: string
           description: Filename containing decoder definitions.
         status:
           type: string
           description: Whether the decoders defined in that file are used by Wazuh or not.
-        path:
+        relative_path:
           type: string
           format: ruleset_path
           description: Decoder file path.

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3551,8 +3551,8 @@ components:
         format: etc_and_ruleset_file_path
     etc_and_ruleset_path:
       in: query
-      name: relative_path
-      description: Filters by relative path
+      name: relative_dirname
+      description: Filters by relative directory name
       schema:
         type: string
         format: etc_and_ruleset_path

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -35,7 +35,7 @@ _ranges = re.compile(r'[\d]+$|^[\d]{1,2}\-[\d]{1,2}$')
 _etc_file_path = re.compile(r'^etc\/(ossec\.conf|(rules|decoders)\/[\w\-\/]+\.xml|lists\/[\w\-\.\/]+)$')
 _etc_and_ruleset_file_path = re.compile(
     r'(^etc\/ossec\.conf$)|(^(etc|ruleset)\/(decoders|rules)\/[\w\-\/]+\.{1}xml$)|(^etc\/lists\/[\w\-\.\/]+)$')
-_etc_and_ruleset_path = re.compile(r'(^(etc|ruleset)\/(decoders|rules))$')
+_etc_and_ruleset_path = re.compile(r'(^(etc|ruleset)\/(decoders|rules|lists(\/[\w\-\_]+)*))$')
 _search_param = re.compile(r'^[^;\|&\^*>]+$')
 _sort_param = re.compile(r'^[\w_\-\,\s\+\.]+$')
 _timeframe_type = re.compile(r'^(\d{1,}[d|h|m|s]?){1}$')

--- a/api/test/integration/test_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoders_endpoints.tavern.yaml
@@ -42,7 +42,7 @@ stages:
             - details: !anything
               filename: !anystr
               name: !anystr
-              relative_path: !anystr
+              relative_dirname: !anystr
               position: !anyint
               status: !anystr
           failed_items: []
@@ -52,7 +52,7 @@ stages:
       save:
         body:
           returned_filename: data.affected_items.0.filename
-          returned_relative_path: data.affected_items.0.relative_path
+          returned_relative_path: data.affected_items.0.relative_dirname
           returned_status: data.affected_items.0.status
           returned_name: data.affected_items.0.name
 
@@ -95,7 +95,7 @@ stages:
             - details: !anything
               filename: "{offset_item.filename}"
               name: "{offset_item.name}"
-              relative_path: "{offset_item.relative_path}"
+              relative_dirname: "{offset_item.relative_dirname}"
               position: !int "{offset_item.position}"
               status: "{offset_item.status}"
           failed_items: []
@@ -136,19 +136,19 @@ stages:
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-    # GET /decoders?limit=1&relative_path={returned_relative_path}
+    # GET /decoders?limit=1&relative_dirname={returned_relative_path}
   - name: Try to get decoders using limit and path parameter
     request:
       <<: *get_decoders
       params:
         limit: 1
-        relative_path: "{returned_relative_path:s}"
+        relative_dirname: "{returned_relative_path:s}"
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - relative_path: "{tavern.request_vars.params.relative_path}"
+            - relative_dirname: "{tavern.request_vars.params.relative_dirname}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
@@ -219,7 +219,7 @@ marks:
       key: field
       vals:
         - filename
-        - relative_path
+        - relative_dirname
         - name
         - position
         - status
@@ -283,7 +283,7 @@ stages:
             - details: !anything
               filename: !anystr
               name: "auditd-selinux_macstatus"
-              relative_path: !anystr
+              relative_dirname: !anystr
               position: !anyint
               status: !anystr
           failed_items: []
@@ -329,7 +329,7 @@ stages:
             - details: !anything
               filename: "{offset_item.filename}"
               name: "{offset_item.name}"
-              relative_path: "{offset_item.relative_path}"
+              relative_dirname: "{offset_item.relative_dirname}"
               position: !int "{offset_item.position}"
               status: "{offset_item.status}"
           failed_items: []
@@ -384,7 +384,7 @@ marks:
       key: field
       vals:
         - filename
-        - relative_path
+        - relative_dirname
         - name
         - position
         - status
@@ -457,7 +457,7 @@ stages:
         data:
           affected_items: &full_items_array_files
             - filename: !anystr
-              relative_path: !anystr
+              relative_dirname: !anystr
               status: !anystr
           failed_items: []
           total_affected_items: !anyint
@@ -466,7 +466,7 @@ stages:
       save:
         body:
           returned_files_filename: data.affected_items.0.filename
-          returned_files_relative_path: data.affected_items.0.relative_path
+          returned_files_relative_path: data.affected_items.0.relative_dirname
           returned_files_status: data.affected_items.0.status
 
 # We implement a dual stage to check offset parameter behaviour
@@ -506,7 +506,7 @@ stages:
           affected_items:
               # Check offset matches with previous request
             - filename: "{offset_item.filename}"
-              relative_path: "{offset_item.relative_path}"
+              relative_dirname: "{offset_item.relative_dirname}"
               status: "{offset_item.status}"
           failed_items: []
           total_affected_items: !anyint
@@ -546,19 +546,19 @@ stages:
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-    # GET /decoders/files?limit=1&relative_path={returned_files_relative_path}
-  - name: Try to get information about all decoders files using limit and relative_path parameter
+    # GET /decoders/files?limit=1&relative_dirname={returned_files_relative_path}
+  - name: Try to get information about all decoders files using limit and relative_dirname parameter
     request:
       <<: *get_decoders_files
       params:
         limit: 1
-        relative_path: "{returned_files_relative_path:s}"
+        relative_dirname: "{returned_files_relative_path:s}"
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - relative_path: "{tavern.request_vars.params.relative_path}"
+            - relative_dirname: "{tavern.request_vars.params.relative_dirname}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
@@ -611,7 +611,7 @@ marks:
       key: field
       vals:
         - filename
-        - relative_path
+        - relative_dirname
         - status
 
 stages:
@@ -683,7 +683,7 @@ stages:
             - details: !anything
               filename: !anystr
               name: !anystr
-              relative_path: !anystr
+              relative_dirname: !anystr
               position: !anyint
               status: !anystr
           total_affected_items: !anyint
@@ -725,7 +725,7 @@ stages:
             - details: !anything
               filename: "{offset_item.filename}"
               name: "{offset_item.name}"
-              relative_path: "{offset_item.relative_path}"
+              relative_dirname: "{offset_item.relative_dirname}"
               position: !int "{offset_item.position}"
               status: "{offset_item.status}"
           total_affected_items: !anyint
@@ -777,7 +777,7 @@ marks:
       vals:
         - filename
         - name
-        - relative_path
+        - relative_dirname
         - position
         - status
 

--- a/api/test/integration/test_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoders_endpoints.tavern.yaml
@@ -40,9 +40,9 @@ stages:
         data:
           affected_items: &full_items_array
             - details: !anything
-              file: !anystr
+              filename: !anystr
               name: !anystr
-              path: !anystr
+              relative_path: !anystr
               position: !anyint
               status: !anystr
           failed_items: []
@@ -51,8 +51,8 @@ stages:
       # Save some data for future use in the test
       save:
         body:
-          returned_file: data.affected_items.0.file
-          returned_path: data.affected_items.0.path
+          returned_filename: data.affected_items.0.filename
+          returned_relative_path: data.affected_items.0.relative_path
           returned_status: data.affected_items.0.status
           returned_name: data.affected_items.0.name
 
@@ -93,9 +93,9 @@ stages:
           affected_items:
               # Check offset matches with previous request
             - details: !anything
-              file: "{offset_item.file}"
+              filename: "{offset_item.filename}"
               name: "{offset_item.name}"
-              path: "{offset_item.path}"
+              relative_path: "{offset_item.relative_path}"
               position: !int "{offset_item.position}"
               status: "{offset_item.status}"
           failed_items: []
@@ -119,36 +119,36 @@ stages:
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-    # GET /decoders?limit=1&file={returned_file}
-  - name: Try to get decoders using limit and file parameter
+    # GET /decoders?limit=1&filename={returned_file}
+  - name: Try to get decoders using limit and filename parameter
     request:
       <<: *get_decoders
       params:
         limit: 1
-        file: "{returned_file:s}"
+        filename: "{returned_filename:s}"
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - file: "{tavern.request_vars.params.file}"
+            - filename: "{tavern.request_vars.params.filename}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-    # GET /decoders?limit=1&path={returned_path}
+    # GET /decoders?limit=1&relative_path={returned_relative_path}
   - name: Try to get decoders using limit and path parameter
     request:
       <<: *get_decoders
       params:
         limit: 1
-        path: "{returned_path:s}"
+        relative_path: "{returned_relative_path:s}"
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - path: "{tavern.request_vars.params.path}"
+            - relative_path: "{tavern.request_vars.params.relative_path}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
@@ -218,8 +218,8 @@ marks:
   - parametrize:
       key: field
       vals:
-        - file
-        - path
+        - filename
+        - relative_path
         - name
         - position
         - status
@@ -281,9 +281,9 @@ stages:
         data: &decoder_name_response
           affected_items:
             - details: !anything
-              file: !anystr
+              filename: !anystr
               name: "auditd-selinux_macstatus"
-              path: !anystr
+              relative_path: !anystr
               position: !anyint
               status: !anystr
           failed_items: []
@@ -327,9 +327,9 @@ stages:
           affected_items:
               # Check offset matches with previous request
             - details: !anything
-              file: "{offset_item.file}"
+              filename: "{offset_item.filename}"
               name: "{offset_item.name}"
-              path: "{offset_item.path}"
+              relative_path: "{offset_item.relative_path}"
               position: !int "{offset_item.position}"
               status: "{offset_item.status}"
           failed_items: []
@@ -383,8 +383,8 @@ marks:
   - parametrize:
       key: field
       vals:
-        - file
-        - path
+        - filename
+        - relative_path
         - name
         - position
         - status
@@ -456,8 +456,8 @@ stages:
       body:
         data:
           affected_items: &full_items_array_files
-            - file: !anystr
-              path: !anystr
+            - filename: !anystr
+              relative_path: !anystr
               status: !anystr
           failed_items: []
           total_affected_items: !anyint
@@ -465,8 +465,8 @@ stages:
       # Save some data for future use in the test
       save:
         body:
-          returned_files_file: data.affected_items.0.file
-          returned_files_path: data.affected_items.0.path
+          returned_files_filename: data.affected_items.0.filename
+          returned_files_relative_path: data.affected_items.0.relative_path
           returned_files_status: data.affected_items.0.status
 
 # We implement a dual stage to check offset parameter behaviour
@@ -505,8 +505,8 @@ stages:
         data:
           affected_items:
               # Check offset matches with previous request
-            - file: "{offset_item.file}"
-              path: "{offset_item.path}"
+            - filename: "{offset_item.filename}"
+              relative_path: "{offset_item.relative_path}"
               status: "{offset_item.status}"
           failed_items: []
           total_affected_items: !anyint
@@ -529,36 +529,36 @@ stages:
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-    # GET /decoders/files?limit=1&file={returned_files_file}
+    # GET /decoders/files?limit=1&filename={returned_files_filename}
   - name: Try to get information about all decoders files using limit and file parameter
     request:
       <<: *get_decoders_files
       params:
         limit: 1
-        file: "{returned_files_file:s}"
+        filename: "{returned_files_filename:s}"
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - file: "{tavern.request_vars.params.file}"
+            - filename: "{tavern.request_vars.params.filename}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-    # GET /decoders/files?limit=1&path={returned_files_path}
-  - name: Try to get information about all decoders files using limit and path parameter
+    # GET /decoders/files?limit=1&relative_path={returned_files_relative_path}
+  - name: Try to get information about all decoders files using limit and relative_path parameter
     request:
       <<: *get_decoders_files
       params:
         limit: 1
-        path: "{returned_files_path:s}"
+        relative_path: "{returned_files_relative_path:s}"
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - path: "{tavern.request_vars.params.path}"
+            - relative_path: "{tavern.request_vars.params.relative_path}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
@@ -610,8 +610,8 @@ marks:
   - parametrize:
       key: field
       vals:
-        - file
-        - path
+        - filename
+        - relative_path
         - status
 
 stages:
@@ -681,9 +681,9 @@ stages:
         data:
           affected_items: &full_items_array_parents
             - details: !anything
-              file: !anystr
+              filename: !anystr
               name: !anystr
-              path: !anystr
+              relative_path: !anystr
               position: !anyint
               status: !anystr
           total_affected_items: !anyint
@@ -723,9 +723,9 @@ stages:
           affected_items:
               # Check offset matches with previous request
             - details: !anything
-              file: "{offset_item.file}"
+              filename: "{offset_item.filename}"
               name: "{offset_item.name}"
-              path: "{offset_item.path}"
+              relative_path: "{offset_item.relative_path}"
               position: !int "{offset_item.position}"
               status: "{offset_item.status}"
           total_affected_items: !anyint
@@ -775,9 +775,9 @@ marks:
   - parametrize:
       key: field
       vals:
-        - file
+        - filename
         - name
-        - path
+        - relative_path
         - position
         - status
 
@@ -819,7 +819,7 @@ stages:
   - name: Download a decoders file
     request:
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/{returned_file:s}/download"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/{returned_filename:s}/download"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_lists_endpoints.tavern.yaml
@@ -265,8 +265,7 @@ stages:
       body:
         data:
           affected_items: &full_items_array_files
-            - folder: !anystr
-              name: !anystr
+            - name: !anystr
               path: !anystr
           failed_items: []
           total_affected_items: !anyint
@@ -274,7 +273,6 @@ stages:
       # Save some data for future use in the test
       save:
         body:
-          returned_folder: data.affected_items.0.folder
           returned_name: data.affected_items.0.name
           returned_path: data.affected_items.0.path
 
@@ -299,7 +297,6 @@ stages:
       # Save second item to check offset in next stage
       save:
         body:
-          offset_item_folder: data.affected_items.1.folder
           offset_item_name: data.affected_items.1.name
           offset_item_path: data.affected_items.1.path
 
@@ -316,8 +313,7 @@ stages:
         data:
           affected_items:
               # Check offset matches with previous request
-            - folder: "{offset_item_folder}"
-              name: "{offset_item_name}"
+            - name: "{offset_item_name}"
               path: "{offset_item_path}"
           failed_items: []
           total_affected_items: !anyint
@@ -351,10 +347,9 @@ stages:
       status_code: 200
       body:
         data:
-          affected_items:
-            - <<: *full_items_array_files
+          affected_items: []
           failed_items: []
-          total_affected_items: !anyint
+          total_affected_items: 0
           total_failed_items: 0
 
     # GET /lists/files?limit=1&search=empty_search

--- a/api/test/integration/test_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_lists_endpoints.tavern.yaml
@@ -51,14 +51,16 @@ stages:
         data:
           affected_items:
             - items: !anything
-              path: !anystr
+              relative_dirname: !anystr
+              filename: !anystr
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
       # Save some data for future use in the test
       save:
         body:
-          returned_path: data.affected_items.0.path
+          returned_relative_dirname: data.affected_items.0.relative_dirname
+          returned_filename: data.affected_items.0.filename
 
     # We implement a dual stage to check offset parameter behaviour
     # GET /lists?limit=2&offset=0
@@ -74,16 +76,19 @@ stages:
         data:
           affected_items:
             - items: !anything
-              path: !anystr
+              relative_dirname: !anystr
+              filename: !anystr
             - items: !anything
-              path: !anystr
+              relative_dirname: !anystr
+              filename: !anystr
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
       # Save second item to check offset in next stage
       save:
         body:
-          offset_item_path: data.affected_items.1.path
+          offset_item_relative_dirname: data.affected_items.1.relative_dirname
+          offset_item_filename: data.affected_items.1.filename
 
     # GET /lists?limit=1&offset=1
   - name: Try to get lists using limit and offset parameter
@@ -98,18 +103,19 @@ stages:
         data:
           affected_items:
             - items: !anything
-              path: "{offset_item_path}"
+              relative_dirname: "{offset_item_relative_dirname}"
+              filename: "{offset_item_filename}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
 
-    # GET /lists?limit=1&search={returned_path:s}
+    # GET /lists?limit=1&search={returned_relative_dirname:s}
   - name: Try to get lists using limit and search parameter
     request:
       <<: *get_lists
       params:
         limit: 1
-        search: "{returned_path:s}"
+        search: "{returned_relative_dirname:s}"
     response:
       status_code: 200
       body:
@@ -120,13 +126,13 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-    # GET /lists?limit=1&search=-{returned_path:s}
+    # GET /lists?limit=1&search=-{returned_filename:s}
   - name: Try to get lists using limit and search parameter
     request:
       <<: *get_lists
       params:
         limit: 1
-        search: "-{returned_path:s}"
+        search: "-{returned_filename:s}"
     response:
       status_code: 200
       body:
@@ -153,75 +159,63 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
-    # GET /lists?limit=1&path={returned_path}
-  - name: Try to get lists using limit and path parameter
+    # GET /lists?limit=1&relative_dirname={returned_relative_dirname}
+  - name: Try to get lists using limit and relative_dirname parameter
     request:
       <<: *get_lists
       params:
         limit: 1
-        path: "{returned_path:s}"
+        relative_dirname: "{returned_relative_dirname:s}"
     response:
       status_code: 200
       body:
         data:
           affected_items:
             - items: !anything
-              path: "{tavern.request_vars.params.path}"
+              relative_dirname: "{tavern.request_vars.params.relative_dirname}"
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
 
-    # GET /lists?limit=1&path=wrong_path
-  - name: Try to get lists using limit and a wrong path parameter
+    # GET /lists?limit=1&relative_dirname=wrong_dirname
+  - name: Try to get lists using limit and a wrong relative_dirname parameter
     request:
       <<: *get_lists
       params:
         limit: 1
-        path: "wrong_path"
+        relative_dirname: "wrong_relative_dirname"
     response:
       status_code: 400
 
-    # GET /lists?path=etc/files/audit-keys.cdb
-  - name: Try to get a CBD list from a bad format etc file path
+    # GET /lists?relative_dirname=etc/files
+  - name: Try to get a CBD list from a bad format etc path
     request:
       method: GET
       url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        path: "etc/lists/audit-keys.cdb"
+        relative_dirname: "etc/files"
     response:
       status_code: 400
-      body:
-        code: 1800
 
-    # GET /lists?path=wrong_filepath
-  - name: Try to get a CBD list from a non existing etc file path
+    # GET /lists?filename=wrong_filename
+  - name: Try to get a CBD list from a non existing filename
     request:
       method: GET
       url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        path: "etc/lists/wrong_filepath"
+        filename: "wrong_dirname"
     response:
-      status_code: 400
+      status_code: 200
       body:
-        code: 1802
-
-    # GET /lists?path=etc/lists/amazon
-  - name: Try to get a CBD list from a directory instead of a file
-    request:
-      method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        path: "etc/lists/amazon"
-    response:
-      status_code: 400
-      body:
-        code: 1804
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
 
 ---
 test_name: GET /lists/files
@@ -265,16 +259,16 @@ stages:
       body:
         data:
           affected_items: &full_items_array_files
-            - name: !anystr
-              path: !anystr
+            - relative_dirname: !anystr
+              filename: !anystr
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
       # Save some data for future use in the test
       save:
         body:
-          returned_name: data.affected_items.0.name
-          returned_path: data.affected_items.0.path
+          returned_relative_dirname: data.affected_items.0.relative_dirname
+          returned_filename: data.affected_items.0.filename
 
     # We implement a dual stage to check offset parameter behaviour
     # GET /lists/files?limit=2&offset=0
@@ -297,8 +291,8 @@ stages:
       # Save second item to check offset in next stage
       save:
         body:
-          offset_item_name: data.affected_items.1.name
-          offset_item_path: data.affected_items.1.path
+          offset_item_relative_dirname: data.affected_items.1.relative_dirname
+          offset_item_filename: data.affected_items.1.filename
 
     # GET /lists/files?limit=1&offset=1
   - name: Try to get paths from all CDB lists using limit and offset parameter
@@ -313,19 +307,19 @@ stages:
         data:
           affected_items:
               # Check offset matches with previous request
-            - name: "{offset_item_name}"
-              path: "{offset_item_path}"
+            - filename: "{offset_item_filename}"
+              relative_dirname: "{offset_item_relative_dirname}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
 
-    # GET /lists/files?limit=1&search={returned_path:s}
+    # GET /lists/files?limit=1&search={returned_relative_dirname:s}
   - name: Try to get paths from all CDB lists using limit and search parameter
     request:
       <<: *get_lists_files
       params:
         limit: 1
-        search: "{returned_path:s}"
+        search: "{returned_relative_dirname:s}"
     response:
       status_code: 200
       body:
@@ -336,13 +330,13 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-    # GET /lists/files?limit=1&search=-{returned_path:s}
+    # GET /lists/files?limit=1&search=-{returned_relative_dirname:s}
   - name: Try to get paths from all CDB lists using limit and search parameter
     request:
       <<: *get_lists_files
       params:
         limit: 1
-        search: "-{returned_path:s}"
+        search: "-{returned_relative_dirname:s}"
     response:
       status_code: 200
       body:

--- a/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
@@ -29,7 +29,7 @@ stages:
               details: !anything
               filename: 0006-json_decoders.xml
               name: !anystr
-              relative_path: !anystr
+              relative_dirname: !anystr
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders
@@ -108,19 +108,19 @@ stages:
         data:
           affected_items:
             - filename: 0006-json_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
             - filename: 0010-active-response_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
             - filename: 0015-aix-ipsec_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
             - filename: 0025-apache_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
             - filename: 0030-arpwatch_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
           failed_items: []
           total_affected_items: !anyint
@@ -141,10 +141,10 @@ stages:
         data:
           affected_items:
             - filename: 0006-json_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
             - filename: 0025-apache_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
           failed_items:
             - error:
@@ -225,7 +225,7 @@ stages:
               details: !anything
               filename: 0006-json_decoders.xml
               name: !anystr
-              relative_path: !anystr
+              relative_dirname: !anystr
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders_parent

--- a/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
@@ -27,19 +27,19 @@ stages:
           affected_items:
             - &full_item_decoders
               details: !anything
-              file: 0006-json_decoders.xml
+              filename: 0006-json_decoders.xml
               name: !anystr
-              path: !anystr
+              relative_path: !anystr
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders
-              file: 0010-active-response_decoders.xml
+              filename: 0010-active-response_decoders.xml
             - <<: *full_item_decoders
-              file: 0010-active-response_decoders.xml
+              filename: 0010-active-response_decoders.xml
             - <<: *full_item_decoders
-              file: 0010-active-response_decoders.xml
+              filename: 0010-active-response_decoders.xml
             - <<: *full_item_decoders
-              file: 0015-aix-ipsec_decoders.xml
+              filename: 0015-aix-ipsec_decoders.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -52,7 +52,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        q: 'file=0005-wazuh_decoders.xml'
+        q: 'filename=0005-wazuh_decoders.xml'
     response:
       status_code: 200
       body:
@@ -107,20 +107,20 @@ stages:
       body:
         data:
           affected_items:
-            - file: 0006-json_decoders.xml
-              path: ruleset/decoders
+            - filename: 0006-json_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
-            - file: 0010-active-response_decoders.xml
-              path: ruleset/decoders
+            - filename: 0010-active-response_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
-            - file: 0015-aix-ipsec_decoders.xml
-              path: ruleset/decoders
+            - filename: 0015-aix-ipsec_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
-            - file: 0025-apache_decoders.xml
-              path: ruleset/decoders
+            - filename: 0025-apache_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
-            - file: 0030-arpwatch_decoders.xml
-              path: ruleset/decoders
+            - filename: 0030-arpwatch_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
           failed_items: []
           total_affected_items: !anyint
@@ -134,17 +134,17 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: 0005-wazuh_decoders.xml,0006-json_decoders.xml,0025-apache_decoders.xml
+        filename: 0005-wazuh_decoders.xml,0006-json_decoders.xml,0025-apache_decoders.xml
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - file: 0006-json_decoders.xml
-              path: ruleset/decoders
+            - filename: 0006-json_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
-            - file: 0025-apache_decoders.xml
-              path: ruleset/decoders
+            - filename: 0025-apache_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
           failed_items:
             - error:
@@ -162,7 +162,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: 0160-netscaler_decoders.xml,0005-wazuh_decoders.xml
+        filename: 0160-netscaler_decoders.xml,0005-wazuh_decoders.xml
     response:
       status_code: 400
       body: &permissions_denied
@@ -181,7 +181,7 @@ test_name: GET DECODERS FILES RBAC (Download)
 
 stages:
 
-  - name: Try get one decoder file
+  - name: Try to get one decoder file
     request:
       url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0025-apache_decoders.xml/download"
       headers:
@@ -192,7 +192,7 @@ stages:
       headers:
         content-type: application/xml
 
-  - name: Try get one decoder file (no permissions)
+  - name: Try to get one decoder file (no permissions)
     request:
       url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml/download"
       headers:
@@ -223,19 +223,19 @@ stages:
           affected_items:
             - &full_item_decoders_parent
               details: !anything
-              file: 0006-json_decoders.xml
+              filename: 0006-json_decoders.xml
               name: !anystr
-              path: !anystr
+              relative_path: !anystr
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders_parent
-              file: 0010-active-response_decoders.xml
+              filename: 0010-active-response_decoders.xml
             - <<: *full_item_decoders_parent
-              file: 0015-aix-ipsec_decoders.xml
+              filename: 0015-aix-ipsec_decoders.xml
             - <<: *full_item_decoders_parent
-              file: 0025-apache_decoders.xml
+              filename: 0025-apache_decoders.xml
             - <<: *full_item_decoders_parent
-              file: 0025-apache_decoders.xml
+              filename: 0025-apache_decoders.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0

--- a/api/test/integration/test_rbac_black_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_lists_endpoints.tavern.yaml
@@ -24,29 +24,32 @@ stages:
         data:
           affected_items:
             - items: !anything
-              path: etc/lists/amazon/aws-sources
+              filename: security-eventchannel
+              relative_dirname: etc/lists
             - items: !anything
-              path: etc/lists/security-eventchannel
+              filename: aws-sources
+              relative_dirname: etc/lists/amazon
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
         message: All specified lists were shown
 
-  - name: Try to show an specified path (Allow)
+  - name: Try to show an specified filename (Allow)
     request:
       url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        path: etc/lists/amazon/aws-sources
+        filename: aws-sources
     response:
       status_code: 200
       body:
         data:
           affected_items:
             - items: !anything
-              path: etc/lists/amazon/aws-sources
+              filename: aws-sources
+              relative_dirname: etc/lists/amazon
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -59,7 +62,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        path: etc/lists/audit-keys
+        relative_dirname: etc/lists
+        filename: audit-keys
     response:
       status_code: 400
       body:
@@ -88,10 +92,10 @@ stages:
       body:
         data:
           affected_items:
-            - name: security-eventchannel
-              path: etc/lists
-            - name: aws-sources
-              path: etc/lists/amazon
+            - filename: security-eventchannel
+              relative_dirname: etc/lists
+            - filename: aws-sources
+              relative_dirname: etc/lists/amazon
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0

--- a/api/test/integration/test_rbac_black_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_lists_endpoints.tavern.yaml
@@ -88,12 +88,10 @@ stages:
       body:
         data:
           affected_items:
-            - folder: etc/lists/amazon
-              name: aws-sources
-              path: etc/lists/amazon/aws-sources
-            - folder: etc/lists
-              name: security-eventchannel
-              path: etc/lists/security-eventchannel
+            - name: security-eventchannel
+              path: etc/lists
+            - name: aws-sources
+              path: etc/lists/amazon
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0

--- a/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
@@ -28,7 +28,7 @@ stages:
             - &full_item_rules
               description: !anystr
               details: !anything
-              file: 0016-wazuh_rules.xml
+              filename: 0016-wazuh_rules.xml
               gdpr: !anything
               gpg13: !anything
               groups: !anything
@@ -36,8 +36,8 @@ stages:
               id: !anyint
               level: !anyint
               nist_800_53: !anything
-              path: !anystr
-              pci: !anything
+              relative_path: !anystr
+              pci_dss: !anything
               status: !anystr
             - <<: *full_item_rules
             - <<: *full_item_rules
@@ -55,7 +55,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        q: 'file=0010-rules_config.xml'
+        q: 'filename=0010-rules_config.xml'
     response:
       status_code: 200
       body:
@@ -113,17 +113,17 @@ stages:
         data:
           affected_items:
             - &full_item_rules_files
-              file: 0016-wazuh_rules.xml
-              path: ruleset/rules
+              filename: 0016-wazuh_rules.xml
+              relative_path: ruleset/rules
               status: enabled
             - <<: *full_item_rules_files
-              file: 0020-syslog_rules.xml
+              filename: 0020-syslog_rules.xml
             - <<: *full_item_rules_files
-              file: 0025-sendmail_rules.xml
+              filename: 0025-sendmail_rules.xml
             - <<: *full_item_rules_files
-              file: 0030-postfix_rules.xml
+              filename: 0030-postfix_rules.xml
             - <<: *full_item_rules_files
-              file: 0035-spamd_rules.xml
+              filename: 0035-spamd_rules.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -136,17 +136,17 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: local_rules.xml,0620-win-generic_rules.xml
+        filename: local_rules.xml,0620-win-generic_rules.xml
     response:
       status_code: 200
       body:
         data:
           affected_items:
             - <<: *full_item_rules_files
-              file: 0620-win-generic_rules.xml
+              filename: 0620-win-generic_rules.xml
             - <<: *full_item_rules_files
-              file: local_rules.xml
-              path: etc/rules
+              filename: local_rules.xml
+              relative_path: etc/rules
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
@@ -159,15 +159,15 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: local_rules.xml,0015-ossec_rules.xml,0010-rules_config.xml
+        filename: local_rules.xml,0015-ossec_rules.xml,0010-rules_config.xml
     response:
       status_code: 200
       body:
         data:
           affected_items:
             - <<: *full_item_rules_files
-              file: local_rules.xml
-              path: etc/rules
+              filename: local_rules.xml
+              relative_path: etc/rules
           failed_items:
             - error:
                 code: 4000
@@ -185,7 +185,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: 0015-ossec_rules.xml,0010-rules_config.xml
+        filename: 0015-ossec_rules.xml,0010-rules_config.xml
     response:
       status_code: 400
       body: &permissions_denied
@@ -248,13 +248,13 @@ stages:
         message: !anystr
 
 ---
-test_name: GET PCI REQUIREMENT RBAC
+test_name: GET pci_dss REQUIREMENT RBAC
 
 stages:
 
   - name: Try to show the groups of rules in the system
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
@@ -36,7 +36,7 @@ stages:
               id: !anyint
               level: !anyint
               nist_800_53: !anything
-              relative_path: !anystr
+              relative_dirname: !anystr
               pci_dss: !anything
               status: !anystr
             - <<: *full_item_rules
@@ -114,7 +114,7 @@ stages:
           affected_items:
             - &full_item_rules_files
               filename: 0016-wazuh_rules.xml
-              relative_path: ruleset/rules
+              relative_dirname: ruleset/rules
               status: enabled
             - <<: *full_item_rules_files
               filename: 0020-syslog_rules.xml
@@ -146,7 +146,7 @@ stages:
               filename: 0620-win-generic_rules.xml
             - <<: *full_item_rules_files
               filename: local_rules.xml
-              relative_path: etc/rules
+              relative_dirname: etc/rules
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
@@ -167,7 +167,7 @@ stages:
           affected_items:
             - <<: *full_item_rules_files
               filename: local_rules.xml
-              relative_path: etc/rules
+              relative_dirname: etc/rules
           failed_items:
             - error:
                 code: 4000

--- a/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
@@ -27,9 +27,9 @@ stages:
           affected_items:
             - &full_item_decoders
               details: !anything
-              file: 0005-wazuh_decoders.xml
+              filename: 0005-wazuh_decoders.xml
               name: !anystr
-              path: !anystr
+              relative_path: !anystr
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders
@@ -48,7 +48,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        q: 'file=0006-json_decoders.xml'
+        q: 'filename=0006-json_decoders.xml'
     response:
       status_code: 200
       body:
@@ -79,7 +79,7 @@ stages:
             - <<: *full_item_decoders
             - <<: *full_item_decoders
             - <<: *full_item_decoders
-              file: 0160-netscaler_decoders.xml
+              filename: 0160-netscaler_decoders.xml
           failed_items:
             - error:
                 code: 1504
@@ -107,11 +107,11 @@ stages:
       body:
         data:
           affected_items:
-            - file: 0005-wazuh_decoders.xml
-              path: ruleset/decoders
+            - filename: 0005-wazuh_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
-            - file: 0160-netscaler_decoders.xml
-              path: ruleset/decoders
+            - filename: 0160-netscaler_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
           failed_items: []
           total_affected_items: !anyint
@@ -125,17 +125,17 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: 0005-wazuh_decoders.xml,0160-netscaler_decoders.xml
+        filename: 0005-wazuh_decoders.xml,0160-netscaler_decoders.xml
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - file: 0005-wazuh_decoders.xml
-              path: ruleset/decoders
+            - filename: 0005-wazuh_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
-            - file: 0160-netscaler_decoders.xml
-              path: ruleset/decoders
+            - filename: 0160-netscaler_decoders.xml
+              relative_path: ruleset/decoders
               status: enabled
           failed_items: []
           total_affected_items: !anyint
@@ -149,7 +149,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: 0064-cisco-asa_decoders.xml,0100-fortigate_decoders.xml
+        filename: 0064-cisco-asa_decoders.xml,0100-fortigate_decoders.xml
     response:
       status_code: 400
       body: &permissions_denied
@@ -168,7 +168,7 @@ test_name: GET DECODERS FILES RBAC (Download)
 
 stages:
 
-  - name: Try get one decoder file
+  - name: Try to get one decoder file
     request:
       url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml/download"
       headers:
@@ -179,7 +179,7 @@ stages:
       headers:
         content-type: application/xml
 
-  - name: Try get one decoder file (no permissions)
+  - name: Try to get one decoder file (no permissions)
     request:
       url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0064-cisco-asa_decoders.xml/download"
       headers:

--- a/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
@@ -29,7 +29,7 @@ stages:
               details: !anything
               filename: 0005-wazuh_decoders.xml
               name: !anystr
-              relative_path: !anystr
+              relative_dirname: !anystr
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders
@@ -108,10 +108,10 @@ stages:
         data:
           affected_items:
             - filename: 0005-wazuh_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
             - filename: 0160-netscaler_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
           failed_items: []
           total_affected_items: !anyint
@@ -132,10 +132,10 @@ stages:
         data:
           affected_items:
             - filename: 0005-wazuh_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
             - filename: 0160-netscaler_decoders.xml
-              relative_path: ruleset/decoders
+              relative_dirname: ruleset/decoders
               status: enabled
           failed_items: []
           total_affected_items: !anyint

--- a/api/test/integration/test_rbac_white_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_lists_endpoints.tavern.yaml
@@ -24,29 +24,32 @@ stages:
         data:
           affected_items:
             - items: !anything
-              path: etc/lists/amazon/aws-eventnames
+              filename: audit-keys
+              relative_dirname: etc/lists
             - items: !anything
-              path: etc/lists/audit-keys
+              filename: aws-eventnames
+              relative_dirname: etc/lists/amazon
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
         message: All specified lists were shown
 
-  - name: Try to show an specified path (Allow)
+  - name: Try to show an specified filename (Allow)
     request:
       url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        path: etc/lists/audit-keys
+        filename: audit-keys
     response:
       status_code: 200
       body:
         data:
           affected_items:
             - items: !anything
-              path: etc/lists/audit-keys
+              filename: audit-keys
+              relative_dirname: etc/lists
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -59,7 +62,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        path: etc/lists/amazon/aws-sources
+        relative_dirname: etc/lists/amazon
+        filename: aws-sources
     response:
       status_code: 400
       body:
@@ -88,10 +92,10 @@ stages:
       body:
         data:
           affected_items:
-            - name: audit-keys
-              path: etc/lists
-            - name: aws-eventnames
-              path: etc/lists/amazon
+            - filename: audit-keys
+              relative_dirname: etc/lists
+            - filename: aws-eventnames
+              relative_dirname: etc/lists/amazon
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0

--- a/api/test/integration/test_rbac_white_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_lists_endpoints.tavern.yaml
@@ -88,12 +88,10 @@ stages:
       body:
         data:
           affected_items:
-            - folder: etc/lists/amazon
-              name: aws-eventnames
-              path: etc/lists/amazon/aws-eventnames
-            - folder: etc/lists
-              name: audit-keys
-              path: etc/lists/audit-keys
+            - name: audit-keys
+              path: etc/lists
+            - name: aws-eventnames
+              path: etc/lists/amazon
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0

--- a/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
@@ -36,7 +36,7 @@ stages:
               id: !anyint
               level: !anyint
               nist_800_53: !anything
-              relative_path: !anystr
+              relative_dirname: !anystr
               pci_dss: !anything
               status: !anystr
             - <<: *full_item_rules
@@ -117,7 +117,7 @@ stages:
           affected_items:
             - &full_item_rules_files
               filename: 0010-rules_config.xml
-              relative_path: ruleset/rules
+              relative_dirname: ruleset/rules
               status: enabled
             - <<: *full_item_rules_files
               filename: 0015-ossec_rules.xml

--- a/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
@@ -28,7 +28,7 @@ stages:
             - &full_item_rules
               description: !anystr
               details: !anything
-              file: 0010-rules_config.xml
+              filename: 0010-rules_config.xml
               gdpr: !anything
               gpg13: !anything
               groups: !anything
@@ -36,8 +36,8 @@ stages:
               id: !anyint
               level: !anyint
               nist_800_53: !anything
-              path: !anystr
-              pci: !anything
+              relative_path: !anystr
+              pci_dss: !anything
               status: !anystr
             - <<: *full_item_rules
             - <<: *full_item_rules
@@ -55,7 +55,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        q: 'file=0020-syslog_rules.xml'
+        q: 'filename=0020-syslog_rules.xml'
     response:
       status_code: 200
       body:
@@ -84,10 +84,10 @@ stages:
             - <<: *full_item_rules
               id: 2
             - <<: *full_item_rules
-              file: 0015-ossec_rules.xml
+              filename: 0015-ossec_rules.xml
               id: 500
             - <<: *full_item_rules
-              file: 0015-ossec_rules.xml
+              filename: 0015-ossec_rules.xml
               id: 700
           failed_items:
             - error:
@@ -116,11 +116,11 @@ stages:
         data:
           affected_items:
             - &full_item_rules_files
-              file: 0010-rules_config.xml
-              path: ruleset/rules
+              filename: 0010-rules_config.xml
+              relative_path: ruleset/rules
               status: enabled
             - <<: *full_item_rules_files
-              file: 0015-ossec_rules.xml
+              filename: 0015-ossec_rules.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -133,16 +133,16 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: 0015-ossec_rules.xml,0010-rules_config.xml
+        filename: 0015-ossec_rules.xml,0010-rules_config.xml
     response:
       status_code: 200
       body:
         data:
           affected_items:
             - <<: *full_item_rules_files
-              file: 0010-rules_config.xml
+              filename: 0010-rules_config.xml
             - <<: *full_item_rules_files
-              file: 0015-ossec_rules.xml
+              filename: 0015-ossec_rules.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -155,7 +155,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        file: 0011-ossec_rules.xml,0011-rules_config.xml
+        filename: 0011-ossec_rules.xml,0011-rules_config.xml
     response:
       status_code: 400
       body: &permissions_denied
@@ -218,13 +218,13 @@ stages:
         message: !anystr
 
 ---
-test_name: GET PCI REQUIREMENT RBAC
+test_name: GET pci_dss REQUIREMENT RBAC
 
 stages:
 
   - name: Try to show the groups of rules in the system
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rules_endpoints.tavern.yaml
@@ -33,7 +33,7 @@ stages:
               groups: !anything
               id: !anyint
               level: !anyint
-              relative_path: !anystr
+              relative_dirname: !anystr
               pci_dss: !anything
               status: !anystr
               gpg13: !anything
@@ -350,11 +350,11 @@ stages:
       body:
         <<: *error_response
 
-  - name: Filter relative_path
+  - name: Filter relative_dirname
     request:
       <<: *general_rules_request
       params:
-        relative_path: ruleset/rules
+        relative_dirname: ruleset/rules
         limit: 2
     response:
       status_code: 200
@@ -367,11 +367,11 @@ stages:
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-  - name: Filter relative_path without limit
+  - name: Filter relative_dirname without limit
     request:
       <<: *general_rules_request
       params:
-        relative_path: ruleset/rules
+        relative_dirname: ruleset/rules
     response:
       status_code: 200
       body:

--- a/api/test/integration/test_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rules_endpoints.tavern.yaml
@@ -28,13 +28,13 @@ stages:
           affected_items: &rules_response
             - description: !anystr
               details: !anything
-              file: !anystr
+              filename: !anystr
               gdpr: !anything
               groups: !anything
               id: !anyint
               level: !anyint
-              path: !anystr
-              pci: !anything
+              relative_path: !anystr
+              pci_dss: !anything
               status: !anystr
               gpg13: !anything
               hipaa: !anything
@@ -56,7 +56,7 @@ stages:
           affected_items:
             - <<: *rules_response
             - description: !anystr
-              file: !anystr
+              filename: !anystr
               status: !anystr
           failed_items: []
           total_affected_items: !anyint
@@ -64,7 +64,7 @@ stages:
       save:
         body:
           second_rule_description: data.affected_items.1.description
-          second_rule_file: data.affected_items.1.file
+          second_rule_filename: data.affected_items.1.filename
           second_rule_status: data.affected_items.1.status
 
   - name: Try to show the rules of the system, offset = 1
@@ -79,7 +79,7 @@ stages:
         data:
           affected_items:
             - description: "{second_rule_description}"
-              file: "{second_rule_file}"
+              filename: "{second_rule_filename}"
               status: "{second_rule_status}"
             - <<: *rules_response
           failed_items: []
@@ -129,7 +129,7 @@ stages:
     request:
       <<: *general_rules_request
       params:
-        sort: -file
+        sort: -filename
     response:
       status_code: 200
       body:
@@ -350,11 +350,11 @@ stages:
       body:
         <<: *error_response
 
-  - name: Filter path
+  - name: Filter relative_path
     request:
       <<: *general_rules_request
       params:
-        path: ruleset/rules
+        relative_path: ruleset/rules
         limit: 2
     response:
       status_code: 200
@@ -367,22 +367,22 @@ stages:
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-  - name: Filter path without limit
+  - name: Filter relative_path without limit
     request:
       <<: *general_rules_request
       params:
-        path: ruleset/rules
+        relative_path: ruleset/rules
     response:
       status_code: 200
       body:
         data:
           total_affected_items: !anyint
 
-  - name: Filter file
+  - name: Filter filename
     request:
       <<: *general_rules_request
       params:
-        file: 0015-ossec_rules.xml
+        filename: 0015-ossec_rules.xml
         limit: 2
     response:
       status_code: 200
@@ -396,17 +396,17 @@ stages:
           total_failed_items: !anyint
       save:
         body:
-          pci_value: data.affected_items.1.pci.0
+          pci_dss_value: data.affected_items.1.pci_dss.0
           gdpr_value: data.affected_items.1.gdpr.0
           gpg13_value: data.affected_items.1.gpg13.0
           hipaa_value: data.affected_items.1.hipaa.0
           nist-800-53_value: data.affected_items.1.nist_800_53.0
 
-  - name: Filter file without limit
+  - name: Filter filename without limit
     request:
       <<: *general_rules_request
       params:
-        file: 0015-ossec_rules.xml
+        filename: 0015-ossec_rules.xml
         offset: 1
         limit: 1
     response:
@@ -414,34 +414,34 @@ stages:
       body:
         data:
           affected_items:
-            - pci:
-              - "{pci_value}"
+            - pci_dss:
+              - "{pci_dss_value}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-  - name: Filter pci
+  - name: Filter pci_dss
     request:
       <<: *general_rules_request
       params:
-        pci: "{pci_value}"
+        pci_dss: "{pci_dss_value}"
         limit: 1
     response:
       status_code: 200
       body:
         data:
           affected_items:
-            - pci:
-              - "{pci_value}"
+            - pci_dss:
+              - "{pci_dss_value}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: !anyint
 
-  - name: Filter pci without limit
+  - name: Filter pci_dss without limit
     request:
       <<: *general_rules_request
       params:
-        pci: "{pci_value}"
+        pci_dss: "{pci_dss_value}"
     response:
       status_code: 200
       body:
@@ -561,13 +561,13 @@ stages:
           total_affected_items: !anyint
 
 ---
-test_name: GET /rules/requirement/pci
+test_name: GET /rules/requirement/pci_dss
 
 stages:
 
-  - name: Try to show the rules by requirement pci
-    request: &pci_rules_request
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci"
+  - name: Try to show the rules by requirement pci_dss
+    request: &pci_dss_rules_request
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -585,9 +585,9 @@ stages:
           total_failed_items: 0
         message: Selected rules were shown
 
-  - name: Try to show the rules by requirement pci, limit and offset
+  - name: Try to show the rules by requirement pci_dss, limit and offset
     request:
-      <<: *pci_rules_request
+      <<: *pci_dss_rules_request
       params:
         limit: 1
         offset: 0
@@ -602,9 +602,9 @@ stages:
           total_failed_items: 0
         message: Selected rules were shown
 
-  - name: Try to show the rules by requirement pci, limit = 0
+  - name: Try to show the rules by requirement pci_dss, limit = 0
     request:
-      <<: *pci_rules_request
+      <<: *pci_dss_rules_request
       params:
         limit: 0
     response:
@@ -614,7 +614,7 @@ stages:
 
   - name: Filter sort
     request:
-      <<: *pci_rules_request
+      <<: *pci_dss_rules_request
       params:
         limit: 1000
     response:
@@ -632,7 +632,7 @@ stages:
 
   - name: Filter sort
     request:
-      <<: *pci_rules_request
+      <<: *pci_dss_rules_request
       params:
         sort: "-"
     response:
@@ -643,7 +643,7 @@ stages:
 
   - name: Filter search
     request:
-      <<: *pci_rules_request
+      <<: *pci_dss_rules_request
       params:
         search: 10
     response:
@@ -657,7 +657,7 @@ stages:
 
   - name: Invalid filter
     request:
-      <<: *pci_rules_request
+      <<: *pci_dss_rules_request
       params:
         noexist: True
     response:
@@ -1186,7 +1186,7 @@ stages:
     request:
       <<: *files_rules_request
       params:
-        sort: "-file"
+        sort: "-filename"
         limit: 1
     response:
       verify_response_with:
@@ -1230,7 +1230,7 @@ stages:
           total_failed_items: !anyint
 
 ---
-test_name: GET /rules/files/{file}/download
+test_name: GET /rules/files/{filename}/download
 
 stages:
 
@@ -1310,7 +1310,7 @@ stages:
       <<: *id_rules_request
       params:
         rule_ids: 200
-        file: 0025-sendmail_rules.xml
+        filename: 0025-sendmail_rules.xml
     response:
       status_code: 200
       body:
@@ -1336,7 +1336,7 @@ stages:
     request:
       <<: *id_rules_request
       params:
-        sort: -file
+        sort: -filename
         rule_ids: 1
     response:
       status_code: 200

--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -13,7 +13,7 @@ from wazuh.utils import process_array
 
 @expose_resources(actions=['lists:read'], resources=['list:path:{path}'])
 def get_lists(path=None, offset=0, limit=common.database_limit, sort_by=None, sort_ascending=True, search_text=None,
-              complementary_search=False, search_in_fields=None):
+              complementary_search=False, search_in_fields=None, relative_dirname=None, filename=None):
     """Get CDB lists
 
     :param path: Relative path of list file to get (if it is not specified, all lists will be returned)
@@ -24,19 +24,25 @@ def get_lists(path=None, offset=0, limit=common.database_limit, sort_by=None, so
     :param search_text: Text to search
     :param complementary_search: Find items without the text to search
     :param search_in_fields: Fields to search in
-    :return: Dictionary: {'items': array of items, 'totalItems': Number of items (without applying the limit)}
+    :param relative_dirname: Filters by relative dirname.
+    :param filename: List of filenames to filter by.
+    :return: AffectedItemsWazuhResult
     """
     result = AffectedItemsWazuhResult(none_msg='No list was shown',
                                       some_msg='Some lists could not be shown',
                                       all_msg='All specified lists were shown')
     lists = list()
     for rel_p in path:
-        lists.append({'items': get_list_from_file(rel_p), 'path': rel_p})
+        if not any([relative_dirname is not None and os.path.dirname(rel_p) != relative_dirname,
+                    filename is not None and os.path.split(rel_p)[1] not in filename]):
+            lists.append({'items': get_list_from_file(rel_p),
+                          'relative_dirname': os.path.dirname(rel_p),
+                          'filename': os.path.split(rel_p)[1]})
 
     result.affected_items = process_array(lists, search_text=search_text, search_in_fields=search_in_fields,
                                           complementary_search=complementary_search, sort_by=sort_by,
-                                          sort_ascending=sort_ascending, allowed_sort_fields=['path'], offset=offset,
-                                          limit=limit)['items']
+                                          sort_ascending=sort_ascending, offset=offset, limit=limit,
+                                          allowed_sort_fields=['relative_dirname', 'filename'])['items']
     result.total_affected_items += len(result.affected_items)
 
     return result
@@ -44,7 +50,8 @@ def get_lists(path=None, offset=0, limit=common.database_limit, sort_by=None, so
 
 @expose_resources(actions=['lists:read'], resources=['list:path:{path}'])
 def get_path_lists(path=None, offset=0, limit=common.database_limit, sort_by=None, sort_ascending=True,
-                   search_text=None, complementary_search=False, search_in_fields=None):
+                   search_text=None, complementary_search=False, search_in_fields=None, relative_dirname=None,
+                   filename=None):
     """Get paths of all CDB lists
 
     :param path: List of paths to read lists from
@@ -55,6 +62,8 @@ def get_path_lists(path=None, offset=0, limit=common.database_limit, sort_by=Non
     :param search_text: Text to search
     :param complementary_search: Find items without the text to search
     :param search_in_fields: Fields to search in
+    :param relative_dirname: Filters by relative dirname.
+    :param filename: List of filenames to filter by.
     :return: AffectedItemsWazuhResult
     """
     result = AffectedItemsWazuhResult(none_msg='No path was shown',
@@ -63,7 +72,9 @@ def get_path_lists(path=None, offset=0, limit=common.database_limit, sort_by=Non
 
     lists = iterate_lists(only_names=True)
     for item in list(lists):
-        if os.path.join(item['path'], item['name']) not in path:
+        if any([relative_dirname is not None and item['relative_dirname'] != relative_dirname,
+               filename is not None and item['filename'] not in filename,
+               os.path.join(item['relative_dirname'], item['filename']) not in path]):
             lists.remove(item)
 
     result.affected_items = process_array(lists, search_text=search_text, search_in_fields=search_in_fields,

--- a/framework/wazuh/core/cdb_list.py
+++ b/framework/wazuh/core/cdb_list.py
@@ -54,10 +54,10 @@ def iterate_lists(absolute_path=common.lists_path, only_names=False):
         if (isfile(new_absolute_path)) and ('.cdb' not in name) and ('~' not in name) and not pattern.search(name):
             if only_names:
                 relative_path = get_relative_path(absolute_path)
-                output.append({'path': relative_path, 'name': name})
+                output.append({'relative_dirname': relative_path, 'filename': name})
             else:
                 items = get_list_from_file(new_relative_path)
-                output.append({'path': new_relative_path, 'items': items})
+                output.append({'relative_dirname': new_relative_path, 'filename': name, 'items': items})
         elif isdir(new_absolute_path):
             output += iterate_lists(new_absolute_path, only_names=only_names)
 

--- a/framework/wazuh/core/cdb_list.py
+++ b/framework/wazuh/core/cdb_list.py
@@ -43,7 +43,7 @@ def iterate_lists(absolute_path=common.lists_path, only_names=False):
     dir_content = listdir(absolute_path)
     output = list()
 
-    # for skipping .swp files
+    # For skipping .swp files
     regex_swp = r'^\.{1}[\w\-/]+(.swp){1}$'
     pattern = re.compile(regex_swp)
 
@@ -54,7 +54,7 @@ def iterate_lists(absolute_path=common.lists_path, only_names=False):
         if (isfile(new_absolute_path)) and ('.cdb' not in name) and ('~' not in name) and not pattern.search(name):
             if only_names:
                 relative_path = get_relative_path(absolute_path)
-                output.append({'path': '{0}/{1}'.format(relative_path, name), 'name': name, 'folder': relative_path})
+                output.append({'path': relative_path, 'name': name})
             else:
                 items = get_list_from_file(new_relative_path)
                 output.append({'path': new_relative_path, 'items': items})

--- a/framework/wazuh/core/decoder.py
+++ b/framework/wazuh/core/decoder.py
@@ -15,7 +15,7 @@ class Status(Enum):
     S_ENABLED = 'enabled'
     S_DISABLED = 'disabled'
     S_ALL = 'all'
-    SORT_FIELDS = ['file', 'path', 'name', 'position', 'status']
+    SORT_FIELDS = ['filename', 'relative_path', 'name', 'position', 'status']
 
 
 def add_detail(detail, value, details):
@@ -54,7 +54,7 @@ def load_decoders_from_file(decoder_file, decoder_path, decoder_status):
         for xml_decoder in list(root):
             # New decoder
             if xml_decoder.tag.lower() == "decoder":
-                decoder = {'file': decoder_file, 'path': decoder_path, 'status': decoder_status,
+                decoder = {'filename': decoder_file, 'relative_path': decoder_path, 'status': decoder_status,
                            'name': xml_decoder.attrib['name'], 'position': position, 'details': dict()}
                 position += 1
 

--- a/framework/wazuh/core/decoder.py
+++ b/framework/wazuh/core/decoder.py
@@ -15,7 +15,7 @@ class Status(Enum):
     S_ENABLED = 'enabled'
     S_DISABLED = 'disabled'
     S_ALL = 'all'
-    SORT_FIELDS = ['filename', 'relative_path', 'name', 'position', 'status']
+    SORT_FIELDS = ['filename', 'relative_dirname', 'name', 'position', 'status']
 
 
 def add_detail(detail, value, details):
@@ -54,7 +54,7 @@ def load_decoders_from_file(decoder_file, decoder_path, decoder_status):
         for xml_decoder in list(root):
             # New decoder
             if xml_decoder.tag.lower() == "decoder":
-                decoder = {'filename': decoder_file, 'relative_path': decoder_path, 'status': decoder_status,
+                decoder = {'filename': decoder_file, 'relative_dirname': decoder_path, 'status': decoder_status,
                            'name': xml_decoder.attrib['name'], 'position': position, 'details': dict()}
                 position += 1
 

--- a/framework/wazuh/core/rule.py
+++ b/framework/wazuh/core/rule.py
@@ -66,8 +66,9 @@ def set_groups(groups, general_groups, rule):
         for key, value in requirements.items():
             if key in g:
                 value[1].append(g.strip()[value[2]:])
-            else:
-                requirements['groups'][1].append(g)
+                break
+        else:
+            requirements['groups'][1].append(g)
 
     for key, value in requirements.items():
         add_unique_element(rule[value[0]], value[1])

--- a/framework/wazuh/core/rule.py
+++ b/framework/wazuh/core/rule.py
@@ -17,7 +17,7 @@ class Status(Enum):
     S_ENABLED = 'enabled'
     S_DISABLED = 'disabled'
     S_ALL = 'all'
-    SORT_FIELDS = ['filename', 'relative_path', 'description', 'id', 'level', 'status']
+    SORT_FIELDS = ['filename', 'relative_dirname', 'description', 'id', 'level', 'status']
 
 
 def add_detail(detail, value, details):
@@ -72,7 +72,7 @@ def load_rules_from_file(rule_filename, rule_relative_path, rule_status):
                     # New rule
                     if xml_rule.tag.lower() == "rule":
                         groups = list()
-                        rule = {'filename': rule_filename, 'relative_path': rule_relative_path,
+                        rule = {'filename': rule_filename, 'relative_dirname': rule_relative_path,
                                 'id': int(xml_rule.attrib['id']), 'level': int(xml_rule.attrib['level']),
                                 'status': rule_status, 'details': dict(), 'pci_dss': list(), 'gpg13': list(),
                                 'gdpr': list(), 'hipaa': list(), 'nist_800_53': list(), 'groups': list(),
@@ -135,7 +135,7 @@ def item_format(data, all_items, exclude_filenames):
         item_name = os.path.basename(item)
         item_dir = os.path.relpath(os.path.dirname(item), start=common.ossec_path)
         item_status = Status.S_DISABLED.value if item_name in exclude_filenames else Status.S_ENABLED.value
-        data.append({'filename': item_name, 'relative_path': item_dir, 'status': item_status})
+        data.append({'filename': item_name, 'relative_dirname': item_dir, 'status': item_status})
 
 
 def _create_rule_decoder_dir_dict(ruleset_conf, tag, exclude_filenames, data):
@@ -154,7 +154,7 @@ def _create_dict(ruleset_conf, tag, exclude_filenames, data):
         full_dir = os.path.dirname(item)
         item_dir = os.path.relpath(full_dir if full_dir else common.ruleset_rules_path, start=common.ossec_path)
         exclude_filenames.append(item_name) if tag == 'rule_exclude' or tag == 'decoder_exclude' else \
-            data.append({'filename': item_name, 'relative_path': item_dir, 'status': item_status})
+            data.append({'filename': item_name, 'relative_dirname': item_dir, 'status': item_status})
 
 
 def format_rule_decoder_file(ruleset_conf, parameters, tags):

--- a/framework/wazuh/core/tests/data/test_cdb_list/subdir/test_lists
+++ b/framework/wazuh/core/tests/data/test_cdb_list/subdir/test_lists
@@ -1,0 +1,5 @@
+test-wazuh-w:write
+test-wazuh-r:read
+test-wazuh-a:attribute
+test-wazuh-x:execute
+test-wazuh-c:command

--- a/framework/wazuh/core/tests/test_cdb_list.py
+++ b/framework/wazuh/core/tests/test_cdb_list.py
@@ -100,7 +100,7 @@ def test_iterate_lists(only_names, path):
     path : str
         Path to iterate lists from.
     """
-    required_fields = ['path', 'name'] if only_names else ['path', 'items']
+    required_fields = ['relative_dirname', 'filename'] if only_names else ['relative_dirname', 'filename', 'items']
 
     common.reset_context_cache()
     result = iterate_lists(absolute_path=path, only_names=only_names)

--- a/framework/wazuh/core/tests/test_cdb_list.py
+++ b/framework/wazuh/core/tests/test_cdb_list.py
@@ -145,8 +145,6 @@ def test_get_list_from_file_with_errors(error_to_raise, wazuh_error_code):
             get_list_from_file("some_path")
             pytest.fail("No exception was raised hence failing the test")
         except WazuhError as e:
-            # if e._code != wazuh_error_code:
-            #     raise
-            assert e._code == wazuh_error_code
+            assert e.code == wazuh_error_code
         except Exception as e:
             assert e.args == (1, "Random")

--- a/framework/wazuh/core/tests/test_cdb_list.py
+++ b/framework/wazuh/core/tests/test_cdb_list.py
@@ -86,7 +86,8 @@ def test_check_path(path, error_expected):
 
 
 @pytest.mark.parametrize('only_names', [True, False])
-def test_iterate_lists(only_names):
+@pytest.mark.parametrize('path', [ABSOLUTE_PATH, os.path.join(ABSOLUTE_PATH, "subdir")])
+def test_iterate_lists(only_names, path):
     """Test `iterate_lists` core functionality.
 
     `Iterate_list` must get the content of all CDB lists in a specified path skipping `.cdb` and `.swp` files. It will
@@ -96,16 +97,18 @@ def test_iterate_lists(only_names):
     ----------
     only_names : bool
         If this parameter is true, only the name of all lists will be showed by `iterate_lists` instead of its content.
+    path : str
+        Path to iterate lists from.
     """
-    folders = [ABSOLUTE_PATH, os.path.join(ABSOLUTE_PATH, "subdir")]
-    required_fields = ['path', 'name', 'folder'] if only_names else ['path', 'items']
+    required_fields = ['path', 'name'] if only_names else ['path', 'items']
 
-    for folder in folders:
-        common.reset_context_cache()
-        result = iterate_lists(absolute_path=folder, only_names=only_names)
-        for entry in result:
-            for field in required_fields:
-                assert field in entry
+    common.reset_context_cache()
+    result = iterate_lists(absolute_path=path, only_names=only_names)
+    assert isinstance(result, list)
+    assert len(result) != 0
+    for entry in result:
+        for field in required_fields:
+            assert field in entry
 
 
 def test_get_list_from_file():
@@ -120,6 +123,7 @@ def test_get_list_from_file():
     (OSError(2, "No such file or directory"), LIST_FILE_NOT_FOUND_ERROR_CODE),
     (OSError(13, "Permission denied"), PERMISSION_ERROR_CODE),
     (OSError(21, "Is a directory"), INVALID_FILEPATH_ERROR_CODE),
+    (OSError(1, "Random"), None),
     (ValueError(), BAD_CDB_FORMAT_ERROR_CODE)
 ])
 def test_get_list_from_file_with_errors(error_to_raise, wazuh_error_code):
@@ -141,5 +145,8 @@ def test_get_list_from_file_with_errors(error_to_raise, wazuh_error_code):
             get_list_from_file("some_path")
             pytest.fail("No exception was raised hence failing the test")
         except WazuhError as e:
-            if e._code != wazuh_error_code:
-                raise
+            # if e._code != wazuh_error_code:
+            #     raise
+            assert e._code == wazuh_error_code
+        except Exception as e:
+            assert e.args == (1, "Random")

--- a/framework/wazuh/core/tests/test_decoder.py
+++ b/framework/wazuh/core/tests/test_decoder.py
@@ -53,7 +53,7 @@ def test_check_status(status, expected_result):
         assert e.code == expected_result.code
 
 
-@pytest.mark.parametrize("filename, relative_path, status, permissions, exception", [
+@pytest.mark.parametrize("filename, relative_dirname, status, permissions, exception", [
     ('test1_decoders.xml', 'decoders', "all", 777, None),
     ('test2_decoders.xml', 'decoders', "enabled", 777, None),
     ('wrong_decoders.xml', 'decoders', "all", 777, WazuhInternalError(1501)),
@@ -61,18 +61,18 @@ def test_check_status(status, expected_result):
     ('test1_decoders.xml', 'decoders', "all", 000, WazuhError(1502)),
 ])
 @patch('wazuh.common.ossec_path', new=test_data_path)
-def test_load_decoders_from_file(filename, relative_path, status, permissions, exception):
-    full_file_path = os.path.join(test_data_path, relative_path, filename)
+def test_load_decoders_from_file(filename, relative_dirname, status, permissions, exception):
+    full_file_path = os.path.join(test_data_path, relative_dirname, filename)
     try:
         # Set file permissions if the file exists
         os.path.exists(full_file_path) and os.chmod(full_file_path, permissions)
         # UUT call
-        result = decoder.load_decoders_from_file(filename, relative_path, status)
+        result = decoder.load_decoders_from_file(filename, relative_dirname, status)
         # Assert result is a list with at least one dict element with the appropriate fields
         assert isinstance(result, list)
         assert len(result) != 0
         for item in result:
-            assert (item['filename'], item['relative_path'], item['status']) == (filename, relative_path, status)
+            assert (item['filename'], item['relative_dirname'], item['status']) == (filename, relative_dirname, status)
             assert {'name', 'position', 'details'}.issubset(set(item))
     except WazuhException as e:
         # If the UUT call returns an exception we check it has the appropriate error code

--- a/framework/wazuh/core/tests/test_decoder.py
+++ b/framework/wazuh/core/tests/test_decoder.py
@@ -53,7 +53,7 @@ def test_check_status(status, expected_result):
         assert e.code == expected_result.code
 
 
-@pytest.mark.parametrize("file, path, status, permissions, exception", [
+@pytest.mark.parametrize("filename, relative_path, status, permissions, exception", [
     ('test1_decoders.xml', 'decoders', "all", 777, None),
     ('test2_decoders.xml', 'decoders', "enabled", 777, None),
     ('wrong_decoders.xml', 'decoders', "all", 777, WazuhInternalError(1501)),
@@ -61,18 +61,18 @@ def test_check_status(status, expected_result):
     ('test1_decoders.xml', 'decoders', "all", 000, WazuhError(1502)),
 ])
 @patch('wazuh.common.ossec_path', new=test_data_path)
-def test_load_decoders_from_file(file, path, status, permissions, exception):
-    full_file_path = os.path.join(test_data_path, path, file)
+def test_load_decoders_from_file(filename, relative_path, status, permissions, exception):
+    full_file_path = os.path.join(test_data_path, relative_path, filename)
     try:
         # Set file permissions if the file exists
         os.path.exists(full_file_path) and os.chmod(full_file_path, permissions)
         # UUT call
-        result = decoder.load_decoders_from_file(file, path, status)
+        result = decoder.load_decoders_from_file(filename, relative_path, status)
         # Assert result is a list with at least one dict element with the appropriate fields
         assert isinstance(result, list)
         assert len(result) != 0
         for item in result:
-            assert (item['file'], item['path'], item['status']) == (file, path, status)
+            assert (item['filename'], item['relative_path'], item['status']) == (filename, relative_path, status)
             assert {'name', 'position', 'details'}.issubset(set(item))
     except WazuhException as e:
         # If the UUT call returns an exception we check it has the appropriate error code

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -80,7 +80,7 @@ def test_load_rules_from_file(rule_file, rule_path, rule_status, exception):
         result = rule.load_rules_from_file(rule_file, rule_path, rule_status)
         for r in result:
             assert r['filename'] == rule_file
-            assert r['relative_path'] == rule_path
+            assert r['relative_dirname'] == rule_path
             assert r['status'] == rule_status
     except WazuhError as e:
         assert e.code == exception.code
@@ -135,10 +135,10 @@ def test_remove_files(tmp_data, parameters, expected_result):
 def test_format_rule_decoder_file(rule_file, rule_path, rule_status):
     """Test format_rule_decoder_file rule core function."""
     result = rule.format_rule_decoder_file(
-        ruleset_conf, {'status': rule_status, 'relative_path': rule_path, 'filename': rule_file},
+        ruleset_conf, {'status': rule_status, 'relative_dirname': rule_path, 'filename': rule_file},
         ['rule_include', 'rule_exclude', 'rule_dir'])
 
-    assert result == [{'filename': rule_file, 'relative_path': rule_path, 'status': rule_status}]
+    assert result == [{'filename': rule_file, 'relative_dirname': rule_path, 'status': rule_status}]
 
 
 @pytest.mark.parametrize('groups, general_groups', [

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -47,20 +47,6 @@ def test_add_detail(detail, value, details):
     assert value in details[detail]
 
 
-@pytest.mark.parametrize('src_list, element', [
-    (['wazuh', 'ossec'], 'rbac'),
-    (['wazuh', 'ossec', 'rbac'], ['new']),
-])
-def test_add_unique_element(src_list, element):
-    """Test add_unique_element rule core function."""
-    rule.add_unique_element(src_list, element)
-    if isinstance(element, list):
-        for e in element:
-            assert e in src_list
-    else:
-        assert element in src_list
-
-
 @pytest.mark.parametrize('status, expected_result', [
     ('enabled', 'enabled'),
     ('disabled', 'disabled'),
@@ -93,8 +79,8 @@ def test_load_rules_from_file(rule_file, rule_path, rule_status, exception):
     try:
         result = rule.load_rules_from_file(rule_file, rule_path, rule_status)
         for r in result:
-            assert r['file'] == rule_file
-            assert r['path'] == rule_path
+            assert r['filename'] == rule_file
+            assert r['relative_path'] == rule_path
             assert r['status'] == rule_status
     except WazuhError as e:
         assert e.code == exception.code
@@ -116,24 +102,24 @@ def test_load_rules_from_file_unknown(mock_load):
 
 @pytest.mark.parametrize('tmp_data, parameters, expected_result', [
     ([
-         {'file': 'one.xml', 'status': 'all'},
-         {'file': 'two.xml', 'status': 'disabled'},
-         {'file': 'three.xml', 'status': None},
-         {'file': 'four.xml', 'status': 'enabled'}
+         {'filename': 'one.xml', 'status': 'all'},
+         {'filename': 'two.xml', 'status': 'disabled'},
+         {'filename': 'three.xml', 'status': None},
+         {'filename': 'four.xml', 'status': 'enabled'}
      ],
      {'status': 'disabled'},
      [
-         {'file': 'two.xml', 'status': 'disabled'},
+         {'filename': 'two.xml', 'status': 'disabled'},
      ]),
     ([
-         {'file': 'one.xml', 'exists': False},
-         {'file': 'two.xml', 'exists': 'true'},
-         {'file': 'three.xml', 'exists': True},
-         {'file': 'four.xml', 'exists': 'false'}
+         {'filename': 'one.xml', 'exists': False},
+         {'filename': 'two.xml', 'exists': 'true'},
+         {'filename': 'three.xml', 'exists': True},
+         {'filename': 'four.xml', 'exists': 'false'}
      ],
      {'exists': 'true'},
      [
-         {'file': 'two.xml', 'exists': 'true'},
+         {'filename': 'two.xml', 'exists': 'true'},
      ])
 ])
 def test_remove_files(tmp_data, parameters, expected_result):
@@ -149,7 +135,21 @@ def test_remove_files(tmp_data, parameters, expected_result):
 def test_format_rule_decoder_file(rule_file, rule_path, rule_status):
     """Test format_rule_decoder_file rule core function."""
     result = rule.format_rule_decoder_file(
-        ruleset_conf, {'status': rule_status, 'path': rule_path, 'file': rule_file},
+        ruleset_conf, {'status': rule_status, 'relative_path': rule_path, 'filename': rule_file},
         ['rule_include', 'rule_exclude', 'rule_dir'])
 
-    assert result == [{'file': rule_file, 'path': rule_path, 'status': rule_status}]
+    assert result == [{'filename': rule_file, 'relative_path': rule_path, 'status': rule_status}]
+
+
+@pytest.mark.parametrize('groups, general_groups', [
+    (['virus', 'pci_dss_5.1', 'pci_dss_5.2', 'pci_dss_10.6.1', 'pci_dss_11.4', 'gpg13_4.2', 'gdpr_IV_35.7.d',
+      'hipaa_164.312.b', 'nist_800_53_SI.3', 'nist_800_53_AU.6', 'nist_800_53_SI.4'], ['mcafee'])
+])
+def test_set_groups(groups, general_groups):
+    """Test set_groups rule core function."""
+    empty_rule = {'pci_dss': [], 'gdpr': [], 'hipaa': [], 'nist_800_53': [], 'gpg13': [], 'groups': []}
+    expected_result = {'pci_dss': ['5.1', '5.2', '10.6.1', '11.4'], 'gdpr': ['IV_35.7.d'], 'hipaa': ['164.312.b'],
+                       'nist_800_53': ['SI.3', 'AU.6', 'SI.4'], 'gpg13': ['4.2'], 'groups': ['virus', 'mcafee']}
+    rule.set_groups(groups, general_groups, empty_rule)
+
+    assert empty_rule == expected_result

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -20,7 +20,7 @@ def get_decoders(names=None, status=None, filename=None, relative_dirname=None, 
     """Gets a list of available decoders.
 
     :param names: Filters by decoder name.
-    :param filename: Filters by file.
+    :param filename: List of filenames to filter by.
     :param status: Filters by status: enabled, disabled, all.
     :param relative_dirname: Filters by relative dirname.
     :param parents: Just parent decoders.
@@ -88,7 +88,7 @@ def get_decoders_files(status=None, relative_dirname=None, filename=None, offset
 
     :param status: Filters by status: enabled, disabled, all.
     :param relative_dirname: Filters by relative dirname.
-    :param filename: Filters by filename.
+    :param filename: List of filenames to filter by.
     :param offset: First item to return.
     :param limit: Maximum number of items to return.
     :param sort_by: Fields to sort the items by

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
@@ -14,15 +14,15 @@ from wazuh.results import AffectedItemsWazuhResult
 from wazuh.utils import process_array
 
 
-def get_decoders(names=None, status=None, file=None, path=None, parents=False, offset=0,
+def get_decoders(names=None, status=None, filename=None, relative_path=None, parents=False, offset=0,
                  limit=common.database_limit, sort_by=None, sort_ascending=True, search_text=None,
                  complementary_search=False, search_in_fields=None, q=''):
     """Gets a list of available decoders.
 
     :param names: Filters by decoder name.
-    :param file: Filters by file.
+    :param filename: Filters by file.
     :param status: Filters by status: enabled, disabled, all.
-    :param path: Filters by path.
+    :param relative_path: Filters by relative path.
     :param parents: Just parent decoders.
     :param offset: First item to return.
     :param limit: Maximum number of items to return.
@@ -43,12 +43,12 @@ def get_decoders(names=None, status=None, file=None, path=None, parents=False, o
         names = list()
 
     for decoder_file in get_decoders_files(limit=None).affected_items:
-        all_decoders.extend(load_decoders_from_file(decoder_file['file'], decoder_file['path'],
+        all_decoders.extend(load_decoders_from_file(decoder_file['filename'], decoder_file['relative_path'],
                                                     decoder_file['status']))
 
     status = check_status(status)
     status = ['enabled', 'disabled'] if status == 'all' else [status]
-    parameters = {'path': path, 'file': file, 'name': names, 'parents': parents, 'status': status}
+    parameters = {'relative_path': relative_path, 'filename': filename, 'name': names, 'parents': parents, 'status': status}
     decoders = list(all_decoders)
     no_existent_files = names[:]
     for d in all_decoders:
@@ -61,9 +61,9 @@ def get_decoders(names=None, status=None, file=None, path=None, parents=False, o
                         no_existent_files.remove(d[key])
                 elif key == 'status' and d[key] not in value and d in decoders:
                     decoders.remove(d)
-                elif key == 'file' and d[key] not in file and d in decoders:
+                elif key == 'filename' and d[key] not in filename and d in decoders:
                     decoders.remove(d)
-                elif key == 'path' and d[key] != path and d in decoders:
+                elif key == 'relative_path' and d[key] != relative_path and d in decoders:
                     decoders.remove(d)
                 elif 'parent' in d['details'] and parents and d in decoders:
                     decoders.remove(d)
@@ -80,14 +80,15 @@ def get_decoders(names=None, status=None, file=None, path=None, parents=False, o
     return result
 
 
-@expose_resources(actions=['decoders:read'], resources=['decoder:file:{file}'])
-def get_decoders_files(status=None, path=None, file=None, offset=0, limit=common.database_limit, sort_by=None,
-                       sort_ascending=True, search_text=None, complementary_search=False, search_in_fields=None):
+@expose_resources(actions=['decoders:read'], resources=['decoder:file:{filename}'])
+def get_decoders_files(status=None, relative_path=None, filename=None, offset=0, limit=common.database_limit,
+                       sort_by=None, sort_ascending=True, search_text=None, complementary_search=False,
+                       search_in_fields=None):
     """Gets a list of the available decoder files.
 
     :param status: Filters by status: enabled, disabled, all.
-    :param path: Filters by path.
-    :param file: Filters by filename.
+    :param relative_path: Filters by relative path.
+    :param filename: Filters by filename.
     :param offset: First item to return.
     :param limit: Maximum number of items to return.
     :param sort_by: Fields to sort the items by
@@ -107,12 +108,16 @@ def get_decoders_files(status=None, path=None, file=None, offset=0, limit=common
 
     decoders_files = list()
     tags = ['decoder_include', 'decoder_exclude', 'decoder_dir']
-    if isinstance(file, list):
-        for f in file:
-            decoders_files.extend(
-                format_rule_decoder_file(ruleset_conf, {'status': status, 'path': path, 'file': f}, tags))
+    if isinstance(filename, list):
+        for f in filename:
+            decoders_files.extend(format_rule_decoder_file(
+                ruleset_conf, {'status': status, 'relative_path': relative_path, 'filename': f},
+                tags))
     else:
-        decoders_files = format_rule_decoder_file(ruleset_conf, {'status': status, 'path': path, 'file': file}, tags)
+        decoders_files = format_rule_decoder_file(
+            ruleset_conf,
+            {'status': status, 'relative_path': relative_path, 'filename': filename},
+            tags)
     result.affected_items = process_array(decoders_files, search_text=search_text, search_in_fields=search_in_fields,
                                           complementary_search=complementary_search, sort_by=sort_by,
                                           sort_ascending=sort_ascending, offset=offset, limit=limit)['items']
@@ -121,24 +126,24 @@ def get_decoders_files(status=None, path=None, file=None, offset=0, limit=common
     return result
 
 
-def get_file(file=None):
+def get_file(filename=None):
     """Reads content of specified file
 
-    :param file: File name to read content from
+    :param filename: Filename to read content from
     :return: File contents
     """
-    decoders = get_decoders_files(file=file).affected_items
+    decoders = get_decoders_files(filename=filename).affected_items
 
     if len(decoders) > 0:
-        decoder_path = decoders[0]['path']
+        decoder_path = decoders[0]['relative_path']
         try:
-            full_path = os.path.join(common.ossec_path, decoder_path, file)
+            full_path = os.path.join(common.ossec_path, decoder_path, filename)
             with open(full_path) as f:
                 file_content = f.read()
             return file_content
         except OSError:
-            raise WazuhError(1502, extra_message=os.path.join('WAZUH_HOME', decoder_path, file))
+            raise WazuhError(1502, extra_message=os.path.join('WAZUH_HOME', decoder_path, filename))
         except Exception:
-            raise WazuhInternalError(1501, extra_message=os.path.join('WAZUH_HOME', decoder_path, file))
+            raise WazuhInternalError(1501, extra_message=os.path.join('WAZUH_HOME', decoder_path, filename))
     else:
         raise WazuhError(1503)

--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -80,7 +80,8 @@ def _expand_resource(resource):
                 tags)
             return {decoder['filename'] for decoder in format_decoders}
         elif resource_type == 'list:path':
-            return {os.path.join(cdb_list['path'], cdb_list['name']) for cdb_list in iterate_lists(only_names=True)}
+            return {os.path.join(cdb_list['relative_dirname'], cdb_list['filename'])
+                    for cdb_list in iterate_lists(only_names=True)}
         elif resource_type == 'node:id':
             return set(cluster_nodes.get())
         elif resource_type == 'file:path':

--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -67,14 +67,18 @@ def _expand_resource(resource):
             return users_system
         elif resource_type == 'rule:file':
             tags = ['rule_include', 'rule_exclude', 'rule_dir']
-            format_rules = format_rule_decoder_file(get_ossec_conf(section='ruleset')['ruleset'],
-                                                    {'status': Status.S_ALL.value, 'path': None, 'file': None}, tags)
-            return {rule['file'] for rule in format_rules}
+            format_rules = format_rule_decoder_file(
+                get_ossec_conf(section='ruleset')['ruleset'],
+                {'status': Status.S_ALL.value, 'relative_path': None, 'filename': None},
+                tags)
+            return {rule['filename'] for rule in format_rules}
         elif resource_type == 'decoder:file':
             tags = ['decoder_include', 'decoder_exclude', 'decoder_dir']
-            format_decoders = format_rule_decoder_file(get_ossec_conf(section='ruleset')['ruleset'],
-                                                       {'status': Status.S_ALL.value, 'path': None, 'file': None}, tags)
-            return {decoder['file'] for decoder in format_decoders}
+            format_decoders = format_rule_decoder_file(
+                get_ossec_conf(section='ruleset')['ruleset'],
+                {'status': Status.S_ALL.value, 'relative_path': None, 'filename': None},
+                tags)
+            return {decoder['filename'] for decoder in format_decoders}
         elif resource_type == 'list:path':
             return {os.path.join(cdb_list['path'], cdb_list['name']) for cdb_list in iterate_lists(only_names=True)}
         elif resource_type == 'node:id':

--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -1,8 +1,9 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
+import os
 import re
 from collections import defaultdict
 from functools import wraps
@@ -75,7 +76,7 @@ def _expand_resource(resource):
                                                        {'status': Status.S_ALL.value, 'path': None, 'file': None}, tags)
             return {decoder['file'] for decoder in format_decoders}
         elif resource_type == 'list:path':
-            return {cdb_list['path'] for cdb_list in iterate_lists(only_names=True)}
+            return {os.path.join(cdb_list['path'], cdb_list['name']) for cdb_list in iterate_lists(only_names=True)}
         elif resource_type == 'node:id':
             return set(cluster_nodes.get())
         elif resource_type == 'file:path':

--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -69,14 +69,14 @@ def _expand_resource(resource):
             tags = ['rule_include', 'rule_exclude', 'rule_dir']
             format_rules = format_rule_decoder_file(
                 get_ossec_conf(section='ruleset')['ruleset'],
-                {'status': Status.S_ALL.value, 'relative_path': None, 'filename': None},
+                {'status': Status.S_ALL.value, 'relative_dirname': None, 'filename': None},
                 tags)
             return {rule['filename'] for rule in format_rules}
         elif resource_type == 'decoder:file':
             tags = ['decoder_include', 'decoder_exclude', 'decoder_dir']
             format_decoders = format_rule_decoder_file(
                 get_ossec_conf(section='ruleset')['ruleset'],
-                {'status': Status.S_ALL.value, 'relative_path': None, 'filename': None},
+                {'status': Status.S_ALL.value, 'relative_dirname': None, 'filename': None},
                 tags)
             return {decoder['filename'] for decoder in format_decoders}
         elif resource_type == 'list:path':

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -27,7 +27,7 @@ def get_rules(rule_ids=None, status=None, group=None, pci_dss=None, gpg13=None, 
     :param hipaa: Filters the rules by hipaa requirement.
     :param nist_800_53: Filters the rules by nist_800_53 requirement.
     :param relative_dirname: Filters the relative dirname.
-    :param filename: Filters the rules by file name.
+    :param filename: List of filenames to filter by.
     :param level: Filters the rules by level. level=2 or level=2-5.
     :param offset: First item to return.
     :param limit: Maximum number of items to return.
@@ -99,7 +99,7 @@ def get_rules_files(status=None, relative_dirname=None, filename=None, offset=0,
 
     :param status: Filters by status: enabled, disabled, all.
     :param relative_dirname: Filters by relative dirname.
-    :param filename: Filters by filename.
+    :param filename: List of filenames to filter by.
     :param offset: First item to return.
     :param limit: Maximum number of items to return.
     :param sort_by: Fields to sort the items by

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -149,15 +149,8 @@ def get_groups(offset=0, limit=common.database_limit, sort_by=None, sort_ascendi
     result = AffectedItemsWazuhResult(none_msg='No groups in rules are shown',
                                       some_msg='Some groups in rules are shown',
                                       all_msg='All groups in rules are shown')
-    requirements = ['pci', 'gdpr', 'hipaa', 'nist_800_53', 'gpg13']
-    groups = set()
-    for rule in get_rules(limit=None).affected_items:
-        for group in rule['groups']:
-            for req in requirements:
-                if req in group:
-                    break
-            else:
-                groups.add(group)
+
+    groups = {group for rule in get_rules(limit=None).affected_items for group in rule['groups']}
 
     result.affected_items = process_array(list(groups), search_text=search_text, search_in_fields=search_in_fields,
                                           complementary_search=complementary_search, sort_by=sort_by,

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -47,8 +47,8 @@ RESULT_GET_LIST_FILE_2 = [{'items': [{'key': 'test-ossec-w', 'value': 'write'},
                                      ],
                            'path': PATH_FILE_2
                            }]
-RESULT_GET_PATH_LIST_FILE_1 = [{'folder': RELATIVE_PATH, 'name': NAME_FILE_1, 'path': PATH_FILE_1}]
-RESULT_GET_PATH_LIST_FILE_2 = [{'folder': RELATIVE_PATH, 'name': NAME_FILE_2, 'path': PATH_FILE_2}]
+RESULT_GET_PATH_LIST_FILE_1 = [{'name': NAME_FILE_1, 'path': RELATIVE_PATH}]
+RESULT_GET_PATH_LIST_FILE_2 = [{'name': NAME_FILE_2, 'path': RELATIVE_PATH}]
 
 RESULTS_GET_LIST = RESULT_GET_LIST_FILE_1 + RESULT_GET_LIST_FILE_2
 RESULTS_GET_PATH_LIST = RESULT_GET_PATH_LIST_FILE_1 + RESULT_GET_PATH_LIST_FILE_2
@@ -190,9 +190,8 @@ def test_get_path_lists_limit(limit):
         Maximum number of items to be returned by `get_path_lists`
     """
     common.reset_context_cache()
-    result = get_path_lists(path=PATHS_FILES, limit=limit, sort_by=['path'])
+    result = get_path_lists(path=PATHS_FILES, limit=limit, sort_by=['name'])
 
-    assert limit > 0
     assert isinstance(result, AffectedItemsWazuhResult)
     assert result.total_affected_items == limit
     assert result.affected_items == RESULTS_GET_PATH_LIST[:limit]
@@ -208,7 +207,7 @@ def test_get_path_lists_offset(offset):
          Indicates the first item to return.
     """
     common.reset_context_cache()
-    result = get_path_lists(path=PATHS_FILES, offset=offset, sort_by=['path'])
+    result = get_path_lists(path=PATHS_FILES, offset=offset, sort_by=['name'])
 
     assert isinstance(result, AffectedItemsWazuhResult)
     assert result.total_affected_items == len(PATHS_FILES) - offset
@@ -219,24 +218,18 @@ def test_get_path_lists_offset(offset):
     ("lists_1", False, None, PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
     ("lists_2", False, None, PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
     ("invalid", False, None, PATHS_FILES, []),
-    ("lists_1", False, "path", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
-    ("lists_2", False, "path", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
+    ("test_cdb_list", False, "path", PATHS_FILES, RESULTS_GET_PATH_LIST),
     ("invalid", False, "path", PATHS_FILES, []),
     ("lists_1", False, "name", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
     ("lists_2", False, "name", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
     ("invalid", False, "name", PATHS_FILES, []),
-    ("test_cdb_list", False, "folder", PATHS_FILES, RESULTS_GET_PATH_LIST),
-
     ("lists_1", True, None, PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
     ("lists_2", True, None, PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
     ("invalid", True, None, PATHS_FILES, RESULTS_GET_PATH_LIST),
-    ("lists_1", True, "path", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
-    ("lists_2", True, "path", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
     ("invalid", True, "path", PATHS_FILES, RESULTS_GET_PATH_LIST),
     ("lists_1", True, "name", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
     ("lists_2", True, "name", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
-    ("invalid", True, "name", PATHS_FILES, RESULTS_GET_PATH_LIST),
-    ("test_cdb_list", True, "folder", PATHS_FILES, [])
+    ("invalid", True, "name", PATHS_FILES, RESULTS_GET_PATH_LIST)
 ])
 def test_get_path_lists_search(search_text, complementary_search, search_in_fields, paths, expected_result):
     """Test `get_path_lists` functionality when using the `search` parameter.
@@ -257,7 +250,7 @@ def test_get_path_lists_search(search_text, complementary_search, search_in_fiel
     """
     common.reset_context_cache()
     result = get_path_lists(path=paths, search_text=search_text, complementary_search=complementary_search,
-                            search_in_fields=search_in_fields, sort_by=['path'])
+                            search_in_fields=search_in_fields, sort_by=['name'])
     assert isinstance(result, AffectedItemsWazuhResult)
     assert result.total_affected_items == len(expected_result)
     assert result.affected_items == expected_result

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -39,16 +39,18 @@ RESULT_GET_LIST_FILE_1 = [{'items': [{'key': 'test-wazuh-w', 'value': 'write'},
                                      {'key': 'test-wazuh-x', 'value': 'execute'},
                                      {'key': 'test-wazuh-c', 'value': 'command'}
                                      ],
-                           'path': PATH_FILE_1
+                           'relative_dirname': RELATIVE_PATH,
+                           'filename': NAME_FILE_1
                            }]
 RESULT_GET_LIST_FILE_2 = [{'items': [{'key': 'test-ossec-w', 'value': 'write'},
                                      {'key': 'test-ossec-r', 'value': 'read'},
                                      {'key': 'test-ossec-x', 'value': 'execute'}
                                      ],
-                           'path': PATH_FILE_2
+                           'relative_dirname': RELATIVE_PATH,
+                           'filename': NAME_FILE_2
                            }]
-RESULT_GET_PATH_LIST_FILE_1 = [{'name': NAME_FILE_1, 'path': RELATIVE_PATH}]
-RESULT_GET_PATH_LIST_FILE_2 = [{'name': NAME_FILE_2, 'path': RELATIVE_PATH}]
+RESULT_GET_PATH_LIST_FILE_1 = [{'filename': NAME_FILE_1, 'relative_dirname': RELATIVE_PATH}]
+RESULT_GET_PATH_LIST_FILE_2 = [{'filename': NAME_FILE_2, 'relative_dirname': RELATIVE_PATH}]
 
 RESULTS_GET_LIST = RESULT_GET_LIST_FILE_1 + RESULT_GET_LIST_FILE_2
 RESULTS_GET_PATH_LIST = RESULT_GET_PATH_LIST_FILE_1 + RESULT_GET_PATH_LIST_FILE_2
@@ -156,8 +158,8 @@ def test_get_lists_search(search_text, complementary_search, search_in_fields, p
 
 def test_get_lists_sort():
     """Test `get_lists` functionality when using the `sort` parameter."""
-    result_a = get_lists(path=PATHS_FILES, sort_by=['path'], sort_ascending=True)
-    result_b = get_lists(path=PATHS_FILES, sort_by=['path'], sort_ascending=False)
+    result_a = get_lists(path=PATHS_FILES, sort_by=['filename'], sort_ascending=True)
+    result_b = get_lists(path=PATHS_FILES, sort_by=['filename'], sort_ascending=False)
 
     assert isinstance(result_a, AffectedItemsWazuhResult)
     assert isinstance(result_b, AffectedItemsWazuhResult)
@@ -190,7 +192,7 @@ def test_get_path_lists_limit(limit):
         Maximum number of items to be returned by `get_path_lists`
     """
     common.reset_context_cache()
-    result = get_path_lists(path=PATHS_FILES, limit=limit, sort_by=['name'])
+    result = get_path_lists(path=PATHS_FILES, limit=limit, sort_by=['filename'])
 
     assert isinstance(result, AffectedItemsWazuhResult)
     assert result.total_affected_items == limit
@@ -207,7 +209,7 @@ def test_get_path_lists_offset(offset):
          Indicates the first item to return.
     """
     common.reset_context_cache()
-    result = get_path_lists(path=PATHS_FILES, offset=offset, sort_by=['name'])
+    result = get_path_lists(path=PATHS_FILES, offset=offset, sort_by=['filename'])
 
     assert isinstance(result, AffectedItemsWazuhResult)
     assert result.total_affected_items == len(PATHS_FILES) - offset
@@ -218,18 +220,18 @@ def test_get_path_lists_offset(offset):
     ("lists_1", False, None, PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
     ("lists_2", False, None, PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
     ("invalid", False, None, PATHS_FILES, []),
-    ("test_cdb_list", False, "path", PATHS_FILES, RESULTS_GET_PATH_LIST),
-    ("invalid", False, "path", PATHS_FILES, []),
-    ("lists_1", False, "name", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
-    ("lists_2", False, "name", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
-    ("invalid", False, "name", PATHS_FILES, []),
+    ("test_cdb_list", False, "relative_dirname", PATHS_FILES, RESULTS_GET_PATH_LIST),
+    ("invalid", False, "relative_dirname", PATHS_FILES, []),
+    ("lists_1", False, "filename", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
+    ("lists_2", False, "filename", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
+    ("invalid", False, "filename", PATHS_FILES, []),
     ("lists_1", True, None, PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
     ("lists_2", True, None, PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
     ("invalid", True, None, PATHS_FILES, RESULTS_GET_PATH_LIST),
-    ("invalid", True, "path", PATHS_FILES, RESULTS_GET_PATH_LIST),
-    ("lists_1", True, "name", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
-    ("lists_2", True, "name", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
-    ("invalid", True, "name", PATHS_FILES, RESULTS_GET_PATH_LIST)
+    ("invalid", True, "relative_dirname", PATHS_FILES, RESULTS_GET_PATH_LIST),
+    ("lists_1", True, "filename", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_2),
+    ("lists_2", True, "filename", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
+    ("invalid", True, "filename", PATHS_FILES, RESULTS_GET_PATH_LIST)
 ])
 def test_get_path_lists_search(search_text, complementary_search, search_in_fields, paths, expected_result):
     """Test `get_path_lists` functionality when using the `search` parameter.
@@ -250,7 +252,7 @@ def test_get_path_lists_search(search_text, complementary_search, search_in_fiel
     """
     common.reset_context_cache()
     result = get_path_lists(path=paths, search_text=search_text, complementary_search=complementary_search,
-                            search_in_fields=search_in_fields, sort_by=['name'])
+                            search_in_fields=search_in_fields, sort_by=['filename'])
     assert isinstance(result, AffectedItemsWazuhResult)
     assert result.total_affected_items == len(expected_result)
     assert result.affected_items == expected_result
@@ -258,8 +260,8 @@ def test_get_path_lists_search(search_text, complementary_search, search_in_fiel
 
 def test_get_path_lists_sort():
     """Test `get_path_lists` functionality when using the `sort` parameter."""
-    result_a = get_path_lists(path=PATHS_FILES, sort_by=['name'], sort_ascending=True)
-    result_b = get_path_lists(path=PATHS_FILES, sort_by=['name'], sort_ascending=False)
+    result_a = get_path_lists(path=PATHS_FILES, sort_by=['filename'], sort_ascending=True)
+    result_b = get_path_lists(path=PATHS_FILES, sort_by=['filename'], sort_ascending=False)
 
     assert isinstance(result_a, AffectedItemsWazuhResult)
     assert isinstance(result_b, AffectedItemsWazuhResult)

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -53,7 +53,7 @@ def mock_ossec_path():
 
 # Tests
 
-@pytest.mark.parametrize('names, status, filename, relative_path, parents, expected_names, expected_total_failed', [
+@pytest.mark.parametrize('names, status, filename, relative_dirname, parents, expected_names, expected_total_failed', [
     (None, None, None, None, False, {'agent-buffer', 'json', 'agent-upgrade', 'wazuh', 'agent-restart'}, 0),
     (['agent-buffer'], None, None, None, False, {'agent-buffer'}, 0),
     (['agent-buffer', 'non_existing'], None, None, None, False, {'agent-buffer'}, 1),
@@ -65,13 +65,13 @@ def mock_ossec_path():
     (None, 'all', None, 'core/tests/data/decoders', True, {'wazuh', 'json'}, 0),
     (None, 'all', None, 'nothing_here', False, set(), 0)
 ])
-def test_get_decoders(names, status, filename, relative_path, parents, expected_names, expected_total_failed):
+def test_get_decoders(names, status, filename, relative_dirname, parents, expected_names, expected_total_failed):
     wrong_decoder_original_path = os.path.join(test_data_path, 'core/tests/data/decoders', 'wrong_decoders.xml')
     wrong_decoder_tmp_path = os.path.join(test_data_path, 'core/tests/data', 'wrong_decoders.xml')
     try:
         os.rename(wrong_decoder_original_path, wrong_decoder_tmp_path)
         # UUT call
-        result = decoder.get_decoders(names=names, status=status, filename=filename, relative_path=relative_path,
+        result = decoder.get_decoders(names=names, status=status, filename=filename, relative_dirname=relative_dirname,
                                       parents=parents)
         assert isinstance(result, AffectedItemsWazuhResult)
         # Build result names set from response for filter validation
@@ -97,14 +97,14 @@ def test_get_decoders_files(conf, exception):
             assert isinstance(result.affected_items, list)
             assert len(result.affected_items) != 0
             for item in result.affected_items:
-                assert {'filename', 'relative_path', 'status'}.issubset(set(item))
+                assert {'filename', 'relative_dirname', 'status'}.issubset(set(item))
             assert result.total_affected_items == len(result.affected_items)
         except WazuhInternalError as e:
             # If the UUT call returns an exception we check it has the appropriate error code
             assert e.code == exception.code
 
 
-@pytest.mark.parametrize('status, relative_path, filename, expected_files', [
+@pytest.mark.parametrize('status, relative_dirname, filename, expected_files', [
     (None, None, None, {'test1_decoders.xml', 'test2_decoders.xml', 'wrong_decoders.xml'}),
     ('all', None, None, {'test1_decoders.xml', 'test2_decoders.xml', 'wrong_decoders.xml'}),
     ('enabled', None, None, {'test1_decoders.xml', 'wrong_decoders.xml'}),
@@ -121,9 +121,9 @@ def test_get_decoders_files(conf, exception):
     ('disabled', None, ['wrong_decoders.xml', 'test2_decoders.xml', 'non_existing.xml'], {'test2_decoders.xml'}),
     (None, None, 'non_existing.xml', set()),
 ])
-def test_get_decoders_files_filters(status, relative_path, filename, expected_files):
+def test_get_decoders_files_filters(status, relative_dirname, filename, expected_files):
     # UUT call
-    result = decoder.get_decoders_files(status=status, relative_path=relative_path, filename=filename)
+    result = decoder.get_decoders_files(status=status, relative_dirname=relative_dirname, filename=filename)
     assert isinstance(result, AffectedItemsWazuhResult)
     # Build result_files set from response for filter validation
     result_files = {d['filename'] for d in result.affected_items}

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -53,7 +53,7 @@ def mock_ossec_path():
 
 # Tests
 
-@pytest.mark.parametrize('names, status, file, path, parents, expected_names, expected_total_failed', [
+@pytest.mark.parametrize('names, status, filename, relative_path, parents, expected_names, expected_total_failed', [
     (None, None, None, None, False, {'agent-buffer', 'json', 'agent-upgrade', 'wazuh', 'agent-restart'}, 0),
     (['agent-buffer'], None, None, None, False, {'agent-buffer'}, 0),
     (['agent-buffer', 'non_existing'], None, None, None, False, {'agent-buffer'}, 1),
@@ -65,13 +65,14 @@ def mock_ossec_path():
     (None, 'all', None, 'core/tests/data/decoders', True, {'wazuh', 'json'}, 0),
     (None, 'all', None, 'nothing_here', False, set(), 0)
 ])
-def test_get_decoders(names, status, file, path, parents, expected_names, expected_total_failed):
+def test_get_decoders(names, status, filename, relative_path, parents, expected_names, expected_total_failed):
     wrong_decoder_original_path = os.path.join(test_data_path, 'core/tests/data/decoders', 'wrong_decoders.xml')
     wrong_decoder_tmp_path = os.path.join(test_data_path, 'core/tests/data', 'wrong_decoders.xml')
     try:
         os.rename(wrong_decoder_original_path, wrong_decoder_tmp_path)
         # UUT call
-        result = decoder.get_decoders(names=names, status=status, file=file, path=path, parents=parents)
+        result = decoder.get_decoders(names=names, status=status, filename=filename, relative_path=relative_path,
+                                      parents=parents)
         assert isinstance(result, AffectedItemsWazuhResult)
         # Build result names set from response for filter validation
         result_names = {d['name'] for d in result.affected_items}
@@ -96,14 +97,14 @@ def test_get_decoders_files(conf, exception):
             assert isinstance(result.affected_items, list)
             assert len(result.affected_items) != 0
             for item in result.affected_items:
-                assert {'file', 'path', 'status'}.issubset(set(item))
+                assert {'filename', 'relative_path', 'status'}.issubset(set(item))
             assert result.total_affected_items == len(result.affected_items)
         except WazuhInternalError as e:
             # If the UUT call returns an exception we check it has the appropriate error code
             assert e.code == exception.code
 
 
-@pytest.mark.parametrize('status, path, file, expected_files', [
+@pytest.mark.parametrize('status, relative_path, filename, expected_files', [
     (None, None, None, {'test1_decoders.xml', 'test2_decoders.xml', 'wrong_decoders.xml'}),
     ('all', None, None, {'test1_decoders.xml', 'test2_decoders.xml', 'wrong_decoders.xml'}),
     ('enabled', None, None, {'test1_decoders.xml', 'wrong_decoders.xml'}),
@@ -120,23 +121,23 @@ def test_get_decoders_files(conf, exception):
     ('disabled', None, ['wrong_decoders.xml', 'test2_decoders.xml', 'non_existing.xml'], {'test2_decoders.xml'}),
     (None, None, 'non_existing.xml', set()),
 ])
-def test_get_decoders_files_filters(status, path, file, expected_files):
+def test_get_decoders_files_filters(status, relative_path, filename, expected_files):
     # UUT call
-    result = decoder.get_decoders_files(status=status, path=path, file=file)
+    result = decoder.get_decoders_files(status=status, relative_path=relative_path, filename=filename)
     assert isinstance(result, AffectedItemsWazuhResult)
     # Build result_files set from response for filter validation
-    result_files = {d['file'] for d in result.affected_items}
+    result_files = {d['filename'] for d in result.affected_items}
     assert result_files == expected_files
 
 
-@pytest.mark.parametrize('file', [
+@pytest.mark.parametrize('filename', [
     'test1_decoders.xml',
     'test2_decoders.xml',
     'wrong_decoders.xml',
 ])
-def test_get_file(file):
+def test_get_file(filename):
     # UUT call
-    result = decoder.get_file(file=file)
+    result = decoder.get_file(filename=filename)
     # We assert the result is a plain text str
     assert isinstance(result, str)
 
@@ -144,16 +145,16 @@ def test_get_file(file):
 def test_get_file_exceptions():
     with pytest.raises(WazuhError, match=r'.* 1503 .*'):
         # UUT 1st call using a non-existing file that returns 0 decoders
-        decoder.get_file(file='non_existing_file.xml')
+        decoder.get_file(filename='non_existing_file.xml')
     with patch('builtins.open', return_value=Exception):
         with pytest.raises(WazuhInternalError, match=r'.* 1501 .*'):
             # UUT 2nd call forcing en error opening decoder file
-            decoder.get_file(file='test1_decoders.xml')
+            decoder.get_file(filename='test1_decoders.xml')
     with pytest.raises(WazuhError, match=r'.* 1502 .*'):
         try:
-            file = 'test2_decoders.xml'
-            os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', file), 000)
+            filename = 'test2_decoders.xml'
+            os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', filename), 000)
             # UUT 3rd call forcing a permissions error opening decoder file
-            decoder.get_file(file=file)
+            decoder.get_file(filename=filename)
         finally:
-            os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', file), 777)
+            os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', filename), 777)

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -242,7 +242,7 @@ def test_get_rules_file_download(mock_config, file_):
 def test_get_rules_file_download_failed(mock_config, file_):
     """Test download a specified rule filter."""
     with patch('wazuh.rule.get_rules_files', return_value=AffectedItemsWazuhResult(
-            all_msg='test', affected_items=[{'relative_path': list(file_.keys())[0]}])):
+            all_msg='test', affected_items=[{'relative_dirname': list(file_.keys())[0]}])):
         try:
             rule.get_file(list(file_.keys())[0])
             assert False

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -105,7 +105,7 @@ def test_get_rules_file_status_include(mock_ossec, status, func):
             if status != 'enabled':
                 index_disabled = next((index for (index, d) in enumerate(
                     d_files['affected_items']) if d["status"] == "disabled"), None)
-                assert d_files['affected_items'][index_disabled]['file'] == '0010-rules_config.xml'
+                assert d_files['affected_items'][index_disabled]['filename'] == '0010-rules_config.xml'
 
 
 @pytest.mark.parametrize('func', [
@@ -119,8 +119,8 @@ def test_get_rules_file_status_include(mock_ossec, status, func):
 @patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)
 def test_get_rules_file_file_param(mock_config, file_, func):
     """Test getting rules using param filter."""
-    d_files = func(file=file_)
-    assert [d_files.affected_items[0]['file']] == file_
+    d_files = func(filename=file_)
+    assert [d_files.affected_items[0]['filename']] == file_
     if func == rule.get_rules_files:
         assert d_files.total_affected_items == 1
     else:
@@ -138,14 +138,14 @@ def test_failed_get_rules_file(mock_config):
 
 @pytest.mark.parametrize('arg', [
     {'group': 'user1'},
-    {'pci': 'user1'},
+    {'pci_dss': 'user1'},
     {'gpg13': '10.0'},
     {'gdpr': 'IV_35.7.a'},
     {'hipaa': '164.312.a'},
     {'nist_800_53': 'AU.1'},
     {'rule_ids': [510], 'status': 'all'},
     {'rule_ids': [1, 1]},
-    {'rule_ids': [510, 1], 'file': ['noexists.xml']},
+    {'rule_ids': [510, 1], 'filename': ['noexists.xml']},
     {'rule_ids': [510, 999999], 'status': 'disabled'},
     {'level': '2'},
     {'level': '2-2'},
@@ -196,7 +196,7 @@ def test_get_groups(mock_config, arg):
 
 
 @pytest.mark.parametrize('requirement', [
-    'pci', 'gdpr', 'hipaa', 'nist_800_53', 'gpg13'
+    'pci_dss', 'gdpr', 'hipaa', 'nist_800_53', 'gpg13'
 ])
 @patch('wazuh.configuration.get_ossec_conf', return_value=rule_ossec_conf)
 def test_get_requirement(mocked_config, requirement):
@@ -242,7 +242,7 @@ def test_get_rules_file_download(mock_config, file_):
 def test_get_rules_file_download_failed(mock_config, file_):
     """Test download a specified rule filter."""
     with patch('wazuh.rule.get_rules_files', return_value=AffectedItemsWazuhResult(
-            all_msg='test', affected_items=[{'path': list(file_.keys())[0]}])):
+            all_msg='test', affected_items=[{'relative_path': list(file_.keys())[0]}])):
         try:
             rule.get_file(list(file_.keys())[0])
             assert False


### PR DESCRIPTION
|Related issue|
|---|
|#4565|

## Description

Hello team,

This PR closes #4565. It fixes the behaviour of new API endpoints `GET /lists/files` and `GET /rules`. It also refactors all decoders, lists and rules endpoints and framework modules.

## API Call Examples

**GET /rules:**
```
curl -X GET "http://localhost:55000/rules?pretty=false&wait_for_complete=false&offset=0&limit=500&q=id%3D184678" -H  "accept: application/json" -H  "Authorization: Bearer {JWT_TOKEN}"
{
  "data": {
    "affected_items": [
      {
        "description": "Sysmon - Suspicious Process - lsm.exe is a Parent Image",
        "details": {
          "if_group": "sysmon_event1",
          "sysmon.parentImage": "lsm.exe"
        },
        "file": "0330-sysmon_rules.xml",
        "gdpr": [
          "IV_35.7.d"
        ],
        "gpg13": [],
        "groups": [
          "sysmon",
          "sysmon_process-anomalies"
        ],
        "hipaa": [
          "164.312.b"
        ],
        "id": 184678,
        "level": 12,
        "nist_800_53": [
          "AU.6",
          "SI.4"
        ],
        "path": "ruleset/rules",
        "pci": [
          "10.6.1",
          "11.4"
        ],
        "status": "enabled"
      }
    ],
    "failed_items": [],
    "total_affected_items": 2859,
    "total_failed_items": 0
  },
  "message": "All selected rules were shown"
}
```

**GET /lists/files:**
```
curl -X GET "http://localhost:55000/lists/files?pretty=false&wait_for_complete=false&offset=0&limit=500" -H  "accept: application/json" -H  "Authorization: Bearer {JWT_TOKEN}"
{
  "data": {
    "affected_items": [
      {
        "name": "audit-keys",
        "path": "etc/lists"
      },
      {
        "name": "security-eventchannel",
        "path": "etc/lists"
      },
      {
        "name": "aws-sources",
        "path": "etc/lists/amazon"
      },
      {
        "name": "aws-eventnames",
        "path": "etc/lists/amazon"
      }
    ],
    "failed_items": [],
    "total_affected_items": 4,
    "total_failed_items": 0
  },
  "message": "All specified paths were shown"
}
```
## Tests

### Rule unit test updated results:
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/davidjiglesias/git/wazuh/framework
collected 22 items                                                                                                                                                                                                                           

wazuh/core/tests/test_rule.py ......................                                                                                                                                                                                   [100%]

======================================================================================================= 22 passed, 1 warning in 0.18s ========================================================================================================

Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
wazuh/core/rule.py     123      0   100%


============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/davidjiglesias/git/wazuh/framework
collected 45 items                                                                                                                                                                                                                           

wazuh/tests/test_rule.py .............................................                                                                                                                                                                 [100%]

======================================================================================================= 45 passed, 1 warning in 0.44s ========================================================================================================

Name            Stmts   Miss  Cover   Missing
---------------------------------------------
wazuh/rule.py      90      0   100%
```
### API rule integration test updated results:
Regular tests:
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-4.5.0, py-1.8.1, pluggy-0.13.1 -- /usr/local/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: tavern-0.34.0
collected 11 items                                                                                                                                                                                                                           

test/integration/test_rules_endpoints.tavern.yaml::GET /rules PASSED                                                                                                                                                                   [  9%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules filters PASSED                                                                                                                                                           [ 18%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules/requirement/pci PASSED                                                                                                                                                   [ 27%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules/requirement/gdpr PASSED                                                                                                                                                  [ 36%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules/requirement/gpg13 PASSED                                                                                                                                                 [ 45%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules/requirement/hipaa PASSED                                                                                                                                                 [ 54%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules/requirement/nist-800-53 PASSED                                                                                                                                           [ 63%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules/groups PASSED                                                                                                                                                            [ 72%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules/files PASSED                                                                                                                                                             [ 81%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules/files/{file}/download PASSED                                                                                                                                             [ 90%]
test/integration/test_rules_endpoints.tavern.yaml::GET /rules?rule_ids PASSED                                                                                                                                                          [100%]

============================================================================================================== warnings summary ==============================================================================================================
test/integration/test_rules_endpoints.tavern.yaml::GET /rules
  /home/davidjiglesias/.local/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

test/integration/test_rules_endpoints.tavern.yaml::GET /rules
test/integration/test_rules_endpoints.tavern.yaml::GET /rules filters
  /home/davidjiglesias/.local/lib/python3.7/site-packages/tavern/util/dict_util.py:189: FutureWarning: In a future version of Tavern, selecting for values to save in nested objects will have to be done as a JMES path query - see http://jmespath.org/ for more information
    warnings.warn(msg, FutureWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================================== 11 passed, 3 warnings in 130.04 seconds ===================================================================================================
```
RBAC Black tests:
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-4.5.0, py-1.8.1, pluggy-0.13.1 -- /usr/local/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: tavern-0.34.0
collected 5 items                                                                                                                                                                                                                            

test/integration/test_rbac_black_rules_endpoints.tavern.yaml::GET RULES RBAC PASSED                                                                                                                                                    [ 20%]
test/integration/test_rbac_black_rules_endpoints.tavern.yaml::GET RULES FILES RBAC PASSED                                                                                                                                              [ 40%]
test/integration/test_rbac_black_rules_endpoints.tavern.yaml::GET RULES FILES RBAC (Download) PASSED                                                                                                                                   [ 60%]
test/integration/test_rbac_black_rules_endpoints.tavern.yaml::GET RULES GROUPS RBAC PASSED                                                                                                                                             [ 80%]
test/integration/test_rbac_black_rules_endpoints.tavern.yaml::GET PCI REQUIREMENT RBAC PASSED                                                                                                                                          [100%]

============================================================================================================== warnings summary ==============================================================================================================
test/integration/test_rbac_black_rules_endpoints.tavern.yaml::GET RULES RBAC
  /home/davidjiglesias/.local/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 5 passed, 1 warnings in 44.59 seconds ====================================================================================================
```
RBAC White tests:
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-4.5.0, py-1.8.1, pluggy-0.13.1 -- /usr/local/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: tavern-0.34.0
collected 5 items                                                                                                                                                                                                                            

test/integration/test_rbac_white_rules_endpoints.tavern.yaml::GET RULES RBAC PASSED                                                                                                                                                    [ 20%]
test/integration/test_rbac_white_rules_endpoints.tavern.yaml::GET RULES FILES RBAC PASSED                                                                                                                                              [ 40%]
test/integration/test_rbac_white_rules_endpoints.tavern.yaml::GET RULES FILES RBAC (Download) PASSED                                                                                                                                   [ 60%]
test/integration/test_rbac_white_rules_endpoints.tavern.yaml::GET RULES GROUPS RBAC PASSED                                                                                                                                             [ 80%]
test/integration/test_rbac_white_rules_endpoints.tavern.yaml::GET PCI REQUIREMENT RBAC PASSED                                                                                                                                          [100%]

============================================================================================================== warnings summary ==============================================================================================================
test/integration/test_rbac_white_rules_endpoints.tavern.yaml::GET RULES RBAC
  /home/davidjiglesias/.local/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 5 passed, 1 warnings in 40.93 seconds ====================================================================================================
```

### Cdb_list unit test updated results:
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/davidjiglesias/git/wazuh/framework
collected 47 items                                                                                                                                                                                                                           

wazuh/tests/test_cdb_list.py ...............................................                                                                                                                                                           [100%]

======================================================================================================= 47 passed, 1 warning in 0.23s ========================================================================================================

Name                Stmts   Miss  Cover   Missing
-------------------------------------------------
wazuh/cdb_list.py      25      0   100%

============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/davidjiglesias/git/wazuh/framework
collected 22 items                                                                                                                                                                                                                           

wazuh/core/tests/test_cdb_list.py ......................                                                                                                                                                                               [100%]

============================================================================================================= 22 passed in 0.08s =============================================================================================================

Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
wazuh/core/cdb_list.py      50      0   100%

```
### API cdb_lists integration test updated results:
Regular tests:
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-4.5.0, py-1.8.1, pluggy-0.13.1 -- /usr/local/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: tavern-0.34.0
collected 2 items                                                                                                                                                                                                                            

test/integration/test_lists_endpoints.tavern.yaml::GET /lists PASSED                                                                                                                                                                   [ 50%]
test/integration/test_lists_endpoints.tavern.yaml::GET /lists/files PASSED                                                                                                                                                             [100%]

============================================================================================================== warnings summary ==============================================================================================================
test/integration/test_lists_endpoints.tavern.yaml::GET /lists
  /home/davidjiglesias/.local/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

test/integration/test_lists_endpoints.tavern.yaml::GET /lists
test/integration/test_lists_endpoints.tavern.yaml::GET /lists/files
  /home/davidjiglesias/.local/lib/python3.7/site-packages/tavern/util/dict_util.py:189: FutureWarning: In a future version of Tavern, selecting for values to save in nested objects will have to be done as a JMES path query - see http://jmespath.org/ for more information
    warnings.warn(msg, FutureWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 2 passed, 3 warnings in 79.46 seconds ====================================================================================================
```
RBAC Black:
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-4.5.0, py-1.8.1, pluggy-0.13.1 -- /usr/local/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: tavern-0.34.0
collected 2 items                                                                                                                                                                                                                            

test/integration/test_rbac_black_lists_endpoints.tavern.yaml::GET LISTS RBAC PASSED                                                                                                                                                    [ 50%]
test/integration/test_rbac_black_lists_endpoints.tavern.yaml::GET LISTS FILES RBAC PASSED                                                                                                                                              [100%]

============================================================================================================== warnings summary ==============================================================================================================
test/integration/test_rbac_black_lists_endpoints.tavern.yaml::GET LISTS RBAC
  /home/davidjiglesias/.local/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 2 passed, 1 warnings in 39.42 seconds ====================================================================================================
```
RBAC White:
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-4.5.0, py-1.8.1, pluggy-0.13.1 -- /usr/local/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/api
plugins: tavern-0.34.0
collected 2 items                                                                                                                                                                                                                            

test/integration/test_rbac_white_lists_endpoints.tavern.yaml::GET LISTS RBAC PASSED                                                                                                                                                    [ 50%]
test/integration/test_rbac_white_lists_endpoints.tavern.yaml::GET LISTS FILES RBAC PASSED                                                                                                                                              [100%]

============================================================================================================== warnings summary ==============================================================================================================
test/integration/test_rbac_white_lists_endpoints.tavern.yaml::GET LISTS RBAC
  /home/davidjiglesias/.local/lib/python3.7/site-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 2 passed, 1 warnings in 40.55 seconds ====================================================================================================
```
