### PR TITLE
Fix a buffer overflow when receiving large events by Syslog over TCP

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -97,7 +97,7 @@
 #define INVALID_TIME    "(1240): Invalid time format: '%s'."
 #define INVALID_DAY     "(1241): Invalid day format: '%s'."
 #define ACCEPT_ERROR    "(1242): Couldn't accept TCP connections: %s (%d)"
-#define RECV_ERROR      "(1243): Couldn't receive message from peer."
+#define RECV_ERROR      "(1243): Couldn't receive message from peer: %s (%d)"
 #define DUP_SECURE      "(1244): Can't add more than one secure connection."
 #define SEND_DISCON     "(1245): Sending message to disconnected agent '%s'."
 #define SHARED_ERROR    "(1246): Unable to send file '%s' to agent ID '%s'."

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -419,16 +419,17 @@ char *OS_RecvTCP(int socket, int sizet)
     return (ret);
 }
 
-/* Receive a TCP packet (from an open socket) */
+/* Receive a TCP packet (from an open socket)
+   Returns the number of bytes received,
+   or -1 if an error occurred */
 int OS_RecvTCPBuffer(int socket, char *buffer, int sizet)
 {
     int retsize;
 
     if ((retsize = recv(socket, buffer, sizet - 1, 0)) > 0) {
         buffer[retsize] = '\0';
-        return (0);
     }
-    return (-1);
+    return (retsize);
 }
 
 /* Receive a UDP packet */

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -55,11 +55,19 @@ static void HandleClient(int client_socket, char *srcip)
 
 
     while (1) {
-        /* If we fail, we need to return and close the socket */
-        if ((r_sz = OS_RecvTCPBuffer(client_socket, buffer, OS_MAXSTR - 2)) < 0) {
+        /* If an error occurred, or received 0 bytes, we need to return and close the socket */
+        r_sz = OS_RecvTCPBuffer(client_socket, buffer, OS_MAXSTR - 2);
+        switch (r_sz) {
+        case -1:
+            merror(RECV_ERROR, strerror(errno), errno);
+            // Fallthrough
+        case 0:
             close(client_socket);
             DeletePID(ARGV0);
             return;
+        default:
+            mdebug2("Received %d bytes from '%s'", r_sz, srcip);
+            break;
         }
 
         /* We must have a new line at the end */
@@ -173,7 +181,7 @@ void HandleSyslogTCP()
         /* Accept new connections */
         int client_socket = OS_AcceptTCP(logr.sock, srcip, IPSIZE);
         if (client_socket < 0) {
-            mwarn("Accepting tcp connection from client failed: %s (%d)", strerror(errno), errno);
+            mwarn("Accepting TCP connection from client failed: %s (%d)", strerror(errno), errno);
             continue;
         }
 

--- a/src/tests/tap.h
+++ b/src/tests/tap.h
@@ -39,14 +39,14 @@ static int tap_fail;
 
 #define TAP_PLAN { printf("1..%d\n", tap_count); }
 
-#define TAP_SUMMARY                                                    \
-{                                                                      \
-    if (tap_fail>0) {                                                  \
-        printf("\n       [ %d TEST FAILED ]\n", tap_fail); \
-    }                                                                  \
-    else {                                                             \
-        printf("\n      [ ALL TESTS PASSED ]\n");          \
-    }                                                                  \
+int tap_summary() {
+    if (tap_fail > 0) {
+        printf("\n       [ %d TEST FAILED ]\n", tap_fail);
+        return 1;
+    } else {
+        printf("\n      [ ALL TESTS PASSED ]\n");
+        return 0;
+    }
 }
 
 /**

--- a/src/tests/tap_fluentd_forwarder.c
+++ b/src/tests/tap_fluentd_forwarder.c
@@ -41,7 +41,7 @@ int test_check_config_no_address(){
     w_assert_int_eq((simple_configuration_no_address = wm_fluent_check_config(fluent)), 0);
     os_free(fluent->address);
     os_free(fluent);
-  
+
     return 1;
 }
 
@@ -192,7 +192,7 @@ int main(void) {
 
     /* Simple configuration, TLS valid */
     TAP_TEST_MSG(test_check_valid_config_tls(), "Test configuration valid configuration");
-    
+
     /* Test connection to Fluentd server, no TLS */
     TAP_TEST_MSG(test_check_default_connection(), "Test connection");
 
@@ -206,7 +206,7 @@ int main(void) {
     TAP_TEST_MSG(test_check_config_dump(), "Test configuration dump");
 
     TAP_PLAN;
-    TAP_SUMMARY;
+    int r = tap_summary();
     printf("\n   ENDING TEST  - FLUENTD FORWARDER MODULE   \n\n");
-    return 0;
+    return r;
 }

--- a/src/tests/tap_os_crypto.c
+++ b/src/tests/tap_os_crypto.c
@@ -193,7 +193,7 @@ int main(void) {
     TAP_TEST_MSG(test_md5_sha1_cmd_file_fail(), "MD5+SHA1 non-existing file to read from using command.");
 
     TAP_PLAN;
-    TAP_SUMMARY;
+    int r = tap_summary();
     printf("\n    ENDING TEST  - OS_CRYPTO   \n\n");
-    return 0;
+    return r;
 }

--- a/src/tests/tap_os_net.c
+++ b/src/tests/tap_os_net.c
@@ -34,7 +34,7 @@ int test_tcpv4_local() {
 
     w_assert_int_eq(OS_SendTCP(client_socket, SENDSTRING), 0);
 
-    w_assert_int_eq(OS_RecvTCPBuffer(server_client_socket, buffer, BUFFERSIZE), 0);
+    w_assert_int_eq(OS_RecvTCPBuffer(server_client_socket, buffer, BUFFERSIZE), 13);
 
     w_assert_str_eq(buffer, SENDSTRING);
 
@@ -69,7 +69,7 @@ int test_tcpv4_inet() {
 
     w_assert_int_eq(OS_SendTCP(client_socket, SENDSTRING), 0);
 
-    w_assert_int_eq(OS_RecvTCPBuffer(server_client_socket, buffer, BUFFERSIZE), 0);
+    w_assert_int_eq(OS_RecvTCPBuffer(server_client_socket, buffer, BUFFERSIZE), 13);
 
     w_assert_str_eq(buffer, SENDSTRING);
 
@@ -104,7 +104,7 @@ int test_tcpv6() {
 
     w_assert_int_eq(OS_SendTCP(client_socket, SENDSTRING), 0);
 
-    w_assert_int_eq(OS_RecvTCPBuffer(server_client_socket, buffer, BUFFERSIZE), 0);
+    w_assert_int_eq(OS_RecvTCPBuffer(server_client_socket, buffer, BUFFERSIZE), 13);
 
     w_assert_str_eq(buffer, SENDSTRING);
 

--- a/src/tests/tap_os_net.c
+++ b/src/tests/tap_os_net.c
@@ -332,7 +332,7 @@ int main(void) {
     TAP_TEST_MSG(test_get_ip(), "Get primary IP address collection.");
 
     TAP_PLAN;
-    TAP_SUMMARY;
+    int r = tap_summary();
     printf("\n    ENDING TEST  - OS_NET   \n\n");
-    return 0;
+    return r;
 }

--- a/src/tests/tap_os_regex.c
+++ b/src/tests/tap_os_regex.c
@@ -878,7 +878,7 @@ int main(void) {
     TAP_TEST_MSG(test_no_rc_execute(), "There is no race condition in OSRegex_Execute_ex().");
 
     TAP_PLAN;
-    TAP_SUMMARY;
+    int r = tap_summary();
     printf("\n    ENDING TEST  - OS_REGEX   \n\n");
-    return 0;
+    return r;
 }

--- a/src/tests/tap_os_xml.c
+++ b/src/tests/tap_os_xml.c
@@ -1006,7 +1006,7 @@ int main(void) {
     TAP_TEST_MSG(test_node_attribute_value_overflow(), "Node attribute value inside XML overflow test.");
 
     TAP_PLAN;
-    TAP_SUMMARY;
+    int r = tap_summary();
     printf("\n   ENDING TEST  - OS_XML   \n\n");
-    return 0;
+    return r;
 }

--- a/src/tests/tap_os_zlib.c
+++ b/src/tests/tap_os_zlib.c
@@ -134,7 +134,7 @@ int main(void) {
     TAP_TEST_MSG(test_fail_uncompress_no_dest_size(), "Try to uncompress using 0 as destination size.");
 
     TAP_PLAN;
-    TAP_SUMMARY;
+    int r = tap_summary();
     printf("\n   ENDING TEST  - OS_ZLIB   \n\n");
-    return 0;
+    return r;
 }

--- a/src/tests/tap_shared.c
+++ b/src/tests/tap_shared.c
@@ -236,7 +236,7 @@ int main(void) {
     TAP_TEST_MSG(test_get_file_content(), "Get the content of a file.");
 
     TAP_PLAN;
-    TAP_SUMMARY;
+    int r = tap_summary();
     printf("\n   ENDING TEST  - OS_SHARED   \n\n");
-    return 0;
+    return r;
 }

--- a/src/tests/tap_wazuhdb_op.c
+++ b/src/tests/tap_wazuhdb_op.c
@@ -81,9 +81,9 @@ int main(void) {
     TAP_TEST_MSG(test_err_query(&wdb_sock), "Send query and receive a message starting with 'err' (Invalid syscheck query syntax).");
 
     TAP_PLAN;
-    TAP_SUMMARY;
+    int r = tap_summary();
     close(wdb_sock);
     printf("\n   ENDING TEST  - WAZUHDB_OS   \n\n");
-    return 0;
+    return r;
 
 }


### PR DESCRIPTION
## Bug description

The remote daemon is capable to work as a syslog server, by receiving syslog events from any source to be processed by the Wazuh manager.

When a TCP connection is established, the receiver checks for every received message if it contains the whole event. In the case the event is arriving by parts, a buffer is used to append that fragments until the end of the event is received, or the buffer is full.

The last condition is never met due to the receiving function `OS_RecvTCPBuffer()` doesn't return the number of bytes read. It always returns 0 on success, so this condition:

https://github.com/wazuh/wazuh/blob/2ccb1f40b2d123933964bfd3763e7beb60c29bc9/src/remoted/syslogtcp.c#L69

is always false and the buffer is filled until it overflows. Here, we can see the valgrind report:

```
2020/03/24 01:03:42 ossec-remoted: INFO: Remote syslog allowed from: '127.0.0.1/32'
2020/03/24 01:03:42 ossec-remoted: ERROR: Could not set resource limit for file descriptors to 65536: Operation not permitted (1)
2020/03/24 01:03:42 ossec-remoted: INFO: Started (pid: 13490). Listening on port 514/TCP (syslog).
==13492== Invalid write of size 1
==13492==    at 0x4C32BDF: strncat (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13492==    by 0x123D8C: HandleClient (syslogtcp.c:76)
--------------------
==13492==  Address 0x1fff001000 is not stack'd, malloc'd or (recently) free'd
==13492==
==13492==
==13492== Process terminating with default action of signal 11 (SIGSEGV)
==13492==  Access not within mapped region at address 0x1FFF001000
==13492==    at 0x4C32BDF: strncat (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13492==    by 0x123D8C: HandleClient (syslogtcp.c:76)
```

Thanks to each TCP connection is handled by a child process under `ossec-remoted`. The crash only affects that particular connection. The other syslog connections and the connection to the agents continue to work properly.

## Fix

The fix is just to make `OS_RecvTCPBuffer()` to return the number of bytes read by `recv()`.

After applying the fix, we get the following log when the buffer is full.

```
2020/03/24 03:13:26 ossec-remoted: ERROR: Full buffer receiving from: '127.0.0.1'
```

## Affected systems

This change affects the remote daemon. Not the communication with agents but the Syslog receiver.

-  _ossec-remoted_

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
