### PR TITLE
explicitly use bash for the pagerduty integration 

### DIFF
--- a/integrations/pagerduty
+++ b/integrations/pagerduty
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Pagerduty Integration
 #
 # Copyright (C) 2015-2019, Wazuh Inc.


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3639|
|https://github.com/wazuh/wazuh-docker/issues/290|

## Description

On some systems like Ubuntu Linux, `sh` does not default to bash (anymore?) meaning this script fails with `bad substitution` as it is obviously using some bash specific substitutions. As the script is called directly, changing the shebang will fix this issue.

One can see [here](https://github.com/wazuh/wazuh/blob/8efa9806a98f469e9cec8df45d7f4c8c88de7a19/src/os_integrator/integrator.c#L386) the script is called directly.

Some discussion on how this fails on Ubuntu is [here](https://stackoverflow.com/questions/20615217/bash-bad-substitution)

## Configuration options

NA

## Logs/Alerts example

NA

## Tests

NA