### PR TITLE
Launch the who-data mode even no directories to monitor exist at start-up

### DIFF
--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -38,6 +38,6 @@
 #define FIM_WARN_SKIP_EVENT                     "(6923): Unable to process file '%s'"
 #define FIM_AUDIT_NORUNNING                     "(6224): Who-data engine cannot start because Auditd is not running."
 #define FIM_INVALID_OPTION_SKIP                 "(6225): Invalid option '%s' for attribute '%s'. The paths '%s' not be monitored."
-#define FIM_WARN_WHODATA_ADD_RULE               "(6226): Unable to add audit rule."
+#define FIM_WARN_WHODATA_ADD_RULE               "(6226): Unable to add audit rule for '%s'."
 
 #endif /* WARN_MESSAGES_H */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -38,5 +38,6 @@
 #define FIM_WARN_SKIP_EVENT                     "(6923): Unable to process file '%s'"
 #define FIM_AUDIT_NORUNNING                     "(6224): Who-data engine cannot start because Auditd is not running."
 #define FIM_INVALID_OPTION_SKIP                 "(6225): Invalid option '%s' for attribute '%s'. The paths '%s' not be monitored."
+#define FIM_WARN_WHODATA_ADD_RULE               "(6226): Rules cannot be added for non-existent dir: '%s'"
 
 #endif /* WARN_MESSAGES_H */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -38,6 +38,6 @@
 #define FIM_WARN_SKIP_EVENT                     "(6923): Unable to process file '%s'"
 #define FIM_AUDIT_NORUNNING                     "(6224): Who-data engine cannot start because Auditd is not running."
 #define FIM_INVALID_OPTION_SKIP                 "(6225): Invalid option '%s' for attribute '%s'. The paths '%s' not be monitored."
-#define FIM_WARN_WHODATA_ADD_RULE               "(6226): Unable to add audit rule for '%s'."
+#define FIM_WARN_WHODATA_ADD_RULE               "(6226): Unable to add audit rule for '%s'"
 
 #endif /* WARN_MESSAGES_H */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -38,6 +38,6 @@
 #define FIM_WARN_SKIP_EVENT                     "(6923): Unable to process file '%s'"
 #define FIM_AUDIT_NORUNNING                     "(6224): Who-data engine cannot start because Auditd is not running."
 #define FIM_INVALID_OPTION_SKIP                 "(6225): Invalid option '%s' for attribute '%s'. The paths '%s' not be monitored."
-#define FIM_WARN_WHODATA_ADD_RULE               "(6226): Rules cannot be added for non-existent dir: '%s'"
+#define FIM_WARN_WHODATA_ADD_RULE               "(6226): Unable to add audit rule."
 
 #endif /* WARN_MESSAGES_H */

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -232,7 +232,12 @@ int add_audit_rules_syscheck(bool first_time) {
                         w_mutex_unlock(&audit_rules_mutex);
                         rules_added++;
                     } else {
-                        mwarn(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
+                        if (first_time) {
+                            mwarn(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
+                        } else {
+                            mdebug1(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
+                        }
+                        
                     }
                 } else if (found == 1) {
                     w_mutex_lock(&audit_rules_mutex);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -233,11 +233,10 @@ int add_audit_rules_syscheck(bool first_time) {
                         rules_added++;
                     } else {
                         if (first_time) {
-                            mwarn(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
+                            mwarn(FIM_WARN_WHODATA_ADD_RULE);
                         } else {
-                            mdebug1(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
+                            mdebug1(FIM_WARN_WHODATA_ADD_RULE);
                         }
-                        
                     }
                 } else if (found == 1) {
                     w_mutex_lock(&audit_rules_mutex);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -233,9 +233,9 @@ int add_audit_rules_syscheck(bool first_time) {
                         rules_added++;
                     } else {
                         if (first_time) {
-                            mwarn(FIM_WARN_WHODATA_ADD_RULE);
+                            mwarn(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
                         } else {
-                            mdebug1(FIM_WARN_WHODATA_ADD_RULE);
+                            mdebug1(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
                         }
                     }
                 } else if (found == 1) {

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -232,7 +232,7 @@ int add_audit_rules_syscheck(bool first_time) {
                         w_mutex_unlock(&audit_rules_mutex);
                         rules_added++;
                     } else {
-                        merror(FIM_ERROR_WHODATA_ADD_RULE, retval, syscheck.dir[i]);
+                        mwarn(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
                     }
                 } else if (found == 1) {
                     w_mutex_lock(&audit_rules_mutex);
@@ -467,12 +467,8 @@ int audit_init(void) {
     // Add Audit rules
     audit_added_rules = W_Vector_init(10);
     audit_added_dirs = W_Vector_init(20);
-    int rules_added = add_audit_rules_syscheck(true);
-    if (rules_added < 1){
-        mdebug1(FIM_AUDIT_NORULES);
-        return (-1);
-    }
 
+    add_audit_rules_syscheck(true);
     atexit(clean_rules);
     auid_err_reported = 0;
 


### PR DESCRIPTION
|Related issue|
|---|
|#4584|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
As seen in #4584 when using whodata="yes" option for a non-existent dir the agent will not run 
the audit socket reader thread. 

This PR remove the comprobation of having at least one audit rule for running the thread and adds 
a warning for the user.

When adding the following line in ossec.conf: 
```
<directories whodata="yes">/home/vagrant/NoExist</directories> 
```
For a non-existent dir "NoExist"

The log now shows:
```
2020/02/18 18:50:49 ossec-syscheckd: WARNING: (6226): Rules cannot be added for non-existent dir: '/home/vagrant/NoExist'
```
And now the audit socket reader thread will run anyway.
Then, when creating the dir:
```
mkdir NoExist
```
The rule will be added as shown by auditctl:
```
-w /home/vagrant/NoExist -p wa -k wazuh_fim
```
## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

