### PR TITLE
Fix bzip2 decompress function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ All notable changes to this project will be documented in this file.
 - Fixed a buffer overflow when receiving large messages from Syslog over TCP connections. ([#4778](https://github.com/wazuh/wazuh/pull/4778))
 - Fixed a malfunction in the Integrator module when analyzing events without a certain field. ([#4851](https://github.com/wazuh/wazuh/pull/4851))
 
-
 ### Fixed
 
 - Fix XML validation with paths ending in `\`. ([#4783](https://github.com/wazuh/wazuh/pull/4783))
+
+### Removed
+
+- Removed support for Ubuntu 12.04 (Precise) in Vulneratiliby Detector as its feed is no longer available.
+
 
 ## [v3.12.0] - 2020-03-24
 

--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -6,7 +6,6 @@
 
     <provider name="canonical">
       <enabled>no</enabled>
-      <os>precise</os>
       <os>trusty</os>
       <os>xenial</os>
       <os>bionic</os>

--- a/src/Makefile
+++ b/src/Makefile
@@ -688,7 +688,7 @@ endif
 
 test_external:
 ifeq ($(wildcard external/*/*),)
-	$(error No external directory found. Run "make deps" before compiling external libraries)
+	$(error No external directory found. Run "${MAKE} deps" before compiling external libraries)
 endif
 
 #### OpenSSL ##########
@@ -747,7 +747,7 @@ os_zlib/%.o: os_zlib/%.c
 #### bzip2 ##########
 
 $(BZIP2_LIB):
-	cd ${EXTERNAL_BZIP2} && make CFLAGS="-fpic -Wall -O2 -D_FILE_OFFSET_BITS=64" libbz2.a
+	cd ${EXTERNAL_BZIP2} && ${MAKE} CFLAGS="-fpic -Wall -O2 -D_FILE_OFFSET_BITS=64" libbz2.a
 
 #### SQLite #########
 
@@ -834,10 +834,9 @@ endif
 #### Audit lib ####
 
 ${AUDIT_LIB}: $(EXTERNAL_AUDIT)Makefile
-	make -C $(EXTERNAL_AUDIT)lib CC=$(CC)
+	${MAKE} -C $(EXTERNAL_AUDIT)lib CC=$(CC)
 
 $(EXTERNAL_AUDIT)Makefile:
-
 	cd $(EXTERNAL_AUDIT) && ./autogen.sh && ./configure CFLAGS=-fPIC --with-libcap-ng=no
 
 #### msgpack #########
@@ -1730,13 +1729,13 @@ ifneq ($(wildcard external/*/*),)
 	-cd ${EXTERNAL_CURL} && ${MAKE} distclean
 	rm -f ${procps_o} $(PROCPS_LIB)
 	rm -f $(sqlite_o) $(EXTERNAL_SQLITE)/libsqlite3.*
-	-cd ${EXTERNAL_AUDIT} && make distclean
-	-cd ${EXTERNAL_LIBFFI} && make clean
+	-cd ${EXTERNAL_AUDIT} && ${MAKE} distclean
+	-cd ${EXTERNAL_LIBFFI} && ${MAKE} clean
 	rm -f $(msgpack_o) $(EXTERNAL_MSGPACK)libmsgpack.a
-	-make -C $(EXTERNAL_BZIP2) clean
+	-${MAKE} -C $(EXTERNAL_BZIP2) clean
 
 ifneq ($(wildcard external/libdb/build_unix/*),)
-	cd ${EXTERNAL_LIBDB} && make realclean
+	cd ${EXTERNAL_LIBDB} && ${MAKE} realclean
 endif
 endif
 

--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -150,7 +150,7 @@ start()
                     if [ $? = 1 ]; then
                         break;
                     fi
-                    sleep 0.5;
+                    sleep 1;
                     j=`expr $j + 1`;
                     if [ "$j" = "${MAX_ITERATION}" ]; then
                         failed=true

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -182,7 +182,7 @@ disable()
         exit 1;
     fi
     daemon=''
-  
+
     if [ "X$2" = "Xdatabase" ]; then
         echo "$DATABASE_MSG"
     elif [ "X$2" = "Xclient-syslog" ]; then
@@ -384,7 +384,7 @@ start()
                         if [ $? = 1 ]; then
                             break;
                         fi
-                        sleep 0.5;
+                        sleep 1;
                         j=`expr $j + 1`;
                         if [ "$j" = "${MAX_ITERATION}" ]; then
                             failed=true

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -367,7 +367,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                         rule_id = json_field ? json_field->valuestring : "";
 
                         json_field = cJSON_GetObjectItem(rule,"level");
-                        alert_level = json_field ? json_field->valueint : "";
+                        alert_level = json_field ? json_field->valueint : 0;
 
                         json_field = cJSON_GetObjectItem(rule,"description");
                         rule_description = json_field ? json_field->valuestring : "";

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -120,9 +120,7 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
     do {
         readbuff = BZ2_bzRead(&bzerror, compressfile, buf, sizeof(buf));
         if (bzerror == BZ_OK || bzerror == BZ_STREAM_END) {
-            if (readbuff > 0) {
-                fwrite(buf, sizeof(char), readbuff, output);
-            }
+            fwrite(buf, sizeof(char), readbuff, output);
         } else {
             mdebug2("BZ2_bzRead(%d)'%s': (%d)-%s",
                     bzerror, filebz2, errno, strerror(errno));
@@ -131,7 +129,7 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
             BZ2_bzReadClose(&bzerror, compressfile);
             return -1;
         }
-    } while (readbuff > 0);
+    } while (bzerror == BZ_OK);
 
     fclose(input);
     fclose(output);

--- a/src/unit_tests/shared/test_bzip2_op.c
+++ b/src/unit_tests/shared/test_bzip2_op.c
@@ -402,12 +402,14 @@ void test_bzip2_uncompress_bzReadsuccess(void **state) {
     will_return(__wrap_BZ2_bzRead, 11);
     will_return(__wrap_BZ2_bzRead, "teststring");
 
-    will_return(__wrap_fwrite, 4);
+    will_return(__wrap_fwrite, 11);
 
     expect_value(__wrap_BZ2_bzRead, f, 3);
-    will_return(__wrap_BZ2_bzRead, BZ_OK);
+    will_return(__wrap_BZ2_bzRead, BZ_STREAM_END);
     will_return(__wrap_BZ2_bzRead, 0);
     will_return(__wrap_BZ2_bzRead, "");
+
+    will_return(__wrap_fwrite, 0);
 
     ret = bzip2_uncompress(file1, file2);
     assert_int_equal(ret, 0);


### PR DESCRIPTION
|Related issue|
|---|
|No issue|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
There is an error in the bzip2 decompression function. The loop that reads the compressed file iterates once more when the reading of the file is completed by returning an error code in the `BZ2_bzRead()` function.
The decompression function ends up returning -1 which ends up not getting the content of the compressed feed.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
The fix complete al feeds correctly:
> select target,count(*) from vulnerabilities group by target;
> BIONIC|27263
> TRUSTY|12908
> XENIAL|32582

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
 - [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

