### PR TITLE
Fix segmentation fault in Fluent Forwarder module

### DIFF
--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -783,7 +783,7 @@ void wm_fluent_poll_server(wm_fluent_t * fluent) {
 
     // Peek connection
 
-    switch (SSL_read(fluent->ssl, buffer, sizeof(buffer))) {
+    switch (fluent->shared_key ? SSL_read(fluent->ssl, buffer, sizeof(buffer)) : recv(fluent->client_sock, buffer, sizeof(buffer), 0)) {
     case -1:
         // No input data. This is the normal case.
         break;


### PR DESCRIPTION
This PR is related but **does not close** issue #4673.

## Configuration

```xml
<fluent-forward>
  <enabled>yes</enabled>
  <poll_interval>5</poll_interval>
  <tag>debug.logcollector</tag>
  <socket_path>/var/run/fluent.sock</socket_path>
  <address>localhost</address>
  <port>24224</port>
</fluent-forward>
```

## Stack trace

```
#0  0x00007ffff730754a in ssl_read_internal () from libwazuhext.so
#1  0x00007ffff73076a5 in SSL_read () from libwazuhext.so
#2  0x000000000043f6fe in wm_fluent_poll_server (fluent=0x6ae230) at wazuh_modules/wm_fluent.c:786
#3  0x000000000043d190 in wm_fluent_main (fluent=0x6ae230) at wazuh_modules/wm_fluent.c:116
#4  0x00007ffff6fcc2de in start_thread () from /lib64/libpthread.so.0
#5  0x00007ffff6cfd133 in clone () from /lib64/libc.so.6
```

## Fix

Fluent Forwarder must call `SSL_read` if and only if SSL is enabled. Otherwise, it must call `read` to poll the connection.

## Tests

- [X] Compile agent for Linux.
- [X] Check that Modulesd issue does not crash after this fix.
- [X] Run _wazuh-modulesd_ on Valgrind.
- [X] Stress test: Logcollector - Fluent Forwarder - Fluentd.

### Valgrind report

```
==1480== HEAP SUMMARY:
==1480==     in use at exit: 67,343 bytes in 18 blocks
==1480==   total heap usage: 4,661 allocs, 4,643 frees, 379,214 bytes allocated
==1480==
==1480== 96 bytes in 1 blocks are definitely lost in loss record 12 of 17
==1480==    at 0x4C30EDB: malloc (vg_replace_malloc.c:309)
==1480==    by 0x5CD70E4: __libc_alloc_buffer_allocate (in /usr/lib64/libc-2.28.so)
==1480==    by 0x5D6C509: __resolv_conf_allocate (in /usr/lib64/libc-2.28.so)
==1480==    by 0x5D6A15B: __resolv_conf_load (in /usr/lib64/libc-2.28.so)
==1480==    by 0x5D6C1DE: __resolv_conf_get_current (in /usr/lib64/libc-2.28.so)
==1480==    by 0x5D6AB4C: __res_vinit (in /usr/lib64/libc-2.28.so)
==1480==    by 0x5D6BACA: context_get.part.1 (in /usr/lib64/libc-2.28.so)
==1480==    by 0x5D5C5EF: gethostbyname (in /usr/lib64/libc-2.28.so)
==1480==    by 0x416842: OS_GetHost (os_net.c:519)
==1480==    by 0x43D575: wm_fluent_connect (wm_fluent.c:189)
==1480==    by 0x43F08F: wm_fluent_handshake (wm_fluent.c:665)
==1480==    by 0x43D0B9: wm_fluent_main (wm_fluent.c:100)
==1480==    by 0x5A362DD: start_thread (in /usr/lib64/libpthread-2.28.so)
==1480==    by 0x5D4A132: clone (in /usr/lib64/libc-2.28.so)
==1480==
==1480== 272 bytes in 1 blocks are possibly lost in loss record 14 of 17
==1480==    at 0x4C331EA: calloc (vg_replace_malloc.c:762)
==1480==    by 0x4012181: allocate_dtv (in /usr/lib64/ld-2.28.so)
==1480==    by 0x4012B11: _dl_allocate_tls (in /usr/lib64/ld-2.28.so)
==1480==    by 0x5A36F26: pthread_create@@GLIBC_2.2.5 (in /usr/lib64/libpthread-2.28.so)
==1480==    by 0x40D2BC: CreateThreadJoinable (pthreads_op.c:47)
==1480==    by 0x40D33A: CreateThread (pthreads_op.c:62)
==1480==    by 0x4058CD: main (main.c:102)
==1480==
==1480== 544 bytes in 2 blocks are possibly lost in loss record 15 of 17
==1480==    at 0x4C331EA: calloc (vg_replace_malloc.c:762)
==1480==    by 0x4012181: allocate_dtv (in /usr/lib64/ld-2.28.so)
==1480==    by 0x4012B11: _dl_allocate_tls (in /usr/lib64/ld-2.28.so)
==1480==    by 0x5A36F26: pthread_create@@GLIBC_2.2.5 (in /usr/lib64/libpthread-2.28.so)
==1480==    by 0x40D2BC: CreateThreadJoinable (pthreads_op.c:47)
==1480==    by 0x40583D: main (main.c:95)
==1480==
==1480== LEAK SUMMARY:
==1480==    definitely lost: 96 bytes in 1 blocks
==1480==    indirectly lost: 0 bytes in 0 blocks
==1480==      possibly lost: 816 bytes in 3 blocks
==1480==    still reachable: 66,431 bytes in 14 blocks
==1480==         suppressed: 0 bytes in 0 blocks
```

The memory leak reported for `gethostbyname` is a known issue in CentOS. However, this leak is not accumulative.