### PR TITLE
Fix leak in fim_db_process_read_file function

### DIFF
--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -562,6 +562,7 @@ int fim_db_process_read_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t
             w_mutex_unlock(mutex);
             if (entry != NULL) {
                 callback(fim_sql, entry, mutex, arg);
+                free_entry(entry);
             }
             os_free(path);
         }
@@ -1149,7 +1150,6 @@ void fim_db_callback_sync_path_range(__attribute__((unused))fdb_t *fim_sql, fim_
     char * plain = dbsync_state_msg("syscheck", entry_data);
     mdebug1("Sync Message for %s sent: %s", entry->path, plain);
     fim_send_sync_msg(plain);
-    free_entry(entry);
     os_free(plain);
 }
 


### PR DESCRIPTION
## Description

The purpose of this PR is to fix a leak in the `fim_db_process_read_file` function.
The `fim_entry *entry` pointer was't being released in all the possible cases.