### PR TITLE
Fix link count alerts for ignored directories

### DIFF
--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -237,11 +237,6 @@ static int read_sys_dir(const char *dir_name, int do_read)
             snprintf(f_name, PATH_MAX + 1, "%s%c%s", dir_name, PATH_SEP, entry->d_name);
         }
 
-        /* Ignore the /proc and /sys filesystems */
-        if (check_ignore(f_name) || !strcmp(f_name, "/proc") || !strcmp(f_name, "/sys")) {
-            continue;
-        }
-
         /* Check if file is a directory */
         if (lstat(f_name, &statbuf_local) == 0) {
             /* On all the systems except Darwin, the
@@ -261,6 +256,11 @@ static int read_sys_dir(const char *dir_name, int do_read)
             {
                 entry_count++;
             }
+        }
+
+        /* Ignore the /proc and /sys filesystems */
+        if (check_ignore(f_name) || !strcmp(f_name, "/proc") || !strcmp(f_name, "/sys")) {
+            continue;
         }
 
         /* Check every file against the rootkit database */


### PR DESCRIPTION
Fix alerts like "Files hidden inside directory '/a/b/c'. Link count does not match number of files" if there is ignored subdirectories in ossec.conf:
<ignore type="sregex">/b/c/d</ignore>.

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Do not skip counting of child directories if they are ignored.

## Configuration options

<rootcheck>
<ignore type="sregex">/b/c/d</ignore>
</rootcheck>

## Logs/Alerts example

** Alert 1581846806.102584252: - ossec,rootcheck,gdpr_IV_35.7.d,
2020 Feb 16 09:53:26 (XXX) 148.251.47.26->rootcheck
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
Files hidden inside directory '/a/b/c'. Link count does not match number of files (39,42).
title: Files hidden inside directory '/a/b/c'.


## Tests

Run and check alerts.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
