### PR TITLE
Fixed defects reported by ScanBuild and Coverity scan on FIM rework

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -945,13 +945,13 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                         continue;
                     }
 
-                    memcpy(srcip,client_source_ip,IPSIZE);
+                    snprintf(srcip, IPSIZE, "%s", client_source_ip);
                 }
 
                 use_client_ip = 1;
             } else if(!config.flags.use_source_ip) {
                 // use_source-ip = 0 and no -I argument in agent
-                memcpy(srcip, "any", 3);
+                snprintf(srcip, IPSIZE, "any");
             }
             // else -> agent IP is already on srcip
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -397,7 +397,7 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
 #ifdef WIN32
 int fim_registry_event(char *key, fim_entry_data *data, int pos) {
 
-    assert(data);
+    assert(data != NULL);
 
     cJSON *json_event = NULL;
     fim_entry *saved;
@@ -413,7 +413,7 @@ int fim_registry_event(char *key, fim_entry_data *data, int pos) {
         alert_type = FIM_MODIFICATION;
     }
 
-    if ((saved && saved->data && strcmp(saved->data->hash_sha1, data->hash_sha1) != 0)
+    if ((saved && data && saved->data && strcmp(saved->data->hash_sha1, data->hash_sha1) != 0)
         || alert_type == FIM_ADD) {
         if (fim_db_insert(syscheck.database, key, data) == -1) {
             free_entry(saved);


### PR DESCRIPTION
|Related issue|
|---|
|#4732|

## Description
Scan-build for winagent and Coverity reported defects related to syscheckd and os_auth and they have been fixed.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer
