### PR TITLE
Fix memory leaks and compile warnings

### DIFF
--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -861,13 +861,16 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_entry_data *en
 
 int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry) {
     int inode_id;
-    unsigned long inode;
-    int res, res_data, res_path, res_inode, res_inode_id;
+    int res, res_data, res_path;
 
 #ifdef WIN32
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
     fim_db_bind_path(fim_sql, FIMDB_STMT_GET_DATA_ROW, file_path);
+
 #else
+    unsigned long inode;
+    int res_inode, res_inode_id;
+
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
     fim_db_bind_get_inode(fim_sql, FIMDB_STMT_GET_DATA_ROW, entry->inode, entry->dev);
 

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -1123,7 +1123,7 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
         w_mutex_unlock(mutex);
 }
 
-void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex, __attribute__((unused))void *arg) {
+void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex, void *arg) {
 
     fim_event_mode mode = (fim_event_mode) arg;
     int conf_file = fim_configuration_directory(entry->path, "file");
@@ -1149,7 +1149,7 @@ void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mute
             break;
     }
 
-    fim_db_remove_path(fim_sql, entry, mutex, 1);
+    fim_db_remove_path(fim_sql, entry, mutex, (void *) (int) 1);
 }
 
 int fim_db_get_row_path(fdb_t * fim_sql, int mode, char **path) {

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -234,8 +234,7 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
  * @param mutex
  * @param arg Directory configuration.
  */
-void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
-                         __attribute__((unused))void *arg);
+void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex, void *arg);
 
 /**
  * @brief Get the last/first row from entry_path.
@@ -334,6 +333,21 @@ int fim_db_get_path_range(fdb_t *fim_sql, char *start, char *top,
  */
 int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file,
                         pthread_mutex_t *mutex, int storage);
+
+/**
+ * @brief Remove a range of paths from database if they have a
+ * specific monitoring mode.
+ *
+ * @param fim_sql FIM database struct.
+ * @param file  Structure of the file which contains all the paths.
+ * @param mutex
+ * @param storage 1 Store database in memory, disk otherwise.
+ *
+ * @return FIMDB_OK on success, FIMDB_ERR otherwise.
+ */
+int fim_db_process_missing_entry(fdb_t *fim_sql, fim_tmp_file *file,
+                                 pthread_mutex_t *mutex, int storage,
+                                 fim_event_mode mode);
 
 /**
  * @brief Get count of all entries in entry_data table.


### PR DESCRIPTION
This PR solve:
1. Possible memory leaks on `fim_registry_event` and `fim_process_missing_entry`.
2. Add the requested change on [4663](https://github.com/wazuh/wazuh/pull/4623).
3. Fix compile warnnings