### PR TITLE
FIM: Fix 2 seconds sleep that was causing the delay in the generation of the alerts

### DIFF
--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -330,7 +330,6 @@ int realtime_win32read(win32rtfim *rtlocald)
                                RTCallBack);
     if (rc == 0) {
         mdebug1(FIM_REALTIME_DIRECTORYCHANGES, rtlocald->dir);
-        sleep(2);
     }
 
     return (0);
@@ -368,7 +367,7 @@ int realtime_adddir(const char *dir, int whodata, __attribute__((unused)) int fo
         syscheck.wdata.dirs_status[whodata - 1].status |= WD_STATUS_EXISTS;
     } else {
         mdebug1(FIM_WARN_REALTIME_OPENFAIL, dir);
-            
+
         syscheck.wdata.dirs_status[whodata - 1].object_type = WD_STATUS_UNK_TYPE;
         syscheck.wdata.dirs_status[whodata - 1].status &= ~WD_STATUS_EXISTS;
         return 0;
@@ -401,12 +400,11 @@ int realtime_adddir(const char *dir, int whodata, __attribute__((unused)) int fo
     /* Set key for hash */
     wdchar[260] = '\0';
     snprintf(wdchar, 260, "%s", dir);
-      if(OSHash_Get_ex(syscheck.realtime->dirtb, wdchar)) {
+    if(OSHash_Get_ex(syscheck.realtime->dirtb, wdchar)) {
         if (!w_directory_exists(wdchar)) {
             rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar);
             free_win32rtfim_data(rtlocald);
         }
-        mdebug2(FIM_REALTIME_HASH_DUP, wdchar);
         w_mutex_unlock(&adddir_mutex);
     }
     else {
@@ -424,7 +422,7 @@ int realtime_adddir(const char *dir, int whodata, __attribute__((unused)) int fo
         if (rtlocald->h == INVALID_HANDLE_VALUE || rtlocald->h == NULL) {
             free(rtlocald);
             rtlocald = NULL;
-            mdebug1(FIM_REALTIME_ADD, dir);
+            mdebug2(FIM_REALTIME_ADD, dir);
             w_mutex_unlock(&adddir_mutex);
             return (0);
         }


### PR DESCRIPTION
|Related issue|
|---|
| #4698 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
When checking if a directory that is monitored doesn't exists, there was a sleep of two seconds and it was causing a delay that caused that the alerts where arriving two slow to the manager. 

<!--
Add a clear description of how the problem has been solved.
-->
The problem was solved by removing the sleep.
## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
