### PR TITLE
Wazuh-apid processes not being killed after restarting wazuh. #4780

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -133,11 +133,11 @@ if __name__ == '__main__':
     else:
         ssl_context = None
 
+    pyDaemonModule.create_pid('wazuh-apid', os.getpid())
+
     app.run(port=configuration['port'],
             host=configuration['host'],
             ssl_context=ssl_context,
             access_log_class=alogging.AccessLogger,
             use_default_access_log=True
             )
-
-    pyDaemonModule.create_pid('wazuh-apid', os.getpid())


### PR DESCRIPTION
Hi team,

This PR closes  #4780. The problem was that api.run(...) never end so we didn't execute the code to create .pid .   

### Test 

```
root@wazuh-master:/var/ossec/var/run# /var/ossec/bin/ossec-control restart
2020/03/27 12:46:47 wazuh-modulesd: WARNING: This vulnerability-detector declaration is deprecated. Use <vulnerability-detector> instead.
2020/03/27 12:46:47 wazuh-modulesd: WARNING: 'disabled' option at module 'vulnerability-detector' is deprecated. Use 'enabled' instead.
2020/03/27 12:46:47 wazuh-modulesd: WARNING: 'feed' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
2020/03/27 12:46:47 wazuh-modulesd: WARNING: 'feed' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
2020/03/27 12:46:47 wazuh-modulesd: WARNING: 'feed' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
Killing wazuh-clusterd...
Killing wazuh-apid...
Killing wazuh-modulesd...
Killing ossec-monitord...
Killing ossec-logcollector...
Killing ossec-remoted...
Killing ossec-syscheckd...
Killing ossec-analysisd...
Killing ossec-maild...
Killing ossec-execd...
Killing wazuh-db...
Killing ossec-authd...
Killing ossec-agentlessd...
Killing ossec-integratord...
ossec-dbd not running...
Killing ossec-csyslogd...
Wazuh v3.12.0 Stopped
Starting Wazuh v3.12.0...
Started ossec-csyslogd...
Started ossec-dbd...
Started ossec-integratord...
Started ossec-agentlessd...
Started ossec-authd...
Started wazuh-db...
Started ossec-execd...
Started ossec-maild...
Started ossec-analysisd...
Started ossec-syscheckd...
Started ossec-remoted...
Started ossec-logcollector...
Started ossec-monitord...
2020/03/27 12:46:52 wazuh-modulesd: WARNING: This vulnerability-detector declaration is deprecated. Use <vulnerability-detector> instead.
2020/03/27 12:46:52 wazuh-modulesd: WARNING: 'disabled' option at module 'vulnerability-detector' is deprecated. Use 'enabled' instead.
2020/03/27 12:46:52 wazuh-modulesd: WARNING: 'feed' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
2020/03/27 12:46:52 wazuh-modulesd: WARNING: 'feed' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
2020/03/27 12:46:52 wazuh-modulesd: WARNING: 'feed' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
Started wazuh-modulesd...
Started wazuh-apid...
Started wazuh-clusterd...
Completed.
```
```
root@wazuh-master:/var/ossec/var/run# ls /var/ossec/var/run/
ossec-agentlessd-23536.pid  ossec-analysisd.state  ossec-csyslogd-23516.pid  ossec-integratord-23529.pid   ossec-maild-23576.pid     ossec-remoted-23598.pid  ossec-syscheckd-23589.pid  wazuh-clusterd-23808.pid  wazuh-modulesd-23615.pid
ossec-analysisd-23583.pid   ossec-authd-23542.pid  ossec-execd-23568.pid     ossec-logcollector-23603.pid  ossec-monitord-23609.pid  ossec-remoted.state      wazuh-apid-23760.pid       wazuh-db-23551.pid

``
