### PR TITLE
Remove compilation warning in fim_process_missing_entry

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -312,7 +312,7 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
 }
 
 
-void fim_realtime_event(char *file, fim_element *item) {
+void fim_realtime_event(char *file) {
 
     struct stat file_stat;
 
@@ -320,7 +320,8 @@ void fim_realtime_event(char *file, fim_element *item) {
     if (w_stat(file, &file_stat) >= 0) {
 
 #ifdef WIN32
-        fim_checker(file, item, NULL, 1);
+        fim_element item = { .mode = FIM_REALTIME };
+        fim_checker(file, &item, NULL, 1);
 #else
         fim_audit_inode_event(file, FIM_REALTIME, NULL);
 #endif
@@ -328,12 +329,12 @@ void fim_realtime_event(char *file, fim_element *item) {
     }
     else {
         // Otherwise, it could be a file deleted or a directory moved (or renamed).
-        fim_process_missing_entry(file, FIM_REALTIME, NULL, item);
+        fim_process_missing_entry(file, FIM_REALTIME, NULL);
     }
 }
 
 // LCOV_EXCL_START
-void fim_whodata_event(whodata_evt * w_evt, fim_element *item) {
+void fim_whodata_event(whodata_evt * w_evt) {
 
     struct stat file_stat;
 
@@ -341,7 +342,8 @@ void fim_whodata_event(whodata_evt * w_evt, fim_element *item) {
     if(w_stat(w_evt->path, &file_stat) >= 0) {
 
 #ifdef WIN32
-        fim_checker(w_evt->path, item, w_evt, 1);
+        fim_element item = { .mode = FIM_WHODATA };
+        fim_checker(w_evt->path, &item, w_evt, 1);
 #else
         fim_audit_inode_event(w_evt->path, FIM_WHODATA, w_evt);
 #endif
@@ -349,14 +351,14 @@ void fim_whodata_event(whodata_evt * w_evt, fim_element *item) {
     }
     // Otherwise, it could be a file deleted or a directory moved (or renamed).
     else {
-        fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt, item);
+        fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
     }
 }
 
 // LCOV_EXCL_STOP
 
 
-void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt * w_evt, fim_element *item) {
+void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt * w_evt) {
 
     fim_entry *saved_data;
 
@@ -369,7 +371,8 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
     if (saved_data) {
 
 #ifdef WIN32
-        fim_checker(pathname, item, w_evt, 1);
+        fim_element item = { .mode = mode };
+        fim_checker(pathname, &item, w_evt, 1);
 #else
         fim_audit_inode_event(pathname, mode, w_evt);
 #endif

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -186,7 +186,7 @@ void realtime_process()
         char ** paths = rbtree_keys(tree);
 
         for (int i = 0; paths[i] != NULL; i++) {
-            fim_realtime_event(paths[i], NULL);
+            fim_realtime_event(paths[i]);
         }
 
         free_strarray(paths);
@@ -254,8 +254,6 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
     }
 
     if (dwBytes) {
-        fim_element *item;
-        os_calloc(1, sizeof(fim_element), item);
 
         do {
             pinfo = (PFILE_NOTIFY_INFORMATION) &rtlocald->buffer[offset];
@@ -287,13 +285,11 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
             Sleep(syscheck.rt_delay);
 
             if (index == file_index) {
-                item->mode = FIM_REALTIME;
                 /* Check the change */
-                fim_realtime_event(final_path, item);
+                fim_realtime_event(final_path);
             }
 
         } while (pinfo->NextEntryOffset != 0);
-        os_free(item);
     }
 
     realtime_win32read(rtlocald);

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -156,17 +156,15 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report);
  * @brief Process FIM realtime event
  *
  * @param [in] file Path of the file to check
- * @param item Pointer to fim_element necesary to call fim_checker function. May be null
  */
-void fim_realtime_event(char *file, fim_element *item);
+void fim_realtime_event(char *file);
 
 /**
  * @brief Process FIM whodata event
  *
  * @param w_evt Whodata event
- * @param item Pointer to fim_element necesary to call fim_checker function. May be null
  */
-void fim_whodata_event(whodata_evt *w_evt, fim_element *item);
+void fim_whodata_event(whodata_evt *w_evt);
 
 /**
  * @brief Process a path that has possibly been deleted
@@ -175,9 +173,8 @@ void fim_whodata_event(whodata_evt *w_evt, fim_element *item);
  * @param pathname Name of path
  * @param mode Monitoring FIM mode
  * @param w_evt Pointer to whodata information
- * @param item Pointer to fim_element necesary to call fim_checker function. May be null
  */
-void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt * w_evt, fim_element *item);
+void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt * w_evt);
 
 /**
  * @brief Process FIM audit event

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -847,7 +847,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt, NULL);
+                                fim_whodata_event(w_evt);
                             }
                         }
                     }
@@ -878,7 +878,7 @@ void audit_parse(char *buffer) {
                             w_evt->path = real_path;
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt, NULL);
+                                fim_whodata_event(w_evt);
                             }
                         }
                     }
@@ -917,7 +917,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt, NULL);
+                                fim_whodata_event(w_evt);
                             }
                         }
                     }
@@ -977,7 +977,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt, NULL);
+                                fim_whodata_event(w_evt);
                             }
                             free(file_path1);
                             w_evt->path = NULL;
@@ -999,7 +999,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt, NULL);
+                                fim_whodata_event(w_evt);
                             }
                         }
                     }
@@ -1041,7 +1041,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name)?w_evt->process_name:"");
 
                             if (w_evt->inode) {
-                                fim_whodata_event(w_evt, NULL);
+                                fim_whodata_event(w_evt);
                             }
                         }
                     }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -752,11 +752,11 @@ add_whodata_evt:
                             w_evt->ignore_remove_event = 0;
                         }
 
-                        fim_whodata_event(w_evt, item);
+                        fim_whodata_event(w_evt);
                     } else if (w_evt->scan_directory == 1) { // Directory scan has been aborted if scan_directory is 2
                         if (mask & DELETE) {
 
-                            fim_whodata_event(w_evt, item);
+                            fim_whodata_event(w_evt);
 
                             // Find new files
                             int pos = fim_configuration_directory(w_evt->path, "file");
@@ -765,7 +765,7 @@ add_whodata_evt:
                         } else if ((mask & FILE_WRITE_DATA) && w_evt->path && (w_dir = OSHash_Get(syscheck.wdata.directories, w_evt->path))) {
                             // Check that a new file has been added
                             GetSystemTime(&w_dir->timestamp);
-                            fim_whodata_event(w_evt, item);
+                            fim_whodata_event(w_evt);
 
                             mdebug1(FIM_WHODATA_SCAN, w_evt->path);
                         } else {


### PR DESCRIPTION
This PR removes the following compilation warning:

```
syscheckd/create_db.c: In function 'fim_process_missing_entry':
syscheckd/create_db.c:359:104: warning: unused parameter 'item' [-Wunused-parameter]
 void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt * w_evt, fim_element *item) {
```

It only uses the variable item in the Windows systems.

### Test
- [x] Scan-build (Linux and Windows)
- [x] Checked the flow of the events doesn't change