### PR TITLE
Fix xfailed RBAC manager tests for the new API

### DIFF
--- a/api/test/integration/env/configurations/rbac/manager/black_configuration_rbac.sh
+++ b/api/test/integration/env/configurations/rbac/manager/black_configuration_rbac.sh
@@ -2,6 +2,6 @@
 
 sed -i 's,"mode": \("white"\|"black"\),"mode": "black",g' /var/ossec/framework/python/lib/python3.7/site-packages/api-4.0.0-py3.7.egg/api/configuration.py
 sed -i "s:    # policies = RBAChecker.run_testing():    policies = RBAChecker.run_testing():g" /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/preprocessor.py
-permissions='[{"actions":["manager:read_config","manager:read_file","manager:restart"],"resources":["*"],"effect":"deny"},{"actions":["manager:delete_file"],"resources":["file:path:local_rules.xml"],"effect":"deny"}]'
+permissions='[{"actions":["manager:read_file"],"resources":["file:path:*"],"effect":"deny"},{"actions":["manager:restart","manager:read_config"],"resources":["*"],"effect":"deny"},{"actions":["manager:delete_file"],"resources":["file:path:etc/rules/local_rules.xml"],"effect":"deny"}]'
 awk -v var="${permissions}" '{sub(/testing_policies = \[\]/, "testing_policies = " var)}1' /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context.py >> /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context1.py
 cat /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context1.py > /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context.py

--- a/api/test/integration/env/configurations/rbac/manager/white_configuration_rbac.sh
+++ b/api/test/integration/env/configurations/rbac/manager/white_configuration_rbac.sh
@@ -2,6 +2,6 @@
 
 sed -i 's,"mode": \("white"\|"black"\),"mode": "white",g' /var/ossec/framework/python/lib/python3.7/site-packages/api-4.0.0-py3.7.egg/api/configuration.py
 sed -i "s:    # policies = RBAChecker.run_testing():    policies = RBAChecker.run_testing():g" /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/preprocessor.py
-permissions='[{"actions":["manager:read_config","manager:read_file","manager:restart"],"resources":["*"],"effect":"allow"},{"actions":["manager:delete_file"],"resources":["file:path:local_rules.xml"],"effect":"allow"}]'
+permissions='[{"actions":["manager:read_file"],"resources":["file:path:*"],"effect":"allow"},{"actions":["manager:read_config","manager:restart"],"resources":["*"],"effect":"allow"},{"actions":["manager:delete_file"],"resources":["file:path:etc/rules/local_rules.xml"],"effect":"allow"}]'
 awk -v var="${permissions}" '{sub(/testing_policies = \[\]/, "testing_policies = " var)}1' /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context.py >> /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context1.py
 cat /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context1.py > /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context.py

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -60,14 +60,11 @@ stages:
 ---
 test_name: DELETE /manager/files
 
-marks:
-  - xfail
-
 stages:
 
   - name: Delete a file (Allowed)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -78,7 +75,7 @@ stages:
 
   - name: Delete a file (Denied)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -92,14 +89,11 @@ stages:
 ---
 test_name: GET /manager/files
 
-marks:
-  - xfail
-
 stages:
 
   - name: Read a file (Denied)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,14 +107,11 @@ stages:
 ---
 test_name: PUT /manager/files
 
-marks:
-  - xfail
-
 stages:
 
   - name: Upload a file (Allowed)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -132,7 +123,7 @@ stages:
 
   - name: Upload a file (Indirectly denied, can't delete while overwriting)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -141,9 +132,20 @@ stages:
         path: 'etc/rules/local_rules.xml'
         overwrite: True
     response:
-      status_code: 400
+      status_code: 200
       body:
-        code: 4000
+        data:
+          affected_items: []
+          total_affected_items: 0
+          total_failed_items: 1
+          failed_items:
+            - id:
+                - 'etc/rules/local_rules.xml'
+              error:
+                code: 4000
+                message: !anystr
+                remediation: !anystr
+        message: !anystr
 
 ---
 test_name: GET /manager/info

--- a/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
@@ -54,14 +54,11 @@ stages:
 ---
 test_name: DELETE /manager/files
 
-marks:
-  - xfail
-
 stages:
 
   - name: Delete a file (Denied)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -74,7 +71,7 @@ stages:
 
   - name: Delete a file (Allowed)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -86,33 +83,40 @@ stages:
 ---
 test_name: GET /manager/files
 
-marks:
-  - xfail
-
 stages:
 
   - name: Read a file (Allowed)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: 'etc/decoders/local_decoder.xml'
+    response:
+      status_code: 200
+
+  - name: Read a file (Allowed, Does not exist)
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         path: 'etc/rules/local_rules.xml'
     response:
-      status_code: 200
+      status_code: 400
+      body:
+        code: 1906
 
 ---
 test_name: PUT /manager/files
-
-marks:
-  - xfail
 
 stages:
 
   - name: Upload a file (Denied)
     request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}//manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -231,7 +231,7 @@ def get_file(path, validate=False):
 
     # check if file exists
     if not exists(full_path):
-        raise WazuhError(1006)
+        raise WazuhError(1906)
 
     try:
         with open(full_path) as f:

--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -85,7 +85,7 @@ def _expand_resource(resource):
         elif resource_type == 'node:id':
             return set(cluster_nodes.get())
         elif resource_type == 'file:path':
-            return get_files
+            return get_files()
         elif resource_type == '*:*':  # Resourceless
             return {'*'}
         return set()


### PR DESCRIPTION
Hello team, this closes #4810 .

We had some xfailed tests in `test_rbac_white_manager_endpoints.tavern.yaml` and `test_rbac_black_manager_endpoints.tavern.yaml`.

As it was suggested in the issue, we needed to change the permissions and update some tests mainly, but some minor changes were needed as well.

## Tests performed
### White
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collected 16 items                                                                                                                                                                                                

test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                            [  6%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED                                                                                                                 [ 12%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                [ 18%]
test_rbac_white_manager_endpoints.tavern.yaml::DELETE /manager/files PASSED                                                                                                                                 [ 25%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/files PASSED                                                                                                                                    [ 31%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/files PASSED                                                                                                                                    [ 37%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                     [ 43%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                     [ 50%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                             [ 56%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                  [ 62%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                    [ 68%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                          [ 75%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                             [ 81%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                            [ 87%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                             [ 93%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                   [100%]

================================================================================================ warnings summary =================================================================================================
test/integration/test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================================================================================== 16 passed, 1 warnings in 23.71 seconds ======================================================================================
```

### Black
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collected 16 items                                                                                                                                                                                                

test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                            [  6%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED                                                                                                                 [ 12%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                [ 18%]
test_rbac_black_manager_endpoints.tavern.yaml::DELETE /manager/files PASSED                                                                                                                                 [ 25%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/files PASSED                                                                                                                                    [ 31%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/files PASSED                                                                                                                                    [ 37%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                     [ 43%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                     [ 50%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                             [ 56%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                  [ 62%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                    [ 68%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                          [ 75%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                             [ 81%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                            [ 87%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                             [ 93%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                   [100%]

================================================================================================ warnings summary =================================================================================================
test/integration/test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================================================================================== 16 passed, 1 warnings in 44.11 seconds ======================================================================================

```

Regards.