### PR TITLE
Do not disable extensions on integratord after failed attemps

### DIFF
--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -394,32 +394,31 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
 
                 if(cmd) {
                     wfd_t * wfd = wpopenv(integrator_config[s]->path, cmd, W_BIND_STDOUT | W_BIND_STDERR | W_CHECK_WRITE);
-
                     if(wfd){
                         char buffer[4096];
                         while (fgets(buffer, sizeof(buffer), wfd->file)) {
                             mdebug2("integratord: %s", buffer);
                         }
-
                         int wp_closefd = wpclose(wfd);
-                        int wstatus = WEXITSTATUS(wp_closefd);
-
-                        if (wstatus == 127) {
-                            // 127 means error in exec
-                            merror("Couldn't execute command (%s). Check file and permissions.", exec_full_cmd);
-                            integrator_config[s]->enabled = 0;
-                        } else if(wstatus != 0){
-                            merror("Unable to run integration for %s -> %s",  integrator_config[s]->name, integrator_config[s]->path);
-                            merror("While running %s -> %s. Output: %s ",  integrator_config[s]->name, integrator_config[s]->path,buffer);
-                            integrator_config[s]->enabled = 0;
+                        if ( WIFEXITED(wp_closefd) ) {
+                            int wstatus = WEXITSTATUS(wp_closefd);
+                            if (wstatus == 127) {
+                                // 127 means error in exec
+                                merror("Couldn't execute command (%s). Check file and permissions.", exec_full_cmd);
+                            } else if(wstatus != 0){
+                                merror("Unable to run integration for %s -> %s",  integrator_config[s]->name, integrator_config[s]->path);
+                                merror("While running %s -> %s. Output: %s ",  integrator_config[s]->name, integrator_config[s]->path, buffer);
+                                merror("Exit status was: %d", wstatus);
+                            } else {
+                                mdebug1("Command ran successfully");
+                            }
                         } else {
-                            mdebug1("Command ran successfully");
+                            merror("Command (%s) execution exited abnormally.", exec_full_cmd);
                         }
+                        
                     } else {
                         merror("Could not launch command %s (%d)", strerror(errno), errno);
-                        integrator_config[s]->enabled = 0;
                     }
-
                     free_strarray(cmd);
                 }
             }


### PR DESCRIPTION
|Related issue|
|---|
| #4418 |

Born out of #4418, but does not close it.

## Description

Integratord current logic is to disable an integration after the first failure. In this PR it has been changed to show error logs for each failed attemp but not to disable it at all.

## Tests

### 1. Inserting a bad hook_url will cause the integration to always fail

#### Configuration options

```
<integration>
    <name>slack</name>
    <hook_url>{wrong url}</hook_url> 
    <alert_format>json</alert_format>
</integration>
```
#### Logs/Alerts example

``` 
2020/03/27 17:56:39 ossec-integratord[15399] main.c:103 at main(): DEBUG: Starting ...
2020/03/27 17:56:39 ossec-integratord[15399] main.c:162 at main(): DEBUG: Chrooted to directory: /var/ossec, using user: ossecm
2020/03/27 17:56:39 ossec-integratord[15399] main.c:172 at main(): INFO: Started (pid: 15399).
2020/03/27 17:56:39 ossec-integratord[15399] integrator.c:51 at OS_IntegratorD(): DEBUG: JSON file queue connected.
2020/03/27 17:56:39 ossec-integratord[15399] integrator.c:116 at OS_IntegratorD(): INFO: Enabling integration for: 'slack'.
2020/03/27 17:56:39 ossec-integratord[15399] intgcom.c:76 at intgcom_main(): DEBUG: Local requests thread ready
2020/03/27 17:56:40 ossec-integratord[15399] integrator.c:131 at OS_IntegratorD(): DEBUG: sending new alert.
2020/03/27 17:56:42 ossec-integratord[15399] integrator.c:389 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/slack /tmp/slack-1585331802--1741554104.alert  htttps://hooks.slack.com/ debug
2020/03/27 17:56:42 ossec-integratord[15399] integrator.c:411 at OS_IntegratorD(): ERROR: Unable to run integration for slack -> /var/ossec/integrations/slack
2020/03/27 17:56:42 ossec-integratord[15399] integrator.c:412 at OS_IntegratorD(): ERROR: While running slack -> /var/ossec/integrations/slack. Output: requests.exceptions.InvalidSchema: No connection adapters were found for 'htttps://hooks.slack.com/'
 
2020/03/27 17:56:42 ossec-integratord[15399] integrator.c:413 at OS_IntegratorD(): ERROR: Exit status was: 1
2020/03/27 17:56:45 ossec-integratord[15399] integrator.c:131 at OS_IntegratorD(): DEBUG: sending new alert.
2020/03/27 17:56:46 ossec-integratord[15399] integrator.c:389 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/slack /tmp/slack-1585331806-1271289654.alert  htttps://hooks.slack.com/ debug
2020/03/27 17:56:46 ossec-integratord[15399] integrator.c:411 at OS_IntegratorD(): ERROR: Unable to run integration for slack -> /var/ossec/integrations/slack
2020/03/27 17:56:46 ossec-integratord[15399] integrator.c:412 at OS_IntegratorD(): ERROR: While running slack -> /var/ossec/integrations/slack. Output: requests.exceptions.InvalidSchema: No connection adapters were found for 'htttps://hooks.slack.com/'
 
2020/03/27 17:56:46 ossec-integratord[15399] integrator.c:413 at OS_IntegratorD(): ERROR: Exit status was: 1
2020/03/27 17:56:47 ossec-integratord[15399] integrator.c:131 at OS_IntegratorD(): DEBUG: sending new alert.
2020/03/27 17:56:48 ossec-integratord[15399] integrator.c:389 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/slack /tmp/slack-1585331808--1784623230.alert  htttps://hooks.slack.com/ debug
2020/03/27 17:56:48 ossec-integratord[15399] integrator.c:411 at OS_IntegratorD(): ERROR: Unable to run integration for slack -> /var/ossec/integrations/slack
2020/03/27 17:56:48 ossec-integratord[15399] integrator.c:412 at OS_IntegratorD(): ERROR: While running slack -> /var/ossec/integrations/slack. Output: requests.exceptions.InvalidSchema: No connection adapters were found for 'htttps://hooks.slack.com/'
 
2020/03/27 17:56:48 ossec-integratord[15399] integrator.c:413 at OS_IntegratorD(): ERROR: Exit status was: 1
```
### 2. Inserting a corrrect hook url and change slack script file permissions between alerts

#### Configuration options

```
<integration>
    <name>slack</name>
    <hook_url>{correct url}</hook_url> 
    <alert_format>json</alert_format>
</integration>
```
#### Logs/Alerts example

```
2020/03/27 17:51:04 ossec-integratord[15230] main.c:103 at main(): DEBUG: Starting ...
2020/03/27 17:51:04 ossec-integratord[15230] main.c:162 at main(): DEBUG: Chrooted to directory: /var/ossec, using user: ossecm
2020/03/27 17:51:04 ossec-integratord[15230] main.c:172 at main(): INFO: Started (pid: 15230).
2020/03/27 17:51:04 ossec-integratord[15230] integrator.c:51 at OS_IntegratorD(): DEBUG: JSON file queue connected.
2020/03/27 17:51:04 ossec-integratord[15230] integrator.c:116 at OS_IntegratorD(): INFO: Enabling integration for: 'slack'.
2020/03/27 17:51:04 ossec-integratord[15230] intgcom.c:76 at intgcom_main(): DEBUG: Local requests thread ready
2020/03/27 17:51:14 ossec-integratord[15230] integrator.c:131 at OS_IntegratorD(): DEBUG: sending new alert.
2020/03/27 17:51:16 ossec-integratord[15230] integrator.c:389 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/slack /tmp/slack-1585331476--25381555.alert  https://hooks.slack.com/services/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 debug
2020/03/27 17:51:17 ossec-integratord[15230] integrator.c:416 at OS_IntegratorD(): DEBUG: Command ran successfully
2020/03/27 17:51:48 ossec-integratord[15230] integrator.c:131 at OS_IntegratorD(): DEBUG: sending new alert.
2020/03/27 17:51:50 ossec-integratord[15230] integrator.c:389 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/slack /tmp/slack-1585331510-1652766434.alert  https://hooks.slack.com/services/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 debug
2020/03/27 17:51:50 ossec-integratord[15230] exec_op.c:139 at wpopenv(): ERROR: At wpopenv(): file '/var/ossec/integrations/slack' has write permissions.
2020/03/27 17:51:50 ossec-integratord[15230] integrator.c:409 at OS_IntegratorD(): ERROR: Couldn't execute command (/var/ossec/integrations/slack /tmp/slack-1585331510-1652766434.alert  https://hooks.slack.com/services/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 debug). Check file and permissions.
2020/03/27 17:52:00 ossec-integratord[15230] integrator.c:131 at OS_IntegratorD(): DEBUG: sending new alert.
2020/03/27 17:52:01 ossec-integratord[15230] integrator.c:389 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/slack /tmp/slack-1585331521-1264257525.alert  https://hooks.slack.com/services/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 debug
2020/03/27 17:52:01 ossec-integratord[15230] exec_op.c:139 at wpopenv(): ERROR: At wpopenv(): file '/var/ossec/integrations/slack' has write permissions.
2020/03/27 17:52:01 ossec-integratord[15230] integrator.c:409 at OS_IntegratorD(): ERROR: Couldn't execute command (/var/ossec/integrations/slack /tmp/slack-1585331521-1264257525.alert  https://hooks.slack.com/services/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 debug). Check file and permissions.
2020/03/27 17:52:20 ossec-integratord[15230] integrator.c:131 at OS_IntegratorD(): DEBUG: sending new alert.
2020/03/27 17:52:21 ossec-integratord[15230] integrator.c:389 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/slack /tmp/slack-1585331541-1125553094.alert  https://hooks.slack.com/services/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 debug
2020/03/27 17:52:22 ossec-integratord[15230] integrator.c:416 at OS_IntegratorD(): DEBUG: Command ran successfully
```

![image](https://user-images.githubusercontent.com/11711684/77785288-b8db1100-703a-11ea-81a4-ae39c1ee5250.png)


## Compiling and Check tools
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer