### PR TITLE
FIMv v2.0: Fix show delete event when using scheduled and in-memory database

### DIFF
--- a/src/shared/vector_op.c
+++ b/src/shared/vector_op.c
@@ -61,10 +61,10 @@ void W_Vector_free(W_Vector *v) {
 
     if (v) {
         for (i=0; i < v->used; i++) {
-            free(v->vector[i]);
+            os_free(v->vector[i]);
         }
-        free (v->vector);
-        free (v);
+        os_free (v->vector);
+        os_free (v);
     }
 }
 

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -434,8 +434,7 @@ void fim_db_clean_file(fim_tmp_file **file, int storage) {
         }
         os_free((*file)->path);
     } else {
-        os_free((*file)->list->vector);
-        os_free((*file)->list);
+        W_Vector_free((*file)->list);
     }
 
     os_free((*file));

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -612,7 +612,7 @@ int fim_db_process_read_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t
                 path = wstr_unescape_json(line);
             }
         } else {
-            path = (char *)W_Vector_get(file->list, i);
+            path = wstr_unescape_json((char *) W_Vector_get(file->list, i));
         }
 
         if (path) {


### PR DESCRIPTION
|Related issue|
|#4736|
## Description
This is a small PR that "unescapes" files' paths which were previously scaped; hence fixing some SQL queries that were failing.

## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
