### PR TITLE
Vulnerability Detector: Add support for Linux CPEs in cve.db

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2821,6 +2821,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
     char hotfix_scan = 0;
     char package_scan = 1;
     char hotfix_config_enabled = 0;
+    int linux_agent = OLD_VERSION;
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_SOFTWARE_REQ, agent->agent_id);
 
@@ -2897,7 +2898,8 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
                     free(data);
                 }
                 free(new_obj);
-            } else if (obj = cJSON_ParseWithOpts(json_str, &jsonErrPtr, 0), obj && cJSON_IsObject(obj)) {                 package_list = cJSON_GetObjectItem(obj, "data");
+            } else if (obj = cJSON_ParseWithOpts(json_str, &jsonErrPtr, 0), obj && cJSON_IsObject(obj)) {
+                package_list = cJSON_GetObjectItem(obj, "data");
                 if (!package_list) {
                     goto end;
                 }
@@ -2916,14 +2918,16 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
         }
     }
 
-    // Avoid checking the same packages again
-    snprintf(buffer, OS_SIZE_6144, vu_queries[VU_SYSC_UPDATE_SCAN], agent->agent_id, scan_id);
-    if (wm_vuldet_wdb_request(buffer, OS_SIZE_6144)) {
-        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_SOFTWARE_REQUEST_ERROR, agent->agent_id);
-        goto end;
+    if (agent->dist == FEED_WIN) {
+        // Avoid checking the same Windows packages by cleaning all the SYS_PROGRAMS CPEs in each scan
+        snprintf(buffer, OS_SIZE_6144, vu_queries[VU_SYSC_UPDATE_SCAN], agent->agent_id, scan_id);
+        if (wm_vuldet_wdb_request(buffer, OS_SIZE_6144)) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_SOFTWARE_REQUEST_ERROR, agent->agent_id);
+            goto end;
+        }
     }
 
-    if (wm_vuldet_get_min_cpe_index(db, &min_cpe_index)) {
+    if (wm_vuldet_get_cpe_index(db, &min_cpe_index, agent->dist)) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_CPE_INDEX_GET_ERROR);
         goto end;
     }
@@ -2967,13 +2971,21 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
             char *vendor = (char *) wm_vuldet_get_json_value(package_list, "vendor");
             char *msu_name = (char *) wm_vuldet_get_json_value(package_list, "msu_name");
 
-            if (name && version && architecture) {
-                struct cpe *s_cpe = NULL;
+            if (name && version && architecture)
+            {
+                cpe *s_cpe = (cpe_str) ? wm_vuldet_decode_cpe(cpe_str) : NULL;
                 char success = 1;
 
-                if (cpe_str) {
-                    s_cpe = wm_vuldet_decode_cpe(cpe_str);
+                if (agent->dist == FEED_WIN && s_cpe)
+                {
                     w_strdup(msu_name, s_cpe->msu_name);
+                }
+
+                // Only set once to NEW_VERSION in order to indicate that this
+                // agent supports NVD.
+                if (agent->dist != FEED_WIN && cpe_str && !linux_agent)
+                {
+                    linux_agent = NEW_VERSION;
                 }
 
                 // Generate the node_list structure with those packages
@@ -3001,8 +3013,8 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
     }
 
     // Generate the agent's CPEs
-    // At the moment, only for Windows agents
-    if (agent->dist == FEED_WIN) {
+    if (agent->dist == FEED_WIN || linux_agent == NEW_VERSION)
+    {
         sqlite3_exec(db, vu_queries[BEGIN_T], NULL, NULL, NULL);
         // Add the cpes obtained from Wazuh-db
         if (node_list && wm_vuldet_insert_cpe_db(db, node_list, 0)) {
@@ -3012,7 +3024,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
         }
 
         // Attempts to generate the remaining CPEs
-        if (wm_vuldet_generate_agent_cpes(db, agent, 1)) {
+        if (agent->dist == FEED_WIN && wm_vuldet_generate_agent_cpes(db, agent, 1)) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_AGENT_CPE_GEN_ERROR, agent->agent_id);
             sqlite3_exec(db, vu_queries[END_T], NULL, NULL, NULL);
             goto end;
@@ -3770,7 +3782,9 @@ int wm_vuldet_insert_agent_data(sqlite3 *db, agent_software *agent, int *cpe_ind
     const char *os_major = NULL;
     char *os_minor = NULL;
 
-    if (agent->dist == FEED_REDHAT) {
+    //If it's an old agent, just use the non-nvd method
+    if (agent->dist == FEED_REDHAT && !ag_cpe)
+    {
         wm_vuldet_get_package_os(version, &os_major, &os_minor);
     }
 
@@ -3797,7 +3811,7 @@ int wm_vuldet_insert_agent_data(sqlite3 *db, agent_software *agent, int *cpe_ind
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_AGENT_CPE_PARSE_ERROR, ag_cpe->raw, atoi(agent->agent_id));
         } else {
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_AGENT_CPE_RECV, ag_cpe->raw, atoi(agent->agent_id));
-            *cpe_index = *cpe_index - 1;
+            (*cpe_index) += (agent->dist == FEED_WIN) ? -1 : 1;
         }
     }
 
@@ -4545,8 +4559,9 @@ end:
 }
 
 void wm_vuldet_reset_tables(sqlite3 *db) {
+    // Delete all agents' information and CPEs
     sqlite3_exec(db, vu_queries[VU_REMOVE_AGENTS_TABLE], NULL, NULL, NULL);
-    sqlite3_exec(db, vu_queries[VU_REMOVE_AGENT_CPE], NULL, NULL, NULL);
+    sqlite3_exec(db, vu_queries[VU_REMOVE_CPE], NULL, NULL, NULL);
     sqlite3_exec(db, vu_queries[VU_REMOVE_HOTFIXES_TABLE], NULL, NULL, NULL);
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -689,7 +689,15 @@ int wm_vuldet_nvd_cpe_parser(char *path, wm_vuldet_db *parsed_vulnerabilities);
 int wm_vuldet_insert_cpe_db(sqlite3 *db, cpe_list *node_list, char overwrite);
 int wm_vuldet_sql_error(sqlite3 *db, sqlite3_stmt *stmt);
 int wm_vuldet_step(sqlite3_stmt *stmt);
-int wm_vuldet_get_min_cpe_index(sqlite3 *db, int *min_index);
+
+/*
+* @brief Get the maximum or minimum cpe index.
+* For Windows negative CPEs.
+* For Linux positive CPEs.
+* @param os: Operating System (Windows/Linux).
+*/
+int wm_vuldet_get_cpe_index(sqlite3 *db, int *index, vu_feed os);
+
 int wm_vuldet_add_cpe(cpe *ncpe, char *cpe_raw, cpe_list *node_list, int index);
 int wm_vuldet_generate_agent_cpes(sqlite3 *db, agent_software *agent, char dic);
 int wm_vuldet_fetch_nvd_cve(update_node *update);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
@@ -30,7 +30,11 @@
 #define SQL_BUSY_SLEEP_MS       1
 #define VU_MAX_PACK_REQ         20
 
-typedef enum vu_query {
+#define NEW_VERSION               1 // New version of vuln-agent which supports NVD
+#define OLD_VERSION               0 // Old version of vuln-agent which doesn't supports NVD
+
+typedef enum vu_query
+{
     SELECT_QUERY,
     DELETE_QUERY,
     VU_CHECK_UPDATES,
@@ -73,6 +77,7 @@ typedef enum vu_query {
     VU_REMOVE_AGENT_CPE,
     VU_SEARCH_AGENT_CPE,
     VU_MIN_CPEINDEX,
+    VU_MAX_CPEINDEX,
     VU_GET_PACK_WITHOUT_CPE,
     VU_GET_AGENT_CPES,
     VU_UPDATE_AGENT_CPE,
@@ -178,6 +183,7 @@ static const char *vu_queries[] = {
     "DELETE FROM CPE_INDEX WHERE ID < 0;",
     "SELECT DISTINCT PART FROM CPE_INDEX WHERE PART = 'a' AND VENDOR = ? AND PRODUCT = ?;",
     "SELECT MIN(ID) FROM CPE_INDEX;",
+    "SELECT MAX(ID) FROM CPE_INDEX;",
     "SELECT VENDOR, PACKAGE_NAME, VERSION, ARCH FROM AGENTS WHERE AGENT_ID = ? AND CPE_INDEX_ID = 0;",
     "SELECT PART, CPE_INDEX.VENDOR, PRODUCT, CPE_INDEX.VERSION, UPDATEV, EDITION, LANGUAGE, SW_EDITION, TARGET_SW, TARGET_HW, OTHER, MSU_NAME, AGENTS.VENDOR, PACKAGE_NAME, AGENTS.VERSION, ARCH FROM AGENTS JOIN CPE_INDEX ON CPE_INDEX_ID = ID WHERE AGENT_ID = ?;",
     "UPDATE AGENTS SET CPE_INDEX_ID = ? WHERE AGENT_ID = ? AND VENDOR IS ? AND PACKAGE_NAME = ? AND VERSION = ? AND ARCH = ?;",
@@ -237,8 +243,7 @@ static const char *vu_queries[] = {
     "SELECT HOTFIX FROM AGENT_HOTFIXES WHERE AGENT_ID = ? AND HOTFIX LIKE ?;",
     // TRANSACTIONS
     "BEGIN TRANSACTION;",
-    "END TRANSACTION;"
-};
+    "END TRANSACTION;"};
 
 extern char *schema_vuln_detector_sql;
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -329,8 +329,9 @@ void wm_vuldet_free_multi_cpe(cpe *node) {
     }
 }
 
-int wm_vuldet_get_min_cpe_index(sqlite3 *db, int *min_index) {
+int wm_vuldet_get_cpe_index(sqlite3 *db, int *index, vu_feed os) {
     sqlite3_stmt *stmt = NULL;
+    vu_query index_request;
     int success = 0;
     char close_db = 0;
 
@@ -342,26 +343,41 @@ int wm_vuldet_get_min_cpe_index(sqlite3 *db, int *min_index) {
         close_db = 1;
     }
 
-    if (sqlite3_prepare_v2(db, vu_queries[VU_MIN_CPEINDEX], -1, &stmt, NULL) != SQLITE_OK) {
+    // Windows CPEs use negative index -1,-2...
+    // Linux CPEs use positive index 1,2...
+    index_request = (os == FEED_WIN) ? VU_MIN_CPEINDEX : VU_MAX_CPEINDEX;
+
+    if (sqlite3_prepare_v2(db, vu_queries[index_request], -1, &stmt, NULL) != SQLITE_OK)
+    {
         wm_vuldet_sql_error(db, stmt);
         return OS_INVALID;
     }
-    if (wm_vuldet_step(stmt) == SQLITE_ROW) {
-        if (*min_index = sqlite3_column_int(stmt, 0), *min_index >= 0) {
-            *min_index = -1;
+
+    if (wm_vuldet_step(stmt) == SQLITE_ROW)
+    {
+        *index = sqlite3_column_int(stmt, 0);
+        if (os == FEED_WIN) {
+            *index = (*index > 0) ? 0 : *index; //Set default to 0
         } else {
-            (*min_index)--;
+            *index = (*index < 0) ? 0 : *index; //Set default to 0
         }
+
+        // Decrement if it's Windows
+        // Increment if it's Linux
+        (*index) += (os == FEED_WIN) ? -1 : 1;
+
     } else {
         goto end;
     }
 
     success = 1;
+
 end:
     sqlite3_finalize(stmt);
     if (close_db) {
         sqlite3_close_v2(db);
     }
+
     return !success;
 }
 
@@ -447,7 +463,7 @@ int wm_vuldet_extract_agent_cpes(agent_software *agent, sqlite3 *db) {
         pkg_terms = pkg_terms->prev;
     }
 
-    if (wm_vuldet_get_min_cpe_index(db, &min_cpe_index)) {
+    if (wm_vuldet_get_cpe_index(db, &min_cpe_index, agent->dist)) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_CPE_INDEX_GET_ERROR);
         goto end;
     }
@@ -2152,7 +2168,7 @@ int wm_vuldet_generate_agent_cpes_with_dic(sqlite3 *db, agent_software *agent) {
     int min_cpe_index;
     int retval = OS_INVALID;
 
-    if (wm_vuldet_get_min_cpe_index(db, &min_cpe_index)) {
+    if (wm_vuldet_get_cpe_index(db, &min_cpe_index, agent->dist)) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_CPE_INDEX_GET_ERROR);
         return OS_INVALID;
     }


### PR DESCRIPTION
|#4763|

## Description
In the current implementation, Vulnerability-detector stores the CPEs of only Windows agents' packages with the purpuse of correlating them with the NVD database. Said CPEs are all saved in the **CPE_INDEX** table.

This PR makes a few changes in the Linux flow so that the CPEs, previously obtained from **SYS_PROGRAM**(wazuh-db), can all be stored in **CPE_INDEX**(cve.db) for later use.

Within **CPE_INDEX** table, the `id` field will have the following values:

-  Linux package: `id` field will be a positive number (1,2,3...).
- Windows package: `id` field will be a negative number (-1,-2,-3...).

Said `id` field will be referenced from the **AGENTS** table, which will hold more information regarding each package.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
