### PR TITLE
Fix a possible memory stomp in get_drive_names()

### DIFF
--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1285,7 +1285,7 @@ int get_drive_names(wchar_t *volume_name, char *device) {
 
     while (1) {
         // Allocate a buffer to hold the paths.
-        os_calloc(MAX_PATH, sizeof(wchar_t), names);
+        os_calloc(char_count, sizeof(wchar_t), names);
 
         // Obtain all of the paths for this volume.
         success = GetVolumePathNamesForVolumeNameW(


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

A simple fix to a possible memory stomp on the get_drive_names function.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [x] Compilation without warnings in Windows
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
