### PR TITLE
Improve API test environment to add new database entries 

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -161,6 +161,22 @@ def environment_syscheck():
     down_env()
 
 
+@pytest.fixture(name="experimental_tests", scope="session")
+def environment_experimental():
+    values = build_and_up("experimental")
+    while values['retries'] < values['max_retries']:
+        master_health = check_health()
+        if master_health:
+            agents_healthy = check_health(node_type='agent', agents=[1, 2, 3])
+            if agents_healthy:
+                time.sleep(10)
+                yield
+                break
+        else:
+            values['retries'] += 1
+    down_env()
+
+
 @pytest.fixture(name="security_white_rbac_tests", scope="session")
 def environment_white_security_rbac():
     values = build_and_up("security_white_rbac")

--- a/api/test/integration/env/base/wazuh-agent/Dockerfile
+++ b/api/test/integration/env/base/wazuh-agent/Dockerfile
@@ -33,6 +33,7 @@ COPY configurations/ciscat/wazuh-agent-ciscat/healthcheck/healthcheck.py /tmp/he
 COPY configurations/ciscat/wazuh-agent-ciscat/ciscat /var/ossec/wodles/ciscat
 RUN cd /var/ossec/wodles/ciscat && if [ -e CIS-CAT.sh ]; then chmod +x CIS-CAT.sh ; fi
 
+FROM wazuh-env-agent-ciscat AS wazuh-env-agent-experimental
 FROM base_agent AS wazuh-env-agent-security_white_rbac
 FROM base_agent AS wazuh-env-agent-security_black_rbac
 FROM base_agent AS wazuh-env-agent-agents_white_rbac

--- a/api/test/integration/env/base/wazuh-manager/manager.Dockerfile
+++ b/api/test/integration/env/base/wazuh-manager/manager.Dockerfile
@@ -34,6 +34,7 @@ FROM base as wazuh-env-lists_white_rbac
 FROM base as wazuh-env-lists_black_rbac
 FROM base AS wazuh-env-syscheck_white_rbac
 FROM base AS wazuh-env-syscheck_black_rbac
+FROM base AS wazuh-env-experimental
 
 FROM base AS wazuh-env-security
 COPY configurations/security/wazuh-master/schema_security_test.sql /var/ossec/api/configuration/security/schema_security_test.sql

--- a/api/test/integration/env/base/wazuh-manager/master.Dockerfile
+++ b/api/test/integration/env/base/wazuh-manager/master.Dockerfile
@@ -35,6 +35,9 @@ FROM base AS wazuh-env-syscheck
 COPY configurations/syscheck/wazuh-master/healthcheck/healthcheck.py /tmp/healthcheck.py
 
 FROM base AS wazuh-env-syscollector
+COPY configurations/syscollector/wazuh-master/wdb_checker.py /wdb_checker.py
+COPY configurations/syscollector/wazuh-master/send_to_wdb.py /send_to_wdb.py
+ADD configurations/syscollector/wazuh-master/entrypoint.sh /scripts/entrypoint.sh
 
 FROM base AS wazuh-env-security
 COPY configurations/security/wazuh-master/schema_security_test.sql /var/ossec/api/configuration/security/schema_security_test.sql
@@ -103,11 +106,11 @@ RUN /scripts/configuration_rbac.sh
 COPY configurations/base/wazuh-master/healthcheck/healthcheck_daemons.py /tmp/healthcheck.py
 COPY configurations/base/wazuh-master/healthcheck/daemons_check.txt /tmp/daemons_check.txt
 
-FROM base AS wazuh-env-syscollector_white_rbac
+FROM wazuh-env-syscollector AS wazuh-env-syscollector_white_rbac
 ADD configurations/rbac/syscollector/white_configuration_rbac.sh /scripts/configuration_rbac.sh
 RUN /scripts/configuration_rbac.sh
 
-FROM base AS wazuh-env-syscollector_black_rbac
+FROM wazuh-env-syscollector AS wazuh-env-syscollector_black_rbac
 ADD configurations/rbac/syscollector/black_configuration_rbac.sh /scripts/configuration_rbac.sh
 RUN /scripts/configuration_rbac.sh
 

--- a/api/test/integration/env/base/wazuh-manager/master.Dockerfile
+++ b/api/test/integration/env/base/wazuh-manager/master.Dockerfile
@@ -39,6 +39,8 @@ COPY configurations/syscollector/wazuh-master/wdb_checker.py /wdb_checker.py
 COPY configurations/syscollector/wazuh-master/send_to_wdb.py /send_to_wdb.py
 ADD configurations/syscollector/wazuh-master/entrypoint.sh /scripts/entrypoint.sh
 
+FROM wazuh-env-syscollector AS wazuh-env-experimental
+
 FROM base AS wazuh-env-security
 COPY configurations/security/wazuh-master/schema_security_test.sql /var/ossec/api/configuration/security/schema_security_test.sql
 RUN sqlite3 /var/ossec/api/configuration/security/rbac.db < /var/ossec/api/configuration/security/schema_security_test.sql
@@ -174,11 +176,11 @@ FROM wazuh-env-cluster AS wazuh-env-cluster_black_rbac
 ADD configurations/rbac/cluster/black_configuration_rbac.sh /scripts/configuration_rbac.sh
 RUN /scripts/configuration_rbac.sh
 
-FROM base AS wazuh-env-experimental_black_rbac
+FROM wazuh-env-syscollector AS wazuh-env-experimental_black_rbac
 ADD configurations/rbac/experimental/black_configuration_rbac.sh /scripts/configuration_rbac.sh
 RUN /scripts/configuration_rbac.sh
 
-FROM base AS wazuh-env-experimental_white_rbac
+FROM wazuh-env-syscollector AS wazuh-env-experimental_white_rbac
 ADD configurations/rbac/experimental/white_configuration_rbac.sh /scripts/configuration_rbac.sh
 RUN /scripts/configuration_rbac.sh
 

--- a/api/test/integration/env/configurations/rbac/experimental/black_configuration_rbac.sh
+++ b/api/test/integration/env/configurations/rbac/experimental/black_configuration_rbac.sh
@@ -2,7 +2,7 @@
 
 sed -i 's,"mode": "white","mode": "black",g' /var/ossec/framework/python/lib/python3.7/site-packages/api-4.0.0-py3.7.egg/api/configuration.py
 sed -i "s:    # policies = RBAChecker.run_testing():    policies = RBAChecker.run_testing():g" /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/preprocessor.py
-permissions='[{"actions":["syscollector:read","syscheck:clear","ciscat:read"],"resources":["agent:id:000","agent:id:001","agent:id:003","agent:id:005","agent:id:007","agent:id:009","agent:id:010","agent:id:011","agent:id:012"],"effect":"deny"}]'
+permissions='[{"actions":["syscollector:read","syscheck:clear","ciscat:read"],"resources":["agent:id:001","agent:id:003","agent:id:005","agent:id:007","agent:id:009","agent:id:010","agent:id:011","agent:id:012"],"effect":"deny"}]'
 awk -v var="${permissions}" '{sub(/testing_policies = \[\]/, "testing_policies = " var)}1' /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context.py >> /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context1.py
 cat /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context1.py > /var/ossec/framework/python/lib/python3.7/site-packages/wazuh-3.12.0-py3.7.egg/wazuh/rbac/auth_context.py
 

--- a/api/test/integration/env/configurations/syscollector/wazuh-master/entrypoint.sh
+++ b/api/test/integration/env/configurations/syscollector/wazuh-master/entrypoint.sh
@@ -9,9 +9,6 @@ sed -i "s:<node_name>node01</node_name>:<node_name>$2</node_name>:g" /var/ossec/
 sed -i "s:<use_source_ip>yes</use_source_ip>:<use_source_ip>no</use_source_ip>:g" /var/ossec/etc/ossec.conf
 sed -i "s:<protocol>udp</protocol>:<protocol>tcp</protocol>:g" /var/ossec/etc/ossec.conf
 
-# Add debug wazuh_db debug level 2
-echo "wazuh_db.debug=2" >> /var/ossec/etc/local_internal_options.conf
-
 if [ "$3" != "master" ]; then
     sed -i "s:<node_type>master</node_type>:<node_type>worker</node_type>:g" /var/ossec/etc/ossec.conf
 else

--- a/api/test/integration/env/configurations/syscollector/wazuh-master/entrypoint.sh
+++ b/api/test/integration/env/configurations/syscollector/wazuh-master/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+sed -i "s:<key></key>:<key>9d273b53510fef702b54a92e9cffc82e</key>:g" /var/ossec/etc/ossec.conf
+sed -i "s:<node>NODE_IP</node>:<node>$1</node>:g" /var/ossec/etc/ossec.conf
+sed -i -e "/<cluster>/,/<\/cluster>/ s|<disabled>[a-z]\+</disabled>|<disabled>no</disabled>|g" /var/ossec/etc/ossec.conf
+sed -i "s:<node_name>node01</node_name>:<node_name>$2</node_name>:g" /var/ossec/etc/ossec.conf
+
+# Add this to configure with nginx load balancer
+sed -i "s:<use_source_ip>yes</use_source_ip>:<use_source_ip>no</use_source_ip>:g" /var/ossec/etc/ossec.conf
+sed -i "s:<protocol>udp</protocol>:<protocol>tcp</protocol>:g" /var/ossec/etc/ossec.conf
+
+# Add debug wazuh_db debug level 2
+echo "wazuh_db.debug=2" >> /var/ossec/etc/local_internal_options.conf
+
+if [ "$3" != "master" ]; then
+    sed -i "s:<node_type>master</node_type>:<node_type>worker</node_type>:g" /var/ossec/etc/ossec.conf
+else
+    sed -i "s:<node_type>master</node_type>:<node_type>master</node_type>:g" /var/ossec/etc/ossec.conf
+    chown root:ossec /var/ossec/etc/ossec.conf
+    chown root:ossec /var/ossec/etc/client.keys
+    chown -R ossec:ossec /var/ossec/queue/agent-groups
+    chown -R ossec:ossec /var/ossec/etc/shared
+    chown root:ossec /var/ossec/etc/shared/ar.conf
+    chown -R ossecr:ossec /var/ossec/queue/agent-info
+fi
+
+sleep 1
+
+/var/ossec/bin/ossec-control restart
+
+/var/ossec/framework/python/bin/python3 /wdb_checker.py
+
+/usr/bin/supervisord

--- a/api/test/integration/env/configurations/syscollector/wazuh-master/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/wazuh-master/healthcheck/healthcheck.py
@@ -1,0 +1,41 @@
+import os
+import sqlite3
+
+
+database = '/var/ossec/queue/db/'
+
+
+def create_connection(agent_id):
+    agent_db = f"{database}{agent_id}.db"
+    conn = None
+    try:
+        conn = sqlite3.connect(agent_db)
+    except sqlite3.Error as e:
+        print(e)
+
+    return conn
+
+
+def check_hotfix_database():
+    conn = create_connection('000')
+    cur = conn.cursor()
+
+    cur.execute("SELECT * FROM sys_hotfixes")
+    result = cur.fetchall()
+    return 0 if result else 1
+
+
+def get_health():
+    os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
+    check = os.popen("diff -q /tmp/output.txt /tmp/agent_control_check.txt").read()
+    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Module started.' /var/ossec/logs/ossec.log")
+    db = check_hotfix_database()
+
+    if "differ" not in check and output == 0 and db == 0:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":
+    exit(get_health())

--- a/api/test/integration/env/configurations/syscollector/wazuh-master/send_to_wdb.py
+++ b/api/test/integration/env/configurations/syscollector/wazuh-master/send_to_wdb.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+#
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute
+# it and/or modify it under the terms of GPLv2
+
+"""This module sends a message to WazuhDB socket."""
+
+import argparse
+import os
+import socket
+import struct
+
+WDB_SOCKET_PATH = os.path.join('/', 'var', 'ossec', 'queue', 'db', 'wdb')
+
+
+def get_script_arguments():
+    """Get script arguments."""
+    parser = argparse.ArgumentParser(usage="usage: %(prog)s [options]",
+                                     description="Tool for sending queries to WazuhDB",  # noqa: E501
+                                     formatter_class=argparse.RawTextHelpFormatter)  # noqa: E501
+
+    parser.add_argument('-q', '--query', dest='query',
+                        help='Query to send to WazuhDB', required=True)
+
+    return parser.parse_args()
+
+
+def send_query_to_wdb(query: str):
+    """Send query to WazuhDB socket.
+    :param query: Query to send
+    """
+    # connect to WazuhDB socket
+    wdb_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    wdb_socket.connect(WDB_SOCKET_PATH)
+    # construct message
+    encoded_message = query.encode(encoding='utf-8')
+    final_message = struct.pack('<I', len(encoded_message)) + encoded_message
+    wdb_socket.send(final_message)
+
+    received = wdb_socket.recv(4096)
+    if len(received) == 4096:
+        while 1:
+            try:  # error means no more data
+                received += wdb_socket.recv(4096, socket.MSG_DONTWAIT)
+            except:
+                break
+
+    wdb_socket.close()
+
+
+if __name__ == '__main__':
+    # get script arguments
+    arguments = get_script_arguments()
+    query = arguments.query
+    # send query to WazuhDB
+    send_query_to_wdb(query)

--- a/api/test/integration/env/configurations/syscollector/wazuh-master/wdb_checker.py
+++ b/api/test/integration/env/configurations/syscollector/wazuh-master/wdb_checker.py
@@ -2,10 +2,15 @@ import os
 import subprocess
 import time
 
+from datetime import datetime
 
 wdb_socket = '/var/ossec/queue/db/wdb'
+timeout = 60
 
+now = datetime.now()
 while not os.path.exists(wdb_socket):
+    if (datetime.now() - now).seconds > timeout:
+        raise TimeoutError
     time.sleep(5)
 
 query = "agent 000 sql insert or ignore into sys_hotfixes(scan_id, scan_time, hotfix) values (1408519641, '2019/08/05 12:06:26', 'KB2533552')"

--- a/api/test/integration/env/configurations/syscollector/wazuh-master/wdb_checker.py
+++ b/api/test/integration/env/configurations/syscollector/wazuh-master/wdb_checker.py
@@ -1,0 +1,13 @@
+import os
+import subprocess
+import time
+
+
+wdb_socket = '/var/ossec/queue/db/wdb'
+
+while not os.path.exists(wdb_socket):
+    time.sleep(5)
+
+query = "agent 000 sql insert or ignore into sys_hotfixes(scan_id, scan_time, hotfix) values (1408519641, '2019/08/05 12:06:26', 'KB2533552')"
+subprocess.check_call(['/var/ossec/framework/python/bin/python3', '/send_to_wdb.py', '-q', query])
+

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -6,8 +6,7 @@ includes:
 
 marks:
   - usefixtures:
-      # We use ciscat environment for experimental tests
-    - ciscat_tests
+    - experimental_tests
 
 stages:
 
@@ -637,7 +636,7 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: !anyint
+          total_affected_items: 1 # Only the agent 000 will have results
           total_failed_items: 0
         message: !anystr
 
@@ -648,13 +647,13 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        list_agents: '001,003,005,007'
+        list_agents: '000,003,005,007' # Only the agent 000 will have results
     response:
       status_code: 200
       body:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: !anyint
+          total_affected_items: 1 # Only the agent 000 will have results
           total_failed_items: 0
         message: !anystr

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -23,14 +23,15 @@ stages:
     response:
       status_code: 200
       body:
-        data:
+        data: &even_affected_agents
           affected_items:
+            - '000'
             - '002'
             - '004'
             - '006'
             - '008'
           failed_items: []
-          total_affected_items: 4
+          total_affected_items: 5
           total_failed_items: 0
         message: !anystr
 
@@ -74,14 +75,7 @@ stages:
       status_code: 200
       body:
         data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
+          <<: *even_affected_agents
         message: !anystr
 
   - name: Request a list of agents (Partially allowed, user aware)
@@ -123,14 +117,15 @@ stages:
     response:
       status_code: 200
       body:
-        data:
+        data: &even_affected_agent_list
           affected_items:
+            - agent_id: '000'
             - agent_id: '002'
             - agent_id: '004'
             - agent_id: '006'
             - agent_id: '008'
           failed_items: []
-          total_affected_items: 4
+          total_affected_items: 5
           total_failed_items: 0
 
   - name: Request a list of agents (Partially allowed, user aware)
@@ -173,14 +168,7 @@ stages:
       status_code: 200
       body:
         data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
+          <<: *even_affected_agent_list
 
   - name: Request a list of agents (Partially allowed, user aware)
     request:
@@ -222,14 +210,7 @@ stages:
       status_code: 200
       body:
         data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
+          <<: *even_affected_agent_list
 
   - name: Request a list of agents (Partially allowed, user aware)
     request:
@@ -271,14 +252,7 @@ stages:
       status_code: 200
       body:
         data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
+          <<: *even_affected_agent_list
 
   - name: Request a list of agents (Partially allowed, user aware)
     request:
@@ -320,14 +294,7 @@ stages:
       status_code: 200
       body:
         data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
+          <<: *even_affected_agent_list
 
   - name: Request a list of agents (Partially allowed, user aware)
     request:
@@ -404,12 +371,17 @@ stages:
       body:
         data:
           affected_items:
+            # agent 000 has 4 different ports as it is the master node
+            - agent_id: '000'
+            - agent_id: '000'
+            - agent_id: '000'
+            - agent_id: '000'
             - agent_id: '002'
             - agent_id: '004'
             - agent_id: '006'
             - agent_id: '008'
           failed_items: []
-          total_affected_items: 4
+          total_affected_items: 8
           total_failed_items: 0
 
   - name: Request
@@ -480,9 +452,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/hotfixes
 
-marks:
-  - xfail
-
 stages:
 
   - name: Request
@@ -497,7 +466,7 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: !anyint
+          total_affected_items: 1  # Only the agent 000 will have results
           total_failed_items: 0
         message: !anystr
 
@@ -508,13 +477,23 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        list_agents: '003,004,005,006'
+        list_agents: '000,004,005,006'  # Only the agent 000 will have results. Agent 005 has no permission
     response:
       status_code: 200
       body:
         data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
+          affected_items:
+            - scan_id: !anyint
+              hotfix: !anystr
+              scan_time: !anystr
+              agent_id: '000'
+          failed_items:
+            - error:
+                code: 4000
+                message: !anystr
+                remediation: !anystr
+              id:
+                - '005'
+          total_affected_items: 1
+          total_failed_items: 1
         message: !anystr

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -75,7 +75,14 @@ stages:
       status_code: 200
       body:
         data:
-          <<: *even_affected_agents
+          affected_items:
+            - agent_id: '002'
+            - agent_id: '004'
+            - agent_id: '006'
+            - agent_id: '008'
+          failed_items: []
+          total_affected_items: 4
+          total_failed_items: 0
         message: !anystr
 
   - name: Request a list of agents (Partially allowed, user aware)

--- a/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
@@ -382,49 +382,7 @@ stages:
 ---
 test_name: GET HOTFIXES SYSCOLLECTOR RBAC
 
-marks:
-  - xfail
-
 stages:
-
-  - name: Get all hotfixes from an agent (Allow)
-    request: &hotfix_request_allow
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/hotfixes"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: GET
-    response:
-      status_code: 200
-      body:
-        data:
-          affected_items:
-            - hotfix: !anystr
-              scan_id: !anyint
-              scan_time: !anystr
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-        message: !anystr
-      save:
-        body:
-          hotfix_filter: data.affected_items.0.hotfix
-
-  - name: Filter hotfix (Allow)
-    request:
-      <<: *hotfix_request_allow
-      params:
-        hotfix: "{hotfix_filter}"
-    response:
-      status_code: 200
-      body:
-        data:
-          affected_items:
-            - hotfix: "{hotfix_filter}"
-              scan_id: !anyint
-              scan_time: !anystr
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Get all hotfixes from an agent (Deny)
     request: &hotfix_request_deny

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -480,9 +480,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/hotfixes
 
-marks:
-  - xfail
-
 stages:
 
   - name: Request
@@ -495,9 +492,9 @@ stages:
       status_code: 200
       body:
         data:
-          affected_items: !anything
+          affected_items: []
           failed_items: []
-          total_affected_items: !anyint
+          total_affected_items: 0  # Only the agent 000 will have results but we don't have permissions
           total_failed_items: 0
         message: !anystr
 
@@ -508,13 +505,22 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        list_agents: '003,004,005,006'
+        list_agents: '000,004,005,006'
     response:
       status_code: 200
       body:
         data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
+          affected_items: [] # Only the agent 000 will have results but we don't have permissions
+          failed_items:
+          # Even agent IDs do not have permissions
+            - error:
+                code: 4000
+                message: !anystr
+                remediation: !anystr
+              id:
+                - '000'
+                - '004'
+                - '006'
+          total_affected_items: 0
+          total_failed_items: 3
         message: !anystr

--- a/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
@@ -382,9 +382,6 @@ stages:
 ---
 test_name: GET HOTFIXES SYSCOLLECTOR RBAC
 
-marks:
-  - xfail
-
 stages:
 
   - name: Get all hotfixes from an agent (Allow)

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -3831,9 +3831,6 @@ stages:
 ---
 test_name: GET /syscollector/{agent_id}/hotfixes
 
-marks:
-  - xfail
-
 stages:
 
   - name: Get all hotfixes from agent


### PR DESCRIPTION
Hello team, this closes #4813 .

To fix those xfail's, I modified the `syscollector` environment to include hotfixes entries and made a new `experimental` environment. A new healthcheck was required for the syscollector environment since the SQL query was not inmediate.

The `experimental` environment is different for each machine:
- **Master**
  - syscollector_env > experimental_env

- **Manager** 
  - base_env > experimental_env

- **Agent**
  - ciscat_env > experimental_env

In addition to this, I refactored some tests because some of them were not accurate enough and the RBAC permissions were not correct.

# Tests performed 

## Syscollector 
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 161 items

test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED [  0%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[architecture] PASSED [  1%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[hostname] PASSED [  1%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.codename] PASSED [  2%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.major] PASSED [  3%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.minor] PASSED [  3%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.name] PASSED [  4%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.platform] PASSED [  4%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.version] PASSED [  5%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[release] PASSED [  6%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.id] PASSED [  6%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.time] PASSED [  7%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[sysname] PASSED [  8%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[version] PASSED [  8%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED [  9%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[board_serial] PASSED [  9%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.cores] PASSED [ 10%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.mhz] PASSED [ 11%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.name] PASSED [ 11%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.free] PASSED [ 12%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.total] PASSED [ 13%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.usage] PASSED [ 13%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.id] PASSED [ 14%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.time] PASSED [ 14%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages PASSED [ 15%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[architecture] PASSED [ 16%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[description] PASSED [ 16%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[format] PASSED [ 17%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[name] PASSED [ 18%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[priority] PASSED [ 18%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[scan.id] PASSED [ 19%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[scan.time] PASSED [ 19%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[section] PASSED [ 20%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[size] PASSED [ 21%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[vendor] PASSED [ 21%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[version] PASSED [ 22%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes PASSED [ 22%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[argvs] PASSED [ 23%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[cmd] PASSED [ 24%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[egroup] PASSED [ 24%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[euser] PASSED [ 25%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[fgroup] PASSED [ 26%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[name] PASSED [ 26%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[nice] PASSED [ 27%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[nlwp] PASSED [ 27%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[pgrp] PASSED [ 28%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[pid] PASSED [ 29%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[ppid] PASSED [ 29%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[priority] PASSED [ 30%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[processor] PASSED [ 31%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[resident] PASSED [ 31%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[rgroup] PASSED [ 32%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[ruser] PASSED [ 32%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[scan.id] PASSED [ 33%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[session] PASSED [ 34%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[sgroup] PASSED [ 34%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[share] PASSED [ 35%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[size] PASSED [ 36%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[start_time] PASSED [ 36%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[state] PASSED [ 37%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[stime] PASSED [ 37%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[suser] PASSED [ 38%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[tgid] PASSED [ 39%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[tty] PASSED [ 39%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[utime] PASSED [ 40%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[vm_size] PASSED [ 40%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/ports PASSED [ 41%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[inode] PASSED [ 42%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[local.ip] PASSED [ 42%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[local.port] PASSED [ 43%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[protocol] PASSED [ 44%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[remote.ip] PASSED [ 44%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[remote.port] PASSED [ 45%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[rx_queue] PASSED [ 45%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[scan.id] PASSED [ 46%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[scan.time] PASSED [ 47%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[state] PASSED [ 47%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[tx_queue] PASSED [ 48%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED [ 49%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[address] PASSED [ 49%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[broadcast] PASSED [ 50%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[iface] PASSED [ 50%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[netmask] PASSED [ 51%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[proto] PASSED [ 52%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[scan.id] PASSED [ 52%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED [ 53%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[dhcp] PASSED [ 54%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[gateway] PASSED [ 54%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[iface] PASSED [ 55%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[scan.id] PASSED [ 55%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[type] PASSED [ 56%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED [ 57%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mac] PASSED [ 57%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mtu] PASSED [ 58%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[name] PASSED [ 59%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.bytes] PASSED [ 59%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.dropped] PASSED [ 60%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.errors] PASSED [ 60%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.packets] PASSED [ 61%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.id] PASSED [ 62%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.time] PASSED [ 62%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[state] PASSED [ 63%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.bytes] PASSED [ 63%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.dropped] PASSED [ 64%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.errors] PASSED [ 65%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.packets] PASSED [ 65%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[type] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[architecture] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[hostname] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.codename] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.major] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.minor] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.name] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.platform] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.version] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[release] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.id] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.time] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[sysname] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[version] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[board_serial] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.cores] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.mhz] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.name] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.free] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.total] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.usage] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.id] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.time] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[address] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[broadcast] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[iface] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[netmask] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[proto] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[scan.id] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[dhcp] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[gateway] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[iface] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[scan.id] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[type] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mac] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mtu] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[name] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.bytes] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.dropped] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.errors] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.packets] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.id] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.time] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[state] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.bytes] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.dropped] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.errors] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.packets] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[type] PASSED [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hotfixes PASSED [ 67%]

=============================== warnings summary ===============================
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/ports
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface
test/integration/test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hotfixes
  /home/vicferpoy/.local/lib/python3.7/site-packages/tavern/util/dict_util.py:119: FutureWarning: In a future version of Tavern, selecting for values to save in nested objects will have to be done as a JMES path query - see http://jmespath.org/ for more information
    warnings.warn(msg, FutureWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================== 161 passed, 15 warnings in 121.82 seconds ===================
```

### RBAC white
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 9 items

test_rbac_white_syscollector_endpoints.tavern.yaml::GET OS SYSCOLLECTOR RBAC PASSED [ 11%]
test_rbac_white_syscollector_endpoints.tavern.yaml::GET HARDWARE SYSCOLLECTOR RBAC PASSED [ 22%]
test_rbac_white_syscollector_endpoints.tavern.yaml::GET NETADDR SYSCOLLECTOR RBAC PASSED [ 33%]
test_rbac_white_syscollector_endpoints.tavern.yaml::GET NETIFACE SYSCOLLECTOR RBAC PASSED [ 44%]
test_rbac_white_syscollector_endpoints.tavern.yaml::GET NETPROTO SYSCOLLECTOR RBAC PASSED [ 55%]
test_rbac_white_syscollector_endpoints.tavern.yaml::GET PACKAGES SYSCOLLECTOR RBAC PASSED [ 66%]
test_rbac_white_syscollector_endpoints.tavern.yaml::GET PORTS SYSCOLLECTOR RBAC PASSED [ 77%]
test_rbac_white_syscollector_endpoints.tavern.yaml::GET PROCESSES SYSCOLLECTOR RBAC PASSED [ 88%]
test_rbac_white_syscollector_endpoints.tavern.yaml::GET HOTFIXES SYSCOLLECTOR RBAC PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml::GET OS SYSCOLLECTOR RBAC
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml::GET HOTFIXES SYSCOLLECTOR RBAC
  /home/vicferpoy/.local/lib/python3.7/site-packages/tavern/util/dict_util.py:119: FutureWarning: In a future version of Tavern, selecting for values to save in nested objects will have to be done as a JMES path query - see http://jmespath.org/ for more information
    warnings.warn(msg, FutureWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 9 passed, 2 warnings in 60.01 seconds =====================
```

### RBAC black
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 9 items

test_rbac_black_syscollector_endpoints.tavern.yaml::GET OS SYSCOLLECTOR RBAC PASSED [ 11%]
test_rbac_black_syscollector_endpoints.tavern.yaml::GET HARDWARE SYSCOLLECTOR RBAC PASSED [ 22%]
test_rbac_black_syscollector_endpoints.tavern.yaml::GET NETADDR SYSCOLLECTOR RBAC PASSED [ 33%]
test_rbac_black_syscollector_endpoints.tavern.yaml::GET NETIFACE SYSCOLLECTOR RBAC PASSED [ 44%]
test_rbac_black_syscollector_endpoints.tavern.yaml::GET NETPROTO SYSCOLLECTOR RBAC PASSED [ 55%]
test_rbac_black_syscollector_endpoints.tavern.yaml::GET PACKAGES SYSCOLLECTOR RBAC PASSED [ 66%]
test_rbac_black_syscollector_endpoints.tavern.yaml::GET PORTS SYSCOLLECTOR RBAC PASSED [ 77%]
test_rbac_black_syscollector_endpoints.tavern.yaml::GET PROCESSES SYSCOLLECTOR RBAC PASSED [ 88%]
test_rbac_black_syscollector_endpoints.tavern.yaml::GET HOTFIXES SYSCOLLECTOR RBAC PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml::GET OS SYSCOLLECTOR RBAC
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 9 passed, 1 warnings in 69.66 seconds =====================
```

## Experimental
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 11 items

test_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED [  9%]
test_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED [ 18%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED [ 27%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED [ 36%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED [ 45%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED [ 54%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED [ 63%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED [ 72%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED [ 81%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED [ 90%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 11 passed, 1 warnings in 159.07 seconds ====================
```

### RBAC white
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 11 items

test_rbac_white_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED [  9%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED [ 18%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED [ 27%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED [ 36%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED [ 45%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED [ 54%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED [ 63%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED [ 72%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED [ 81%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED [ 90%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_rbac_white_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 11 passed, 1 warnings in 178.55 seconds ====================
```

### RBAC black
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 11 items

test_rbac_black_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED [  9%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED [ 18%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED [ 27%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED [ 36%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED [ 45%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED [ 54%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED [ 63%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED [ 72%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED [ 81%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED [ 90%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_rbac_black_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 11 passed, 1 warnings in 235.28 seconds ====================
```

Regards.
