### PR TITLE
Update kibana.yml

### DIFF
--- a/extensions/kibana/7.x/kibana.yml
+++ b/extensions/kibana/7.x/kibana.yml
@@ -1,5 +1,5 @@
 server.host: <kibana_ip>
-elasticsearch.hosts: https://<elasticsearch_ip>:9200
+elasticsearch.hosts: ["https://<elasticsearch_ip>:9200"]
 elasticsearch.password: <elasticsearch_password>
 
 # Elasticsearch from/to Kibana


### PR DESCRIPTION
Hello,

This PR proposes changes in **kibana.yml** template for **elasticsearch.hosts** setting.


## Description
In case of having more than one Elasticsearch node, Kibana can be configured to connect to multiple Elasticsearch nodes in the same cluster. The nodes’ IPs should be in square brackets, in double-quotes each and separated with commas. 

This template helps in understanding the required format. 

All the best,
Daria  