### PR TITLE
Fix memory leak on windows

### DIFF
--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -272,10 +272,9 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int pos)
 
         if (result = fim_registry_event(path, data, pos), result == -1) {
             mdebug1(FIM_REGISTRY_EVENT_FAIL, path);
-            free_entry_data(data);
-        } else if (result == 0) {
-            free_entry_data(data);
         }
+
+        free_entry_data(data);
     }
 }
 


### PR DESCRIPTION
| Issue |
| --- |
| [4634](https://github.com/wazuh/wazuh/issues/4634) |

There was memory leak on function `os_winreg_querykey`. It was caused function `fim_registry_event ` can return -1, and it didn't process this case:
```C
        if (result = fim_registry_event(path, data, pos), result == -1) {
            mdebug1(FIM_REGISTRY_EVENT_FAIL, path);
            free_entry_data(data);
        } else if (result == 0) {
            free_entry_data(data);
        }
```

### Test

- [x]  Monitoring Windows registries using low frequency. To check the memory used by Wazuh we use Process Explorer.

### Configuration

```xml
  <syscheck>
    <frequency>10</frequency>
    <windows_registry>HKEY_LOCAL_MACHINE\Software</windows_registry>
  </syscheck>
```
