### PR TITLE
FIM v2.0: Monitor non-existing directories with realtime in Windows

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -152,7 +152,6 @@
 #define FIM_HEALTHCHECK_SUCCESS             "(6261): Whodata health-check: Success."
 #define FIM_HEALTHCHECK_CHECK_RULE          "(6262): Couldn't delete audit health check rule."
 #define FIM_SACL_CHECK_CONFIGURE            "(6263): Setting up SACL for '%s'"
-#define FIM_SCAL_NOCONFIGURE                "(6264): It is not necessary to configure the SACL of '%s'"
 #define FIM_SACL_RESTORED                   "(6265): The SACL of '%s' has been restored correctly."
 #define FIM_SACL_CONFIGURE                  "(6266): The SACL of '%s' will be configured."
 #define FIM_SACL_NOT_FOUND                  "(6267): No SACL found on target. A new one will be created."

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -861,13 +861,15 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_entry_data *en
 
 int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry) {
     int inode_id;
-    unsigned long inode;
-    int res, res_data, res_path, res_inode, res_inode_id;
+    int res, res_data, res_path;
 
 #ifdef WIN32
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
     fim_db_bind_path(fim_sql, FIMDB_STMT_GET_DATA_ROW, file_path);
 #else
+    unsigned long inode;
+    int res_inode, res_inode_id;
+
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
     fim_db_bind_get_inode(fim_sql, FIMDB_STMT_GET_DATA_ROW, entry->inode, entry->dev);
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -301,12 +301,14 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
     while (1) {
 #ifdef WIN32
         // Directories in Windows configured with real-time add recursive watches
-        int i = 0;
-        while (syscheck.dir[i]) {
+        for (int i = 0; syscheck.dir[i]; i++) {
             if (syscheck.opts[i] & REALTIME_ACTIVE) {
                 realtime_adddir(syscheck.dir[i], 0);
             }
-            i++;
+
+            if (syscheck.opts[i] & WHODATA_ACTIVE) {
+                realtime_adddir(syscheck.dir[i], i + 1);
+            }
         }
 #endif
 #ifdef WIN_WHODATA

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -296,18 +296,19 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
 
 #ifdef WIN32
     set_priority_windows_thread();
-
-    // Directories in Windows configured with real-time add recursive watches
-    int i = 0;
-    while (syscheck.dir[i]) {
-        if (syscheck.opts[i] & REALTIME_ACTIVE) {
-            realtime_adddir(syscheck.dir[i], 0);
-        }
-        i++;
-    }
 #endif
 
     while (1) {
+#ifdef WIN32
+        // Directories in Windows configured with real-time add recursive watches
+        int i = 0;
+        while (syscheck.dir[i]) {
+            if (syscheck.opts[i] & REALTIME_ACTIVE) {
+                realtime_adddir(syscheck.dir[i], 0);
+            }
+            i++;
+        }
+#endif
 #ifdef WIN_WHODATA
         if (syscheck.realtime_change) {
             set_whodata_mode_changes();

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -379,7 +379,8 @@ int realtime_adddir(const char *dir, int whodata)
         syscheck.wdata.dirs_status[whodata - 1].object_type = WD_STATUS_FILE_TYPE;
         syscheck.wdata.dirs_status[whodata - 1].status |= WD_STATUS_EXISTS;
     } else {
-        mwarn(FIM_WARN_REALTIME_OPENFAIL, dir);
+        mdebug1(FIM_WARN_REALTIME_OPENFAIL, dir);
+            
         syscheck.wdata.dirs_status[whodata - 1].object_type = WD_STATUS_UNK_TYPE;
         syscheck.wdata.dirs_status[whodata - 1].status &= ~WD_STATUS_EXISTS;
         return 0;

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -132,7 +132,7 @@ int set_winsacl(const char *dir, int position) {
             }
         break;
         case 1:
-            mdebug1(FIM_SCAL_NOCONFIGURE, dir);
+            // It is not necessary to configure the SACL of the directory
             retval = 0;
             goto end;
         case 2:


### PR DESCRIPTION
| Related issue  |
|---------------|
| #4640             |

## Description

In Windows, when monitoring a directory with `realtime`/`whodata` that was not created when performing the initial scan, after the next scan performed after the creation of the folder, `syscheck` was not sending events in `realtime`/`whodata`.

Closes #4640.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer
