### PR TITLE
FIM v2.0: Fix the "tag" attribute when deleting file

### DIFF
--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -1171,8 +1171,13 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
         cJSON * json_event      = NULL;
         char * json_formatted    = NULL;
         int pos = 0;
-
         const char *FIM_ENTRY_TYPE[] = {"file", "registry"};
+
+        // Obtaining the position of the directory, in @syscheck.dir, where @entry belongs
+        if (pos = fim_configuration_directory(entry->path,
+            FIM_ENTRY_TYPE[entry->data->entry_type]), pos < 0) {
+            goto end;
+        }
 
         json_event = fim_json_event(entry->path, NULL, entry->data, pos,
                                                 FIM_DELETE, mode, whodata_event);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4727|

## Description

We have made a fix within the function `fim_db_remove_path()`, where the directory position was harcoded to 0. Now the position is dynamic depending on the directory.


## Test
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
