### PR TITLE
Delete pi character compilation error

### DIFF
--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -105,7 +105,7 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc)
 }
 
 /* Send a message to socket */
-int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute__((unused)) πchar loc, logtarget * target)
+int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute__((unused)) char loc, logtarget * target)
 {
     int __mq_rcode;
     char tmpstr[OS_MAXSTR + 1];


### PR DESCRIPTION
## Description

This Pull Request deletes a π character that causes a compilation error.

https://github.com/wazuh/wazuh/blob/264d99eb0205d733aa70a1fcd369ede3d3669255/src/shared/mq_op.c#L108

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

