### PR TITLE
Add agent-version validator for overview tests (new API)

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -102,3 +102,16 @@ def test_sort_response(response, affected_items):
     for index, item_response in enumerate(response.json()['data']['affected_items']):
         assert item_response != affected_items[reverse_index - index]
     return
+
+
+def test_validate_data_dict_field(response, fields_dict):
+    assert fields_dict, f'Fields dict is empty'
+    for field, dikt in fields_dict.items():
+        field_list = response.json()['data'][field]
+
+        for element in field_list:
+            try:
+                assert (isinstance(element[key], eval(value)) for key, value in dikt.items())
+            except KeyError:
+                assert len(element) == 1
+                assert isinstance(element['count'], int)

--- a/api/test/integration/test_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_overview_endpoints.tavern.yaml
@@ -19,6 +19,16 @@ stages:
      headers:
        Authorization: "Bearer {test_login_token}"
    response:
+     verify_response_with:
+       function: tavern_utils:test_validate_data_dict_field
+       extra_kwargs:
+         fields_dict:
+           agent_version:
+             version: str
+             count: int
+           nodes:
+             node: str
+             count: int
      status_code: 200
      body:
        data:
@@ -45,14 +55,7 @@ stages:
            never_connected: 2
            pending: 0
            total: 13
-         agent_version:
-           - count: !anyint
-             version: !anystr
-           - count: !anyint
-             version: !anystr
-           - count: !anyint
-             version: !anystr
-           - count: !anyint
+         agent_version: !anything
          groups:
            - configSum: !anystr
              count: !anyint
@@ -93,12 +96,4 @@ stages:
              registerIP: any
              status: active
              version: !anystr
-         nodes:
-           - count: !anyint
-             node_name: !anything
-           - count: !anyint
-             node_name: !anything
-           - count: !anyint
-             node_name: !anything
-           - count: !anyint
-             node_name: !anything
+         nodes: !anything

--- a/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
@@ -19,6 +19,16 @@ stages:
      headers:
        Authorization: "Bearer {test_login_token}"
    response:
+     verify_response_with:
+       function: tavern_utils:test_validate_data_dict_field
+       extra_kwargs:
+         fields_dict:
+           agent_version:
+             version: str
+             count: int
+           nodes:
+             node: str
+             count: int
      status_code: 200
      body:
        data:
@@ -40,12 +50,7 @@ stages:
            never_connected: 1
            pending: 0
            total: 6
-         agent_version:
-           - count: !anyint
-             version: !anystr
-           - count: !anyint
-             version: !anystr
-           - count: !anyint
+         agent_version: !anything
          groups:
            - configSum: !anystr
              count: !anyint
@@ -86,10 +91,4 @@ stages:
              registerIP: any
              status: active
              version: !anystr
-         nodes:
-           - count: !anyint
-             node_name: !anything
-           - count: !anyint
-             node_name: !anything
-           - count: !anyint
-             node_name: !anything
+         nodes: !anything

--- a/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
@@ -19,6 +19,16 @@ stages:
      headers:
        Authorization: "Bearer {test_login_token}"
    response:
+     verify_response_with:
+       function: tavern_utils:test_validate_data_dict_field
+       extra_kwargs:
+         fields_dict:
+           agent_version:
+             version: str
+             count: int
+           nodes:
+             node: str
+             count: int
      status_code: 200
      body:
        data:
@@ -45,14 +55,7 @@ stages:
            never_connected: 1
            pending: 0
            total: 7
-         agent_version:
-           - count: !anyint
-             version: !anystr
-           - count: !anyint
-             version: !anystr
-           - count: !anyint
-             version: !anystr
-           - count: !anyint
+         agent_version: !anything # This will be tested with an external function
          groups: []
          last_registered_agent:
            - configSum: !anystr
@@ -77,12 +80,4 @@ stages:
              registerIP: any
              status: active
              version: !anystr
-         nodes:
-           - count: !anyint
-             node_name: !anything
-           - count: !anyint
-             node_name: !anything
-           - count: !anyint
-             node_name: !anything
-           - count: !anyint
-             node_name: !anything
+         nodes: !anything


### PR DESCRIPTION
Hello team.

The `/overview/agents` endpoint has some fields which can change over time depending on the environment. To avoid this, I have added a new function to validate these fields no matter the environment.

## Tests performed
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 1 item

test_overview_endpoints.tavern.yaml::GET /overview/agents PASSED         [100%]

=============================== warnings summary ===============================
test/integration/test_overview_endpoints.tavern.yaml::GET /overview/agents
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 1 passed, 1 warnings in 72.65 seconds =====================

```

```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 1 item

test_rbac_black_overview_endpoints.tavern.yaml::GET /overview/agents PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_rbac_black_overview_endpoints.tavern.yaml::GET /overview/agents
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 1 passed, 1 warnings in 72.36 seconds =====================

```

```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 1 item

test_rbac_white_overview_endpoints.tavern.yaml::GET /overview/agents PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_rbac_white_overview_endpoints.tavern.yaml::GET /overview/agents
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 1 passed, 1 warnings in 72.63 seconds =====================

```

Regards.