### PR TITLE
Update filebeat_all_in_one.yml

### DIFF
--- a/extensions/filebeat/7.x/filebeat_all_in_one.yml
+++ b/extensions/filebeat/7.x/filebeat_all_in_one.yml
@@ -1,5 +1,5 @@
 # Wazuh - Filebeat configuration file
-output.elasticsearch.hosts: <elasticsearch_ip>:9200
+output.elasticsearch.hosts: ["<elasticsearch_ip>:9200"]
 output.elasticsearch.password: <elasticsearch_password>
 
 filebeat.modules:


### PR DESCRIPTION
Hello,

This PR proposes changes in **filebeat_all_in_one.yml** template for **output.elasticsearch.hosts** setting.

## Description
Filebeat can be configured to connect to multiple Elasticsearch nodes. The nodes’ IPs should be in square brackets, in double-quotes each and separated with commas. If only one Elasticsearch node is present, the template should follow the same pattern as it helps in understanding the required format.

All the best,
Daria

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
