### PR TITLE
Have FIM generate alerts when rename or move directory

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -304,7 +304,7 @@ void fim_realtime_event(char *file, fim_element *item) {
 
     struct stat file_stat;
 
-    // If file exist, generate add or modify events.
+    // If the file exist, generate add or modify events.
     if (w_stat(file, &file_stat) >= 0) {
 
 #ifdef WIN32
@@ -328,7 +328,7 @@ void fim_whodata_event(whodata_evt * w_evt, fim_element *item) {
 
     struct stat file_stat;
 
-    // If file exist, generate add or modify events.
+    // If the file exist, generate add or modify events.
     if(w_stat(w_evt->path, &file_stat) >= 0) {
 
 #ifdef WIN32
@@ -393,7 +393,7 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
         return;
     }
 
-    // If doesn't exist, research if it's directory and have files in DB.
+    // Since the file doesn't exist, research if it's directory and have files in DB.
     char **paths;
     char first_entry[PATH_MAX];
     char last_entry[PATH_MAX];

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -300,38 +300,158 @@ int fim_file (char *file, fim_element *item, whodata_evt *w_evt, int report) {
 }
 
 
-void fim_realtime_event(char *file) {
-    char inode_key[OS_SIZE_128];
+void fim_realtime_event(char *file, fim_element *item) {
+
     struct stat file_stat;
 
+    // If file exist, generate add or modify events.
     if (w_stat(file, &file_stat) >= 0) {
-        // Add and modify events
+
+#ifdef WIN32
+        fim_checker(file, item, NULL, 1);
+#else
+        char inode_key[OS_SIZE_128];
+
         snprintf(inode_key, OS_SIZE_128, "%ld:%ld", (unsigned long)file_stat.st_dev, (unsigned long)file_stat.st_ino);
-    } else {
-        // Deleted file need get inode and dev from saved data
-        w_mutex_lock(&syscheck.fim_entry_mutex);
-        fim_entry_data * saved_data = NULL;
+        fim_audit_inode_event(file, inode_key, FIM_REALTIME, NULL);
+#endif
 
-        if (saved_data = (fim_entry_data *) rbtree_get(syscheck.fim_entry, file), saved_data) {
-            snprintf(inode_key, OS_SIZE_128, "%ld:%ld", (unsigned long)saved_data->dev, (unsigned long)saved_data->inode);
-        } else {
-            w_mutex_unlock(&syscheck.fim_entry_mutex);
-            return;
-        }
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
     }
-    fim_audit_inode_event(file, inode_key, FIM_REALTIME, NULL);
+    else {
+        // It's possible file deleted or directory moved.
+        fim_process_missing_entry(file, FIM_REALTIME, NULL, item);
+    }
 }
-
 
 // LCOV_EXCL_START
-void fim_whodata_event(whodata_evt * w_evt) {
-    char inode_key[OS_SIZE_128];
+void fim_whodata_event(whodata_evt * w_evt, fim_element *item) {
 
-    snprintf(inode_key, OS_SIZE_128, "%s:%s", w_evt->dev, w_evt->inode);
-    fim_audit_inode_event(w_evt->path, inode_key, FIM_WHODATA, w_evt);
+    struct stat file_stat;
+
+    // If file exist, generate add or modify events.
+    if(w_stat(w_evt->path, &file_stat) >= 0) {
+
+#ifdef WIN32
+        fim_checker(w_evt->path, item, w_evt, 1);
+
+#else
+        char inode_key[OS_SIZE_128];
+
+        snprintf(inode_key, OS_SIZE_128, "%s:%s", w_evt->dev, w_evt->inode);
+        fim_audit_inode_event(w_evt->path, inode_key, FIM_WHODATA, w_evt);
+#endif
+
+    }
+    // It's possible file deleted or directory moved.
+    else {
+        fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt, item);
+    }
 }
+
 // LCOV_EXCL_STOP
+
+
+void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt * w_evt, fim_element *item) {
+
+    fim_entry_data *saved_data;
+    int found = 0;
+
+#ifndef WIN32
+    char inode_key[OS_SIZE_128];
+    unsigned long dev = 0;
+    unsigned long inode = 0;
+#endif
+
+    // Search path in DB.
+    w_mutex_lock(&syscheck.fim_entry_mutex);
+    saved_data = (fim_entry_data *)rbtree_get(syscheck.fim_entry, pathname);
+
+    if (saved_data) {
+        found = 1;
+
+#ifndef WIN32
+        dev = saved_data->dev;
+        inode = saved_data->inode;
+#endif
+
+    }
+
+    w_mutex_unlock(&syscheck.fim_entry_mutex);
+
+    // Exists, create event.
+    if (found) {
+
+#ifdef WIN32
+        fim_checker(pathname, item, w_evt, 1);
+
+#else
+        snprintf(inode_key, OS_SIZE_128, "%ld:%ld", dev, inode);
+        fim_audit_inode_event(pathname, inode_key, mode, w_evt);
+
+#endif
+
+        return;
+    }
+
+    // If doesn't exist, research if it's directory and have files in DB.
+    char **paths;
+    char first_entry[PATH_MAX];
+    char last_entry[PATH_MAX];
+    int config_file;
+    int config_dir;
+
+    config_dir = fim_configuration_directory(pathname, "file");
+
+#ifdef WIN32
+    snprintf(first_entry, PATH_MAX, "%s\\", pathname);
+    snprintf(last_entry, PATH_MAX, "%s]", pathname);
+
+#else
+    snprintf(first_entry, PATH_MAX, "%s/", pathname);
+    snprintf(last_entry, PATH_MAX, "%s0", pathname);
+
+#endif
+
+    w_mutex_lock(&syscheck.fim_entry_mutex);
+    paths = rbtree_range(syscheck.fim_entry, first_entry, last_entry);
+    w_mutex_unlock(&syscheck.fim_entry_mutex);
+
+    if (paths == NULL) {
+        return;
+    }
+
+    for (int i = 0; paths[i]; i++) {
+
+        config_file = fim_configuration_directory(paths[i], "file");
+
+        if (config_file == config_dir) {
+
+#ifdef WIN32
+            fim_checker(paths[i], item, w_evt, 1);
+
+#else
+            w_mutex_lock(&syscheck.fim_entry_mutex);
+            saved_data = (fim_entry_data *)rbtree_get(syscheck.fim_entry, paths[i]);
+
+            if (saved_data) {
+                found = 1;
+                dev = saved_data->dev;
+                inode = saved_data->inode;
+            }
+            w_mutex_unlock(&syscheck.fim_entry_mutex);
+
+            if (found) {
+                snprintf(inode_key, OS_SIZE_128, "%ld:%ld", dev, inode);
+                fim_audit_inode_event(paths[i], inode_key, mode, w_evt);
+                found = 0;
+            }
+
+#endif
+        }
+    }
+
+    free_strarray(paths);
+}
 
 
 void fim_audit_inode_event(char *file, const char *inode_key, fim_event_mode mode, whodata_evt * w_evt) {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -185,7 +185,7 @@ void realtime_process()
         char ** paths = rbtree_keys(tree);
 
         for (int i = 0; paths[i] != NULL; i++) {
-            fim_realtime_event(paths[i]);
+            fim_realtime_event(paths[i], NULL);
         }
 
         free_strarray(paths);
@@ -285,12 +285,12 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
 
             Sleep(syscheck.rt_delay);
 
-
             if (index == file_index) {
                 item->mode = FIM_REALTIME;
                 /* Check the change */
-                fim_checker(final_path, item, NULL, 1);
+                fim_realtime_event(final_path, item);
             }
+
         } while (pinfo->NextEntryOffset != 0);
         os_free(item);
     }

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -162,7 +162,7 @@ void fim_whodata_event(whodata_evt *w_evt, fim_element *item);
 /**
  * @brief Process a path that has possibly been deleted
  *
- * @note On Windows, calls function fim_checker meanwhile, on Linux, calls function fim_audit_inode_event. It's due Windows haven't got inodes.
+ * @note On Windows, calls function fim_checker meanwhile, on Linux, calls function fim_audit_inode_event. It's because Windows haven't got inodes.
  * @param pathname Name of path
  * @param mode Monitoring FIM mode
  * @param w_evt Pointer to whodata information

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -147,15 +147,28 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report);
  * @brief Process FIM realtime event
  *
  * @param [in] file Path of the file to check
+ * @param item Pointer to fim_element necesary to call fim_checker function. May be null
  */
-void fim_realtime_event(char *file);
+void fim_realtime_event(char *file, fim_element *item);
 
 /**
  * @brief Process FIM whodata event
  *
  * @param w_evt Whodata event
+ * @param item Pointer to fim_element necesary to call fim_checker function. May be null
  */
-void fim_whodata_event(whodata_evt *w_evt);
+void fim_whodata_event(whodata_evt *w_evt, fim_element *item);
+
+/**
+ * @brief Process a path that has possibly been deleted
+ *
+ * @note On Windows, calls function fim_checker meanwhile, on Linux, calls function fim_audit_inode_event. It's due Windows haven't got inodes.
+ * @param pathname Name of path
+ * @param mode Monitoring FIM mode
+ * @param w_evt Pointer to whodata information
+ * @param item Pointer to fim_element necesary to call fim_checker function. May be null
+ */
+void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt * w_evt, fim_element *item);
 
 /**
  * @brief Process FIM audit event
@@ -163,7 +176,7 @@ void fim_whodata_event(whodata_evt *w_evt);
  * @param [in] file Path of the file to check
  * @param [in] inode_key Inode key of the file to check
  * @param [in] mode 1 means realtime, 2 means whodata
- * @param [in] w_evt Whodata event
+ * @param [in] w_evt Whodata event, it may be null
  */
 void fim_audit_inode_event(char *file, const char *inode_key, fim_event_mode mode, whodata_evt *w_evt);
 

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -847,7 +847,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt);
+                                fim_whodata_event(w_evt, NULL);
                             }
                         }
                     }
@@ -878,7 +878,7 @@ void audit_parse(char *buffer) {
                             w_evt->path = real_path;
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt);
+                                fim_whodata_event(w_evt, NULL);
                             }
                         }
                     }
@@ -917,7 +917,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt);
+                                fim_whodata_event(w_evt, NULL);
                             }
                         }
                     }
@@ -977,7 +977,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt);
+                                fim_whodata_event(w_evt, NULL);
                             }
                             free(file_path1);
                             w_evt->path = NULL;
@@ -999,7 +999,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt);
+                                fim_whodata_event(w_evt, NULL);
                             }
                         }
                     }
@@ -1041,7 +1041,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt);
+                                fim_whodata_event(w_evt, NULL);
                             }
                         }
                     }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -753,14 +753,20 @@ add_whodata_evt:
                         } else {
                             // At this point the file can be created
                         }
-                        fim_checker(w_evt->path, item, w_evt, 1);
+                        fim_whodata_event(w_evt, item);
                     } else if (w_evt->scan_directory == 1) { // Directory scan has been aborted if scan_directory is 2
                         if (mask & DELETE) {
-                            fim_checker(w_evt->path, item, w_evt, 1);
+
+                            fim_whodata_event(w_evt, item);
+
+                            // Find new files
+                            int pos = fim_configuration_directory(w_evt->path, "file");
+                            fim_checker(syscheck.dir[pos], item, NULL, 1);
+
                         } else if ((mask & FILE_WRITE_DATA) && w_evt->path && (w_dir = OSHash_Get(syscheck.wdata.directories, w_evt->path))) {
                             // Check that a new file has been added
                             GetSystemTime(&w_dir->timestamp);
-                            fim_checker(w_evt->path, item, w_evt, 1);
+                            fim_whodata_event(w_evt, item);
 
                             mdebug1(FIM_WHODATA_SCAN, w_evt->path);
                         } else {

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -741,18 +741,17 @@ add_whodata_evt:
 
                 if (w_evt = OSHash_Delete_ex(syscheck.wdata.fd, hash_id), w_evt && w_evt->path) {
                     unsigned int mask = w_evt->mask;
+
                     if (!w_evt->scan_directory) {
+
                         if (w_evt->deleted) {
                             // Check if the file has been deleted
                             w_evt->ignore_remove_event = 0;
                         } else if (mask & DELETE) {
                             // The file has been moved or renamed
                             w_evt->ignore_remove_event = 0;
-                        } else if (mask & modify_criteria) {
-                            // Check if the file has been modified
-                        } else {
-                            // At this point the file can be created
                         }
+
                         fim_whodata_event(w_evt, item);
                     } else if (w_evt->scan_directory == 1) { // Directory scan has been aborted if scan_directory is 2
                         if (mask & DELETE) {

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -49,7 +49,7 @@ list(APPEND tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fgets -Wl,--wrap,fclose")
 list(APPEND tests_names "test_create_db")
 list(APPEND tests_flags "-Wl,--wrap,rbtree_insert -Wl,--wrap,rbtree_get -Wl,--wrap,rbtree_replace -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 \
                          -Wl,--wrap,OSHash_Add -Wl,--wrap,lstat -Wl,--wrap,fim_send_scan_info -Wl,--wrap,send_syscheck_msg -Wl,--wrap,rbtree_keys -Wl,--wrap,readdir -Wl,--wrap,opendir -Wl,--wrap,closedir \
-                         -Wl,--wrap,rbtree_delete -Wl,--wrap,OSHash_Delete -Wl,--wrap,print_rbtree -Wl,--wrap,realtime_adddir -Wl,--wrap,HasFilesystem")
+                         -Wl,--wrap,rbtree_delete -Wl,--wrap,OSHash_Delete -Wl,--wrap,print_rbtree -Wl,--wrap,realtime_adddir -Wl,--wrap,HasFilesystem -Wl,--wrap,rbtree_range")
 
 list(APPEND tests_names "test_syscheck_audit")
 list(APPEND tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,IsSocket -Wl,--wrap,IsFile -Wl,--wrap,IsDir -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,audit_restart \

--- a/src/unit_tests/test_create_db.c
+++ b/src/unit_tests/test_create_db.c
@@ -98,6 +98,10 @@ void *__wrap_rbtree_get(const rb_tree *tree, const char *key) {
     return mock_type(fim_entry_data *);
 }
 
+void *__wrap_rbtree_range() {
+    return mock_type(char *);
+}
+
 int __wrap_OSHash_Add(OSHash *self, const char *key, void *data) {
     check_expected(key);
 
@@ -1404,7 +1408,7 @@ void test_fim_realtime_event_add(void **state)
     // Inside fim_checker
     expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'test'");
 
-    fim_realtime_event("test");
+    fim_realtime_event("test", NULL);
 }
 
 
@@ -1412,11 +1416,13 @@ void test_fim_realtime_event_deleted(void **state)
 {
     will_return(__wrap_lstat, -1);
 
+    // Inside fim_process_missing_entry
     expect_value(__wrap_rbtree_get, tree, syscheck.fim_entry);
-    expect_string(__wrap_rbtree_get, key, "test");
+    expect_string(__wrap_rbtree_get, key, "/media/test.file");
     will_return(__wrap_rbtree_get, NULL);
+    will_return(__wrap_rbtree_range, NULL);
 
-    fim_realtime_event("test");
+    fim_realtime_event("/media/test.file", NULL);
 }
 
 
@@ -1435,7 +1441,57 @@ void test_fim_realtime_event_deleted_saved(void **state)
     // Inside fim_checker
     expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'test'");
 
-    fim_realtime_event("test");
+    fim_realtime_event("test", NULL);
+}
+
+
+void test_fim_process_missing_entry_found(void **state)
+{
+    fim_data_t *fim_data = *state;
+
+    expect_value(__wrap_rbtree_get, tree, syscheck.fim_entry);
+    expect_string(__wrap_rbtree_get, key, "test");
+    will_return(__wrap_rbtree_get, fim_data->old_data);
+
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    // Inside fim_checker
+    expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'test'");
+
+    fim_process_missing_entry("test", FIM_REALTIME, NULL, NULL);
+}
+
+
+void test_fim_process_missing_entry_not_found_path(void **state)
+{
+    expect_value(__wrap_rbtree_get, tree, syscheck.fim_entry);
+    expect_string(__wrap_rbtree_get, key, "/media/test.file");
+    will_return(__wrap_rbtree_get, NULL);
+    will_return(__wrap_rbtree_range, NULL);
+
+    fim_process_missing_entry("/media/test.file", FIM_REALTIME, NULL, NULL);
+}
+
+
+void test_fim_process_missing_entry_is_dir(void **state)
+{
+    char ** path = NULL;
+    path = os_AddStrArray("/media/test.file", path);
+    fim_data_t *fim_data = *state;
+
+    expect_value(__wrap_rbtree_get, tree, syscheck.fim_entry);
+    expect_string(__wrap_rbtree_get, key, "/media");
+    will_return(__wrap_rbtree_get, NULL);
+    will_return(__wrap_rbtree_range, path);
+    expect_value(__wrap_rbtree_get, tree, syscheck.fim_entry);
+    expect_string(__wrap_rbtree_get, key, path[0]);
+    will_return(__wrap_rbtree_get, fim_data->old_data);
+
+    // Inside fim_checker
+    will_return(__wrap_OSHash_Get_ex, NULL);
+    will_return(__wrap_lstat, -1);
+
+    fim_process_missing_entry("/media", FIM_REALTIME, NULL, NULL);
 }
 
 
@@ -1675,6 +1731,11 @@ int main(void) {
         cmocka_unit_test(test_fim_realtime_event_add),
         cmocka_unit_test(test_fim_realtime_event_deleted),
         cmocka_unit_test(test_fim_realtime_event_deleted_saved),
+
+        /* fim_process_missing_entry */
+        cmocka_unit_test(test_fim_process_missing_entry_found),
+        cmocka_unit_test(test_fim_process_missing_entry_not_found_path),
+        cmocka_unit_test(test_fim_process_missing_entry_is_dir),
 
         /* check_deleted_files */
         cmocka_unit_test(test_check_deleted_files),


### PR DESCRIPTION
|Related issue|
|---|
|[4557](https://github.com/wazuh/wazuh/issues/4557)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Functions `fim_realtime_event` and `fim_whodata_event` must be improved to process directories. Currently, these functions work thinking they only process files.

The proposed solution has the following behavior:

Functions `fim_realtime_event` and `fim_whodata_event` try open path using `w_stat`. If it's a success, the path exists so, call `fim_audit_inode_event` to generate modified or added event. Else, call `fim_process_missing_event`.

Function `fim_process_missing_event` search path in DB. If it exists, it's a file, and it has deleted. Call `fim_audit_inode_event` to generate a deleted event. Else, it may be directory so, search its files in DB. Then, call `fim_audit_inode_event` to generate an event.


## Logs/Alerts example

Move subdirectory monitored in Whodata to another directory also monitored:
```
2020/02/06 12:17:47 ossec-syscheckd[20055] run_check.c:76 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/home/lopezziur/testing1/subdir6/tes8","mode":"whodata","type":"deleted","timestamp":1580987829,"attributes":{"type":"file","size":0,"perm":"rw-rw-r--","uid":"1000","gid":"1000","user_name":"lopezziur","group_name":"lopezziur","inode":10773684,"mtime":1580904641,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"180e1da817153155cda78417fc93fb26464937ed"},"audit":{"path":"/home/lopezziur/testing1/subdir6","user_id":"1000","user_name":"lopezziur","process_name":"/bin/mv","process_id":20243,"group_id":"1000","group_name":"lopezziur","audit_uid":"1000","audit_name":"lopezziur","effective_uid":"1000","effective_name":"lopezziur","ppid":13792}}}
2020/02/06 12:17:47 ossec-syscheckd[20055] run_check.c:76 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/home/lopezziur/testing2/subdir6/tes8","mode":"whodata","type":"added","timestamp":1580987867,"attributes":{"type":"file","size":0,"perm":"rw-rw-r--","uid":"1000","gid":"1000","user_name":"lopezziur","group_name":"lopezziur","inode":10773684,"mtime":1580904641,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"180e1da817153155cda78417fc93fb26464937ed"},"audit":{"path":"/home/lopezziur/testing2/subdir6","user_id":"1000","user_name":"lopezziur","process_name":"/bin/mv","process_id":20243,"group_id":"1000","group_name":"lopezziur","audit_uid":"1000","audit_name":"lopezziur","effective_uid":"1000","effective_name":"lopezziur","ppid":13792}}}
```

Move subdirectory monitored in Realtime to another directory also monitored:
```
2020/02/06 09:57:39 ossec-syscheckd[28982] run_check.c:76 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/home/lopezziur/testing1/subdir6/tes8","mode":"real-time","type":"deleted","timestamp":1580979390,"attributes":{"type":"file","size":0,"perm":"rw-rw-r--","uid":"1000","gid":"1000","user_name":"lopezziur","group_name":"lopezziur","inode":10773684,"mtime":1580904641,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"180e1da817153155cda78417fc93fb26464937ed"}}}
2020/02/06 09:57:39 ossec-syscheckd[28982] run_check.c:76 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/home/lopezziur/testing2/subdir6/tes8","mode":"real-time","type":"added","timestamp":1580979459,"attributes":{"type":"file","size":0,"perm":"rw-rw-r--","uid":"1000","gid":"1000","user_name":"lopezziur","group_name":"lopezziur","inode":10773684,"mtime":1580904641,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"180e1da817153155cda78417fc93fb26464937ed"}}}
```

## Tests

- [x] Works on Linux
- [x] Works on Windows
- [x] Review logs syntax and correct language
- [x] Scan-build report on Linux
- [x] Scan-build report on Windows
- [x] Added unit tests (for new features)
- [x] Execute integrate test (basic usage and move/rename dir)

