### PR TITLE
FIM v2.0: Update inode_id when inode changes

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -40,6 +40,7 @@ typedef enum fdb_stmt {
     FIMDB_STMT_GET_INODE_ID,
     FIMDB_STMT_GET_COUNT_PATH,
     FIMDB_STMT_GET_COUNT_DATA,
+    FIMDB_STMT_GET_INODE,
     FIMDB_STMT_SIZE
 } fdb_stmt;
 

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -876,6 +876,7 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry) 
     break;
 
     case SQLITE_DONE:
+#ifndef WIN32
         fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_INODE);
         fim_db_bind_get_path_inode(fim_sql, file_path);
 
@@ -922,6 +923,7 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry) 
             merror("SQL ERROR: (%d)%s", res_inode, sqlite3_errmsg(fim_sql->db));
             return FIMDB_ERR;
         }
+#endif
 
         inode_id = 0;
     break;


### PR DESCRIPTION
| Related issue  |
|---------------|
| #4629             |

## Description

When the inode of a file is modified, the `inode_id` of the `entry_path` table is not updated, while the inode of the `entry_data` table does get updated, causing the tables to unbalance and send `added` alerts instead of `modify` alerts.  

To solve this, this Pull Request updates the `inode_id` of the `entry_path` table when the inode of a file gets changed.

Also, I have updated the `fim_db_insert` function to delete and re-insert the `entry_data` info only when the inode changes.

Closes #4629. 

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer
