### PR TITLE
Stop monitoring of recycle bin folders.

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -161,6 +161,13 @@ void fim_checker(char *path, fim_element *item, whodata_evt *w_evt, int report) 
     int node;
     int depth;
 
+#ifdef WIN32
+    // Ignore the recycle bin.
+    if (check_removed_file(path)){
+        return;
+    }
+#endif
+
     if (item->mode == FIM_SCHEDULED) {
         // If the directory have another configuration will come back
         if (node = fim_configuration_directory(path, "file"), node < 0 || item->index != node) {


### PR DESCRIPTION
|Related issue|
|---|
|#3934|

## Description

We have found that when an entire volume is monitored in windows like `<directories>D:\</directories>` the recycle bin is monitored and this is not the expected behavior. 

To fix this, before adding the directory to the monitoring, syscheck will check if the path of the directory contains `:\\$recycle.bin`, that is the beginning of the recycle bin's folder. 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Windows
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Dr. Memory

