### PR TITLE
FIM v2.0: Fix hashing on certain Windows register types

### DIFF
--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -239,7 +239,7 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int pos)
                     break;
                 default:
                     for (j = 0; j < data_size; j++) {
-                        snprintf(buffer, OS_SIZE_2048, "%02x", (unsigned int)data_buffer[j]);
+                        snprintf(buffer, 3, "%02x", (unsigned int)data_buffer[j] & 0xFF);
                         EVP_DigestUpdate(ctx, buffer, strlen(buffer));
                         buffer[0] = '\0';
                     }

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -233,7 +233,7 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name, int pos)
                     }
                     break;
                 case REG_DWORD:
-                    snprintf(buffer, OS_SIZE_2048, "%08x", (unsigned int)*data_buffer);
+                    snprintf(buffer, OS_SIZE_2048, "%08x", *((unsigned int*)data_buffer));
                     EVP_DigestUpdate(ctx, buffer, strlen(buffer));
                     buffer[0] = '\0';
                     break;


### PR DESCRIPTION
|Related issue|
|---|
|#3319|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
While developing unit tests for the Windows agent, some of the hashing mechanisms were taking values in an incorrect way when creating the sha1 hashes. This PR aims to correct them.

## Tests
When running the corresponding unit tests, we can see that the `REG_DWORD` and `default` register types where not properly generating the strings used to update the digest context.
```
[ RUN      ] test_os_winreg_querykey_values_number
[  ERROR   ] --- "ffffffe8" != "000003e8"
/home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_win_registry.c:81: error: Check of parameter data, function __wrap_EVP_DigestUpdate failed
/home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_win_registry.c:317: note: Expected parameter declared here
[   LINE   ] --- /home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_win_registry.c:81: error: Failure!
[  FAILED  ] test_os_winreg_querykey_values_number
[ RUN      ] test_os_winreg_querykey_values_binary
[  ERROR   ] --- "ffffffdc" != "dc"
/home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_win_registry.c:81: error: Check of parameter data, function __wrap_EVP_DigestUpdate failed
/home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_win_registry.c:365: note: Expected parameter declared here
[   LINE   ] --- /home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_win_registry.c:81: error: Failure!
TEST VALUE: 2afe80dc


[  FAILED  ] test_os_winreg_querykey_values_binary
```
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

These tests can be found on branch `4569-fim-rework-unit-tests-for-windows`
