### PR TITLE
Fixed defects and compilation warn

### DIFF
--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -14,6 +14,9 @@
 #if defined(__MINGW32__) || defined(__hppa__)
 static int setenv(const char *name, const char *val, __attribute__((unused)) int overwrite)
 {
+    assert(name);
+    assert(val);
+
     int len = strlen(name) + strlen(val) + 2;
     char *str = (char *)malloc(len);
     snprintf(str, len, "%s=%s", name, val);

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -18,9 +18,14 @@ static int setenv(const char *name, const char *val, __attribute__((unused)) int
     assert(val);
 
     int len = strlen(name) + strlen(val) + 2;
-    char *str = (char *)malloc(len);
+    char *str;
+    os_malloc(len, str);
+
     snprintf(str, len, "%s=%s", name, val);
     putenv(str);
+
+    os_free(str);
+
     return 0;
 }
 #endif

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -353,8 +353,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         char **values = NULL;
 
         tmp_dir = *dir;
-        restrictfile = NULL;
-        tag = NULL;
 
         /* Remove spaces at the beginning */
         while (*tmp_dir == ' ') {
@@ -595,10 +593,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             }
             /* Check file restriction */
             else if (strcmp(*attrs, xml_restrict) == 0) {
-                if (restrictfile) {
-                    free(restrictfile);
-                    restrictfile = NULL;
-                }
+                os_free(restrictfile);
                 os_strdup(*values, restrictfile);
 #ifdef WIN32
                 str_lowercase(restrictfile);
@@ -622,10 +617,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 
             /* Check tag */
             else if (strcmp(*attrs, xml_tag) == 0) {
-                if (tag) {
-                    free(tag);
-                    tag = NULL;
-                }
+                os_free(tag);
                 os_strdup(*values, tag);
             }
             /* Check follow symbolic links */
@@ -655,25 +647,23 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 
         if (tag) {
             if (clean_tag = os_strip_char(tag, ' '), !clean_tag) {
-                merror("Processing tag '%s'.", tag);
+                merror("Processing tag '%s'", tag);
                 goto out_free;
             } else {
-                free(tag);
-                tag = NULL;
+                os_free(tag);
                 os_strdup(clean_tag, tag);
-                free(clean_tag);
+                os_free(clean_tag);
             }
             if (clean_tag = os_strip_char(tag, '!'), !clean_tag) {
-                merror("Processing tag '%s'.", tag);
+                merror("Processing tag '%s'", tag);
                 goto out_free;
             } else {
-                free(tag);
-                tag = NULL;
+                os_free(tag);
                 os_strdup(clean_tag, tag);
-                free(clean_tag);
+                os_free(clean_tag);
             }
             if (clean_tag = os_strip_char(tag, ':'), !clean_tag) {
-                merror("Processing tag '%s'.", tag);
+                merror("Processing tag '%s'", tag);
                 goto out_free;
             }
         }
@@ -719,12 +709,16 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 
             if (glob(tmp_dir, 0, NULL, &g) != 0) {
                 merror(GLOB_ERROR, real_path);
+                os_free(restrictfile);
+                os_free(tag);
                 dir++;
                 continue;
             }
 
             if (g.gl_pathv[0] == NULL) {
                 merror(GLOB_NFOUND, real_path);
+                os_free(restrictfile);
+                os_free(tag);
                 dir++;
                 continue;
             }
@@ -766,18 +760,9 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile, recursion_limit, clean_tag, NULL);
 #endif
 
-        if (restrictfile) {
-            free(restrictfile);
-            restrictfile = NULL;
-        }
-
-        if (tag) {
-            free(tag);
-            if (clean_tag)
-                free(clean_tag);
-            tag = NULL;
-            clean_tag = NULL;
-        }
+        os_free(restrictfile);
+        os_free(tag);
+        os_free(clean_tag);
 
         /* Next entry */
         dir++;
@@ -791,13 +776,9 @@ out_free:
     }
 
     free(dir_org);
-    free(restrictfile);
-    if (tag) {
-        free(tag);
-    }
-    if (clean_tag) {
-        free(clean_tag);
-    }
+    os_free(restrictfile);
+    os_free(tag);
+    os_free(clean_tag);
 
     return 1;
 }
@@ -1054,7 +1035,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 syscheck->database_store = FIM_DB_MEMORY;
             }
             else if (strcmp(node[i]->content, "disk") == 0){
-                syscheck->database_store = FIM_DB_DISK; 
+                syscheck->database_store = FIM_DB_DISK;
             }
         }
 

--- a/src/config/wmodules-command.c
+++ b/src/config/wmodules-command.c
@@ -72,7 +72,7 @@ int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg)
             if (strlen(nodes[i]->content) == 0) {
                 mwarn("Empty content for tag '%s' at module '%s'.", XML_TAG, WM_COMMAND_CONTEXT.name);
                 command_tag_length = strlen(WM_COMMAND_CONTEXT.name) + 2;
-                command_tag = malloc(sizeof(char) * command_tag_length);
+                os_malloc(sizeof(char) * command_tag_length, command_tag);
                 snprintf(command_tag, command_tag_length, "%s", WM_COMMAND_CONTEXT.name);
                 empty = 1;
             }

--- a/src/config/wmodules-command.c
+++ b/src/config/wmodules-command.c
@@ -27,7 +27,6 @@ static const char *XML_SKIP_VERIFICATION = "skip_verification";
 
 int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg)
 {
-    assert(WM_COMMAND_CONTEXT.name);
 
     int i;
     int empty = 0;
@@ -83,7 +82,7 @@ int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg)
 
             if (!empty) {
                 command_tag_length = strlen(WM_COMMAND_CONTEXT.name) + strlen(command->tag) + 2;
-                command_tag = malloc(sizeof(char) * command_tag_length);
+                os_malloc(sizeof(char) * command_tag_length, command_tag);
                 snprintf(command_tag, command_tag_length, "%s:%s", WM_COMMAND_CONTEXT.name, command->tag);
             }
 

--- a/src/config/wmodules-command.c
+++ b/src/config/wmodules-command.c
@@ -27,6 +27,8 @@ static const char *XML_SKIP_VERIFICATION = "skip_verification";
 
 int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg)
 {
+    assert(WM_COMMAND_CONTEXT.name);
+
     int i;
     int empty = 0;
     wm_command_t * command;

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -409,7 +409,7 @@ int main(int argc, char **argv)
     }
 
     /* Append new line character */
-    strncat(buf,"\n",1);
+    strcat(buf,"\n");
     ret = SSL_write(ssl, buf, strlen(buf));
     if (ret < 0) {
         merror("SSL write error (unable to send message.)");

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -951,7 +951,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                 use_client_ip = 1;
             } else if(!config.flags.use_source_ip) {
                 // use_source-ip = 0 and no -I argument in agent
-                memcpy(srcip,"any",IPSIZE);
+                memcpy(srcip, "any", 3);
             }
             // else -> agent IP is already on srcip
 

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -384,7 +384,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             {
                 int dbg_lvl = isDebug();
                 snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL?"":integrator_config[s]->apikey, integrator_config[s]->hookurl==NULL?"":integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
-                if (dbg_lvl <= 0) strncat(exec_full_cmd, " > /dev/null 2>&1", 17);
+                if (dbg_lvl <= 0) strcat(exec_full_cmd, " > /dev/null 2>&1");
 
                 mdebug1("Running: %s", exec_full_cmd);
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -67,54 +67,54 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
     if (al_data->old_md5) {
         log_size = strlen(al_data->old_md5) + 16 + 4;
         if (body_size > log_size) {
-            strncat(logs, "Old md5sum was: ", 16);
+            strcat(logs, "Old md5sum was: ");
             strncat(logs, al_data->old_md5, body_size);
-            strncat(logs, "\r\n", 4);
+            strcat(logs, "\r\n");
             body_size -= log_size;
         }
     }
     if (al_data->new_md5) {
         log_size = strlen(al_data->new_md5) + 16 + 4;
         if (body_size > log_size) {
-            strncat(logs, "New md5sum is : ", 16);
+            strcat(logs, "New md5sum is : ");
             strncat(logs, al_data->new_md5, body_size);
-            strncat(logs, "\r\n", 4);
+            strcat(logs, "\r\n");
             body_size -= log_size;
         }
     }
     if (al_data->old_sha1) {
         log_size = strlen(al_data->old_sha1) + 17 + 4;
         if (body_size > log_size) {
-            strncat(logs, "Old sha1sum was: ", 17);
+            strcat(logs, "Old sha1sum was: ");
             strncat(logs, al_data->old_sha1, body_size);
-            strncat(logs, "\r\n", 4);
+            strcat(logs, "\r\n");
             body_size -= log_size;
         }
     }
     if (al_data->new_sha1) {
         log_size = strlen(al_data->new_sha1) + 17 + 4;
         if (body_size > log_size) {
-            strncat(logs, "New sha1sum is : ", 17);
+            strcat(logs, "New sha1sum is : ");
             strncat(logs, al_data->new_sha1, body_size);
-            strncat(logs, "\r\n", 4);
+            strcat(logs, "\r\n");
             body_size -= log_size;
         }
     }
     if (al_data->old_sha256) {
         log_size = strlen(al_data->old_sha256) + 19 + 4;
         if (body_size > log_size) {
-            strncat(logs, "Old sha256sum was: ", 19);
+            strcat(logs, "Old sha256sum was: ");
             strncat(logs, al_data->old_sha256, body_size);
-            strncat(logs, "\r\n", 4);
+            strcat(logs, "\r\n");
             body_size -= log_size;
         }
     }
     if (al_data->new_sha256) {
         log_size = strlen(al_data->new_sha256) + 19 + 4;
         if (body_size > log_size) {
-            strncat(logs, "New sha256sum is : ", 1256);
+            strcat(logs, "New sha256sum is : ");
             strncat(logs, al_data->new_sha256, body_size);
-            strncat(logs, "\r\n", 4);
+            strcat(logs, "\r\n");
             body_size -= log_size;
         }
     }
@@ -404,7 +404,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 6;
             if (body_size > log_size) {
-                strncat(logs, "File: ", 6);
+                strcat(logs, "File: ");
                 strncat(logs, json_field->valuestring, body_size);
                 body_size -= log_size;
             }
@@ -414,9 +414,9 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 1 + 4;
             if (body_size > log_size) {
-                strncat(logs, " ", 1);
+                strcat(logs, " ");
                 strncat(logs, json_field->valuestring, body_size);
-                strncat(logs, "\r\n", 4);
+                strcat(logs, "\r\n");
                 body_size -= log_size;
             }
         }
@@ -425,9 +425,9 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 16 + 4;
             if (body_size > log_size) {
-                strncat(logs, "Old md5sum was: ", 16);
+                strcat(logs, "Old md5sum was: ");
                 strncat(logs, json_field->valuestring, body_size);
-                strncat(logs, "\r\n", 4);
+                strcat(logs, "\r\n");
                 body_size -= log_size;
             }
         }
@@ -436,9 +436,9 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 15 + 4;
             if (body_size > log_size) {
-                strncat(logs, "New md5sum is: ", 15);
+                strcat(logs, "New md5sum is: ");
                 strncat(logs, json_field->valuestring, body_size);
-                strncat(logs, "\r\n", 4);
+                strcat(logs, "\r\n");
                 body_size -= log_size;
             }
         }
@@ -447,9 +447,9 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 17 + 4;
             if (body_size > log_size) {
-                strncat(logs, "Old sha1sum was: ", 17);
+                strcat(logs, "Old sha1sum was: ");
                 strncat(logs, json_field->valuestring, body_size);
-                strncat(logs, "\r\n", 4);
+                strcat(logs, "\r\n");
                 body_size -= log_size;
             }
         }
@@ -458,9 +458,9 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 16 + 4;
             if (body_size > log_size) {
-                strncat(logs, "New sha1sum is: ", 16);
+                strcat(logs, "New sha1sum is: ");
                 strncat(logs, json_field->valuestring, body_size);
-                strncat(logs, "\r\n", 4);
+                strcat(logs, "\r\n");
                 body_size -= log_size;
             }
         }
@@ -469,9 +469,9 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 19 + 4;
             if (body_size > log_size) {
-                strncat(logs, "Old sha256sum was: ", 19);
+                strcat(logs, "Old sha256sum was: ");
                 strncat(logs, json_field->valuestring, body_size);
-                strncat(logs, "\r\n", 4);
+                strcat(logs, "\r\n");
                 body_size -= log_size;
             }
         }
@@ -480,9 +480,9 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         if (json_field) {
             log_size = strlen(json_field->valuestring) + 18 + 4;
             if (body_size > log_size) {
-                strncat(logs, "New sha256sum is: ", 18);
+                strcat(logs, "New sha256sum is: ");
                 strncat(logs, json_field->valuestring, body_size);
-                strncat(logs, "\r\n", 4);
+                strcat(logs, "\r\n");
             }
         }
     }

--- a/src/shared/custom_output_search_replace.c
+++ b/src/shared/custom_output_search_replace.c
@@ -13,6 +13,8 @@
 
 char *searchAndReplace(const char *orig, const char *search, const char *value)
 {
+    assert(orig);
+
     char *p;
     const size_t orig_len = strlen(orig);
     const size_t search_len = strlen(search);
@@ -102,7 +104,7 @@ char *escape_newlines(const char *orig)
         ptr++;
     }
 
-    ret = (char *) malloc (size);
+    os_malloc (size, ret);
     ptr = orig;
     retptr = ret;
     while (*ptr) {

--- a/src/shared/custom_output_search_replace.c
+++ b/src/shared/custom_output_search_replace.c
@@ -13,8 +13,6 @@
 
 char *searchAndReplace(const char *orig, const char *search, const char *value)
 {
-    assert(orig);
-
     char *p;
     const size_t orig_len = strlen(orig);
     const size_t search_len = strlen(search);
@@ -40,7 +38,7 @@ char *searchAndReplace(const char *orig, const char *search, const char *value)
     /* Copy content before first match, if any */
     if (inx_start > 0) {
         total_bytes_allocated = inx_start + 1;
-        tmp = (char *) malloc(sizeof(char) * total_bytes_allocated);
+        os_malloc(sizeof(char) * total_bytes_allocated, tmp);
         strncpy(tmp, orig, inx_start);
         tmp_offset = inx_start;
     }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2459,7 +2459,7 @@ char ** wreaddir(const char * name) {
         return NULL;
     }
 
-    files = malloc(sizeof(char *));
+    os_malloc(sizeof(char *), files);
 
     while (dirent = readdir(dir), dirent) {
         // Skip "." and ".."

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2467,7 +2467,7 @@ char ** wreaddir(const char * name) {
             continue;
         }
 
-        files = realloc(files, (i + 2) * sizeof(char *));
+        os_realloc(files, (i + 2) * sizeof(char *), files);
         if(!files){
            merror_exit(MEM_ERROR, errno, strerror(errno));
         }

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -169,6 +169,9 @@ char * w_strtrim(char * string) {
 
 // Add a dynamic field with object nesting
 void W_JSON_AddField(cJSON *root, const char *key, const char *value) {
+
+    assert(key);
+
     cJSON *object;
     char *current;
     char *nest = strchr(key, '.');

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -170,8 +170,6 @@ char * w_strtrim(char * string) {
 // Add a dynamic field with object nesting
 void W_JSON_AddField(cJSON *root, const char *key, const char *value) {
 
-    assert(key);
-
     cJSON *object;
     char *current;
     char *nest = strchr(key, '.');
@@ -179,7 +177,7 @@ void W_JSON_AddField(cJSON *root, const char *key, const char *value) {
 
     if (nest) {
         length = nest - key;
-        current = malloc(length + 1);
+        os_malloc(length + 1, current);
         strncpy(current, key, length);
         current[length] = '\0';
 

--- a/src/shared/vector_op.c
+++ b/src/shared/vector_op.c
@@ -13,7 +13,8 @@
 
 W_Vector *W_Vector_init(int initialSize) {
 
-    W_Vector *v = malloc(sizeof(W_Vector));
+    W_Vector *v;
+    os_malloc(sizeof(W_Vector), v);
     v->vector = (char **)malloc(initialSize * sizeof(char *));
     v->used = 0;
     v->size = initialSize;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -300,12 +300,10 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
 
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
-    if (!_base_line && item->configuration & CHECK_SEECHANGES) {
+    if (!_base_line && strlen(file) > 0 && item->configuration & CHECK_SEECHANGES) {
         // The first backup is created. It should return NULL.
         char *file_changed = seechanges_addfile(file);
-        if (file_changed) {
-            os_free(file_changed);
-        }
+        os_free(file_changed);
     }
 
     if (json_event && _base_line && report) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -104,14 +104,6 @@ void fim_checker(char *path, fim_element *item, whodata_evt *w_evt, int report) 
     int node;
     int depth;
 
-#ifdef WIN_WHODATA
-    if (w_evt && w_evt->scan_directory == 1) {
-        if (w_update_sacl(path)) {
-            mdebug1(FIM_SCAL_NOREFRESH, path);
-            }
-        }
-#endif
-
     if (item->mode == FIM_SCHEDULED) {
         // If the directory have another configuration will come back
         if (node = fim_configuration_directory(path, "file"), node < 0 || item->index != node) {
@@ -171,6 +163,14 @@ void fim_checker(char *path, fim_element *item, whodata_evt *w_evt, int report) 
 
         return;
     }
+
+#ifdef WIN_WHODATA
+    if (w_evt && w_evt->scan_directory == 1) {
+        if (w_update_sacl(path)) {
+            mdebug1(FIM_SCAL_NOREFRESH, path);
+            }
+        }
+#endif
 
     if (HasFilesystem(path, syscheck.skip_fs)) {
         return;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -300,7 +300,7 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
 
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
-    if (!_base_line && strlen(file) > 0 && item->configuration & CHECK_SEECHANGES) {
+    if (!_base_line && item->configuration & CHECK_SEECHANGES) {
         // The first backup is created. It should return NULL.
         char *file_changed = seechanges_addfile(file);
         os_free(file_changed);
@@ -330,7 +330,7 @@ void fim_realtime_event(char *file) {
          * (and finding the file removed)
          */
         fim_rt_delay();
-      
+
         fim_element item = { .mode = FIM_REALTIME };
         fim_checker(file, &item, NULL, 1);
     }

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -569,12 +569,9 @@ int fim_db_process_read_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t
             if (fgets(line, sizeof(line), file->fd)) {
                 size_t len = strlen(line);
 
-                switch (line[len - 1]) {
-                case '\n':
+                if (len > 2 && line[len - 1] == '\n') {
                     line[len - 1] = '\0';
-                    break;
-
-                default:
+                } else {
                     merror("Temporary path file '%s' is corrupt: missing line end.", file->path);
                     continue;
                 }

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1275,7 +1275,7 @@ int get_volume_names() {
 }
 
 int get_drive_names(wchar_t *volume_name, char *device) {
-    char *convert_name;
+
     wchar_t *names = NULL;
     wchar_t *nameit = NULL;
     unsigned long char_count = MAX_PATH + 1;
@@ -1308,10 +1308,10 @@ int get_drive_names(wchar_t *volume_name, char *device) {
 
     if (success) {
         // Save information in FIM whodata structure
-        os_calloc(MAX_PATH, sizeof(char), convert_name);
+        char convert_name[MAX_PATH] = "";
 
         for (nameit = names; nameit[0] != L'\0'; nameit += wcslen(nameit) + 1) {
-            wcstombs(convert_name, nameit, strlen(nameit));
+            wcstombs(convert_name, nameit, sizeof(nameit));
             mdebug1(FIM_WHODATA_DEVICE_LETTER, device, convert_name);
 
             if(syscheck.wdata.device) {
@@ -1343,7 +1343,6 @@ int get_drive_names(wchar_t *volume_name, char *device) {
                 syscheck.wdata.drive[1] = NULL;
             }
         }
-        os_free(convert_name);
     }
     os_free(names);
 

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1311,7 +1311,7 @@ int get_drive_names(wchar_t *volume_name, char *device) {
         char convert_name[MAX_PATH] = "";
 
         for (nameit = names; nameit[0] != L'\0'; nameit += wcslen(nameit) + 1) {
-            wcstombs(convert_name, nameit, sizeof(nameit));
+            wcstombs(convert_name, nameit, wcslen(nameit));
             mdebug1(FIM_WHODATA_DEVICE_LETTER, device, convert_name);
 
             if(syscheck.wdata.device) {


### PR DESCRIPTION
### Coverity report

Fixed following defects reported by Coverity:
- Assign null values because variables didn't check before the assignment
- Assign values to pointers without memory allocated because it doesn't check if memory allocated.
- Insecure data handling

1. `/shared/string_op.c: 180 in W_JSON_AddField()`
```
>>>     CID 206123:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "current" when calling "strncpy".
180             strncpy(current, key, length);
```

2. `shared/custom_output_search_replace.c: 42 in searchAndReplace()`
```
>>>     CID 206122:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "tmp" when calling "strncpy".
42             strncpy(tmp, orig, inx_start);
```

3. `/shared/custom_output_search_replace.c: 123 in escape_newlines()`
```
>>>     CID 206121:    (NULL_RETURNS)
>>>     Dereferencing "retptr", which is known to be "NULL".
```

4. `/addagent/main.c: 19 in setenv()`
```
>>>     CID 206120:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "str" when calling "snprintf". [Note: The source code implementation of the function has been overridden by a builtin model.]
19         snprintf(str, len, "%s=%s", name, val);
```

5. `/shared/vector_op.c: 17 in W_Vector_init()`
```
14     W_Vector *W_Vector_init(int initialSize) {
15     
16         W_Vector *v = malloc(sizeof(W_Vector));
>>>     CID 206119:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing "v", which is known to be "NULL".
17         v->vector = (char **)malloc(initialSize * sizeof(char *));
18         v->used = 0;
19         v->size = initialSize;
20         return v;
21     }
```

6. `/config/wmodules-command.c: 85 in wm_command_read()`
```
>>>     CID 206118:    (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "command_tag" when calling "snprintf". [Note: The source code implementation of the function has been overridden by a builtin model.]
85                     snprintf(command_tag, command_tag_length, "%s:%s", WM_COMMAND_CONTEXT.name, command->tag);

>>>     CID 206118:    (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "command_tag" when calling "snprintf". [Note: The source code implementation of the function has been overridden by a builtin model.]
75                     snprintf(command_tag, command_tag_length, "%s", WM_COMMAND_CONTEXT.name);
```

7. `shared/file_op.c: 2477 in wreaddir()`
```
>>>     CID 206117:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing "files", which is known to be "NULL".
```

8. `/syscheckd/create_db.c: 295 in fim_file()`
```
>>>     CID 208488:  Insecure data handling  (TAINTED_SCALAR)
>>>     Passing tainted variable "file" to a tainted sink.
295             char *file_changed = seechanges_addfile(file);
```

9. `/syscheckd/create_db.c: 62 in fim_scan()`
```
>>>     CID 207874:  Insecure data handling  (TAINTED_SCALAR)
>>>     Passing tainted variable "syscheck.dir[it]" to a tainted sink.
62             fim_checker(syscheck.dir[it], item, NULL, 1);
```

10. `/logcollector/logcollector.c: 1816 in w_output_thread()`
```
1815                     while(1) {
>>>     CID 208405:  Resource leaks  (RESOURCE_LEAK)
>>>     Overwriting handle "logr_queue" in "logr_queue = StartMQ("/var/ossec/queue/ossec/queue", 2)" leaks the handle.
1816                         if(logr_queue = StartMQ(DEFAULTQPATH, WRITE), logr_queue > 0) {
1817                             if (SendMSGtoSCK(logr_queue, message->buffer, message->file, message->queue_mq, message->log_target) == 0) {
1818                                 minfo("Successfully reconnected to '%s'", DEFAULTQPATH);
1819                                 break;  //  We sent the message successfully, we can go on.
1820                             }
1821                         }
```

11.  `/os_auth/main-server.c: 954 in run_dispatcher()`
```
>>>     CID 208404:  Memory - corruptions  (OVERRUN)
>>>     Overrunning array ""any"" of 4 bytes by passing it to a function which accesses it at byte offset 45 using argument "46UL".
954                     memcpy(srcip,"any",IPSIZE);
```

12. `analysisd/decoders/security_configuration_assessment.c: 1526 in HandlePoliciesInfo()`
```
>>>     CID 204072:  Insecure data handling  (TAINTED_SCALAR)
>>>     Passing tainted variable "*policies_ids" to a tainted sink.
1526                     p_id = strtok_r(policies_ids, ",", &saveptr);
```


### Windows compilation warnings

Fixed following compilation warinings on Windows:
```
syscheckd/win_whodata.c: In function ‘get_drive_names’:
syscheckd/win_whodata.c:1314:51: warning: passing argument 1 of ‘strlen’ from incompatible pointer type [-Wincompatible-pointer-types]
             wcstombs(convert_name, nameit, strlen(nameit));
                                                   ^~~~~~
In file included from /usr/share/mingw-w64/include/io.h:10,
                 from /usr/share/mingw-w64/include/sys/stat.h:14,
                 from ./headers/shared.h:40,
                 from syscheckd/win_whodata.c:10:
/usr/share/mingw-w64/include/string.h:64:37: note: expected ‘const char *’ but argument is of type ‘wchar_t *’ {aka ‘short unsigned int *’}
   size_t __cdecl strlen(const char *_Str);
```

```
os_auth/main-client.c: In function ‘main’:
os_auth/main-client.c:412:5: warning: ‘strncat’ specified bound 1 equals source length [-Wstringop-overflow=]
     strncat(buf,"\n",1);
     ^~~~~~~~~~~~~~~~~~~
```
### Scan-build report

1. Memory leak in `addagent/main.c:15 setenv(...)`. Variable `str` doesn't free:
```c
static int setenv(const char *name, const char *val, __attribute__((unused)) int overwrite)
{
    int len = strlen(name) + strlen(val) + 2;
    char *str = (char *)malloc(len);
    snprintf(str, len, "%s=%s", name, val);
    putenv(str);
    return 0;
}
```

### Linux warning

```
os_integrator/integrator.c: In function ‘OS_IntegratorD’:
os_integrator/integrator.c:387:35: warning: ‘strncat’ specified bound 17 equals source length [-Wstringop-overflow=]
                 if (dbg_lvl <= 0) strncat(exec_full_cmd, " > /dev/null 2>&1", 17);
                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
os_maild/os_maild_client.c: In function ‘OS_RecvMailQ’:
os_maild/os_maild_client.c:70:13: warning: ‘strncat’ specified bound 16 equals source length [-Wstringop-overflow=]
             strncat(logs, "Old md5sum was: ", 16);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_maild/os_maild_client.c:79:13: warning: ‘strncat’ specified bound 16 equals source length [-Wstringop-overflow=]
             strncat(logs, "New md5sum is : ", 16);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_maild/os_maild_client.c:88:13: warning: ‘strncat’ specified bound 17 equals source length [-Wstringop-overflow=]
             strncat(logs, "Old sha1sum was: ", 17);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_maild/os_maild_client.c:97:13: warning: ‘strncat’ specified bound 17 equals source length [-Wstringop-overflow=]
             strncat(logs, "New sha1sum is : ", 17);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_maild/os_maild_client.c:106:13: warning: ‘strncat’ specified bound 19 equals source length [-Wstringop-overflow=]
             strncat(logs, "Old sha256sum was: ", 19);
```

### Test
  - [x] Compilation without warnings in Linux
  - [x] Compilation without warnings in Windows
  - [x] Scan-build report (Linux and Windows)
  - [ ] Coverity
