### PR TITLE
Avoid following symbolic links in realtime when follow_symbolic_link setting is disabled

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -56,7 +56,7 @@ void fim_scan() {
         item->index = it;
 #ifndef WIN32
         if (syscheck.opts[it] & REALTIME_ACTIVE) {
-            realtime_adddir(syscheck.dir[it], 0);
+            realtime_adddir(syscheck.dir[it], 0, (syscheck.opts[it] & CHECK_FOLLOW) ? 1 : 0);
         }
 #endif
         fim_checker(syscheck.dir[it], item, NULL, 1);
@@ -188,7 +188,7 @@ void fim_checker(char *path, fim_element *item, whodata_evt *w_evt, int report) 
     case FIM_DIRECTORY:
 #ifndef WIN32
         if (item->configuration & REALTIME_ACTIVE) {
-            realtime_adddir(path, 0);
+            realtime_adddir(path, 0, (item->configuration & CHECK_FOLLOW) ? 1 : 0);
         }
 #endif
         fim_directory(path, item, w_evt, report);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -309,11 +309,11 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
         // Directories in Windows configured with real-time add recursive watches
         for (int i = 0; syscheck.dir[i]; i++) {
             if (syscheck.opts[i] & REALTIME_ACTIVE) {
-                realtime_adddir(syscheck.dir[i], 0);
+                realtime_adddir(syscheck.dir[i], 0, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0);
             }
 
             if (syscheck.opts[i] & WHODATA_ACTIVE) {
-                realtime_adddir(syscheck.dir[i], i + 1);
+                realtime_adddir(syscheck.dir[i], i + 1, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0);
             }
         }
 #endif
@@ -398,7 +398,7 @@ int fim_whodata_initialize() {
 
     for (int i = 0; syscheck.dir[i]; i++) {
         if (syscheck.opts[i] & WHODATA_ACTIVE) {
-            realtime_adddir(syscheck.dir[i], i + 1);
+            realtime_adddir(syscheck.dir[i], i + 1, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0);
         }
     }
 
@@ -652,7 +652,7 @@ static void fim_link_silent_scan(char *path, int pos) {
     item->mode = FIM_SCHEDULED;
 
     if (syscheck.opts[pos] & REALTIME_ACTIVE) {
-        realtime_adddir(path, 0);
+        realtime_adddir(path, 0, (syscheck.opts[pos] & CHECK_FOLLOW) ? 1 : 0);
     }
 
     fim_checker(path, item, NULL, 0);
@@ -698,7 +698,7 @@ void set_whodata_mode_changes() {
             // At this point the directories in whodata mode that have been deconfigured are added to realtime
             syscheck.wdata.dirs_status[i].status &= ~WD_CHECK_REALTIME;
             syscheck.opts[i] |= REALTIME_ACTIVE;
-            if (realtime_adddir(syscheck.dir[i], 0) != 1) {
+            if (realtime_adddir(syscheck.dir[i], 0, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0) != 1) {
                 merror(FIM_ERROR_REALTIME_ADDDIR_FAILED, syscheck.dir[i]);
             } else {
                 mdebug1(FIM_REALTIME_MONITORING, syscheck.dir[i]);

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -50,7 +50,7 @@ int realtime_start()
 }
 
 /* Add a directory to real time checking */
-int realtime_adddir(const char *dir, __attribute__((unused)) int whodata)
+int realtime_adddir(const char *dir, __attribute__((unused)) int whodata, __attribute__((unused))int followsl)
 {
     if (whodata && audit_thread_active) {
         // Save dir into saved rules list
@@ -75,7 +75,7 @@ int realtime_adddir(const char *dir, __attribute__((unused)) int whodata)
 
             wd = inotify_add_watch(syscheck.realtime->fd,
                                    dir,
-                                   REALTIME_MONITOR_FLAGS);
+                                   (0 == followsl) ? (REALTIME_MONITOR_FLAGS|IN_DONT_FOLLOW) : REALTIME_MONITOR_FLAGS);
             if (wd < 0) {
                 if (errno == 28) {
                     merror(FIM_ERROR_INOTIFY_ADD_MAX_REACHED, dir, wd, errno);
@@ -337,7 +337,7 @@ int realtime_win32read(win32rtfim *rtlocald)
 }
 
 // In Windows the whodata parameter contains the directory position + 1 to be able to reference it
-int realtime_adddir(const char *dir, int whodata)
+int realtime_adddir(const char *dir, int whodata, int followsl)
 {
     char wdchar[260 + 1];
     win32rtfim *rtlocald;
@@ -449,7 +449,7 @@ int realtime_start()
     return (0);
 }
 
-int realtime_adddir(__attribute__((unused)) const char *dir, __attribute__((unused))int whodata)
+int realtime_adddir(__attribute__((unused)) const char *dir, __attribute__((unused))int whodata, __attribute__((unused))int followsl)
 {
     return (0);
 }

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -326,9 +326,10 @@ int realtime_start(void);
  *
  * @param dir Path to file or directory
  * @param whodata If the path is configured with whodata option
+ * @param followsl If the path is configured with follow sym link option
  * @return 0 on success, -1 on error
  */
-int realtime_adddir(const char *dir, int whodata) __attribute__((nonnull(1)));
+int realtime_adddir(const char *dir, int whodata, int followsl) __attribute__((nonnull(1)));
 
 /**
  * @brief Process events in the real time queue

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -1191,7 +1191,7 @@ void * audit_main(int *audit_sock) {
                 syscheck.opts[pos] &= ~ WHODATA_ACTIVE;
                 syscheck.opts[pos] |= REALTIME_ACTIVE;
 
-                realtime_adddir(path, 0);
+                realtime_adddir(path, 0, (syscheck.opts[pos] & CHECK_FOLLOW) ? 1 : 0);
             }
             os_free(path);
         }

--- a/src/unit_tests/test_create_db.c
+++ b/src/unit_tests/test_create_db.c
@@ -161,7 +161,7 @@ int __wrap_closedir() {
     return 1;
 }
 
-int __wrap_realtime_adddir(const char *dir, __attribute__((unused)) int whodata)
+int __wrap_realtime_adddir(const char *dir, __attribute__((unused)) int whodata, __attribute__((unused))int followsl)
 {
     check_expected(dir);
 

--- a/src/unit_tests/test_run_realtime.c
+++ b/src/unit_tests/test_run_realtime.c
@@ -211,7 +211,7 @@ void test_realtime_adddir_whodata(void **state) {
     expect_string(__wrap_W_Vector_insert_unique, element, "/etc/folder");
     will_return(__wrap_W_Vector_insert_unique, 1);
 
-    ret = realtime_adddir(path, 1);
+    ret = realtime_adddir(path, 1, 0);
 
     assert_int_equal(ret, 1);
 }
@@ -226,7 +226,7 @@ void test_realtime_adddir_realtime_failure(void **state)
 
     syscheck.realtime->fd = -1;
 
-    ret = realtime_adddir(path, 0);
+    ret = realtime_adddir(path, 0), 0;
 
     assert_int_equal(ret, -1);
 }
@@ -244,7 +244,7 @@ void test_realtime_adddir_realtime_add(void **state)
     will_return(__wrap_OSHash_Get_ex, 0);
     will_return(__wrap_OSHash_Add_ex, 1);
 
-    ret = realtime_adddir(path, 0);
+    ret = realtime_adddir(path, 0, 0);
 
     assert_int_equal(ret, 1);
 }
@@ -262,7 +262,7 @@ void test_realtime_adddir_realtime_update(void **state)
     will_return(__wrap_OSHash_Get_ex, 1);
     will_return(__wrap_OSHash_Update_ex, 1);
 
-    ret = realtime_adddir(path, 0);
+    ret = realtime_adddir(path, 0, 0);
 
     assert_int_equal(ret, 1);
 }
@@ -282,7 +282,7 @@ void test_realtime_adddir_realtime_update_failure(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Unable to update 'dirtb'. Directory not found: '/etc/folder'");
 
-    ret = realtime_adddir(path, 0);
+    ret = realtime_adddir(path, 0, 0);
 
     assert_int_equal(ret, -1);
 }


### PR DESCRIPTION
|Related issue|
|---|
|[4671](https://github.com/wazuh/wazuh/issues/4671)|

## Description

When the `follow_symbolic_link` option is disabled, it shouldn't follow the symbolic links and shouldn't monitor the content of the folders where the links are pointing to.

The issue being fixed here is, even having this setting disabled if the realtime setting is enabled over the same directory, the symbolic links are followed. This PR fixes this behavior in order to don't follow the links.

## Configuration options

No new configurations.

## Logs/Alerts example

No new logs.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities