### PR TITLE
FIM: Check if synchronization is enabled in Windows

### DIFF
--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -185,10 +185,12 @@ void start_daemon()
     w_create_thread(symlink_checker_thread, NULL);
 
 #else
-    if (CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)fim_run_integrity,
-            &syscheck, 0, NULL) == NULL) {
-        merror(THREAD_ERROR);
+    if (syscheck.enable_synchronization) {
+        if (CreateThread(NULL, 0, fim_run_integrity, &syscheck, 0, NULL) == NULL) {
+            merror(THREAD_ERROR);
+        }
     }
+
     if (CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)fim_run_realtime,
             &syscheck, 0, NULL) == NULL) {
         merror(THREAD_ERROR);


### PR DESCRIPTION
| Related issue  |
|---------------|
| #4706             |

## Description

Check synchronization configuration in Windows.

Closes #4706.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
