### PR TITLE
Let FIM parameter rt_delay apply on both realtime and whodata

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -276,7 +276,7 @@ monitord.delete_old_agents=0
 
 # Syscheck perform a delay when dispatching real-time notifications so it avoids
 # triggering on some temporary files like vim edits. (ms) [1..1000]
-syscheck.rt_delay=1
+syscheck.rt_delay=10
 
 # Maximum number of directories monitored for realtime on windows [1..1024]
 syscheck.max_fd_win_rt=256

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -318,6 +318,10 @@ void fim_realtime_event(char *file, fim_element *item) {
 
     // If the file exists, generate add or modify events.
     if (w_stat(file, &file_stat) >= 0) {
+        /* Need a sleep here to avoid triggering on vim
+         * (and finding the file removed)
+         */
+        fim_rt_delay();
 
 #ifdef WIN32
         fim_checker(file, item, NULL, 1);
@@ -339,6 +343,7 @@ void fim_whodata_event(whodata_evt * w_evt, fim_element *item) {
 
     // If the file exists, generate add or modify events.
     if(w_stat(w_evt->path, &file_stat) >= 0) {
+        fim_rt_delay();
 
 #ifdef WIN32
         fim_checker(w_evt->path, item, w_evt, 1);
@@ -1146,3 +1151,18 @@ void fim_print_info(struct timespec start, struct timespec end, clock_t cputime_
 
     return;
 }
+
+// LCOV_EXCL_START
+
+// Sleep during rt_delay milliseconds
+
+void fim_rt_delay() {
+#ifdef WIN32
+    Sleep(syscheck.rt_delay);
+#else
+    struct timeval timeout = {0, syscheck.rt_delay * 1000};
+    select(0, NULL, NULL, NULL, &timeout);
+#endif
+}
+
+// LCOV_EXCL_STOP

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -177,12 +177,6 @@ void realtime_process()
             }
         }
 
-        /* Need a sleep here to avoid triggering on vim
-         * (and finding the file removed)
-         */
-        struct timeval timeout = {0, syscheck.rt_delay * 1000};
-        select(0, NULL, NULL, NULL, &timeout);
-
         char ** paths = rbtree_keys(tree);
 
         for (int i = 0; paths[i] != NULL; i++) {
@@ -283,8 +277,6 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
 
             int index = fim_configuration_directory(wdchar, "file");
             int file_index = fim_configuration_directory(final_path, "file");
-
-            Sleep(syscheck.rt_delay);
 
             if (index == file_index) {
                 item->mode = FIM_REALTIME;

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -247,6 +247,12 @@ void fim_get_checksum(fim_entry_data *data);
 void fim_print_info(struct timespec start, struct timespec end, clock_t cputime_start);
 
 /**
+ * @brief Sleep during rt_delay milliseconds
+ *
+ */
+void fim_rt_delay();
+
+/**
  * @brief Checks for deleted files, deletes them from the agent's database and sends a deletion event on scheduled scans
  *
  */


### PR DESCRIPTION
## Symptom

Inserting some data into a file monitored by FIM may take a short. This could make Syscheck report more than one event for a single operation. For instance:

```sh
head -c1048576 /dev/urandom > random.1m
```

While the real-time mode makes a small delay (`rt_delay` milliseconds) to prevent this situation, the who-data mode dispatches the input events as soon as possible and reads the files before the operation has ended.

## Fix proposal

Let the who-data mode apply the same delay as the real-time mode.

- Remove `sleep` from `RTCallback` and `realtime_process`.
- Create a new function, `fim_rt_delay`, to implement the delay for Windows and UNIX.
- Let `fim_realtime_event` and `fim_whodata_event` call `fim_rt_delay` if the object file exists. Do not delay if the file was not found.

## Tests

- [X] Compile manager for Linux.
- [X] Compile agent for Windows.

We are not dealing with dynamic memory here.