### PR TITLE
3812 set real time when audit fails

### DIFF
--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -351,7 +351,7 @@ int run_whodata_scan() {
             mwarn(FIM_WARN_WHODATA_AUTOCONF);
         } else {
             mwarn(FIM_WARN_WHODATA_LOCALPOLICIES);
-            return 1;
+            return 0;
         }
     }
     // Select the interesting fields
@@ -878,7 +878,7 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
             exists = 0;
             d_status = &syscheck.wdata.dirs_status[i];
 
-            if (!(syscheck.wdata.dirs_status[i].status & WD_CHECK_WHODATA)) {
+            if (!(d_status->status & WD_CHECK_WHODATA)) {
                 // It is not whodata
                 continue;
             }
@@ -890,16 +890,16 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
                 break;
                 case 1:
                     exists = 1;
-                    syscheck.wdata.dirs_status[i].object_type = WD_STATUS_FILE_TYPE;
+                    d_status->object_type = WD_STATUS_FILE_TYPE;
                 break;
                 case 2:
                     exists = 1;
-                    syscheck.wdata.dirs_status[i].object_type = WD_STATUS_DIR_TYPE;
+                    d_status->object_type = WD_STATUS_DIR_TYPE;
                 break;
 
             }
 
-            if (exists) {
+            if (exists && restore_policies) {
                 if (!(d_status->status & WD_STATUS_EXISTS)) {
                     minfo(FIM_WHODATA_READDED, syscheck.dir[i]);
                     if (set_winsacl(syscheck.dir[i], i)) {
@@ -912,17 +912,25 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
                     if (check_object_sacl(syscheck.dir[i], (d_status->object_type == WD_STATUS_FILE_TYPE) ? 1 : 0)) {
                         syscheck.realtime_change = 1;
                         minfo(FIM_WHODATA_SACL_CHANGED, syscheck.dir[i]);
-                        // Mark the directory to prevent its children from sending partial whodata alerts
-                        syscheck.wdata.dirs_status[i].status |= WD_CHECK_REALTIME;
-                        syscheck.wdata.dirs_status[i].status &= ~WD_CHECK_WHODATA;
-                        // Removes CHECK_WHODATA from directory properties to prevent from being found in the whodata callback for Windows (find_dir_pos)
+                        // Mark the directory to prevent its children from
+                        // sending partial whodata alerts
+                        d_status->status |= WD_CHECK_REALTIME;
+                        d_status->status &= ~WD_CHECK_WHODATA;
+                        // Removes CHECK_WHODATA from directory properties to prevent from
+                        // being found in the whodata callback for Windows (find_dir_pos)
                         syscheck.opts[i] &= ~WHODATA_ACTIVE;
                         // Mark it to prevent the restoration of its SACL
-                        syscheck.wdata.dirs_status[i].status &= ~WD_IGNORE_REST;
+                        d_status->status &= ~WD_IGNORE_REST;
                         notify_SACL_change(syscheck.dir[i]);
                         continue;
                     }
                 }
+            } else if (exists && !restore_policies) {
+                // If the restore_policies flag is not set, it means that something happened during
+                // the configuration and so, the monitoring will be performed in real-time
+                d_status->status |= WD_STATUS_EXISTS;
+                d_status->status |= WD_CHECK_REALTIME;
+                d_status->status &= ~WD_CHECK_WHODATA;
             } else {
                 mdebug1(FIM_WHODATA_DELETE, syscheck.dir[i]);
                 d_status->status &= ~WD_STATUS_EXISTS;


### PR DESCRIPTION
|Related issue|
|---|
|[3812](https://github.com/wazuh/wazuh/issues/3812)|

## Description

During the win whodata initialization, when the audit policies are configured, there was an error being returned in the case that the policy configuration would fail. With this change, we just log the information related to the configuration failure, and then we configure the folders to be monitored in real-time.

## Tests

In order to verify the fix, it is necessary to force an audit policy configuration. There are two ways to do it and both should make the agent work as described above.

1.  The first option is to block the agent from access to the `auditpol.exe` utility. To do this just change the name of the executable file and then the agent will not be able to make use of it.
2.  The second option is to block the agent from access to the files used to perform the audit policies back up. This can be done with this PowerShell script.

```powershell
$path1 = "C:\Program Files (x86)\ossec-agent\tmp\backup-policies"
$path2 = "C:\Program Files (x86)\ossec-agent\tmp\new-policies"
$mode = "Open"
$access = "Read"
$share = "None"

$file1 = [System.IO.File]::Open($path1, $mode, $access, $share)
$file2 = [System.IO.File]::Open($path2, $mode, $access, $share)

# Sleep some time to avoid the agent access during the initialization
Start-Sleep -s 60

$file1.close()
$file2.close()
```

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Dr. Memory