### PR TITLE
Improve error log when Agentd cannot connect to the control module

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -69,7 +69,7 @@ char *get_agent_ip()
     }
 
     if(sock < 0) {
-        merror("Unable to bind to socket '%s': (%d) %s.", CONTROL_SOCK_PATH, errno, strerror(errno));
+        mdebug1("Cannot get the agent host's IP because the control module is not available: (%d) %s.", errno, strerror(errno));
     }
 #endif
     return agent_ip;


### PR DESCRIPTION
|Related issue|
|---|
|#3156|

The agent daemon (_ossec-agentd_) needs the control module (running in _wazuh-modulesd_) to get the current host's IP. If the agent fails to connect to that module, it prints this error log:

```
ossec-agentd: ERROR: Unable to bind to socket '/var/ossec/queue/ossec/control': (111) Connection refused.
```

This log is not friendly, and it may flood the agent's log (_ossec.log_).

## Proposed fix

1. Improve the log description.
2. Switch the log mode to _debug-1_.

## Log sample

```
ossec-agentd[6205] notify.c:72 at get_agent_ip(): DEBUG: Cannot get the agent host's IP because the control module is not available: (111) Connection refused.
```

## Tests

- [X] Compile agent for Linux.
- [X] Compile agent for Windows.
- [X] Compile agent for macOS.
- [X] Source installation.
- [X] Review logs syntax and correct language.