### PR TITLE
Fix error code for invalid format in cdb-list in API 4.0

### DIFF
--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1152,7 +1152,7 @@ stages:
           affected_items: []
           failed_items:
             - error:
-                code: 1802
+                code: 1800
               id:
                 - 'etc/lists/new-list'
           total_affected_items: 0

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -128,7 +128,7 @@ def upload_list(list_file, path):
 
     # validate CDB list
     if not validate_cdb_list(tmp_file_path):
-        raise WazuhError(1802)
+        raise WazuhError(1800)
 
     # move temporary file to group folder
     try:


### PR DESCRIPTION
Hello team, this closes #4830 .

When trying to upload a CDB list with wrong format using `PUT /manager/files`, the error code was not accurate. We were using the code **1802** `('Lists file not found')` while the **1800** is exactly what we are looking for `('Bad format in CDB list {path}')`.

Our tests did not detect this because they were expecting the code **1802** as well.

## Response after the change using wrong format

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1800,
          "message": "Bad format in CDB list {path}",
          "remediation": null
        },
        "id": [
          "etc/lists/test"
        ]
      }
    ]
  },
  "message": "Could not upload file"
}
```

## Integration tests
### Before the change

```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 32 items

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED           [  3%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED             [  6%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED [  9%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED [ 12%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED [ 15%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED [ 18%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED [ 21%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[open-scap] PASSED [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED [ 43%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED [ 46%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED [ 50%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED [ 53%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED    [ 56%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED            [ 59%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED     [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED     [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED  [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED    [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED             [ 75%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED     [ 78%]
test_manager_endpoints.tavern.yaml::GET /manager/files PASSED            [ 81%]
test_manager_endpoints.tavern.yaml::PUT /manager/files FAILED            [ 84%]

=================================== FAILURES ===================================
```

### After the change

```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: tavern-0.30.3, cov-2.8.1
collecting ... collected 32 items

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED           [  3%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED             [  6%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED [  9%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED [ 12%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED [ 15%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED [ 18%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED [ 21%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[open-scap] PASSED [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED [ 43%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED [ 46%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED [ 50%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED [ 53%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED    [ 56%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED            [ 59%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED     [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED     [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED  [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED    [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED             [ 75%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED     [ 78%]
test_manager_endpoints.tavern.yaml::GET /manager/files PASSED            [ 81%]
test_manager_endpoints.tavern.yaml::PUT /manager/files PASSED            [ 84%]
test_manager_endpoints.tavern.yaml::DELETE /manager/files PASSED         [ 87%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED [ 90%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED  [ 93%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED [ 96%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED          [100%]

=============================== warnings summary ===============================
test/integration/test_manager_endpoints.tavern.yaml::GET /manager/status
  /usr/lib/python3/dist-packages/jwt/api_jwt.py:81: DeprecationWarning: It is strongly recommended that you pass in a value for the "algorithms" argument when calling decode(). This argument will be mandatory in a future version.
    DeprecationWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 32 passed, 1 warnings in 692.43 seconds ====================
```

Regards.