### PR TITLE
Extend the coverage for the FIM unit tests

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -91,6 +91,7 @@ static int decode_event_delete;
 static int decode_event_modify;
 
 // Initialize the necessary information to process the syscheck information
+// LCOV_EXCL_START
 int fim_init(void) {
     //Create hash table for agent information
     fim_agentinfo = OSHash_Create();
@@ -1046,7 +1047,7 @@ int fim_get_scantime (long *ts, Eventinfo *lf, _sdb *sdb, const char* param) {
     os_free(response);
     return (1);
 }
-
+// LCOV_EXCL_STOP
 
 int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
     /* Every syscheck message must be in the following JSON format, as of agent version v3.11

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1682,6 +1682,16 @@ void Free_Syscheck(syscheck_config * config) {
         }
 
         free_strarray(config->audit_key);
+
+        if (config->fim_entry) {
+            rbtree_destroy(config->fim_entry);
+        }
+        if (config->fim_inode) {
+            OSHash_Free(config->fim_inode);
+        }
+        w_mutex_destroy(&config->fim_entry_mutex);
+        w_mutex_destroy(&config->fim_scan_mutex);
+        w_mutex_destroy(&config->fim_realtime_mutex);
     }
 }
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -67,7 +67,7 @@ void fim_scan() {
 
 
 #ifdef WIN32
-        os_winreg_check();
+    os_winreg_check();
 #endif
 
     gettime(&end);
@@ -1133,9 +1133,7 @@ int fim_check_ignore (const char *file_name) {
     return 0;
 }
 
-
-// LCOV_EXCL_START
-int fim_check_restrict (const char *file_name, OSMatch *restriction) {
+int fim_check_restrict(const char *file_name, OSMatch *restriction) {
     if (file_name == NULL) {
         merror(NULL_ERROR);
         return 1;
@@ -1151,7 +1149,6 @@ int fim_check_restrict (const char *file_name, OSMatch *restriction) {
 
     return 0;
 }
-// LCOV_EXCL_STOP
 
 void free_entry_data(fim_entry_data * data) {
     if (!data) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -82,7 +82,7 @@ void fim_scan() {
     fim_send_scan_info(FIM_SCAN_END);
 
     if (isDebug()) {
-        fim_print_info(start, end, cputime_start);
+        fim_print_info(start, end, cputime_start); // LCOV_EXCL_LINE
     }
 
 #ifdef DEBUGAD
@@ -252,9 +252,11 @@ int fim_file (char *file, fim_element *item, whodata_evt *w_evt, int report) {
 
     //Get file attributes
     if (entry_data = fim_get_data(file, item), !entry_data) {
+        // LCOV_EXCL_START
         mdebug1(FIM_GET_ATTRIBUTES, file);
         w_mutex_unlock(&syscheck.fim_entry_mutex);
         return 0;
+        // LCOV_EXCL_STOP
     }
 
     if (saved_data = (fim_entry_data *) rbtree_get(syscheck.fim_entry, file), !saved_data) {
@@ -323,7 +325,6 @@ void fim_realtime_event(char *file) {
     fim_audit_inode_event(file, inode_key, FIM_REALTIME, NULL);
 }
 
-
 // LCOV_EXCL_START
 void fim_whodata_event(whodata_evt * w_evt) {
     char inode_key[OS_SIZE_128];
@@ -332,7 +333,6 @@ void fim_whodata_event(whodata_evt * w_evt) {
     fim_audit_inode_event(w_evt->path, inode_key, FIM_WHODATA, w_evt);
 }
 // LCOV_EXCL_STOP
-
 
 void fim_audit_inode_event(char *file, const char *inode_key, fim_event_mode mode, whodata_evt * w_evt) {
     struct fim_element *item;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -276,6 +276,7 @@ int fim_file (char *file, fim_element *item, whodata_evt *w_evt, int report) {
         if (json_event = fim_json_event(file, saved_data, entry_data, item->index, FIM_MODIFICATION, item->mode, w_evt), json_event) {
             if (fim_update(file, entry_data, saved_data) == -1) {
                 free_entry_data(entry_data);
+                cJSON_Delete(json_event);
                 w_mutex_unlock(&syscheck.fim_entry_mutex);
                 return OS_INVALID;
             }

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -264,7 +264,7 @@ void fim_sync_dispatch(char * payload) {
         mdebug1(FIM_DBSYNC_DEC_ID, fim_sync_cur_id);
     } else if (id->valuedouble > fim_sync_cur_id) {
         mdebug1(FIM_DBSYNC_DROP_MESSAGE, (long)id->valuedouble, fim_sync_cur_id);
-        return;
+        goto end;
     }
 
     char * begin = cJSON_GetStringValue(cJSON_GetObjectItem(root, "begin"));

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -821,7 +821,7 @@ void audit_parse(char *buffer) {
                     snprintf(w_evt->dev, OS_SIZE_64, "%s%s", dev, aux);
                     snprintf(w_evt->dev, OS_SIZE_64, "%ld", strtol(w_evt->dev, NULL, 16));
                 } else {
-                    merror("Couldn't decode device chunk of audit log: colon not found in this string: \"%s\".", dev);
+                    merror("Couldn't decode device chunk of audit log: colon not found in this string: \"%s\".", dev); // LCOV_EXCL_LINE
                 }
 
                 free(dev);
@@ -870,8 +870,8 @@ void audit_parse(char *buffer) {
                             char *real_path = NULL;
                             os_calloc(PATH_MAX + 2, sizeof(char), real_path);
                             if (realpath(w_evt->path, real_path), !real_path) {
-                                mdebug1(FIM_CHECK_LINK_REALPATH, w_evt->path);
-                                break;
+                                mdebug1(FIM_CHECK_LINK_REALPATH, w_evt->path); // LCOV_EXCL_LINE
+                                break; // LCOV_EXCL_LINE
                             }
 
                             free(file_path);

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -50,8 +50,8 @@ list(APPEND tests_names "test_create_db")
 list(APPEND tests_flags "-Wl,--wrap,rbtree_insert -Wl,--wrap,rbtree_get -Wl,--wrap,rbtree_replace -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \
                          -Wl,--wrap,OSHash_Add -Wl,--wrap,lstat -Wl,--wrap,fim_send_scan_info -Wl,--wrap,send_syscheck_msg -Wl,--wrap,rbtree_keys -Wl,--wrap,readdir -Wl,--wrap,opendir -Wl,--wrap,closedir \
                          -Wl,--wrap,rbtree_delete -Wl,--wrap,OSHash_Delete -Wl,--wrap,print_rbtree -Wl,--wrap,realtime_adddir -Wl,--wrap,HasFilesystem \
-                         -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Next -Wl,--wrap,rbtree_size \
-                         -Wl,--wrap,clock")
+                         -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Next -Wl,--wrap,rbtree_size -Wl,--wrap,clock -Wl,--wrap,seechanges_addfile \
+                         -Wl,--wrap,delete_target_file -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,OS_MD5_SHA1_SHA256_File")
 
 list(APPEND tests_names "test_syscheck_audit")
 list(APPEND tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,IsSocket -Wl,--wrap,IsFile -Wl,--wrap,IsDir -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,audit_restart \
@@ -75,7 +75,7 @@ list(APPEND tests_flags "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -W
                         -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,rbtree_keys -Wl,--wrap,fim_realtime_event")
 
 list(APPEND tests_names "test_syscheck_config")
-list(APPEND tests_flags "-Wl,--wrap,_merror")
+list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
 
 list(APPEND tests_names "test_syscheck")
 list(APPEND tests_flags "-Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_setSize -Wl,--wrap,_mwarn")
@@ -121,6 +121,8 @@ list(APPEND tests_flags "-Wl,--wrap,_merror -Wl,--wrap,OS_ConnectUnixDomain -Wl,
 
 # Config files
 configure_file("test_syscheck.conf" "test_syscheck.conf" COPYONLY)
+configure_file("test_syscheck2.conf" "test_syscheck2.conf" COPYONLY)
+configure_file("test_empty_config.conf" "test_empty_config.conf" COPYONLY)
 
 
 # Generate syscheck library

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -67,8 +67,12 @@ list(APPEND tests_names "test_syscom")
 list(APPEND tests_flags "-Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheckConfig -Wl,--wrap,getSyscheckInternalOptions -Wl,--wrap,fim_sync_push_msg")
 
 list(APPEND tests_names "test_run_realtime")
-list(APPEND tests_flags "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,read \
-                        -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Get -Wl,--wrap,rbtree_insert -Wl,--wrap,_merror -Wl,--wrap,W_Vector_insert_unique")
+list(APPEND tests_flags "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -Wl,--wrap,OSHash_Get_ex \
+                        -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,read \
+                        -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Get -Wl,--wrap,rbtree_insert \
+                        -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 \
+                        -Wl,--wrap,_merror_exit -Wl,--wrap,W_Vector_insert_unique -Wl,--wrap,send_log_msg \
+                        -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,rbtree_keys -Wl,--wrap,fim_realtime_event")
 
 list(APPEND tests_names "test_syscheck_config")
 list(APPEND tests_flags "-Wl,--wrap,_merror")

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -54,9 +54,9 @@ list(APPEND tests_flags "-Wl,--wrap,rbtree_insert -Wl,--wrap,rbtree_get -Wl,--wr
                          -Wl,--wrap,delete_target_file -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,OS_MD5_SHA1_SHA256_File")
 
 list(APPEND tests_names "test_syscheck_audit")
-list(APPEND tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,IsSocket -Wl,--wrap,IsFile -Wl,--wrap,IsDir -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,audit_restart \
+list(APPEND tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,IsSocket -Wl,--wrap,IsFile -Wl,--wrap,IsDir -Wl,--wrap,IsLink -Wl,--wrap,audit_restart \
                          -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,fopen -Wl,--wrap,fwrite -Wl,--wrap,fprintf -Wl,--wrap,fclose -Wl,--wrap,symlink -Wl,--wrap,unlink \
-                         -Wl,--wrap,audit_open -Wl,--wrap,audit_get_rule_list -Wl,--wrap,audit_close -Wl,--wrap,mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,W_Vector_length -Wl,--wrap,search_audit_rule \
+                         -Wl,--wrap,audit_open -Wl,--wrap,audit_get_rule_list -Wl,--wrap,audit_close -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,W_Vector_length -Wl,--wrap,search_audit_rule \
                          -Wl,--wrap,audit_add_rule -Wl,--wrap,W_Vector_insert_unique -Wl,--wrap,SendMSG -Wl,--wrap,fim_whodata_event \
                          -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc -Wl,--wrap,closeproc -Wl,--wrap,_mdebug2 -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,realpath")
 
@@ -64,13 +64,14 @@ list(APPEND tests_names "test_seechanges")
 list(APPEND tests_flags " ")
 
 list(APPEND tests_names "test_syscom")
-list(APPEND tests_flags "-Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheckConfig -Wl,--wrap,getSyscheckInternalOptions -Wl,--wrap,fim_sync_push_msg")
+list(APPEND tests_flags "-Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheckConfig -Wl,--wrap,getSyscheckInternalOptions -Wl,--wrap,fim_sync_push_msg \
+                         -Wl,--wrap,_mdebug1")
 
 list(APPEND tests_names "test_run_realtime")
 list(APPEND tests_flags "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -Wl,--wrap,OSHash_Get_ex \
                         -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,read \
                         -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Get -Wl,--wrap,rbtree_insert \
-                        -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 \
+                        -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \
                         -Wl,--wrap,_merror_exit -Wl,--wrap,W_Vector_insert_unique -Wl,--wrap,send_log_msg \
                         -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,rbtree_keys -Wl,--wrap,fim_realtime_event")
 

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -47,9 +47,11 @@ list(APPEND tests_names "test_version_op")
 list(APPEND tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fgets -Wl,--wrap,fclose")
 
 list(APPEND tests_names "test_create_db")
-list(APPEND tests_flags "-Wl,--wrap,rbtree_insert -Wl,--wrap,rbtree_get -Wl,--wrap,rbtree_replace -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 \
+list(APPEND tests_flags "-Wl,--wrap,rbtree_insert -Wl,--wrap,rbtree_get -Wl,--wrap,rbtree_replace -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \
                          -Wl,--wrap,OSHash_Add -Wl,--wrap,lstat -Wl,--wrap,fim_send_scan_info -Wl,--wrap,send_syscheck_msg -Wl,--wrap,rbtree_keys -Wl,--wrap,readdir -Wl,--wrap,opendir -Wl,--wrap,closedir \
-                         -Wl,--wrap,rbtree_delete -Wl,--wrap,OSHash_Delete -Wl,--wrap,print_rbtree -Wl,--wrap,realtime_adddir -Wl,--wrap,HasFilesystem")
+                         -Wl,--wrap,rbtree_delete -Wl,--wrap,OSHash_Delete -Wl,--wrap,print_rbtree -Wl,--wrap,realtime_adddir -Wl,--wrap,HasFilesystem \
+                         -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Next -Wl,--wrap,rbtree_size \
+                         -Wl,--wrap,clock")
 
 list(APPEND tests_names "test_syscheck_audit")
 list(APPEND tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,IsSocket -Wl,--wrap,IsFile -Wl,--wrap,IsDir -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,audit_restart \

--- a/src/unit_tests/test_empty_config.conf
+++ b/src/unit_tests/test_empty_config.conf
@@ -1,0 +1,2 @@
+<ossec_config>
+</ossec_config>

--- a/src/unit_tests/test_run_check.c
+++ b/src/unit_tests/test_run_check.c
@@ -24,6 +24,14 @@ int __wrap__minfo(const char * file, int line, const char * func, const char *ms
     return 1;
 }
 
+/* teardown */
+
+static int free_syscheck(void **state)
+{
+    (void) state;
+    Free_Syscheck(&syscheck);
+    return 0;
+}
 
 /* tests */
 
@@ -31,10 +39,14 @@ void test_log_realtime_status(void **state)
 {
     (void) state;
 
+    log_realtime_status(2);
+
     expect_string(__wrap__minfo, msg, FIM_REALTIME_STARTED);
+    log_realtime_status(1);
     log_realtime_status(1);
 
     expect_string(__wrap__minfo, msg, FIM_REALTIME_PAUSED);
+    log_realtime_status(2);
     log_realtime_status(2);
 
     expect_string(__wrap__minfo, msg, FIM_REALTIME_RESUMED);
@@ -59,7 +71,7 @@ void test_fim_whodata_initialize(void **state)
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_log_realtime_status),
-        cmocka_unit_test(test_fim_whodata_initialize),
+        cmocka_unit_test_teardown(test_fim_whodata_initialize, free_syscheck),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/test_run_realtime.c
+++ b/src/unit_tests/test_run_realtime.c
@@ -32,7 +32,7 @@ int __wrap_OSHash_Get_ex() {
 }
 
 char *__wrap_OSHash_Get() {
-    return mock_type(char*);
+    return mock_type(char *);
 }
 
 int __wrap_OSHash_Add_ex() {
@@ -48,10 +48,9 @@ int __wrap_OSHash_Update_ex(OSHash *self, const char *key, void *data) {
     return retval;
 }
 
-void * __wrap_OSHash_Delete_ex(OSHash *self, const char *key) {
-
-    char * ret = mock_type(char*);
-    os_calloc(1, sizeof(char*), ret);
+void *__wrap_OSHash_Delete_ex() {
+    char *ret = mock_type(char *);
+    ret = calloc(1, sizeof(char *));
 
     return (void*)ret;
 }
@@ -88,25 +87,8 @@ void __wrap__mwarn(const char * file, int line, const char * func, const char *m
     check_expected(formatted_msg);
 }
 
-// In some cases such as the Setup function, we are not interesting in checking the mdebug1() uses
-void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    switch(mock_type(int)) {
-    case 0:     // Ignore checks
-        return;
-    default:
-
-        va_start(args, msg);
-        vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-        va_end(args);
-
-        check_expected(formatted_msg);
-    }
-}
-
-void __wrap__merror_exit(const char * file, int line, const char * func, const char *msg, ...) {
+void __wrap__merror_exit(const char * file, int line, const char * func, const char *msg, ...)
+{
     char formatted_msg[OS_MAXSTR];
     va_list args;
 
@@ -117,26 +99,63 @@ void __wrap__merror_exit(const char * file, int line, const char * func, const c
     check_expected(formatted_msg);
 }
 
-int __wrap_send_log_msg(const char * msg) {
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    switch(mock()) {
+        case 0:
+            return;
+        default:
+            va_start(args, msg);
+            vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+            va_end(args);
+
+            check_expected(formatted_msg);
+    }
+}
+
+void __wrap__mdebug2(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+int __wrap_send_log_msg() {
     return mock();
+}
+
+char **__wrap_rbtree_keys(const rb_tree *tree) {
+    return mock_type(char **);
+}
+
+void __wrap_fim_realtime_event(char *file) {
+    check_expected(file);
 }
 
 ssize_t __real_read(int fildes, void *buf, size_t nbyte);
 ssize_t __wrap_read(int fildes, void *buf, size_t nbyte) {
+    //static char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     switch(mock_type(int)){
-    case 0:
+        case 0:
         return __real_read(fildes, buf, nbyte);
-    case 1:
 
-        memcpy(buf,mock_ptr_type(char*),32);
+        case 1:
+        return mock_type(ssize_t);
+
+        case 2:
+        memcpy(buf, mock_type(char *), 32);
         return mock_type(ssize_t);
     }
     // We should never reach this point
     return __real_read(fildes, buf, nbyte);
-}
-
-int __wrap_os_random(void) {
-    return mock();
 }
 
 int __wrap_W_Vector_insert_unique(W_Vector *v, const char *element) {
@@ -146,20 +165,13 @@ int __wrap_W_Vector_insert_unique(W_Vector *v, const char *element) {
     return mock();
 }
 
-char ** __wrap_rbtree_keys(const rb_tree * tree) {
-    return mock_type(char **);
-}
-
-void __wrap_fim_realtime_event(char *file) {
-    check_expected(file);
-}
-
 /* setup/teardown */
 static int setup_group(void **state) {
     will_return_always(__wrap__mdebug1, 0);
     Read_Syscheck_Config("test_syscheck.conf");
 
     syscheck.realtime = (rtfim *) calloc(1, sizeof(rtfim));
+
 
     if(syscheck.realtime == NULL)
         return -1;
@@ -168,7 +180,7 @@ static int setup_group(void **state) {
 }
 
 static int teardown_group(void **state) {
-    free(syscheck.realtime);
+    Free_Syscheck(&syscheck);
 
     return 0;
 }
@@ -197,8 +209,8 @@ static int setup_realtime_start(void **state) {
 
     *state = hash;
 
-    // free the global syscheck.realtime before running syscheck_start
-    free(syscheck.realtime);
+    state[1] = syscheck.realtime;
+    syscheck.realtime = NULL;
 
     return 0;
 }
@@ -207,6 +219,13 @@ static int teardown_realtime_start(void **state) {
     OSHash *hash = *state;
 
     free(hash);
+
+    if (syscheck.realtime) {
+        free(syscheck.realtime);
+    }
+
+    syscheck.realtime = state[1];
+    state[1] = NULL;
 
     return 0;
 }
@@ -256,23 +275,6 @@ void test_realtime_start_failure_inotify(void **state) {
     assert_int_equal(ret, -1);
 }
 
-void test_realtime_adddir_whodata_fail(void **state) {
-    int ret;
-
-    const char * path = "/etc/folder";
-
-    audit_thread_active = 1;
-
-    expect_value(__wrap_W_Vector_insert_unique, v, audit_added_dirs);
-    expect_string(__wrap_W_Vector_insert_unique, element, "/etc/folder");
-    will_return(__wrap_W_Vector_insert_unique, 0);
-    expect_string(__wrap__mdebug1, formatted_msg, "(6230): Monitoring with Audit: '/etc/folder'");
-    will_return(__wrap__mdebug1, 1);
-
-    ret = realtime_adddir(path, 1);
-
-    assert_int_equal(ret, 1);
-}
 
 void test_realtime_adddir_whodata(void **state) {
     int ret;
@@ -284,6 +286,25 @@ void test_realtime_adddir_whodata(void **state) {
     expect_value(__wrap_W_Vector_insert_unique, v, audit_added_dirs);
     expect_string(__wrap_W_Vector_insert_unique, element, "/etc/folder");
     will_return(__wrap_W_Vector_insert_unique, 1);
+
+    ret = realtime_adddir(path, 1);
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_realtime_adddir_whodata_new_directory(void **state) {
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    audit_thread_active = 1;
+
+    expect_value(__wrap_W_Vector_insert_unique, v, audit_added_dirs);
+    expect_string(__wrap_W_Vector_insert_unique, element, "/etc/folder");
+    will_return(__wrap_W_Vector_insert_unique, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6230): Monitoring with Audit: '/etc/folder'");
+    will_return(__wrap__mdebug1, 1);
 
     ret = realtime_adddir(path, 1);
 
@@ -305,24 +326,29 @@ void test_realtime_adddir_realtime_failure(void **state)
     assert_int_equal(ret, -1);
 }
 
-void test_realtime_adddir_realtime_add_limit(void **state)
+
+void test_realtime_adddir_realtime_watch_max_reached_failure(void **state)
 {
     (void) state;
     int ret;
 
     const char * path = "/etc/folder";
+
     syscheck.realtime->fd = 1;
     will_return(__wrap_inotify_add_watch, -1);
-    errno = ENOSPC;
-    expect_string(__wrap__merror, formatted_msg, "(6700): Unable to add inotify watch to real time monitoring: '/etc/folder'. '-1' '28': The maximum limit of inotify watches has been reached.");
+    expect_string(__wrap__merror, formatted_msg, "(6700): Unable to add inotify watch to real time monitoring: '/etc/folder'. '-1' '28': "
+                                                 "The maximum limit of inotify watches has been reached.");
+    errno = 28;
 
     ret = realtime_adddir(path, 0);
 
     errno = 0;
+
     assert_int_equal(ret, 1);
 }
 
-void test_realtime_adddir_realtime_add_failure(void **state)
+
+void test_realtime_adddir_realtime_watch_generic_failure(void **state)
 {
     (void) state;
     int ret;
@@ -331,34 +357,14 @@ void test_realtime_adddir_realtime_add_failure(void **state)
 
     syscheck.realtime->fd = 1;
     will_return(__wrap_inotify_add_watch, -1);
-    errno = EPERM;
-    expect_string(__wrap__mdebug1, formatted_msg, "(6272): Unable to add inotify watch to real time monitoring: '/etc/folder'. '-1' '1':'Operation not permitted'");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6272): Unable to add inotify watch to real time monitoring: '/etc/folder'. '-1' '0':'Success'");
     will_return(__wrap__mdebug1, 1);
 
     ret = realtime_adddir(path, 0);
 
-    errno = 0;
     assert_int_equal(ret, 1);
 }
 
-void test_realtime_adddir_realtime_add_hash_failure(void **state)
-{
-    (void) state;
-    int ret;
-
-    const char * path = "/etc/folder";
-
-    syscheck.realtime->fd = 1;
-    will_return_always(__wrap__mdebug1, 0);
-    will_return(__wrap_inotify_add_watch, 1);
-    will_return(__wrap_OSHash_Get_ex, 0);
-    will_return(__wrap_OSHash_Add_ex, 0);
-    expect_string(__wrap__merror_exit, formatted_msg, "(6697): Out of memory. Exiting.");
-
-    ret = realtime_adddir(path, 0);
-
-    assert_int_equal(ret, 1);
-}
 
 void test_realtime_adddir_realtime_add(void **state)
 {
@@ -371,8 +377,29 @@ void test_realtime_adddir_realtime_add(void **state)
     will_return(__wrap_inotify_add_watch, 1);
     will_return(__wrap_OSHash_Get_ex, 0);
     will_return(__wrap_OSHash_Add_ex, 1);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6224): Entry '/etc/folder' already exists in the RT hash table.");
     expect_string(__wrap__mdebug1, formatted_msg, "(6227): Directory added for real time monitoring: '/etc/folder'");
     will_return(__wrap__mdebug1, 1);
+
+    ret = realtime_adddir(path, 0);
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_realtime_adddir_realtime_add_hash_failure(void **state)
+{
+    (void) state;
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    syscheck.realtime->fd = 1;
+    will_return(__wrap_inotify_add_watch, 1);
+    will_return(__wrap_OSHash_Get_ex, 0);
+    will_return(__wrap_OSHash_Add_ex, 0);
+    expect_string(__wrap__merror_exit, formatted_msg, "(6697): Out of memory. Exiting.");
+    will_return_always(__wrap__mdebug1, 0);
 
     ret = realtime_adddir(path, 0);
 
@@ -442,13 +469,118 @@ void test_free_syscheck_dirtb_data_null(void **state)
 void test_realtime_process(void **state)
 {
     (void) state;
-    char event[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
     syscheck.realtime->fd = 1;
 
-    will_return(__wrap_read, 1);
-    will_return(__wrap_read, event);
+    will_return(__wrap_read, 1); // Use wrap
     will_return(__wrap_read, 0);
+
+    realtime_process();
+}
+
+void test_realtime_process_len(void **state)
+{
+    (void) state;
+
+    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    will_return(__wrap_OSHash_Get, "test");
+    expect_string(__wrap__mdebug2, formatted_msg, "Duplicate event in real-time buffer: test/test");
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_len_zero(void **state)
+{
+    (void) state;
+
+    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    will_return(__wrap_OSHash_Get, "test");
+    expect_string(__wrap__mdebug2, formatted_msg, "Duplicate event in real-time buffer: test");
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_len_path_separator(void **state)
+{
+    (void) state;
+
+    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    will_return(__wrap_OSHash_Get, "test/");
+    expect_string(__wrap__mdebug2, formatted_msg, "Duplicate event in real-time buffer: test/test");
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_overflow(void **state)
+{
+    (void) state;
+
+    char event[] = {255, 255, 255, 255, 0, 64, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    expect_string(__wrap__mwarn, formatted_msg, "Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
+    will_return(__wrap_send_log_msg, 1);
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_delete(void **state)
+{
+    (void) state;
+
+    char event[] = {1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 2); // Use wrap
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 16);
+    will_return(__wrap_OSHash_Get, "test");
+    expect_string(__wrap__mdebug2, formatted_msg, "Duplicate event in real-time buffer: test/test");
+    char *data;
+    will_return_always(__wrap_OSHash_Delete_ex, data);
+    char **paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
 
     realtime_process();
 }
@@ -456,12 +588,10 @@ void test_realtime_process(void **state)
 void test_realtime_process_failure(void **state)
 {
     (void) state;
-    char event[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
     syscheck.realtime->fd = 1;
 
-    will_return(__wrap_read, 1);
-    will_return(__wrap_read, event);
+    will_return(__wrap_read, 1); // Use wrap
     will_return(__wrap_read, -1);
 
     expect_string(__wrap__merror, formatted_msg, FIM_ERROR_REALTIME_READ_BUFFER);
@@ -469,129 +599,30 @@ void test_realtime_process_failure(void **state)
     realtime_process();
 }
 
-void test_realtime_process_queue_full(void **state)
-{
-    (void) state;
-    char event[] = {255, 255, 255, 255, 0, 64, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};     // event->wd = -1 & event->mask = IN_Q_OVERFLOW (0x4000)
-
-    syscheck.realtime->fd = 1;
-
-    will_return(__wrap_read, 1);
-    will_return(__wrap_read, event);
-    will_return(__wrap_read, 1);
-
-    expect_string(__wrap__mwarn, formatted_msg, "Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
-    will_return(__wrap_send_log_msg, 0);
-    char ** paths = NULL;
-    paths = os_AddStrArray("/test", paths);
-    will_return(__wrap_rbtree_keys, paths);
-    expect_string(__wrap_fim_realtime_event, file, "/test");
-
-    realtime_process();
-}
-
-void test_realtime_process_success(void **state)
-{
-    (void) state;
-    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-
-    syscheck.realtime->fd = 1;
-
-    will_return(__wrap_read, 1);
-    will_return(__wrap_read, event);
-    will_return(__wrap_read, 32);
-    will_return_always(__wrap_OSHash_Get, "test");
-
-    char ** paths = NULL;
-    paths = os_AddStrArray("/test", paths);
-    will_return(__wrap_rbtree_keys, paths);
-    expect_string(__wrap_fim_realtime_event, file, "/test");
-
-    realtime_process();
-}
-
-void test_realtime_process_path_separator(void **state)
-{
-    (void) state;
-    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-
-    syscheck.realtime->fd = 1;
-
-    will_return(__wrap_read, 1);
-    will_return(__wrap_read, event);
-    will_return(__wrap_read, 32);
-    will_return_always(__wrap_OSHash_Get, "test/");
-    char ** paths = NULL;
-    paths = os_AddStrArray("/test", paths);
-    will_return(__wrap_rbtree_keys, paths);
-    expect_string(__wrap_fim_realtime_event, file, "/test");
-
-    realtime_process();
-}
-
-void test_realtime_process_event_length_zero(void **state)
-{
-    (void) state;
-    char event[] = {1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};  // event->length == 0
-
-    syscheck.realtime->fd = 1;
-
-    will_return(__wrap_read, 1);
-    will_return(__wrap_read, event);
-    will_return(__wrap_read, 32);
-    will_return_always(__wrap_OSHash_Get, "test/");
-    char ** paths = NULL;
-    paths = os_AddStrArray("/test", paths);
-    will_return(__wrap_rbtree_keys, paths);
-    expect_string(__wrap_fim_realtime_event, file, "/test");
-
-    realtime_process();
-}
-
-void test_realtime_process_success_delete(void **state)
-{
-    (void) state;
-    char event[] = {1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};  // event->mask == IN_DELETE_SELF (0x400)
-
-    syscheck.realtime->fd = 1;
-
-    will_return(__wrap_read, 1);
-    will_return(__wrap_read, event);
-    will_return(__wrap_read, 1);
-    will_return_always(__wrap_OSHash_Get, "test");
-    char * data;
-    will_return(__wrap_OSHash_Delete_ex, data);
-    char ** paths = NULL;
-    paths = os_AddStrArray("/test", paths);
-    will_return(__wrap_rbtree_keys, paths);
-    expect_string(__wrap_fim_realtime_event, file, "/test");
-
-    realtime_process();
-}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_realtime_start_success, setup_realtime_start, teardown_realtime_start),
         cmocka_unit_test_setup_teardown(test_realtime_start_failure_hash, setup_realtime_start, teardown_realtime_start),
         cmocka_unit_test_setup_teardown(test_realtime_start_failure_inotify, setup_realtime_start, teardown_realtime_start),
-        cmocka_unit_test_setup_teardown(test_realtime_adddir_whodata_fail, setup_w_vector, teardown_w_vector),
         cmocka_unit_test_setup_teardown(test_realtime_adddir_whodata, setup_w_vector, teardown_w_vector),
+        cmocka_unit_test_setup_teardown(test_realtime_adddir_whodata_new_directory, setup_w_vector, teardown_w_vector),
         cmocka_unit_test(test_realtime_adddir_realtime_failure),
-        cmocka_unit_test(test_realtime_adddir_realtime_add_limit),
-        cmocka_unit_test(test_realtime_adddir_realtime_add_failure),
-        cmocka_unit_test(test_realtime_adddir_realtime_add_hash_failure),
+        cmocka_unit_test(test_realtime_adddir_realtime_watch_max_reached_failure),
+        cmocka_unit_test(test_realtime_adddir_realtime_watch_generic_failure),
         cmocka_unit_test(test_realtime_adddir_realtime_add),
+        cmocka_unit_test(test_realtime_adddir_realtime_add_hash_failure),
         cmocka_unit_test(test_realtime_adddir_realtime_update),
         cmocka_unit_test(test_realtime_adddir_realtime_update_failure),
         cmocka_unit_test(test_free_syscheck_dirtb_data),
         cmocka_unit_test(test_free_syscheck_dirtb_data_null),
         cmocka_unit_test(test_realtime_process),
+        cmocka_unit_test(test_realtime_process_len),
+        cmocka_unit_test(test_realtime_process_len_zero),
+        cmocka_unit_test(test_realtime_process_len_path_separator),
+        cmocka_unit_test(test_realtime_process_overflow),
+        cmocka_unit_test(test_realtime_process_delete),
         cmocka_unit_test(test_realtime_process_failure),
-        cmocka_unit_test(test_realtime_process_queue_full),
-        cmocka_unit_test(test_realtime_process_success),
-        cmocka_unit_test(test_realtime_process_path_separator),
-        cmocka_unit_test(test_realtime_process_event_length_zero),
-        cmocka_unit_test(test_realtime_process_success_delete),
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);

--- a/src/unit_tests/test_run_realtime.c
+++ b/src/unit_tests/test_run_realtime.c
@@ -32,8 +32,7 @@ int __wrap_OSHash_Get_ex() {
 }
 
 char *__wrap_OSHash_Get() {
-    static char * file = "test";
-    return file;
+    return mock_type(char*);
 }
 
 int __wrap_OSHash_Add_ex() {
@@ -47,6 +46,14 @@ int __wrap_OSHash_Update_ex(OSHash *self, const char *key, void *data) {
         free(data); //  This won't be used, free it
 
     return retval;
+}
+
+void * __wrap_OSHash_Delete_ex(OSHash *self, const char *key) {
+
+    char * ret = mock_type(char*);
+    os_calloc(1, sizeof(char*), ret);
+
+    return (void*)ret;
 }
 
 void * __wrap_rbtree_insert() {
@@ -69,18 +76,59 @@ void __wrap__merror(const char * file, int line, const char * func, const char *
     check_expected(formatted_msg);
 }
 
+void __wrap__mwarn(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+// In some cases such as the Setup function, we are not interesting in checking the mdebug1() uses
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    switch(mock_type(int)) {
+    case 0:     // Ignore checks
+        return;
+    default:
+
+        va_start(args, msg);
+        vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+        va_end(args);
+
+        check_expected(formatted_msg);
+    }
+}
+
+void __wrap__merror_exit(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+int __wrap_send_log_msg(const char * msg) {
+    return mock();
+}
+
 ssize_t __real_read(int fildes, void *buf, size_t nbyte);
 ssize_t __wrap_read(int fildes, void *buf, size_t nbyte) {
-    static char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     switch(mock_type(int)){
-        case 0:
+    case 0:
         return __real_read(fildes, buf, nbyte);
+    case 1:
 
-        case 1:
-        return mock_type(ssize_t);
-
-        case 2:
-        memcpy(buf, event, 32);
+        memcpy(buf,mock_ptr_type(char*),32);
         return mock_type(ssize_t);
     }
     // We should never reach this point
@@ -98,8 +146,17 @@ int __wrap_W_Vector_insert_unique(W_Vector *v, const char *element) {
     return mock();
 }
 
+char ** __wrap_rbtree_keys(const rb_tree * tree) {
+    return mock_type(char **);
+}
+
+void __wrap_fim_realtime_event(char *file) {
+    check_expected(file);
+}
+
 /* setup/teardown */
 static int setup_group(void **state) {
+    will_return_always(__wrap__mdebug1, 0);
     Read_Syscheck_Config("test_syscheck.conf");
 
     syscheck.realtime = (rtfim *) calloc(1, sizeof(rtfim));
@@ -199,6 +256,23 @@ void test_realtime_start_failure_inotify(void **state) {
     assert_int_equal(ret, -1);
 }
 
+void test_realtime_adddir_whodata_fail(void **state) {
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    audit_thread_active = 1;
+
+    expect_value(__wrap_W_Vector_insert_unique, v, audit_added_dirs);
+    expect_string(__wrap_W_Vector_insert_unique, element, "/etc/folder");
+    will_return(__wrap_W_Vector_insert_unique, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6230): Monitoring with Audit: '/etc/folder'");
+    will_return(__wrap__mdebug1, 1);
+
+    ret = realtime_adddir(path, 1);
+
+    assert_int_equal(ret, 1);
+}
 
 void test_realtime_adddir_whodata(void **state) {
     int ret;
@@ -231,6 +305,60 @@ void test_realtime_adddir_realtime_failure(void **state)
     assert_int_equal(ret, -1);
 }
 
+void test_realtime_adddir_realtime_add_limit(void **state)
+{
+    (void) state;
+    int ret;
+
+    const char * path = "/etc/folder";
+    syscheck.realtime->fd = 1;
+    will_return(__wrap_inotify_add_watch, -1);
+    errno = ENOSPC;
+    expect_string(__wrap__merror, formatted_msg, "(6700): Unable to add inotify watch to real time monitoring: '/etc/folder'. '-1' '28': The maximum limit of inotify watches has been reached.");
+
+    ret = realtime_adddir(path, 0);
+
+    errno = 0;
+    assert_int_equal(ret, 1);
+}
+
+void test_realtime_adddir_realtime_add_failure(void **state)
+{
+    (void) state;
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    syscheck.realtime->fd = 1;
+    will_return(__wrap_inotify_add_watch, -1);
+    errno = EPERM;
+    expect_string(__wrap__mdebug1, formatted_msg, "(6272): Unable to add inotify watch to real time monitoring: '/etc/folder'. '-1' '1':'Operation not permitted'");
+    will_return(__wrap__mdebug1, 1);
+
+    ret = realtime_adddir(path, 0);
+
+    errno = 0;
+    assert_int_equal(ret, 1);
+}
+
+void test_realtime_adddir_realtime_add_hash_failure(void **state)
+{
+    (void) state;
+    int ret;
+
+    const char * path = "/etc/folder";
+
+    syscheck.realtime->fd = 1;
+    will_return_always(__wrap__mdebug1, 0);
+    will_return(__wrap_inotify_add_watch, 1);
+    will_return(__wrap_OSHash_Get_ex, 0);
+    will_return(__wrap_OSHash_Add_ex, 0);
+    expect_string(__wrap__merror_exit, formatted_msg, "(6697): Out of memory. Exiting.");
+
+    ret = realtime_adddir(path, 0);
+
+    assert_int_equal(ret, 1);
+}
 
 void test_realtime_adddir_realtime_add(void **state)
 {
@@ -243,6 +371,8 @@ void test_realtime_adddir_realtime_add(void **state)
     will_return(__wrap_inotify_add_watch, 1);
     will_return(__wrap_OSHash_Get_ex, 0);
     will_return(__wrap_OSHash_Add_ex, 1);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6227): Directory added for real time monitoring: '/etc/folder'");
+    will_return(__wrap__mdebug1, 1);
 
     ret = realtime_adddir(path, 0);
 
@@ -312,23 +442,13 @@ void test_free_syscheck_dirtb_data_null(void **state)
 void test_realtime_process(void **state)
 {
     (void) state;
+    char event[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
     syscheck.realtime->fd = 1;
 
-    will_return(__wrap_read, 1); // Use wrap
+    will_return(__wrap_read, 1);
+    will_return(__wrap_read, event);
     will_return(__wrap_read, 0);
-
-    realtime_process();
-}
-
-void test_realtime_process_len(void **state)
-{
-    (void) state;
-
-    syscheck.realtime->fd = 1;
-
-    will_return(__wrap_read, 2); // Use wrap
-    will_return(__wrap_read, 16);
 
     realtime_process();
 }
@@ -336,10 +456,12 @@ void test_realtime_process_len(void **state)
 void test_realtime_process_failure(void **state)
 {
     (void) state;
+    char event[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
     syscheck.realtime->fd = 1;
 
-    will_return(__wrap_read, 1); // Use wrap
+    will_return(__wrap_read, 1);
+    will_return(__wrap_read, event);
     will_return(__wrap_read, -1);
 
     expect_string(__wrap__merror, formatted_msg, FIM_ERROR_REALTIME_READ_BUFFER);
@@ -347,22 +469,129 @@ void test_realtime_process_failure(void **state)
     realtime_process();
 }
 
+void test_realtime_process_queue_full(void **state)
+{
+    (void) state;
+    char event[] = {255, 255, 255, 255, 0, 64, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};     // event->wd = -1 & event->mask = IN_Q_OVERFLOW (0x4000)
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 1);
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 1);
+
+    expect_string(__wrap__mwarn, formatted_msg, "Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
+    will_return(__wrap_send_log_msg, 0);
+    char ** paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_success(void **state)
+{
+    (void) state;
+    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 1);
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 32);
+    will_return_always(__wrap_OSHash_Get, "test");
+
+    char ** paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_path_separator(void **state)
+{
+    (void) state;
+    char event[] = {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 1);
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 32);
+    will_return_always(__wrap_OSHash_Get, "test/");
+    char ** paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_event_length_zero(void **state)
+{
+    (void) state;
+    char event[] = {1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};  // event->length == 0
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 1);
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 32);
+    will_return_always(__wrap_OSHash_Get, "test/");
+    char ** paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
+
+void test_realtime_process_success_delete(void **state)
+{
+    (void) state;
+    char event[] = {1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 't', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};  // event->mask == IN_DELETE_SELF (0x400)
+
+    syscheck.realtime->fd = 1;
+
+    will_return(__wrap_read, 1);
+    will_return(__wrap_read, event);
+    will_return(__wrap_read, 1);
+    will_return_always(__wrap_OSHash_Get, "test");
+    char * data;
+    will_return(__wrap_OSHash_Delete_ex, data);
+    char ** paths = NULL;
+    paths = os_AddStrArray("/test", paths);
+    will_return(__wrap_rbtree_keys, paths);
+    expect_string(__wrap_fim_realtime_event, file, "/test");
+
+    realtime_process();
+}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_realtime_start_success, setup_realtime_start, teardown_realtime_start),
         cmocka_unit_test_setup_teardown(test_realtime_start_failure_hash, setup_realtime_start, teardown_realtime_start),
         cmocka_unit_test_setup_teardown(test_realtime_start_failure_inotify, setup_realtime_start, teardown_realtime_start),
+        cmocka_unit_test_setup_teardown(test_realtime_adddir_whodata_fail, setup_w_vector, teardown_w_vector),
         cmocka_unit_test_setup_teardown(test_realtime_adddir_whodata, setup_w_vector, teardown_w_vector),
         cmocka_unit_test(test_realtime_adddir_realtime_failure),
+        cmocka_unit_test(test_realtime_adddir_realtime_add_limit),
+        cmocka_unit_test(test_realtime_adddir_realtime_add_failure),
+        cmocka_unit_test(test_realtime_adddir_realtime_add_hash_failure),
         cmocka_unit_test(test_realtime_adddir_realtime_add),
         cmocka_unit_test(test_realtime_adddir_realtime_update),
         cmocka_unit_test(test_realtime_adddir_realtime_update_failure),
         cmocka_unit_test(test_free_syscheck_dirtb_data),
         cmocka_unit_test(test_free_syscheck_dirtb_data_null),
         cmocka_unit_test(test_realtime_process),
-        cmocka_unit_test(test_realtime_process_len),
         cmocka_unit_test(test_realtime_process_failure),
+        cmocka_unit_test(test_realtime_process_queue_full),
+        cmocka_unit_test(test_realtime_process_success),
+        cmocka_unit_test(test_realtime_process_path_separator),
+        cmocka_unit_test(test_realtime_process_event_length_zero),
+        cmocka_unit_test(test_realtime_process_success_delete),
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);

--- a/src/unit_tests/test_seechanges.c
+++ b/src/unit_tests/test_seechanges.c
@@ -19,6 +19,19 @@
 
 /* redefinitons/wrapping */
 
+/* Setup/teardown */
+
+static int setup_group(void **state) {
+    (void) state;
+    Read_Syscheck_Config("test_syscheck.conf");
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    (void) state;
+    Free_Syscheck(&syscheck);
+    return 0;
+}
 
 /* tests */
 
@@ -26,8 +39,6 @@ void test_is_nodiff_true(void **state)
 {
     (void) state;
     int ret;
-
-    Read_Syscheck_Config("test_syscheck.conf");
 
     const char * file_name = "/etc/ssl/private.key";
 
@@ -42,8 +53,6 @@ void test_is_nodiff_false(void **state)
     (void) state;
     int ret;
 
-    Read_Syscheck_Config("test_syscheck.conf");
-
     const char * file_name = "/dummy_file.key";
 
     ret = is_nodiff(file_name);
@@ -56,8 +65,6 @@ void test_is_nodiff_regex_true(void **state)
 {
     (void) state;
     int ret;
-
-    Read_Syscheck_Config("test_syscheck.conf");
 
     const char * file_name = "file.test";
 
@@ -72,8 +79,6 @@ void test_is_nodiff_regex_false(void **state)
     (void) state;
     int ret;
 
-    Read_Syscheck_Config("test_syscheck.conf");
-
     const char * file_name = "test.file";
 
     ret = is_nodiff(file_name);
@@ -86,7 +91,21 @@ void test_is_nodiff_no_nodiff(void **state)
 {
     (void) state;
     int ret;
+    int i;
 
+    if (syscheck.nodiff) {
+        for (i=0; syscheck.nodiff[i] != NULL; i++) {
+            free(syscheck.nodiff[i]);
+        }
+        free(syscheck.nodiff);
+    }
+    if (syscheck.nodiff_regex) {
+        for (i=0; syscheck.nodiff_regex[i] != NULL; i++) {
+            OSMatch_FreePattern(syscheck.nodiff_regex[i]);
+            free(syscheck.nodiff_regex[i]);
+        }
+        free(syscheck.nodiff_regex);
+    }
     syscheck.nodiff = NULL;
     syscheck.nodiff_regex = NULL;
 
@@ -107,5 +126,5 @@ int main(void) {
         cmocka_unit_test(test_is_nodiff_no_nodiff),
     };
 
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/test_syscheck.c
+++ b/src/unit_tests/test_syscheck.c
@@ -39,6 +39,15 @@ void __wrap__mwarn(const char * file, int line, const char * func, const char *m
     check_expected(formatted_msg);
 }
 
+/* setup/teardowns */
+
+static int teardown_free_fim_entry(void **state) {
+    (void) state;
+
+    rbtree_destroy(syscheck.fim_entry);
+
+    return 0;
+}
 
 /* tests */
 
@@ -80,8 +89,8 @@ void test_read_internal(void **state)
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_fim_initialize),
-        cmocka_unit_test(test_fim_initialize_warn),
+        cmocka_unit_test_teardown(test_fim_initialize, teardown_free_fim_entry),
+        cmocka_unit_test_teardown(test_fim_initialize_warn, teardown_free_fim_entry),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/test_syscheck2.conf
+++ b/src/unit_tests/test_syscheck2.conf
@@ -1,0 +1,47 @@
+<ossec_config>
+  <syscheck>
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <scan_on_start>no</scan_on_start>
+
+    <!-- Generate alert when new file detected -->
+    <alert_new_files>no</alert_new_files>
+
+    <!-- Don't ignore files that change more than 'frequency' times -->
+    <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories whodata="yes" tags="tag1,tag2">/etc,/usr/bin,/usr/sbin</directories>
+    <directories realtime="yes" restrict="file$">/media,/home,/boot</directories>
+    <directories report_changes="yes" check_all="yes">/root</directories>
+    <directories check_all="no">/tmp</directories>
+
+    <skip_nfs>no</skip_nfs>
+    <skip_dev>no</skip_dev>
+    <skip_proc>no</skip_proc>
+    <skip_sys>no</skip_sys>
+
+    <allow_remote_prefilter_cmd>no</allow_remote_prefilter_cmd>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>200</max_eps>
+
+    <!-- Whodata options -->
+    <whodata>
+      <restart_audit>no</restart_audit>
+      <startup_healthcheck>no</startup_healthcheck>
+    </whodata>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>no</enabled>
+      <interval>10m</interval>
+      <max_interval>1h</max_interval>
+      <queue_size>64</queue_size>
+    </synchronization>
+  </syscheck>
+</ossec_config>

--- a/src/unit_tests/test_syscheck_audit.c
+++ b/src/unit_tests/test_syscheck_audit.c
@@ -20,6 +20,8 @@
 
 extern volatile int audit_health_check_deletion;
 
+int test_mode = 0;
+
 /* redefinitons/wrapping */
 
 int __wrap_OS_ConnectUnixDomain()
@@ -61,14 +63,52 @@ int __wrap__minfo()
     return 0;
 }
 
-int __wrap__merror()
+void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...)
 {
-    return 0;
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+
+    check_expected(formatted_msg);
+
+    va_end(args);
+
+    return;
 }
 
-int __wrap__mwarn()
+void __wrap__mwarn(const char * file, int line, const char * func, const char *msg, ...)
 {
-    return 0;
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+
+    check_expected(formatted_msg);
+
+    va_end(args);
+
+    return;
+}
+
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+
+    check_expected(formatted_msg);
+
+    va_end(args);
+
+    return;
 }
 
 void __wrap__mdebug2(const char * file, int line, const char * func, const char *msg, ...)
@@ -89,7 +129,6 @@ void __wrap__mdebug2(const char * file, int line, const char * func, const char 
     return;
 }
 
-
 int __wrap_fopen(const char *filename, const char *mode)
 {
     check_expected(filename);
@@ -100,6 +139,7 @@ int __wrap_fopen(const char *filename, const char *mode)
 char * __wrap_realpath(const char * path, char * resolved_path)
 {
     snprintf(resolved_path, OS_SIZE_1024, "%s", mock_ptr_type(char *));
+    return resolved_path;
 }
 
 size_t __real_fwrite(const void * ptr, size_t size, size_t count, FILE * stream);
@@ -116,14 +156,20 @@ int __wrap_fprintf()
     return 1;
 }
 
-int __wrap_fclose()
+int __real_fclose(FILE *fp);
+int __wrap_fclose(FILE *fp)
 {
-    return 0;
+    if (test_mode) {
+        return mock();
+    }
+    else {
+        return __real_fclose(fp);
+    }
 }
 
 int __wrap_unlink()
 {
-    return 1;
+    return mock();
 }
 
 int __wrap_symlink(const char *path1, const char *path2)
@@ -223,6 +269,20 @@ char *__wrap_get_user(__attribute__((unused)) const char *path, int uid, __attri
 }
 
 /* setup/teardown */
+static int setup_group(void **state) {
+    (void) state;
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    (void) state;
+    memset(&syscheck, 0, sizeof(syscheck_config));
+    Free_Syscheck(&syscheck);
+    test_mode = 0;
+    return 0;
+}
+
 static int free_string(void **state)
 {
     char * string = *state;
@@ -268,7 +328,7 @@ void test_check_auditd_enabled_success(void **state)
 
     ret = check_auditd_enabled();
     assert_return_code(ret, 0);
-    os_free(mock_proc);
+    free(mock_proc);
 }
 
 void test_check_auditd_enabled_openproc_error(void **state)
@@ -319,6 +379,8 @@ void test_init_auditd_socket_failure(void **state)
     int ret;
 
     will_return(__wrap_OS_ConnectUnixDomain, -5);
+    expect_string(__wrap__merror, formatted_msg, "(6636): Cannot connect to socket '/var/ossec/queue/ossec/audit'.");
+
     ret = init_auditd_socket();
     assert_int_equal(ret, -1);
 }
@@ -343,6 +405,24 @@ void test_set_auditd_config_audit3_plugin_created(void **state)
 
     expect_string(__wrap_IsSocket, sock, "/var/ossec/queue/ossec/audit");
     will_return(__wrap_IsSocket, 0);
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, 0);
+}
+
+
+void test_set_auditd_config_wrong_audit_version(void **state)
+{
+    (void) state;
+
+    // Not Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 1);
+    // Not Audit 2
+    expect_string(__wrap_IsDir, file, "/etc/audisp/plugins.d");
+    will_return(__wrap_IsDir, 1);
 
     int ret;
     ret = set_auditd_config();
@@ -382,6 +462,37 @@ void test_set_auditd_config_audit2_plugin_created(void **state)
 
 
 void test_set_auditd_config_audit_socket_not_created(void **state)
+{
+    (void) state;
+
+    syscheck.restart_audit = 0;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin already created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 0);
+
+    expect_string(__wrap_IsFile, file, audit3_socket);
+    will_return(__wrap_IsFile, 0);
+
+    expect_string(__wrap_IsSocket, sock, "/var/ossec/queue/ossec/audit");
+    will_return(__wrap_IsSocket, 1);
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6909): Audit socket (/var/ossec/queue/ossec/audit) does not exist. You need to restart Auditd. Who-data will be disabled.");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_set_auditd_config_audit_socket_not_created_restart(void **state)
 {
     (void) state;
 
@@ -430,6 +541,8 @@ void test_set_auditd_config_audit_plugin_not_created(void **state)
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
+    will_return(__wrap_fclose, 0);
+
     // Create plugin
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
@@ -443,6 +556,62 @@ void test_set_auditd_config_audit_plugin_not_created(void **state)
     ret = set_auditd_config();
 
     assert_int_equal(ret, 99);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state)
+{
+    (void) state;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 1);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "(1103): Could not open file '/var/ossec/etc/af_wazuh.conf' due to [(0)-(Success)].");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, -1);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state)
+{
+    (void) state;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 1);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fclose, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "(1140): Could not close file '/var/ossec/etc/af_wazuh.conf' due to [(0)-(Success)].");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, -1);
 }
 
 
@@ -464,11 +633,61 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink(void **sta
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
+    will_return(__wrap_fclose, 0);
+
     // Create plugin
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
     will_return(__wrap_symlink, -1);
     errno = EEXIST;
+
+    will_return(__wrap_unlink, 0);
+
+    // Delete and create
+    expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_symlink, path2, audit3_socket);
+    will_return(__wrap_symlink, 0);
+
+    // Do not restart
+    syscheck.restart_audit = 0;
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6910): Audit plugin configuration was modified. You need to restart Auditd. Who-data will be disabled.");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_restart(void **state)
+{
+    (void) state;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 1);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fclose, 0);
+
+    // Create plugin
+    expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_symlink, path2, audit3_socket);
+    will_return(__wrap_symlink, -1);
+    errno = EEXIST;
+
+    will_return(__wrap_unlink, 0);
+
     // Delete and create
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
@@ -503,15 +722,59 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_error(void
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
+    will_return(__wrap_fclose, 0);
+
     // Create plugin
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
     will_return(__wrap_symlink, -1);
     errno = EEXIST;
+
+    will_return(__wrap_unlink, 0);
+
     // Delete and create
     expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
     expect_string(__wrap_symlink, path2, audit3_socket);
     will_return(__wrap_symlink, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "(1134): Unable to link from '/etc/audit/plugins.d/af_wazuh.conf' to '/var/ossec/etc/af_wazuh.conf' due to [(17)-(File exists)].");
+
+    int ret;
+    ret = set_auditd_config();
+
+    assert_int_equal(ret, -1);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_unlink_error(void **state)
+{
+    (void) state;
+
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_string(__wrap_IsLink, file, audit3_socket);
+    will_return(__wrap_IsLink, 1);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fclose, 0);
+
+    // Create plugin
+    expect_string(__wrap_symlink, path1, "/var/ossec/etc/af_wazuh.conf");
+    expect_string(__wrap_symlink, path2, audit3_socket);
+    will_return(__wrap_symlink, -1);
+    errno = EEXIST;
+
+    will_return(__wrap_unlink, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "(1123): Unable to delete file: '/etc/audit/plugins.d/af_wazuh.conf' due to [(17)-(File exists)].");
 
     int ret;
     ret = set_auditd_config();
@@ -531,6 +794,33 @@ void test_audit_get_id(void **state)
     *state = ret;
 
     assert_string_equal(ret, "1571145421.379:659");
+}
+
+
+void test_audit_get_id_begin_error(void **state)
+{
+    (void) state;
+
+    const char* event = "audit1571145421.379:659): pid=16455 uid=0 old-auid=4294967295 auid=0 tty=(none) old-ses=4294967295 ses=57 res=1";
+
+    char *ret;
+    ret = audit_get_id(event);
+
+    assert_null(ret);
+}
+
+
+void test_audit_get_id_end_error(void **state)
+{
+    (void) state;
+
+    const char* event = "type=LOGIN msg=audit(1571145421.379:659";
+
+    char *ret;
+    ret = audit_get_id(event);
+
+    assert_null(ret);
+
 }
 
 
@@ -558,7 +848,9 @@ void test_add_audit_rules_syscheck_not_added(void **state)
     syscheck.max_audit_entries = 100;
 
     // Read loaded rules in Audit
-    will_return(__wrap_audit_get_rule_list, 5);
+    will_return(__wrap_audit_get_rule_list, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "(6637): Could not read audit loaded rules.");
 
     // Audit added rules
     will_return(__wrap_W_Vector_length, 3);
@@ -569,6 +861,48 @@ void test_add_audit_rules_syscheck_not_added(void **state)
     // Add rule
     will_return(__wrap_audit_add_rule, 1);
     will_return(__wrap_W_Vector_insert_unique, 1);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6322): Reloaded audit rule for monitoring directory: '/var/test'");
+
+    int ret;
+    ret = add_audit_rules_syscheck(0);
+
+    free(syscheck.opts);
+    free(syscheck.dir[0]);
+    free(syscheck.dir);
+
+    assert_int_equal(ret, 1);
+}
+
+
+void test_add_audit_rules_syscheck_not_added_new(void **state)
+{
+    (void) state;
+
+    char *entry = "/var/test";
+    syscheck.dir = calloc (2, sizeof(char *));
+    syscheck.dir[0] = calloc(strlen(entry) + 2, sizeof(char));
+    snprintf(syscheck.dir[0], strlen(entry) + 1, "%s", entry);
+    syscheck.opts = calloc (2, sizeof(int *));
+    syscheck.opts[0] |= WHODATA_ACTIVE;
+    syscheck.max_audit_entries = 100;
+
+    // Read loaded rules in Audit
+    will_return(__wrap_audit_get_rule_list, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "(6637): Could not read audit loaded rules.");
+
+    // Audit added rules
+    will_return(__wrap_W_Vector_length, 3);
+
+    // Rule already not added
+    will_return(__wrap_search_audit_rule, 0);
+
+    // Add rule
+    will_return(__wrap_audit_add_rule, 1);
+    will_return(__wrap_W_Vector_insert_unique, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6270): Added audit rule for monitoring directory: '/var/test'");
 
     int ret;
     ret = add_audit_rules_syscheck(0);
@@ -603,7 +937,9 @@ void test_add_audit_rules_syscheck_added(void **state)
     will_return(__wrap_search_audit_rule, 1);
 
     // Add rule
-    will_return(__wrap_W_Vector_insert_unique, 1);
+    will_return(__wrap_W_Vector_insert_unique, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6271): Audit rule for monitoring directory '/var/test' already added.");
 
     int ret;
     ret = add_audit_rules_syscheck(0);
@@ -621,11 +957,15 @@ void test_add_audit_rules_syscheck_max(void **state)
     (void) state;
 
     char *entry = "/var/test";
-    syscheck.dir = calloc(2, sizeof(char *));
+    char *entry2 = "/var/test2";
+    syscheck.dir = calloc(3, sizeof(char *));
     syscheck.dir[0] = calloc(strlen(entry) + 2, sizeof(char));
+    syscheck.dir[1] = calloc(strlen(entry2) + 2, sizeof(char));
     snprintf(syscheck.dir[0], strlen(entry) + 1, "%s", entry);
-    syscheck.opts = calloc(2, sizeof(int *));
+    snprintf(syscheck.dir[1], strlen(entry2) + 1, "%s", entry2);
+    syscheck.opts = calloc(3, sizeof(int *));
     syscheck.opts[0] |= WHODATA_ACTIVE;
+    syscheck.opts[1] |= WHODATA_ACTIVE;
     syscheck.max_audit_entries = 3;
 
     // Read loaded rules in Audit
@@ -634,10 +974,18 @@ void test_add_audit_rules_syscheck_max(void **state)
     // Audit added rules
     will_return(__wrap_W_Vector_length, 3);
 
+    expect_string(__wrap__merror, formatted_msg, "(6640): Unable to monitor who-data for directory: '/var/test' - Maximum size permitted (3).");
+
+    // Audit added rules
+    will_return(__wrap_W_Vector_length, 3);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6640): Unable to monitor who-data for directory: '/var/test2' - Maximum size permitted (3).");
+
     int ret;
-    ret = add_audit_rules_syscheck(1);
+    ret = add_audit_rules_syscheck(0);
 
     free(syscheck.dir[0]);
+    free(syscheck.dir[1]);
     free(syscheck.dir);
     free(syscheck.opts);
 
@@ -829,6 +1177,21 @@ void test_gen_audit_path7(void **state)
 }
 
 
+void test_gen_audit_path8(void **state)
+{
+    (void) state;
+
+    char * cwd = "/root";
+    char * path0 = "file";
+
+    char * ret;
+    ret = gen_audit_path(cwd, path0, NULL);
+    *state = ret;
+
+    assert_string_equal(ret, "/root/file");
+}
+
+
 void test_audit_parse(void **state)
 {
     (void) state;
@@ -849,6 +1212,8 @@ void test_audit_parse(void **state)
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("root"));
 
+    expect_string(__wrap__mdebug1, formatted_msg, "(6334): Audit: Invalid 'auid' value read. Check Audit configuration (PAM).");
+
     will_return(__wrap_get_group, "root");
 
     expect_string(__wrap__mdebug2, msg,
@@ -867,6 +1232,107 @@ void test_audit_parse(void **state)
     expect_string(__wrap_fim_whodata_event, w_evt->effective_uid, "0");
     expect_string(__wrap_fim_whodata_event, w_evt->inode, "19");
     expect_value(__wrap_fim_whodata_event, w_evt->ppid, 3211);
+
+    audit_parse(buffer);
+}
+
+
+void test_audit_parse3(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=SYSCALL msg=audit(1571914029.306:3004254): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c5f8170490 a2=0 a3=7ff365c5eca0 items=3 ppid=3211 pid=44082 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts3 ses=5 comm=\"test\" exe=\"74657374C3B1\" key=\"wazuh_fim\" \
+        type=CWD msg=audit(1571914029.306:3004254): cwd=\"/root/test\" \
+        type=PATH msg=audit(1571925844.299:3004308): item=0 name=\"./\" inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=1 name=\"folder/\" inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=2 name=\"./test\" inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1571914029.306:3004254): proctitle=726D0074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__mdebug2, msg,
+        "(6247): audit_event: uid=%s, auid=%s, euid=%s, gid=%s, pid=%i, ppid=%i, inode=%s, path=%s, pname=%s");
+    expect_string(__wrap__mdebug2, formatted_msg,
+        "(6247): audit_event: uid=root, auid=, euid=root, gid=root, pid=44082, ppid=3211, inode=28, path=/root/test/test, pname=74657374C3B1");
+
+    expect_value(__wrap_fim_whodata_event, w_evt->process_id, 44082);
+    expect_string(__wrap_fim_whodata_event, w_evt->user_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->group_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->process_name, "74657374C3B1");
+    expect_string(__wrap_fim_whodata_event, w_evt->path, "/root/test/test");
+    expect_value(__wrap_fim_whodata_event, w_evt->audit_uid, 0);
+    expect_string(__wrap_fim_whodata_event, w_evt->effective_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->inode, "28");
+    expect_value(__wrap_fim_whodata_event, w_evt->ppid, 3211);
+
+    audit_parse(buffer);
+}
+
+
+void test_audit_parse4(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=SYSCALL msg=audit(1571923546.947:3004294): arch=c000003e syscall=316 success=yes exit=0 a0=ffffff9c a1=7ffe425fc770 a2=ffffff9c a3=7ffe425fc778 items=4 ppid=3212 pid=51452 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts3 ses=5 comm=\"mv\" exe=66696C655FC3B1 key=\"wazuh_fim\" \
+        type=CWD msg=audit(1571923546.947:3004294): cwd=2F726F6F742F746573742F74657374C3B1 \
+        type=PATH msg=audit(1571923546.947:3004294): item=0 name=\"./\" inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571923546.947:3004294): item=1 name=\"folder/\" inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571923546.947:3004294): item=2 name=\"./test\" inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571923546.947:3004294): item=3 name=\"folder/test\" inode=19 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1571923546.947:3004294): proctitle=6D760066696C655FC3B1002E2E2F74657374C3B1322F66696C655FC3B163 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__mdebug2, msg,
+        "(6248): audit_event_1/2: uid=%s, auid=%s, euid=%s, gid=%s, pid=%i, ppid=%i, inode=%s, path=%s, pname=%s");
+    expect_string(__wrap__mdebug2, msg,
+        "(6249): audit_event_2/2: uid=%s, auid=%s, euid=%s, gid=%s, pid=%i, ppid=%i, inode=%s, path=%s, pname=%s");
+    expect_string(__wrap__mdebug2, formatted_msg,
+        "(6248): audit_event_1/2: uid=root, auid=root, euid=root, gid=root, pid=51452, ppid=3212, inode=19, path=/root/test/testñ/test, pname=file_ñ");
+    expect_string(__wrap__mdebug2, formatted_msg,
+        "(6249): audit_event_2/2: uid=root, auid=root, euid=root, gid=root, pid=51452, ppid=3212, inode=19, path=/root/test/testñ/folder/test, pname=file_ñ");
+
+    expect_value(__wrap_fim_whodata_event, w_evt->process_id, 51452);
+    expect_string(__wrap_fim_whodata_event, w_evt->user_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->group_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->process_name, "file_ñ");
+    expect_string(__wrap_fim_whodata_event, w_evt->path, "/root/test/testñ/test");
+    expect_string(__wrap_fim_whodata_event, w_evt->audit_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->effective_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->inode, "19");
+    expect_value(__wrap_fim_whodata_event, w_evt->ppid, 3212);
+
+    expect_value(__wrap_fim_whodata_event, w_evt->process_id, 51452);
+    expect_string(__wrap_fim_whodata_event, w_evt->user_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->group_id, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->process_name, "file_ñ");
+    expect_string(__wrap_fim_whodata_event, w_evt->path, "/root/test/testñ/folder/test");
+    expect_string(__wrap_fim_whodata_event, w_evt->audit_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->effective_uid, "0");
+    expect_string(__wrap_fim_whodata_event, w_evt->inode, "19");
+    expect_value(__wrap_fim_whodata_event, w_evt->ppid, 3212);
 
     audit_parse(buffer);
 }
@@ -931,11 +1397,27 @@ void test_audit_parse_hex(void **state)
 }
 
 
+void test_audit_parse_empty_fields(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=SYSCALL msg=audit(1571914029.306:3004254): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c5f8170490 a2=0 a3=7ff365c5eca0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts3 ses=5 comm=\"test\" key=\"wazuh_fim\" \
+        type=PROCTITLE msg=audit(1571914029.306:3004254): proctitle=726D0074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    audit_parse(buffer);
+}
+
+
 void test_audit_parse_delete(void **state)
 {
     (void) state;
 
-    char * buffer = "type=CONFIG_CHANGE msg=audit(1571920603.069:3004276): auid=0 ses=5 op=remove_rule key=\"wazuh_fim\" list=4 res=1";
+    char * buffer = "type=CONFIG_CHANGE msg=audit(1571920603.069:3004276): auid=0 ses=5 op=\"remove_rule\" key=\"wazuh_fim\" list=4 res=1";
 
     // In audit_reload_rules()
     char *entry = "/var/test";
@@ -948,6 +1430,9 @@ void test_audit_parse_delete(void **state)
 
     expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
     expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6275): Reloading Audit rules.");
 
     // Read loaded rules in Audit
     will_return(__wrap_audit_get_rule_list, 5);
@@ -962,6 +1447,8 @@ void test_audit_parse_delete(void **state)
     will_return(__wrap_W_Vector_insert_unique, 1);
 
     expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6276): Audit rules reloaded. Rules loaded: 1");
 
     audit_parse(buffer);
 
@@ -1001,11 +1488,31 @@ void test_audit_parse_delete_recursive(void **state)
     expect_string_count(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed", 4);
     expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
 
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6275): Reloading Audit rules.");
+    expect_string(__wrap__merror, formatted_msg, "(6639): Error checking Audit rules list.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6276): Audit rules reloaded. Rules loaded: 0");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6275): Reloading Audit rules.");
+    expect_string(__wrap__merror, formatted_msg, "(6639): Error checking Audit rules list.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6276): Audit rules reloaded. Rules loaded: 0");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6275): Reloading Audit rules.");
+    expect_string(__wrap__merror, formatted_msg, "(6639): Error checking Audit rules list.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6276): Audit rules reloaded. Rules loaded: 0");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+
     int i;
     for (i = 0; i < 4; i++) {
         audit_parse(buffer);
     }
 
+    free(syscheck.opts);
+    free(syscheck.dir[0]);
+    free(syscheck.dir);
 }
 
 
@@ -1350,6 +1857,136 @@ void test_audit_parse_delete_folder_hex(void **state)
 }
 
 
+void test_audit_parse_delete_folder_hex3_error(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=CONFIG_CHANGE msg=audit(1572878838.610:220): op=remove_rule dir=0 key=\"wazuh_fim\" list=4 res=1 \
+        type=SYSCALL msg=audit(1572878838.610:220): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c2b7d7f490 a2=200 a3=7f2b8055bca0 items=3 ppid=4340 pid=62845 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=7 comm=\"rm\" exe=1 key=(null) \
+        type=CWD msg=audit(1572878838.610:220): cwd=2 \
+        type=PATH msg=audit(1571925844.299:3004308): item=0 name=3 inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=1 name=4 inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=2 name=5 inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1572878838.610:220): proctitle=726D002D72660074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '0'");
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '1'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '2'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '3'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '4'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '5'");
+
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed");
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
+
+    audit_parse(buffer);
+}
+
+
+void test_audit_parse_delete_folder_hex4_error(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=CONFIG_CHANGE msg=audit(1572878838.610:220): op=remove_rule dir=0 key=\"wazuh_fim\" list=4 res=1 \
+        type=SYSCALL msg=audit(1572878838.610:220): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c2b7d7f490 a2=200 a3=7f2b8055bca0 items=4 ppid=4340 pid=62845 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=7 comm=\"rm\" exe=1 key=(null) \
+        type=CWD msg=audit(1572878838.610:220): cwd=2 \
+        type=PATH msg=audit(1571925844.299:3004308): item=0 name=3 inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=1 name=4 inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=2 name=5 inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=3 name=6 inode=19 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1572878838.610:220): proctitle=726D002D72660074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '0'");
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '1'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '2'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '3'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '4'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '5'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '6'");
+
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed");
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
+
+    audit_parse(buffer);
+}
+
+
+void test_audit_parse_delete_folder_hex5_error(void **state)
+{
+    (void) state;
+
+    char * buffer = " \
+        type=CONFIG_CHANGE msg=audit(1572878838.610:220): op=remove_rule dir=0 key=\"wazuh_fim\" list=4 res=1 \
+        type=SYSCALL msg=audit(1572878838.610:220): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55c2b7d7f490 a2=200 a3=7f2b8055bca0 items=5 ppid=4340 pid=62845 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=7 comm=\"rm\" exe=1 key=(null) \
+        type=CWD msg=audit(1572878838.610:220): cwd=2 \
+        type=PATH msg=audit(1571925844.299:3004308): item=0 name=3 inode=110 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=1 name=4 inode=24 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=2 name=5 inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=3 name=6 inode=19 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PATH msg=audit(1571925844.299:3004308): item=4 name=7 inode=28 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 \
+        type=PROCTITLE msg=audit(1572878838.610:220): proctitle=726D002D72660074657374 \
+    ";
+
+    expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '0'");
+    expect_string(__wrap__mwarn, formatted_msg, "(6911): Detected Audit rules manipulation: Audit rules removed.");
+
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, strdup("root"));
+
+    will_return(__wrap_get_group, "root");
+
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '1'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '2'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '3'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '4'");
+    expect_string(__wrap__merror, formatted_msg, "Error found while decoding HEX bufer: '7'");
+
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed");
+    expect_string(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
+
+    audit_parse(buffer);
+}
+
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_check_auditd_enabled_success),
@@ -1357,16 +1994,25 @@ int main(void) {
         cmocka_unit_test(test_check_auditd_enabled_readproc_error),
         cmocka_unit_test(test_init_auditd_socket_success),
         cmocka_unit_test(test_init_auditd_socket_failure),
+        cmocka_unit_test(test_set_auditd_config_wrong_audit_version),
         cmocka_unit_test(test_set_auditd_config_audit2_plugin_created),
         cmocka_unit_test(test_set_auditd_config_audit3_plugin_created),
         cmocka_unit_test(test_set_auditd_config_audit_socket_not_created),
+        cmocka_unit_test(test_set_auditd_config_audit_socket_not_created_restart),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_fopen_error),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_fclose_error),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_symlink),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_symlink_restart),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_symlink_error),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_symlink_unlink_error),
         cmocka_unit_test_teardown(test_audit_get_id, free_string),
+        cmocka_unit_test(test_audit_get_id_begin_error),
+        cmocka_unit_test(test_audit_get_id_end_error),
         cmocka_unit_test(test_init_regex),
         cmocka_unit_test(test_add_audit_rules_syscheck_added),
         cmocka_unit_test(test_add_audit_rules_syscheck_not_added),
+        cmocka_unit_test(test_add_audit_rules_syscheck_not_added_new),
         cmocka_unit_test(test_add_audit_rules_syscheck_max),
         cmocka_unit_test(test_filterkey_audit_events_custom),
         cmocka_unit_test(test_filterkey_audit_events_discard),
@@ -1379,8 +2025,12 @@ int main(void) {
         cmocka_unit_test_teardown(test_gen_audit_path5, free_string),
         cmocka_unit_test_teardown(test_gen_audit_path6, free_string),
         cmocka_unit_test_teardown(test_gen_audit_path7, free_string),
+        cmocka_unit_test_teardown(test_gen_audit_path8, free_string),
         cmocka_unit_test(test_audit_parse),
+        cmocka_unit_test(test_audit_parse3),
+        cmocka_unit_test(test_audit_parse4),
         cmocka_unit_test(test_audit_parse_hex),
+        cmocka_unit_test(test_audit_parse_empty_fields),
         cmocka_unit_test(test_audit_parse_delete),
         cmocka_unit_test(test_audit_parse_delete_recursive),
         cmocka_unit_test(test_audit_parse_mv),
@@ -1392,6 +2042,9 @@ int main(void) {
         cmocka_unit_test(test_audit_parse_unknown_hc),
         cmocka_unit_test(test_audit_parse_delete_folder),
         cmocka_unit_test(test_audit_parse_delete_folder_hex),
+        cmocka_unit_test(test_audit_parse_delete_folder_hex3_error),
+        cmocka_unit_test(test_audit_parse_delete_folder_hex4_error),
+        cmocka_unit_test(test_audit_parse_delete_folder_hex5_error),
     };
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/test_syscheck_config.c
+++ b/src/unit_tests/test_syscheck_config.c
@@ -83,7 +83,6 @@ void test_Read_Syscheck_Config_success(void **state)
     assert_int_equal(syscheck.send_delay, 5000);
 }
 
-
 void test_Read_Syscheck_Config_invalid(void **state)
 {
     (void) state;
@@ -93,7 +92,6 @@ void test_Read_Syscheck_Config_invalid(void **state)
 
     assert_int_equal(ret, OS_INVALID);
 }
-
 
 void test_Read_Syscheck_Config_undefined(void **state)
 {
@@ -135,7 +133,6 @@ void test_Read_Syscheck_Config_undefined(void **state)
     assert_int_equal(syscheck.send_delay, 5000);
 }
 
-
 void test_Read_Syscheck_Config_unparsed(void **state)
 {
     (void) state;
@@ -176,7 +173,6 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     assert_int_equal(syscheck.max_eps, 200);
     assert_int_equal(syscheck.send_delay, 5000);
 }
-
 
 void test_getSyscheckConfig(void **state)
 {
@@ -244,7 +240,6 @@ void test_getSyscheckConfig(void **state)
     assert_int_equal(synchronization_queue_size->valueint, 64);
 }
 
-
 void test_getSyscheckConfig_no_audit(void **state)
 {
     (void) state;
@@ -311,7 +306,6 @@ void test_getSyscheckConfig_no_audit(void **state)
     assert_int_equal(synchronization_queue_size->valueint, 64);
 }
 
-
 void test_getSyscheckConfig_no_directories(void **state)
 {
     (void) state;
@@ -323,7 +317,6 @@ void test_getSyscheckConfig_no_directories(void **state)
 
     assert_null(ret);
 }
-
 
 void test_getSyscheckInternalOptions(void **state)
 {

--- a/src/unit_tests/test_syscheck_config.c
+++ b/src/unit_tests/test_syscheck_config.c
@@ -24,10 +24,19 @@ int __wrap__merror()
     return 0;
 }
 
-static int delete_json(void **state)
+int __wrap__mdebug1()
+{
+    return 0;
+}
+
+static int restart_syscheck(void **state)
 {
     cJSON *data = *state;
-    cJSON_Delete(data);
+    if (data) {
+        cJSON_Delete(data);
+    }
+    Free_Syscheck(&syscheck);
+    memset(&syscheck, 0, sizeof(syscheck_config));
     return 0;
 }
 
@@ -83,6 +92,89 @@ void test_Read_Syscheck_Config_invalid(void **state)
     ret = Read_Syscheck_Config("invalid.conf");
 
     assert_int_equal(ret, OS_INVALID);
+}
+
+
+void test_Read_Syscheck_Config_undefined(void **state)
+{
+    (void) state;
+    int ret;
+
+    ret = Read_Syscheck_Config("test_syscheck2.conf");
+
+    assert_int_equal(ret, 0);
+    assert_int_equal(syscheck.rootcheck, 0);
+
+    assert_int_equal(syscheck.disabled, 0);
+    assert_int_equal(syscheck.skip_fs.nfs, 0);
+    assert_int_equal(syscheck.skip_fs.dev, 0);
+    assert_int_equal(syscheck.skip_fs.sys, 0);
+    assert_int_equal(syscheck.skip_fs.proc, 0);
+    assert_int_equal(syscheck.scan_on_start, 0);
+    assert_int_equal(syscheck.time, 43200);
+    assert_null(syscheck.ignore);
+    assert_null(syscheck.ignore_regex);
+    assert_null(syscheck.nodiff);
+    assert_null(syscheck.nodiff_regex);
+    assert_null(syscheck.scan_day);
+    assert_null(syscheck.scan_time);
+    assert_non_null(syscheck.dir);
+    assert_non_null(syscheck.opts);
+    assert_int_equal(syscheck.enable_synchronization, 0);
+    assert_int_equal(syscheck.restart_audit, 0);
+    assert_int_equal(syscheck.enable_whodata, 1);
+    assert_null(syscheck.realtime);
+    assert_int_equal(syscheck.audit_healthcheck, 0);
+    assert_int_equal(syscheck.process_priority, 10);
+    assert_int_equal(syscheck.allow_remote_prefilter_cmd, false);
+    assert_null(syscheck.prefilter_cmd);
+    assert_int_equal(syscheck.sync_interval, 600);
+    assert_int_equal(syscheck.sync_response_timeout, 30);
+    assert_int_equal(syscheck.sync_queue_size, 64);
+    assert_int_equal(syscheck.max_eps, 200);
+    assert_int_equal(syscheck.send_delay, 5000);
+}
+
+
+void test_Read_Syscheck_Config_unparsed(void **state)
+{
+    (void) state;
+    int ret;
+
+    ret = Read_Syscheck_Config("test_empty_config.conf");
+
+    assert_int_equal(ret, 1);
+
+    // Default values
+    assert_int_equal(syscheck.rootcheck, 0);
+    assert_int_equal(syscheck.disabled, 1);
+    assert_int_equal(syscheck.skip_fs.nfs, 1);
+    assert_int_equal(syscheck.skip_fs.dev, 1);
+    assert_int_equal(syscheck.skip_fs.sys, 1);
+    assert_int_equal(syscheck.skip_fs.proc, 1);
+    assert_int_equal(syscheck.scan_on_start, 1);
+    assert_int_equal(syscheck.time, 43200);
+    assert_null(syscheck.ignore);
+    assert_null(syscheck.ignore_regex);
+    assert_null(syscheck.nodiff);
+    assert_null(syscheck.nodiff_regex);
+    assert_null(syscheck.scan_day);
+    assert_null(syscheck.scan_time);
+    assert_null(syscheck.dir);
+    assert_null(syscheck.opts);
+    assert_int_equal(syscheck.enable_synchronization, 1);
+    assert_int_equal(syscheck.restart_audit, 1);
+    assert_int_equal(syscheck.enable_whodata, 0);
+    assert_null(syscheck.realtime);
+    assert_int_equal(syscheck.audit_healthcheck, 1);
+    assert_int_equal(syscheck.process_priority, 10);
+    assert_int_equal(syscheck.allow_remote_prefilter_cmd, false);
+    assert_null(syscheck.prefilter_cmd);
+    assert_int_equal(syscheck.sync_interval, 300);
+    assert_int_equal(syscheck.sync_response_timeout, 30);
+    assert_int_equal(syscheck.sync_queue_size, 16384);
+    assert_int_equal(syscheck.max_eps, 200);
+    assert_int_equal(syscheck.send_delay, 5000);
 }
 
 
@@ -153,6 +245,86 @@ void test_getSyscheckConfig(void **state)
 }
 
 
+void test_getSyscheckConfig_no_audit(void **state)
+{
+    (void) state;
+    cJSON * ret;
+
+    Read_Syscheck_Config("test_syscheck2.conf");
+
+    ret = getSyscheckConfig();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_int_equal(cJSON_GetArraySize(ret), 1);
+
+    cJSON *sys_items = cJSON_GetObjectItem(ret, "syscheck");
+    assert_int_equal(cJSON_GetArraySize(sys_items), 13);
+
+    cJSON *disabled = cJSON_GetObjectItem(sys_items, "disabled");
+    assert_string_equal(cJSON_GetStringValue(disabled), "no");
+    cJSON *frequency = cJSON_GetObjectItem(sys_items, "frequency");
+    assert_int_equal(frequency->valueint, 43200);
+    cJSON *skip_nfs = cJSON_GetObjectItem(sys_items, "skip_nfs");
+    assert_string_equal(cJSON_GetStringValue(skip_nfs), "no");
+    cJSON *skip_dev = cJSON_GetObjectItem(sys_items, "skip_dev");
+    assert_string_equal(cJSON_GetStringValue(skip_dev), "no");
+    cJSON *skip_sys = cJSON_GetObjectItem(sys_items, "skip_sys");
+    assert_string_equal(cJSON_GetStringValue(skip_sys), "no");
+    cJSON *skip_proc = cJSON_GetObjectItem(sys_items, "skip_proc");
+    assert_string_equal(cJSON_GetStringValue(skip_proc), "no");
+    cJSON *scan_on_start = cJSON_GetObjectItem(sys_items, "scan_on_start");
+    assert_string_equal(cJSON_GetStringValue(scan_on_start), "no");
+
+    cJSON *sys_dir = cJSON_GetObjectItem(sys_items, "directories");
+    assert_int_equal(cJSON_GetArraySize(sys_dir), 8);
+
+    cJSON *sys_nodiff = cJSON_GetObjectItem(sys_items, "nodiff");
+    assert_null(sys_nodiff);
+
+    cJSON *sys_ignore = cJSON_GetObjectItem(sys_items, "ignore");
+    assert_null(sys_ignore);
+
+    cJSON *sys_whodata = cJSON_GetObjectItem(sys_items, "whodata");
+    cJSON *whodata_restart_audit = cJSON_GetObjectItem(sys_whodata, "restart_audit");
+    assert_string_equal(cJSON_GetStringValue(whodata_restart_audit), "no");
+    cJSON *whodata_audit_key = cJSON_GetObjectItem(sys_whodata, "audit_key");
+    assert_null(whodata_audit_key);
+    cJSON *whodata_startup_healthcheck = cJSON_GetObjectItem(sys_whodata, "startup_healthcheck");
+    assert_string_equal(cJSON_GetStringValue(whodata_startup_healthcheck), "no");
+
+    cJSON *allow_remote_prefilter_cmd = cJSON_GetObjectItem(sys_items, "allow_remote_prefilter_cmd");
+    assert_string_equal(cJSON_GetStringValue(allow_remote_prefilter_cmd), "no");
+    cJSON *prefilter_cmd = cJSON_GetObjectItem(sys_items, "prefilter_cmd");
+    assert_null(prefilter_cmd);
+
+    cJSON *sys_synchronization = cJSON_GetObjectItem(sys_items, "synchronization");
+    cJSON *synchronization_enabled = cJSON_GetObjectItem(sys_synchronization, "enabled");
+    assert_string_equal(cJSON_GetStringValue(synchronization_enabled), "no");
+    cJSON *synchronization_max_interval = cJSON_GetObjectItem(sys_synchronization, "max_interval");
+    assert_int_equal(synchronization_max_interval->valueint, 3600);
+    cJSON *synchronization_interval = cJSON_GetObjectItem(sys_synchronization, "interval");
+    assert_int_equal(synchronization_interval->valueint, 600);
+    cJSON *synchronization_response_timeout = cJSON_GetObjectItem(sys_synchronization, "response_timeout");
+    assert_int_equal(synchronization_response_timeout->valueint, 30);
+    cJSON *synchronization_queue_size = cJSON_GetObjectItem(sys_synchronization, "queue_size");
+    assert_int_equal(synchronization_queue_size->valueint, 64);
+}
+
+
+void test_getSyscheckConfig_no_directories(void **state)
+{
+    (void) state;
+    cJSON * ret;
+
+    Read_Syscheck_Config("test_empty_config.conf");
+
+    ret = getSyscheckConfig();
+
+    assert_null(ret);
+}
+
+
 void test_getSyscheckInternalOptions(void **state)
 {
     (void) state;
@@ -176,10 +348,14 @@ void test_getSyscheckInternalOptions(void **state)
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_Read_Syscheck_Config_success),
-        cmocka_unit_test(test_Read_Syscheck_Config_invalid),
-        cmocka_unit_test_teardown(test_getSyscheckConfig, delete_json),
-        cmocka_unit_test_teardown(test_getSyscheckInternalOptions, delete_json),
+        cmocka_unit_test_teardown(test_Read_Syscheck_Config_success, restart_syscheck),
+        cmocka_unit_test_teardown(test_Read_Syscheck_Config_invalid, restart_syscheck),
+        cmocka_unit_test_teardown(test_Read_Syscheck_Config_undefined, restart_syscheck),
+        cmocka_unit_test_teardown(test_Read_Syscheck_Config_unparsed, restart_syscheck),
+        cmocka_unit_test_teardown(test_getSyscheckConfig, restart_syscheck),
+        cmocka_unit_test_teardown(test_getSyscheckConfig_no_audit, restart_syscheck),
+        cmocka_unit_test_teardown(test_getSyscheckConfig_no_directories, restart_syscheck),
+        cmocka_unit_test_teardown(test_getSyscheckInternalOptions, restart_syscheck),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/test_syscom.c
+++ b/src/unit_tests/test_syscom.c
@@ -47,6 +47,17 @@ static int delete_string(void **state)
     return 0;
 }
 
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
 
 /* tests */
 
@@ -58,6 +69,8 @@ void test_syscom_dispatch_getconfig(void **state)
 
     char command[] = "getconfig args";
     char * output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'args' section.");
 
     ret = syscom_dispatch(command, &output);
     *state = output;
@@ -74,6 +87,8 @@ void test_syscom_dispatch_getconfig_noargs(void **state)
 
     char command[] = "getconfig";
     char * output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6281): SYSCOM getconfig needs arguments.");
 
     ret = syscom_dispatch(command, &output);
     *state = output;
@@ -107,6 +122,8 @@ void test_syscom_dispatch_dbsync_noargs(void **state)
     char command[] = "dbsync";
     char *output;
 
+    expect_string(__wrap__mdebug1, formatted_msg, "(6281): SYSCOM dbsync needs arguments.");
+
     ret = syscom_dispatch(command, &output);
 
     assert_int_equal(ret, 0);
@@ -134,6 +151,8 @@ void test_syscom_dispatch_getconfig_unrecognized(void **state)
 
     char command[] = "invalid";
     char * output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6282): SYSCOM Unrecognized command 'invalid'");
 
     ret = syscom_dispatch(command, &output);
     *state = output;
@@ -185,6 +204,8 @@ void test_syscom_getconfig_syscheck_failure(void **state)
     char * output;
 
     will_return(__wrap_getSyscheckConfig, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'syscheck' section.");
+
     ret = syscom_getconfig(section, &output);
     *state = output;
 
@@ -222,6 +243,8 @@ void test_syscom_getconfig_rootcheck_failure(void **state)
     char * output;
 
     will_return(__wrap_getRootcheckConfig, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'rootcheck' section.");
+
     ret = syscom_getconfig(section, &output);
     *state = output;
 
@@ -259,6 +282,8 @@ void test_syscom_getconfig_internal_failure(void **state)
     char * output;
 
     will_return(__wrap_getSyscheckInternalOptions, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'internal' section.");
+
     ret = syscom_getconfig(section, &output);
     *state = output;
 

--- a/src/unit_tests/test_wdb_integrity.c
+++ b/src/unit_tests/test_wdb_integrity.c
@@ -18,6 +18,8 @@
 #include "../os_crypto/sha1/sha1_op.h"
 #include "../external/sqlite/sqlite3.h"
 
+void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long timestamp);
+
 /* setup/teardown */
 static int setup_wdb_t(void **state) {
     wdb_t *data = calloc(1, sizeof(wdb_t));

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -19,6 +19,7 @@ static const char *SQL_DELETE_EVENT = "DELETE FROM fim_event;";
 static const char *SQL_DELETE_FILE = "DELETE FROM fim_file;";
 
 /* Find file: returns ID, or 0 if it doesn't exists, or -1 on error. */
+// LCOV_EXCL_START
 int wdb_insert_file(sqlite3 *db, const char *path, int type) {
     sqlite3_stmt *stmt = NULL;
     int result;
@@ -364,6 +365,8 @@ end:
     sk_sum_clean(&sum);
     return retval;
 }
+
+// LCOV_EXCL_STOP
 int wdb_syscheck_save2(wdb_t * wdb, const char * payload) {
     int retval = -1;
     cJSON * data = cJSON_Parse(payload);
@@ -372,7 +375,7 @@ int wdb_syscheck_save2(wdb_t * wdb, const char * payload) {
         merror("WDB object cannot be null.");
         goto end;
     }
- 
+
     if (data == NULL) {
         mdebug1("DB(%s): cannot parse FIM payload: '%s'", wdb->agent_id, payload);
         goto end;
@@ -396,6 +399,7 @@ end:
 }
 
 // Find file entry: returns 1 if found, 0 if not, or -1 on error.
+// LCOV_EXCL_START
 int wdb_fim_find_entry(wdb_t * wdb, const char * path) {
     sqlite3_stmt *stmt = NULL;
 
@@ -478,6 +482,7 @@ int wdb_fim_insert_entry(wdb_t * wdb, const char * file, int ftype, const sk_sum
         return -1;
     }
 }
+// LCOV_EXCL_STOP
 
 int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
     if (!wdb) {
@@ -486,7 +491,7 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
     }
 
     cJSON *json_path = cJSON_GetObjectItem(data, "path");
-    
+
     if (!json_path) {
         merror("DB(%s) fim/save request with no file path argument.", wdb->agent_id);
         return -1;
@@ -578,6 +583,7 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
     return 0;
 }
 
+// LCOV_EXCL_START
 int wdb_fim_update_entry(wdb_t * wdb, const char * file, const sk_sum_t * sum) {
     sqlite3_stmt *stmt = NULL;
     char s_perm[16];
@@ -711,3 +717,4 @@ int wdb_fim_clean_old_entries(wdb_t * wdb) {
 
     return 0;
 }
+// LCOV_EXCL_STOP


### PR DESCRIPTION
## Description

This PR adds new tests to cover more functions and branches of the following files:

- syscheckd/create_db.c

- syscheckd/run_realtime.c

### Previous coverage

![image](https://user-images.githubusercontent.com/29475387/74453001-1a2b9400-4e82-11ea-8857-b71ce5fe5703.png)

### New coverage

![image](https://user-images.githubusercontent.com/29475387/74452479-6de9ad80-4e81-11ea-9d9a-aa4c5ea2577e.png)

It also fixes a warning related to a static declaration:

```
In file included from /root/wazuh/src/unit_tests/test_wdb_integrity.c:13:0:
/root/wazuh/src/unit_tests/test_wdb_integrity.c: In function ‘test_wdbi_update_completion_wbs_null’:
/root/wazuh/src/unit_tests/test_wdb_integrity.c:374:27: warning: implicit declaration of function ‘wdbi_update_completion’; did you mean ‘wdbi_update_attempt’? [-Wimplicit-function-declaration]
     expect_assert_failure(wdbi_update_completion(NULL, 0, 0));
                           ^
```

### Remaining files to increase coverage

 - syscheckd/config.c

- syscheckd/create_db.c

- syscheckd/fim_sync.c

- syscheckd/syscheck_audit.c
