### PR TITLE
Following symbolic links only when follow-symbolic-link is enabled and the link is specified in the directories tag

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -67,7 +67,13 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
         if (syscheck->dir == NULL) {
             os_calloc(2, sizeof(char *), syscheck->dir);
             os_calloc(strlen(entry) + 2, sizeof(char), syscheck->dir[0]);
-            snprintf(syscheck->dir[0], strlen(entry) + 1, "%s", entry);
+            if (link && !(CHECK_FOLLOW & vals)) {
+                // Taking the link itself if follow_symbolic_link is not enabled
+                snprintf(syscheck->dir[0], strlen(link) + 1, "%s", link);
+            }
+            else {
+                snprintf(syscheck->dir[0], strlen(entry) + 1, "%s", entry);
+            }
             syscheck->dir[1] = NULL;
 
 #ifdef WIN32
@@ -96,7 +102,13 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
             os_realloc(syscheck->dir, (pl + 2) * sizeof(char *), syscheck->dir);
             syscheck->dir[pl + 1] = NULL;
             os_calloc(strlen(entry) + 2, sizeof(char), syscheck->dir[pl]);
-            snprintf(syscheck->dir[pl], strlen(entry) + 1, "%s", entry);
+            if (link && !(CHECK_FOLLOW & vals)) {
+                // Taking the link itself if follow_symbolic_link is not enabled
+                snprintf(syscheck->dir[pl], strlen(link) + 1, "%s", link);
+            }
+            else {
+                snprintf(syscheck->dir[pl], strlen(entry) + 1, "%s", entry);
+            }
 
 #ifdef WIN32
             os_realloc(syscheck->wdata.dirs_status, (pl + 2) * sizeof(whodata_dir_status),

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -455,7 +455,14 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
                 continue;
             }
 
-            real_path = realpath(syscheck.symbolic_links[i], NULL);
+            if (CHECK_FOLLOW & syscheck.opts[i]) {
+                real_path = realpath(syscheck.symbolic_links[i], NULL);
+            }
+            else {
+                // Taking the link itself if follow_symbolic_link is not enabled
+                os_calloc(strlen(syscheck.symbolic_links[i]) + 1, sizeof(char), real_path);
+                snprintf(real_path, strlen(syscheck.symbolic_links[i]) + 1, "%s", syscheck.symbolic_links[i]);
+            }
 
             if (*syscheck.dir[i]) {
                 if (real_path) {


### PR DESCRIPTION
|Related issue|
|---|
|[4614](https://github.com/wazuh/wazuh/issues/4614)|

## Description

As part of the **syscheck** module rework, the `follow_symbolic_link` option should only monitor links that are specified in the directories tag. To implement this, we are doing a check of the setting just before the symbolic link is expanded. If the setting is enabled, we expand the symbolic link to the file or folder where it is pointing to and then we follow that path. If the setting is disabled, we take the path of the link itself.

## Configuration options

No new configurations were added.

## Logs/Alerts example

No new logs added.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
