### PR TITLE
avoid duplicated date bucket prefix

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -573,6 +573,8 @@ class AWSBucket(WazuhIntegration):
             sys.exit(10)
 
     def marker_only_logs_after(self, aws_region, aws_account_id):
+        if self.only_logs_after.strftime('%Y/%m/%d') in self.get_full_prefix(aws_account_id, aws_region):
+                return self.get_full_prefix(aws_account_id, aws_region)
         return '{init}{only_logs_after}'.format(
             init=self.get_full_prefix(aws_account_id, aws_region),
             only_logs_after=self.only_logs_after.strftime('%Y/%m/%d')


### PR DESCRIPTION
|Related issue|
|---|
|Will create shortly|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Our company has a specific use of the "custom" integration. We found that we need to periodically dump the sqllite db and make clever use of the `<only_logs_after>` option and restart the process at midnight UTC.

All was good, but because we are using Kinesis to write to a bucket that disallows deletion of objects, we are seeing that the marker on our custom bucket with a custom prefix is stuck.

We found that this happens because when cloudwatch transformation failures occur, Kinesis will append the object prefix and write failures in "processing_failed" path.

We attempted to get around this and just manually specify the year, month, day to the `<tail_prefix>AWSLogs/{ACCOUNT_ID}/ecs/us-east-1/2020/02/10</trail_prefix>` option.

However, on the first run I saw the prefix `--trail_prefix AWSLogs/{ACCOUNT_ID}/ecs/us-east-1/2020/02/10/2020/02/10/`. This has to do with the handling of `only_logs_after` option when no index exists in the sqllite db.

So the proposal is to simply detect if the trail_prefix already includes the parameter `only_logs_after` and if so, do not append it.