### PR TITLE
Remove CRITICAL message when Syscheckd conf is invalid

### DIFF
--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -167,7 +167,8 @@ int rootcheck_init(int test_config)
 
     /* Read configuration  --function specified twice (check makefile) */
     if (Read_Rootcheck_Config(cfg) < 0) {
-        mterror_exit(ARGV0, CONFIG_ERROR, cfg);
+        merror(RCONFIG_ERROR, ARGV0, cfg);
+        return (1);
     }
 
 #ifndef WIN32

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -106,7 +106,8 @@ int main(int argc, char **argv)
 
     /* Read syscheck config */
     if ((r = Read_Syscheck_Config(cfg)) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        merror(RCONFIG_ERROR, SYSCHECK, cfg);
+        syscheck.disabled = 1;
     } else if ((r == 1) || (syscheck.disabled == 1)) {
         if (!syscheck.dir) {
             if (!test_config) {

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -110,7 +110,8 @@ int Start_win32_Syscheck()
 
     /* Read syscheck config */
     if ((r = Read_Syscheck_Config(cfg)) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        merror(RCONFIG_ERROR, SYSCHECK, cfg);
+        syscheck.disabled = 1;
     } else if ((r == 1) || (syscheck.disabled == 1)) {
         /* Disabled */
         if (!syscheck.dir) {

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -140,7 +140,7 @@ else()
   list(APPEND syscheckd_tests_flags "${SYSCHECK_CONFIG_BASE_FLAGS}")
 endif()
 
-set(SYSCHECK_BASE_FLAGS "-Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror_exit -Wl,--wrap,_minfo -Wl,--wrap,fim_db_init -Wl,--wrap,getDefine_Int")
+set(SYSCHECK_BASE_FLAGS "-Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_merror_exit -Wl,--wrap,_minfo -Wl,--wrap,fim_db_init -Wl,--wrap,getDefine_Int")
 list(APPEND syscheckd_tests_names "test_syscheck")
 if(${TARGET} STREQUAL "winagent")
   list(APPEND syscheckd_tests_flags "${SYSCHECK_BASE_FLAGS} \


### PR DESCRIPTION
|Related issue|
|---|
|[4665](https://github.com/wazuh/wazuh/issues/4665)|

## Description

FIM behaves differently than other modules when the configuration isn't valid. Meanwhile, other modules print error messages and don't work, FIM prints critical message causing the stop of the thread (or the process in case of Windows). This PR modifies this behavior for:
+ Wazuh agent doesn't stop on Windows platforms if FIM configuration is invalid.
+ Allow Rootcheck works if FIM configuration is invalid (in all platforms).

## Tests

**Syscheckd invalid configuration (Linux)**

```
2020/04/07 15:52:51 ossec-authd: INFO: Started (pid: 18913).
2020/04/07 15:52:51 ossec-authd: INFO: Accepting connections on port 1515. No password required.
2020/04/07 15:52:51 ossec-authd: INFO: Setting network timeout to 1.000000 sec.
2020/04/07 15:52:52 wazuh-db: INFO: Started (pid: 18928).
2020/04/07 15:52:53 ossec-execd: INFO: Started (pid: 18951).
2020/04/07 15:52:53 ossec-analysisd: INFO: Total rules enabled: '3614'
2020/04/07 15:52:53 ossec-analysisd: INFO: Started (pid: 18965).
2020/04/07 15:52:54 ossec-syscheckd: ERROR: (1235): Invalid value for element 'disabled': 123.
2020/04/07 15:52:54 ossec-syscheckd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
2020/04/07 15:52:54 ossec-syscheckd: ERROR: (1207): syscheck remote configuration in '/var/ossec/etc/ossec.conf' is corrupted.
2020/04/07 15:52:54 rootcheck: INFO: Starting rootcheck scan.
2020/04/07 15:52:54 ossec-remoted: INFO: Started (pid: 19075). Listening on port 1514/UDP (secure).
2020/04/07 15:52:54 ossec-remoted: INFO: (4111): Maximum number of agents allowed: '100000'.
2020/04/07 15:52:54 ossec-remoted: INFO: (1410): Reading authentication keys file.
2020/04/07 15:52:55 ossec-logcollector: INFO: (1950): Analyzing file: '/home/lopezziur/fail2ban.log'.
2020/04/07 15:52:55 ossec-logcollector: INFO: Started (pid: 19105).
2020/04/07 15:52:55 ossec-monitord: INFO: Started (pid: 19120).
2020/04/07 15:52:55 wazuh-modulesd: INFO: Process started.
2020/04/07 15:52:55 wazuh-modulesd:oscap: INFO: Module disabled. Exiting...
2020/04/07 15:52:55 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2020/04/07 15:52:55 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2020/04/07 15:52:55 wazuh-modulesd:syscollector: INFO: Module started.
2020/04/07 15:52:55 sca: INFO: Module started.
2020/04/07 15:52:55 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_debian9_L1.yml'
2020/04/07 15:52:55 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_debian9_L2.yml'
2020/04/07 15:52:55 wazuh-modulesd:database: INFO: Module started.
2020/04/07 15:52:55 wazuh-modulesd:download: INFO: Module started
2020/04/07 15:52:55 wazuh-modulesd:control: INFO: Starting control thread.
2020/04/07 15:52:55 sca: INFO: Starting Security Configuration Assessment scan.
2020/04/07 15:52:55 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_debian9_L1.yml'
2020/04/07 15:52:56 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2020/04/07 15:52:58 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_debian9_L1.yml'
2020/04/07 15:52:58 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_debian9_L2.yml'
2020/04/07 15:53:02 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_debian9_L2.yml'
2020/04/07 15:53:03 sca: INFO: Security Configuration Assessment scan finished. Duration: 8 seconds.
2020/04/07 15:53:34 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```

**Rootcheck invalid configuration (Linux)**

```
2020/04/07 16:24:07 ossec-authd: INFO: Started (pid: 26452).
2020/04/07 16:24:07 ossec-authd: INFO: Accepting connections on port 1515. No password required.
2020/04/07 16:24:07 ossec-authd: INFO: Setting network timeout to 1.000000 sec.
2020/04/07 16:24:07 wazuh-db: INFO: Started (pid: 26467).
2020/04/07 16:24:08 ossec-execd: INFO: Started (pid: 26491).
2020/04/07 16:24:08 ossec-analysisd: INFO: Total rules enabled: '3614'
2020/04/07 16:24:08 ossec-analysisd: INFO: Started (pid: 26502).
2020/04/07 16:24:09 ossec-syscheckd: INFO: (6001): File integrity monitoring disabled.
2020/04/07 16:24:09 ossec-syscheckd: ERROR: (1235): Invalid value for element 'disabled': 123.
2020/04/07 16:24:09 ossec-syscheckd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
2020/04/07 16:24:09 ossec-syscheckd: ERROR: (1207): rootcheck remote configuration in '/var/ossec/etc/ossec.conf' is corrupted.
2020/04/07 16:24:09 ossec-remoted: INFO: Started (pid: 26612). Listening on port 1514/UDP (secure).
2020/04/07 16:24:09 ossec-remoted: INFO: (4111): Maximum number of agents allowed: '100000'.
2020/04/07 16:24:09 ossec-remoted: INFO: (1410): Reading authentication keys file.
2020/04/07 16:24:10 ossec-logcollector: INFO: (1950): Analyzing file: '/home/lopezziur/fail2ban.log'.
2020/04/07 16:24:10 ossec-logcollector: INFO: Started (pid: 26642).
2020/04/07 16:24:10 ossec-monitord: INFO: Started (pid: 26657).
2020/04/07 16:24:10 wazuh-modulesd: INFO: Process started.
2020/04/07 16:24:10 wazuh-modulesd:oscap: INFO: Module disabled. Exiting...
2020/04/07 16:24:10 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2020/04/07 16:24:10 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2020/04/07 16:24:10 wazuh-modulesd:syscollector: INFO: Module started.
2020/04/07 16:24:10 sca: INFO: Module started.
2020/04/07 16:24:10 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_debian9_L1.yml'
2020/04/07 16:24:10 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_debian9_L2.yml'
2020/04/07 16:24:10 wazuh-modulesd:database: INFO: Module started.
2020/04/07 16:24:10 wazuh-modulesd:download: INFO: Module started
2020/04/07 16:24:10 wazuh-modulesd:control: INFO: Starting control thread.
2020/04/07 16:24:10 sca: INFO: Starting Security Configuration Assessment scan.
2020/04/07 16:24:10 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_debian9_L1.yml'
2020/04/07 16:24:11 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2020/04/07 16:24:13 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_debian9_L1.yml'
2020/04/07 16:24:13 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_debian9_L2.yml'
2020/04/07 16:24:17 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_debian9_L2.yml'
2020/04/07 16:24:18 sca: INFO: Security Configuration Assessment scan finished. Duration: 8 seconds.
2020/04/07 16:24:49 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```

**Syscheckd invalid configuration (Windows)**

```
2020/04/07 15:34:03 ossec-agent: INFO: Using notify time: 10 and max time to reconnect: 60
2020/04/07 15:34:03 ossec-agent: INFO: (1350): Active response disabled.
2020/04/07 15:34:03 ossec-agent: INFO: (1410): Reading authentication keys file.
2020/04/07 15:34:03 ossec-agent: INFO: Trying to connect to server (11.0.0.1:1514/udp).
2020/04/07 15:34:03 ossec-agent: ERROR: (1235): Invalid value for element 'disabled': 123.
2020/04/07 15:34:03 ossec-agent: ERROR: (1202): Configuration error at 'ossec.conf'.
2020/04/07 15:34:03 ossec-agent: ERROR: (1207): syscheckd remote configuration in 'ossec.conf' is corrupted.
2020/04/07 15:34:03 rootcheck: INFO: Started (pid: 2224).
2020/04/07 15:34:04 ossec-agent: INFO: (4102): Connected to the server (11.0.0.1:1514/udp).
2020/04/07 15:34:04 ossec-agent: INFO: Windows version is 6.0 or newer. (Microsoft Windows Server 2012 Standard Evaluation [Ver: 6.2.9200] - Wazuh v3.12.1).
2020/04/07 15:34:04 ossec-agent: INFO: (1951): Analyzing event log: 'Application'.
2020/04/07 15:34:04 ossec-agent: INFO: (1951): Analyzing event log: 'Security'.
2020/04/07 15:34:04 sca: INFO: Module started.
2020/04/07 15:34:04 sca: INFO: Loaded policy 'C:\Program Files (x86)\ossec-agent\ruleset\sca\sca_win_audit.yml'
2020/04/07 15:34:04 sca: INFO: Starting Security Configuration Assessment scan.
2020/04/07 15:34:04 sca: INFO: Starting evaluation of policy: 'C:\Program Files (x86)\ossec-agent\ruleset\sca\sca_win_audit.yml'
2020/04/07 15:34:04 wazuh-modulesd:syscollector: INFO: Module started.
2020/04/07 15:34:04 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2020/04/07 15:34:04 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2020/04/07 15:34:04 ossec-agent: INFO: (1951): Analyzing event log: 'System'.
2020/04/07 15:34:04 ossec-agent: INFO: (1950): Analyzing file: 'active-response\active-responses.log'.
2020/04/07 15:34:04 ossec-agent: INFO: Started (pid: 2224).
2020/04/07 15:34:05 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2020/04/07 15:34:06 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2020/04/07 15:34:07 sca: INFO: Evaluation finished for policy 'C:\Program Files (x86)\ossec-agent\ruleset\sca\sca_win_audit.yml'
2020/04/07 15:34:08 ossec-agent: INFO: Agent is now online. Process unlocked, continuing...
2020/04/07 15:34:08 sca: INFO: Security Configuration Assessment scan finished. Duration: 4 seconds.
2020/04/07 15:34:08 rootcheck: INFO: Starting rootcheck scan.
2020/04/07 15:34:13 rootcheck: INFO: Ending rootcheck scan.
```

**Rootcheck invalid configuration (Windows)**

```
2020/04/07 16:14:44 ossec-agent: INFO: Using notify time: 10 and max time to reconnect: 60
2020/04/07 16:14:44 ossec-agent: INFO: (1350): Active response disabled.
2020/04/07 16:14:44 ossec-agent: INFO: (1410): Reading authentication keys file.
2020/04/07 16:14:44 ossec-agent: INFO: Trying to connect to server (11.0.0.1:1514/udp).
2020/04/07 16:14:44 ossec-agent: ERROR: (1235): Invalid value for element 'disabled': 123.
2020/04/07 16:14:44 ossec-agent: ERROR: (1202): Configuration error at 'ossec.conf'.
2020/04/07 16:14:44 ossec-agent: ERROR: (1207): rootcheck remote configuration in 'ossec.conf' is corrupted.
2020/04/07 16:14:44 ossec-agent: INFO: (6003): Monitoring directory/file: 'c:\testing\subdir2', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | whodata'.
2020/04/07 16:14:44 ossec-agent: INFO: (6003): Monitoring directory/file: 'c:\testing\subdir1', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | whodata'.
2020/04/07 16:14:44 ossec-agent: INFO: (6003): Monitoring directory/file: 'c:\testing\subdir3', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | whodata'.
2020/04/07 16:14:44 ossec-agent: INFO: Started (pid: 1436).
2020/04/07 16:14:45 ossec-agent: INFO: (4102): Connected to the server (11.0.0.1:1514/udp).
2020/04/07 16:14:45 ossec-agent: INFO: Windows version is 6.0 or newer. (Microsoft Windows Server 2012 Standard Evaluation [Ver: 6.2.9200] - Wazuh v3.12.1).
2020/04/07 16:14:45 ossec-agent: INFO: (1951): Analyzing event log: 'Application'.
2020/04/07 16:14:45 ossec-agent: INFO: (1951): Analyzing event log: 'Security'.
2020/04/07 16:14:45 sca: INFO: Module started.
2020/04/07 16:14:45 sca: INFO: Loaded policy 'C:\Program Files (x86)\ossec-agent\ruleset\sca\sca_win_audit.yml'
2020/04/07 16:14:45 sca: INFO: Starting Security Configuration Assessment scan.
2020/04/07 16:14:45 sca: INFO: Starting evaluation of policy: 'C:\Program Files (x86)\ossec-agent\ruleset\sca\sca_win_audit.yml'
2020/04/07 16:14:45 wazuh-modulesd:syscollector: INFO: Module started.
2020/04/07 16:14:45 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2020/04/07 16:14:45 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2020/04/07 16:14:45 ossec-agent: INFO: (1951): Analyzing event log: 'System'.
2020/04/07 16:14:45 ossec-agent: INFO: (1950): Analyzing file: 'active-response\active-responses.log'.
2020/04/07 16:14:45 ossec-agent: INFO: Started (pid: 1436).
2020/04/07 16:14:46 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2020/04/07 16:14:47 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2020/04/07 16:14:48 sca: INFO: Evaluation finished for policy 'C:\Program Files (x86)\ossec-agent\ruleset\sca\sca_win_audit.yml'
2020/04/07 16:14:49 ossec-agent: INFO: Agent is now online. Process unlocked, continuing...
2020/04/07 16:14:49 ossec-agent: INFO: (6000): Starting daemon...
2020/04/07 16:14:49 ossec-agent: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2020/04/07 16:14:49 ossec-agent: INFO: (6008): File integrity monitoring scan started.
2020/04/07 16:14:49 ossec-agent: INFO: (6009): File integrity monitoring scan ended.
2020/04/07 16:14:49 sca: INFO: Security Configuration Assessment scan finished. Duration: 4 seconds.
2020/04/07 16:14:49 ossec-agent: INFO: (6036): Analyzing Windows volumes
2020/04/07 16:14:49 ossec-agent: INFO: (6019): File integrity monitoring real-time Whodata engine started.
```

## Unit tests

```
lopezziur@lopezziur:~/wazuh/wazuh/src/unit_tests/build/syscheckd$ ./test_syscheck
[==========] Running 5 test(s).
[ RUN      ] test_fim_initialize
[       OK ] test_fim_initialize
[ RUN      ] test_fim_initialize
[       OK ] test_fim_initialize
[ RUN      ] test_fim_initialize_error
[       OK ] test_fim_initialize_error
[ RUN      ] test_read_internal
[       OK ] test_read_internal
[ RUN      ] test_read_internal_debug
[       OK ] test_read_internal_debug
[==========] 5 test(s) run.
[  PASSED  ] 5 test(s).
lopezziur@lopezziur:~/wazuh/wazuh/src/unit_tests/build/syscheckd$ 
```
```
lopezziur@lopezziur:~/wazuh/wazuh/src/unit_tests/build/syscheckd$ wine ./test_syscheck.exe 
[==========] tests: Running 11 test(s).
[ RUN      ] test_fim_initialize
[       OK ] test_fim_initialize
[ RUN      ] test_fim_initialize
[       OK ] test_fim_initialize
[ RUN      ] test_fim_initialize_error
[       OK ] test_fim_initialize_error
[ RUN      ] test_read_internal
[       OK ] test_read_internal
[ RUN      ] test_read_internal_debug
[       OK ] test_read_internal_debug
[ RUN      ] test_Start_win32_Syscheck_no_config_file
[       OK ] test_Start_win32_Syscheck_no_config_file
[ RUN      ] test_Start_win32_Syscheck_corrupted_config_file
[       OK ] test_Start_win32_Syscheck_corrupted_config_file
[ RUN      ] test_Start_win32_Syscheck_syscheck_disabled_1
[       OK ] test_Start_win32_Syscheck_syscheck_disabled_1
[ RUN      ] test_Start_win32_Syscheck_syscheck_disabled_2
[       OK ] test_Start_win32_Syscheck_syscheck_disabled_2
[ RUN      ] test_Start_win32_Syscheck_dirs_and_registry
[       OK ] test_Start_win32_Syscheck_dirs_and_registry
[ RUN      ] test_Start_win32_Syscheck_whodata_active
[       OK ] test_Start_win32_Syscheck_whodata_active
[==========] tests: 11 test(s) run.
[  PASSED  ] 11 test(s).
lopezziur@lopezziur:~/wazuh/wazuh/src/unit_tests/build/syscheckd$
```
