### PR TITLE
FIM: Fix folder descriptor not freed when removing folder

### DIFF
--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -291,6 +291,14 @@ const char *get_group(int gid);
 char *get_user(const char *path, __attribute__((unused)) int uid, char **sid);
 
 /**
+ * @brief Check if a directory exists
+ *
+ * @param path Path of the directory to check
+ * @return The FILE_ATTRIBUTE_DIRECTORY bit mask on success, 0 on failure
+ */
+unsigned int w_directory_exists(const char *path);
+
+/**
  * @brief Retrieves the attributes of a specific file (Windows)
  *
  * @param file_path The path of the file to check the attributes of

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -879,12 +879,21 @@ int w_get_account_info(SID *sid, char **account_name, char **account_domain) {
     return 0;
 }
 
+unsigned int w_directory_exists(const char *path){
+    if (path != NULL){
+        unsigned int attrs = w_get_file_attrs(path);
+        return attrs & FILE_ATTRIBUTE_DIRECTORY;
+    }
+
+    return 0;
+}
+
 unsigned int w_get_file_attrs(const char *file_path) {
     unsigned int attrs;
 
     if (attrs = GetFileAttributesA(file_path), attrs == INVALID_FILE_ATTRIBUTES) {
         attrs = 0;
-        merror("The attributes for '%s' could not be obtained. Error '%ld'.", file_path, GetLastError());
+        mdebug2("The attributes for '%s' could not be obtained. Error '%ld'.", file_path, GetLastError());
     }
 
     return attrs;

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -412,9 +412,7 @@ int realtime_adddir(const char *dir, int whodata, int followsl)
     wdchar[260] = '\0';
     snprintf(wdchar, 260, "%s", dir);
       if(OSHash_Get_ex(syscheck.realtime->dirtb, wdchar)) {
-        minfo("The entry %s exists", wdchar);
         if (!DirectoryExists(wdchar)) {
-            minfo("Delete key: %s from hash table", wdchar);
             rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar);
             free_win32rtfim_data(rtlocald);
         }
@@ -422,7 +420,6 @@ int realtime_adddir(const char *dir, int whodata, int followsl)
         w_mutex_unlock(&adddir_mutex);
     }
     else {
-        minfo("The entry: %s doesn`t exists");
         os_calloc(1, sizeof(win32rtfim), rtlocald);
 
         rtlocald->h = CreateFile(dir,

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -336,14 +336,6 @@ int realtime_win32read(win32rtfim *rtlocald)
     return (0);
 }
 
-int directory_exists(const char *dir)
-{
-  DWORD dwAttrib = GetFileAttributes(dir);
-
-  return (dwAttrib != INVALID_FILE_ATTRIBUTES && 
-         (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
-}
-
 // In Windows the whodata parameter contains the directory position + 1 to be able to reference it
 int realtime_adddir(const char *dir, int whodata, int followsl)
 {
@@ -410,7 +402,7 @@ int realtime_adddir(const char *dir, int whodata, int followsl)
     wdchar[260] = '\0';
     snprintf(wdchar, 260, "%s", dir);
       if(OSHash_Get_ex(syscheck.realtime->dirtb, wdchar)) {
-        if (!directory_exists(wdchar)) {
+        if (!w_directory_exists(wdchar)) {
             rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar);
             free_win32rtfim_data(rtlocald);
         }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -323,10 +323,8 @@ int realtime_win32read(win32rtfim *rtlocald)
                                rtlocald->buffer,
                                sizeof(rtlocald->buffer) / sizeof(TCHAR),
                                TRUE,
-                               FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_FILE_NAME | 
-                               FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SIZE | 
-                               FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_LAST_ACCESS | 
-                               FILE_NOTIFY_CHANGE_CREATION | FILE_NOTIFY_CHANGE_SECURITY,
+                               FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_SIZE |
+                               FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SECURITY,
                                0,
                                &rtlocald->overlap,
                                RTCallBack);

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -338,9 +338,9 @@ int realtime_win32read(win32rtfim *rtlocald)
     return (0);
 }
 
-int DirectoryExists(const char * szPath)
+int directory_exists(const char *dir)
 {
-  DWORD dwAttrib = GetFileAttributes(szPath);
+  DWORD dwAttrib = GetFileAttributes(dir);
 
   return (dwAttrib != INVALID_FILE_ATTRIBUTES && 
          (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
@@ -412,7 +412,7 @@ int realtime_adddir(const char *dir, int whodata, int followsl)
     wdchar[260] = '\0';
     snprintf(wdchar, 260, "%s", dir);
       if(OSHash_Get_ex(syscheck.realtime->dirtb, wdchar)) {
-        if (!DirectoryExists(wdchar)) {
+        if (!directory_exists(wdchar)) {
             rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar);
             free_win32rtfim_data(rtlocald);
         }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -323,8 +323,10 @@ int realtime_win32read(win32rtfim *rtlocald)
                                rtlocald->buffer,
                                sizeof(rtlocald->buffer) / sizeof(TCHAR),
                                TRUE,
-                               FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_SIZE |
-                               FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SECURITY,
+                               FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_FILE_NAME | 
+                               FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SIZE | 
+                               FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_LAST_ACCESS | 
+                               FILE_NOTIFY_CHANGE_CREATION | FILE_NOTIFY_CHANGE_SECURITY,
                                0,
                                &rtlocald->overlap,
                                RTCallBack);
@@ -402,6 +404,17 @@ int realtime_adddir(const char *dir, int whodata, int followsl)
     wdchar[260] = '\0';
     snprintf(wdchar, 260, "%s", dir);
     if(OSHash_Get_ex(syscheck.realtime->dirtb, wdchar)) {
+        struct stat statbuf;
+#ifdef WIN32
+
+        minfo("Stat check of : %s ", wdchar);
+        // Probar con open y capturar el error
+        if (w_stat(wdchar, &statbuf) == -1) {
+            minfo("Delete key: %s from hash table", wdchar);
+            rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar);
+            free_win32rtfim_data(rtlocald);
+        }
+ #endif
         mdebug2(FIM_REALTIME_HASH_DUP, wdchar);
         w_mutex_unlock(&adddir_mutex);
     }


### PR DESCRIPTION
|Related issue|
|---|
| #4667 |
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
When a monitored folder was deleted (shift+delete), the descriptor of that folder wasn't freed.
<!--
Add a clear description of how the problem has been solved.
-->
Modified realtime_addir function to check if a directory that exists in the hash table has been deleted. If the directory has been deleted, the key is removed from the hash table and the descriptor is freed.
## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
