### PR TITLE
Fix slow output in FIM on Windows

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -424,7 +424,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     opts &= ~ CHECK_ATTRS;
 #endif
                 } else {
-                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);       
+                    mwarn(FIM_INVALID_OPTION_SKIP, *values, *attrs, dirs);
                     goto out_free;
                 }
             }
@@ -616,8 +616,8 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     mwarn("Recursion level '%d' exceeding limit. Setting %d.", recursion_limit, MAX_DEPTH_ALLOWED);
                     recursion_limit = syscheck->max_depth;
                 }
-            } 
-            
+            }
+
             /* Check tag */
             else if (strcmp(*attrs, xml_tag) == 0) {
                 if (tag) {
@@ -1468,7 +1468,6 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 }
 
                 syscheck->max_eps = value;
-                syscheck->send_delay = 1000000 / value;
             }
         } /* Allow prefilter cmd */
         else if (strcmp(node[i]->element, xml_allow_remote_prefilter_cmd) == 0) {

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -246,7 +246,6 @@ typedef struct _config {
     long sync_response_timeout;     /* Minimum time between receiving a sync response and starting a new sync session */
     long sync_queue_size;           /* Data synchronization message queue size */
     unsigned max_eps;               /* Maximum events per second. */
-    unsigned send_delay;            /* Time delay after send operation (1 / max_eps) (microseconds) */
 
     /* Windows only registry checking */
 #ifdef WIN32

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -61,7 +61,6 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.sync_response_timeout = 30;
     syscheck.sync_queue_size = 16384;
     syscheck.max_eps        = 200;
-    syscheck.send_delay     = 5000; /* 1000000 / max_eps */
     syscheck.allow_remote_prefilter_cmd  = false;
 
     mdebug1(FIM_CONFIGURATION_FILE, cfgfile);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -60,11 +60,17 @@ static void fim_send_msg(char mq, const char * location, const char * msg) {
 
 // LCOV_EXCL_START
 // Send a data synchronization control message
+
+static unsigned n_msg_sent = 0;
+
 void fim_send_sync_msg(const char * msg) {
     mdebug2(FIM_DBSYNC_SEND, msg);
     fim_send_msg(DBSYNC_MQ, SYSCHECK, msg);
-    struct timespec timeout = { syscheck.send_delay / 1000000, syscheck.send_delay % 1000000 * 1000 };
-    nanosleep(&timeout, NULL);
+
+    if (++n_msg_sent == syscheck.max_eps) {
+        sleep(1);
+        n_msg_sent = 0;
+    }
 }
 // LCOV_EXCL_STOP
 
@@ -75,8 +81,11 @@ void send_syscheck_msg(const char *msg)
 {
     mdebug2(FIM_SEND, msg);
     fim_send_msg(SYSCHECK_MQ, SYSCHECK, msg);
-    struct timespec timeout = { syscheck.send_delay / 1000000, syscheck.send_delay % 1000000 * 1000 };
-    nanosleep(&timeout, NULL);
+
+    if (++n_msg_sent == syscheck.max_eps) {
+        sleep(1);
+        n_msg_sent = 0;
+    }
 }
 // LCOV_EXCL_STOP
 

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -79,7 +79,7 @@ list(APPEND tests_flags "-Wl,--wrap,rbtree_keys -Wl,--wrap,rbtree_get -Wl,--wrap
                          -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,queue_push_ex")
 
 list(APPEND tests_names "test_run_check")
-list(APPEND tests_flags "-Wl,--wrap,_minfo")
+list(APPEND tests_flags "-Wl,--wrap,_minfo -Wl,--wrap,sleep -Wl,--wrap,SendMSG")
 
 list(APPEND tests_names "test_syscheck_op")
 list(APPEND tests_flags "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \

--- a/src/unit_tests/test_syscheck_config.c
+++ b/src/unit_tests/test_syscheck_config.c
@@ -71,7 +71,6 @@ void test_Read_Syscheck_Config_success(void **state)
     assert_int_equal(syscheck.sync_response_timeout, 30);
     assert_int_equal(syscheck.sync_queue_size, 64);
     assert_int_equal(syscheck.max_eps, 200);
-    assert_int_equal(syscheck.send_delay, 5000);
 }
 
 


### PR DESCRIPTION
|Branch|Platform|
|---|---|
|3319-fim-rework|Windows|

We connected one Windows agent, with the default output configuration (200 EPS).

This was the input throughput in the Syscheck decoder:

```
syscheck_events_decoded='92'
syscheck_edps='30'
```

## Reason

This problem was due to the `nanosleep()` function, which seems not to have the accuracy enough on Windows.

## Proposed fix

For a default configuration (200 events × second⁻¹), the current implementation would make FIM sleep during  5 ms (200 s⁻¹).

Since `sleep()` is not very accurate, we propose changing the algorithm to sleep 1 second every 200 messages sent.

## Configuration options

```xml
<syscheck>
  <max_eps>200</max_eps>
</syscheck>
```

## Statistic file

### ossec-analysisd.state

This is the input throughput for one agent:

#### File events

```shell
syscheck_events_decoded='400'
syscheck_edps='200'
```


#### Synchronization messages

```shell
dbsync_messages_dispatched='400'
dbsync_mdps='200'
```

## Tests

- [X] Compile manager on Linux.
- [X] Compile agent for Windows.
- [X] Test feature on Windows.
- [x] Review unit tests.