### PR TITLE
Decrement windows_audit_interval

### DIFF
--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -119,7 +119,7 @@
     <registry_ignore type="sregex">\Enum$</registry_ignore>
 
     <!-- Frequency for ACL checking (seconds) -->
-    <windows_audit_interval>300</windows_audit_interval>
+    <windows_audit_interval>60</windows_audit_interval>
 
     <!-- Nice value for Syscheck module -->
     <process_priority>10</process_priority>

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -138,7 +138,7 @@
     <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\ADOVMPPackage\Final</registry_ignore>
 
     <!-- Frequency for ACL checking (seconds) -->
-    <windows_audit_interval>300</windows_audit_interval>
+    <windows_audit_interval>60</windows_audit_interval>
 
     <!-- Nice value for Syscheck module -->
     <process_priority>10</process_priority>


### PR DESCRIPTION
Hello team,

This PR decrement the sleep interval of `state_checker` from 300 to 60 seconds.

`state_checker` thread lets FIM monitor new directories, and changes to `realtime` mode a directory when users modify its policies.

Regards,
Eva