### PR TITLE
Correct argv between integratord and integration scripts

### DIFF
--- a/framework/wrappers/generic_wrapper.sh
+++ b/framework/wrappers/generic_wrapper.sh
@@ -35,4 +35,4 @@ case ${DIR_NAME} in
 esac
 
 
-${WAZUH_PATH}/${WPYTHON_BIN} ${PYTHON_SCRIPT} $@
+${WAZUH_PATH}/${WPYTHON_BIN} ${PYTHON_SCRIPT} "$@"

--- a/integrations/slack
+++ b/integrations/slack
@@ -42,7 +42,7 @@ def main(args):
 
     # Read args
     alert_file_location = args[1]
-    webhook = args[2]
+    webhook = args[3]
 
     debug("# Webhook")
     debug(webhook)

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -383,7 +383,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             if(temp_file_created == 1)
             {
                 int dbg_lvl = isDebug();
-                snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL?"":integrator_config[s]->apikey, integrator_config[s]->hookurl==NULL?"":integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
+                snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL? "None":integrator_config[s]->apikey, integrator_config[s]->hookurl==NULL? "None" : integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
                 if (dbg_lvl <= 0) strcat(exec_full_cmd, " > /dev/null 2>&1");
 
                 mdebug1("Running: %s", exec_full_cmd);

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -383,7 +383,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             if(temp_file_created == 1)
             {
                 int dbg_lvl = isDebug();
-                snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL? "None":integrator_config[s]->apikey, integrator_config[s]->hookurl==NULL? "None" : integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
+                snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL ? "" : integrator_config[s]->apikey, integrator_config[s]->hookurl == NULL ? "" : integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
                 if (dbg_lvl <= 0) strcat(exec_full_cmd, " > /dev/null 2>&1");
 
                 mdebug1("Running: %s", exec_full_cmd);


### PR DESCRIPTION
|Related issue|
|---|
| #4798 |


## Description
Solve mismatch in integration scripts when debug flag is set to active 

## Configuration options
Establish configuration for the 3 integrations:

```
<integration>
  <name>slack</name>
  <hook_url>https://hooks.slack.com/services/...</hook_url> <!-- Replace with your Slack hook URL -->
  <alert_format>json</alert_format>
</integration>

<integration>
  <name>pagerduty</name>
  <api_key>API_KEY</api_key> <!-- Replace with your PagerDuty API key -->
</integration>

<integration>
  <name>virustotal</name>
  <api_key>API_KEY</api_key> <!-- Replace with your VirusTotal API key -->
  <group>syscheck</group>
  <alert_format>json</alert_format>
</integration>
```

## Tests
Manually tested the 3 existen integrations
