### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add multi-target support for unit testing. ([#4564](https://github.com/wazuh/wazuh/pull/4564))
 - Add FIM module unit testing for Windows source code. ([#4633](https://github.com/wazuh/wazuh/pull/4633))
 
-## Changed
+### Changed
 
 - Move the FIM logic engine to the agent. ([#3319](https://github.com/wazuh/wazuh/issues/3319))
 - Make Logcollector continuously attempt to reconnect with the agent daemon. ([#4435](https://github.com/wazuh/wazuh/pull/4435))
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.11.4] - 2020-02-25
 
-## Changed
+### Changed
 
 - Remove chroot in Agentd to allow it resolve DNS at any time. ([#4652](https://github.com/wazuh/wazuh/issues/4652))
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1538,7 +1538,7 @@ install_dependencies: install_python
 
 install_framework: install_python
 	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET}
-	chown -R root:${OSSEC_GROUP} ${WPYTHON_DIR}/*
+	chown -R root:${OSSEC_GROUP} ${WPYTHON_DIR}
 	chmod -R o=- ${WPYTHON_DIR}/*
 
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -795,7 +795,6 @@ InstallCommon()
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/alerts
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/ossec
   ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/diff
-  ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/db
   ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/fim
   ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/fim/db
 


### PR DESCRIPTION
This PR is about fixing minor problems.

- Delete an unused folder. This folder was created as the first location of the FIM database in the agent that was later relocated.
- Fix a command that uses a meaningless asterisk.
- Correct the CHANGELOG.md description header