### PR TITLE
Add library bz2 to compress and uncompress Ubuntu ovals

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -747,7 +747,7 @@ os_zlib/%.o: os_zlib/%.c
 #### bzip2 ##########
 
 $(BZIP2_LIB):
-	cd ${EXTERNAL_BZIP2} && make CFLAGS=-fpic -Wall -O2 -D_FILE_OFFSET_BITS=64 libbz2.a
+	cd ${EXTERNAL_BZIP2} && make CFLAGS="-fpic -Wall -O2 -D_FILE_OFFSET_BITS=64" libbz2.a
 
 #### SQLite #########
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -229,7 +229,7 @@ endif
 
 OSSEC_CFLAGS+=${DEFINES}
 OSSEC_CFLAGS+=-pipe -Wall -Wextra -std=gnu99
-OSSEC_CFLAGS+=-I./ -I./headers/ -I${EXTERNAL_OPENSSL}include -I$(EXTERNAL_JSON) -I${EXTERNAL_LIBYAML}include -I${EXTERNAL_CURL}include -I${EXTERNAL_MSGPACK}include
+OSSEC_CFLAGS+=-I./ -I./headers/ -I${EXTERNAL_OPENSSL}include -I$(EXTERNAL_JSON) -I${EXTERNAL_LIBYAML}include -I${EXTERNAL_CURL}include -I${EXTERNAL_MSGPACK}include -I${EXTERNAL_BZIP2}
 
 OSSEC_CFLAGS += ${CFLAGS}
 OSSEC_LDFLAGS += ${LDFLAGS}
@@ -746,35 +746,8 @@ os_zlib/%.o: os_zlib/%.c
 
 #### bzip2 ##########
 
-BZIP2_CFLAGS   = -fpic -Wall -O2 -g -D_FILE_OFFSET_BITS=64
-
-BZIP2_O       := ${EXTERNAL_BZIP2}blocksort.o \
-	             ${EXTERNAL_BZIP2}huffman.o \
-	             ${EXTERNAL_BZIP2}crctable.o \
-	             ${EXTERNAL_BZIP2}randtable.o \
-	             ${EXTERNAL_BZIP2}compress.o \
-	             ${EXTERNAL_BZIP2}decompress.o \
-	             ${EXTERNAL_BZIP2}bzlib.o
-
-
-$(BZIP2_LIB): $(BZIP2_O)
-	$(OSSEC_LINK) $(BZIP2_LIB) $(BZIP2_O)
-
-${EXTERNAL_BZIP2}blocksort.o: ${EXTERNAL_BZIP2}blocksort.c
-	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}blocksort.c -o ${EXTERNAL_BZIP2}blocksort.o
-${EXTERNAL_BZIP2}huffman.o: ${EXTERNAL_BZIP2}huffman.c
-	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}huffman.c -o ${EXTERNAL_BZIP2}huffman.o
-${EXTERNAL_BZIP2}crctable.o: ${EXTERNAL_BZIP2}crctable.c
-	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}crctable.c -o ${EXTERNAL_BZIP2}crctable.o
-${EXTERNAL_BZIP2}randtable.o: ${EXTERNAL_BZIP2}randtable.c
-	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}randtable.c -o ${EXTERNAL_BZIP2}randtable.o
-${EXTERNAL_BZIP2}compress.o: ${EXTERNAL_BZIP2}compress.c
-	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}compress.c -o ${EXTERNAL_BZIP2}compress.o
-${EXTERNAL_BZIP2}decompress.o: ${EXTERNAL_BZIP2}decompress.c
-	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}decompress.c -o ${EXTERNAL_BZIP2}decompress.o
-${EXTERNAL_BZIP2}bzlib.o: ${EXTERNAL_BZIP2}bzlib.c
-	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}bzlib.c -o ${EXTERNAL_BZIP2}bzlib.o
-
+$(BZIP2_LIB):
+	cd ${EXTERNAL_BZIP2} && make CFLAGS=-fpic -Wall -O2 -D_FILE_OFFSET_BITS=64 libbz2.a
 
 #### SQLite #########
 
@@ -1760,6 +1733,7 @@ ifneq ($(wildcard external/*/*),)
 	-cd ${EXTERNAL_AUDIT} && make distclean
 	-cd ${EXTERNAL_LIBFFI} && make clean
 	rm -f $(msgpack_o) $(EXTERNAL_MSGPACK)libmsgpack.a
+	-make -C $(EXTERNAL_BZIP2) clean
 
 ifneq ($(wildcard external/libdb/build_unix/*),)
 	cd ${EXTERNAL_LIBDB} && make realclean

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,6 +26,7 @@ EXTERNAL_AUDIT=external/audit-userspace/
 EXTERNAL_LIBFFI=external/libffi/
 EXTERNAL_CPYTHON=external/cpython/
 EXTERNAL_MSGPACK=external/msgpack/
+EXTERNAL_BZIP2=external/bzip2/
 ifneq (${TARGET},winagent)
 EXTERNAL_PROCPS=external/procps/
 EXTERNAL_LIBDB=external/libdb/build_unix/
@@ -658,13 +659,14 @@ LIBCURL_LIB = $(EXTERNAL_CURL)lib/.libs/libcurl.a
 AUDIT_LIB = $(EXTERNAL_AUDIT)lib/.libs/libaudit.a
 LIBFFI_LIB = $(EXTERNAL_LIBFFI)$(TARGET)/.libs/libffi.a
 MSGPACK_LIB = $(EXTERNAL_MSGPACK)libmsgpack.a
+BZIP2_LIB   = $(EXTERNAL_BZIP2)libbz2.a
 
 EXTERNAL_LIBS := $(JSON_LIB) $(ZLIB_LIB) $(OPENSSL_LIB) $(CRYPTO_LIB) $(SQLITE_LIB) $(LIBYAML_LIB)
 
 ifneq (${TARGET},winagent)
 EXTERNAL_LIBS += $(MSGPACK_LIB)
 ifneq (${TARGET},agent)
-EXTERNAL_LIBS += $(LIBCURL_LIB) $(LIBFFI_LIB)
+EXTERNAL_LIBS += $(LIBCURL_LIB) $(LIBFFI_LIB) $(BZIP2_LIB)
 endif
 ifeq (${uname_S},Linux)
 ifneq (,$(filter ${USE_AUDIT},YES yes y Y 1))
@@ -741,6 +743,38 @@ os_zlib_o := $(os_zlib_c:.c=.o)
 
 os_zlib/%.o: os_zlib/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $< -o $@
+
+#### bzip2 ##########
+
+BZIP2_CFLAGS   = -fpic -Wall -O2 -g -D_FILE_OFFSET_BITS=64
+
+BZIP2_O       := ${EXTERNAL_BZIP2}blocksort.o \
+	             ${EXTERNAL_BZIP2}huffman.o \
+	             ${EXTERNAL_BZIP2}crctable.o \
+	             ${EXTERNAL_BZIP2}randtable.o \
+	             ${EXTERNAL_BZIP2}compress.o \
+	             ${EXTERNAL_BZIP2}decompress.o \
+	             ${EXTERNAL_BZIP2}bzlib.o
+
+
+$(BZIP2_LIB): $(BZIP2_O)
+	$(OSSEC_LINK) $(BZIP2_LIB) $(BZIP2_O)
+
+${EXTERNAL_BZIP2}blocksort.o: ${EXTERNAL_BZIP2}blocksort.c
+	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}blocksort.c -o ${EXTERNAL_BZIP2}blocksort.o
+${EXTERNAL_BZIP2}huffman.o: ${EXTERNAL_BZIP2}huffman.c
+	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}huffman.c -o ${EXTERNAL_BZIP2}huffman.o
+${EXTERNAL_BZIP2}crctable.o: ${EXTERNAL_BZIP2}crctable.c
+	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}crctable.c -o ${EXTERNAL_BZIP2}crctable.o
+${EXTERNAL_BZIP2}randtable.o: ${EXTERNAL_BZIP2}randtable.c
+	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}randtable.c -o ${EXTERNAL_BZIP2}randtable.o
+${EXTERNAL_BZIP2}compress.o: ${EXTERNAL_BZIP2}compress.c
+	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}compress.c -o ${EXTERNAL_BZIP2}compress.o
+${EXTERNAL_BZIP2}decompress.o: ${EXTERNAL_BZIP2}decompress.c
+	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}decompress.c -o ${EXTERNAL_BZIP2}decompress.o
+${EXTERNAL_BZIP2}bzlib.o: ${EXTERNAL_BZIP2}bzlib.c
+	$(OSSEC_CC) $(BZIP2_CFLAGS) -c ${EXTERNAL_BZIP2}bzlib.c -o ${EXTERNAL_BZIP2}bzlib.o
+
 
 #### SQLite #########
 
@@ -887,7 +921,7 @@ endif
 endif
 
 
-EXTERNAL_RES := cJSON $(CPYTHON) curl libdb libffi libyaml openssl procps sqlite zlib audit-userspace msgpack
+EXTERNAL_RES := cJSON $(CPYTHON) curl libdb libffi libyaml openssl procps sqlite zlib audit-userspace msgpack bzip2
 EXTERNAL_DIR :=  $(EXTERNAL_RES:%=external/%)
 EXTERNAL_TAR := $(EXTERNAL_RES:%=external/%.tar.gz)
 

--- a/src/headers/bzip2_op.h
+++ b/src/headers/bzip2_op.h
@@ -8,9 +8,14 @@
  * Foundation.
  */
 
+#ifndef BZIP2_OP_H
+#define BZIP2_OP_H
+
 #include "shared.h"
 #include "../external/bzip2/bzlib.h"
 #include "../error_messages/error_messages.h"
 
 int bzip2_compress(const char *file, const char *filebz2);
 int bzip2_uncompress(const char *file, const char *filebz2);
+
+#endif /* BZIP2_OP_H */

--- a/src/headers/bzip2_op.h
+++ b/src/headers/bzip2_op.h
@@ -13,6 +13,8 @@
 
 #include <bzlib.h>
 
+#define BZIP2_BUFFER_SIZE 4096
+
 /**
  * @brief bzpi2 library, function to compress
  *

--- a/src/headers/bzip2_op.h
+++ b/src/headers/bzip2_op.h
@@ -11,9 +11,7 @@
 #ifndef BZIP2_OP_H
 #define BZIP2_OP_H
 
-#include "shared.h"
-#include "../external/bzip2/bzlib.h"
-#include "../error_messages/error_messages.h"
+#include <bzlib.h>
 
 int bzip2_compress(const char *file, const char *filebz2);
 int bzip2_uncompress(const char *file, const char *filebz2);

--- a/src/headers/bzip2_op.h
+++ b/src/headers/bzip2_op.h
@@ -13,7 +13,24 @@
 
 #include <bzlib.h>
 
+/**
+ * @brief bzpi2 library, function to compress
+ *
+ * @param file File path to compress
+ * @param filebz2 File name compressed
+ *
+ * @retval 0 on success, -1 on error
+ */
 int bzip2_compress(const char *file, const char *filebz2);
-int bzip2_uncompress(const char *file, const char *filebz2);
+
+/**
+ * @brief bzpi2 library, function to uncompress
+ *
+ * @param filebz2 File path to uncompress
+ * @param file File name uncompressed
+ *
+ * @retval 0 on success, -1 on error
+ */
+int bzip2_uncompress(const char *filebz2, const char *file);
 
 #endif /* BZIP2_OP_H */

--- a/src/headers/bzip2_op.h
+++ b/src/headers/bzip2_op.h
@@ -30,7 +30,8 @@ int bzip2_compress(const char *file, const char *filebz2);
  * @param filebz2 File path to uncompress
  * @param file File name uncompressed
  *
- * @retval 0 on success, -1 on error
+ * @retval 0 on success
+ * @retval -1 on error
  */
 int bzip2_uncompress(const char *filebz2, const char *file);
 

--- a/src/headers/bzip2_op.h
+++ b/src/headers/bzip2_op.h
@@ -19,7 +19,8 @@
  * @param file File path to compress
  * @param filebz2 File name compressed
  *
- * @retval 0 on success, -1 on error
+ * @retval 0 on success
+ * @retval -1 on error
  */
 int bzip2_compress(const char *file, const char *filebz2);
 

--- a/src/headers/bzip2_op.h
+++ b/src/headers/bzip2_op.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * December 18, 2018.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "shared.h"
+#include "../external/bzip2/bzlib.h"
+#include "../error_messages/error_messages.h"
+
+int bzip2_compress(const char *file, const char *filebz2);
+int bzip2_uncompress(const char *file, const char *filebz2);

--- a/src/headers/bzip2_op.h
+++ b/src/headers/bzip2_op.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015-2020, Wazuh Inc.
- * December 18, 2018.
+ * April, 2020.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -258,5 +258,6 @@ extern const char *__local_name;
 #include "cluster_utils.h"
 #include "auth_client.h"
 #include "os_utils.h"
+#include "bzip2_op.h"
 
 #endif /* SHARED_H */

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -99,7 +99,7 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
         return -1;
     }
 
-     output= fopen(file, "wb" );
+     output = fopen(file, "wb");
     if (!output) {
         mdebug2(FOPEN_ERROR, file, errno, strerror(errno));
         fclose(input);

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -27,7 +27,7 @@ int bzip2_compress(const char *file, const char *filebz2) {
         return -1;
     }
 
-    output = fopen(filebz2, "wb" );
+    output = fopen(filebz2, "wb");
     if (!output) {
         mdebug2(FOPEN_ERROR, filebz2, errno, strerror(errno));
         fclose(input);
@@ -43,7 +43,7 @@ int bzip2_compress(const char *file, const char *filebz2) {
         return -1;
     }
 
-    char buf[2048];
+    char buf[BZIP2_BUFFER_SIZE];
     int readbuff;
     while (readbuff = fread(buf, sizeof(char), sizeof(buf), input), readbuff > 0) {
         BZ2_bzWrite(&bzerror, compressfile, (void*)buf, readbuff);
@@ -115,7 +115,7 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
         return -1;
     }
 
-    char buf[2048];
+    char buf[BZIP2_BUFFER_SIZE];
     int readbuff;
     do {
         readbuff = BZ2_bzRead(&bzerror, compressfile, buf, sizeof(buf));

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -8,7 +8,6 @@
  * Foundation.
  */
 
-
 #include "../headers/shared.h"
 
 
@@ -50,7 +49,7 @@ int bzip2_compress(const char *file, const char *filebz2) {
         BZ2_bzWrite(&bzerror, compressfile, (void*)buf, readbuff);
 
         if (bzerror != BZ_OK) {
-            mdebug2("Could not write bz2 file (bz2error:%d): (%d)-%s",
+            mdebug2("Could not write bz2 file (%d)'%s': (%d)-%s",
                     bzerror, filebz2, errno, strerror(errno));
             fclose(input);
             fclose(output);
@@ -96,13 +95,13 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
 
     input = fopen(filebz2, "rb");
     if (!input) {
-        mdebug2(FOPEN_ERROR, file, errno, strerror(errno));
+        mdebug2(FOPEN_ERROR, filebz2, errno, strerror(errno));
         return -1;
     }
 
-    output = fopen(file, "wb" );
+     output= fopen(file, "wb" );
     if (!output) {
-        mdebug2(FOPEN_ERROR, filebz2, errno, strerror(errno));
+        mdebug2(FOPEN_ERROR, file, errno, strerror(errno));
         fclose(input);
         return -1;
     }
@@ -120,18 +119,17 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
     int readbuff;
     do {
         readbuff = BZ2_bzRead(&bzerror, compressfile, buf, 2048);
-
         if (bzerror == BZ_OK || bzerror == BZ_STREAM_END) {
             if (readbuff > 0) {
                 fwrite(buf, sizeof(char), readbuff, output);
-            } else {
-                mdebug2("BZ2_bzRead(%d)'%s': (%d)-%s",
-                        bzerror, filebz2, errno, strerror(errno));
-                fclose(input);
-                fclose(output);
-                BZ2_bzReadClose(&bzerror, compressfile);
-                return -1;
             }
+        } else {
+            mdebug2("BZ2_bzRead(%d)'%s': (%d)-%s",
+                    bzerror, filebz2, errno, strerror(errno));
+            fclose(input);
+            fclose(output);
+            BZ2_bzReadClose(&bzerror, compressfile);
+            return -1;
         }
     } while (readbuff > 0);
 

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -45,7 +45,7 @@ int bzip2_compress(const char *file, const char *filebz2) {
 
     char buf[2048];
     int readbuff;
-    while (readbuff = fread(buf, sizeof(char), 2048, input), readbuff > 0) {
+    while (readbuff = fread(buf, sizeof(char), sizeof(buf), input), readbuff > 0) {
         BZ2_bzWrite(&bzerror, compressfile, (void*)buf, readbuff);
 
         if (bzerror != BZ_OK) {

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015-2020, Wazuh Inc.
- * December 18, 2018.
+ * April, 2020.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -19,20 +19,20 @@ int bzip2_compress(const char *file, const char *filebz2) {
     int bzerror;
 
     if (!file || !filebz2) {
-        return OS_INVALID;
+        return -1;
     }
 
     input = fopen(file, "rb");
     if (!input) {
         merror(FOPEN_ERROR, file, errno, strerror(errno));
-        return OS_INVALID;
+        return -1;
     }
 
     output = fopen(filebz2, "wb" );
     if (!output) {
         merror(FOPEN_ERROR, filebz2, errno, strerror(errno));
         fclose(input);
-        return OS_INVALID;
+        return -1;
     }
 
     compressfile = BZ2_bzWriteOpen(&bzerror, output, 9, 0, 1);
@@ -41,7 +41,7 @@ int bzip2_compress(const char *file, const char *filebz2) {
                 bzerror, errno, strerror(errno));
         fclose(input);
         fclose(output);
-        return OS_INVALID;
+        return -1;
     }
 
     char buf[2048];
@@ -55,7 +55,7 @@ int bzip2_compress(const char *file, const char *filebz2) {
             fclose(input);
             fclose(output);
             BZ2_bzReadClose(&bzerror, compressfile);
-            return OS_INVALID;
+            return -1;
         }
     }
 
@@ -72,7 +72,7 @@ int bzip2_compress(const char *file, const char *filebz2) {
         fclose(input);
         fclose(output);
         BZ2_bzReadClose(&bzerror, compressfile);
-        return OS_INVALID;
+        return -1;
     }
 
     fclose(input);
@@ -90,20 +90,20 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
     int nUnused = 0;
 
     if (!file || !filebz2) {
-        return OS_INVALID;
+        return -1;
     }
 
     input = fopen(filebz2, "rb");
     if (!input) {
         merror(FOPEN_ERROR, file, errno, strerror(errno));
-        return OS_INVALID;
+        return -1;
     }
 
     output = fopen(file, "wb" );
     if (!output) {
         merror(FOPEN_ERROR, filebz2, errno, strerror(errno));
         fclose(input);
-        return OS_INVALID;
+        return -1;
     }
 
     compressfile = BZ2_bzReadOpen(&bzerror, input, 0, 0, unused, nUnused);
@@ -111,7 +111,7 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
         merror("BZ2_bzReadOpen(%d): (%d)-%s", bzerror, errno, strerror(errno));
         fclose(input);
         fclose(output);
-        return OS_INVALID;
+        return -1;
     }
 
     char buf[2048];
@@ -127,7 +127,7 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
                 fclose(input);
                 fclose(output);
                 BZ2_bzReadClose(&bzerror, compressfile);
-                return OS_INVALID;
+                return -1;
             }
         }
     } while (readbuff > 0);

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * December 18, 2018.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+
+#include "../headers/bzip2_op.h"
+
+
+int bzip2_compress(const char *file, const char *filebz2) {
+    FILE* input;
+    FILE* output;
+    BZFILE* compressfile;
+    int bzerror;
+
+    if (!file || !filebz2) {
+        return OS_INVALID;
+    }
+
+    input = fopen(file, "rb");
+    if (!input) {
+        merror(FOPEN_ERROR, file, errno, strerror(errno));
+        return OS_INVALID;
+    }
+
+    output = fopen(filebz2, "wb" );
+    if (!output) {
+        merror(FOPEN_ERROR, filebz2, errno, strerror(errno));
+        fclose(input);
+        return OS_INVALID;
+    }
+
+    compressfile = BZ2_bzWriteOpen(&bzerror, output, 9, 0, 1);
+    if (bzerror != BZ_OK) {
+        merror("Could not open to write bz2 file (bz2error:%d): (%d)-%s",
+                bzerror, errno, strerror(errno));
+        fclose(input);
+        fclose(output);
+        return OS_INVALID;
+    }
+
+    char buf[2048];
+    int readbuff;
+    while (readbuff = fread(buf, sizeof(char), 2048, input), readbuff > 0) {
+        BZ2_bzWrite(&bzerror, compressfile, (void*)buf, readbuff);
+
+        if (bzerror != BZ_OK) {
+            merror("Could not write bz2 file (bz2error:%d): (%d)-%s",
+                    bzerror, errno, strerror(errno));
+            fclose(input);
+            fclose(output);
+            BZ2_bzReadClose(&bzerror, compressfile);
+            return OS_INVALID;
+        }
+    }
+
+    unsigned int nbytes_in_lo32;
+    unsigned int nbytes_in_hi32;
+    unsigned int nbytes_out_lo32;
+    unsigned int nbytes_out_hi32;
+    BZ2_bzWriteClose64(&bzerror, compressfile, 0,
+                       &nbytes_in_lo32, &nbytes_in_hi32,
+                       &nbytes_out_lo32, &nbytes_out_hi32);
+
+    if (bzerror != BZ_OK) {
+        merror("BZ2_bzWriteClose64(%d): (%d)-%s", bzerror, errno, strerror(errno));
+        fclose(input);
+        fclose(output);
+        BZ2_bzReadClose(&bzerror, compressfile);
+        return OS_INVALID;
+    }
+
+    fclose(input);
+    fclose(output);
+    BZ2_bzReadClose(&bzerror, compressfile);
+    return 0;
+}
+
+int bzip2_uncompress(const char *filebz2, const char *file) {
+    FILE* input;
+    FILE* output;
+    BZFILE* compressfile;
+    int bzerror;
+    unsigned char unused[BZ_MAX_UNUSED];
+    int nUnused = 0;
+
+    if (!file || !filebz2) {
+        return OS_INVALID;
+    }
+
+    input = fopen(filebz2, "rb");
+    if (!input) {
+        merror(FOPEN_ERROR, file, errno, strerror(errno));
+        return OS_INVALID;
+    }
+
+    output = fopen(file, "wb" );
+    if (!output) {
+        merror(FOPEN_ERROR, filebz2, errno, strerror(errno));
+        fclose(input);
+        return OS_INVALID;
+    }
+
+    compressfile = BZ2_bzReadOpen(&bzerror, input, 0, 0, unused, nUnused);
+    if (compressfile == NULL || bzerror != BZ_OK) {
+        merror("BZ2_bzReadOpen(%d): (%d)-%s", bzerror, errno, strerror(errno));
+        fclose(input);
+        fclose(output);
+        return OS_INVALID;
+    }
+
+    char buf[2048];
+    int readbuff;
+    do {
+        readbuff = BZ2_bzRead(&bzerror, compressfile, buf, 2048);
+
+        if (readbuff > 0) {
+            if (bzerror == BZ_OK || bzerror == BZ_STREAM_END) {
+                fwrite(buf, sizeof(char), readbuff, output);
+            } else {
+                merror("BZ2_bzRead(%d): (%d)-%s", bzerror, errno, strerror(errno));
+                fclose(input);
+                fclose(output);
+                BZ2_bzReadClose(&bzerror, compressfile);
+                return OS_INVALID;
+            }
+        }
+    } while (readbuff > 0);
+
+    fclose(input);
+    fclose(output);
+    BZ2_bzReadClose(&bzerror, compressfile);
+    return 0;
+}

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -118,7 +118,7 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
     char buf[2048];
     int readbuff;
     do {
-        readbuff = BZ2_bzRead(&bzerror, compressfile, buf, 2048);
+        readbuff = BZ2_bzRead(&bzerror, compressfile, buf, sizeof(buf));
         if (bzerror == BZ_OK || bzerror == BZ_STREAM_END) {
             if (readbuff > 0) {
                 fwrite(buf, sizeof(char), readbuff, output);

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ message(Source folder: ${SRC_FOLDER})
 include_directories(${SRC_FOLDER}/headers)
 include_directories(${SRC_FOLDER}/external/openssl/include)
 include_directories(${SRC_FOLDER}/external/audit-userspace/lib)
+include_directories(${SRC_FOLDER}/external/bzip2)
 include_directories(${SRC_FOLDER})
 
 # Wazuh libraries

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -12,6 +12,11 @@ list(APPEND shared_tests_flags " ")
 list(APPEND shared_tests_names "test_version_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fgets -Wl,--wrap,fclose")
 
+if(${TARGET} STREQUAL "server")
+list(APPEND shared_tests_names "test_bzip2_op")
+list(APPEND shared_tests_flags "-Wl,--wrap=fopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen,--wrap=BZ2_bzWriteClose64,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen,--wrap=BZ2_bzRead,--wrap=BZ2_bzWrite,--wrap=_mdebug2")
+endif()
+
 set(SYSCHECK_OP_BASE_FLAGS "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \
                             -Wl,--wrap,_mwarn -Wl,--wrap,_merror -Wl,--wrap,getpwuid_r -Wl,--wrap,getgrgid \
                             -Wl,--wrap,wstr_split -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP,--wrap=sysconf")

--- a/src/unit_tests/shared/test_bzip2_op.c
+++ b/src/unit_tests/shared/test_bzip2_op.c
@@ -1,0 +1,470 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include "shared.h"
+
+#include "../headers/bzip2_op.h"
+
+static int unit_testing;
+
+
+extern FILE* __real_fopen(const char* path, const char* mode);
+FILE* __wrap_fopen(const char* path, const char* mode) {
+    if(unit_testing) {
+        check_expected_ptr(path);
+        check_expected(mode);
+        return mock_ptr_type(FILE*);
+    }
+    return __real_fopen(path, mode);
+}
+
+size_t __real_fread(void *ptr, size_t size, size_t n, FILE *stream);
+size_t __wrap_fread(void *ptr, size_t size, size_t n, FILE *stream) {
+    if (unit_testing) {
+        strncpy((char *) ptr, mock_type(char *), n);
+        return mock();
+    }
+    return __real_fread(ptr, size, n, stream);
+}
+
+size_t __real_fwrite(const void * ptr, size_t size, size_t count, FILE * stream);
+size_t __wrap_fwrite(const void * ptr, size_t size, size_t count, FILE * stream) {
+    if (unit_testing) {
+        return mock();
+    }
+    return __real_fwrite(ptr, size, count, stream);
+}
+
+int __wrap_fclose() {
+    return 0;
+}
+
+BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,
+                               FILE* f,
+                               int blockSize100k,
+                               int verbosity,
+                               int workFactor) {
+    check_expected_ptr(f);
+    *bzerror = mock();
+
+    return mock_type(BZFILE*);
+}
+
+void __wrap_BZ2_bzReadClose(int* bzerror,
+                            BZFILE* f,
+                            int abandon,
+                            unsigned int* nbytes_in,
+                            unsigned int* nbytes_out) {
+    return;
+}
+
+void __wrap_BZ2_bzWriteClose64(int* bzerror,
+                               BZFILE* f,
+                               int abandon,
+                               unsigned int* nbytes_in_lo32,
+                               unsigned int* nbytes_in_hi32,
+                               unsigned int* nbytes_out_lo32,
+                               unsigned int* nbytes_out_hi32) {
+    check_expected_ptr(f);
+    *bzerror = mock();
+}
+
+BZFILE* __wrap_BZ2_bzReadOpen(int* bzerror,
+                          FILE* f,
+                          int verbosity,
+                          int small,
+                          void* unused,
+                          int nUnused) {
+    check_expected_ptr(f);
+    *bzerror = mock();
+
+    return mock_type(BZFILE*);
+}
+
+int __wrap_BZ2_bzRead(int* bzerror,
+                      BZFILE* f,
+                      void* buf,
+                      int len) {
+    check_expected_ptr(f);
+    *bzerror = mock();
+    int n = mock();
+    if(n <= len) {
+        memcpy(buf, mock_type(void*), n);
+    }
+    return n;
+}
+
+void __wrap_BZ2_bzWrite(int* bzerror,
+                       BZFILE* f,
+                       void* buf,
+                       int len) {
+    check_expected_ptr(f);
+    check_expected(buf);
+    check_expected(len);
+    *bzerror = mock();
+}
+
+void __wrap__mdebug2(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+    check_expected(formatted_msg);
+}
+
+/* setups/teardowns */
+static int setup_group(void **state) {
+    unit_testing = 1;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    unit_testing = 0;
+    return 0;
+}
+
+void test_bzip2_compress_nullfile(void **state) {
+    int ret;
+
+    ret = bzip2_compress(NULL, "test");
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_compress_nullfilebz2(void **state) {
+    int ret;
+
+    ret = bzip2_compress("test", NULL);
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_compress_firstfopenfail(void **state) {
+    int ret;
+    char *string = "testfile";
+
+    expect_value(__wrap_fopen, path, string);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "(1103): Could not open file 'testfile' due to [(0)-(Success)].");
+    ret = bzip2_compress(string, "testbz2");
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_compress_secondfopenfail(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "(1103): Could not open file 'testfile2' due to [(0)-(Success)].");
+    ret = bzip2_compress(file1, file2);
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_compress_bzWriteOpen(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 2);
+
+    expect_value(__wrap_BZ2_bzWriteOpen, f, 2);
+    will_return(__wrap_BZ2_bzWriteOpen, BZ_MEM_ERROR);
+    will_return(__wrap_BZ2_bzWriteOpen, NULL);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Could not open to write bz2 file (-3)'testfile2': (0)-Success");
+
+    ret = bzip2_compress(file1, file2);
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_compress_BZ2_bzWrite(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 2);
+
+    expect_value(__wrap_BZ2_bzWriteOpen, f, 2);
+    will_return(__wrap_BZ2_bzWriteOpen, BZ_OK);
+    will_return(__wrap_BZ2_bzWriteOpen, 3);
+
+    will_return(__wrap_fread, "teststring");
+    will_return(__wrap_fread, 10);
+
+    expect_value(__wrap_BZ2_bzWrite, f, 3);
+    expect_string(__wrap_BZ2_bzWrite, buf, "teststring");
+    expect_value(__wrap_BZ2_bzWrite, len, 10);
+    will_return(__wrap_BZ2_bzWrite, BZ_MEM_ERROR);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Could not write bz2 file (-3)'testfile2': (0)-Success");
+
+    ret = bzip2_compress(file1, file2);
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_compress_bzWriteClose64(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 2);
+
+    expect_value(__wrap_BZ2_bzWriteOpen, f, 2);
+    will_return(__wrap_BZ2_bzWriteOpen, BZ_OK);
+    will_return(__wrap_BZ2_bzWriteOpen, 3);
+
+    will_return(__wrap_fread, "teststring");
+    will_return(__wrap_fread, 10);
+
+    expect_value(__wrap_BZ2_bzWrite, f, 3);
+    expect_string(__wrap_BZ2_bzWrite, buf, "teststring");
+    expect_value(__wrap_BZ2_bzWrite, len, 10);
+    will_return(__wrap_BZ2_bzWrite, BZ_OK);
+
+    will_return(__wrap_fread, "");
+    will_return(__wrap_fread, 0);
+
+    expect_value(__wrap_BZ2_bzWriteClose64, f, 3);
+    will_return(__wrap_BZ2_bzWriteClose64, BZ_MEM_ERROR);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "BZ2_bzWriteClose64(-3)'testfile2': (0)-Success");
+
+    ret = bzip2_compress(file1, file2);
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_compress_success(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 2);
+
+    expect_value(__wrap_BZ2_bzWriteOpen, f, 2);
+    will_return(__wrap_BZ2_bzWriteOpen, BZ_OK);
+    will_return(__wrap_BZ2_bzWriteOpen, 3);
+
+    will_return(__wrap_fread, "teststring");
+    will_return(__wrap_fread, 10);
+
+    expect_value(__wrap_BZ2_bzWrite, f, 3);
+    expect_string(__wrap_BZ2_bzWrite, buf, "teststring");
+    expect_value(__wrap_BZ2_bzWrite, len, 10);
+    will_return(__wrap_BZ2_bzWrite, BZ_OK);
+
+    will_return(__wrap_fread, "");
+    will_return(__wrap_fread, 0);
+
+    expect_value(__wrap_BZ2_bzWriteClose64, f, 3);
+    will_return(__wrap_BZ2_bzWriteClose64, BZ_OK);
+
+    ret = bzip2_compress(file1, file2);
+    assert_int_equal(ret, 0);
+}
+
+
+void test_bzip2_uncompress_nullfile(void **state) {
+    int ret;
+
+    ret = bzip2_uncompress(NULL, "test");
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_uncompress_nullfilebz2(void **state) {
+    int ret;
+
+    ret = bzip2_uncompress("test", NULL);
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_uncompress_firstfopenfail(void **state) {
+    int ret;
+    char *string = "testfile";
+
+    expect_value(__wrap_fopen, path, string);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "(1103): Could not open file 'testfile' due to [(0)-(Success)].");
+    ret = bzip2_uncompress(string, "testbz2");
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_uncompress_secondfopenfail(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "(1103): Could not open file 'testfile2' due to [(0)-(Success)].");
+    ret = bzip2_uncompress(file1, file2);
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_uncompress_bzReadOpen(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 2);
+
+    expect_value(__wrap_BZ2_bzReadOpen, f, 1);
+    will_return(__wrap_BZ2_bzReadOpen, BZ_MEM_ERROR);
+    will_return(__wrap_BZ2_bzReadOpen, NULL);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "BZ2_bzReadOpen(-3)'testfile': (0)-Success");
+
+    ret = bzip2_uncompress(file1, file2);
+    assert_int_equal(ret, -1);
+}
+
+void test_bzip2_uncompress_bzReadsuccess(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 2);
+
+    expect_value(__wrap_BZ2_bzReadOpen, f, 1);
+    will_return(__wrap_BZ2_bzReadOpen, BZ_OK);
+    will_return(__wrap_BZ2_bzReadOpen, 3);
+
+    expect_value(__wrap_BZ2_bzRead, f, 3);
+    will_return(__wrap_BZ2_bzRead, BZ_OK);
+    will_return(__wrap_BZ2_bzRead, 11);
+    will_return(__wrap_BZ2_bzRead, "teststring");
+
+    will_return(__wrap_fwrite, 4);
+
+    expect_value(__wrap_BZ2_bzRead, f, 3);
+    will_return(__wrap_BZ2_bzRead, BZ_OK);
+    will_return(__wrap_BZ2_bzRead, 0);
+    will_return(__wrap_BZ2_bzRead, "");
+
+    ret = bzip2_uncompress(file1, file2);
+    assert_int_equal(ret, 0);
+}
+
+void test_bzip2_uncompress_bzReadfail(void **state) {
+    int ret;
+    char *file1 = "testfile";
+    char *file2 = "testfile2";
+
+    expect_value(__wrap_fopen, path, file1);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fopen, path, file2);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 2);
+
+    expect_value(__wrap_BZ2_bzReadOpen, f, 1);
+    will_return(__wrap_BZ2_bzReadOpen, BZ_OK);
+    will_return(__wrap_BZ2_bzReadOpen, 3);
+
+    expect_value(__wrap_BZ2_bzRead, f, 3);
+    will_return(__wrap_BZ2_bzRead, BZ_OK);
+    will_return(__wrap_BZ2_bzRead, 11);
+    will_return(__wrap_BZ2_bzRead, "teststring");
+
+    will_return(__wrap_fwrite, 4);
+
+    expect_value(__wrap_BZ2_bzRead, f, 3);
+    will_return(__wrap_BZ2_bzRead, BZ_MEM_ERROR);
+    will_return(__wrap_BZ2_bzRead, 0);
+    will_return(__wrap_BZ2_bzRead, "");
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "BZ2_bzRead(-3)'testfile': (0)-Success");
+
+    ret = bzip2_uncompress(file1, file2);
+    assert_int_equal(ret, -1);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_bzip2_compress_nullfile),
+        cmocka_unit_test(test_bzip2_compress_nullfilebz2),
+        cmocka_unit_test(test_bzip2_compress_firstfopenfail),
+        cmocka_unit_test(test_bzip2_compress_secondfopenfail),
+        cmocka_unit_test(test_bzip2_compress_bzWriteOpen),
+        cmocka_unit_test(test_bzip2_compress_BZ2_bzWrite),
+        cmocka_unit_test(test_bzip2_compress_bzWriteClose64),
+        cmocka_unit_test(test_bzip2_compress_success),
+        cmocka_unit_test(test_bzip2_uncompress_nullfile),
+        cmocka_unit_test(test_bzip2_uncompress_nullfilebz2),
+        cmocka_unit_test(test_bzip2_uncompress_firstfopenfail),
+        cmocka_unit_test(test_bzip2_uncompress_secondfopenfail),
+        cmocka_unit_test(test_bzip2_uncompress_bzReadOpen),
+        cmocka_unit_test(test_bzip2_uncompress_bzReadsuccess),
+        cmocka_unit_test(test_bzip2_uncompress_bzReadfail),
+    };
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
+}

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -13,6 +13,7 @@
 #include <cmocka.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "../headers/file_op.h"
 
@@ -40,9 +41,10 @@ int __wrap_File_DateofChange(const char *file)
     return 1;
 }
 
-int __wrap_stat()
+int __wrap_stat(const char * path, struct stat * buf)
 {
-    return 1;
+    memset(buf, 0, sizeof(struct stat));
+    return 0;
 }
 
 int __wrap_unlink(const char *file)

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2235,6 +2235,9 @@ free_mem:
     if (remove(VU_FIT_TEMP_FILE) < 0) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, "remove(%s): %s", VU_FIT_TEMP_FILE, strerror(errno));
     }
+    if (remove(VU_TEMP_FILE_BZ2) < 0) {
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, "remove(%s): %s", VU_TEMP_FILE_BZ2, strerror(errno));
+    }
 
     if (success) {
         return 0;
@@ -2253,7 +2256,14 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
     vu_logic retval = VU_INV_FEED;
 
     for (attempts = 0;; attempts++) {
-        if (!wurl_request(repo, VU_TEMP_FILE_BZ2, NULL, NULL)) {
+        int res_url_request;
+        if (update->dist_ref == FEED_UBUNTU) {
+            res_url_request = wurl_request(repo, VU_TEMP_FILE_BZ2, NULL, NULL);
+        } else {
+            res_url_request = wurl_request(repo, VU_TEMP_FILE, NULL, NULL);
+        }
+
+        if (!res_url_request) {
             break;
         } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
             goto end;
@@ -2262,7 +2272,9 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
         sleep(attempts);
     }
 
-    bzip2_uncompress(VU_TEMP_FILE_BZ2, VU_TEMP_FILE);
+    if (update->dist_ref == FEED_UBUNTU) {
+        bzip2_uncompress(VU_TEMP_FILE_BZ2, VU_TEMP_FILE);
+    }
 
     if (fp = fopen(VU_TEMP_FILE, "r"), !fp) {
         goto end;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2253,7 +2253,7 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
     vu_logic retval = VU_INV_FEED;
 
     for (attempts = 0;; attempts++) {
-        if (!wurl_request(repo, VU_TEMP_FILE, NULL, NULL)) {
+        if (!wurl_request(repo, VU_TEMP_FILE_BZ2, NULL, NULL)) {
             break;
         } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
             goto end;
@@ -2261,6 +2261,8 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
         mdebug1(VU_DOWNLOAD_FAIL, attempts);
         sleep(attempts);
     }
+
+    bzip2_uncompress(VU_TEMP_FILE_BZ2, VU_TEMP_FILE);
 
     if (fp = fopen(VU_TEMP_FILE, "r"), !fp) {
         goto end;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2273,7 +2273,10 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
     }
 
     if (update->dist_ref == FEED_UBUNTU) {
-        bzip2_uncompress(VU_TEMP_FILE_BZ2, VU_TEMP_FILE);
+        int result;
+        if (result = bzip2_uncompress(VU_TEMP_FILE_BZ2, VU_TEMP_FILE), result == -1) {
+            goto end;
+        }
     }
 
     if (fp = fopen(VU_TEMP_FILE, "r"), !fp) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -26,6 +26,7 @@
 #define WM_VULNDETECTOR_DOWN_ATTEMPTS  5
 #define VU_DEF_IGNORE_TIME 21600 // 6 hours
 #define VU_TEMP_FILE "tmp/vuln-temp"
+#define VU_TEMP_FILE_BZ2 "tmp/vuln-temp.bz2"
 #define VU_FIT_TEMP_FILE VU_TEMP_FILE "-fitted"
 #define VU_TEMP_METADATA_FILE VU_TEMP_FILE "-metadata"
 #define VU_DICTIONARIES DEFAULTDIR "/queue/vulnerabilities/dictionaries"
@@ -33,7 +34,7 @@
 #define VU_MSU_FILE VU_DICTIONARIES "/msu.json"
 #define VU_MSU_FILE_GZ VU_MSU_FILE ".gz"
 #define VU_CPEHELPER_FORMAT_VERSION 1
-#define CANONICAL_REPO "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.%s.cve.oval.xml"
+#define CANONICAL_REPO "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.%s.cve.oval.xml.bz2"
 #define DEBIAN_REPO "https://www.debian.org/security/oval/oval-definitions-%s.xml"
 #define RED_HAT_REPO_DEFAULT_MIN_YEAR 2010
 #define RED_HAT_REPO_MAX_REQ_ITS 100

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -26,7 +26,7 @@
 #define WM_VULNDETECTOR_DOWN_ATTEMPTS  5
 #define VU_DEF_IGNORE_TIME 21600 // 6 hours
 #define VU_TEMP_FILE "tmp/vuln-temp"
-#define VU_TEMP_FILE_BZ2 "tmp/vuln-temp.bz2"
+#define VU_TEMP_FILE_BZ2 VU_TEMP_FILE ".bz2"
 #define VU_FIT_TEMP_FILE VU_TEMP_FILE "-fitted"
 #define VU_TEMP_METADATA_FILE VU_TEMP_FILE "-metadata"
 #define VU_DICTIONARIES DEFAULTDIR "/queue/vulnerabilities/dictionaries"


### PR DESCRIPTION
|Related issue|
|---|
|[4808](https://github.com/wazuh/wazuh/issues/4808)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Since a few days the Ubuntu feed is obtained from a compressed file in bz2 format. 
With this PR the corresponding library is added to be able to compress and decompress this file format.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
Not aplicable.
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
Check the Debian and Ubuntu feeds are in database
> select target, count(*) from vulnerabilities group by target

|FEED|CVEs|
|---|---|
|BIONIC|26718|
|BUSTER|18617|
|JESSIE|23353|
|STRETCH|21597|
|TRUSTY|10019|
|WHEEZY|835|
|XENIAL|32544|

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
