### PR TITLE
Fix RBAC black /cluster tests for the new API

### DIFF
--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -508,56 +508,6 @@ stages:
         <<: *permission_denied
 
 ---
-test_name: PUT /cluster/restart
-
-stages:
-
-  - name: Restart cluster
-    request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        list_nodes: 'worker1,worker2'
-    response:
-      status_code: 200
-      body:
-        data:
-          affected_items:
-            - worker2
-          failed_items:
-            - error:
-                code: 4000
-                message: !anystr
-                remediation: !anystr
-              id:
-                - worker1
-          total_affected_items: 1
-          total_failed_items: 1
-        message: !anystr
-    delay_after: 30
-
-  - name: Restart cluster
-    request:
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      body:
-        data:
-          affected_items:
-            - 'master-node'
-            - 'worker2'
-          failed_items: []
-          total_affected_items: 2
-          total_failed_items: 0
-        message: !anystr
-    delay_after: 30
-
----
 test_name: GET /cluster/{node_id}/files
 
 stages:
@@ -701,3 +651,52 @@ stages:
       body:
         <<: *permission_denied
 
+---
+test_name: PUT /cluster/restart
+
+stages:
+
+  - name: Restart cluster
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_nodes: 'worker1,worker2'
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items:
+            - worker2
+          failed_items:
+            - error:
+                code: 4000
+                message: !anystr
+                remediation: !anystr
+              id:
+                - worker1
+          total_affected_items: 1
+          total_failed_items: 1
+        message: !anystr
+    delay_after: 30
+
+  - name: Restart cluster
+    request:
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      body:
+        data:
+          affected_items:
+            - 'master-node'
+            - 'worker2'
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: 0
+        message: !anystr
+    delay_after: 30


### PR DESCRIPTION
Hello team.

Quick change to make these tests compatible between them.

As we have permission to restart the **master** node, once we make `/cluster/restart` we lose our token and the rest of the tests will fail due to a **401** code. We need to make this request the last.

Regards.