### PR TITLE
Fixed the processing of long audit messages

### DIFF
--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -24,7 +24,7 @@
 #define PLUGINS_DIR_AUDIT_3 "/etc/audit/plugins.d"
 #define AUDIT_CONF_LINK "af_wazuh.conf"
 #define AUDIT_SOCKET DEFAULTDIR "/queue/ossec/audit"
-#define BUF_SIZE 6144
+#define BUF_SIZE 61440
 #define AUDIT_KEY "wazuh_fim"
 #define AUDIT_LOAD_RETRIES 5 // Max retries to reload Audit rules
 #define MAX_CONN_RETRIES 5 // Max retries to reconnect to Audit socket

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -24,7 +24,7 @@
 #define PLUGINS_DIR_AUDIT_3 "/etc/audit/plugins.d"
 #define AUDIT_CONF_LINK "af_wazuh.conf"
 #define AUDIT_SOCKET DEFAULTDIR "/queue/ossec/audit"
-#define BUF_SIZE 61440
+#define BUF_SIZE OS_MAXSTR
 #define AUDIT_KEY "wazuh_fim"
 #define AUDIT_LOAD_RETRIES 5 // Max retries to reload Audit rules
 #define MAX_CONN_RETRIES 5 // Max retries to reconnect to Audit socket


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4598|

## Description

This PR solves the problem in monitoring files with whodata when the message generated by audit is too long.

If the message we get from audit is too long,  we lose the event and show the following error:
```
ERROR: (6643): Caching Audit message: event too long.
```
And no warning is shown about what happens to the file.

## Configuration options
The following configuration in the ossec.conf file:
``` xml
  <syscheck>
	<disabled>no</disabled>
	<directories check_all="yes" recursion_level="320" whodata="yes">/test recursion 320</directories>
  </syscheck>
```
320 subdirectories are created with spaces in the names:
``` python
path = "/test recursion 320/dir 1/dir 2/dir 3/dir 4/dir 5/dir 6/dir 7/dir 8/dir 9/dir 10/dir 11/dir 12/dir 13/dir 14/dir 15/dir 16/dir 17/dir 18/dir 19/dir 20/dir 21/dir 22/dir 23/dir 24/dir 25/dir 26/dir 27/dir 28/dir 29/dir 30/dir 31/dir 32/dir 33/dir 34/dir 35/dir 36/dir 37/dir 38/dir 39/dir 40/dir 41/dir 42/dir 43/dir 44/dir 45/dir 46/dir 47/dir 48/dir 49/dir 50/dir 51/dir 52/dir 53/dir 54/dir 55/dir 56/dir 57/dir 58/dir 59/dir 60/dir 61/dir 62/dir 63/dir 64/dir 65/dir 66/dir 67/dir 68/dir 69/dir 70/dir 71/dir 72/dir 73/dir 74/dir 75/dir 76/dir 77/dir 78/dir 79/dir 80/dir 81/dir 82/dir 83/dir 84/dir 85/dir 86/dir 87/dir 88/dir 89/dir 90/dir 91/dir 92/dir 93/dir 94/dir 95/dir 96/dir 97/dir 98/dir 99/dir 100/dir 101/dir 102/dir 103/dir 104/dir 105/dir 106/dir 107/dir 108/dir 109/dir 110/dir 111/dir 112/dir 113/dir 114/dir 115/dir 116/dir 117/dir 118/dir 119/dir 120/dir 121/dir 122/dir 123/dir 124/dir 125/dir 126/dir 127/dir 128/dir 129/dir 130/dir 131/dir 132/dir 133/dir 134/dir 135/dir 136/dir 137/dir 138/dir 139/dir 140/dir 141/dir 142/dir 143/dir 144/dir 145/dir 146/dir 147/dir 148/dir 149/dir 150/dir 151/dir 152/dir 153/dir 154/dir 155/dir 156/dir 157/dir 158/dir 159/dir 160/dir 161/dir 162/dir 163/dir 164/dir 165/dir 166/dir 167/dir 168/dir 169/dir 170/dir 171/dir 172/dir 173/dir 174/dir 175/dir 176/dir 177/dir 178/dir 179/dir 180/dir 181/dir 182/dir 183/dir 184/dir 185/dir 186/dir 187/dir 188/dir 189/dir 190/dir 191/dir 192/dir 193/dir 194/dir 195/dir 196/dir 197/dir 198/dir 199/dir 200/dir 201/dir 202/dir 203/dir 204/dir 205/dir 206/dir 207/dir 208/dir 209/dir 210/dir 211/dir 212/dir 213/dir 214/dir 215/dir 216/dir 217/dir 218/dir 219/dir 220/dir 221/dir 222/dir 223/dir 224/dir 225/dir 226/dir 227/dir 228/dir 229/dir 230/dir 231/dir 232/dir 233/dir 234/dir 235/dir 236/dir 237/dir 238/dir 239/dir 240/dir 241/dir 242/dir 243/dir 244/dir 245/dir 246/dir 247/dir 248/dir 249/dir 250/dir 251/dir 252/dir 253/dir 254/dir 255/dir 256/dir 257/dir 258/dir 259/dir 260/dir 261/dir 262/dir 263/dir 264/dir 265/dir 266/dir 267/dir 268/dir 269/dir 270/dir 271/dir 272/dir 273/dir 274/dir 275/dir 276/dir 277/dir 278/dir 279/dir 280/dir 281/dir 282/dir 283/dir 284/dir 285/dir 286/dir 287/dir 288/dir 289/dir 290/dir 291/dir 292/dir 293/dir 294/dir 295/dir 296/dir 297/dir 298/dir 299/dir 300/dir 301/dir 302/dir 303/dir 304/dir 305/dir 306/dir 307/dir 308/dir 309/dir 310/dir 311/dir 312/dir 313/dir 314/dir 315/dir 316/dir 317/dir 318/dir 319/dir 320"

os.makedirs(path)
```

A file is created in the `dir 320` directory:
``` python
name = "testfile0"

def create():
    with open(os.path.join(path, name), "w") as f:
        f.write("test")
```
The file is modified:
``` python
path_to_file = os.path.join(path, name)
content = "hello world"
with open(path_to_file, 'a') as f:
    f.write(content)
```
and delete the file:
``` python
os.remove(os.path.join(path, name))
```

## Logs/Alerts example
Added alert:
```
** Alert 1581613083.11729: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 13 17:58:03 cabrera-Machine->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/test recursion 320/dir 1/dir 2/dir 3/dir 4/dir 5/dir 6/dir 7/dir 8/dir 9/dir 10/dir 11/dir 12/dir 13/dir 14/dir 15/dir 16/dir 17/dir 18/dir 19/dir 20/dir 21/dir 22/dir 23/dir 24/dir 25/dir 26/dir 27/dir 28/dir 29/dir 30/dir 31/dir 32/dir 33/dir 34/dir 35/dir 36/dir 37/dir 38/dir 39/dir 40/dir 41/dir 42/dir 43/dir 44/dir 45/dir 46/dir 47/dir 48/dir 49/dir 50/dir 51/dir 52/dir 53/dir 54/dir 55/dir 56/dir 57/dir 58/dir 59/dir 60/dir 61/dir 62/dir 63/dir 64/dir 65/dir 66/dir 67/dir 68/dir 69/dir 70/dir 71/dir 72/dir 73/dir 74/dir 75/dir 76/dir 77/dir 78/dir 79/dir 80/dir 81/dir 82/dir 83/dir 84/dir 85/dir 86/dir 87/dir 88/dir 89/dir 90/dir 91/dir 92/dir 93/dir 94/dir 95/dir 96/dir 97/dir 98/dir 99/dir 100/dir 101/dir 102/dir 103/dir 104/dir 105/dir ' added
Mode: whodata

Attributes:
 - Size: 4
 - Permissions: rw-r--r--
 - Date: Thu Feb 13 17:58:02 2020
 - Inode: 11141442
 - User: root (0)
 - Group: root (0)
 - MD5: 4d186321c1a7f0f354b297e8914ab240
 - SHA1: 99800b85d3383e3a2fb45eb7d0066a4879a9dad0
 - SHA256: b221d9dbb083a7f33428d7c2a3c3198ae925614d70210e28716ccaa7cd4ddb79
 - (Audit) User name: root
 - (Audit) Audit name: cabrera
 - (Audit) Effective name: root
 - (Audit) Group name: root
 - (Audit) Process id: 17396
 - (Audit) Process name: /usr/bin/python3.6
```
Modified alert:
```
** Alert 1581613095.13246: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 13 17:58:15 cabrera-Machine->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/test recursion 320/dir 1/dir 2/dir 3/dir 4/dir 5/dir 6/dir 7/dir 8/dir 9/dir 10/dir 11/dir 12/dir 13/dir 14/dir 15/dir 16/dir 17/dir 18/dir 19/dir 20/dir 21/dir 22/dir 23/dir 24/dir 25/dir 26/dir 27/dir 28/dir 29/dir 30/dir 31/dir 32/dir 33/dir 34/dir 35/dir 36/dir 37/dir 38/dir 39/dir 40/dir 41/dir 42/dir 43/dir 44/dir 45/dir 46/dir 47/dir 48/dir 49/dir 50/dir 51/dir 52/dir 53/dir 54/dir 55/dir 56/dir 57/dir 58/dir 59/dir 60/dir 61/dir 62/dir 63/dir 64/dir 65/dir 66/dir 67/dir 68/dir 69/dir 70/dir 71/dir 72/dir 73/dir 74/dir 75/dir 76/dir 77/dir 78/dir 79/dir 80/dir 81/dir 82/dir 83/dir 84/dir 85/dir 86/dir 87/dir 88/dir 89/dir 90/dir 91/dir 92/dir 93/dir 94/dir 95/dir 96/dir 97/dir 98/dir 99/dir 100/dir 101/dir 102/dir 103/dir 104/dir 105/dir ' modified
Mode: whodata
Changed attributes: inode
Old inode was: '11141442', now it is '395815'

Attributes:
 - Size: 4
 - Permissions: rw-r--r--
 - Date: Thu Feb 13 17:58:02 2020
 - Inode: 395815
 - User: root (0)
 - Group: root (0)
 - MD5: 4d186321c1a7f0f354b297e8914ab240
 - SHA1: 99800b85d3383e3a2fb45eb7d0066a4879a9dad0
 - SHA256: b221d9dbb083a7f33428d7c2a3c3198ae925614d70210e28716ccaa7cd4ddb79
 - (Audit) User name: root
 - (Audit) Audit name: cabrera
 - (Audit) Effective name: root
 - (Audit) Group name: root
 - (Audit) Process id: 17396
 - (Audit) Process name: /usr/bin/python3.6
```

Deleted alert:
```
** Alert 1581613165.14838: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 13 17:59:25 cabrera-Machine->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/test recursion 320/dir 1/dir 2/dir 3/dir 4/dir 5/dir 6/dir 7/dir 8/dir 9/dir 10/dir 11/dir 12/dir 13/dir 14/dir 15/dir 16/dir 17/dir 18/dir 19/dir 20/dir 21/dir 22/dir 23/dir 24/dir 25/dir 26/dir 27/dir 28/dir 29/dir 30/dir 31/dir 32/dir 33/dir 34/dir 35/dir 36/dir 37/dir 38/dir 39/dir 40/dir 41/dir 42/dir 43/dir 44/dir 45/dir 46/dir 47/dir 48/dir 49/dir 50/dir 51/dir 52/dir 53/dir 54/dir 55/dir 56/dir 57/dir 58/dir 59/dir 60/dir 61/dir 62/dir 63/dir 64/dir 65/dir 66/dir 67/dir 68/dir 69/dir 70/dir 71/dir 72/dir 73/dir 74/dir 75/dir 76/dir 77/dir 78/dir 79/dir 80/dir 81/dir 82/dir 83/dir 84/dir 85/dir 86/dir 87/dir 88/dir 89/dir 90/dir 91/dir 92/dir 93/dir 94/dir 95/dir 96/dir 97/dir 98/dir 99/dir 100/dir 101/dir 102/dir 103/dir 104/dir 105/dir ' deleted
Mode: whodata

Attributes:
 - Size: 4
 - Permissions: rw-r--r--
 - Date: Thu Feb 13 17:58:02 2020
 - Inode: 395815
 - User: root (0)
 - Group: root (0)
 - MD5: 4d186321c1a7f0f354b297e8914ab240
 - SHA1: 99800b85d3383e3a2fb45eb7d0066a4879a9dad0
 - SHA256: b221d9dbb083a7f33428d7c2a3c3198ae925614d70210e28716ccaa7cd4ddb79
 - (Audit) User name: root
 - (Audit) Audit name: cabrera
 - (Audit) Effective name: root
 - (Audit) Group name: root
 - (Audit) Process id: 17396
 - (Audit) Process name: /usr/bin/python3.6
```