### PR TITLE
Slow down reporting throughput in FIM to prevent overflow

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -110,6 +110,7 @@
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -102,7 +102,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -117,7 +117,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -125,6 +125,7 @@
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -117,7 +117,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -125,6 +125,7 @@
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -146,6 +146,7 @@
       <interval>5m</interval>
       <response_timeout>30</response_timeout>
       <queue_size>16384</queue_size>
+      <max_eps>10</max_eps>
   </syscheck>
 
   <!-- Active response -->

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -138,7 +138,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -40,7 +40,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -47,5 +47,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -55,5 +55,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -48,7 +48,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -40,7 +40,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -47,5 +47,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -53,5 +53,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -46,7 +46,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -796,6 +796,7 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
     const char *xml_max_sync_interval = "max_interval";
     const char *xml_response_timeout = "response_timeout";
     const char *xml_sync_queue_size = "queue_size";
+    const char *xml_max_eps = "max_eps";
 
     for (int i = 0; node[i]; i++) {
         if (strcmp(node[i]->element, xml_enabled) == 0) {
@@ -838,6 +839,15 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscheck->sync_queue_size = value;
+            }
+        } else if (strcmp(node[i]->element, xml_max_eps) == 0) {
+            char * end;
+            long value = strtol(node[i]->content, &end, 10);
+
+            if (value < 0 || value > 1000000 || *end) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            } else {
+                syscheck->sync_max_eps = value;
             }
         } else {
             mwarn(XML_INVELEM, node[i]->element);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1474,13 +1474,9 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             char * end;
             long value = strtol(node[i]->content, &end, 10);
 
-            if (value < 1 || value > 1000000 || *end) {
+            if (value < 0 || value > 1000000 || *end) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
-                if (value > 1000000) {
-                    mdebug1("<%s> exceeds the maximum allowed value (1000000). EPS limitation is disabled.", node[i]->element);
-                }
-
                 syscheck->max_eps = value;
             }
         } /* Allow prefilter cmd */

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -299,6 +299,7 @@ typedef struct _config {
     long sync_interval;             /* Synchronization interval (seconds) */
     long sync_response_timeout;     /* Minimum time between receiving a sync response and starting a new sync session */
     long sync_queue_size;           /* Data synchronization message queue size */
+    long sync_max_eps;              /* Maximum events per second for synchronization messages. */
     unsigned max_eps;               /* Maximum events per second. */
 
     /* Windows only registry checking */

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -62,7 +62,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.sync_response_timeout = 30;
     syscheck.sync_queue_size = 16384;
     syscheck.sync_max_eps = 10;
-    syscheck.max_eps        = 200;
+    syscheck.max_eps        = 100;
     syscheck.allow_remote_prefilter_cmd  = false;
 
     mdebug1(FIM_CONFIGURATION_FILE, cfgfile);

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -61,6 +61,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.max_sync_interval = 3600;
     syscheck.sync_response_timeout = 30;
     syscheck.sync_queue_size = 16384;
+    syscheck.sync_max_eps = 10;
     syscheck.max_eps        = 200;
     syscheck.allow_remote_prefilter_cmd  = false;
 
@@ -312,6 +313,7 @@ cJSON *getSyscheckConfig(void) {
     cJSON_AddNumberToObject(synchronization, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(synchronization, "response_timeout", syscheck.sync_response_timeout);
     cJSON_AddNumberToObject(synchronization, "queue_size", syscheck.sync_queue_size);
+    cJSON_AddNumberToObject(synchronization, "max_eps", syscheck.sync_max_eps);
     cJSON_AddItemToObject(syscfg, "synchronization", synchronization);
 
     cJSON_AddNumberToObject(syscfg, "max_eps", syscheck.max_eps);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -59,7 +59,6 @@ static void fim_send_msg(char mq, const char * location, const char * msg) {
 // LCOV_EXCL_STOP
 
 
-// LCOV_EXCL_START
 // Send a data synchronization control message
 
 void fim_send_sync_msg(const char * msg) {
@@ -77,10 +76,8 @@ void fim_send_sync_msg(const char * msg) {
         n_msg_sent = 0;
     }
 }
-// LCOV_EXCL_STOP
 
 
-// LCOV_EXCL_START
 // Send a message related to syscheck change/addition
 void send_syscheck_msg(const char *msg)
 {
@@ -98,7 +95,6 @@ void send_syscheck_msg(const char *msg)
         n_msg_sent = 0;
     }
 }
-// LCOV_EXCL_STOP
 
 
 // LCOV_EXCL_START

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -62,13 +62,17 @@ static void fim_send_msg(char mq, const char * location, const char * msg) {
 // LCOV_EXCL_START
 // Send a data synchronization control message
 
-static unsigned n_msg_sent = 0;
-
 void fim_send_sync_msg(const char * msg) {
     mdebug2(FIM_DBSYNC_SEND, msg);
     fim_send_msg(DBSYNC_MQ, SYSCHECK, msg);
 
-    if (++n_msg_sent == syscheck.max_eps) {
+    if (syscheck.sync_max_eps == 0) {
+        return;
+    }
+
+    static long n_msg_sent = 0;
+
+    if (++n_msg_sent == syscheck.sync_max_eps) {
         sleep(1);
         n_msg_sent = 0;
     }
@@ -82,6 +86,12 @@ void send_syscheck_msg(const char *msg)
 {
     mdebug2(FIM_SEND, msg);
     fim_send_msg(SYSCHECK_MQ, SYSCHECK, msg);
+
+    if (syscheck.max_eps == 0) {
+        return;
+    }
+
+    static unsigned n_msg_sent = 0;
 
     if (++n_msg_sent == syscheck.max_eps) {
         sleep(1);

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -125,7 +125,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -132,6 +132,7 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -151,6 +151,7 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -144,7 +144,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>


### PR DESCRIPTION
|Related issue|
|---|
|#4622|

This PR aims to apply the changes proposed in #4622.

## Configuration options

## Tests

- [X] Compile manager on Linux.
- [x] Compile agent on macOS.
- [x] Compile agent for Windows.
- [X] Source installation on Debian.
- [x] Review logs syntax and correct language.
- [X] Unit tests.
- [x] Configuration on-demand reports new parameters.