### PR TITLE
Update /manager/configuration endpoint to add new syscheck config options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Make Logcollector continuously attempt to reconnect with the agent daemon. ([#4435](https://github.com/wazuh/wazuh/pull/4435))
 - Make Windows agents to send the keep-alive independently. ([#4077](https://github.com/wazuh/wazuh/pull/4077))
 - Do not enforce source IP checking by default in the registration process. ([#4083](https://github.com/wazuh/wazuh/pull/4083))
+- Updated API manager/configuration endpoint to also return the new synchronization and whodata syscheck fields ([#4818](https://github.com/wazuh/wazuh/pull/4818))
 
 ### Fixed
 

--- a/framework/wazuh/configuration.py
+++ b/framework/wazuh/configuration.py
@@ -1,6 +1,6 @@
 
 
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import json
@@ -183,6 +183,11 @@ def _read_option(section_name, opt):
                 json_path = json_attribs.copy()
                 json_path['path'] = path.strip()
                 opt_value.append(json_path)
+    elif section_name == 'syscheck' and opt_name in ('synchronization', 'whodata'):
+        opt_value = {}
+        for child in opt:
+            child_section, child_config = _read_option(child.tag.lower(), child)
+            opt_value[child_section] = child_config.split(',') if child_config.find(',') > 0 else child_config
     elif (section_name == 'cluster' and opt_name == 'nodes') or \
         (section_name == 'sca' and opt_name == 'policies'):
         opt_value = [child.text for child in opt]


### PR DESCRIPTION
This PR closes #4790.

The endpoint GET /manager/configuration returns the configuration in the ossec.conf file in JSON format. This PR modifies `_read_option` function in `configuration.py` to apply the appropiate format to the new `whodata` and `synchronization` options.

Here is an example after the modification:

```
curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/configuration?section=syscheck&pretty"
{
   "error": 0,
   "data": {
      "disabled": "no",
      "frequency": "43200",
      "scan_on_start": "yes",
      "alert_new_files": "yes",
      "auto_ignore": {
         "frequency": "10",
         "timeframe": "3600",
         "item": "no"
      },
      "directories": [
         {
            "path": "/etc"
         },
         {
            "path": "/usr/bin"
         },
         {
            "path": "/usr/sbin"
         },
         {
            "path": "/bin"
         },
         {
            "path": "/sbin"
         },
         {
            "path": "/boot"
         }
      ],
      "ignore": [
         "/etc/mtab",
         "/etc/hosts.deny",
         "/etc/mail/statistics",
         "/etc/random-seed",
         "/etc/random.seed",
         "/etc/adjtime",
         "/etc/httpd/logs",
         "/etc/utmpx",
         "/etc/wtmpx",
         "/etc/cups/certs",
         "/etc/dumpdates",
         "/etc/svc/volatile",
         {
            "type": "sregex",
            "item": ".log$|.swp$"
         }
      ],
      "nodiff": [
         "/etc/ssl/private.key"
      ],
      "skip_nfs": "yes",
      "skip_dev": "yes",
      "skip_proc": "yes",
      "skip_sys": "yes",
      "process_priority": "10",
      "max_eps": "100",
      "whodata": {
         "restart_audit": "yes",
         "audit_key": [
            "auditkey1",
            "auditkey2"
         ],
         "startup_healthcheck": "yes"
      },
      "synchronization": {
         "enabled": "yes",
         "interval": "5m",
         "max_interval": "1h",
         "max_eps": "10"
      }
   }
}
```

## Test results

Here are the results of the mocha tests:
```
Manager
    GET/manager/status
(node:6419) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
      ✓ Request (375ms)
    GET/manager/info
      ✓ Request (344ms)
    GET/manager/configuration
      ✓ Request (331ms)
      ✓ Filters: Missing field section (97ms)
      ✓ Filters: Section (342ms)
      ✓ Errors: Invalid Section (334ms)
      ✓ Filters: Section - field (311ms)
      ✓ Errors: Invalid field (311ms)
      ✓ Filters: Invalid filter (97ms)
      ✓ Filters: Invalid filter - Extra field (95ms)
    GET/manager/stats
      ✓ Request (337ms)
      ✓ Filters: date (378ms)
      ✓ Filters: Invalid date (118ms)
      ✓ Filters: Invalid filter (90ms)
      ✓ Filters: Invalid filter - Extra field (95ms)
    GET/manager/stats/hourly
      ✓ Request (325ms)
    GET/manager/stats/weekly
      ✓ Request (328ms)
    GET/manager/stats/analysisd
      ✓ Request (341ms)
    GET/manager/stats/remoted
      ✓ Request (316ms)
    GET/manager/logs
      ✓ Request (376ms)
      ✓ Pagination (353ms)
      ✓ Retrieve all elements with limit=0 (352ms)
      ✓ Sort (396ms)
      ✓ SortField (370ms)
      ✓ Search (409ms)
      ✓ Filters: type_log (398ms)
      ✓ Filters: category (351ms)
      ✓ Filters: type_log and category (579ms)
      ✓ Filters: Invalid filter (93ms)
      ✓ Filters: Invalid filter - Extra field (93ms)
      ✓ Filters: query 1 (350ms)
      ✓ Filters: query 2 (380ms)
      ✓ Filters: query 3 (376ms)
      ✓ Filters: wrong query (89ms)
    GET/manager/logs/summary
      ✓ Request (293ms)
    POST/manager/files
      ✓ Upload ossec.conf (281ms)
      ✓ Upload ossec.conf (overwrite=false) (371ms)
      ✓ Upload rules (new rule) (380ms)
      ✓ Upload rules (overwrite=true) (383ms)
      ✓ Upload rules (overwrite=false) (383ms)
      ✓ Upload decoder (overwrite=true) (314ms)
      ✓ Upload decoder (without overwrite parameter) (297ms)
      ✓ Upload list (overwrite=true) (349ms)
      ✓ Upload list (without overwrite parameter) (363ms)
      ✓ Upload malformed rule (99ms)
      ✓ Upload malformed decoder (98ms)
      ✓ Upload malformed list (100ms)
      ✓ Upload list with empty path (108ms)
      ✓ Upload a file with a wrong content type (95ms)
    GET/manager/files
      ✓ Request ossec.conf (421ms)
      ✓ Request rules (local) (369ms)
      ✓ Request rules (global) (367ms)
      ✓ Request decoders (local) (325ms)
      ✓ Request decoders (global) (346ms)
      ✓ Request lists (401ms)
      ✓ Request wrong path 1 (108ms)
      ✓ Request wrong path 2 (91ms)
      ✓ Request wrong path 3 (112ms)
      ✓ Request unexisting file (398ms)
      ✓ Request file with empty path (107ms)
      ✓ Request file with validation parameter (true) (378ms)
    DELETE/manager/files
      ✓ Delete rules (329ms)
      ✓ Delete decoders (342ms)
      ✓ Delete CDB list (378ms)
      ✓ Delete file with empty path (111ms)
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (1293ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (421ms)
    GET/manager/config/:component/:configuration
      ✓ Request-Agentless-Agentless (373ms)
      ✓ Request-Analysis-Global (418ms)
      ✓ Request-Analysis-Active-response (464ms)
      ✓ Request-Analysis-Alerts (419ms)
      ✓ Request-Analysis-Command (415ms)
      ✓ Request-Analysis-Internal (449ms)
      ✓ Request-Auth-Auth (435ms)
      ✓ Request-Com-Active-response (390ms)
      ✓ Request-Com-Internal (375ms)
      ✓ Request-Csyslog-Csyslog (319ms)
      ✓ Request-Integrator-Integration (339ms)
      ✓ Request-Logcollector-Localfile (318ms)
      ✓ Request-Logcollector-Socket (412ms)
      ✓ Request-Logcollector-Internal (432ms)
      ✓ Request-Mail-Global (467ms)
      ✓ Request-Mail-Alerts (417ms)
      ✓ Request-Mail-Internal (435ms)
      ✓ Request-Monitor-Internal (327ms)
      ✓ Request-Request-Remote (324ms)
      ✓ Request-Request-Internal (336ms)
      ✓ Request-Syscheck-Syscheck (424ms)
      ✓ Request-Syscheck-Rootcheck (380ms)
      ✓ Request-Syscheck-Internal (419ms)
      ✓ Request-Wmodules-Wmodules (377ms)
    PUT/manager/restart
      ✓ Request (311ms)


  92 passing (32s)
```