### PR TITLE
Adding the database option when requesting on-demand configuration.

### DIFF
--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -319,6 +319,10 @@ cJSON *getSyscheckConfig(void) {
     cJSON_AddNumberToObject(syscfg, "max_eps", syscheck.max_eps);
     cJSON_AddNumberToObject(syscfg, "process_priority", syscheck.process_priority);
 
+    // Add sql database information
+    cJSON_AddStringToObject(syscfg, "database", syscheck.database_store ? "memory" : "disk");
+
+
     cJSON_AddItemToObject(root,"syscheck",syscfg);
 
     return root;

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -436,7 +436,7 @@ void test_getSyscheckConfig_no_directories(void **state)
     assert_int_equal(cJSON_GetArraySize(ret), 1);
 
     cJSON *sys_items = cJSON_GetObjectItem(ret, "syscheck");
-    assert_int_equal(cJSON_GetArraySize(sys_items), 14);
+    assert_int_equal(cJSON_GetArraySize(sys_items), 15);
     cJSON *disabled = cJSON_GetObjectItem(sys_items, "disabled");
     assert_string_equal(cJSON_GetStringValue(disabled), "yes");
     cJSON *frequency = cJSON_GetObjectItem(sys_items, "frequency");

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -228,9 +228,9 @@ void test_getSyscheckConfig(void **state)
 
     cJSON *sys_items = cJSON_GetObjectItem(ret, "syscheck");
     #if defined(TEST_SERVER) || defined(TEST_AGENT)
-    assert_int_equal(cJSON_GetArraySize(sys_items), 17);
+    assert_int_equal(cJSON_GetArraySize(sys_items), 18);
     #elif defined(TEST_WINAGENT)
-    assert_int_equal(cJSON_GetArraySize(sys_items), 20);
+    assert_int_equal(cJSON_GetArraySize(sys_items), 21);
     #endif
 
     cJSON *disabled = cJSON_GetObjectItem(sys_items, "disabled");
@@ -316,6 +316,9 @@ void test_getSyscheckConfig(void **state)
     assert_int_equal(sys_max_eps->valueint, 200);
     cJSON *sys_process_priority = cJSON_GetObjectItem(sys_items, "process_priority");
     assert_int_equal(sys_process_priority->valueint, 10);
+
+    cJSON *database = cJSON_GetObjectItem(sys_items, "database");
+    assert_string_equal(cJSON_GetStringValue(database), "disk");
 }
 
 void test_getSyscheckConfig_no_audit(void **state)
@@ -401,6 +404,9 @@ void test_getSyscheckConfig_no_audit(void **state)
     assert_int_equal(synchronization_response_timeout->valueint, 30);
     cJSON *synchronization_queue_size = cJSON_GetObjectItem(sys_synchronization, "queue_size");
     assert_int_equal(synchronization_queue_size->valueint, 64);
+
+    cJSON *database = cJSON_GetObjectItem(sys_items, "database");
+    assert_string_equal(cJSON_GetStringValue(database), "memory");
 }
 
 #ifndef TEST_WINAGENT

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -336,9 +336,9 @@ void test_getSyscheckConfig_no_audit(void **state)
 
     cJSON *sys_items = cJSON_GetObjectItem(ret, "syscheck");
     #ifndef TEST_WINAGENT
-    assert_int_equal(cJSON_GetArraySize(sys_items), 13);
+    assert_int_equal(cJSON_GetArraySize(sys_items), 14);
     #else
-    assert_int_equal(cJSON_GetArraySize(sys_items), 16);
+    assert_int_equal(cJSON_GetArraySize(sys_items), 17);
     #endif
 
     cJSON *disabled = cJSON_GetObjectItem(sys_items, "disabled");

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -66,6 +66,6 @@
       <max_interval>1h</max_interval>
       <queue_size>64</queue_size>
     </synchronization>
-  </syscheck>
   <database>disk</database>
+  </syscheck>
 </ossec_config>

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -66,6 +66,6 @@
       <max_interval>1h</max_interval>
       <queue_size>64</queue_size>
     </synchronization>
-  <database>disk</database>
+    <database>disk</database>
   </syscheck>
 </ossec_config>

--- a/src/unit_tests/test_syscheck.conf
+++ b/src/unit_tests/test_syscheck.conf
@@ -67,4 +67,5 @@
       <queue_size>64</queue_size>
     </synchronization>
   </syscheck>
+  <database>disk</database>
 </ossec_config>

--- a/src/unit_tests/test_syscheck2.conf
+++ b/src/unit_tests/test_syscheck2.conf
@@ -43,6 +43,6 @@
       <max_interval>1h</max_interval>
       <queue_size>64</queue_size>
     </synchronization>
-  <database>memory</database>
+    <database>memory</database>
   </syscheck>
 </ossec_config>

--- a/src/unit_tests/test_syscheck2.conf
+++ b/src/unit_tests/test_syscheck2.conf
@@ -43,6 +43,6 @@
       <max_interval>1h</max_interval>
       <queue_size>64</queue_size>
     </synchronization>
-  </syscheck>
   <database>memory</database>
+  </syscheck>
 </ossec_config>

--- a/src/unit_tests/test_syscheck2.conf
+++ b/src/unit_tests/test_syscheck2.conf
@@ -44,4 +44,5 @@
       <queue_size>64</queue_size>
     </synchronization>
   </syscheck>
+  <database>memory</database>
 </ossec_config>

--- a/src/unit_tests/test_syscheck_win.conf
+++ b/src/unit_tests/test_syscheck_win.conf
@@ -109,5 +109,6 @@
       <max_interval>1h</max_interval>
       <queue_size>64</queue_size>
     </synchronization>
+    <database>disk</database>
   </syscheck>
 </ossec_config>

--- a/src/unit_tests/test_syscheck_win2.conf
+++ b/src/unit_tests/test_syscheck_win2.conf
@@ -100,5 +100,6 @@
       <max_interval>1h</max_interval>
       <queue_size>64</queue_size>
     </synchronization>
+    <database>memory</database>
   </syscheck>
 </ossec_config>


### PR DESCRIPTION
|Related issue|
|---|
|[#4784](https://github.com/wazuh/wazuh/issues/4784)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Added syscheck store option in configuration on demand API call.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
All FIM configuration.
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
```json
{
   "error": 0,
   "data": {
      "syscheck": {
         "disabled": "no",
         "frequency": 43200,
         "skip_nfs": "yes",
         "skip_dev": "yes",
         "skip_sys": "yes",
         "skip_proc": "yes",
         "scan_on_start": "yes",
         "directories": [
            {
               "opts": [
                  "check_md5sum",
                  "check_sha1sum",
                  "check_perm",
                  "check_size",
                  "check_owner",
                  "check_group",
                  "check_mtime",
                  "check_inode",
                  "check_sha256sum"
               ],
               "dir": "/etc",
               "recursion_level": 256
            },
            {
               "opts": [
                  "check_md5sum",
                  "check_sha1sum",
                  "check_perm",
                  "check_size",
                  "check_owner",
                  "check_group",
                  "check_mtime",
                  "check_inode",
                  "check_sha256sum"
               ],
               "dir": "/usr/bin",
               "recursion_level": 256
            },
            {
               "opts": [
                  "check_md5sum",
                  "check_sha1sum",
                  "check_perm",
                  "check_size",
                  "check_owner",
                  "check_group",
                  "check_mtime",
                  "check_inode",
                  "check_sha256sum"
               ],
               "dir": "/usr/sbin",
               "recursion_level": 256
            },
            {
               "opts": [
                  "check_md5sum",
                  "check_sha1sum",
                  "check_perm",
                  "check_size",
                  "check_owner",
                  "check_group",
                  "check_mtime",
                  "check_inode",
                  "check_sha256sum"
               ],
               "dir": "/bin",
               "recursion_level": 256
            },
            {
               "opts": [
                  "check_md5sum",
                  "check_sha1sum",
                  "check_perm",
                  "check_size",
                  "check_owner",
                  "check_group",
                  "check_mtime",
                  "check_inode",
                  "check_sha256sum"
               ],
               "dir": "/sbin",
               "recursion_level": 256
            },
            {
               "opts": [
                  "check_md5sum",
                  "check_sha1sum",
                  "check_perm",
                  "check_size",
                  "check_owner",
                  "check_group",
                  "check_mtime",
                  "check_inode",
                  "check_sha256sum"
               ],
               "dir": "/boot",
               "recursion_level": 256
            },
            {
               "opts": [
                  "check_md5sum",
                  "check_sha1sum",
                  "check_perm",
                  "check_size",
                  "check_owner",
                  "check_group",
                  "check_mtime",
                  "check_inode",
                  "report_changes",
                  "check_sha256sum",
                  "check_whodata"
               ],
               "dir": "/test",
               "recursion_level": 256
            }
         ],
         "nodiff": [
            "/etc/ssl/private.key"
         ],
         "ignore": [
            "/etc/mtab",
            "/etc/hosts.deny",
            "/etc/mail/statistics",
            "/etc/random-seed",
            "/etc/random.seed",
            "/etc/adjtime",
            "/etc/httpd/logs",
            "/etc/utmpx",
            "/etc/wtmpx",
            "/etc/cups/certs",
            "/etc/dumpdates",
            "/etc/svc/volatile"
         ],
         "ignore_sregex": [
            ".log$|.swp$"
         ],
         "whodata": {
            "restart_audit": "yes",
            "audit_key": [
               "auditkey1",
               "auditkey2"
            ],
            "startup_healthcheck": "yes"
         },
         "allow_remote_prefilter_cmd": "no",
         "synchronization": {
            "enabled": "yes",
            "max_interval": 3600,
            "interval": 300,
            "response_timeout": 30,
            "queue_size": 16384,
            "max_eps": 10
         },
         "max_eps": 100,
         "process_priority": 10,
         "database": "memory"
      }
   }
}

```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
