### PR TITLE
Remove chroot in Agentd to allow it resolve DNS at any time

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -60,12 +60,6 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
         merror_exit(SETGID_ERROR, group, errno, strerror(errno));
     }
 
-    /* chroot */
-    if (Privsep_Chroot(dir) < 0) {
-        merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));
-    }
-    nowChroot();
-
     if (Privsep_SetUser(uid) < 0) {
         merror_exit(SETUID_ERROR, user, errno, strerror(errno));
     }
@@ -74,8 +68,8 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     os_setwait();
 
     /* Create the queue and read from it. Exit if fails. */
-    if ((agt->m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
-        merror_exit(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+    if ((agt->m_queue = StartMQ(DEFAULTQUEUE_PATH, READ)) < 0) {
+        merror_exit(QUEUE_ERROR, DEFAULTQUEUE_PATH, strerror(errno));
     }
 
 #ifdef HPUX
@@ -162,7 +156,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 
     /* Connect to the execd queue */
     if (agt->execdq == 0) {
-        if ((agt->execdq = StartMQ(EXECQUEUE, WRITE)) < 0) {
+        if ((agt->execdq = StartMQ(EXECQUEUEPATH, WRITE)) < 0) {
             minfo("Unable to connect to the active response "
                    "queue (disabled).");
             agt->execdq = -1;

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -68,8 +68,8 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     os_setwait();
 
     /* Create the queue and read from it. Exit if fails. */
-    if ((agt->m_queue = StartMQ(DEFAULTQUEUE_PATH, READ)) < 0) {
-        merror_exit(QUEUE_ERROR, DEFAULTQUEUE_PATH, strerror(errno));
+    if ((agt->m_queue = StartMQ(DEFAULTQPATH, READ)) < 0) {
+        merror_exit(QUEUE_ERROR, DEFAULTQPATH, strerror(errno));
     }
 
 #ifdef HPUX

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -175,8 +175,8 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     sigaction(SIGPIPE, &act, NULL);
 
     /* Send integrity message for agent configs */
-    intcheck_file(OSSECCONF, dir);
-    intcheck_file(OSSEC_DEFINES, dir);
+    intcheck_file(DEFAULTCPATH, dir);
+    intcheck_file(OSSEC_DEFINES_PATH, dir);
 
     // Start request module
     req_init();

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -166,8 +166,8 @@ void run_notify()
 
     /* Create message */
     if(*agent_ip && strcmp(agent_ip,"Err")){
-        if ((File_DateofChange(AGENTCONFIGINT) > 0 ) &&
-                (OS_MD5_File(AGENTCONFIGINT, md5sum, OS_TEXT) == 0)) {
+        if ((File_DateofChange(AGENTCONFIG) > 0 ) &&
+                (OS_MD5_File(AGENTCONFIG, md5sum, OS_TEXT) == 0)) {
             snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%s%s%s\n%s",
                     getuname(), md5sum, tmp_labels, shared_files, label_ip, keep_alive_random);
         } else {
@@ -176,8 +176,8 @@ void run_notify()
         }
     }
     else{
-        if ((File_DateofChange(AGENTCONFIGINT) > 0 ) &&
-                (OS_MD5_File(AGENTCONFIGINT, md5sum, OS_TEXT) == 0)) {
+        if ((File_DateofChange(AGENTCONFIG) > 0 ) &&
+                (OS_MD5_File(AGENTCONFIG, md5sum, OS_TEXT) == 0)) {
             snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%s%s\n%s",
                     getuname(), md5sum, tmp_labels, shared_files, keep_alive_random);
         } else {

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -45,7 +45,7 @@ char *getsharedfiles()
     char *ret;
     os_md5 md5sum;
 
-    if (OS_MD5_File(SHAREDCFG_FILE, md5sum, OS_TEXT) != 0) {
+    if (OS_MD5_File(SHAREDCFG_FILEPATH, md5sum, OS_TEXT) != 0) {
         md5sum[0] = 'x';
         md5sum[1] = '\0';
     }

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -150,7 +150,7 @@ int receive_msg()
                         merror("Error communicating with Security configuration assessment");
                         close(agt->cfgadq);
 
-                        if ((agt->cfgadq = StartMQ(CFGAQUEUE, WRITE)) < 0) {
+                        if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE)) < 0) {
                             merror("Unable to connect to the Security configuration assessment "
                                     "queue (disabled).");
                             agt->cfgadq = -1;
@@ -161,7 +161,7 @@ int receive_msg()
                         }
                     }
                 } else {
-                    if ((agt->cfgadq = StartMQ(CFGAQUEUE, WRITE)) < 0) {
+                    if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE)) < 0) {
                         merror("Unable to connect to the Security configuration assessment "
                             "queue (disabled).");
                         agt->cfgadq = -1;

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -220,7 +220,7 @@ int receive_msg()
                 }
 
                 snprintf(file, OS_SIZE_1024, "%s/%s",
-                         SHAREDCFG_DIR,
+                         SHAREDCFG_DIRPATH,
                          tmp_msg);
 
                 fp = fopen(file, "w");
@@ -260,11 +260,11 @@ int receive_msg()
                         final_file = strrchr(file, '/');
                         if (final_file) {
                             if (strcmp(final_file + 1, SHAREDCFG_FILENAME) == 0) {
-                                if (cldir_ex_ignore(SHAREDCFG_DIR, IGNORE_LIST)) {
+                                if (cldir_ex_ignore(SHAREDCFG_DIRPATH, IGNORE_LIST)) {
                                     mwarn("Could not clean up shared directory.");
                                 }
 
-                                if(!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT)){
+                                if(!UnmergeFiles(file, SHAREDCFG_DIRPATH, OS_TEXT)){
                                     char msg_output[OS_MAXSTR];
 
                                     snprintf(msg_output, OS_MAXSTR, "%c:%s:%s",  LOCALFILE_MQ, "ossec-agent", AG_IN_UNMERGE);

--- a/src/client-agent/request.c
+++ b/src/client-agent/request.c
@@ -148,7 +148,7 @@ int req_push(char * buffer, size_t length) {
 
         if (strcmp(target, "agent")) {
             char sockname[PATH_MAX];
-            snprintf(sockname, PATH_MAX, "/queue/ossec/%s", target);
+            snprintf(sockname, PATH_MAX, DEFAULTDIR "/queue/ossec/%s", target);
 
             if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
                 switch (errno) {

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -52,8 +52,14 @@ int connect_server(int initial_id)
             // Resolve hostname
             if (!isChroot()) {
                 resolveHostname(&agt->server[rc].rip, 5);
+
+                tmp_str = strchr(agt->server[rc].rip, '/');
+                if(tmp_str) {
+                    tmp_str++;
+                }
+            } else {
+                tmp_str++;
             }
-            tmp_str++;
         } else {
             tmp_str = agt->server[rc].rip;
         }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -65,7 +65,7 @@ int connect_server(int initial_id)
         }
 
         // The hostname was not resolved correctly
-        if (strlen(tmp_str) == 0) {
+        if (tmp_str == NULL || *tmp_str == '\0') {
             int rip_l = strlen(agt->server[rc].rip);
             mdebug2("Could not resolve hostname '%.*s'", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
             rc++;

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -120,6 +120,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 
 /* Default queue */
 #define DEFAULTQUEUE    "/queue/ossec/queue"
+#define DEFAULTQUEUE_PATH DEFAULTDIR DEFAULTQUEUE
 
 // Authd local socket
 #define AUTH_LOCAL_SOCK "/queue/ossec/auth"
@@ -141,6 +142,9 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define MON_LOCAL_SOCK  "/queue/ossec/monitor"
 #define CLUSTER_SOCK "/queue/cluster/c-internal.sock"
 #define CONTROL_SOCK "/queue/ossec/control"
+
+// Absolute path local requests socket
+#define CONTROL_SOCK_PATH DEFAULTDIR CONTROL_SOCK
 
 // Attempts to check sockets availability
 #define SOCK_ATTEMPTS   10

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -279,6 +279,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #ifndef WIN32
 #define OSSEC_DEFINES   "/etc/internal_options.conf"
 #define OSSEC_LDEFINES   "/etc/local_internal_options.conf"
+#define OSSEC_DEFINES_PATH DEFAULTDIR OSSEC_DEFINES
 #else
 #define OSSEC_DEFINES   "internal_options.conf"
 #define OSSEC_LDEFINES   "local_internal_options.conf"

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -120,7 +120,6 @@ https://www.gnu.org/licenses/gpl.html\n"
 
 /* Default queue */
 #define DEFAULTQUEUE    "/queue/ossec/queue"
-#define DEFAULTQUEUE_PATH DEFAULTDIR DEFAULTQUEUE
 
 // Authd local socket
 #define AUTH_LOCAL_SOCK "/queue/ossec/auth"

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -158,6 +158,7 @@ void os_set_agent_crypto_method(keystore * keys,const int method);
 /** Remote IDs directories and internal definitions */
 #ifndef WIN32
 #define RIDS_DIR        "/queue/rids"
+#define RIDS_DIR_PATH   DEFAULTDIR RIDS_DIR
 #else
 #define RIDS_DIR        "rids"
 #endif

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -161,6 +161,7 @@ void os_set_agent_crypto_method(keystore * keys,const int method);
 #define RIDS_DIR_PATH   DEFAULTDIR RIDS_DIR
 #else
 #define RIDS_DIR        "rids"
+#define RIDS_DIR_PATH   RIDS_DIR
 #endif
 
 #define SENDER_COUNTER  "sender_counter"

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -84,11 +84,11 @@ void OS_StartCounter(keystore *keys)
         /* On i == keysize, we deal with the sender counter */
         if (i == keys->keysize) {
             snprintf(rids_file, OS_FLSIZE, "%s/%s",
-                     RIDS_DIR,
+                     isChroot() ? RIDS_DIR : RIDS_DIR_PATH,
                      SENDER_COUNTER);
         } else {
             snprintf(rids_file, OS_FLSIZE, "%s/%s",
-                     RIDS_DIR,
+                     isChroot() ? RIDS_DIR : RIDS_DIR_PATH,
                      keys->keyentries[i]->id);
         }
 
@@ -195,7 +195,7 @@ static void ReloadCounter(const keystore *keys, unsigned int id, const char * ci
     ino_t new_inode;
     char rids_file[OS_FLSIZE + 1];
 
-    snprintf(rids_file, OS_FLSIZE, "%s/%s", RIDS_DIR, cid);
+    snprintf(rids_file, OS_FLSIZE, "%s/%s", isChroot() ? RIDS_DIR : RIDS_DIR_PATH, cid);
     new_inode = File_Inode(rids_file);
 
     w_mutex_lock(&keys->keyentries[id]->mutex);

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -39,13 +39,13 @@ int os_set_restart_syscheck()
 {
     FILE *fp;
 
-    fp = fopen(SYSCHECK_RESTART, "w");
+    fp = fopen(isChroot() ? SYSCHECK_RESTART : SYSCHECK_RESTART_PATH, "w");
     if (!fp) {
-        merror(FOPEN_ERROR, SYSCHECK_RESTART, errno, strerror(errno));
+        merror(FOPEN_ERROR, isChroot() ? SYSCHECK_RESTART : SYSCHECK_RESTART_PATH, errno, strerror(errno));
         return (0);
     }
 
-    fprintf(fp, "%s\n", SYSCHECK_RESTART);
+    fprintf(fp, "%s\n", isChroot() ? SYSCHECK_RESTART : SYSCHECK_RESTART_PATH);
     fclose(fp);
 
     return (1);

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -228,9 +228,9 @@ int os_write_agent_info(const char *agent_name, __attribute__((unused)) const ch
 {
     FILE *fp;
 
-    fp = fopen(AGENT_INFO_FILE, "w");
+    fp = fopen(isChroot() ? AGENT_INFO_FILE : AGENT_INFO_FILEP, "w");
     if (!fp) {
-        merror(FOPEN_ERROR, AGENT_INFO_FILE, errno, strerror(errno));
+        merror(FOPEN_ERROR, isChroot() ? AGENT_INFO_FILE : AGENT_INFO_FILEP, errno, strerror(errno));
         return (0);
     }
 
@@ -769,7 +769,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 /* Connect to the control socket if available */
 #if defined (__linux__) || defined (__MACH__) || defined(sun)
 int control_check_connection() {
-    int sock = OS_ConnectUnixDomain(isChroot() ? CONTROL_SOCK : DEFAULTDIR CONTROL_SOCK, SOCK_STREAM, OS_SIZE_128);
+    int sock = OS_ConnectUnixDomain(CONTROL_SOCK_PATH, SOCK_STREAM, OS_SIZE_128);
 
     if (sock < 0) {
         return -1;


### PR DESCRIPTION
This PR is a rebase of #4241 by @Molter73.

## Tests

- [X] Compile manager on Linux.
- [X] Compile agent on Linux.
- [X] Compile agent on macOS.
- [X] Compile agent for Windows.

### Tests performed on macOS and Windows

- [X] Connect agent to a manager.
- [X] Receive shared configuration, validate it and restart the agent.
- [X] Remote restart (Active response).
- [X] Query Syscheck configuration.
- [X] Shared configuration filters.
- [X] State file.
- [X] Report the current host IP to the manager.
- [X] Start the agent while no DNS is available, then let the agent connect.