### PR TITLE
FIM v2.0: Fix delete alerts for realtime and whodata modes

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -98,9 +98,6 @@ void fim_scan() {
 }
 
 void fim_checker(char *path, fim_element *item, whodata_evt *w_evt, int report) {
-    // SQLite Development
-    // fim_entry_data *saved_data;
-    cJSON *json_event = NULL;
     int node;
     int depth;
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -407,7 +407,7 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
 
     if (files && files->elements) {
         if (fim_db_process_missing_entry(syscheck.database, files, &syscheck.fim_entry_mutex,
-            syscheck.database_store, mode) != FIMDB_OK) {
+            syscheck.database_store, mode, w_evt) != FIMDB_OK) {
                 merror(FIM_DB_ERROR_RM_RANGE, first_entry, last_entry);
             }
     }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -147,7 +147,8 @@ void fim_checker(char *path, fim_element *item, whodata_evt *w_evt, int report) 
 
         if (saved_entry) {
             json_event = fim_json_event(path, NULL, saved_entry->data, item->index, FIM_DELETE, item->mode, w_evt);
-            fim_db_remove_path(syscheck.database, saved_entry, &syscheck.fim_entry_mutex, (void *) (int) 0);
+            fim_db_remove_path(syscheck.database, saved_entry, &syscheck.fim_entry_mutex, (void *) (int) false,
+                                (void *) (fim_event_mode) item->mode, (void *) w_evt);
             free_entry(saved_entry);
             saved_entry = NULL;
         }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -156,19 +156,11 @@ void fim_checker(char *path, fim_element *item, whodata_evt *w_evt, int report) 
         w_mutex_unlock(&syscheck.fim_entry_mutex);
 
         if (saved_entry) {
-            json_event = fim_json_event(path, NULL, saved_entry->data, item->index, FIM_DELETE, item->mode, w_evt);
-            fim_db_remove_path(syscheck.database, saved_entry, &syscheck.fim_entry_mutex, (void *) (int) false,
+            fim_db_remove_path(syscheck.database, saved_entry, &syscheck.fim_entry_mutex, (void *) (int) true,
                                 (void *) (fim_event_mode) item->mode, (void *) w_evt);
             free_entry(saved_entry);
             saved_entry = NULL;
         }
-
-        if (json_event && report) {
-            char *json_formated = cJSON_PrintUnformatted(json_event);
-            send_syscheck_msg(json_formated);
-            os_free(json_formated);
-        }
-        cJSON_Delete(json_event);
 
         return;
     }

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -551,12 +551,6 @@ int fim_db_process_missing_entry(fdb_t *fim_sql, fim_tmp_file *file, pthread_mut
                                     (void *) true, (void *) (fim_event_mode) mode, (void *) w_evt);
 }
 
-
-/* 
-     TODO:
-         - Move mode, w_evt and send_alert to an array to not send so many unused variables to
-         the functions that don't need them.
-  */
 int fim_db_process_read_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex,
     void (*callback)(fdb_t *, fim_entry *, pthread_mutex_t *, void *, void *, void *),
     int storage, void * alert, void * mode, void * w_evt) {

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -186,11 +186,12 @@ static int fim_db_create_file(const char *path, const char *source, const int st
  * @param mutex
  * @param storage 1 Store database in memory, disk otherwise.
  * @param callback Function to call within a step.
- * @param args Adicional arguments for callback function.
+ * @param mode FIM mode for callback function.
+ * @param w_evt Whodata information for callback function.
  *
  */
  static int fim_db_process_read_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex,
-        void (*callback)(fdb_t *, fim_entry *, pthread_mutex_t *, void *), int storage, void * arg);
+        void (*callback)(fdb_t *, fim_entry *, pthread_mutex_t *, void *), int storage, void * mode, void * w_evt);
 
 
 /**
@@ -528,27 +529,29 @@ int fim_db_exec_simple_wquery(fdb_t *fim_sql, const char *query) {
 }
 
 int fim_db_sync_path_range(fdb_t * fim_sql, pthread_mutex_t *mutex, fim_tmp_file *file, int storage) {
-    return fim_db_process_read_file(fim_sql, file, mutex, fim_db_callback_sync_path_range,
-            storage, (void *) (int) 0);
+    return fim_db_process_read_file(fim_sql, file, mutex, fim_db_callback_sync_path_range, storage,
+                                    (void *) (int) 0, (void *) (int) 0);
 }
 
 int fim_db_delete_not_scanned(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage) {
-    return fim_db_process_read_file(fim_sql, file, mutex, fim_db_remove_path,
-            storage, (void *) (int) 1);
+    return fim_db_process_read_file(fim_sql, file, mutex, fim_db_process_path, storage,
+                                    (void *) (int) FIM_SCHEDULED, (void *) (int) 0);
 }
 
 int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage) {
-    return fim_db_process_read_file(fim_sql, file, mutex, fim_db_remove_path,
-            storage, (void *) (int) 0);
+    return fim_db_process_read_file(fim_sql, file, mutex, fim_db_process_path, storage,
+                                    (void *) (int) FIM_SCHEDULED, (void *) (int) 0);
 }
 
-int fim_db_process_missing_entry(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage, fim_event_mode mode) {
-    return fim_db_process_read_file(fim_sql, file, mutex, fim_db_process_path, storage, (void *) (fim_event_mode) mode);
+int fim_db_process_missing_entry(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage,
+                                    fim_event_mode mode, whodata_evt * w_evt) {
+    return fim_db_process_read_file(fim_sql, file, mutex, fim_db_process_path, storage, (void *) (fim_event_mode) mode,
+                                    (void *) (whodata_evt) * w_evt);
 }
 
 int fim_db_process_read_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex,
     void (*callback)(fdb_t *, fim_entry *, pthread_mutex_t *, void *),
-    int storage, void * arg) {
+    int storage, void * mode, void * w_evt) {
 
     char line[PATH_MAX + 1];
     char *path = NULL;
@@ -587,7 +590,7 @@ int fim_db_process_read_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t
             fim_entry *entry = fim_db_get_path(fim_sql, path);
             w_mutex_unlock(mutex);
             if (entry != NULL) {
-                callback(fim_sql, entry, mutex, arg);
+                callback(fim_sql, entry, mutex, mode, w_evt);
                 free_entry(entry);
             }
             os_free(path);
@@ -1059,9 +1062,9 @@ end:
 }
 
 void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
-     __attribute__((unused))void *arg) {
+     __attribute__((unused))void *alert, void *fim_ev_mode, void *w_evt) {
 
-    int *alert = (int *) arg;
+    int *alert = (int *) alert;
     int rows = 0;
 
     w_mutex_lock(mutex);
@@ -1103,6 +1106,8 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
 
 
     if (alert && rows >= 1) {
+        fim_event_mode mode = (fim_event_mode) fim_ev_mode;
+        whodata_evt whodata = (whodata_evt) w_evt;
         cJSON * json_event      = NULL;
         char * json_formated    = NULL;
         int pos = 0;
@@ -1115,7 +1120,7 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
         }
 
         json_event = fim_json_event(entry->path, NULL, entry->data, pos,
-                                                FIM_DELETE, FIM_SCHEDULED, NULL);
+                                                FIM_DELETE, fim_ev_mode, w_evt);
 
         if (!strcmp(FIM_ENTRY_TYPE[entry->data->entry_type], "file") &&
             syscheck.opts[pos] & CHECK_SEECHANGES) {
@@ -1138,33 +1143,39 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
         w_mutex_unlock(mutex);
 }
 
-void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex, void *arg) {
+void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex, void *fim_ev_mode, void *w_evt) {
 
-    fim_event_mode mode = (fim_event_mode) arg;
+    fim_event_mode mode = (fim_event_mode) fim_ev_mode;
     int conf_file = fim_configuration_directory(entry->path, "file");
 
     switch (mode) {
+        /*
+            Don't send alert if received mode and mode in configuration aren't the same
+        */
 
         case FIM_REALTIME:
             if (!(syscheck.opts[conf_file] & REALTIME_ACTIVE)){
+                fim_db_remove_path(fim_sql, entry, mutex, (void *) (int) false, (void *) mode, w_evt);
                 return;
             }
             break;
 
         case FIM_WHODATA:
             if (!(syscheck.opts[conf_file] & WHODATA_ACTIVE)) {
+                fim_db_remove_path(fim_sql, entry, mutex, (void *) (int) false, (void *) mode, w_evt);
                 return;
             }
             break;
 
         case FIM_SCHEDULED:
             if (!(syscheck.opts[conf_file] & SCHEDULED_ACTIVE)) {
+                fim_db_remove_path(fim_sql, entry, mutex, (void *) (int) false, (void *) mode, w_evt);
                 return;
             }
             break;
     }
 
-    fim_db_remove_path(fim_sql, entry, mutex, (void *) (int) 1);
+    fim_db_remove_path(fim_sql, entry, mutex, (void *) (int) true, (void *) mode, w_evt);
 }
 
 int fim_db_get_row_path(fdb_t * fim_sql, int mode, char **path) {
@@ -1230,7 +1241,8 @@ void fim_db_callback_save_path(__attribute__((unused))fdb_t * fim_sql, fim_entry
 }
 
 void fim_db_callback_sync_path_range(__attribute__((unused))fdb_t *fim_sql, fim_entry *entry,
-    __attribute__((unused))pthread_mutex_t *mutex, __attribute__((unused))void *args) {
+    __attribute__((unused))pthread_mutex_t *mutex, __attribute__((unused))void *mode,
+    __attribute__((unused))void *w_event) {
 
     cJSON * entry_data = fim_entry_json(entry->path, entry->data);
     char * plain = dbsync_state_msg("syscheck", entry_data);

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -220,11 +220,16 @@ int fim_db_get_count_range(fdb_t *fim_sql, char *start, char *top, int *counter)
  * @param fim_sql FIM database struct.
  * @param file_path File path.
  * @param mutex
- * @param arg 0 No send alert, 1 send delete alert.
+ * @param alert False don't send alert, True send delete alert.
+ * @param fim_ev_mode FIM Mode (scheduled/realtime/whodata)
+ * @param w_evt Whodata information
+ * 
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
 void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
-                         __attribute__((unused))void *arg);
+                        __attribute__((unused))void *alert,
+                        __attribute__((unused))void *fim_ev_mode,
+                        __attribute__((unused))void *w_evt);
 
 /**
  * @brief Process missing entries
@@ -232,9 +237,11 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
  * @param fim_sql FIM database struct.
  * @param file_path File path.
  * @param mutex
- * @param arg Directory configuration.
+ * @param fim_ev_mode Directory configuration.
+ * @param w_evt Whodata information.
+ * 
  */
-void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex, void *arg);
+void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex, void *fim_ev_mode, void *w_evt);
 
 /**
  * @brief Get the last/first row from entry_path.

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -232,18 +232,6 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
                         __attribute__((unused))void *w_evt);
 
 /**
- * @brief Process missing entries
- *
- * @param fim_sql FIM database struct.
- * @param file_path File path.
- * @param mutex
- * @param fim_ev_mode Directory configuration.
- * @param w_evt Whodata information.
- * 
- */
-void fim_db_process_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex, void *fim_ev_mode, void *w_evt);
-
-/**
  * @brief Get the last/first row from entry_path.
  *
  * @param mode FIM_FIRST_ROW or FIM_LAST_ROW.
@@ -299,8 +287,8 @@ void fim_db_callback_save_path(fdb_t *fim_sql, fim_entry *entry, int storage, vo
  * @param w_event Unused argument.
  */
 void fim_db_callback_sync_path_range(__attribute__((unused))fdb_t *fim_sql, fim_entry *entry,
-    __attribute__((unused))pthread_mutex_t *mutex, __attribute__((unused))void *mode,
-    __attribute__((unused))void *w_event);
+    __attribute__((unused))pthread_mutex_t *mutex, __attribute__((unused))void *alert,
+    __attribute__((unused))void *mode, __attribute__((unused))void *w_event);
 
 /**
  * @brief Delete not scanned entries from database.

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -288,10 +288,12 @@ void fim_db_callback_save_path(fdb_t *fim_sql, fim_entry *entry, int storage, vo
  * @param fim_sql FIM database struct.
  * @param entry Entry data to be inserted.
  * @param mutex FIM database's mutex for thread synchronization.
- * @param args  Unused arguments.
+ * @param mode  Unused argument.
+ * @param w_event Unused argument.
  */
 void fim_db_callback_sync_path_range(__attribute__((unused))fdb_t *fim_sql, fim_entry *entry,
-    __attribute__((unused))pthread_mutex_t *mutex, __attribute__((unused))void *args);
+    __attribute__((unused))pthread_mutex_t *mutex, __attribute__((unused))void *mode,
+    __attribute__((unused))void *w_event);
 
 /**
  * @brief Delete not scanned entries from database.
@@ -342,12 +344,15 @@ int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file,
  * @param file  Structure of the file which contains all the paths.
  * @param mutex
  * @param storage 1 Store database in memory, disk otherwise.
+ * @param mode FIM mode (scheduled, realtime or whodata)
+ * @param w_evt Whodata information
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
 int fim_db_process_missing_entry(fdb_t *fim_sql, fim_tmp_file *file,
                                  pthread_mutex_t *mutex, int storage,
-                                 fim_event_mode mode);
+                                 fim_event_mode mode,
+                                 whodata_evt * w_evt);
 
 /**
  * @brief Get count of all entries in entry_data table.

--- a/src/unit_tests/test_fim_db.c
+++ b/src/unit_tests/test_fim_db.c
@@ -1226,113 +1226,6 @@ void test_fim_db_remove_path_failed_path(void **state) {
 }
 
 /*----------------------------------------------*/
-/*----------fim_db_process_path()------------------*/
-void test_fim_db_process_path_realtime_active(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-
-    will_return(__wrap_fim_configuration_directory, 3);
-
-    // Inside fim_db_remove_path()
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_ROW);
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 0);
-    expect_value(__wrap_sqlite3_column_int, iCol, 1);
-    will_return(__wrap_sqlite3_column_int, 1);
-    wraps_fim_db_check_transaction();
-
-    time_t last_commit =  test_data->fim_sql->transaction.last_commit;
-
-    fim_db_process_path(test_data->fim_sql, test_data->entry, &syscheck.fim_entry_mutex, (void *) FIM_REALTIME);
-
-    assert_int_not_equal(last_commit, test_data->fim_sql->transaction.last_commit);
-}
-
-void test_fim_db_process_path_realtime_not_active(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-
-    will_return(__wrap_fim_configuration_directory, 0);
-
-    time_t last_commit =  test_data->fim_sql->transaction.last_commit;
-
-    fim_db_process_path(test_data->fim_sql, test_data->entry, &syscheck.fim_entry_mutex, (void *) FIM_REALTIME);
-
-    assert_int_equal(last_commit, test_data->fim_sql->transaction.last_commit);
-}
-
-void test_fim_db_process_path_whodata_active(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-
-    will_return(__wrap_fim_configuration_directory, 0);
-
-    // Inside fim_db_remove_path()
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_ROW);
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 0);
-    expect_value(__wrap_sqlite3_column_int, iCol, 1);
-    will_return(__wrap_sqlite3_column_int, 1);
-    wraps_fim_db_check_transaction();
-
-    time_t last_commit =  test_data->fim_sql->transaction.last_commit;
-
-    fim_db_process_path(test_data->fim_sql, test_data->entry, &syscheck.fim_entry_mutex, (void *) FIM_WHODATA);
-
-    assert_int_not_equal(last_commit, test_data->fim_sql->transaction.last_commit);
-}
-
-void test_fim_db_process_path_whodata_not_active(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-
-    will_return(__wrap_fim_configuration_directory, 3);
-
-    time_t last_commit =  test_data->fim_sql->transaction.last_commit;
-
-    fim_db_process_path(test_data->fim_sql, test_data->entry, &syscheck.fim_entry_mutex, (void *) FIM_WHODATA);
-
-    assert_int_equal(last_commit, test_data->fim_sql->transaction.last_commit);
-}
-
-void test_fim_db_process_path_scheduled_active(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-
-    will_return(__wrap_fim_configuration_directory, 6);
-
-    // Inside fim_db_remove_path()
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_ROW);
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 0);
-    expect_value(__wrap_sqlite3_column_int, iCol, 1);
-    will_return(__wrap_sqlite3_column_int, 1);
-    wraps_fim_db_check_transaction();
-
-    time_t last_commit =  test_data->fim_sql->transaction.last_commit;
-
-    fim_db_process_path(test_data->fim_sql, test_data->entry, &syscheck.fim_entry_mutex, (void *) FIM_SCHEDULED);
-
-    assert_int_not_equal(last_commit, test_data->fim_sql->transaction.last_commit);
-}
-
-void test_fim_db_process_path_scheduled_not_active(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-
-    will_return(__wrap_fim_configuration_directory, 0);
-
-    time_t last_commit =  test_data->fim_sql->transaction.last_commit;
-
-    fim_db_process_path(test_data->fim_sql, test_data->entry, &syscheck.fim_entry_mutex, (void *) FIM_SCHEDULED);
-
-    assert_int_equal(last_commit, test_data->fim_sql->transaction.last_commit);
-}
-
-/*----------------------------------------------*/
 /*----------fim_db_get_path()------------------*/
 void test_fim_db_get_path_inexistent(void **state) {
     test_fim_db_insert_data *test_data = *state;
@@ -2128,7 +2021,7 @@ void test_fim_db_process_missing_entry(void **state) {
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     wraps_fim_db_decode_full_row();
 
-    // Inside fim_db_process_path()
+    // Inside fim_db_remove_path()
     will_return(__wrap_fim_configuration_directory, 3);
 
     // Inside fim_db_remove_path (callback)
@@ -2498,13 +2391,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_db_remove_path_multiple_entry, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_remove_path_multiple_entry_step_fail, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_remove_path_failed_path, test_fim_db_setup, test_fim_db_teardown),
-        // fim_db_process_path
-        cmocka_unit_test_setup_teardown(test_fim_db_process_path_realtime_active, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_process_path_realtime_not_active, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_process_path_whodata_active, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_process_path_whodata_not_active, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_process_path_scheduled_active, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_process_path_scheduled_not_active, test_fim_db_setup, test_fim_db_teardown),
         // fim_db_get_path
         cmocka_unit_test_setup_teardown(test_fim_db_get_path_inexistent, test_fim_db_setup, test_fim_db_entry_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_get_path_existent, test_fim_db_setup, test_fim_db_entry_teardown),


### PR DESCRIPTION
| Related issue  |
|---------------|
| #4663             |

## Description

Modified callback functions' headers and parametrized the deletion of folders to check `FIM MODE` and `whodata information`.

Closes #4663.

## Logs/Alerts example

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer
