### PR TITLE
Add Auditd's field cwd in Syscheck alerts

### DIFF
--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -260,6 +260,9 @@ void OS_LogOutput(Eventinfo *lf)
         if (lf->fields[FIM_PROC_NAME].value && *lf->fields[FIM_PROC_NAME].value) {
             printf(" - (Audit) %s: %s\n", "Process name", lf->fields[FIM_PROC_NAME].value);
         }
+        if (lf->fields[FIM_AUDIT_CWD].value && *lf->fields[FIM_AUDIT_CWD].value) {
+            printf(" - (Audit) %s: %s\n", "Process cwd", lf->fields[FIM_AUDIT_CWD].value);
+        }
     }
 
     if (lf->filename && lf->sk_tag) {
@@ -449,6 +452,9 @@ void OS_Log(Eventinfo *lf)
         }
         if (lf->fields[FIM_PROC_NAME].value && strcmp(lf->fields[FIM_PROC_NAME].value, "") != 0) {
             fprintf(_aflog, " - (Audit) %s: %s\n", "Process name", lf->fields[FIM_PROC_NAME].value);
+        }
+        if (lf->fields[FIM_AUDIT_CWD].value && strcmp(lf->fields[FIM_AUDIT_CWD].value, "") != 0) {
+            fprintf(_aflog, " - (Audit) %s: %s\n", "Process cwd", lf->fields[FIM_AUDIT_CWD].value);
         }
 
         if (lf->fields[FIM_DIFF].value) {

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -263,6 +263,15 @@ void OS_LogOutput(Eventinfo *lf)
         if (lf->fields[FIM_AUDIT_CWD].value && *lf->fields[FIM_AUDIT_CWD].value) {
             printf(" - (Audit) %s: %s\n", "Process cwd", lf->fields[FIM_AUDIT_CWD].value);
         }
+        if (lf->fields[FIM_PROC_PNAME].value && *lf->fields[FIM_PROC_PNAME].value) {
+            printf(" - (Audit) %s: %s\n", "Parent process name", lf->fields[FIM_PROC_PNAME].value);
+        }
+        if (lf->fields[FIM_PPID].value && *lf->fields[FIM_PPID].value) {
+            printf(" - (Audit) %s: %s\n", "Parent process id", lf->fields[FIM_PPID].value);
+        }
+        if (lf->fields[FIM_AUDIT_PCWD].value && strcmp(lf->fields[FIM_AUDIT_PCWD].value, "") != 0) {
+            printf(" - (Audit) %s: %s\n", "Parent process cwd", lf->fields[FIM_AUDIT_PCWD].value);
+        }
     }
 
     if (lf->filename && lf->sk_tag) {
@@ -455,6 +464,15 @@ void OS_Log(Eventinfo *lf)
         }
         if (lf->fields[FIM_AUDIT_CWD].value && strcmp(lf->fields[FIM_AUDIT_CWD].value, "") != 0) {
             fprintf(_aflog, " - (Audit) %s: %s\n", "Process cwd", lf->fields[FIM_AUDIT_CWD].value);
+        }
+        if (lf->fields[FIM_PROC_PNAME].value && strcmp(lf->fields[FIM_PROC_PNAME].value, "") != 0) {
+            fprintf(_aflog, " - (Audit) %s: %s\n", "Parent process name", lf->fields[FIM_PROC_PNAME].value);
+        }
+        if (lf->fields[FIM_PPID].value && strcmp(lf->fields[FIM_PPID].value, "") != 0) {
+            fprintf(_aflog, " - (Audit) %s: %s\n", "Parent process id", lf->fields[FIM_PPID].value);
+        }
+        if (lf->fields[FIM_AUDIT_PCWD].value && strcmp(lf->fields[FIM_AUDIT_PCWD].value, "") != 0) {
+            fprintf(_aflog, " - (Audit) %s: %s\n", "Parent process cwd", lf->fields[FIM_AUDIT_PCWD].value);
         }
 
         if (lf->fields[FIM_DIFF].value) {

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -186,7 +186,7 @@ void OS_LogOutput(Eventinfo *lf)
 
     /* FIM events */
 
-    if (lf->filename && lf->event_type != FIM_DELETED) {
+    if (lf->filename) {
         printf("Attributes:\n");
 
         if (lf->fields[FIM_SIZE].value && *lf->fields[FIM_SIZE].value) {
@@ -272,16 +272,20 @@ void OS_LogOutput(Eventinfo *lf)
         if (lf->fields[FIM_AUDIT_PCWD].value && strcmp(lf->fields[FIM_AUDIT_PCWD].value, "") != 0) {
             printf(" - (Audit) %s: %s\n", "Parent process cwd", lf->fields[FIM_AUDIT_PCWD].value);
         }
-    }
 
-    if (lf->filename && lf->sk_tag) {
-        if (strcmp(lf->sk_tag, "") != 0) {
-            printf("\nTags:\n");
-            char * tag;
-            tag = strtok_r(lf->sk_tag, ",", &saveptr);
-            while (tag != NULL) {
-                printf(" - %s\n", tag);
-                tag = strtok_r(NULL, ",", &saveptr);
+        if (lf->fields[FIM_DIFF].value) {
+            fprintf(_aflog, "\nWhat changed:\n%s\n", lf->fields[FIM_DIFF].value);
+        }
+
+        if (lf->sk_tag) {
+            if (strcmp(lf->sk_tag, "") != 0) {
+                printf("\nTags:\n");
+                char * tag;
+                tag = strtok_r(lf->sk_tag, ",", &saveptr);
+                while (tag != NULL) {
+                    printf(" - %s\n", tag);
+                    tag = strtok_r(NULL, ",", &saveptr);
+                }
             }
         }
     }

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -140,6 +140,7 @@ void sdb_init(_sdb *localsdb, OSDecoderInfo *fim_decoder) {
     fim_decoder->fields[FIM_GROUP_ID] = "group_id";
     fim_decoder->fields[FIM_GROUP_NAME] = "group_name";
     fim_decoder->fields[FIM_PROC_NAME] = "process_name";
+    fim_decoder->fields[FIM_AUDIT_CWD] = "cwd";
     fim_decoder->fields[FIM_AUDIT_ID] = "audit_uid";
     fim_decoder->fields[FIM_AUDIT_NAME] = "audit_name";
     fim_decoder->fields[FIM_EFFECTIVE_UID] = "effective_uid";
@@ -1115,6 +1116,7 @@ int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
      *       group_id:          string
      *       group_name:        string
      *       process_name:      string
+     *       cwd:               string
      *       audit_uid:         string
      *       audit_name:        string
      *       effective_uid:     string
@@ -1398,6 +1400,8 @@ static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
                 os_strdup(object->valuestring, lf->fields[FIM_GROUP_NAME].value);
             } else if (strcmp(object->string, "process_name") == 0) {
                 os_strdup(object->valuestring, lf->fields[FIM_PROC_NAME].value);
+            } else if (strcmp(object->string, "cwd") == 0) {
+                os_strdup(object->valuestring, lf->fields[FIM_AUDIT_CWD].value);
             } else if (strcmp(object->string, "audit_uid") == 0) {
                 os_strdup(object->valuestring, lf->fields[FIM_AUDIT_ID].value);
             } else if (strcmp(object->string, "audit_name") == 0) {

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -140,6 +140,8 @@ void sdb_init(_sdb *localsdb, OSDecoderInfo *fim_decoder) {
     fim_decoder->fields[FIM_GROUP_ID] = "group_id";
     fim_decoder->fields[FIM_GROUP_NAME] = "group_name";
     fim_decoder->fields[FIM_PROC_NAME] = "process_name";
+    fim_decoder->fields[FIM_PROC_PNAME] = "parent_name";
+    fim_decoder->fields[FIM_AUDIT_PCWD] = "parent_cwd";
     fim_decoder->fields[FIM_AUDIT_CWD] = "cwd";
     fim_decoder->fields[FIM_AUDIT_ID] = "audit_uid";
     fim_decoder->fields[FIM_AUDIT_NAME] = "audit_name";
@@ -1121,6 +1123,8 @@ int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
      *       audit_name:        string
      *       effective_uid:     string
      *       effective_name:    string
+     *       parent_name:       string
+     *       parent_cwd:        string
      *       ppid:              number
      *       process_id:        number
      *     }
@@ -1400,9 +1404,13 @@ static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
                 os_strdup(object->valuestring, lf->fields[FIM_GROUP_NAME].value);
             } else if (strcmp(object->string, "process_name") == 0) {
                 os_strdup(object->valuestring, lf->fields[FIM_PROC_NAME].value);
+            } else if (strcmp(object->string, "parent_name") == 0) {
+                os_strdup(object->valuestring, lf->fields[FIM_PROC_PNAME].value);
             } else if (strcmp(object->string, "cwd") == 0) {
                 os_strdup(object->valuestring, lf->fields[FIM_AUDIT_CWD].value);
-            } else if (strcmp(object->string, "audit_uid") == 0) {
+            } else if (strcmp(object->string, "parent_cwd") == 0) {
+                os_strdup(object->valuestring, lf->fields[FIM_AUDIT_PCWD].value);
+            }else if (strcmp(object->string, "audit_uid") == 0) {
                 os_strdup(object->valuestring, lf->fields[FIM_AUDIT_ID].value);
             } else if (strcmp(object->string, "audit_name") == 0) {
                 os_strdup(object->valuestring, lf->fields[FIM_AUDIT_NAME].value);

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1010,6 +1010,9 @@ void Free_Eventinfo(Eventinfo *lf)
     if (lf->process_name) {
         free(lf->process_name);
     }
+    if (lf->cwd) {
+        free(lf->cwd);
+    }
     if (lf->audit_uid) {
         free(lf->audit_uid);
     }
@@ -1021,6 +1024,12 @@ void Free_Eventinfo(Eventinfo *lf)
     }
     if (lf->effective_name) {
         free(lf->effective_name);
+    }
+    if (lf->parent_name) {
+        free(lf->parent_name);
+    }
+    if (lf->parent_cwd) {
+        free(lf->parent_cwd);
     }
     if (lf->ppid) {
         free(lf->ppid);

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -112,6 +112,7 @@ typedef struct _Eventinfo {
     char *group_id;
     char *group_name;
     char *process_name;
+    char *cwd;
     char *audit_uid;
     char *audit_name;
     char *effective_uid;

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -117,6 +117,8 @@ typedef struct _Eventinfo {
     char *audit_name;
     char *effective_uid;
     char *effective_name;
+    char *parent_name;
+    char *parent_cwd;
     char *ppid;
     char *process_id;
     u_int16_t decoder_syscheck_id;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -389,6 +389,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         // Process section
         add_json_field(process_sect, "id", lf->fields[FIM_PROC_ID].value, "");
         add_json_field(process_sect, "name", lf->fields[FIM_PROC_NAME].value, "");
+        add_json_field(process_sect, "cwd", lf->fields[FIM_AUDIT_CWD].value, "");
         add_json_field(process_sect, "ppid", lf->fields[FIM_PPID].value, "");
 
         // Auser sect

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -390,6 +390,8 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
         add_json_field(process_sect, "id", lf->fields[FIM_PROC_ID].value, "");
         add_json_field(process_sect, "name", lf->fields[FIM_PROC_NAME].value, "");
         add_json_field(process_sect, "cwd", lf->fields[FIM_AUDIT_CWD].value, "");
+        add_json_field(process_sect, "parent_name", lf->fields[FIM_PROC_PNAME].value, "");
+        add_json_field(process_sect, "parent_cwd", lf->fields[FIM_AUDIT_PCWD].value, "");
         add_json_field(process_sect, "ppid", lf->fields[FIM_PPID].value, "");
 
         // Auser sect

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -136,6 +136,8 @@ typedef struct whodata_evt {
     char *effective_name;  // Linux
     char *inode;  // Linux
     char *dev;  // Linux
+    char *parent_name; // Linux
+    char *parent_cwd;
     int ppid;  // Linux
     char *cwd; // Linux
 #ifndef WIN32

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -137,6 +137,7 @@ typedef struct whodata_evt {
     char *inode;  // Linux
     char *dev;  // Linux
     int ppid;  // Linux
+    char *cwd; // Linux
 #ifndef WIN32
     unsigned int process_id;
 #else

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -101,6 +101,7 @@ typedef enum fim_fields {
     FIM_GROUP_ID,
     FIM_GROUP_NAME,
     FIM_PROC_NAME,
+    FIM_AUDIT_CWD,
     FIM_AUDIT_ID,
     FIM_AUDIT_NAME,
     FIM_EFFECTIVE_UID,
@@ -149,6 +150,7 @@ typedef struct sk_sum_wdata {
     char *group_id;
     char *group_name;
     char *process_name;
+    char *cwd;
     char *audit_uid;
     char *audit_name;
     char *effective_uid;

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -101,7 +101,9 @@ typedef enum fim_fields {
     FIM_GROUP_ID,
     FIM_GROUP_NAME,
     FIM_PROC_NAME,
+    FIM_PROC_PNAME,
     FIM_AUDIT_CWD,
+    FIM_AUDIT_PCWD,
     FIM_AUDIT_ID,
     FIM_AUDIT_NAME,
     FIM_EFFECTIVE_UID,
@@ -155,6 +157,8 @@ typedef struct sk_sum_wdata {
     char *audit_name;
     char *effective_uid;
     char *effective_name;
+    char *parent_name;
+    char *parent_cwd;
     char *ppid;
     char *process_id;
 } sk_sum_wdata;

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -459,6 +459,11 @@ void sk_fill_event(Eventinfo *lf, const char *f_name, const sk_sum_t *sum) {
         os_strdup(sum->wdata.process_name, lf->fields[FIM_PROC_NAME].value);
     }
 
+    if(sum->wdata.cwd) {
+        os_strdup(sum->wdata.cwd, lf->cwd);
+        os_strdup(sum->wdata.cwd, lf->fields[FIM_AUDIT_CWD].value);
+    }
+
     if(sum->wdata.audit_uid) {
         os_strdup(sum->wdata.audit_uid, lf->audit_uid);
         os_strdup(sum->wdata.audit_uid, lf->fields[FIM_AUDIT_ID].value);

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -459,9 +459,19 @@ void sk_fill_event(Eventinfo *lf, const char *f_name, const sk_sum_t *sum) {
         os_strdup(sum->wdata.process_name, lf->fields[FIM_PROC_NAME].value);
     }
 
+    if(sum->wdata.parent_name) {
+        os_strdup(sum->wdata.parent_name, lf->parent_name);
+        os_strdup(sum->wdata.parent_name, lf->fields[FIM_PROC_PNAME].value);
+    }
+
     if(sum->wdata.cwd) {
         os_strdup(sum->wdata.cwd, lf->cwd);
         os_strdup(sum->wdata.cwd, lf->fields[FIM_AUDIT_CWD].value);
+    }
+
+    if(sum->wdata.parent_cwd) {
+        os_strdup(sum->wdata.parent_cwd, lf->parent_cwd);
+        os_strdup(sum->wdata.parent_cwd, lf->fields[FIM_AUDIT_PCWD].value);
     }
 
     if(sum->wdata.audit_uid) {
@@ -563,6 +573,9 @@ void sk_sum_clean(sk_sum_t * sum) {
     os_free(sum->attributes);
     os_free(sum->wdata.user_name);
     os_free(sum->wdata.process_name);
+    os_free(sum->wdata.parent_cwd);
+    os_free(sum->wdata.cwd);
+    os_free(sum->wdata.parent_name);
     os_free(sum->uname);
     os_free(sum->win_perm);
 }

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -123,6 +123,7 @@ void free_whodata_event(whodata_evt *w_evt) {
         LocalFree(w_evt->user_id);
 #endif
     }
+    if (w_evt->cwd) free(w_evt->cwd);
     if (w_evt->audit_name) free(w_evt->audit_name);
     if (w_evt->audit_uid) free(w_evt->audit_uid);
     if (w_evt->effective_name) free(w_evt->effective_name);

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -131,6 +131,8 @@ void free_whodata_event(whodata_evt *w_evt) {
     if (w_evt->group_id) free(w_evt->group_id);
     if (w_evt->path) free(w_evt->path);
     if (w_evt->process_name) free(w_evt->process_name);
+    if (w_evt->parent_name) free(w_evt->parent_name);
+    if (w_evt->parent_cwd) free(w_evt->parent_cwd);
     if (w_evt->inode) free(w_evt->inode);
     if (w_evt->dev) free(w_evt->dev);
     free(w_evt);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -967,6 +967,8 @@ cJSON * fim_audit_json(const whodata_evt * w_evt) {
     cJSON_AddStringToObject(fim_audit, "audit_name", w_evt->audit_name);
     cJSON_AddStringToObject(fim_audit, "effective_uid", w_evt->effective_uid);
     cJSON_AddStringToObject(fim_audit, "effective_name", w_evt->effective_name);
+    cJSON_AddStringToObject(fim_audit, "parent_name", w_evt->parent_name);
+    cJSON_AddStringToObject(fim_audit, "parent_cwd", w_evt->parent_cwd);
     cJSON_AddNumberToObject(fim_audit, "ppid", w_evt->ppid);
 #endif
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -960,6 +960,7 @@ cJSON * fim_audit_json(const whodata_evt * w_evt) {
     cJSON_AddStringToObject(fim_audit, "process_name", w_evt->process_name);
     cJSON_AddNumberToObject(fim_audit, "process_id", w_evt->process_id);
 #ifndef WIN32
+    cJSON_AddStringToObject(fim_audit, "cwd", w_evt->cwd);
     cJSON_AddStringToObject(fim_audit, "group_id", w_evt->group_id);
     cJSON_AddStringToObject(fim_audit, "group_name", w_evt->group_name);
     cJSON_AddStringToObject(fim_audit, "audit_uid", w_evt->audit_uid);

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -475,6 +475,15 @@ void *audit_healthcheck_thread(int *audit_sock);
 char *gen_audit_path(char *cwd, char *path0, char *path1);
 
 /**
+ * @brief Add cwd and exe of parent process
+ *
+ * @param ppid ID of parent process
+ * @param parent_name String where save the parent name (exe)
+ * @param parent_cwd String where save the parent working directory (cwd)
+ */
+void get_parent_process_info(char *ppid, char **parent_name, char **parent_cwd);
+
+/**
  * @brief Reloads audit rules to configured directories
  * This is necessary to include audit rules for hot added directories in the configuration
  *

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -481,7 +481,7 @@ char *gen_audit_path(char *cwd, char *path0, char *path1);
  * @param parent_name String where save the parent name (exe)
  * @param parent_cwd String where save the parent working directory (cwd)
  */
-void get_parent_process_info(char *ppid, char **parent_name, char **parent_cwd);
+void get_parent_process_info(char *ppid, char ** const parent_name, char ** const parent_cwd);
 
 /**
  * @brief Reloads audit rules to configured directories

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -585,7 +585,6 @@ void audit_parse(char *buffer) {
     char *path2 = NULL;
     char *path3 = NULL;
     char *path4 = NULL;
-    char *cwd = NULL;
     char *file_path = NULL;
     char *dev = NULL;
     whodata_evt *w_evt;
@@ -749,15 +748,15 @@ void audit_parse(char *buffer) {
             // cwd
             if(regexec(&regexCompiled_cwd, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
-                os_malloc(match_size + 1, cwd);
-                snprintf (cwd, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
+                os_malloc(match_size + 1, w_evt->cwd);
+                snprintf (w_evt->cwd, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
             } else if (regexec(&regexCompiled_cwd_hex, buffer, 2, match, 0) == 0) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 char *decoded_buffer = decode_hex_buffer_2_ascii_buffer(buffer + match[1].rm_so, match_size);
                 if (decoded_buffer) {
                     const int decoded_length = match_size / 2;
-                    os_malloc(decoded_length + 1, cwd);
-                    snprintf(cwd, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
+                    os_malloc(decoded_length + 1, w_evt->cwd);
+                    snprintf(w_evt->cwd, decoded_length + 1, "%.*s", decoded_length, decoded_buffer);
                     os_free(decoded_buffer);
                 } else {
                     merror("Error found while decoding HEX bufer: '%.*s'", match_size, buffer + match[1].rm_so);
@@ -832,8 +831,8 @@ void audit_parse(char *buffer) {
             switch(items) {
 
                 case 1:
-                    if (cwd && path0) {
-                        if (file_path = gen_audit_path(cwd, path0, NULL), file_path) {
+                    if (w_evt->cwd && path0) {
+                        if (file_path = gen_audit_path(w_evt->cwd, path0, NULL), file_path) {
                             w_evt->path = file_path;
                             mdebug2(FIM_AUDIT_EVENT
                                 (w_evt->user_name)?w_evt->user_name:"",
@@ -853,8 +852,8 @@ void audit_parse(char *buffer) {
                     }
                     break;
                 case 2:
-                    if (cwd && path0 && path1) {
-                        if (file_path = gen_audit_path(cwd, path0, path1), file_path) {
+                    if (w_evt->cwd && path0 && path1) {
+                        if (file_path = gen_audit_path(w_evt->cwd, path0, path1), file_path) {
                             w_evt->path = file_path;
                             mdebug2(FIM_AUDIT_EVENT
                                 (w_evt->user_name)?w_evt->user_name:"",
@@ -902,8 +901,8 @@ void audit_parse(char *buffer) {
                         }
                     }
 
-                    if (cwd && path1 && path2) {
-                        if (file_path = gen_audit_path(cwd, path1, path2), file_path) {
+                    if (w_evt->cwd && path1 && path2) {
+                        if (file_path = gen_audit_path(w_evt->cwd, path1, path2), file_path) {
                             w_evt->path = file_path;
                             mdebug2(FIM_AUDIT_EVENT
                                 (w_evt->user_name)?w_evt->user_name:"",
@@ -960,10 +959,10 @@ void audit_parse(char *buffer) {
                         }
                     }
 
-                    if (cwd && path0 && path1 && path2 && path3) {
+                    if (w_evt->cwd && path0 && path1 && path2 && path3) {
                         // Send event 1/2
                         char *file_path1;
-                        if (file_path1 = gen_audit_path(cwd, path0, path2), file_path1) {
+                        if (file_path1 = gen_audit_path(w_evt->cwd, path0, path2), file_path1) {
                             w_evt->path = file_path1;
                             mdebug2(FIM_AUDIT_EVENT1
                                 (w_evt->user_name)?w_evt->user_name:"",
@@ -985,7 +984,7 @@ void audit_parse(char *buffer) {
 
                         // Send event 2/2
                         char *file_path2;
-                        if (file_path2 = gen_audit_path(cwd, path1, path3), file_path2) {
+                        if (file_path2 = gen_audit_path(w_evt->cwd, path1, path3), file_path2) {
                             w_evt->path = file_path2;
                             mdebug2(FIM_AUDIT_EVENT2
                                 (w_evt->user_name)?w_evt->user_name:"",
@@ -1025,9 +1024,9 @@ void audit_parse(char *buffer) {
                         }
                     }
 
-                    if (cwd && path1 && path4) {
+                    if (w_evt->cwd && path1 && path4) {
                         char *file_path;
-                        if (file_path = gen_audit_path(cwd, path1, path4), file_path) {
+                        if (file_path = gen_audit_path(w_evt->cwd, path1, path4), file_path) {
                             w_evt->path = file_path;
                             mdebug2(FIM_AUDIT_EVENT
                                 (w_evt->user_name)?w_evt->user_name:"",
@@ -1048,7 +1047,7 @@ void audit_parse(char *buffer) {
                     free(path4);
                     break;
             }
-            free(cwd);
+
             free(path0);
             free(path1);
             free_whodata_event(w_evt);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -573,7 +573,7 @@ char *gen_audit_path(char *cwd, char *path0, char *path1) {
     return gen_path;
 }
 
-void get_parent_process_info(char *ppid, char **parent_name, char **parent_cwd) {
+void get_parent_process_info(char *ppid, char ** const parent_name, char ** const parent_cwd) {
 
     char *slinkexe = NULL;
     char *slinkcwd = NULL;
@@ -588,14 +588,14 @@ void get_parent_process_info(char *ppid, char **parent_name, char **parent_cwd) 
     snprintf(slinkcwd, tam_slink, "/proc/%s/cwd", ppid);
 
     if(tam_ppname = readlink(slinkexe, *parent_name, OS_FLSIZE), tam_ppname < 0) {
-        merror("Failure to obtain the name of the process: '%s'. Error: %s", ppid, strerror(errno));
+        mdebug1("Failure to obtain the name of the process: '%s'. Error: %s", ppid, strerror(errno));
         parent_name[0][0] = '\0';
     } else {
         parent_name[0][tam_ppname] = '\0';
     }
 
     if(tam_pcwd = readlink(slinkcwd, *parent_cwd, OS_FLSIZE), tam_pcwd < 0) {
-        merror("Failure to obtain the cwd of the process: '%s'. Error: %s", ppid, strerror(errno));
+        mdebug1("Failure to obtain the cwd of the process: '%s'. Error: %s", ppid, strerror(errno));
         parent_cwd[0][0] = '\0';
     } else {
         parent_cwd[0][tam_pcwd] = '\0';

--- a/src/unit_tests/analysisd/test_analysisd_syscheck.c
+++ b/src/unit_tests/analysisd/test_analysisd_syscheck.c
@@ -231,7 +231,10 @@ static int setup_fim_data(void **state) {
                 "\"effective_uid\":\"effective_uid\","
                 "\"effective_name\":\"effective_name\","
                 "\"ppid\":12345,"
-                "\"process_id\":23456}}}";
+                "\"process_id\":23456,"
+                "\"cwd\":\"cwd\","
+                "\"parent_name\":\"parent_name\","
+                "\"parent_cwd\":\"parent_cwd\"}}}";
 
     if(data = calloc(1, sizeof(fim_data_t)), data == NULL)
         return -1;
@@ -311,6 +314,12 @@ static int setup_fim_data(void **state) {
     if(data->lf->decoder_info->fields[FIM_TAG] = strdup("tag"), data->lf->decoder_info->fields[FIM_TAG] == NULL)
         return -1;
     if(data->lf->decoder_info->fields[FIM_SYM_PATH] = strdup("sym_path"), data->lf->decoder_info->fields[FIM_SYM_PATH] == NULL)
+        return -1;
+    if(data->lf->decoder_info->fields[FIM_AUDIT_CWD] = strdup("cwd"), data->lf->decoder_info->fields[FIM_AUDIT_CWD] == NULL)
+        return -1;
+    if(data->lf->decoder_info->fields[FIM_PROC_PNAME] = strdup("parent_name"), data->lf->decoder_info->fields[FIM_PROC_PNAME] == NULL)
+        return -1;
+    if(data->lf->decoder_info->fields[FIM_AUDIT_PCWD] = strdup("parent_cwd"), data->lf->decoder_info->fields[FIM_AUDIT_PCWD] == NULL)
         return -1;
 
     *state = data;
@@ -397,7 +406,10 @@ static int setup_decode_fim_event(void **state) {
                 "\"effective_uid\":\"effective_uid\","
                 "\"effective_name\":\"effective_name\","
                 "\"ppid\":12345,"
-                "\"process_id\":23456}}}";
+                "\"process_id\":23456,"
+                "\"cwd\":\"cwd\","
+                "\"parent_name\":\"parent_name\","
+                "\"parent_cwd\":\"parent_cwd\"}}}";
 
     if(data = calloc(1, sizeof(Eventinfo)), data == NULL)
         return -1;
@@ -468,6 +480,12 @@ static int setup_decode_fim_event(void **state) {
     if(data->decoder_info->fields[FIM_TAG] = strdup("tag"), data->decoder_info->fields[FIM_TAG] == NULL)
         return -1;
     if(data->decoder_info->fields[FIM_SYM_PATH] = strdup("sym_path"), data->decoder_info->fields[FIM_SYM_PATH] == NULL)
+        return -1;
+    if(data->decoder_info->fields[FIM_AUDIT_CWD] = strdup("cwd"), data->decoder_info->fields[FIM_AUDIT_CWD] == NULL)
+        return -1;
+    if(data->decoder_info->fields[FIM_PROC_PNAME] = strdup("parent_name"), data->decoder_info->fields[FIM_PROC_PNAME] == NULL)
+        return -1;
+    if(data->decoder_info->fields[FIM_AUDIT_PCWD] = strdup("parent_cwd"), data->decoder_info->fields[FIM_AUDIT_PCWD] == NULL)
         return -1;
 
     if(data->log = strdup(plain_event), data->log == NULL)

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -94,7 +94,8 @@ else()
                        -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,fopen -Wl,--wrap,fwrite -Wl,--wrap,fprintf -Wl,--wrap,fclose -Wl,--wrap,symlink -Wl,--wrap,unlink \
                        -Wl,--wrap,audit_open -Wl,--wrap,audit_get_rule_list -Wl,--wrap,audit_close -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,W_Vector_length -Wl,--wrap,search_audit_rule \
                        -Wl,--wrap,audit_add_rule -Wl,--wrap,W_Vector_insert_unique -Wl,--wrap,SendMSG -Wl,--wrap,fim_whodata_event \
-                       -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc -Wl,--wrap,closeproc -Wl,--wrap,_mdebug2 -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,realpath")
+                       -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc -Wl,--wrap,closeproc -Wl,--wrap,_mdebug2 -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,realpath \
+                       -Wl,--wrap,readlink")
 endif()
 
 set(SEECHANGES_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,lstat -Wl,--wrap,stat -Wl,--wrap,abspath -Wl,--wrap,fopen -Wl,--wrap,fread \

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -362,6 +362,9 @@ static int setup_group(void **state) {
     fim_data->w_evt->dev = strdup("12345678");
     fim_data->w_evt->ppid = 1000;
     fim_data->w_evt->process_id = 1001;
+    fim_data->w_evt->cwd = strdup("process_cwd");
+    fim_data->w_evt->parent_cwd = strdup("parent_cwd");
+    fim_data->w_evt->parent_name = strdup("parent_name");
 
     // Setup mock old fim_entry
     fim_data->old_data->size = 1500;
@@ -619,7 +622,7 @@ static void test_fim_json_event_whodata(void **state) {
     #ifdef TEST_WINAGENT
     assert_int_equal(cJSON_GetArraySize(audit), 5);
     #else
-    assert_int_equal(cJSON_GetArraySize(audit), 12);
+    assert_int_equal(cJSON_GetArraySize(audit), 15);
     #endif
     cJSON *diff = cJSON_GetObjectItem(data, "content_changes");
     assert_string_equal(cJSON_GetStringValue(diff), "diff");
@@ -923,7 +926,7 @@ static void test_fim_audit_json(void **state) {
     #ifdef TEST_WINAGENT
     assert_int_equal(cJSON_GetArraySize(fim_data->json), 5);
     #else
-    assert_int_equal(cJSON_GetArraySize(fim_data->json), 12);
+    assert_int_equal(cJSON_GetArraySize(fim_data->json), 15);
     #endif
 
     cJSON *path = cJSON_GetObjectItem(fim_data->json, "path");
@@ -939,6 +942,8 @@ static void test_fim_audit_json(void **state) {
     assert_int_equal(process_id->valueint, 1001);
 
     #ifndef TEST_WINAGENT
+    cJSON *cwd = cJSON_GetObjectItem(fim_data->json, "cwd");
+    assert_string_equal(cJSON_GetStringValue(cwd), "process_cwd");
     cJSON *group_id = cJSON_GetObjectItem(fim_data->json, "group_id");
     assert_string_equal(cJSON_GetStringValue(group_id), "1000");
     cJSON *group_name = cJSON_GetObjectItem(fim_data->json, "group_name");
@@ -954,6 +959,10 @@ static void test_fim_audit_json(void **state) {
     cJSON *ppid = cJSON_GetObjectItem(fim_data->json, "ppid");
     assert_non_null(ppid);
     assert_int_equal(ppid->valueint, 1000);
+    cJSON *parent_cwd = cJSON_GetObjectItem(fim_data->json, "parent_cwd");
+    assert_string_equal(cJSON_GetStringValue(parent_cwd), "parent_cwd");
+    cJSON *parent_name = cJSON_GetObjectItem(fim_data->json, "parent_name");
+    assert_string_equal(cJSON_GetStringValue(parent_name), "parent_name");
     #endif
 }
 

--- a/src/unit_tests/syscheckd/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/test_syscheck_audit.c
@@ -1284,10 +1284,10 @@ void test_get_process_parent_info_failed(void **state)
     parent_cwd = malloc(10);
 
     will_return(__wrap_readlink, -1);
-    expect_string(__wrap__merror, formatted_msg, "Failure to obtain the name of the process: '1515'. Error: File exists");
+    expect_string(__wrap__mdebug1, formatted_msg, "Failure to obtain the name of the process: '1515'. Error: File exists");
 
     will_return(__wrap_readlink, -1);
-    expect_string(__wrap__merror, formatted_msg, "Failure to obtain the cwd of the process: '1515'. Error: File exists");
+    expect_string(__wrap__mdebug1, formatted_msg, "Failure to obtain the cwd of the process: '1515'. Error: File exists");
 
     state[0] = parent_name;
     state[1] = parent_cwd;


### PR DESCRIPTION
|Related issue| Wazuh-QA PR|
|---|---|
|[4175](https://github.com/wazuh/wazuh/issues/4175), [1310](https://github.com/wazuh/wazuh/issues/1310)|[630](https://github.com/wazuh/wazuh-qa/pull/630)|


## Description

This PR adds three new fields in the Linux whodata alerts:

1. **Field cwd:**
Auditd's field cwd shows the working directory. You can read it in [Redhat documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security_guide/sec-understanding_audit_log_files). As our community user explains on issue 4175, cwd is very useful to generate new rules.

2. **Parent process name:**
As Kevin Branch tells in issue 1310, Auditd doesn't show process parent name in its logs. But it's a useful field.

3. **Parent proces cwd:**


## Configuration options

```xml
  <syscheck>
    <disabled>no</disabled>
    <frequency>43200</frequency>
    <scan_on_start>yes</scan_on_start>
    <directories whodata="yes" check_all="yes">/home/lopezziur/testing1</directories>
  </syscheck>
```

## Logs/Alerts example

**auditd.log:**
```
type=SYSCALL msg=audit(1585556427.627:485): arch=c000003e syscall=257 success=yes exit=3 a0=ffffff9c a1=7ffe63d352a4 a2=941 a3=1b6 items=2 ppid=28027 pid=8772 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=pts0 ses=2 comm="touch" exe="/bin/touch" key="wazuh_fim"
type=CWD msg=audit(1585556427.627:485): cwd="/home/lopezziur"
type=PATH msg=audit(1585556427.627:485): item=0 name="testing1/" inode=10773501 dev=103:05 mode=040775 ouid=1000 ogid=1000 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0
type=PATH msg=audit(1585556427.627:485): item=1 name="testing1/test" inode=10786885 dev=103:05 mode=0100664 ouid=1000 ogid=1000 rdev=00:00 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0
```

**FIM event sent to analysisd:**
```
2020/03/30 10:20:28 ossec-syscheckd[8446] run_check.c:110 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/home/lopezziur/testing1/test","mode":"whodata","type":"added","timestamp":1585556428,"attributes":{"type":"file","size":0,"perm":"rw-rw-r--","uid":"1000","gid":"1000","user_name":"lopezziur","group_name":"lopezziur","inode":10786885,"mtime":1585556427,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"e4257b743b6a4518c3602087f59fb4dbace586ab"},"audit":{"path":"/home/lopezziur/testing1/test","user_id":"1000","user_name":"lopezziur","process_name":"/bin/touch","process_id":8772,"cwd":"/home/lopezziur","group_id":"1000","group_name":"lopezziur","audit_uid":"1000","audit_name":"lopezziur","effective_uid":"1000","effective_name":"lopezziur","parent_name":"/bin/bash","parent_cwd":"/home/lopezziur","ppid":28027}}}
```

**alerts.log:**
```
** Alert 1585556428.15792: - ossec,syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,
2020 Mar 30 10:20:28 lopezziur->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/home/lopezziur/testing1/test' added
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-rw-r--
 - Date: Mon Mar 30 10:20:27 2020
 - Inode: 10786885
 - User: lopezziur (1000)
 - Group: lopezziur (1000)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: lopezziur
 - (Audit) Audit name: lopezziur
 - (Audit) Effective name: lopezziur
 - (Audit) Group name: lopezziur
 - (Audit) Process id: 8772
 - (Audit) Process name: /bin/touch
 - (Audit) Process cwd: /home/lopezziur
 - (Audit) Parent process name: /bin/bash
 - (Audit) Parent process id: 28027
 - (Audit) Parent process cwd: /home/lopezziur
```

**alerts.json:**
```json
{

    "timestamp":"2020-03-30T10:20:28.643+0200",
    "rule":{
        "level":5,
        "description":"File added to the system.",
        "id":"554",
        "firedtimes":1,
        "mail":false,
        "groups":[
            "ossec",
            "syscheck"
        ],
        "pci_dss":[
            "11.5"
        ],
        "gpg13":[
            "4.11"
        ],
        "gdpr":[
            "II_5.1.f"
        ],
        "hipaa":[
            "164.312.c.1",
            "164.312.c.2"
        ],
        "nist_800_53":[
            "SI.7"
        ]
    },
    "agent":{
        "id":"000",
        "name":"lopezziur"
    },
    "manager":{
        "name":"lopezziur"
    },
    "id":"1585556428.15792",
    "full_log":"File '/home/lopezziur/testing1/test' added\nMode: whodata\n",
    "syscheck":{
        "path":"/home/lopezziur/testing1/test",
        "size_after":"0",
        "perm_after":"rw-rw-r--",
        "uid_after":"1000",
        "gid_after":"1000",
        "md5_after":"d41d8cd98f00b204e9800998ecf8427e",
        "sha1_after":"da39a3ee5e6b4b0d3255bfef95601890afd80709",
        "sha256_after":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
        "uname_after":"lopezziur",
        "gname_after":"lopezziur",
        "mtime_after":"2020-03-30T10:20:27",
        "inode_after":10786885,
        "event":"added",
        "audit":{
            "user":{
                "id":"1000",
                "name":"lopezziur"
            },
            "process":{
                "id":"8772",
                "name":"/bin/touch",
                "cwd":"/home/lopezziur",
                "parent_name":"/bin/bash",
                "parent_cwd":"/home/lopezziur",
                "ppid":"28027"
            },
            "group":{
                "id":"1000",
                "name":"lopezziur"
            },
            "login_user":{
                "id":"1000",
                "name":"lopezziur"
            },
            "effective_user":{
                "id":"1000",
                "name":"lopezziur"
            }
        }
    },
    "decoder":{
        "name":"syscheck_new_entry"
    },
    "location":"syscheck"

}
```

## Tests

- [x] Compilation without warnings in  Linux
- [x] Compilation without warnings in  Windows
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] Scan-build report (Windows and linux)
- [x] Valgrind (memcheck and descriptor leaks check)
- [x] Unit test
- [x] Integration test

