### PR TITLE
Fix reload of Audit rules on Windows

### DIFF
--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -305,10 +305,6 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
             if (syscheck.opts[i] & REALTIME_ACTIVE) {
                 realtime_adddir(syscheck.dir[i], 0, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0);
             }
-
-            if (syscheck.opts[i] & WHODATA_ACTIVE) {
-                realtime_adddir(syscheck.dir[i], i + 1, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0);
-            }
         }
 #endif
 #ifdef WIN_WHODATA


### PR DESCRIPTION
## Description

Wazuh only must reload policies if a directory has just been created.
Currently, Windows Audit policies are reloaded although users remove manually.
Additionally, if Wazuh shuts down, Audit policies must return to the original state.



## Tests

- [x] Compilation without warnings on Windows
- [ ] Scan-build report on Windows
- [x] If we delete/modify the audit rules manually, it goes to realtime
- [x] If we stop Wazuh the rules must return to their original state
- [x] When creating a directory that should be monitored by whodata after starting Wazuh, the rules should be added
- [x] When deleting a folder with watcher and re-creating it, the audit rules must be reloaded.
