### PR TITLE
Fixed deleted alerts for Windows registries

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -226,5 +226,6 @@
 #define FIM_INODES_INFO                     "(6336): Fim inode entries: %d, path count: %d"
 #define FIM_WHODATA_INVALID_UNKNOWN_UID     "(6337): The user ID could not be extracted from the event."
 #define FIM_EMPTY_DIRECTORIES_CONFIG        "(6338): Empty directories tag found in the configuration."
+#define FIM_DELETE_EVENT_PATH_NOCONF        "(6339): Delete event from path without configuration: '%s'"
 
 #endif /* DEBUG_MESSAGES_H */

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -1099,7 +1099,7 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
             }
         } else {
             mdebug2(FIM_DELETE_EVENT_PATH_NOCONF, entry->path);
-                return;
+            return;
         }
     }
 

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -1070,33 +1070,36 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
     fim_event_mode mode = (fim_event_mode) fim_ev_mode;
     int rows = 0;
     int conf_file = fim_configuration_directory(entry->path, "file");
+    int conf_registry = fim_configuration_directory(entry->path, "registry");
 
-    if (conf_file < 0) {
+    if (conf_file < 0 && conf_registry < 0) {
         return;
     }
 
-    switch (mode) {
-        /*
-            Don't send alert if received mode and mode in configuration aren't the same
-        */
+    if (conf_file > -1) {
+        switch (mode) {
+            /*
+                Don't send alert if received mode and mode in configuration aren't the same
+            */
 
-        case FIM_REALTIME:
-            if (!(syscheck.opts[conf_file] & REALTIME_ACTIVE)){
-                return;
-            }
-            break;
+            case FIM_REALTIME:
+                if (!(syscheck.opts[conf_file] & REALTIME_ACTIVE)) {
+                    return;
+                }
+                break;
 
-        case FIM_WHODATA:
-            if (!(syscheck.opts[conf_file] & WHODATA_ACTIVE)) {
-                return;
-            }
-            break;
+            case FIM_WHODATA:
+                if (!(syscheck.opts[conf_file] & WHODATA_ACTIVE)) {
+                    return;
+                }
+                break;
 
-        case FIM_SCHEDULED:
-            if (!(syscheck.opts[conf_file] & SCHEDULED_ACTIVE)) {
-                return;
-            }
-            break;
+            case FIM_SCHEDULED:
+                if (!(syscheck.opts[conf_file] & SCHEDULED_ACTIVE)) {
+                    return;
+                }
+                break;
+        }
     }
 
     w_mutex_lock(mutex);

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -258,6 +258,7 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int pos)
 
         // Set registry entry type
         data->entry_type = FIM_TYPE_REGISTRY;
+        data->mode = FIM_SCHEDULED;
         snprintf(path, MAX_PATH + 7, "%s%s", syscheck.registry[pos].arch == ARCH_64BIT ? "[x64] " : "[x32] ", full_key_name);
         data->last_event = time(NULL);
         data->options |= CHECK_SHA1SUM | CHECK_MTIME;


### PR DESCRIPTION
|Related issue|
|---|
|#4703|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
fim_db_remove_path function did not store the fim configuration directory for 'registry' entry but for a 'file' entry. It is necessary to store both. Then, only check the mode for 'file' entry.

## Logs/Alerts example
In Manager Host: tail -f /var/ossec/logs/alerts/alerts.log
```
** Alert 1583480566.468316: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Mar 06 07:42:46 (windows7) 172.19.0.1->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '[x32] HKEY_LOCAL_MACHINE\HARDWARE\testkey' added
Mode: scheduled

Attributes:
 - Date: Sun Mar  1 07:42:27 2020
 - SHA1: 506549dfe73bc5e86dc387795fd3fa04658ea262

** Alert 1583480601.468726: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Mar 06 07:43:21 (windows7) 172.19.0.1->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '[x32] HKEY_LOCAL_MACHINE\HARDWARE\testkey' modified
Mode: scheduled
Changed attributes: mtime,sha1
Old modification time was: '1583048547', now it is '1583048583'
Old sha1sum was: '506549dfe73bc5e86dc387795fd3fa04658ea262'
New sha1sum is : '3fa8c83b6091511aa17f72d30b8c10e7d93cfef3'

Attributes:
 - Date: Sun Mar  1 07:43:03 2020
 - SHA1: 3fa8c83b6091511aa17f72d30b8c10e7d93cfef3

** Alert 1583480621.469356: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Mar 06 07:43:41 (windows7) 172.19.0.1->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '[x32] HKEY_LOCAL_MACHINE\HARDWARE\testkey' deleted
Mode: scheduled

Attributes:
 - Date: Sun Mar  1 07:43:03 2020
 - SHA1: 3fa8c83b6091511aa17f72d30b8c10e7d93cfef3
```

## Tests
Integration test:
`python -m pytest \test_fim\test_windows_registry\ -v `

![image](https://user-images.githubusercontent.com/24528466/76209787-01a16600-6203-11ea-974c-c61d837606d1.png)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory

## Scan-build report
Some errors reported by Scan-build but none related to the PR.

[scan-build.zip](https://github.com/wazuh/wazuh/files/4306447/scan-build.zip)
- [x] Scan-build