### PR TITLE
Fix logger and filter memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - Add support for monitoring AWS S3 buckets in GovCloud regions. ([#3953](https://github.com/wazuh/wazuh/issues/3953))
 - Add support for monitoring Cisco Umbrella S3 buckets. ([#3890](https://github.com/wazuh/wazuh/issues/3890))
 
+### Fixed
+
+- Fixed a small memory leak in clusterd. ([#4465](https://github.com/wazuh/wazuh/pull/4465))
+
 
 ## [v3.11.3] - 2020-01-28
 

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -67,6 +67,8 @@ def print_version():
 # Master main
 #
 async def master_main(args, cluster_config, cluster_items, logger):
+    cluster.context_tag.set('Master')
+    cluster.context_subtag.set("Main")
     my_server = master.Master(performance_test=args.performance_test, concurrency_test=args.concurrency_test,
                               configuration=cluster_config, enable_ssl=args.ssl, logger=logger,
                               cluster_items=cluster_items)
@@ -81,6 +83,8 @@ async def master_main(args, cluster_config, cluster_items, logger):
 # Worker main
 #
 async def worker_main(args, cluster_config, cluster_items, logger):
+    cluster.context_tag.set('Worker')
+    cluster.context_subtag.set("Main")
     while True:
         my_client = worker.Worker(configuration=cluster_config, enable_ssl=args.ssl,
                                   performance_test=args.performance_test, concurrency_test=args.concurrency_test,

--- a/framework/wazuh/cluster/client.py
+++ b/framework/wazuh/cluster/client.py
@@ -34,10 +34,12 @@ class AbstractClientManager:
         self.concurrency_test = concurrency_test
         self.file = file
         self.string = string
-        self.logger = logger.getChild(tag)
+        self.logger = logging.getLogger('wazuh')
         # logging tag
         self.tag = tag
-        self.logger.addFilter(cluster.ClusterFilter(tag=self.tag, subtag="Main"))
+        # modify filter tags with context vars
+        cluster.context_tag.set(self.tag)
+        cluster.context_subtag.set("Main")
         self.tasks = []
         self.handler_class = AbstractClient
         self.client = None

--- a/framework/wazuh/cluster/common.py
+++ b/framework/wazuh/cluster/common.py
@@ -155,11 +155,12 @@ class Handler(asyncio.Protocol):
         # object use to encrypt and decrypt requests
         self.my_fernet = cryptography.fernet.Fernet(base64.b64encode(fernet_key.encode())) if fernet_key else None
         # logging.Logger object used to write logs
-        self.logger = logger.getChild(tag)
+        self.logger = logging.getLogger('wazuh')
         # logging tag
         self.tag = tag
-        self.logger_filter = cluster.ClusterFilter(tag=self.tag, subtag="Main")
-        self.logger.addFilter(self.logger_filter)
+        # modify filter tags with context vars
+        cluster.context_tag.set(self.tag)
+        cluster.context_subtag.set("Main")
         self.cluster_items = cluster_items
         # transports in asyncio are an abstraction of sockets
         self.transport = None

--- a/framework/wazuh/cluster/dapi/dapi.py
+++ b/framework/wazuh/cluster/dapi/dapi.py
@@ -368,11 +368,12 @@ class APIRequestQueue:
     def __init__(self, server):
         self.request_queue = asyncio.Queue()
         self.server = server
-        self.logger = logging.getLogger('wazuh').getChild('dapi')
-        self.logger.addFilter(cluster.ClusterFilter(tag='Cluster', subtag='D API'))
+        self.logger = logging.getLogger('wazuh')
         self.pending_requests = {}
 
     async def run(self):
+        cluster.context_tag.set('Cluster')
+        cluster.context_subtag.set('D API')
         while True:
             # name    -> node name the request must be sent to. None if called from a worker node.
             # id      -> id of the request.

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -146,6 +146,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.node_type = ""
         # dictionary to save loggers for each sync task
         self.task_loggers = {}
+        cluster.context_tag.set("Worker")
 
     def to_dict(self):
         """

--- a/framework/wazuh/cluster/master.py
+++ b/framework/wazuh/cluster/master.py
@@ -146,7 +146,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.node_type = ""
         # dictionary to save loggers for each sync task
         self.task_loggers = {}
-        cluster.context_tag.set("Worker")
+        cluster.context_tag.set(self.tag)
 
     def to_dict(self):
         """


### PR DESCRIPTION
|Related issue|
|---|
|#4463|

## Description

The fix is the one explained in #4463

## Tests

After applying the fix, the same test using `pympler` have being done in both master and worker nodes, with similar results:
```
  types |   # objects |   total size
======= | =========== | ============
```

From time to time, other objects (timer.Handler) appeared but after some seconds they were deleted, so it shows the memory leak is gone.

Test stages:
- [x] Same information for tag and subtags shown in `cluster.log` for both master and worker
- [x] No errors in `cluster.log` for both master and worker
