### PR TITLE
Fixed reloading of audit rules

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -94,6 +94,14 @@ void fim_checker(char *path, fim_element *item, whodata_evt *w_evt, int report) 
     int node;
     int depth;
 
+#ifdef WIN_WHODATA
+    if (w_evt && w_evt->scan_directory == 1) {
+        if (w_update_sacl(path)) {
+            mdebug1(FIM_SCAL_NOREFRESH, path);
+            }
+        }
+#endif
+
     if (item->mode == FIM_SCHEDULED) {
         // If the directory have another configuration will come back
         if (node = fim_configuration_directory(path, "file"), node < 0 || item->index != node) {


### PR DESCRIPTION
## Description
No modification or deletion alerts are generated in Windows whodata with a file that we have moved from an unmonitored folder to a monitored one. This is because that file does not inherit the folder's audit policies.

This PR solves this problem.

## Configuration options
ossec.conf:
``` xml
<syscheck>
     <disabled>no</disabled>
     <directories check_all="yes" whodata="yes">C:\testW</directories>
</syscheck>
```
## Test
We create a file outside the monitored folder and move it to the `c:\testw` folder. We see an add alert:
```
** Alert 1582038779.5992526: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 18 16:12:59 (vm-win2016) 11.0.0.1->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File 'c:\testw\testWhodata.txt' added
Mode: whodata
Attributes:
 - Size: 0
 - Permissions: SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administrators (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Users (allowed): read_control|synchronize|read_data|read_ea|execute|read_attributes
 - Date: Tue Feb 18 15:12:49 2020
 - User: Administrators (S-1-5-32-544)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - File attributes: ARCHIVE
 - (Audit) User name: Administrator
 - (Audit) Process id: 2860
 - (Audit) Process name: C:\Windows\explorer.exe
```

We modify the file and see the modified alert:
```
** Alert 1582038792.5993660: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 18 16:13:12 (vm-win2016) 11.0.0.1->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File 'c:\testw\testWhodata.txt' modified
Mode: whodata
Changed attributes: size,mtime,md5,sha1,sha256
Size changed from '0' to '12'
Old modification time was: '1582035169', now it is '1582035182'
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : '886fc408bdb363e0f6bbaa42dc4fb34b'
Old sha1sum was: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
New sha1sum is : 'd5d9258ca774478e7e2f6c707558ea0a56314755'
Old sha256sum was: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
New sha256sum is : 'e530f4f948721788b40866f98982a3f55725853f7971e601d9492a43482d7cf8'
Attributes:
 - Size: 12
 - Permissions: SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administrators (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Users (allowed): read_control|synchronize|read_data|read_ea|execute|read_attributes
 - Date: Tue Feb 18 15:13:02 2020
 - User: Administrators (S-1-5-32-544)
 - MD5: 886fc408bdb363e0f6bbaa42dc4fb34b
 - SHA1: d5d9258ca774478e7e2f6c707558ea0a56314755
 - SHA256: e530f4f948721788b40866f98982a3f55725853f7971e601d9492a43482d7cf8
 - File attributes: ARCHIVE
```

We delete the file and see the alert:
```
** Alert 1582038792.5995224: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 18 16:13:12 (vm-win2016) 11.0.0.1->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File 'c:\testw\asdasd.txt' deleted
Mode: scheduled
Attributes:
 - Size: 0
 - Permissions: SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administrators (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Users (allowed): read_control|synchronize|read_data|read_ea|execute|read_attributes
 - Date: Tue Feb 18 15:11:45 2020
 - User: Administrators (S-1-5-32-544)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - File attributes: ARCHIVE
```