### PR TITLE
Switch warning about invalid registry key to debug.

### DIFF
--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -317,7 +317,7 @@ void os_winreg_check()
 
         rk = os_winreg_sethkey(syscheck.registry[i].entry);
         if (sub_tree == NULL) {
-            mwarn(FIM_INV_REG, syscheck.registry[i].entry, syscheck.registry[i].arch == ARCH_64BIT ? "[x64] " : "[x32]");
+            mdebug1(FIM_INV_REG, syscheck.registry[i].entry, syscheck.registry[i].arch == ARCH_64BIT ? "[x64] " : "[x32]");
             *syscheck.registry[i].entry = '\0';
             i++;
             continue;


### PR DESCRIPTION
|Related issue|
|---|
|#4636|

This FIM configuration:

```xml
<syscheck>
  <windows_registry>HKEY_CURRENT_USER\Console</windows_registry>
</syscheck
```

Produced this warning log:

```
2020/02/26 15:06:36 ossec-agent: DEBUG: (6919): Invalid syscheck registry entry: 'HKEY_CURRENT_USER\Console' arch: '[x32]'.
```
## Cause

This warning appeared when the defined key exists but it's not reflected in the 32-bit architecture.

## Proposed change

Switch this message to level-1 debug:
```
2020/02/26 15:08:24 ossec-agent[4868] win-registry.c:320 at os_winreg_check(): DEBUG: (6919): Invalid syscheck registry entry: 'HKEY_CURRENT_USER\Console' arch: '[x32]'.
```

## Tests

- [X] Compile agent for Windows.
- [X] Source installation: replace `ossec-agent-eventchannel.exe`.
- [X] Check that the message appears as debug log.