### PR TITLE
Fix infinite loop in Logcollector when sending a message to a socket

### DIFF
--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -35,11 +35,46 @@
 #define MAX_OPENQ_ATTEMPS 15
 
 extern int sock_fail_time;
-
+/**
+ *  Starts a Message Queue. 
+ *  @param key path where the message queue will be created
+ *  @param type WRITE||READ 
+ *  @return 
+ *  UNIX -> OS_INVALID if queue failed to start
+ *  UNIX -> int(rc) file descriptor of initialized queue  
+ *  WIN32 -> 0 
+ */
 int StartMQ(const char *key, short int type) __attribute__((nonnull));
 
+/**
+ * Sends a message string through a message queue
+ * @param queue file descriptor of the queue where the message will be sent (UNIX)
+ * @param message string containing the message
+ * @param locmsg path to the queue file
+ * @param loc  queue location (WIN32)
+ * @return 
+ * UNIX -> 0 if file descriptor is still available
+ * UNIX -> -1 if there is an error in the socket. The socket will be closed before returning (StartMQ should be called to restore queue)
+ * WIN32 -> 0
+ * Notes: (UNIX) If the socket is busy when trying to send a message a DEBUG2 message will be loggeed but the return code will be 0
+ */
 int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
 
+/**
+ * Sends a message to a socket. If the socket has not been created yet it will be created based on 
+ * the target information. If a message fails to be sent the method will not try to send it again until *sock_fail_time* has passed
+ * @param queue file descriptor of the queue where the error message will be sent (UNIX)
+ * @param message string containing the message that will be sent
+ * @param locmsg path to the queue file
+ * @param loc  queue location (WIN32)
+ * @param target logtarget ptr with the socket information
+ * @return
+ * UNIX -> -1 invalid protocol or cannot create socket 
+ * UNIX ->  0 message was sent or discarded
+ * WIN32 -> -1 invalid target
+ * WIN32 -> 0 valid target
+ * Notes: (UNIX) If the message is not sent because the socket is busy, the return code will be 0  
+ */
 int SendMSGtoSCK(int queue, const char *message, const char *locmsg, char loc, logtarget * target) __attribute__((nonnull (2, 3, 5)));
 
 void mq_log_builder_init();

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1812,7 +1812,7 @@ void * w_output_thread(void * args){
 
         if (strcmp(message->log_target->log_socket->name, "agent") == 0) {
             // When dealing with this type of messages we don't want any of them to be lost
-            // Continuously attempt to reconnect to the queue and send the message. 
+            // Continuously attempt to reconnect to the queue and send the message.
 
             if(SendMSG(logr_queue, message->buffer, message->file, message->queue_mq) != 0) {
                 #ifdef CLIENT
@@ -1836,14 +1836,12 @@ void * w_output_thread(void * args){
                         sleep_time += 5;
                 }
             }
-            
+
         } else {
-            int messageSent = 0;
             const int MAX_RETRIES = 3;
             int retries = 0;
-            while (messageSent <= 0 && retries < MAX_RETRIES) {
-                messageSent = SendMSGtoSCK(logr_queue, message->buffer, message->file, message->queue_mq, message->log_target);
-                if (messageSent < 0) {
+            while (retries < MAX_RETRIES) {
+                if (SendMSGtoSCK(logr_queue, message->buffer, message->file, message->queue_mq, message->log_target) < 0) {
                     merror(QUEUE_SEND);
 
                     sleep(sleep_time);
@@ -1851,6 +1849,8 @@ void * w_output_thread(void * args){
                     // If we failed, we will wait longer before reattempting to connect
                     sleep_time += 5;
                     retries++;
+                } else {
+                    break;
                 }
             }
             if (retries == MAX_RETRIES) {


### PR DESCRIPTION
|Version|Component|Install type|
|---|---|---|
| 3.12.0 | Logcollector | Agent | 

PR #4696 proposed a change to prevent Logcollector from leaking a descriptor leak. However, it's producing an infinite loop when delivering logs to an external socket like Fluent-Bit or Fluentd.

### Configuration

```xml
<socket>
  <name>fluent_socket</name>
  <location>/var/run/fluent.sock</location>
  <mode>udp</mode>
</socket>

<localfile>
  <log_format>syslog</log_format>
  <location>/root/test/demo.log</location>
  <target>fluent_socket,agent</target>
</localfile>
```

### Sample input log

```
Hello world
```

### Fluent-bit output
```
[47553] syslog.0: [1585350811.997969091, {"log"=>"Hello World"}]
[47554] syslog.0: [1585350811.998074091, {"log"=>"Hello World"}]
[47555] syslog.0: [1585350811.998160799, {"log"=>"Hello World"}]
[47556] syslog.0: [1585350811.998226686, {"log"=>"Hello World"}]
[47557] syslog.0: [1585350811.998309274, {"log"=>"Hello World"}]
(...)
```

## Proposed fix

We should break the loop when Logcollector manages to send a log successfully.

## Tests

- [X] Compile agent for Linux.
- [X] Fluent-Bit receives a log once.
- [X] Logcollector reconnects to Fluent-Bit if that's restarted.