### PR TITLE
Fixed hard links

### DIFF
--- a/extensions/elasticsearch/6.x/wazuh-template.json
+++ b/extensions/elasticsearch/6.x/wazuh-template.json
@@ -139,6 +139,9 @@
               "type": "keyword",
               "doc_values": "true"
             },
+            "hard_links": {
+              "type": "keyword"
+            },
             "sha1_before": {
               "type": "keyword",
               "doc_values": "true"

--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -558,6 +558,9 @@
           "path": {
             "type": "keyword"
           },
+          "hard_links": {
+            "type": "keyword"
+          },
           "sha1_before": {
             "type": "keyword"
           },

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1055,7 +1055,7 @@ int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
      *   type:                  "event"
      *   data: {
      *     path:                string
-     *     hard_links:          string
+     *     hard_links:          array
      *     mode:                "scheduled"|"real-time"|"whodata"
      *     type:                "added"|"deleted"|"modified"
      *     timestamp:           number
@@ -1438,16 +1438,18 @@ static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
     char changed_attributes[OS_SIZE_256];
     snprintf(changed_attributes, OS_SIZE_256, "Changed attributes: %s\n", lf->fields[FIM_CHFIELDS].value);
 
-    cJSON *tmp = cJSON_Parse(lf->fields[FIM_HARD_LINKS].value);
-    cJSON *item;
-    char * hard_links_tmp = NULL;
-    cJSON_ArrayForEach(item, tmp) {
-        wm_strcat(&hard_links_tmp, item->valuestring, ',');
-    }
-
     char hard_links[OS_SIZE_256];
-    snprintf(hard_links, OS_SIZE_256, "Hard links: %s\n", hard_links_tmp);
-    os_free(hard_links_tmp);
+    cJSON *tmp = cJSON_Parse(lf->fields[FIM_HARD_LINKS].value);
+    if (lf->fields[FIM_HARD_LINKS].value) {
+        cJSON *item;
+        char * hard_links_tmp = NULL;
+        cJSON_ArrayForEach(item, tmp) {
+            wm_strcat(&hard_links_tmp, item->valuestring, ',');
+        }
+
+        snprintf(hard_links, OS_SIZE_256, "Hard links: %s\n", hard_links_tmp);
+        os_free(hard_links_tmp);
+    }
 
     snprintf(lf->full_log, OS_MAXSTR,
             "File '%.756s' %s\n"
@@ -1474,7 +1476,6 @@ static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
             //lf->fields[FIM_SYM_PATH].value
     );
 
-    cJSON_Delete(item);
     cJSON_Delete(tmp);
 
     return 0;

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -117,6 +117,7 @@ void sdb_init(_sdb *localsdb, OSDecoderInfo *fim_decoder) {
     os_calloc(Config.decoder_order_size, sizeof(char *), fim_decoder->fields);
     fim_decoder->fields[FIM_FILE] = "file";
     fim_decoder->fields[FIM_SIZE] = "size";
+    fim_decoder->fields[FIM_HARD_LINKS] = "hard_links";
     fim_decoder->fields[FIM_PERM] = "perm";
     fim_decoder->fields[FIM_UID] = "uid";
     fim_decoder->fields[FIM_GID] = "gid";
@@ -1054,6 +1055,7 @@ int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
      *   type:                  "event"
      *   data: {
      *     path:                string
+     *     hard_links:          string
      *     mode:                "scheduled"|"real-time"|"whodata"
      *     type:                "added"|"deleted"|"modified"
      *     timestamp:           number
@@ -1209,6 +1211,8 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
                 cJSON_ArrayForEach(item, object) {
                     wm_strcat(&lf->fields[FIM_CHFIELDS].value, item->valuestring, ',');
                 }
+            } else if (strcmp(object->string, "hard_links") == 0) {
+                lf->fields[FIM_HARD_LINKS].value = cJSON_PrintUnformatted(object);
             }
 
             break;
@@ -1274,6 +1278,7 @@ void fim_send_db_save(_sdb * sdb, const char * agent_id, cJSON * data) {
     cJSON_DeleteItemFromObject(data, "tags");
     cJSON_DeleteItemFromObject(data, "content_changes");
     cJSON_DeleteItemFromObject(data, "changed_attributes");
+    cJSON_DeleteItemFromObject(data, "hard_links");
     cJSON_DeleteItemFromObject(data, "old_attributes");
     cJSON_DeleteItemFromObject(data, "audit");
 
@@ -1433,12 +1438,25 @@ static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
     char changed_attributes[OS_SIZE_256];
     snprintf(changed_attributes, OS_SIZE_256, "Changed attributes: %s\n", lf->fields[FIM_CHFIELDS].value);
 
+    cJSON *tmp = cJSON_Parse(lf->fields[FIM_HARD_LINKS].value);
+    cJSON *item;
+    char * hard_links_tmp = NULL;
+    cJSON_ArrayForEach(item, tmp) {
+        wm_strcat(&hard_links_tmp, item->valuestring, ',');
+    }
+
+    char hard_links[OS_SIZE_256];
+    snprintf(hard_links, OS_SIZE_256, "Hard links: %s\n", hard_links_tmp);
+    os_free(hard_links_tmp);
+
     snprintf(lf->full_log, OS_MAXSTR,
             "File '%.756s' %s\n"
+            "%s"
             "Mode: %s\n"
             "%s"
             "%s%s%s%s%s%s%s%s%s%s%s%s",
             lf->fields[FIM_FILE].value, event_type,
+            lf->fields[FIM_HARD_LINKS].value ? hard_links : "",
             mode,
             lf->fields[FIM_CHFIELDS].value ? changed_attributes : "",
             change_size,
@@ -1455,6 +1473,9 @@ static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
             change_win_attributes
             //lf->fields[FIM_SYM_PATH].value
     );
+
+    cJSON_Delete(item);
+    cJSON_Delete(tmp);
 
     return 0;
 }

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -86,6 +86,7 @@ typedef struct _Eventinfo {
     /* SYSCHECK Results variables */
     syscheck_event_t event_type;
     char *filename;
+    char *hard_links;
     char *sk_tag;
     char *sym_path;
     char *perm_before;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -169,6 +169,10 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         cJSON_AddItemToObject(root, "syscheck", file_diff);
         cJSON_AddStringToObject(file_diff, "path", lf->filename);
 
+        if (lf->fields[FIM_HARD_LINKS].value && *lf->fields[FIM_HARD_LINKS].value) {
+            cJSON_AddItemToObject(file_diff, "hard_links", cJSON_Parse(lf->fields[FIM_HARD_LINKS].value));
+        }
+
         if (lf->sym_path && *lf->sym_path) {
             cJSON_AddStringToObject(file_diff, "symbolic_path", lf->sym_path);
         }

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -81,6 +81,7 @@
 /* Fields for rules */
 typedef enum fim_fields {
     FIM_FILE,
+    FIM_HARD_LINKS,
     FIM_SIZE,
     FIM_PERM,
     FIM_UID,

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -318,14 +318,8 @@ void fim_realtime_event(char *file) {
 
     // If the file exists, generate add or modify events.
     if (w_stat(file, &file_stat) >= 0) {
-
-#ifdef WIN32
         fim_element item = { .mode = FIM_REALTIME };
         fim_checker(file, &item, NULL, 1);
-#else
-        fim_audit_inode_event(file, FIM_REALTIME, NULL);
-#endif
-
     }
     else {
         // Otherwise, it could be a file deleted or a directory moved (or renamed).
@@ -340,14 +334,8 @@ void fim_whodata_event(whodata_evt * w_evt) {
 
     // If the file exists, generate add or modify events.
     if(w_stat(w_evt->path, &file_stat) >= 0) {
-
-#ifdef WIN32
         fim_element item = { .mode = FIM_WHODATA };
         fim_checker(w_evt->path, &item, w_evt, 1);
-#else
-        fim_audit_inode_event(w_evt->path, FIM_WHODATA, w_evt);
-#endif
-
     }
     // Otherwise, it could be a file deleted or a directory moved (or renamed).
     else {
@@ -369,14 +357,8 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
 
     // Exists, create event.
     if (saved_data) {
-
-#ifdef WIN32
         fim_element item = { .mode = mode };
         fim_checker(pathname, &item, w_evt, 1);
-#else
-        fim_audit_inode_event(pathname, mode, w_evt);
-#endif
-
         free_entry(saved_data);
         return;
     }
@@ -406,64 +388,6 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
                 merror(FIM_DB_ERROR_RM_RANGE, first_entry, last_entry);
             }
     }
-}
-
-
-void fim_audit_inode_event(char *file, fim_event_mode mode, whodata_evt * w_evt) {
-    struct fim_element *item;
-    char **paths = NULL;
-
-    w_mutex_lock(&syscheck.fim_entry_mutex);
-
-    if (mode == FIM_WHODATA) {
-        paths = fim_db_get_paths_from_inode(syscheck.database, atoi(w_evt->inode), atoi(w_evt->dev));
-    } else {
-        struct stat statbuf;
-        fim_entry *entry;
-        if (w_stat(file, &statbuf) < 0) {
-            entry = fim_db_get_path(syscheck.database, file);
-
-            if (entry) {
-                paths = fim_db_get_paths_from_inode(syscheck.database, entry->data->inode, entry->data->dev);
-                free_entry(entry);
-            }
-        } else {
-            paths = fim_db_get_paths_from_inode(syscheck.database, statbuf.st_ino, statbuf.st_dev);
-        }
-    }
-
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
-
-    os_calloc(1, sizeof(fim_element), item);
-    item->mode = mode;
-
-    if (paths && paths[0]) {
-        int i = 0;
-
-        // For add events we don't have the path saved.
-        if (!w_is_str_in_array(paths, file)) {
-            fim_checker(file, item, w_evt, 1);
-        }
-
-        // An alert is generated for each path with the same inode
-        for(i = 0; paths[i]; i++) {
-            struct fim_element *hard_link_items;
-
-            os_calloc(1, sizeof(fim_element), hard_link_items);
-            hard_link_items->mode = mode;
-            fim_checker(paths[i], hard_link_items, w_evt, 1);
-            os_free(paths[i]);
-            os_free(hard_link_items);
-        }
-    } else {
-        // Add events
-        fim_checker(file, item, w_evt, 1);
-    }
-
-    os_free(paths);
-    os_free(item);
-
-    return;
 }
 
 #ifdef WIN32
@@ -809,6 +733,29 @@ cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_da
     cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[mode]);
     cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[type]);
     cJSON_AddNumberToObject(data, "timestamp", new_data->last_event);
+
+#ifndef WIN32
+    if (old_data != NULL) {
+        char** paths = NULL;
+
+        paths = fim_db_get_paths_from_inode(syscheck.database, old_data->inode, old_data->dev);
+
+        if(paths[1]){
+            cJSON *hard_links = cJSON_CreateArray();
+            int i;
+            for(i = 0; paths[i]; i++) {
+                if(strcmp(file_name, paths[i])) {
+                    cJSON_AddItemToArray(hard_links, cJSON_CreateString(paths[i]));
+                }
+                os_free(paths[i]);
+            }
+            os_free(paths);
+
+            cJSON_AddItemToObject(data, "hard_links", hard_links);
+        }
+    }
+
+#endif
 
     cJSON_AddItemToObject(data, "attributes", fim_attributes_json(new_data));
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -747,7 +747,7 @@ cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_da
 
         paths = fim_db_get_paths_from_inode(syscheck.database, old_data->inode, old_data->dev);
 
-        if(paths[1]){
+        if(paths[0] && paths[1]){
             cJSON *hard_links = cJSON_CreateArray();
             int i;
             for(i = 0; paths[i]; i++) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -756,10 +756,13 @@ cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_da
                 }
                 os_free(paths[i]);
             }
-            os_free(paths);
 
             cJSON_AddItemToObject(data, "hard_links", hard_links);
+        } else {
+            os_free(paths[0]);
         }
+
+        os_free(paths);
     }
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4648|

## Description
When a hard link is modified, only an alert is generated for the modified file, and not for the linked file. 

Now, every time we modify a file that has hard links, the alert will be notified of the hard links associated with the file.

## Tests

The following configuration in the `ossec.conf` file:
``` xml
  <syscheck>
	<disabled>no</disabled>
        <frequency>30</frequency>
	<directories check_all="yes">/testdir</directories></syscheck>
  </syscheck>
```
We create a file in the monitored directory: 
``` bash
echo > /testdir/regular
```
And we created two hard links to that file:
``` python
import os
os.link("regular", "link0")
os.link("regular", "link1")
```
The following added alerts are generated:
```
** Alert 1582286456.520288: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 21 13:00:56 cabrera-Machine->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/testdir/regular' added
Mode: real-time

Attributes:
 - Size: 5
 - Permissions: rw-r--r--
 - Date: Fri Feb 21 13:00:38 2020
 - Inode: 5898242
 - User: root (0)
 - Group: root (0)
 - MD5: 916f4c31aaa35d6b867dae9a7f54270d
 - SHA1: 63bbfea82b8880ed33cdb762aa11fab722a90a24
 - SHA256: 133ee989293f92736301280c6f14c89d521200c17dcdcecca30cd20705332d44

** Alert 1582286549.520877: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 21 13:02:29 cabrera-Machine->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/testdir/link0' added
Mode: real-time

Attributes:
 - Size: 5
 - Permissions: rw-r--r--
 - Date: Fri Feb 21 13:00:38 2020
 - Inode: 5898242
 - User: root (0)
 - Group: root (0)
 - MD5: 916f4c31aaa35d6b867dae9a7f54270d
 - SHA1: 63bbfea82b8880ed33cdb762aa11fab722a90a24
 - SHA256: 133ee989293f92736301280c6f14c89d521200c17dcdcecca30cd20705332d44

** Alert 1582286549.521464: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 21 13:02:29 cabrera-Machine->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/testdir/link1' added
Mode: real-time

Attributes:
 - Size: 5
 - Permissions: rw-r--r--
 - Date: Fri Feb 21 13:00:38 2020
 - Inode: 5898242
 - User: root (0)
 - Group: root (0)
 - MD5: 916f4c31aaa35d6b867dae9a7f54270d
 - SHA1: 63bbfea82b8880ed33cdb762aa11fab722a90a24
 - SHA256: 133ee989293f92736301280c6f14c89d521200c17dcdcecca30cd20705332d44
```
And if we modified the file `regular`, an alert is generated for the modified file notifying of the hard links associated with it.
`alerts.log`:
```
** Alert 1582719677.150246: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Feb 26 13:21:17 cabrera-Machine->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/testdir1/regular' modified
Hard links: /testdir1/link0,/testdir1/link1
Mode: real-time
Changed attributes: size,mtime,md5,sha1,sha256
Size changed from '182' to '189'
Old modification time was: '1582719394', now it is '1582719677'
Old md5sum was: '9a2e8a683def07cfbc20b81e90cd1f4a'
New md5sum is : 'f7a440da2e0992dfaa7742153c268ac4'
Old sha1sum was: '6b155293c372f0ddf06033efad1fd3e2b331ee15'
New sha1sum is : 'cee50b670a8fc8352eceee186c8255f91b5cf49d'
Old sha256sum was: 'abc4c1621dd00bf63d916f4cef978c10f8729328a794eba1dd5e2d1750e45bc4'
New sha256sum is : '3acccbfb6f21c4ec5723f7b01d7924f7a2a5316abe92eb22a9499596ee559736'

Attributes:
 - Size: 189
 - Permissions: rw-r--r--
 - Date: Wed Feb 26 13:21:17 2020
 - Inode: 5898242
 - User: root (0)
 - Group: root (0)
 - MD5: f7a440da2e0992dfaa7742153c268ac4
 - SHA1: cee50b670a8fc8352eceee186c8255f91b5cf49d
 - SHA256: 3acccbfb6f21c4ec5723f7b01d7924f7a2a5316abe92eb22a9499596ee559736

```
`alerts.json`
```
{"timestamp":"2020-02-26T13:21:17.525+0100","rule":{"level":7,"description":"Integrity checksum changed.","id":"550","firedtimes":5,"mail":false,"groups":["ossec","syscheck"],"pci_dss":["11.5"],"gpg13":["4.11"],"gdpr":["II_5.1.f"],"hipaa":["164.312.c.1","164.312.c.2"],"nist_800_53":["SI.7"]},"agent":{"id":"000","name":"cabrera-Machine"},"manager":{"name":"cabrera-Machine"},"id":"1582719677.150246","full_log":"File '/testdir1/regular' modified\nHard links: /testdir1/link0,/testdir1/link1\nMode: real-time\nChanged attributes: size,mtime,md5,sha1,sha256\nSize changed from '182' to '189'\nOld modification time was: '1582719394', now it is '1582719677'\nOld md5sum was: '9a2e8a683def07cfbc20b81e90cd1f4a'\nNew md5sum is : 'f7a440da2e0992dfaa7742153c268ac4'\nOld sha1sum was: '6b155293c372f0ddf06033efad1fd3e2b331ee15'\nNew sha1sum is : 'cee50b670a8fc8352eceee186c8255f91b5cf49d'\nOld sha256sum was: 'abc4c1621dd00bf63d916f4cef978c10f8729328a794eba1dd5e2d1750e45bc4'\nNew sha256sum is : '3acccbfb6f21c4ec5723f7b01d7924f7a2a5316abe92eb22a9499596ee559736'\n","syscheck":{"path":"/testdir1/regular","hard_links":["/testdir1/link0","/testdir1/link1"],"size_before":"182","size_after":"189","perm_after":"rw-r--r--","uid_after":"0","gid_after":"0","md5_before":"9a2e8a683def07cfbc20b81e90cd1f4a","md5_after":"f7a440da2e0992dfaa7742153c268ac4","sha1_before":"6b155293c372f0ddf06033efad1fd3e2b331ee15","sha1_after":"cee50b670a8fc8352eceee186c8255f91b5cf49d","sha256_before":"abc4c1621dd00bf63d916f4cef978c10f8729328a794eba1dd5e2d1750e45bc4","sha256_after":"3acccbfb6f21c4ec5723f7b01d7924f7a2a5316abe92eb22a9499596ee559736","uname_after":"root","gname_after":"root","mtime_before":"2020-02-26T13:16:34","mtime_after":"2020-02-26T13:21:17","inode_after":5898242,"changed_attributes":["size","mtime","md5","sha1","sha256"],"event":"modified"},"decoder":{"name":"syscheck_integrity_changed"},"location":"syscheck"}
```
![imagen](https://user-images.githubusercontent.com/39765143/75343785-7be3f900-5899-11ea-8607-88d992125d4c.png)

`kibana`:
![imagen](https://user-images.githubusercontent.com/39765143/75343752-653da200-5899-11ea-91ea-3f6f34d14f41.png)

