### PR TITLE
Fix status filter with multiple values API 4.0

### DIFF
--- a/api/test/integration/test_agentsGET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agentsGET_endpoints.tavern.yaml
@@ -4,7 +4,6 @@ test_name: GET /agents
 marks:
   - usefixtures:
     - agents_tests
-  - xfail # STAGE (Filter by agent status 2) XFAILS DUE TO https://github.com/wazuh/wazuh/issues/4825
 
 includes:
  - !include common.yaml
@@ -2038,9 +2037,6 @@ stages:
 
 ---
 test_name: GET /groups/{group_id}/agents
-
-marks:
-  - xfail # STAGE (Status multiple) XFAILS DUE TO https://github.com/wazuh/wazuh/issues/4825
 
 stages:
 

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -979,10 +979,11 @@ class WazuhDBQuery(object):
         self.query_filters += [{'value': None if subvalue == "null" else subvalue,
                                 'field': '{}${}'.format(name, i),
                                 'operator': '=',
-                                'separator': 'OR' if len(value) > 1 else 'AND',
+                                'separator': 'AND' if len(value) <= 1 or len(value) == i + 1 else 'OR',
                                 'level': 0 if i == len(value) - 1 else 1}
                                for name, value in legacy_filters_as_list.items()
-                               for subvalue, i in zip(value, range(len(value))) if not self._pass_filter(subvalue)]
+                               for i, subvalue in enumerate(value) if not self._pass_filter(subvalue)]
+
         if self.query_filters:
             # if only traditional filters have been defined, remove last AND from the query.
             self.query_filters[-1]['separator'] = '' if not self.q else 'AND'


### PR DESCRIPTION
Hello team, this closes #4825 .

We noticed that multiple values in filters were not being applied and they actually did the opposite. This issue was for the status filter, but analyzing the code I saw that this was not working in any of our filters. The reason for this was that we were not building the query correctly when having multiple values because we only used `OR`. 

Before:

`filter1.1 OR filter1.2 OR filter2.1 OR filter2.2 OR ...`

After:

`filter1.1 OR filter1.2 AND filter2.1 OR filter2.2 AND ...`

This fixes the xfail on `test_agentsGET` as well.


## Tests performed
### Unit tests
#### Agent

```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: tavern-0.30.3, cov-2.8.1
collected 95 items                                                             

wazuh/tests/test_agent.py::test_agent_get_distinct_agents[fields0-expected_items0] PASSED [  1%]
wazuh/tests/test_agent.py::test_agent_get_distinct_agents[fields1-expected_items1] PASSED [  2%]
wazuh/tests/test_agent.py::test_agent_get_distinct_agents[fields2-expected_items2] PASSED [  3%]
wazuh/tests/test_agent.py::test_agent_get_distinct_agents[fields3-expected_items3] PASSED [  4%]
wazuh/tests/test_agent.py::test_agent_get_distinct_agents[fields4-expected_items4] PASSED [  5%]
wazuh/tests/test_agent.py::test_agent_get_agents_summary_status PASSED   [  6%]
wazuh/tests/test_agent.py::test_agent_get_agents_summary_os PASSED       [  7%]
wazuh/tests/test_agent.py::test_agent_restart_agents[agent_list0-expected_items0-None] PASSED [  8%]
wazuh/tests/test_agent.py::test_agent_restart_agents[agent_list1-expected_items1-1703] PASSED [  9%]
wazuh/tests/test_agent.py::test_agent_restart_agents[agent_list2-expected_items2-1701] PASSED [ 10%]
wazuh/tests/test_agent.py::test_agent_get_agents[agent_list0-expected_items0] PASSED [ 11%]
wazuh/tests/test_agent.py::test_agent_get_agents[agent_list1-expected_items1] PASSED [ 12%]
wazuh/tests/test_agent.py::test_agent_get_agent_by_name[agent-1-001] PASSED [ 13%]
wazuh/tests/test_agent.py::test_agent_get_agent_by_name[nc-agent-003] PASSED [ 14%]
wazuh/tests/test_agent.py::test_agent_get_agent_by_name[master-000] PASSED [ 15%]
wazuh/tests/test_agent.py::test_agent_get_agent_by_name[invalid-agent-False] PASSED [ 16%]
wazuh/tests/test_agent.py::test_agent_get_agent_by_name[master-4000] PASSED [ 17%]
wazuh/tests/test_agent.py::test_agent_get_agent_by_name[master-1000] PASSED [ 18%]
wazuh/tests/test_agent.py::test_agent_get_agents_in_group[default-True-expected_agents0] PASSED [ 20%]
wazuh/tests/test_agent.py::test_agent_get_agents_in_group[not_exists_group-False-None] PASSED [ 21%]
wazuh/tests/test_agent.py::test_agent_get_agents_keys[agent_list0-expected_items0] PASSED [ 22%]
wazuh/tests/test_agent.py::test_agent_get_agents_keys[agent_list1-expected_items1] PASSED [ 23%]
wazuh/tests/test_agent.py::test_agent_delete_agents[agent_list0-1s-Agent deleted successfully.-None-expected_items0] PASSED [ 24%]
wazuh/tests/test_agent.py::test_agent_delete_agents[agent_list1-1s-None-1703-expected_items1] PASSED [ 25%]
wazuh/tests/test_agent.py::test_agent_delete_agents[agent_list2-1s-Agent deleted successfully.-1701-expected_items2] PASSED [ 26%]
wazuh/tests/test_agent.py::test_agent_delete_agents[agent_list3-1s-remove_msg3-1700-expected_items3] PASSED [ 27%]
wazuh/tests/test_agent.py::test_agent_delete_agents_different_status PASSED [ 28%]
wazuh/tests/test_agent.py::test_agent_add_agent[agent-1-001-b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f] PASSED [ 29%]
wazuh/tests/test_agent.py::test_agent_add_agent[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-002-f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d] PASSED [ 30%]
wazuh/tests/test_agent.py::test_agent_get_agent_groups[group_list0-expected_result0] PASSED [ 31%]
wazuh/tests/test_agent.py::test_agent_get_agent_groups[group_list1-expected_result1] PASSED [ 32%]
wazuh/tests/test_agent.py::test_agent_get_agent_groups_exceptions[Invalid path-valid-group-1600] PASSED [ 33%]
wazuh/tests/test_agent.py::test_agent_get_agent_groups_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/global.db-valid-group-1000] PASSED [ 34%]
wazuh/tests/test_agent.py::test_agent_get_agent_groups_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/global.db-invalid-group-1710] PASSED [ 35%]
wazuh/tests/test_agent.py::test_agent_get_group_files[group_list0] PASSED [ 36%]
wazuh/tests/test_agent.py::test_agent_get_group_files[group_list1] PASSED [ 37%]
wazuh/tests/test_agent.py::test_agent_get_group_files_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/agent/shared-group_list0-False-None-WazuhError-1710] PASSED [ 38%]
wazuh/tests/test_agent.py::test_agent_get_group_files_exceptions[invalid-path-group_list1-True-None-WazuhError-1006] PASSED [ 40%]
wazuh/tests/test_agent.py::test_agent_get_group_files_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/agent/shared-group_list2-True-side_effect2-WazuhError-1405] PASSED [ 41%]
wazuh/tests/test_agent.py::test_agent_get_group_files_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/agent/shared-group_list3-True-side_effect3-WazuhInternalError-1727] PASSED [ 42%]
wazuh/tests/test_agent.py::test_create_group[non-existant-group] PASSED  [ 43%]
wazuh/tests/test_agent.py::test_create_group[invalid-group] PASSED       [ 44%]
wazuh/tests/test_agent.py::test_create_group_exceptions[default-WazuhError-1711] PASSED [ 45%]
wazuh/tests/test_agent.py::test_create_group_exceptions[group-1-WazuhError-1711] PASSED [ 46%]
wazuh/tests/test_agent.py::test_create_group_exceptions[invalid!-WazuhError-1722] PASSED [ 47%]
wazuh/tests/test_agent.py::test_create_group_exceptions[delete-me-WazuhInternalError-1005] PASSED [ 48%]
wazuh/tests/test_agent.py::test_agent_delete_groups[group_list0] PASSED  [ 49%]
wazuh/tests/test_agent.py::test_agent_delete_groups[group_list1] PASSED  [ 50%]
wazuh/tests/test_agent.py::test_agent_delete_groups_permission_exception[test_group] PASSED [ 51%]
wazuh/tests/test_agent.py::test_agent_delete_groups_other_exceptions[group_list0-expected_errors0] PASSED [ 52%]
wazuh/tests/test_agent.py::test_agent_delete_groups_other_exceptions[group_list1-expected_errors1] PASSED [ 53%]
wazuh/tests/test_agent.py::test_agent_delete_groups_other_exceptions[group_list2-expected_errors2] PASSED [ 54%]
wazuh/tests/test_agent.py::test_agent_delete_groups_other_exceptions[group_list3-expected_errors3] PASSED [ 55%]
wazuh/tests/test_agent.py::test_assign_agents_to_group[group_list0-agent_list0-0] PASSED [ 56%]
wazuh/tests/test_agent.py::test_assign_agents_to_group[group_list1-agent_list1-0] PASSED [ 57%]
wazuh/tests/test_agent.py::test_assign_agents_to_group[group_list2-agent_list2-1] PASSED [ 58%]
wazuh/tests/test_agent.py::test_agent_assign_agents_to_group_exceptions[group_list0-agent_list0-expected_error0-True] PASSED [ 60%]
wazuh/tests/test_agent.py::test_agent_assign_agents_to_group_exceptions[group_list1-agent_list1-expected_error1-False] PASSED [ 61%]
wazuh/tests/test_agent.py::test_agent_assign_agents_to_group_exceptions[group_list2-agent_list2-expected_error2-False] PASSED [ 62%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_group[default-001] PASSED [ 63%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_group[group-1-005] PASSED [ 64%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_group_exceptions[any-group-100-expected_error0] PASSED [ 65%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_group_exceptions[any-group-000-expected_error1] PASSED [ 66%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_group_exceptions[group-1-005-expected_error2] PASSED [ 67%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_groups[group_list0-agent_list0] PASSED [ 68%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_groups_exceptions[group_list0-agent_list0-expected_error0-True] PASSED [ 69%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_groups_exceptions[group_list1-agent_list1-expected_error1-True] PASSED [ 70%]
wazuh/tests/test_agent.py::test_agent_remove_agent_from_groups_exceptions[group_list2-agent_list2-expected_error2-False] PASSED [ 71%]
wazuh/tests/test_agent.py::test_agent_remove_agents_from_group[group_list0-agent_list0] PASSED [ 72%]
wazuh/tests/test_agent.py::test_agent_remove_agents_from_group_exceptions[group_list0-agent_list0-expected_error0-True] PASSED [ 73%]
wazuh/tests/test_agent.py::test_agent_remove_agents_from_group_exceptions[group_list1-agent_list1-expected_error1-False] PASSED [ 74%]
wazuh/tests/test_agent.py::test_agent_remove_agents_from_group_exceptions[group_list2-agent_list2-expected_error2-False] PASSED [ 75%]
wazuh/tests/test_agent.py::test_agent_get_outdated_agents[agent_list0-outdated_agents0] PASSED [ 76%]
wazuh/tests/test_agent.py::test_agent_upgrade_agents[agent_list0] PASSED [ 77%]
wazuh/tests/test_agent.py::test_agent_upgrade_agents[agent_list1] PASSED [ 78%]
wazuh/tests/test_agent.py::test_agent_get_upgrade_result[agent_list0] PASSED [ 80%]
wazuh/tests/test_agent.py::test_agent_get_upgrade_result[agent_list1] PASSED [ 81%]
wazuh/tests/test_agent.py::test_agent_upgrade_agents_custom[agent_list0] PASSED [ 82%]
wazuh/tests/test_agent.py::test_agent_upgrade_agents_custom[agent_list1] PASSED [ 83%]
wazuh/tests/test_agent.py::test_agent_upgrade_agents_custom_exceptions[None-installer] FAILED [ 84%]
wazuh/tests/test_agent.py::test_agent_upgrade_agents_custom_exceptions[any-path-None] FAILED [ 85%]
wazuh/tests/test_agent.py::test_agent_upgrade_agents_custom_exceptions[None-None] FAILED [ 86%]
wazuh/tests/test_agent.py::test_agent_get_agent_config[agent_list0-logcollector-internal] PASSED [ 87%]
wazuh/tests/test_agent.py::test_agent_get_agent_config_exceptions[agent_list0] PASSED [ 88%]
wazuh/tests/test_agent.py::test_agent_get_agents_sync_group[agent_list0] PASSED [ 89%]
wazuh/tests/test_agent.py::test_agent_get_agents_sync_group_exceptions[agent_list0-expected_error0] PASSED [ 90%]
wazuh/tests/test_agent.py::test_agent_get_agents_sync_group_exceptions[agent_list1-expected_error1] PASSED [ 91%]
wazuh/tests/test_agent.py::test_agent_get_file_conf[agent.conf-group_list0] PASSED [ 92%]
wazuh/tests/test_agent.py::test_agent_get_agent_conf[group_list0] PASSED [ 93%]
wazuh/tests/test_agent.py::test_agent_upload_group_file[group_list0] PASSED [ 94%]
wazuh/tests/test_agent.py::test_agent_get_full_overview[agent_list0-group_list0-False-001] PASSED [ 95%]
wazuh/tests/test_agent.py::test_agent_get_full_overview[agent_list1-group_list1-False-002] PASSED [ 96%]
wazuh/tests/test_agent.py::test_agent_get_full_overview[agent_list2-group_list2-False-002] PASSED [ 97%]
wazuh/tests/test_agent.py::test_agent_get_full_overview[agent_list3-group_list3-False-004] PASSED [ 98%]
wazuh/tests/test_agent.py::test_agent_get_full_overview[agent_list4-group_list4-True-None] PASSED [100%]

=================================== FAILURES ===================================
```

_Upgrade tests fail due to a change in our custom_upgrade function. They need to be modified._

#### Core agent

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: tavern-0.30.3, cov-2.8.1
collected 175 items                                                                                                                                                                                               

wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents__init__[True] PASSED                                                                                                                           [  0%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents__init__[False] PASSED                                                                                                                          [  1%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status[active-(last_keepalive >= :time_active AND version IS NOT NULL) or id = 0] PASSED                                                [  1%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status[disconnected-last_keepalive < :time_active] PASSED                                                                               [  2%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status[never_connected-last_keepalive IS NULL AND id != 0] PASSED                                                                       [  2%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status[pending-last_keepalive IS NOT NULL AND version IS NULL] PASSED                                                                   [  3%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status_ko PASSED                                                                                                                        [  4%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_date PASSED                                                                                                                             [  4%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_sort_query[status-last_keepAlive asc] PASSED                                                                                                   [  5%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_sort_query[os.version-CAST(os_major AS INTEGER) asc, CAST(os_minor AS INTEGER) asc] PASSED                                                     [  5%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_sort_query[id-id asc] PASSED                                                                                                                   [  6%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_add_search_to_query PASSED                                                                                                                     [  6%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_format_data_into_dictionary PASSED                                                                                                             [  7%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_parse_legacy_filters PASSED                                                                                                                    [  8%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_process_filter[group-field-q_filter0] PASSED                                                                                                   [  8%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_process_filter[group-test-q_filter1] PASSED                                                                                                    [  9%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_process_filter[os.name-field-q_filter2] PASSED                                                                                                 [  9%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroupByAgents__init__ PASSED                                                                                                                          [ 10%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups__init__ PASSED                                                                                                                            [ 10%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups_default_query[null] PASSED                                                                                                                [ 11%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups_default_query[test] PASSED                                                                                                                [ 12%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups_default_count_query PASSED                                                                                                                [ 12%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups_get_total_items PASSED                                                                                                                    [ 13%]
wazuh/core/tests/test_core_agent.py::test_agent__init__[1-127.0.0.1-test_agent-b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747D] PASSED                                                     [ 13%]
wazuh/core/tests/test_core_agent.py::test_agent__str__ PASSED                                                                                                                                               [ 14%]
wazuh/core/tests/test_core_agent.py::test_agent_to_dict PASSED                                                                                                                                              [ 14%]
wazuh/core/tests/test_core_agent.py::test_agent_load_info_from_db[000-127.0.0.1-master-Bionic Beaver] PASSED                                                                                                [ 15%]
wazuh/core/tests/test_core_agent.py::test_agent_load_info_from_db[001-172.17.0.202-agent-1-Bionic Beaver] PASSED                                                                                            [ 16%]
wazuh/core/tests/test_core_agent.py::test_agent_load_info_from_db[002-172.17.0.201-agent-2-Xenial] PASSED                                                                                                   [ 16%]
wazuh/core/tests/test_core_agent.py::test_agent_load_info_from_db_ko PASSED                                                                                                                                 [ 17%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[0-None] PASSED                                                                                                                        [ 17%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[3-None] PASSED                                                                                                                        [ 18%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[0-select2] PASSED                                                                                                                     [ 18%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[5-select3] PASSED                                                                                                                     [ 19%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[0-select4] PASSED                                                                                                                     [ 20%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[2-select5] PASSED                                                                                                                     [ 20%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[0-MCBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                              [ 21%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[1-MSBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                              [ 21%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[2-MiBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                              [ 22%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[3-MyBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                              [ 22%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[4-NCBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                              [ 23%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[5-NSBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                              [ 24%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[1-MDAxIGFnZW50LTEgYW55IGIzNjUwZTExZWJhMmYyN2VyNGQxNjBjNjlkZTUzM2VlN2VlZDYwMTYzNmE4NWJhMjQ1NWQ1M2E5MDkyNzc0N2Y=] PASSED                              [ 24%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[2-MDAyIGFnZW50LTIgMTcyLjE3LjAuMjAxIGIzNjUwZTExZWJhMmYyN2VyNGQxNjBjNjlkZTUzM2VlN2VlZDYwMTZmZ2E4NWJhMjQ1NWQ1M2E5MDkyNzc0N2Y=] PASSED                  [ 25%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[3-MDAzIG5jLWFnZW50IGFueSBmMzA0ZjU4MmYyNDE3YTNmZGRhZDY5ZDlhZTJiNGYzYjZlNmZkYTc4ODIyOTY2OGFmOWE2OTM0ZDQ1NGVmNDRk] PASSED                              [ 25%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[4-MDA0IHBlbmRpbmctYWdlbnQgYW55IDI4NTViY2Y0OTI3M2M3NTllZjViMTE2ODI5Y2M1ODJmMTUzYzZjMTk5ZGY3Njc2ZTUzZDU5Mzc4NTVmZjU5MDI=] PASSED                      [ 26%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[5-MDA1IGFnZW50LTUgMTcyLjE3LjAuMzAwIGIzNjUwZTExZWJhMmYyN2VyNGQxNjBjNjlkZTUzM2VlN2VlZDYwMTYzNmE0MmJhMjQ1NWQ1M2E5MDkyNzc0N2Y=] PASSED                  [ 26%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key_ko PASSED                                                                                                                                           [ 27%]
wazuh/core/tests/test_core_agent.py::test_agent_restart PASSED                                                                                                                                              [ 28%]
wazuh/core/tests/test_core_agent.py::test_agent_restart_ko PASSED                                                                                                                                           [ 28%]
wazuh/core/tests/test_core_agent.py::test_agent_remove[stopped] PASSED                                                                                                                                      [ 29%]
wazuh/core/tests/test_core_agent.py::test_agent_remove[running] PASSED                                                                                                                                      [ 29%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_ko PASSED                                                                                                                                            [ 30%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_authd PASSED                                                                                                                                         [ 30%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual[False-False] PASSED                                                                                                                           [ 31%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual[True-False] PASSED                                                                                                                            [ 32%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual[True-True] PASSED                                                                                                                             [ 32%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[001-1746] PASSED                                                                                                                           [ 33%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[006-1701] PASSED                                                                                                                           [ 33%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[001-1600] PASSED                                                                                                                           [ 34%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[001-1748] PASSED                                                                                                                           [ 34%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[001-1747] PASSED                                                                                                                           [ 35%]
wazuh/core/tests/test_core_agent.py::test_agent_add[192.168.0.0-None-None--1-running] PASSED                                                                                                                [ 36%]
wazuh/core/tests/test_core_agent.py::test_agent_add[192.168.0.0-None-None--1-stopped] PASSED                                                                                                                [ 36%]
wazuh/core/tests/test_core_agent.py::test_agent_add[192.168.0.0/28-002-None--1-running] PASSED                                                                                                              [ 37%]
wazuh/core/tests/test_core_agent.py::test_agent_add[192.168.0.0/28-002-None--1-stopped] PASSED                                                                                                              [ 37%]
wazuh/core/tests/test_core_agent.py::test_agent_add[any-002-WMPlw93l2PnwQMN--1-running] PASSED                                                                                                              [ 38%]
wazuh/core/tests/test_core_agent.py::test_agent_add[any-002-WMPlw93l2PnwQMN--1-stopped] PASSED                                                                                                              [ 38%]
wazuh/core/tests/test_core_agent.py::test_agent_add[any-003-WMPlw93l2PnwQMN-1-running] PASSED                                                                                                               [ 39%]
wazuh/core/tests/test_core_agent.py::test_agent_add[any-003-WMPlw93l2PnwQMN-1-stopped] PASSED                                                                                                               [ 40%]
wazuh/core/tests/test_core_agent.py::test_agent_add_ko PASSED                                                                                                                                               [ 40%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd[test_agent-172.19.0.100-None-None] PASSED                                                                                                         [ 41%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd[test_agent-172.19.0.100-002-MDAyIHdpbmRvd3MtYWdlbnQyIGFueSAzNDA2MjgyMjEwYmUwOWVlMWViNDAyZTYyODZmNWQ2OTE5MjBkODNjNTVjZDE5N2YyMzk3NzA0YWRhNjg1YzQz] PASSED [ 41%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[None-None] PASSED                                                                                                                              [ 42%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[mocked_exception1-.* 1705 .*] PASSED                                                                                                           [ 42%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[mocked_exception2-.* 1706 .*] PASSED                                                                                                           [ 43%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[mocked_exception3-.* 1708 .*] PASSED                                                                                                           [ 44%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[mocked_exception4-.* None] PASSED                                                                                                              [ 44%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual[192.168.0.0-002-None--1] PASSED                                                                                                                  [ 45%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual[192.168.0.0/28-002-None--1] PASSED                                                                                                               [ 45%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual[any-002-WMPlw93l2PnwQMN--1] PASSED                                                                                                               [ 46%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual[any-003-WMPlw93l2PnwQMN-1] PASSED                                                                                                                [ 46%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual_ko PASSED                                                                                                                                        [ 47%]
wazuh/core/tests/test_core_agent.py::test_agent_delete_single_group PASSED                                                                                                                                  [ 48%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[0-os_name-Ubuntu] PASSED                                                                                                                     [ 48%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[7-os_name-Windows] PASSED                                                                                                                    [ 49%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[5-status-updated] PASSED                                                                                                                     [ 49%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[2-register_ip-172.17.0.201] PASSED                                                                                                           [ 50%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[1-os_arch-x86_64] PASSED                                                                                                                     [ 50%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr_ko PASSED                                                                                                                                    [ 51%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_default PASSED                                                                                                                          [ 52%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select0-all-None-0] PASSED                                                                                                       [ 52%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select1-all-None-1] PASSED                                                                                                       [ 53%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select2-all-None-1] PASSED                                                                                                       [ 53%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select3-active,pending-None-0] PASSED                                                                                            [ 54%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select4-disconnected-None-1] PASSED                                                                                              [ 54%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select5-disconnected-1s-1] PASSED                                                                                                [ 55%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select6-disconnected-2h-0] PASSED                                                                                                [ 56%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select7-all-15m-2] PASSED                                                                                                        [ 56%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select8-active-15m-0] PASSED                                                                                                     [ 57%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select9-active,pending-15m-1] PASSED                                                                                             [ 57%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select10-status10-15m-1] PASSED                                                                                                  [ 58%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search0-3] PASSED                                                                                                                [ 58%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search1-6] PASSED                                                                                                                [ 59%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search2-1] PASSED                                                                                                                [ 60%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search3-8] PASSED                                                                                                                [ 60%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search4-2] PASSED                                                                                                                [ 61%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[ip=172.17.0.201-1] PASSED                                                                                                         [ 61%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[ip=172.17.0.202-1] PASSED                                                                                                         [ 62%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[ip=172.17.0.202;registerIP=any-1] PASSED                                                                                          [ 62%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[status=disconnected;lastKeepAlive>34m-1] PASSED                                                                                   [ 63%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[(status=active,status=pending);lastKeepAlive>5m-4] PASSED                                                                         [ 64%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_status_olderthan[active-9m-4-None] PASSED                                                                                               [ 64%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_status_olderthan[all-1s-8-None] PASSED                                                                                                  [ 65%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_status_olderthan[pending,never_connected-30m-1-None] PASSED                                                                             [ 65%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_status_olderthan[55-30m-0-1729] PASSED                                                                                                  [ 66%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_sort[sort0-000] PASSED                                                                                                                  [ 66%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_sort[sort1-004] PASSED                                                                                                                  [ 67%]
wazuh/core/tests/test_core_agent.py::test_agent_add_group_to_agent[002-test_group-False-False-None] PASSED                                                                                                  [ 68%]
wazuh/core/tests/test_core_agent.py::test_agent_add_group_to_agent[002-test_group-True-False-None] PASSED                                                                                                   [ 68%]
wazuh/core/tests/test_core_agent.py::test_agent_add_group_to_agent[002-test_group-False-True-replace_list2] PASSED                                                                                          [ 69%]
wazuh/core/tests/test_core_agent.py::test_agent_add_group_to_agent_ko PASSED                                                                                                                                [ 69%]
wazuh/core/tests/test_core_agent.py::test_agent_check_if_delete_agent[002-10-True] PASSED                                                                                                                   [ 70%]
wazuh/core/tests/test_core_agent.py::test_agent_check_if_delete_agent[002-700-False] PASSED                                                                                                                 [ 70%]
wazuh/core/tests/test_core_agent.py::test_agent_check_if_delete_agent_ko PASSED                                                                                                                             [ 71%]
wazuh/core/tests/test_core_agent.py::test_agent_group_exists[True] PASSED                                                                                                                                   [ 72%]
wazuh/core/tests/test_core_agent.py::test_agent_group_exists[False] PASSED                                                                                                                                  [ 72%]
wazuh/core/tests/test_core_agent.py::test_agent_group_exists_ko PASSED                                                                                                                                      [ 73%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_group_file[True] PASSED                                                                                                                          [ 73%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_group_file[False] PASSED                                                                                                                         [ 74%]
wazuh/core/tests/test_core_agent.py::test_agent_set_agent_group_file PASSED                                                                                                                                 [ 74%]
wazuh/core/tests/test_core_agent.py::test_agent_set_agent_group_file_ko PASSED                                                                                                                              [ 75%]
wazuh/core/tests/test_core_agent.py::test_agent_check_multigroup_limit[default0,default1,default2,default3-True] PASSED                                                                                     [ 76%]
wazuh/core/tests/test_core_agent.py::test_agent_check_multigroup_limit[default0,default1-False] PASSED                                                                                                      [ 76%]
wazuh/core/tests/test_core_agent.py::test_agent_check_multigroup_limit[-False] PASSED                                                                                                                       [ 77%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent[002-test_group-False-default,test_group,another_test-False] PASSED                                                                 [ 77%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent[002-test_group-True-default,test_group,another_test-False] PASSED                                                                  [ 78%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent[002-test_group-False-test_group-True] PASSED                                                                                       [ 78%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent[002-test_group-False-test_group,another_test-False] PASSED                                                                         [ 79%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent_ko PASSED                                                                                                                          [ 80%]
wazuh/core/tests/test_core_agent.py::test_agent_get_protocol[packages.wazuh.com/wpk/linux/x86_64/wazuh_agent_v3.11.4_linux_x86_64.wpk-False-https://] PASSED                                                [ 80%]
wazuh/core/tests/test_core_agent.py::test_agent_get_protocol[packages.wazuh.com/wpk/linux/x86_64/wazuh_agent_v3.11.4_linux_x86_64.wpk-True-http://] PASSED                                                  [ 81%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions[001-ubuntu-None-https://packages.wazuh.com/wpk/linux/x86_64/versions] PASSED                                                                   [ 81%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions[002-ubuntu-v3.3.0-https://packages.wazuh.com/wpk/ubuntu/16.04/x86_64/versions] PASSED                                                          [ 82%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions[002-windows-v3.3.0-https://packages.wazuh.com/wpk/windows/versions] PASSED                                                                     [ 82%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions[002-debian-v3.3.0-https://packages.wazuh.com/wpk/debian/16/x86_64/versions] PASSED                                                             [ 83%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions_ko PASSED                                                                                                                                      [ 84%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[001-None-ubuntu-False-False] PASSED                                                                                                            [ 84%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[001-v3.9.0-ubuntu-False-False] PASSED                                                                                                          [ 85%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[002-v3.9.0-windows-False-False] PASSED                                                                                                         [ 85%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[002-v3.3.9-debian-True-True] PASSED                                                                                                            [ 86%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[002-v3.3.9-ubuntu-True-True] PASSED                                                                                                            [ 86%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file_ko PASSED                                                                                                                                      [ 87%]
wazuh/core/tests/test_core_agent.py::test_agent_send_wpk_file[001] PASSED                                                                                                                                   [ 88%]
wazuh/core/tests/test_core_agent.py::test_agent_send_wpk_file[002] PASSED                                                                                                                                   [ 88%]
wazuh/core/tests/test_core_agent.py::test_agent_send_wpk_file_ko PASSED                                                                                                                                     [ 89%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade[001-Ubuntu] PASSED                                                                                                                                  [ 89%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade[002-Ubuntu] PASSED                                                                                                                                  [ 90%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade[008-Windows] PASSED                                                                                                                                 [ 90%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_ko PASSED                                                                                                                                           [ 91%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_result[001] PASSED                                                                                                                                  [ 92%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_result[002] PASSED                                                                                                                                  [ 92%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_result_ko PASSED                                                                                                                                    [ 93%]
wazuh/core/tests/test_core_agent.py::test_agent_send_custom_wpk_file[001] PASSED                                                                                                                            [ 93%]
wazuh/core/tests/test_core_agent.py::test_agent_send_custom_wpk_file[002] PASSED                                                                                                                            [ 94%]
wazuh/core/tests/test_core_agent.py::test_agent_send_custom_wpk_file_ko PASSED                                                                                                                              [ 94%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_custom[001] PASSED                                                                                                                                  [ 95%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_custom[002] PASSED                                                                                                                                  [ 96%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_custom_ko PASSED                                                                                                                                    [ 96%]
wazuh/core/tests/test_core_agent.py::test_agent_getconfig PASSED                                                                                                                                            [ 97%]
wazuh/core/tests/test_core_agent.py::test_agent_getconfig_ko PASSED                                                                                                                                         [ 97%]
wazuh/core/tests/test_core_agent.py::test_calculate_status[10-False-active] PASSED                                                                                                                          [ 98%]
wazuh/core/tests/test_core_agent.py::test_calculate_status[1900-False-disconnected] PASSED                                                                                                                  [ 98%]
wazuh/core/tests/test_core_agent.py::test_calculate_status[10-True-pending] PASSED                                                                                                                          [ 99%]
wazuh/core/tests/test_core_agent.py::test_send_restart_command PASSED                                                                                                                                       [100%]

================================================================================================ warnings summary =================================================================================================
wazuh/results.py:19
  /home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/results.py:19: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    class AbstractWazuhResult(collections.MutableMapping):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================================================================================== 175 passed, 1 warnings in 0.75 seconds ======================================================================================
```

### Integration tests
#### agentsGET

```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 90 items

test_agentsGET_endpoints.tavern.yaml::GET /agents PASSED                  [  1%]
test_agentsGET_endpoints.tavern.yaml::GET /agents with single agent id PASSED [  2%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED [  3%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED [  4%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED  [  5%]
test_agentsGET_endpoints.tavern.yaml::GET /groups PASSED                 [  6%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED [  7%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED [  8%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED [ 10%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED [ 11%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED [ 12%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED [ 13%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED [ 14%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED [ 15%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED [ 16%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED [ 17%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED [ 18%]
test_agentsGET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED [ 20%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED [ 21%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED [ 22%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED [ 23%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED [ 24%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED [ 25%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED [ 26%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED [ 27%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED [ 28%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED [ 30%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED [ 31%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED [ 32%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED [ 33%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED [ 34%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED [ 35%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED [ 36%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED [ 37%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED [ 38%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED [ 40%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED [ 41%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED [ 42%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED [ 43%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED [ 44%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED [ 45%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED [ 46%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED [ 47%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED [ 48%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED [ 50%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED [ 51%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED [ 52%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED [ 53%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED [ 54%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED [ 55%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED [ 56%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED [ 57%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED [ 58%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED [ 60%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED [ 61%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED [ 62%]
test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED [ 63%]
test_agentsGET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED [ 64%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group PASSED        [ 65%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED [ 66%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED [ 67%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED [ 68%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED [ 70%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED [ 71%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED [ 72%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED [ 73%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/outdated PASSED        [ 74%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED  [ 75%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED [ 76%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED [ 77%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED [ 78%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED [ 80%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED [ 81%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED [ 82%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED [ 83%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED [ 84%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED [ 85%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED [ 86%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED [ 87%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED [ 88%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED [ 90%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED [ 91%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED [ 92%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED [ 93%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED [ 94%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED [ 95%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED [ 96%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/status PASSED  [ 97%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/summary/os PASSED      [ 98%]
test_agentsGET_endpoints.tavern.yaml::GET /agents/{agent_id}/upgrade_result PASSED [100%]

=============================== warnings summary ===============================
test/integration/test_agentsGET_endpoints.tavern.yaml::GET /agents
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

test/integration/test_agentsGET_endpoints.tavern.yaml::GET /agents
test/integration/test_agentsGET_endpoints.tavern.yaml::GET /groups
test/integration/test_agentsGET_endpoints.tavern.yaml::GET /groups/{group_id}/files
  /home/vicferpoy/.local/lib/python3.7/site-packages/tavern/util/dict_util.py:119: FutureWarning: In a future version of Tavern, selecting for values to save in nested objects will have to be done as a JMES path query - see http://jmespath.org/ for more information
    warnings.warn(msg, FutureWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============== 90 passed, 4 warnings in 693.36 seconds ==============
```
