### PR TITLE
FIM: Fix Windows compilation warnings

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -553,7 +553,7 @@ int OS_SetKeepalive(int socket)
 }
 
 // Set keepalive parameters for a socket
-void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt)
+void OS_SetKeepalive_Options(__attribute__((unused)) int socket, int idle, int intvl, int cnt)
 {
     if (cnt > 0) {
 #if !defined(sun) && !defined(WIN32) && !defined(OpenBSD)

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -95,7 +95,7 @@ int OS_SetKeepalive(int socket);
  * @param intvl Interval between probes, in seconds.
  * @param cnt Number of probes sent before closing the connection.
  */
-void OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt);
+void OS_SetKeepalive_Options(__attribute__((unused)) int socket, int idle, int intvl, int cnt);
 
 /* Set the delivery timeout for a socket
  * Returns 0 on success, else -1

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -106,8 +106,11 @@ void rootcheck_connect();
 void run_rk_check(void);
 
 /* Rootcheck thread */
+#ifdef WIN32
+DWORD WINAPI w_rootcheck_thread(__attribute__((unused)) void * args);
+#else
 void * w_rootcheck_thread(__attribute__((unused)) void * args);
-
+#endif
 /*** Plugins prototypes ***/
 void check_rc_files(const char *basedir, FILE *fp);
 void check_rc_trojans(const char *basedir, FILE *fp);

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -297,8 +297,11 @@ void run_rk_check()
     return;
 }
 
+#ifdef WIN32
+DWORD WINAPI w_rootcheck_thread(__attribute__((unused)) void * args){
+#else
 void * w_rootcheck_thread(__attribute__((unused)) void * args) {
-
+#endif
     time_t curr_time = 0;
     time_t prev_time_rk = 0;
     syscheck_config *syscheck = args;
@@ -321,7 +324,9 @@ void * w_rootcheck_thread(__attribute__((unused)) void * args) {
         sleep(1);
     }
 
+#ifndef WIN32
     return NULL;
+#endif
 }
 
 void log_realtime_status_rk(int next) {

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -38,7 +38,11 @@ static w_queue_t * fim_sync_queue;
 
 // LCOV_EXCL_START
 // Starting data synchronization thread
+#ifdef WIN32
+DWORD WINAPI fim_run_integrity(void __attribute__((unused)) * args) {
+#else
 void * fim_run_integrity(void * args) {
+#endif
     // Keep track of synchronization failures
     long sync_interval = syscheck.sync_interval;
     struct timespec start;
@@ -85,7 +89,9 @@ void * fim_run_integrity(void * args) {
         }
     }
 
+#ifndef WIN32
     return args;
+#endif
 }
 // LCOV_EXCL_STOP
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -25,7 +25,12 @@
 #include "fim_db.h"
 
 // Prototypes
+#ifdef WIN32
+DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args);
+#else
 void * fim_run_realtime(__attribute__((unused)) void * args);
+#endif
+
 int fim_whodata_initialize();
 #ifdef WIN32
 static void set_priority_windows_thread();
@@ -142,8 +147,7 @@ void start_daemon()
     // Launch rootcheck thread
     w_create_thread(w_rootcheck_thread, &syscheck);
 #else
-    if (CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)w_rootcheck_thread,
-            &syscheck, 0, NULL) == NULL) {
+    if (CreateThread(NULL, 0, w_rootcheck_thread, &syscheck, 0, NULL) == NULL) {
         merror(THREAD_ERROR);
     }
 #endif
@@ -185,12 +189,10 @@ void start_daemon()
     w_create_thread(symlink_checker_thread, NULL);
 
 #else
-    if (CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)fim_run_integrity,
-            &syscheck, 0, NULL) == NULL) {
+    if (CreateThread(NULL, 0, fim_run_integrity, &syscheck, 0, NULL) == NULL) {
         merror(THREAD_ERROR);
     }
-    if (CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)fim_run_realtime,
-            &syscheck, 0, NULL) == NULL) {
+    if (CreateThread(NULL, 0, fim_run_realtime, &syscheck, 0, NULL) == NULL) {
         merror(THREAD_ERROR);
     }
 #endif
@@ -290,7 +292,11 @@ void start_daemon()
 
 // LCOV_EXCL_START
 // Starting Real-time thread
+#ifdef WIN32
+DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
+#else
 void * fim_run_realtime(__attribute__((unused)) void * args) {
+#endif
 
 #if defined INOTIFY_ENABLED || defined WIN32
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -630,7 +630,11 @@ int w_update_sacl(const char *obj_path);
  *
  * @param args To be used with NULL value
  */
+#ifdef WIN32
+DWORD WINAPI fim_run_integrity(void __attribute__((unused)) * args);
+#else
 void *fim_run_integrity(void *args);
+#endif
 
 /**
  * @brief Calculates the checksum of the FIM entry files and sends it to the database for integrity checking


### PR DESCRIPTION
| Related issue  |
|---------------|
| #4704             |

## Description

Fix compilation warnings in syscheck for Windows.

Closes #4704.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
