### PR TITLE
Fix #4773 with GNU Make 4.3

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -859,9 +859,7 @@ endif
 TAR := tar -xf
 GUNZIP := gunzip
 CURL := curl -so
-space =
-space +=
-VERSION = $(subst $(space),.,$(wordlist 1,2,$(subst ., ,$(patsubst v%,%,$(shell cat VERSION)))))
+VERSION = $(subst $() $(),.,$(wordlist 1,2,$(subst ., ,$(patsubst v%,%,$(shell cat VERSION)))))
 RESOURCES_URL := https://packages.wazuh.com/deps/$(VERSION)
 CPYTHON := cpython
 ifneq (${PREFIX},/var/ossec)


### PR DESCRIPTION
|#4773|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Update Makefile syntax for make 4.3's handling of spaces in `subst` to get the correct version, download correct deps, etc.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Arch
- [x] Ubuntu18
- [x] Centos7
- [x] Centos5
- [x] Solaris10
- [x] Solaris11
- [ ] HP-UX
- [ ] AIX