### PR TITLE
Update date filters

### DIFF
--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -86,8 +86,11 @@ class WazuhDBQuerySyscheck(WazuhDBQuery):
                          get_data=True, date_fields={'mtime', 'date'}, *args, **kwargs)
 
     def _filter_date(self, date_filter, filter_db_name):
-        # dates are stored as timestamps
-        date_filter['value'] = int(datetime.timestamp(datetime.strptime(date_filter['value'], "%Y-%m-%d %H:%M:%S")))
+        # Dates are stored as timestamps in the database
+        try:
+            date_filter['value'] = int(datetime.timestamp(datetime.strptime(date_filter['value'], "%Y-%m-%d %H:%M:%S")))
+        except ValueError:
+            date_filter['value'] = int(datetime.timestamp(datetime.strptime(date_filter['value'], "%Y-%m-%d")))
         self.query += "{0} IS NOT NULL AND {0} {1} :{2}".format(self.fields[filter_db_name], date_filter['operator'],
                                                                 date_filter['field'])
         self.request[date_filter['field']] = date_filter['value']

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -981,7 +981,7 @@ class WazuhDBQuery(object):
     def _process_filter(self, field_name, field_filter, q_filter):
         if field_name == "status":
             self._filter_status(q_filter)
-        elif field_name in self.date_fields and re.match("^[0-9]+(\.([0-9]+))?$", q_filter['value']) is None:
+        elif field_name in self.date_fields and re.match(r"^[0-9]+(\.([0-9]+))?$", q_filter['value']) is None:
             # Filter a date, but only if it is in string (YYYY-MM-DD hh:mm:ss) format.
             # If it matches the same format as DB (timestamp integer), filter directly by value (next if cond).
             self._filter_date(q_filter, field_name)


### PR DESCRIPTION
|Related issue|
|#4466|

## Description

This PR fixes date filter for q parameter in `syscheck` endpoints. It adds the option to use `"%Y-%m-%d"` format apart from `timestamp` and `"%Y-%m-%d %H:%M:%S"`
