### PR TITLE
Fix memory errors in the Integrator Daemon

### DIFF
--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -258,10 +258,12 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 else
                 {
                     if(integrator_config[s]->alert_format != NULL && strncmp(integrator_config[s]->alert_format, "json", 4) == 0){
-                        fprintf(fp, "%s", cJSON_PrintUnformatted(al_json));
+                        char * unformatted = cJSON_PrintUnformatted(al_json);
+                        fprintf(fp, "%s", unformatted);
                         temp_file_created = 1;
                         mdebug2("file %s was written.", exec_tmp_file);
                         fclose(fp);
+                        free(unformatted);
                     }else{
                         int log_count = 0;
                         char *srcip = NULL;

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -266,7 +266,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                         int log_count = 0;
                         char *srcip = NULL;
                         json_field = cJSON_GetObjectItem(al_json, "full_log");
-                        char *full_log = json_field->valuestring;
+                        char *full_log = json_field ? json_field->valuestring : "";
                         char *tmpstr = full_log;
 
                         while(*tmpstr != '\0')
@@ -356,19 +356,19 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                         char *rule_description = NULL;
 
                         json_field = cJSON_GetObjectItem(al_json,"timestamp");
-                        date = json_field->valuestring;
+                        date = json_field ? json_field->valuestring : "";
 
                         json_field = cJSON_GetObjectItem(al_json,"location");
-                        location = json_field->valuestring;
+                        location = json_field ? json_field->valuestring : "";
 
                         json_field = cJSON_GetObjectItem(rule,"id");
-                        rule_id = json_field->valuestring;
+                        rule_id = json_field ? json_field->valuestring : "";
 
                         json_field = cJSON_GetObjectItem(rule,"level");
-                        alert_level = json_field->valueint;
+                        alert_level = json_field ? json_field->valueint : "";
 
                         json_field = cJSON_GetObjectItem(rule,"description");
-                        rule_description = json_field->valuestring;
+                        rule_description = json_field ? json_field->valuestring : "";
 
 
                         fprintf(fp, "alertdate='%s'\nalertlocation='%s'\nruleid='%s'\nalertlevel='%d'\nruledescription='%s'\nalertlog='%s'\nsrcip='%s'", date, location, rule_id, alert_level, rule_description, full_log, srcip == NULL?"":srcip);


### PR DESCRIPTION
This PR aims to fix issue #4370: prevent Integratord from crashing with a segmentation fault signal while it's parsing an alert object that misses any of the following members:

- `full_log`
- `timestamp`
- `location`
- `id`
- `level`
- `description`

In addition, it fixes a memory leak affecting the option:
```xml
<alert_format>json</alert_format>
```

## Tests

- [X] Handle an alert missing the `full_log` member.
- [X] Handle an empty object.
- [X] Handle an alert having an empty object as `rule` member.
- [X] Handle an alert on an integration that set `<alert_format>` to `json`.
- [X] Compile the manager code on Linux.
- [X] Run Integratord built from sources.
- [X] Run Integratord on Valgrind and check that neither memory leaks nor invalid memory accesses happen.
- [X] Check _Scan Build_ reports no errors on the Integrator code.
