### PR TITLE
Fix leak when the FIM decoders fails to parse the event data

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1149,6 +1149,7 @@ int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
         if (strcmp(type, "event") == 0) {
             if (fim_process_alert(sdb, lf, data) == -1) {
                 merror("Can't generate fim alert for event: '%s'", lf->log);
+                cJSON_Delete(root_json);
                 return retval;
             }
 
@@ -1160,6 +1161,7 @@ int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
         }
     } else {
         merror("Invalid FIM event");
+        cJSON_Delete(root_json);
         return retval;
     }
 


### PR DESCRIPTION
Hi team,

during running the unit tests I found a memory leak when failing to process the FIM event.

## Description

A memory leak was found at `decode_fim_event()` when the parsed FIM event has certain properties such as not containing the field `data`.

## Valgrind report

### Unit test

```
==21834== 5,136 (64 direct, 5,072 indirect) bytes in 1 blocks are definitely lost in loss record 22 of 22
==21834==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21834==    by 0x4F360C8: cJSON_New_Item (cJSON.c:214)
==21834==    by 0x4F37477: cJSON_ParseWithOpts (cJSON.c:1029)
==21834==    by 0x4F375CF: cJSON_Parse (cJSON.c:1092)
==21834==    by 0x1B5774: decode_fim_event (syscheck.c:1141)
==21834==    by 0x18A4CE: test_decode_fim_event_no_type (test_analysisd_syscheck.c:3271)
==21834==    by 0x56ECC17: ??? (in /usr/lib/x86_64-linux-gnu/libcmocka.so.0.4.1)
==21834==    by 0x56ED536: _cmocka_run_group_tests (in /usr/lib/x86_64-linux-gnu/libcmocka.so.0.4.1)
==21834==    by 0x18AF27: main (test_analysisd_syscheck.c:3487)
```

### Analysisd execution

```
==18810== 925 (256 direct, 669 indirect) bytes in 4 blocks are definitely lost in loss record 263 of 404
==18810==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18810==    by 0x4F360C8: cJSON_New_Item (cJSON.c:214)
==18810==    by 0x4F37477: cJSON_ParseWithOpts (cJSON.c:1029)
==18810==    by 0x4F375CF: cJSON_Parse (cJSON.c:1092)
==18810==    by 0x150FF8: decode_fim_event (syscheck.c:1141)
==18810==    by 0x13818A: w_decode_syscheck_thread (analysisd.c:2005)
==18810==    by 0x58F76DA: start_thread (pthread_create.c:463)
==18810==    by 0x5C3088E: clone (clone.S:95)
```

## Steps to reproduce it

Run `ossec-analysisd` with valgrind:

```
# valgrind --leak-check=full --num-callers=20 --track-origins=yes /var/ossec/bin/ossec-analysisd -fd
```

Inject one of the following events to it:

```
8:[001] (vm-ubuntu-agent) 192.168.57.2->syscheck:{"type":"event"}
8:[001] (vm-ubuntu-agent) 192.168.57.2->syscheck:{"data":{"test":"test"}}
8:[001] (vm-ubuntu-agent) 192.168.57.2->syscheck:{"type":"event","data":{"test":"test"}}
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)