### PR TITLE
Fixing unit tests for FIM v2 SQLite development

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -91,6 +91,7 @@ static int decode_event_delete;
 static int decode_event_modify;
 
 // Initialize the necessary information to process the syscheck information
+// LCOV_EXCL_START
 int fim_init(void) {
     //Create hash table for agent information
     fim_agentinfo = OSHash_Create();
@@ -1046,7 +1047,7 @@ int fim_get_scantime (long *ts, Eventinfo *lf, _sdb *sdb, const char* param) {
     os_free(response);
     return (1);
 }
-
+// LCOV_EXCL_STOP
 
 int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
     /* Every syscheck message must be in the following JSON format, as of agent version v3.11

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1590,9 +1590,15 @@ int Test_Syscheck(const char * path){
 void Free_Syscheck(syscheck_config * config) {
     if (config) {
         int i;
-        free(config->opts);
-        free(config->scan_day);
-        free(config->scan_time);
+        if (config->opts) {
+            free(config->opts);
+        }
+        if (config->scan_day) {
+            free(config->scan_day);
+        }
+        if (config->scan_time) {
+            free(config->scan_time);
+        }
         if (config->ignore) {
             for (i=0; config->ignore[i] != NULL; i++) {
                 free(config->ignore[i]);
@@ -1622,17 +1628,21 @@ void Free_Syscheck(syscheck_config * config) {
         if (config->dir) {
             for (i=0; config->dir[i] != NULL; i++) {
                 free(config->dir[i]);
-                if(config->filerestrict[i]) {
+                if(config->filerestrict && config->filerestrict[i]) {
                     OSMatch_FreePattern(config->filerestrict[i]);
                     free(config->filerestrict[i]);
                 }
-                if(config->tag[i]) {
+                if(config->tag && config->tag[i]) {
                     free(config->tag[i]);
                 }
             }
             free(config->dir);
-            free(config->filerestrict);
-            free(config->tag);
+            if (config->filerestrict) {
+                free(config->filerestrict);
+            }
+            if (config->tag) {
+                free(config->tag);
+            }
         }
         if (config->symbolic_links) {
             for (i=0; config->symbolic_links[i] != NULL; i++) {
@@ -1640,7 +1650,9 @@ void Free_Syscheck(syscheck_config * config) {
             }
             free(config->symbolic_links);
         }
-        free(config->recursion_level);
+        if (config->recursion_level) {
+            free(config->recursion_level);
+        }
 
     #ifdef WIN32
         if (config->registry_ignore) {
@@ -1675,7 +1687,9 @@ void Free_Syscheck(syscheck_config * config) {
 #endif
             free(config->realtime);
         }
-        free(config->prefilter_cmd);
+        if (config->prefilter_cmd) {
+            free(config->prefilter_cmd);
+        }
 
         free_strarray(config->audit_key);
     }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1667,7 +1667,9 @@ void Free_Syscheck(syscheck_config * config) {
     #endif
 
         if (config->realtime) {
-            OSHash_Free(config->realtime->dirtb);
+            if (config->realtime->dirtb) {
+                OSHash_Free(config->realtime->dirtb);
+            }
 #ifdef WIN32
             CloseEventLog(config->realtime->evt);
 #endif

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1602,6 +1602,7 @@ void Free_Syscheck(syscheck_config * config) {
         if (config->ignore_regex) {
             for (i=0; config->ignore_regex[i] != NULL; i++) {
                 OSMatch_FreePattern(config->ignore_regex[i]);
+                free(config->ignore_regex[i]);
             }
             free(config->ignore_regex);
         }
@@ -1614,7 +1615,9 @@ void Free_Syscheck(syscheck_config * config) {
         if (config->nodiff_regex) {
             for (i=0; config->nodiff_regex[i] != NULL; i++) {
                 OSMatch_FreePattern(config->nodiff_regex[i]);
+                free(config->nodiff_regex[i]);
             }
+            free(config->nodiff_regex);
         }
         if (config->dir) {
             for (i=0; config->dir[i] != NULL; i++) {
@@ -1631,6 +1634,13 @@ void Free_Syscheck(syscheck_config * config) {
             free(config->filerestrict);
             free(config->tag);
         }
+        if (config->symbolic_links) {
+            for (i=0; config->symbolic_links[i] != NULL; i++) {
+                free(config->symbolic_links[i]);
+            }
+            free(config->symbolic_links);
+        }
+        free(config->recursion_level);
 
     #ifdef WIN32
         if (config->registry_ignore) {

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -477,11 +477,11 @@
 
 #define FIM_DB_ERROR_COUNT_RANGE                    "(6703): Couldn't get range size between '%s' and '%s'"
 #define FIM_DB_ERROR_GET_PATH                       "(6704): Couldn't get path of '%s'"
-#define FIM_DB_ERROR_SYNC_DB                        "(6705): Failed to synchronize database"
-#define FIM_DB_ERROR_GET_ROW_PATH                   "(6706): Couldn't get %s row's path"
-#define FIM_DB_ERROR_CALC_CHECKSUM                  "(6707): Failed to calculate database checksum"
+#define FIM_DB_ERROR_SYNC_DB                        "(6705): Failed to synchronize database."
+#define FIM_DB_ERROR_GET_ROW_PATH                   "(6706): Couldn't get %s row's path."
+#define FIM_DB_ERROR_CALC_CHECKSUM                  "(6707): Failed to calculate database checksum."
 #define FIM_DB_ERROR_RM_RANGE                       "(6708): Failed to delete a range of paths between '%s' and '%s'"
-#define FIM_DB_ERROR_RM_NOT_SCANNED                 "(6709): Failed to delete from db all unscanned files"
+#define FIM_DB_ERROR_RM_NOT_SCANNED                 "(6709): Failed to delete from db all unscanned files."
 
 /* Verbose messages */
 #define STARTUP_MSG "Started (pid: %d)."

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -218,7 +218,7 @@ fdb_t *fim_db_init(int memory) {
 
 free_fim:
     if (fim->db){
-        sqlite3_close(fim->db);
+        sqlite3_close_v2(fim->db);
     }
     os_free(fim);
     return NULL;

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -762,7 +762,7 @@ int fim_db_data_checksum_range(fdb_t *fim_sql, const char *start, const char *to
     for (i = m; i < n; i++) {
         if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATH_RANGE]) != SQLITE_ROW) {
             merror("SQL ERROR: %s", sqlite3_errmsg(fim_sql->db));
-            goto end1;
+            goto end;
         }
         entry = fim_db_decode_full_row(fim_sql->stmt[FIMDB_STMT_GET_PATH_RANGE]);
         if (i == m && entry->path) {
@@ -774,7 +774,7 @@ int fim_db_data_checksum_range(fdb_t *fim_sql, const char *start, const char *to
 
     if (!str_pathlh || !str_pathuh) {
         merror("Failed to obtain required paths in order to form message");
-        goto end1;
+        goto end;
     }
 
     // Send message with checksum of first half
@@ -793,13 +793,11 @@ int fim_db_data_checksum_range(fdb_t *fim_sql, const char *start, const char *to
 
     retval = FIMDB_OK;
 
-end1:
+end:
+    EVP_MD_CTX_destroy(ctx_left);
     EVP_MD_CTX_destroy(ctx_right);
     os_free(str_pathlh);
     os_free(str_pathuh);
-
-end:
-    EVP_MD_CTX_destroy(ctx_left);
     return retval;
 }
 

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -585,7 +585,7 @@ char **fim_db_get_paths_from_inode(fdb_t *fim_sql, const unsigned long int inode
 
         while (result = sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATHS_INODE]), result == SQLITE_ROW) {
             if (i >= rows) {
-                minfo("The count returned is smaller than the actual elements. This shouldn't happen.\n");
+                minfo("The count returned is smaller than the actual elements. This shouldn't happen.");
                 break;
             }
             os_strdup((char *)sqlite3_column_text(fim_sql->stmt[FIMDB_STMT_GET_PATHS_INODE], 0), paths[i]);

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -139,8 +139,7 @@ void fim_sync_checksum() {
         os_free(plain);
     }
 
-    end:
-        os_free(start);
+end:    os_free(start);
         os_free(top);
         EVP_MD_CTX_destroy(ctx);
 }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -91,6 +91,7 @@ int realtime_adddir(const char *dir, __attribute__((unused)) int whodata)
 
                 if (!OSHash_Get_ex(syscheck.realtime->dirtb, wdchar)) {
                     if (retval = OSHash_Add_ex(syscheck.realtime->dirtb, wdchar, data), retval == 0) {
+                        os_free(data);
                         merror_exit(FIM_CRITICAL_ERROR_OUT_MEM);
                     } else if (retval == 1) {
                         mdebug2(FIM_REALTIME_HASH_DUP, data);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -821,7 +821,7 @@ void audit_parse(char *buffer) {
                     snprintf(w_evt->dev, OS_SIZE_64, "%s%s", dev, aux);
                     snprintf(w_evt->dev, OS_SIZE_64, "%ld", strtol(w_evt->dev, NULL, 16));
                 } else {
-                    merror("Couldn't decode device chunk of audit log: colon not found in this string: \"%s\".", dev);
+                    merror("Couldn't decode device chunk of audit log: colon not found in this string: \"%s\".", dev); // LCOV_EXCL_LINE
                 }
 
                 free(dev);
@@ -870,8 +870,8 @@ void audit_parse(char *buffer) {
                             char *real_path = NULL;
                             os_calloc(PATH_MAX + 2, sizeof(char), real_path);
                             if (realpath(w_evt->path, real_path), !real_path) {
-                                mdebug1(FIM_CHECK_LINK_REALPATH, w_evt->path);
-                                break;
+                                mdebug1(FIM_CHECK_LINK_REALPATH, w_evt->path); // LCOV_EXCL_LINE
+                                break; // LCOV_EXCL_LINE
                             }
 
                             free(file_path);

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -68,7 +68,8 @@ list(APPEND tests_names "test_seechanges")
 list(APPEND tests_flags " ")
 
 list(APPEND tests_names "test_syscom")
-list(APPEND tests_flags "-Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheckConfig -Wl,--wrap,getSyscheckInternalOptions -Wl,--wrap,fim_sync_push_msg")
+list(APPEND tests_flags "-Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheckConfig -Wl,--wrap,getSyscheckInternalOptions -Wl,--wrap,fim_sync_push_msg \
+                         -Wl,--wrap,_mdebug1")
 
 list(APPEND tests_names "test_run_realtime")
 list(APPEND tests_flags "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Delete_ex \

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -52,7 +52,7 @@ list(APPEND tests_flags "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn 
                          -Wl,--wrap,fim_send_scan_info -Wl,--wrap,send_syscheck_msg -Wl,--wrap,readdir \
                          -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,realtime_adddir -Wl,--wrap,HasFilesystem \
                          -Wl,--wrap,fim_db_get_path -Wl,--wrap,fim_db_get_paths_from_inode -Wl,--wrap,delete_target_file \
-                         -Wl,--wrap,fim_db_insert_data -Wl,--wrap,OS_MD5_SHA1_SHA256_File -Wl,--wrap,seechanges_addfile\
+                         -Wl,--wrap,fim_db_insert -Wl,--wrap,OS_MD5_SHA1_SHA256_File -Wl,--wrap,seechanges_addfile\
                          -Wl,--wrap,fim_db_delete_not_scanned -Wl,--wrap,fim_db_set_all_unscanned \
                          -Wl,--wrap,fim_db_set_scanned -Wl,--wrap,get_user -Wl,--wrap,get_group \
                          -Wl,--wrap,fim_db_remove_path")

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -98,7 +98,7 @@ list(APPEND tests_flags "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,_mde
                          -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP")
 
 list(APPEND tests_names "test_fim_db")
-list(APPEND tests_flags "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2,--wrap=sqlite3_exec,--wrap=_merror \
+list(APPEND tests_flags "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2,--wrap=sqlite3_exec,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=sqlite3_prepare_v2,--wrap=sqlite3_step,--wrap=sqlite3_finalize,--wrap=sqlite3_close_v2 \
                          -Wl,--wrap=chmod,--wrap=sqlite3_free,--wrap=sqlite3_reset,--wrap=sqlite3_clear_bindings \
                          -Wl,--wrap=sqlite3_errmsg,--wrap=sqlite3_bind_int,--wrap=sqlite3_bind_text,--wrap=sqlite3_column_int \

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -133,6 +133,8 @@ list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,OS_ConnectUnixDomain -Wl,
 
 # Config files
 configure_file("test_syscheck.conf" "test_syscheck.conf" COPYONLY)
+configure_file("test_syscheck2.conf" "test_syscheck2.conf" COPYONLY)
+configure_file("test_empty_config.conf" "test_empty_config.conf" COPYONLY)
 
 
 # Generate syscheck library

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -48,7 +48,7 @@ list(APPEND tests_names "test_version_op")
 list(APPEND tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fgets -Wl,--wrap,fclose")
 
 list(APPEND tests_names "test_create_db")
-list(APPEND tests_flags "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,lstat \
+list(APPEND tests_flags "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,lstat \
                          -Wl,--wrap,fim_send_scan_info -Wl,--wrap,send_syscheck_msg -Wl,--wrap,readdir \
                          -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,realtime_adddir -Wl,--wrap,HasFilesystem \
                          -Wl,--wrap,fim_db_get_path -Wl,--wrap,fim_db_get_paths_from_inode -Wl,--wrap,delete_target_file \
@@ -103,7 +103,8 @@ list(APPEND tests_flags "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_
                          -Wl,--wrap=chmod,--wrap=sqlite3_free,--wrap=sqlite3_reset,--wrap=sqlite3_clear_bindings \
                          -Wl,--wrap=sqlite3_errmsg,--wrap=sqlite3_bind_int,--wrap=sqlite3_bind_text,--wrap=sqlite3_column_int \
                          -Wl,--wrap=sqlite3_column_text,--wrap=printf,--wrap=fim_send_sync_msg,--wrap=dbsync_state_msg \
-                         -Wl,--wrap=fim_entry_json,--wrap=sqlite3_last_insert_rowid,--wrap=EVP_DigestUpdate")
+                         -Wl,--wrap=fim_entry_json,--wrap=sqlite3_last_insert_rowid,--wrap=EVP_DigestUpdate \
+                         -Wl,--wrap=fim_configuration_directory,--wrap=fim_json_event,--wrap=send_syscheck_msg,--wrap=delete_target_file")
 
 list(APPEND tests_names "test_wdb_fim")
 list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,cJSON_Parse -Wl,--wrap,wdb_begin2 \

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -103,7 +103,7 @@ list(APPEND tests_flags "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_
                          -Wl,--wrap=chmod,--wrap=sqlite3_free,--wrap=sqlite3_reset,--wrap=sqlite3_clear_bindings \
                          -Wl,--wrap=sqlite3_errmsg,--wrap=sqlite3_bind_int,--wrap=sqlite3_bind_text,--wrap=sqlite3_column_int \
                          -Wl,--wrap=sqlite3_column_text,--wrap=printf,--wrap=fim_send_sync_msg,--wrap=dbsync_state_msg \
-                         -Wl,--wrap=fim_entry_json,--wrap=sqlite3_last_insert_rowid")
+                         -Wl,--wrap=fim_entry_json,--wrap=sqlite3_last_insert_rowid,--wrap=EVP_DigestUpdate")
 
 list(APPEND tests_names "test_wdb_fim")
 list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,cJSON_Parse -Wl,--wrap,wdb_begin2 \

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -60,7 +60,7 @@ list(APPEND tests_flags "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn 
 list(APPEND tests_names "test_syscheck_audit")
 list(APPEND tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,IsSocket -Wl,--wrap,IsFile -Wl,--wrap,IsDir -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,audit_restart \
                          -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,fopen -Wl,--wrap,fwrite -Wl,--wrap,fprintf -Wl,--wrap,fclose -Wl,--wrap,symlink -Wl,--wrap,unlink \
-                         -Wl,--wrap,audit_open -Wl,--wrap,audit_get_rule_list -Wl,--wrap,audit_close -Wl,--wrap,mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,W_Vector_length -Wl,--wrap,search_audit_rule \
+                         -Wl,--wrap,audit_open -Wl,--wrap,audit_get_rule_list -Wl,--wrap,audit_close -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,W_Vector_length -Wl,--wrap,search_audit_rule \
                          -Wl,--wrap,audit_add_rule -Wl,--wrap,W_Vector_insert_unique -Wl,--wrap,SendMSG -Wl,--wrap,fim_whodata_event \
                          -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc -Wl,--wrap,closeproc -Wl,--wrap,_mdebug2 -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,realpath")
 

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -75,7 +75,7 @@ list(APPEND tests_flags "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -W
                         -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Get -Wl,--wrap,rbtree_insert -Wl,--wrap,_merror -Wl,--wrap,W_Vector_insert_unique")
 
 list(APPEND tests_names "test_syscheck_config")
-list(APPEND tests_flags "-Wl,--wrap,_merror")
+list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
 
 list(APPEND tests_names "test_syscheck")
 list(APPEND tests_flags "-Wl,--wrap,_mwarn -Wl,--wrap,fim_db_init")
@@ -98,7 +98,7 @@ list(APPEND tests_flags "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,_mde
                          -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP")
 
 list(APPEND tests_names "test_fim_db")
-list(APPEND tests_flags "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2,--wrap=sqlite3_exec,--wrap=_minfo,--wrap=_merror \
+list(APPEND tests_flags "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2,--wrap=sqlite3_exec,--wrap=_minfo,--wrap=_merror,--wrap=_mdebug1,--wrap=_mdebug2 \
                          -Wl,--wrap=sqlite3_prepare_v2,--wrap=sqlite3_step,--wrap=sqlite3_finalize,--wrap=sqlite3_close_v2 \
                          -Wl,--wrap=chmod,--wrap=sqlite3_free,--wrap=sqlite3_reset,--wrap=sqlite3_clear_bindings \
                          -Wl,--wrap=sqlite3_errmsg,--wrap=sqlite3_bind_int,--wrap=sqlite3_bind_text,--wrap=sqlite3_column_int \

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -71,8 +71,9 @@ list(APPEND tests_names "test_syscom")
 list(APPEND tests_flags "-Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheckConfig -Wl,--wrap,getSyscheckInternalOptions -Wl,--wrap,fim_sync_push_msg")
 
 list(APPEND tests_names "test_run_realtime")
-list(APPEND tests_flags "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,read \
-                        -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Get -Wl,--wrap,rbtree_insert -Wl,--wrap,_merror -Wl,--wrap,W_Vector_insert_unique")
+list(APPEND tests_flags "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Delete_ex \
+                        -Wl,--wrap,read -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Get -Wl,--wrap,rbtree_insert -Wl,--wrap,_merror -Wl,--wrap,W_Vector_insert_unique \
+                        -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,_merror_exit -Wl,--wrap,send_log_msg -Wl,--wrap,rbtree_keys -Wl,--wrap,fim_realtime_event")
 
 list(APPEND tests_names "test_syscheck_config")
 list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1")

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -103,7 +103,7 @@ list(APPEND tests_flags "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_
                          -Wl,--wrap=chmod,--wrap=sqlite3_free,--wrap=sqlite3_reset,--wrap=sqlite3_clear_bindings \
                          -Wl,--wrap=sqlite3_errmsg,--wrap=sqlite3_bind_int,--wrap=sqlite3_bind_text,--wrap=sqlite3_column_int \
                          -Wl,--wrap=sqlite3_column_text,--wrap=printf,--wrap=fim_send_sync_msg,--wrap=dbsync_state_msg \
-                         -Wl,--wrap=fim_entry_json")
+                         -Wl,--wrap=fim_entry_json,--wrap=sqlite3_last_insert_rowid")
 
 list(APPEND tests_names "test_wdb_fim")
 list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,cJSON_Parse -Wl,--wrap,wdb_begin2 \

--- a/src/unit_tests/test_create_db.c
+++ b/src/unit_tests/test_create_db.c
@@ -66,6 +66,10 @@ void __wrap__mwarn(const char * file, int line, const char * func, const char *m
     check_expected(formatted_msg);
 }
 
+int __wrap__mdebug1() {
+    return 1;
+}
+
 void __wrap__mdebug2(const char * file, int line, const char * func, const char *msg, ...) {
     char formatted_msg[OS_MAXSTR];
     va_list args;
@@ -288,6 +292,8 @@ static int setup_group(void **state) {
     syscheck.rt_delay = 1;
     syscheck.max_depth = 256;
     syscheck.file_max_size = 1024;
+
+    nowDebug();
 
     return 0;
 }

--- a/src/unit_tests/test_create_db.c
+++ b/src/unit_tests/test_create_db.c
@@ -312,15 +312,6 @@ static int teardown_delete_json(void **state) {
     return 0;
 }
 
-static int setup_fim_database(void **state) {
-    os_calloc(1, sizeof(fdb_t), syscheck.database);
-    return 0;
-}
-static int teardown_fim_database(void **state) {
-    os_free(syscheck.database);
-    return 0;
-}
-
 static int setup_fim_entry(void **state) {
     fim_data_t *fim_data = *state;
 

--- a/src/unit_tests/test_create_db.c
+++ b/src/unit_tests/test_create_db.c
@@ -293,6 +293,8 @@ static int setup_group(void **state) {
     syscheck.max_depth = 256;
     syscheck.file_max_size = 1024;
 
+    nowDebug();
+
     return 0;
 }
 

--- a/src/unit_tests/test_create_db.c
+++ b/src/unit_tests/test_create_db.c
@@ -293,8 +293,6 @@ static int setup_group(void **state) {
     syscheck.max_depth = 256;
     syscheck.file_max_size = 1024;
 
-    nowDebug();
-
     return 0;
 }
 

--- a/src/unit_tests/test_empty_config.conf
+++ b/src/unit_tests/test_empty_config.conf
@@ -1,0 +1,2 @@
+<ossec_config>
+</ossec_config>

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -1187,13 +1187,13 @@ void test_fim_db_get_row_path_sqlite_row(void **state) {
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value_count(__wrap_sqlite3_column_text, iCol, 0, 2);
-    will_return_count(__wrap_sqlite3_column_text, "A query response", 2);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "/some/random/path");
 
     ret = fim_db_get_row_path(test_data->fim_sql, FIMDB_STMT_GET_FIRST_PATH, &path);
 
     assert_int_equal(ret, FIMDB_OK);
-    assert_string_equal(path, "A query response");
+    assert_string_equal(path, "/some/random/path");
     free(path);
 }
 
@@ -1441,6 +1441,11 @@ void test_fim_db_callback_calculate_checksum(void **state) {
     strcpy(data->test_data->entry->data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
     strcpy(data->test_data->entry->data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
     data->test_data->entry->data->mtime = 6789;
+
+    // Mock EVP_DigestUpdate()
+    expect_string(__wrap_EVP_DigestUpdate, d, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    expect_value(__wrap_EVP_DigestUpdate, cnt, 40);
+    will_return(__wrap_EVP_DigestUpdate, 0);
 
     fim_db_callback_calculate_checksum(data->test_data->fim_sql, data->test_data->entry, data->ctx);
 

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -645,7 +645,8 @@ void test_fim_db_insert_inode_id_null(void **state) {
     test_fim_db_insert_data *test_data = *state;
     will_return(__wrap_sqlite3_reset, SQLITE_OK);
     will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_count(__wrap_sqlite3_bind_int, 0, 2);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_text, 0);
 
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
 

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -415,6 +415,10 @@ void test_fim_db_init_failed_execution(void **state) {
     will_return(__wrap_sqlite3_exec, "ERROR_MESSAGE");
     will_return(__wrap_sqlite3_exec, SQLITE_ERROR);
     expect_string(__wrap__merror, formatted_msg, "SQL ERROR: ERROR_MESSAGE");
+    // fim_db_finalize_stmt()
+    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_finalize, SQLITE_OK);
     fdb_t* fim_db;
     fim_db = fim_db_init(0);
     assert_null(fim_db);
@@ -435,6 +439,10 @@ void test_fim_db_init_failed_simple_query(void **state) {
     will_return(__wrap_sqlite3_exec, "ERROR_MESSAGE");
     will_return(__wrap_sqlite3_exec, SQLITE_ERROR);
     expect_string(__wrap__merror, formatted_msg, "SQL ERROR: ERROR_MESSAGE");
+    // fim_db_finalize_stmt()
+    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_finalize, SQLITE_OK);
     fdb_t* fim_db;
     fim_db = fim_db_init(0);
     assert_null(fim_db);

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -834,11 +834,18 @@ void test_fim_db_sync_path_range(void **state) {
     test_fim_db_insert_data *test_data = *state;
     will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
     will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    //will_return_always(__wrap_sqlite3_bind_int, 0);
     will_return_always(__wrap_sqlite3_bind_text, 0);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
-    will_return(__wrap_sqlite3_step, SQLITE_DONE);
     wraps_fim_db_decode_full_row();
+
+    // fim_db_callback_sync_path_range()
+    cJSON *root = cJSON_CreateObject();
+    will_return(__wrap_fim_entry_json, root);
+    expect_string(__wrap_dbsync_state_msg, component, "syscheck");
+    expect_value(__wrap_dbsync_state_msg, data, root);
+    will_return(__wrap_dbsync_state_msg, strdup("This is the returned JSON"));
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);  // Ending the loop at fim_db_process_get_query()
     wraps_fim_db_check_transaction();
 
     int ret = fim_db_sync_path_range(test_data->fim_sql, "init", "top");

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -588,31 +588,6 @@ void test_fim_db_remove_path_failed_path(void **state) {
     assert_int_equal(last_commit, test_data->fim_sql->transaction.last_commit);
 }
 /*----------------------------------------------*/
-/*----------fim_db_get_inode------------------*/
-void test_fim_db_get_inode_non_existent(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_maybe(__wrap_sqlite3_bind_int, 0);
-    will_return_maybe(__wrap_sqlite3_bind_text, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
-    wraps_fim_db_check_transaction();
-    int ret = fim_db_get_inode(test_data->fim_sql, 1, 1);
-    assert_int_equal(ret, 0);
-}
-
-void test_fim_db_get_inode_existent(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_maybe(__wrap_sqlite3_bind_int, 0);
-    will_return_maybe(__wrap_sqlite3_bind_text, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_ROW);
-    wraps_fim_db_check_transaction();
-    int ret = fim_db_get_inode(test_data->fim_sql, 1, 1);
-    assert_int_equal(ret, 1);
-}
-/*----------------------------------------------*/
 /*----------fim_db_get_path()------------------*/
 void test_fim_db_get_path_inexistent(void **state) {
     test_fim_db_insert_data *test_data = *state;
@@ -1347,9 +1322,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_db_remove_path_one_entry, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_remove_path_multiple_entry, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_remove_path_failed_path, test_fim_db_setup, test_fim_db_teardown),
-        // fim_db_get_inode
-        cmocka_unit_test_setup_teardown(test_fim_db_get_inode_non_existent, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_get_inode_existent, test_fim_db_setup, test_fim_db_teardown),
         // fim_db_get_path
         cmocka_unit_test_setup_teardown(test_fim_db_get_path_inexistent, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_get_path_existent, test_fim_db_setup, test_fim_db_teardown),

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -120,6 +120,18 @@ int __wrap_printf(const char *fmt, ...) {
     fail();
 }
 
+void __wrap__minfo(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
 void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...)
 {
     char formatted_msg[OS_MAXSTR];
@@ -932,8 +944,8 @@ void test_fim_db_get_paths_from_inode_multiple_unamatched_rows(void **state) {
         snprintf(buffer, 10, "Path %d", i + 1);
         will_return(__wrap_sqlite3_column_text, strdup(buffer));
     }
-    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
-    expect_string(__wrap__merror, formatted_msg, "Error in fim_db_get_paths_from_inode(): Unmatched number of rows in queries");
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+    expect_string(__wrap__minfo, formatted_msg, "The count returned is smaller than the actual elements. This shouldn't happen.");
     wraps_fim_db_check_transaction();
     char **paths;
     paths = fim_db_get_paths_from_inode(test_data->fim_sql, 1, 1);

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -519,6 +519,62 @@ void test_fim_db_insert_data_rowid_success(void **state) {
     assert_int_equal(ret, FIMDB_OK);
 }
 /*-----------------------------------------*/
+/*----------fim_db_insert_path()---------------*/
+void test_fim_db_insert_path_error(void **state) {
+    test_fim_db_insert_data *test_data = *state;
+    will_return(__wrap_sqlite3_reset, SQLITE_OK);
+    will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "SQL ERROR: (1)ERROR MESSAGE");
+    int ret;
+    ret = fim_db_insert_path(test_data->fim_sql, test_data->entry->path, test_data->entry->data, 1);
+    assert_int_equal(ret, FIMDB_ERR);
+}
+
+void test_fim_db_insert_path_constraint_error(void **state) {
+    test_fim_db_insert_data *test_data = *state;
+    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_CONSTRAINT);
+    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "SQL ERROR: (1)ERROR MESSAGE");
+    int ret;
+    ret = fim_db_insert_path(test_data->fim_sql, test_data->entry->path, test_data->entry->data, 1);
+    assert_int_equal(ret, FIMDB_ERR);
+}
+
+void test_fim_db_insert_path_constraint_success(void **state) {
+    test_fim_db_insert_data *test_data = *state;
+    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_CONSTRAINT);
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+    int ret;
+    ret = fim_db_insert_path(test_data->fim_sql, test_data->entry->path, test_data->entry->data, 1);
+    assert_int_equal(ret, FIMDB_OK);
+}
+
+void test_fim_db_insert_path_success(void **state) {
+    test_fim_db_insert_data *test_data = *state;
+    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+    int ret;
+    ret = fim_db_insert_path(test_data->fim_sql, test_data->entry->path, test_data->entry->data, 1);
+    assert_int_equal(ret, FIMDB_OK);
+}
+
+/*-----------------------------------------*/
 /*----------fim_db_remove_path------------------*/
 void test_fim_db_remove_path_no_entry(void **state) {
     test_fim_db_insert_data *test_data = *state;
@@ -1296,6 +1352,11 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_db_insert_data_no_rowid_success, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_insert_data_rowid_error, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_insert_data_rowid_success, test_fim_db_setup, test_fim_db_teardown),
+        // fim_db_insert_path
+        cmocka_unit_test_setup_teardown(test_fim_db_insert_path_error, test_fim_db_setup, test_fim_db_teardown),
+        cmocka_unit_test_setup_teardown(test_fim_db_insert_path_constraint_error, test_fim_db_setup, test_fim_db_teardown),
+        cmocka_unit_test_setup_teardown(test_fim_db_insert_path_constraint_success, test_fim_db_setup, test_fim_db_teardown),
+        cmocka_unit_test_setup_teardown(test_fim_db_insert_path_success, test_fim_db_setup, test_fim_db_teardown),
         // fim_db_remove_path
         cmocka_unit_test_setup_teardown(test_fim_db_remove_path_no_entry, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_remove_path_one_entry, test_fim_db_setup, test_fim_db_teardown),

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -1110,11 +1110,19 @@ void test_fim_db_data_checksum_range_second_half_failed(void **state) {
     will_return(__wrap_sqlite3_reset, SQLITE_OK);
     will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
     will_return_always(__wrap_sqlite3_bind_text, 0);
+
+    // First half
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     wraps_fim_db_decode_full_row();
+    expect_string(__wrap_EVP_DigestUpdate, d, "checksum");
+    expect_value(__wrap_EVP_DigestUpdate, cnt, 8);
+    will_return(__wrap_EVP_DigestUpdate, 0);
+
+    // Second half
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "SQL ERROR: ERROR MESSAGE");
+
     int ret;
     ret = fim_db_data_checksum_range(test_data->fim_sql, "init", "end", 1, 2);
     assert_int_equal(ret, FIMDB_ERR);
@@ -1125,10 +1133,21 @@ void test_fim_db_data_checksum_range_success(void **state) {
     will_return(__wrap_sqlite3_reset, SQLITE_OK);
     will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
     will_return_always(__wrap_sqlite3_bind_text, 0);
+
+    // Fist half
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     wraps_fim_db_decode_full_row();
+    expect_string(__wrap_EVP_DigestUpdate, d, "checksum");
+    expect_value(__wrap_EVP_DigestUpdate, cnt, 8);
+    will_return(__wrap_EVP_DigestUpdate, 0);
+
+    // Second half
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     wraps_fim_db_decode_full_row();
+    expect_string(__wrap_EVP_DigestUpdate, d, "checksum");
+    expect_value(__wrap_EVP_DigestUpdate, cnt, 8);
+    will_return(__wrap_EVP_DigestUpdate, 0);
+
     int ret;
     ret = fim_db_data_checksum_range(test_data->fim_sql, "init", "end", 1, 2);
     assert_int_equal(ret, FIMDB_OK);

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -186,7 +186,7 @@ static void wraps_fim_db_clean() {
  * Successfully wrappes a fim_db_create_file() call
  * */
 static void wraps_fim_db_create_file() {
-    expect_string(__wrap_sqlite3_open_v2, filename, "/var/ossec/queue/db/fim.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "/var/ossec/queue/fim/db/fim.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -368,10 +368,11 @@ void test_fim_db_init_failed_db_clean(void **state) {
 
 void test_fim_db_init_failed_file_creation(void **state) {
     wraps_fim_db_clean();
-    expect_string(__wrap_sqlite3_open_v2, filename, "/var/ossec/queue/db/fim.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "/var/ossec/queue/fim/db/fim.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
-    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite database '/var/ossec/queue/fim/db/fim.db': ERROR MESSAGE");
     will_return(__wrap_sqlite3_close_v2, 0);
     fdb_t* fim_db;
     fim_db = fim_db_init(0);
@@ -381,7 +382,7 @@ void test_fim_db_init_failed_file_creation(void **state) {
 void test_fim_db_init_failed_open_db(void **state) {
     wraps_fim_db_clean();
     wraps_fim_db_create_file();
-    expect_string(__wrap_sqlite3_open_v2, filename, "/var/ossec/queue/db/fim.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "/var/ossec/queue/fim/db/fim.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
     fdb_t* fim_db;

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -841,12 +841,8 @@ void test_fim_db_sync_path_range(void **state) {
 void test_fim_db_check_transaction_last_commit_is_0(void **state) {
     test_fim_db_insert_data *test_data = *state;
     test_data->fim_sql->transaction.last_commit = 0;
-    expect_string(__wrap_sqlite3_exec, sql, "END;");
-    will_return(__wrap_sqlite3_exec, "ERROR MESSAGE");
-    will_return(__wrap_sqlite3_exec, SQLITE_ERROR);
-    expect_string(__wrap__merror, formatted_msg, "SQL ERROR: ERROR MESSAGE");
     fim_db_check_transaction(test_data->fim_sql);
-    assert_int_equal(test_data->fim_sql->transaction.last_commit, 0);
+    assert_int_not_equal(test_data->fim_sql->transaction.last_commit, 0);
 }
 
 void test_fim_db_check_transaction_failed(void **state) {

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -770,7 +770,6 @@ void test_fim_db_close_failed(void **state) {
     will_return(__wrap_sqlite3_errmsg, "REASON GOES HERE");
     expect_string(__wrap__merror, formatted_msg, "Error in fim_db_finalize_stmt(): statement(0)'INSERT INTO entry_data (dev, inode, size, perm, attributes, uid, gid, user_name, group_name, hash_md5, hash_sha1, hash_sha256, mtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);' REASON GOES HERE");
     will_return(__wrap_sqlite3_close_v2, SQLITE_BUSY);
-    expect_string(__wrap__merror, formatted_msg, "Error in fim_db_close(): Fim db couldn't close");
     fim_db_close(test_data->fim_sql);
 }
 

--- a/src/unit_tests/test_fim_sync.c
+++ b/src/unit_tests/test_fim_sync.c
@@ -256,7 +256,7 @@ static void test_fim_sync_checksum_first_row_error(void **state) {
     will_return(__wrap_fim_db_get_row_path, NULL);
     will_return(__wrap_fim_db_get_row_path, FIMDB_ERR);
 
-    expect_string(__wrap__merror, formatted_msg, "(6706): Couldn't get FIRST row's path");
+    expect_string(__wrap__merror, formatted_msg, "(6706): Couldn't get FIRST row's path.");
 
     fim_sync_checksum();
 }
@@ -270,7 +270,7 @@ static void test_fim_sync_checksum_last_row_error(void **state) {
     will_return(__wrap_fim_db_get_row_path, NULL);
     will_return(__wrap_fim_db_get_row_path, FIMDB_ERR);
 
-    expect_string(__wrap__merror, formatted_msg, "(6706): Couldn't get LAST row's path");
+    expect_string(__wrap__merror, formatted_msg, "(6706): Couldn't get LAST row's path.");
 
     fim_sync_checksum();
 }

--- a/src/unit_tests/test_run_check.c
+++ b/src/unit_tests/test_run_check.c
@@ -24,6 +24,14 @@ int __wrap__minfo(const char * file, int line, const char * func, const char *ms
     return 1;
 }
 
+/* teardown */
+
+static int free_syscheck(void **state)
+{
+    (void) state;
+    Free_Syscheck(&syscheck);
+    return 0;
+}
 
 /* tests */
 
@@ -31,10 +39,14 @@ void test_log_realtime_status(void **state)
 {
     (void) state;
 
+    log_realtime_status(2);
+
     expect_string(__wrap__minfo, msg, FIM_REALTIME_STARTED);
+    log_realtime_status(1);
     log_realtime_status(1);
 
     expect_string(__wrap__minfo, msg, FIM_REALTIME_PAUSED);
+    log_realtime_status(2);
     log_realtime_status(2);
 
     expect_string(__wrap__minfo, msg, FIM_REALTIME_RESUMED);
@@ -59,7 +71,7 @@ void test_fim_whodata_initialize(void **state)
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_log_realtime_status),
-        cmocka_unit_test(test_fim_whodata_initialize),
+        cmocka_unit_test_teardown(test_fim_whodata_initialize, free_syscheck),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/test_run_realtime.c
+++ b/src/unit_tests/test_run_realtime.c
@@ -32,8 +32,7 @@ int __wrap_OSHash_Get_ex() {
 }
 
 char *__wrap_OSHash_Get() {
-    static char * file = "test";
-    return file;
+    return mock_type(char *);
 }
 
 int __wrap_OSHash_Add_ex() {
@@ -47,6 +46,13 @@ int __wrap_OSHash_Update_ex(OSHash *self, const char *key, void *data) {
         free(data); //  This won't be used, free it
 
     return retval;
+}
+
+void *__wrap_OSHash_Delete_ex() {
+    char *ret = mock_type(char *);
+    ret = calloc(1, sizeof(char *));
+
+    return (void*)ret;
 }
 
 void * __wrap_rbtree_insert() {
@@ -69,9 +75,74 @@ void __wrap__merror(const char * file, int line, const char * func, const char *
     check_expected(formatted_msg);
 }
 
+void __wrap__mwarn(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+void __wrap__merror_exit(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    switch(mock()) {
+        case 0:
+            return;
+        default:
+            va_start(args, msg);
+            vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+            va_end(args);
+
+            check_expected(formatted_msg);
+    }
+}
+
+void __wrap__mdebug2(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+int __wrap_send_log_msg() {
+    return mock();
+}
+
+char **__wrap_rbtree_keys(const rb_tree *tree) {
+    return mock_type(char **);
+}
+
+void __wrap_fim_realtime_event(char *file) {
+    check_expected(file);
+}
+
 ssize_t __real_read(int fildes, void *buf, size_t nbyte);
 ssize_t __wrap_read(int fildes, void *buf, size_t nbyte) {
-    static char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    //static char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     switch(mock_type(int)){
         case 0:
         return __real_read(fildes, buf, nbyte);
@@ -80,15 +151,11 @@ ssize_t __wrap_read(int fildes, void *buf, size_t nbyte) {
         return mock_type(ssize_t);
 
         case 2:
-        memcpy(buf, event, 32);
+        memcpy(buf, mock_type(char *), 32);
         return mock_type(ssize_t);
     }
     // We should never reach this point
     return __real_read(fildes, buf, nbyte);
-}
-
-int __wrap_os_random(void) {
-    return mock();
 }
 
 int __wrap_W_Vector_insert_unique(W_Vector *v, const char *element) {
@@ -100,9 +167,11 @@ int __wrap_W_Vector_insert_unique(W_Vector *v, const char *element) {
 
 /* setup/teardown */
 static int setup_group(void **state) {
+    will_return_always(__wrap__mdebug1, 0);
     Read_Syscheck_Config("test_syscheck.conf");
 
     syscheck.realtime = (rtfim *) calloc(1, sizeof(rtfim));
+
 
     if(syscheck.realtime == NULL)
         return -1;
@@ -111,7 +180,7 @@ static int setup_group(void **state) {
 }
 
 static int teardown_group(void **state) {
-    free(syscheck.realtime);
+    Free_Syscheck(&syscheck);
 
     return 0;
 }
@@ -140,8 +209,8 @@ static int setup_realtime_start(void **state) {
 
     *state = hash;
 
-    // free the global syscheck.realtime before running syscheck_start
-    free(syscheck.realtime);
+    state[1] = syscheck.realtime;
+    syscheck.realtime = NULL;
 
     return 0;
 }
@@ -150,6 +219,13 @@ static int teardown_realtime_start(void **state) {
     OSHash *hash = *state;
 
     free(hash);
+
+    if (syscheck.realtime) {
+        free(syscheck.realtime);
+    }
+
+    syscheck.realtime = state[1];
+    state[1] = NULL;
 
     return 0;
 }
@@ -217,6 +293,25 @@ void test_realtime_adddir_whodata(void **state) {
 }
 
 
+void test_realtime_adddir_whodata_new_directory(void **state) {
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    audit_thread_active = 1;
+
+    expect_value(__wrap_W_Vector_insert_unique, v, audit_added_dirs);
+    expect_string(__wrap_W_Vector_insert_unique, element, "/etc/folder");
+    will_return(__wrap_W_Vector_insert_unique, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6230): Monitoring with Audit: '/etc/folder'");
+    will_return(__wrap__mdebug1, 1);
+
+    ret = realtime_adddir(path, 1);
+
+    assert_int_equal(ret, 1);
+}
+
+
 void test_realtime_adddir_realtime_failure(void **state)
 {
     (void) state;
@@ -232,6 +327,45 @@ void test_realtime_adddir_realtime_failure(void **state)
 }
 
 
+void test_realtime_adddir_realtime_watch_max_reached_failure(void **state)
+{
+    (void) state;
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    syscheck.realtime->fd = 1;
+    will_return(__wrap_inotify_add_watch, -1);
+    expect_string(__wrap__merror, formatted_msg, "(6700): Unable to add inotify watch to real time monitoring: '/etc/folder'. '-1' '28': "
+                                                 "The maximum limit of inotify watches has been reached.");
+    errno = 28;
+
+    ret = realtime_adddir(path, 0);
+
+    errno = 0;
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_realtime_adddir_realtime_watch_generic_failure(void **state)
+{
+    (void) state;
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    syscheck.realtime->fd = 1;
+    will_return(__wrap_inotify_add_watch, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6272): Unable to add inotify watch to real time monitoring: '/etc/folder'. '-1' '0':'Success'");
+    will_return(__wrap__mdebug1, 1);
+
+    ret = realtime_adddir(path, 0);
+
+    assert_int_equal(ret, 1);
+}
+
+
 void test_realtime_adddir_realtime_add(void **state)
 {
     (void) state;
@@ -243,6 +377,29 @@ void test_realtime_adddir_realtime_add(void **state)
     will_return(__wrap_inotify_add_watch, 1);
     will_return(__wrap_OSHash_Get_ex, 0);
     will_return(__wrap_OSHash_Add_ex, 1);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6224): Entry '/etc/folder' already exists in the RT hash table.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6227): Directory added for real time monitoring: '/etc/folder'");
+    will_return(__wrap__mdebug1, 1);
+
+    ret = realtime_adddir(path, 0);
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_realtime_adddir_realtime_add_hash_failure(void **state)
+{
+    (void) state;
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    syscheck.realtime->fd = 1;
+    will_return(__wrap_inotify_add_watch, 1);
+    will_return(__wrap_OSHash_Get_ex, 0);
+    will_return(__wrap_OSHash_Add_ex, 0);
+    expect_string(__wrap__merror_exit, formatted_msg, "(6697): Out of memory. Exiting.");
+    will_return_always(__wrap__mdebug1, 0);
 
     ret = realtime_adddir(path, 0);
 
@@ -325,10 +482,105 @@ void test_realtime_process_len(void **state)
 {
     (void) state;
 
+    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
     syscheck.realtime->fd = 1;
 
     will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
     will_return(__wrap_read, 16);
+    will_return(__wrap_OSHash_Get, "test");
+    expect_string(__wrap__mdebug2, formatted_msg, "Duplicate event in real-time buffer: test/test");
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_len_zero(void **state)
+{
+    (void) state;
+
+    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    will_return(__wrap_OSHash_Get, "test");
+    expect_string(__wrap__mdebug2, formatted_msg, "Duplicate event in real-time buffer: test");
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_len_path_separator(void **state)
+{
+    (void) state;
+
+    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    will_return(__wrap_OSHash_Get, "test/");
+    expect_string(__wrap__mdebug2, formatted_msg, "Duplicate event in real-time buffer: test/test");
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_overflow(void **state)
+{
+    (void) state;
+
+    char event[] = {255, 255, 255, 255, 0, 64, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    expect_string(__wrap__mwarn, formatted_msg, "Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
+    will_return(__wrap_send_log_msg, 1);
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_delete(void **state)
+{
+    (void) state;
+
+    char event[] = {1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    will_return(__wrap_OSHash_Get, "test");
+    expect_string(__wrap__mdebug2, formatted_msg, "Duplicate event in real-time buffer: test/test");
+    char *data;
+    will_return_always(__wrap_OSHash_Delete_ex, data);
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
 
     realtime_process();
 }
@@ -354,14 +606,22 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_realtime_start_failure_hash, setup_realtime_start, teardown_realtime_start),
         cmocka_unit_test_setup_teardown(test_realtime_start_failure_inotify, setup_realtime_start, teardown_realtime_start),
         cmocka_unit_test_setup_teardown(test_realtime_adddir_whodata, setup_w_vector, teardown_w_vector),
+        cmocka_unit_test_setup_teardown(test_realtime_adddir_whodata_new_directory, setup_w_vector, teardown_w_vector),
         cmocka_unit_test(test_realtime_adddir_realtime_failure),
+        cmocka_unit_test(test_realtime_adddir_realtime_watch_max_reached_failure),
+        cmocka_unit_test(test_realtime_adddir_realtime_watch_generic_failure),
         cmocka_unit_test(test_realtime_adddir_realtime_add),
+        cmocka_unit_test(test_realtime_adddir_realtime_add_hash_failure),
         cmocka_unit_test(test_realtime_adddir_realtime_update),
         cmocka_unit_test(test_realtime_adddir_realtime_update_failure),
         cmocka_unit_test(test_free_syscheck_dirtb_data),
         cmocka_unit_test(test_free_syscheck_dirtb_data_null),
         cmocka_unit_test(test_realtime_process),
         cmocka_unit_test(test_realtime_process_len),
+        cmocka_unit_test(test_realtime_process_len_zero),
+        cmocka_unit_test(test_realtime_process_len_path_separator),
+        cmocka_unit_test(test_realtime_process_overflow),
+        cmocka_unit_test(test_realtime_process_delete),
         cmocka_unit_test(test_realtime_process_failure),
     };
 

--- a/src/unit_tests/test_seechanges.c
+++ b/src/unit_tests/test_seechanges.c
@@ -19,6 +19,19 @@
 
 /* redefinitons/wrapping */
 
+/* Setup/teardown */
+
+static int setup_group(void **state) {
+    (void) state;
+    Read_Syscheck_Config("test_syscheck.conf");
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    (void) state;
+    Free_Syscheck(&syscheck);
+    return 0;
+}
 
 /* tests */
 
@@ -26,8 +39,6 @@ void test_is_nodiff_true(void **state)
 {
     (void) state;
     int ret;
-
-    Read_Syscheck_Config("test_syscheck.conf");
 
     const char * file_name = "/etc/ssl/private.key";
 
@@ -42,8 +53,6 @@ void test_is_nodiff_false(void **state)
     (void) state;
     int ret;
 
-    Read_Syscheck_Config("test_syscheck.conf");
-
     const char * file_name = "/dummy_file.key";
 
     ret = is_nodiff(file_name);
@@ -56,8 +65,6 @@ void test_is_nodiff_regex_true(void **state)
 {
     (void) state;
     int ret;
-
-    Read_Syscheck_Config("test_syscheck.conf");
 
     const char * file_name = "file.test";
 
@@ -72,8 +79,6 @@ void test_is_nodiff_regex_false(void **state)
     (void) state;
     int ret;
 
-    Read_Syscheck_Config("test_syscheck.conf");
-
     const char * file_name = "test.file";
 
     ret = is_nodiff(file_name);
@@ -86,7 +91,21 @@ void test_is_nodiff_no_nodiff(void **state)
 {
     (void) state;
     int ret;
+    int i;
 
+    if (syscheck.nodiff) {
+        for (i=0; syscheck.nodiff[i] != NULL; i++) {
+            free(syscheck.nodiff[i]);
+        }
+        free(syscheck.nodiff);
+    }
+    if (syscheck.nodiff_regex) {
+        for (i=0; syscheck.nodiff_regex[i] != NULL; i++) {
+            OSMatch_FreePattern(syscheck.nodiff_regex[i]);
+            free(syscheck.nodiff_regex[i]);
+        }
+        free(syscheck.nodiff_regex);
+    }
     syscheck.nodiff = NULL;
     syscheck.nodiff_regex = NULL;
 
@@ -107,5 +126,5 @@ int main(void) {
         cmocka_unit_test(test_is_nodiff_no_nodiff),
     };
 
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/test_syscheck2.conf
+++ b/src/unit_tests/test_syscheck2.conf
@@ -1,0 +1,47 @@
+<ossec_config>
+  <syscheck>
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <scan_on_start>no</scan_on_start>
+
+    <!-- Generate alert when new file detected -->
+    <alert_new_files>no</alert_new_files>
+
+    <!-- Don't ignore files that change more than 'frequency' times -->
+    <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories whodata="yes" tags="tag1,tag2">/etc,/usr/bin,/usr/sbin</directories>
+    <directories realtime="yes" restrict="file$">/media,/home,/boot</directories>
+    <directories report_changes="yes" check_all="yes">/root</directories>
+    <directories check_all="no">/tmp</directories>
+
+    <skip_nfs>no</skip_nfs>
+    <skip_dev>no</skip_dev>
+    <skip_proc>no</skip_proc>
+    <skip_sys>no</skip_sys>
+
+    <allow_remote_prefilter_cmd>no</allow_remote_prefilter_cmd>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>200</max_eps>
+
+    <!-- Whodata options -->
+    <whodata>
+      <restart_audit>no</restart_audit>
+      <startup_healthcheck>no</startup_healthcheck>
+    </whodata>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>no</enabled>
+      <interval>10m</interval>
+      <max_interval>1h</max_interval>
+      <queue_size>64</queue_size>
+    </synchronization>
+  </syscheck>
+</ossec_config>

--- a/src/unit_tests/test_syscheck_audit.c
+++ b/src/unit_tests/test_syscheck_audit.c
@@ -20,6 +20,8 @@
 
 extern volatile int audit_health_check_deletion;
 
+int test_mode = 0;
+
 /* redefinitons/wrapping */
 
 int __wrap_OS_ConnectUnixDomain()
@@ -61,14 +63,52 @@ int __wrap__minfo()
     return 0;
 }
 
-int __wrap__merror()
+void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...)
 {
-    return 0;
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+
+    check_expected(formatted_msg);
+
+    va_end(args);
+
+    return;
 }
 
-int __wrap__mwarn()
+void __wrap__mwarn(const char * file, int line, const char * func, const char *msg, ...)
 {
-    return 0;
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+
+    check_expected(formatted_msg);
+
+    va_end(args);
+
+    return;
+}
+
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+
+    check_expected(formatted_msg);
+
+    va_end(args);
+
+    return;
 }
 
 void __wrap__mdebug2(const char * file, int line, const char * func, const char *msg, ...)
@@ -88,7 +128,6 @@ void __wrap__mdebug2(const char * file, int line, const char * func, const char 
 
     return;
 }
-
 
 int __wrap_fopen(const char *filename, const char *mode)
 {
@@ -117,14 +156,20 @@ int __wrap_fprintf()
     return 1;
 }
 
-int __wrap_fclose()
+int __real_fclose(FILE *fp);
+int __wrap_fclose(FILE *fp)
 {
-    return 0;
+    if (test_mode) {
+        return mock();
+    }
+    else {
+        return __real_fclose(fp);
+    }
 }
 
 int __wrap_unlink()
 {
-    return 1;
+    return mock();
 }
 
 int __wrap_symlink(const char *path1, const char *path2)
@@ -224,6 +269,20 @@ char *__wrap_get_user(__attribute__((unused)) const char *path, int uid, __attri
 }
 
 /* setup/teardown */
+static int setup_group(void **state) {
+    (void) state;
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    (void) state;
+    memset(&syscheck, 0, sizeof(syscheck_config));
+    Free_Syscheck(&syscheck);
+    test_mode = 0;
+    return 0;
+}
+
 static int free_string(void **state)
 {
     char * string = *state;
@@ -269,7 +328,7 @@ void test_check_auditd_enabled_success(void **state)
 
     ret = check_auditd_enabled();
     assert_return_code(ret, 0);
-    os_free(mock_proc);
+    free(mock_proc);
 }
 
 void test_check_auditd_enabled_openproc_error(void **state)
@@ -320,6 +379,8 @@ void test_init_auditd_socket_failure(void **state)
     int ret;
 
     will_return(__wrap_OS_ConnectUnixDomain, -5);
+    expect_string(__wrap__merror, formatted_msg, "(6636): Cannot connect to socket '/var/ossec/queue/ossec/audit'.");
+
     ret = init_auditd_socket();
     assert_int_equal(ret, -1);
 }
@@ -344,6 +405,24 @@ void test_set_auditd_config_audit3_plugin_created(void **state)
 
     expect_string(__wrap_IsSocket, sock, "/var/ossec/queue/ossec/audit");
     will_return(__wrap_IsSocket, 0);
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, 0);
+}
+
+
+void test_set_auditd_config_wrong_audit_version(void **state)
+{
+    (void) state;
+
+    // Not Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 1);
+    // Not Audit 2
+    expect_string(__wrap_IsDir, file, "/etc/audisp/plugins.d");
+    will_return(__wrap_IsDir, 1);
 
     int ret;
     ret = set_auditd_config();
@@ -383,6 +462,37 @@ void test_set_auditd_config_audit2_plugin_created(void **state)
 
 
 void test_set_auditd_config_audit_socket_not_created(void **state)
+{
+    (void) state;
+
+    syscheck.restart_audit = 0;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin already created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 0);
+
+    expect_string(__wrap_IsFile, file, audit3_socket);
+    will_return(__wrap_IsFile, 0);
+
+    expect_string(__wrap_IsSocket, sock, "/var/ossec/queue/ossec/audit");
+    will_return(__wrap_IsSocket, 1);
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6909): Audit socket (/var/ossec/queue/ossec/audit) does not exist. You need to restart Auditd. Who-data will be disabled.");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_set_auditd_config_audit_socket_not_created_restart(void **state)
 {
     (void) state;
 
@@ -431,6 +541,8 @@ void test_set_auditd_config_audit_plugin_not_created(void **state)
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
+    will_return(__wrap_fclose, 0);
+
     // Create plugin
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
@@ -444,6 +556,62 @@ void test_set_auditd_config_audit_plugin_not_created(void **state)
     ret = set_auditd_config();
 
     assert_int_equal(ret, 99);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state)
+{
+    (void) state;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 1);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "(1103): Could not open file '/var/ossec/etc/af_wazuh.conf' due to [(0)-(Success)].");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, -1);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state)
+{
+    (void) state;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 1);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fclose, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "(1140): Could not close file '/var/ossec/etc/af_wazuh.conf' due to [(0)-(Success)].");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, -1);
 }
 
 
@@ -465,11 +633,61 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink(void **sta
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
+    will_return(__wrap_fclose, 0);
+
     // Create plugin
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
     will_return(__wrap_symlink, -1);
     errno = EEXIST;
+
+    will_return(__wrap_unlink, 0);
+
+    // Delete and create
+    expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_symlink, path2, audit3_socket);
+    will_return(__wrap_symlink, 0);
+
+    // Do not restart
+    syscheck.restart_audit = 0;
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6910): Audit plugin configuration was modified. You need to restart Auditd. Who-data will be disabled.");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_restart(void **state)
+{
+    (void) state;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 1);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fclose, 0);
+
+    // Create plugin
+    expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_symlink, path2, audit3_socket);
+    will_return(__wrap_symlink, -1);
+    errno = EEXIST;
+
+    will_return(__wrap_unlink, 0);
+
     // Delete and create
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
@@ -504,15 +722,59 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_error(void
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
+    will_return(__wrap_fclose, 0);
+
     // Create plugin
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
     will_return(__wrap_symlink, -1);
     errno = EEXIST;
+
+    will_return(__wrap_unlink, 0);
+
     // Delete and create
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
     will_return(__wrap_symlink, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "(1134): Unable to link from '/etc/audit/plugins.d/af_wazuh.conf' to '/var/ossec/etc/af_wazuh.conf' due to [(17)-(File exists)].");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, -1);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_unlink_error(void **state)
+{
+    (void) state;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 1);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fclose, 0);
+
+    // Create plugin
+    expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_symlink, path2, audit3_socket);
+    will_return(__wrap_symlink, -1);
+    errno = EEXIST;
+
+    will_return(__wrap_unlink, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "(1123): Unable to delete file: '/etc/audit/plugins.d/af_wazuh.conf' due to [(17)-(File exists)].");
 
     int ret;
     ret = set_auditd_config();
@@ -532,6 +794,33 @@ void test_audit_get_id(void **state)
     *state = ret;
 
     assert_string_equal(ret, "1571145421.379:659");
+}
+
+
+void test_audit_get_id_begin_error(void **state)
+{
+    (void) state;
+
+    const char* event = "audit1571145421.379:659): pid=16455 uid=0 old-auid=4294967295 auid=0 tty=(none) old-ses=4294967295 ses=57 res=1";
+
+    char *ret;
+    ret = audit_get_id(event);
+
+    assert_null(ret);
+}
+
+
+void test_audit_get_id_end_error(void **state)
+{
+    (void) state;
+
+    const char* event = "type=LOGIN msg=audit(1571145421.379:659";
+
+    char *ret;
+    ret = audit_get_id(event);
+
+    assert_null(ret);
+
 }
 
 
@@ -559,7 +848,9 @@ void test_add_audit_rules_syscheck_not_added(void **state)
     syscheck.max_audit_entries = 100;
 
     // Read loaded rules in Audit
-    will_return(__wrap_audit_get_rule_list, 5);
+    will_return(__wrap_audit_get_rule_list, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "(6637): Could not read audit loaded rules.");
 
     // Audit added rules
     will_return(__wrap_W_Vector_length, 3);
@@ -570,6 +861,48 @@ void test_add_audit_rules_syscheck_not_added(void **state)
     // Add rule
     will_return(__wrap_audit_add_rule, 1);
     will_return(__wrap_W_Vector_insert_unique, 1);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6322): Reloaded audit rule for monitoring directory: '/var/test'");
+
+    int ret;
+    ret = add_audit_rules_syscheck(0);
+
+    free(syscheck.opts);
+    free(syscheck.dir[0]);
+    free(syscheck.dir);
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_add_audit_rules_syscheck_not_added_new(void **state)
+{
+    (void) state;
+
+    char *entry = "/var/test";
+    syscheck.dir = calloc (2, sizeof(char *));
+    syscheck.dir[0] = calloc(strlen(entry) + 2, sizeof(char));
+    snprintf(syscheck.dir[0], strlen(entry) + 1, "%s", entry);
+    syscheck.opts = calloc (2, sizeof(int *));
+    syscheck.opts[0] |= WHODATA_ACTIVE;
+    syscheck.max_audit_entries = 100;
+
+    // Read loaded rules in Audit
+    will_return(__wrap_audit_get_rule_list, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "(6637): Could not read audit loaded rules.");
+
+    // Audit added rules
+    will_return(__wrap_W_Vector_length, 3);
+
+    // Rule already not added
+    will_return(__wrap_search_audit_rule, 0);
+
+    // Add rule
+    will_return(__wrap_audit_add_rule, 1);
+    will_return(__wrap_W_Vector_insert_unique, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6270): Added audit rule for monitoring directory: '/var/test'");
 
     int ret;
     ret = add_audit_rules_syscheck(0);
@@ -604,7 +937,9 @@ void test_add_audit_rules_syscheck_added(void **state)
     will_return(__wrap_search_audit_rule, 1);
 
     // Add rule
-    will_return(__wrap_W_Vector_insert_unique, 1);
+    will_return(__wrap_W_Vector_insert_unique, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6271): Audit rule for monitoring directory '/var/test' already added.");
 
     int ret;
     ret = add_audit_rules_syscheck(0);
@@ -622,11 +957,15 @@ void test_add_audit_rules_syscheck_max(void **state)
     (void) state;
 
     char *entry = "/var/test";
-    syscheck.dir = calloc(2, sizeof(char *));
+    char *entry2 = "/var/test2";
+    syscheck.dir = calloc(3, sizeof(char *));
     syscheck.dir[0] = calloc(strlen(entry) + 2, sizeof(char));
+    syscheck.dir[1] = calloc(strlen(entry2) + 2, sizeof(char));
     snprintf(syscheck.dir[0], strlen(entry) + 1, "%s", entry);
-    syscheck.opts = calloc(2, sizeof(int *));
+    snprintf(syscheck.dir[1], strlen(entry2) + 1, "%s", entry2);
+    syscheck.opts = calloc(3, sizeof(int *));
     syscheck.opts[0] |= WHODATA_ACTIVE;
+    syscheck.opts[1] |= WHODATA_ACTIVE;
     syscheck.max_audit_entries = 3;
 
     // Read loaded rules in Audit
@@ -635,10 +974,18 @@ void test_add_audit_rules_syscheck_max(void **state)
     // Audit added rules
     will_return(__wrap_W_Vector_length, 3);
 
+    expect_string(__wrap__merror, formatted_msg, "(6640): Unable to monitor who-data for directory: '/var/test' - Maximum size permitted (3).");
+
+    // Audit added rules
+    will_return(__wrap_W_Vector_length, 3);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6640): Unable to monitor who-data for directory: '/var/test2' - Maximum size permitted (3).");
+
     int ret;
-    ret = add_audit_rules_syscheck(1);
+    ret = add_audit_rules_syscheck(0);
 
     free(syscheck.dir[0]);
+    free(syscheck.dir[1]);
     free(syscheck.dir);
     free(syscheck.opts);
 
@@ -830,6 +1177,21 @@ void test_gen_audit_path7(void **state)
 }
 
 
+void test_gen_audit_path8(void **state)
+{
+    (void) state;
+
+    char * cwd = "/root";
+    char * path0 = "file";
+
+    char * ret;
+    ret = gen_audit_path(cwd, path0, NULL);
+    *state = ret;
+
+    assert_string_equal(ret, "/root/file");
+}
+
+
 void test_audit_parse(void **state)
 {
     (void) state;
@@ -850,6 +1212,8 @@ void test_audit_parse(void **state)
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("root"));
 
+    expect_string(__wrap__mdebug1, formatted_msg, "(6334): Audit: Invalid 'auid' value read. Check Audit configuration (PAM).");
+
     will_return(__wrap_get_group, "root");
 
     expect_string(__wrap__mdebug2, msg,
@@ -868,6 +1232,107 @@ void test_audit_parse(void **state)
     expect_string(__wrap_fim_whodata_event, w_evt->effective_uid, "0");
     expect_string(__wrap_fim_whodata_event, w_evt->inode, "19");
     expect_value(__wrap_fim_whodata_event, w_evt->ppid, 3211);
+
+    audit_parse(buffer);
+}
+
+
+void test_audit_parse3(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=SYSCALL msg=audit(1571914029.306:3004254): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c5f8170490 a2=0 a3=7ff365c5eca0 items=3 ppid=3211 pid=44082 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts3 ses=5 comm=\"test\" exe=\"74657374C3B1\" key=\"wazuh_fim\" \
+        type=CWD msg=audit(1571914029.306:3004254): cwd=\"/root/test\" \
+        type=PATH msg=audit(1571925844.299:3004308): item=0 name=\"./\" inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=1 name=\"folder/\" inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=2 name=\"./test\" inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1571914029.306:3004254): proctitle=726D0074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__mdebug2, msg,
+        "(6247): audit_event: uid=%s, auid=%s, euid=%s, gid=%s, pid=%i, ppid=%i, inode=%s, path=%s, pname=%s");
+    expect_string(__wrap__mdebug2, formatted_msg,
+        "(6247): audit_event: uid=root, auid=, euid=root, gid=root, pid=44082, ppid=3211, inode=28, path=/root/test/test, pname=74657374C3B1");
+
+    expect_value(__wrap_fim_whodata_event, w_evt->process_id, 44082);
+    expect_string(__wrap_fim_whodata_event, w_evt->user_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->group_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->process_name, "74657374C3B1");
+    expect_string(__wrap_fim_whodata_event, w_evt->path, "/root/test/test");
+    expect_value(__wrap_fim_whodata_event, w_evt->audit_uid, 0);
+    expect_string(__wrap_fim_whodata_event, w_evt->effective_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->inode, "28");
+    expect_value(__wrap_fim_whodata_event, w_evt->ppid, 3211);
+
+    audit_parse(buffer);
+}
+
+
+void test_audit_parse4(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=SYSCALL msg=audit(1571923546.947:3004294): arch=c000003e syscall=316 success=yes exit=0 a0=ffffff9c a1=7ffe425fc770 a2=ffffff9c a3=7ffe425fc778 items=4 ppid=3212 pid=51452 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts3 ses=5 comm=\"mv\" exe=66696C655FC3B1 key=\"wazuh_fim\" \
+        type=CWD msg=audit(1571923546.947:3004294): cwd=2F726F6F742F746573742F74657374C3B1 \
+        type=PATH msg=audit(1571923546.947:3004294): item=0 name=\"./\" inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571923546.947:3004294): item=1 name=\"folder/\" inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571923546.947:3004294): item=2 name=\"./test\" inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571923546.947:3004294): item=3 name=\"folder/test\" inode=19 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1571923546.947:3004294): proctitle=6D760066696C655FC3B1002E2E2F74657374C3B1322F66696C655FC3B163 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__mdebug2, msg,
+        "(6248): audit_event_1/2: uid=%s, auid=%s, euid=%s, gid=%s, pid=%i, ppid=%i, inode=%s, path=%s, pname=%s");
+    expect_string(__wrap__mdebug2, msg,
+        "(6249): audit_event_2/2: uid=%s, auid=%s, euid=%s, gid=%s, pid=%i, ppid=%i, inode=%s, path=%s, pname=%s");
+    expect_string(__wrap__mdebug2, formatted_msg,
+        "(6248): audit_event_1/2: uid=root, auid=root, euid=root, gid=root, pid=51452, ppid=3212, inode=19, path=/root/test/testñ/test, pname=file_ñ");
+    expect_string(__wrap__mdebug2, formatted_msg,
+        "(6249): audit_event_2/2: uid=root, auid=root, euid=root, gid=root, pid=51452, ppid=3212, inode=19, path=/root/test/testñ/folder/test, pname=file_ñ");
+
+    expect_value(__wrap_fim_whodata_event, w_evt->process_id, 51452);
+    expect_string(__wrap_fim_whodata_event, w_evt->user_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->group_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->process_name, "file_ñ");
+    expect_string(__wrap_fim_whodata_event, w_evt->path, "/root/test/testñ/test");
+    expect_string(__wrap_fim_whodata_event, w_evt->audit_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->effective_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->inode, "19");
+    expect_value(__wrap_fim_whodata_event, w_evt->ppid, 3212);
+
+    expect_value(__wrap_fim_whodata_event, w_evt->process_id, 51452);
+    expect_string(__wrap_fim_whodata_event, w_evt->user_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->group_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->process_name, "file_ñ");
+    expect_string(__wrap_fim_whodata_event, w_evt->path, "/root/test/testñ/folder/test");
+    expect_string(__wrap_fim_whodata_event, w_evt->audit_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->effective_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->inode, "19");
+    expect_value(__wrap_fim_whodata_event, w_evt->ppid, 3212);
 
     audit_parse(buffer);
 }
@@ -936,7 +1401,7 @@ void test_audit_parse_delete(void **state)
 {
     (void) state;
 
-    char * buffer = "type=CONFIG_CHANGE msg=audit(1571920603.069:3004276): auid=0 ses=5 op=remove_rule key=\"wazuh_fim\" list=4 res=1";
+    char * buffer = "type=CONFIG_CHANGE msg=audit(1571920603.069:3004276): auid=0 ses=5 op=\"remove_rule\" key=\"wazuh_fim\" list=4 res=1";
 
     // In audit_reload_rules()
     char *entry = "/var/test";
@@ -949,6 +1414,9 @@ void test_audit_parse_delete(void **state)
 
     expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
     expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6275): Reloading Audit rules.");
 
     // Read loaded rules in Audit
     will_return(__wrap_audit_get_rule_list, 5);
@@ -963,6 +1431,8 @@ void test_audit_parse_delete(void **state)
     will_return(__wrap_W_Vector_insert_unique, 1);
 
     expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6276): Audit rules reloaded. Rules loaded: 1");
 
     audit_parse(buffer);
 
@@ -1002,11 +1472,31 @@ void test_audit_parse_delete_recursive(void **state)
     expect_string_count(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed", 4);
     expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
 
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6275): Reloading Audit rules.");
+    expect_string(__wrap__merror, formatted_msg, "(6639): Error checking Audit rules list.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6276): Audit rules reloaded. Rules loaded: 0");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6275): Reloading Audit rules.");
+    expect_string(__wrap__merror, formatted_msg, "(6639): Error checking Audit rules list.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6276): Audit rules reloaded. Rules loaded: 0");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6275): Reloading Audit rules.");
+    expect_string(__wrap__merror, formatted_msg, "(6639): Error checking Audit rules list.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6276): Audit rules reloaded. Rules loaded: 0");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+
     int i;
     for (i = 0; i < 4; i++) {
         audit_parse(buffer);
     }
 
+    free(syscheck.opts);
+    free(syscheck.dir[0]);
+    free(syscheck.dir);
 }
 
 
@@ -1351,6 +1841,136 @@ void test_audit_parse_delete_folder_hex(void **state)
 }
 
 
+void test_audit_parse_delete_folder_hex3_error(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=CONFIG_CHANGE msg=audit(1572878838.610:220): op=remove_rule dir=0 key=\"wazuh_fim\" list=4 res=1 \
+        type=SYSCALL msg=audit(1572878838.610:220): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c2b7d7f490 a2=200 a3=7f2b8055bca0 items=3 ppid=4340 pid=62845 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=7 comm=\"rm\" exe=1 key=(null) \
+        type=CWD msg=audit(1572878838.610:220): cwd=2 \
+        type=PATH msg=audit(1571925844.299:3004308): item=0 name=3 inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=1 name=4 inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=2 name=5 inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1572878838.610:220): proctitle=726D002D72660074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '0'");
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '1'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '2'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '3'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '4'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '5'");
+
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed");
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
+
+    audit_parse(buffer);
+}
+
+
+void test_audit_parse_delete_folder_hex4_error(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=CONFIG_CHANGE msg=audit(1572878838.610:220): op=remove_rule dir=0 key=\"wazuh_fim\" list=4 res=1 \
+        type=SYSCALL msg=audit(1572878838.610:220): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c2b7d7f490 a2=200 a3=7f2b8055bca0 items=4 ppid=4340 pid=62845 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=7 comm=\"rm\" exe=1 key=(null) \
+        type=CWD msg=audit(1572878838.610:220): cwd=2 \
+        type=PATH msg=audit(1571925844.299:3004308): item=0 name=3 inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=1 name=4 inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=2 name=5 inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=3 name=6 inode=19 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1572878838.610:220): proctitle=726D002D72660074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '0'");
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '1'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '2'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '3'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '4'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '5'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '6'");
+
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed");
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
+
+    audit_parse(buffer);
+}
+
+
+void test_audit_parse_delete_folder_hex5_error(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=CONFIG_CHANGE msg=audit(1572878838.610:220): op=remove_rule dir=0 key=\"wazuh_fim\" list=4 res=1 \
+        type=SYSCALL msg=audit(1572878838.610:220): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c2b7d7f490 a2=200 a3=7f2b8055bca0 items=5 ppid=4340 pid=62845 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=7 comm=\"rm\" exe=1 key=(null) \
+        type=CWD msg=audit(1572878838.610:220): cwd=2 \
+        type=PATH msg=audit(1571925844.299:3004308): item=0 name=3 inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=1 name=4 inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=2 name=5 inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=3 name=6 inode=19 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=4 name=7 inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1572878838.610:220): proctitle=726D002D72660074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '0'");
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '1'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '2'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '3'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '4'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '7'");
+
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed");
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
+
+    audit_parse(buffer);
+}
+
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_check_auditd_enabled_success),
@@ -1358,16 +1978,25 @@ int main(void) {
         cmocka_unit_test(test_check_auditd_enabled_readproc_error),
         cmocka_unit_test(test_init_auditd_socket_success),
         cmocka_unit_test(test_init_auditd_socket_failure),
+        cmocka_unit_test(test_set_auditd_config_wrong_audit_version),
         cmocka_unit_test(test_set_auditd_config_audit2_plugin_created),
         cmocka_unit_test(test_set_auditd_config_audit3_plugin_created),
         cmocka_unit_test(test_set_auditd_config_audit_socket_not_created),
+        cmocka_unit_test(test_set_auditd_config_audit_socket_not_created_restart),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_fopen_error),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_fclose_error),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_symlink),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_symlink_restart),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_symlink_error),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_symlink_unlink_error),
         cmocka_unit_test_teardown(test_audit_get_id, free_string),
+        cmocka_unit_test(test_audit_get_id_begin_error),
+        cmocka_unit_test(test_audit_get_id_end_error),
         cmocka_unit_test(test_init_regex),
         cmocka_unit_test(test_add_audit_rules_syscheck_added),
         cmocka_unit_test(test_add_audit_rules_syscheck_not_added),
+        cmocka_unit_test(test_add_audit_rules_syscheck_not_added_new),
         cmocka_unit_test(test_add_audit_rules_syscheck_max),
         cmocka_unit_test(test_filterkey_audit_events_custom),
         cmocka_unit_test(test_filterkey_audit_events_discard),
@@ -1380,7 +2009,10 @@ int main(void) {
         cmocka_unit_test_teardown(test_gen_audit_path5, free_string),
         cmocka_unit_test_teardown(test_gen_audit_path6, free_string),
         cmocka_unit_test_teardown(test_gen_audit_path7, free_string),
+        cmocka_unit_test_teardown(test_gen_audit_path8, free_string),
         cmocka_unit_test(test_audit_parse),
+        cmocka_unit_test(test_audit_parse3),
+        cmocka_unit_test(test_audit_parse4),
         cmocka_unit_test(test_audit_parse_hex),
         cmocka_unit_test(test_audit_parse_delete),
         cmocka_unit_test(test_audit_parse_delete_recursive),
@@ -1393,6 +2025,9 @@ int main(void) {
         cmocka_unit_test(test_audit_parse_unknown_hc),
         cmocka_unit_test(test_audit_parse_delete_folder),
         cmocka_unit_test(test_audit_parse_delete_folder_hex),
+        cmocka_unit_test(test_audit_parse_delete_folder_hex3_error),
+        cmocka_unit_test(test_audit_parse_delete_folder_hex4_error),
+        cmocka_unit_test(test_audit_parse_delete_folder_hex5_error),
     };
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/test_syscheck_audit.c
+++ b/src/unit_tests/test_syscheck_audit.c
@@ -1397,6 +1397,22 @@ void test_audit_parse_hex(void **state)
 }
 
 
+void test_audit_parse_empty_fields(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=SYSCALL msg=audit(1571914029.306:3004254): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c5f8170490 a2=0 a3=7ff365c5eca0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts3 ses=5 comm=\"test\" key=\"wazuh_fim\" \
+        type=PROCTITLE msg=audit(1571914029.306:3004254): proctitle=726D0074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    audit_parse(buffer);
+}
+
+
 void test_audit_parse_delete(void **state)
 {
     (void) state;
@@ -2014,6 +2030,7 @@ int main(void) {
         cmocka_unit_test(test_audit_parse3),
         cmocka_unit_test(test_audit_parse4),
         cmocka_unit_test(test_audit_parse_hex),
+        cmocka_unit_test(test_audit_parse_empty_fields),
         cmocka_unit_test(test_audit_parse_delete),
         cmocka_unit_test(test_audit_parse_delete_recursive),
         cmocka_unit_test(test_audit_parse_mv),

--- a/src/unit_tests/test_syscheck_config.c
+++ b/src/unit_tests/test_syscheck_config.c
@@ -24,6 +24,13 @@ int __wrap__merror()
     return 0;
 }
 
+static int restart_syscheck(void **state)
+{
+    (void) state;
+    memset(&syscheck, 0, sizeof(syscheck_config));
+    return 0;
+}
+
 static int delete_json(void **state)
 {
     cJSON *data = *state;
@@ -74,7 +81,6 @@ void test_Read_Syscheck_Config_success(void **state)
     assert_int_equal(syscheck.send_delay, 5000);
 }
 
-
 void test_Read_Syscheck_Config_invalid(void **state)
 {
     (void) state;
@@ -85,6 +91,86 @@ void test_Read_Syscheck_Config_invalid(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
+void test_Read_Syscheck_Config_undefined(void **state)
+{
+    (void) state;
+    int ret;
+
+    ret = Read_Syscheck_Config("test_syscheck2.conf");
+
+    assert_int_equal(ret, 0);
+    assert_int_equal(syscheck.rootcheck, 0);
+
+    assert_int_equal(syscheck.disabled, 0);
+    assert_int_equal(syscheck.skip_fs.nfs, 0);
+    assert_int_equal(syscheck.skip_fs.dev, 0);
+    assert_int_equal(syscheck.skip_fs.sys, 0);
+    assert_int_equal(syscheck.skip_fs.proc, 0);
+    assert_int_equal(syscheck.scan_on_start, 0);
+    assert_int_equal(syscheck.time, 43200);
+    assert_null(syscheck.ignore);
+    assert_null(syscheck.ignore_regex);
+    assert_null(syscheck.nodiff);
+    assert_null(syscheck.nodiff_regex);
+    assert_null(syscheck.scan_day);
+    assert_null(syscheck.scan_time);
+    assert_non_null(syscheck.dir);
+    assert_non_null(syscheck.opts);
+    assert_int_equal(syscheck.enable_synchronization, 0);
+    assert_int_equal(syscheck.restart_audit, 0);
+    assert_int_equal(syscheck.enable_whodata, 1);
+    assert_null(syscheck.realtime);
+    assert_int_equal(syscheck.audit_healthcheck, 0);
+    assert_int_equal(syscheck.process_priority, 10);
+    assert_int_equal(syscheck.allow_remote_prefilter_cmd, false);
+    assert_null(syscheck.prefilter_cmd);
+    assert_int_equal(syscheck.sync_interval, 600);
+    assert_int_equal(syscheck.sync_response_timeout, 30);
+    assert_int_equal(syscheck.sync_queue_size, 64);
+    assert_int_equal(syscheck.max_eps, 200);
+    assert_int_equal(syscheck.send_delay, 5000);
+}
+
+void test_Read_Syscheck_Config_unparsed(void **state)
+{
+    (void) state;
+    int ret;
+
+    ret = Read_Syscheck_Config("test_empty_config.conf");
+
+    assert_int_equal(ret, 1);
+
+    // Default values
+    assert_int_equal(syscheck.rootcheck, 0);
+    assert_int_equal(syscheck.disabled, 1);
+    assert_int_equal(syscheck.skip_fs.nfs, 1);
+    assert_int_equal(syscheck.skip_fs.dev, 1);
+    assert_int_equal(syscheck.skip_fs.sys, 1);
+    assert_int_equal(syscheck.skip_fs.proc, 1);
+    assert_int_equal(syscheck.scan_on_start, 1);
+    assert_int_equal(syscheck.time, 43200);
+    assert_null(syscheck.ignore);
+    assert_null(syscheck.ignore_regex);
+    assert_null(syscheck.nodiff);
+    assert_null(syscheck.nodiff_regex);
+    assert_null(syscheck.scan_day);
+    assert_null(syscheck.scan_time);
+    assert_null(syscheck.dir);
+    assert_null(syscheck.opts);
+    assert_int_equal(syscheck.enable_synchronization, 1);
+    assert_int_equal(syscheck.restart_audit, 1);
+    assert_int_equal(syscheck.enable_whodata, 0);
+    assert_null(syscheck.realtime);
+    assert_int_equal(syscheck.audit_healthcheck, 1);
+    assert_int_equal(syscheck.process_priority, 10);
+    assert_int_equal(syscheck.allow_remote_prefilter_cmd, false);
+    assert_null(syscheck.prefilter_cmd);
+    assert_int_equal(syscheck.sync_interval, 300);
+    assert_int_equal(syscheck.sync_response_timeout, 30);
+    assert_int_equal(syscheck.sync_queue_size, 16384);
+    assert_int_equal(syscheck.max_eps, 200);
+    assert_int_equal(syscheck.send_delay, 5000);
+}
 
 void test_getSyscheckConfig(void **state)
 {
@@ -152,6 +238,83 @@ void test_getSyscheckConfig(void **state)
     assert_int_equal(synchronization_queue_size->valueint, 64);
 }
 
+void test_getSyscheckConfig_no_audit(void **state)
+{
+    (void) state;
+    cJSON * ret;
+
+    Read_Syscheck_Config("test_syscheck2.conf");
+
+    ret = getSyscheckConfig();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_int_equal(cJSON_GetArraySize(ret), 1);
+
+    cJSON *sys_items = cJSON_GetObjectItem(ret, "syscheck");
+    assert_int_equal(cJSON_GetArraySize(sys_items), 13);
+
+    cJSON *disabled = cJSON_GetObjectItem(sys_items, "disabled");
+    assert_string_equal(cJSON_GetStringValue(disabled), "no");
+    cJSON *frequency = cJSON_GetObjectItem(sys_items, "frequency");
+    assert_int_equal(frequency->valueint, 43200);
+    cJSON *skip_nfs = cJSON_GetObjectItem(sys_items, "skip_nfs");
+    assert_string_equal(cJSON_GetStringValue(skip_nfs), "no");
+    cJSON *skip_dev = cJSON_GetObjectItem(sys_items, "skip_dev");
+    assert_string_equal(cJSON_GetStringValue(skip_dev), "no");
+    cJSON *skip_sys = cJSON_GetObjectItem(sys_items, "skip_sys");
+    assert_string_equal(cJSON_GetStringValue(skip_sys), "no");
+    cJSON *skip_proc = cJSON_GetObjectItem(sys_items, "skip_proc");
+    assert_string_equal(cJSON_GetStringValue(skip_proc), "no");
+    cJSON *scan_on_start = cJSON_GetObjectItem(sys_items, "scan_on_start");
+    assert_string_equal(cJSON_GetStringValue(scan_on_start), "no");
+
+    cJSON *sys_dir = cJSON_GetObjectItem(sys_items, "directories");
+    assert_int_equal(cJSON_GetArraySize(sys_dir), 8);
+
+    cJSON *sys_nodiff = cJSON_GetObjectItem(sys_items, "nodiff");
+    assert_null(sys_nodiff);
+
+    cJSON *sys_ignore = cJSON_GetObjectItem(sys_items, "ignore");
+    assert_null(sys_ignore);
+
+    cJSON *sys_whodata = cJSON_GetObjectItem(sys_items, "whodata");
+    cJSON *whodata_restart_audit = cJSON_GetObjectItem(sys_whodata, "restart_audit");
+    assert_string_equal(cJSON_GetStringValue(whodata_restart_audit), "no");
+    cJSON *whodata_audit_key = cJSON_GetObjectItem(sys_whodata, "audit_key");
+    assert_null(whodata_audit_key);
+    cJSON *whodata_startup_healthcheck = cJSON_GetObjectItem(sys_whodata, "startup_healthcheck");
+    assert_string_equal(cJSON_GetStringValue(whodata_startup_healthcheck), "no");
+
+    cJSON *allow_remote_prefilter_cmd = cJSON_GetObjectItem(sys_items, "allow_remote_prefilter_cmd");
+    assert_string_equal(cJSON_GetStringValue(allow_remote_prefilter_cmd), "no");
+    cJSON *prefilter_cmd = cJSON_GetObjectItem(sys_items, "prefilter_cmd");
+    assert_null(prefilter_cmd);
+
+    cJSON *sys_synchronization = cJSON_GetObjectItem(sys_items, "synchronization");
+    cJSON *synchronization_enabled = cJSON_GetObjectItem(sys_synchronization, "enabled");
+    assert_string_equal(cJSON_GetStringValue(synchronization_enabled), "no");
+    cJSON *synchronization_max_interval = cJSON_GetObjectItem(sys_synchronization, "max_interval");
+    assert_int_equal(synchronization_max_interval->valueint, 3600);
+    cJSON *synchronization_interval = cJSON_GetObjectItem(sys_synchronization, "interval");
+    assert_int_equal(synchronization_interval->valueint, 600);
+    cJSON *synchronization_response_timeout = cJSON_GetObjectItem(sys_synchronization, "response_timeout");
+    assert_int_equal(synchronization_response_timeout->valueint, 30);
+    cJSON *synchronization_queue_size = cJSON_GetObjectItem(sys_synchronization, "queue_size");
+    assert_int_equal(synchronization_queue_size->valueint, 64);
+}
+
+void test_getSyscheckConfig_no_directories(void **state)
+{
+    (void) state;
+    cJSON * ret;
+
+    Read_Syscheck_Config("test_empty_config.conf");
+
+    ret = getSyscheckConfig();
+
+    assert_null(ret);
+}
 
 void test_getSyscheckInternalOptions(void **state)
 {
@@ -176,10 +339,14 @@ void test_getSyscheckInternalOptions(void **state)
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_Read_Syscheck_Config_success),
-        cmocka_unit_test(test_Read_Syscheck_Config_invalid),
-        cmocka_unit_test_teardown(test_getSyscheckConfig, delete_json),
-        cmocka_unit_test_teardown(test_getSyscheckInternalOptions, delete_json),
+        cmocka_unit_test_setup(test_Read_Syscheck_Config_success, restart_syscheck),
+        cmocka_unit_test_setup(test_Read_Syscheck_Config_invalid, restart_syscheck),
+        cmocka_unit_test_setup(test_Read_Syscheck_Config_undefined, restart_syscheck),
+        cmocka_unit_test_setup(test_Read_Syscheck_Config_unparsed, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_getSyscheckConfig, restart_syscheck, delete_json),
+        cmocka_unit_test_setup_teardown(test_getSyscheckConfig_no_audit, restart_syscheck, delete_json),
+        cmocka_unit_test_setup(test_getSyscheckConfig_no_directories, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_getSyscheckInternalOptions, restart_syscheck, delete_json),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/test_syscheck_config.c
+++ b/src/unit_tests/test_syscheck_config.c
@@ -26,15 +26,12 @@ int __wrap__merror()
 
 static int restart_syscheck(void **state)
 {
-    (void) state;
-    memset(&syscheck, 0, sizeof(syscheck_config));
-    return 0;
-}
-
-static int delete_json(void **state)
-{
     cJSON *data = *state;
-    cJSON_Delete(data);
+    if (data) {
+        cJSON_Delete(data);
+    }
+    Free_Syscheck(&syscheck);
+    memset(&syscheck, 0, sizeof(syscheck_config));
     return 0;
 }
 
@@ -339,14 +336,14 @@ void test_getSyscheckInternalOptions(void **state)
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup(test_Read_Syscheck_Config_success, restart_syscheck),
-        cmocka_unit_test_setup(test_Read_Syscheck_Config_invalid, restart_syscheck),
-        cmocka_unit_test_setup(test_Read_Syscheck_Config_undefined, restart_syscheck),
-        cmocka_unit_test_setup(test_Read_Syscheck_Config_unparsed, restart_syscheck),
-        cmocka_unit_test_setup_teardown(test_getSyscheckConfig, restart_syscheck, delete_json),
-        cmocka_unit_test_setup_teardown(test_getSyscheckConfig_no_audit, restart_syscheck, delete_json),
-        cmocka_unit_test_setup(test_getSyscheckConfig_no_directories, restart_syscheck),
-        cmocka_unit_test_setup_teardown(test_getSyscheckInternalOptions, restart_syscheck, delete_json),
+        cmocka_unit_test_teardown(test_Read_Syscheck_Config_success, restart_syscheck),
+        cmocka_unit_test_teardown(test_Read_Syscheck_Config_invalid, restart_syscheck),
+        cmocka_unit_test_teardown(test_Read_Syscheck_Config_undefined, restart_syscheck),
+        cmocka_unit_test_teardown(test_Read_Syscheck_Config_unparsed, restart_syscheck),
+        cmocka_unit_test_teardown(test_getSyscheckConfig, restart_syscheck),
+        cmocka_unit_test_teardown(test_getSyscheckConfig_no_audit, restart_syscheck),
+        cmocka_unit_test_teardown(test_getSyscheckConfig_no_directories, restart_syscheck),
+        cmocka_unit_test_teardown(test_getSyscheckInternalOptions, restart_syscheck),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/test_syscheck_config.c
+++ b/src/unit_tests/test_syscheck_config.c
@@ -24,6 +24,11 @@ int __wrap__merror()
     return 0;
 }
 
+int __wrap__mdebug1()
+{
+    return 0;
+}
+
 static int restart_syscheck(void **state)
 {
     cJSON *data = *state;

--- a/src/unit_tests/test_syscom.c
+++ b/src/unit_tests/test_syscom.c
@@ -47,6 +47,17 @@ static int delete_string(void **state)
     return 0;
 }
 
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
 
 /* tests */
 
@@ -58,6 +69,8 @@ void test_syscom_dispatch_getconfig(void **state)
 
     char command[] = "getconfig args";
     char * output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'args' section.");
 
     ret = syscom_dispatch(command, &output);
     *state = output;
@@ -74,6 +87,8 @@ void test_syscom_dispatch_getconfig_noargs(void **state)
 
     char command[] = "getconfig";
     char * output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6281): SYSCOM getconfig needs arguments.");
 
     ret = syscom_dispatch(command, &output);
     *state = output;
@@ -107,6 +122,8 @@ void test_syscom_dispatch_dbsync_noargs(void **state)
     char command[] = "dbsync";
     char *output;
 
+    expect_string(__wrap__mdebug1, formatted_msg, "(6281): SYSCOM dbsync needs arguments.");
+
     ret = syscom_dispatch(command, &output);
 
     assert_int_equal(ret, 0);
@@ -134,6 +151,8 @@ void test_syscom_dispatch_getconfig_unrecognized(void **state)
 
     char command[] = "invalid";
     char * output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6282): SYSCOM Unrecognized command 'invalid'");
 
     ret = syscom_dispatch(command, &output);
     *state = output;
@@ -185,6 +204,8 @@ void test_syscom_getconfig_syscheck_failure(void **state)
     char * output;
 
     will_return(__wrap_getSyscheckConfig, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'syscheck' section.");
+
     ret = syscom_getconfig(section, &output);
     *state = output;
 
@@ -222,6 +243,8 @@ void test_syscom_getconfig_rootcheck_failure(void **state)
     char * output;
 
     will_return(__wrap_getRootcheckConfig, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'rootcheck' section.");
+
     ret = syscom_getconfig(section, &output);
     *state = output;
 
@@ -259,6 +282,8 @@ void test_syscom_getconfig_internal_failure(void **state)
     char * output;
 
     will_return(__wrap_getSyscheckInternalOptions, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'internal' section.");
+
     ret = syscom_getconfig(section, &output);
     *state = output;
 

--- a/src/unit_tests/test_wdb_integrity.c
+++ b/src/unit_tests/test_wdb_integrity.c
@@ -18,6 +18,8 @@
 #include "../os_crypto/sha1/sha1_op.h"
 #include "../external/sqlite/sqlite3.h"
 
+void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long timestamp);
+
 /* setup/teardown */
 static int setup_wdb_t(void **state) {
     wdb_t *data = calloc(1, sizeof(wdb_t));

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -19,6 +19,7 @@ static const char *SQL_DELETE_EVENT = "DELETE FROM fim_event;";
 static const char *SQL_DELETE_FILE = "DELETE FROM fim_file;";
 
 /* Find file: returns ID, or 0 if it doesn't exists, or -1 on error. */
+// LCOV_EXCL_START
 int wdb_insert_file(sqlite3 *db, const char *path, int type) {
     sqlite3_stmt *stmt = NULL;
     int result;
@@ -364,6 +365,8 @@ end:
     sk_sum_clean(&sum);
     return retval;
 }
+
+// LCOV_EXCL_STOP
 int wdb_syscheck_save2(wdb_t * wdb, const char * payload) {
     int retval = -1;
     cJSON * data = cJSON_Parse(payload);
@@ -372,7 +375,7 @@ int wdb_syscheck_save2(wdb_t * wdb, const char * payload) {
         merror("WDB object cannot be null.");
         goto end;
     }
- 
+
     if (data == NULL) {
         mdebug1("DB(%s): cannot parse FIM payload: '%s'", wdb->agent_id, payload);
         goto end;
@@ -396,6 +399,7 @@ end:
 }
 
 // Find file entry: returns 1 if found, 0 if not, or -1 on error.
+// LCOV_EXCL_START
 int wdb_fim_find_entry(wdb_t * wdb, const char * path) {
     sqlite3_stmt *stmt = NULL;
 
@@ -478,6 +482,7 @@ int wdb_fim_insert_entry(wdb_t * wdb, const char * file, int ftype, const sk_sum
         return -1;
     }
 }
+// LCOV_EXCL_STOP
 
 int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
     if (!wdb) {
@@ -486,7 +491,7 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
     }
 
     cJSON *json_path = cJSON_GetObjectItem(data, "path");
-    
+
     if (!json_path) {
         merror("DB(%s) fim/save request with no file path argument.", wdb->agent_id);
         return -1;
@@ -578,6 +583,7 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
     return 0;
 }
 
+// LCOV_EXCL_START
 int wdb_fim_update_entry(wdb_t * wdb, const char * file, const sk_sum_t * sum) {
     sqlite3_stmt *stmt = NULL;
     char s_perm[16];
@@ -711,3 +717,4 @@ int wdb_fim_clean_old_entries(wdb_t * wdb) {
 
     return 0;
 }
+// LCOV_EXCL_STOP


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4501|

## Description

After the merge of #4562, we have to adapt the unit tests for the affected functions.

This PR fixes the tests for `fim_db.c`:

```
# ./test_fim_db
[==========] Running 71 test(s).
....
....
[==========] 71 test(s) run.
[  PASSED  ] 71 test(s).
```

It also adds tests for the new functions:

- fim_db_decode_full_row()
- fim_db_set_scanned()
- fim_db_exec_simple_wquery()
- fim_db_insert_path()
- fim_db_insert()

**Update**

Fixed all tests for the SQLite development:

```
# make test
Running tests...
Test project /root/wazuh/src/unit_tests/build
      Start  1: test_file_op
 1/20 Test  #1: test_file_op .....................   Passed    0.00 sec
      Start  2: test_integrity_op
 2/20 Test  #2: test_integrity_op ................   Passed    0.00 sec
      Start  3: test_rbtree_op
 3/20 Test  #3: test_rbtree_op ...................   Passed    0.00 sec
      Start  4: test_version_op
 4/20 Test  #4: test_version_op ..................   Passed    0.01 sec
      Start  5: test_create_db
 5/20 Test  #5: test_create_db ...................   Passed    0.02 sec
      Start  6: test_syscheck_audit
 6/20 Test  #6: test_syscheck_audit ..............   Passed    0.02 sec
      Start  7: test_seechanges
 7/20 Test  #7: test_seechanges ..................   Passed    0.02 sec
      Start  8: test_syscom
 8/20 Test  #8: test_syscom ......................   Passed    0.00 sec
      Start  9: test_run_realtime
 9/20 Test  #9: test_run_realtime ................   Passed    0.01 sec
      Start 10: test_syscheck_config
10/20 Test #10: test_syscheck_config .............   Passed    0.01 sec
      Start 11: test_syscheck
11/20 Test #11: test_syscheck ....................   Passed    0.00 sec
      Start 12: test_fim_sync
12/20 Test #12: test_fim_sync ....................   Passed    0.01 sec
      Start 13: test_run_check
13/20 Test #13: test_run_check ...................   Passed    0.02 sec
      Start 14: test_syscheck_op
14/20 Test #14: test_syscheck_op .................   Passed    0.01 sec
      Start 15: test_fim_db
15/20 Test #15: test_fim_db ......................   Passed    0.02 sec
      Start 16: test_wdb_fim
16/20 Test #16: test_wdb_fim .....................   Passed    0.01 sec
      Start 17: test_wdb_parser
17/20 Test #17: test_wdb_parser ..................   Passed    0.01 sec
      Start 18: test_analysisd_syscheck
18/20 Test #18: test_analysisd_syscheck ..........   Passed    0.02 sec
      Start 19: test_wdb_integrity
19/20 Test #19: test_wdb_integrity ...............   Passed    0.00 sec
      Start 20: test_dbsync
20/20 Test #20: test_dbsync ......................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 20

Total Test time (real) =   0.25 sec
```

### Update:

#### New coverage for syscheck:

- 100% of lines.
- 75% of branches.
![image](https://user-images.githubusercontent.com/11877311/74554177-a946b380-4f37-11ea-9343-ba3931361754.png)

- Also, some small leaks have been fixed in the code.