### PR TITLE
Allow long group name handling in the Privsep library

### DIFF
--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
     /* Get the group name */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, "", group);
+        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
     /* Set the group */

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -894,7 +894,7 @@ int OS_LoadUid() {
     gid = Privsep_GetGroup(GROUPGLOBAL);
 
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror(USER_ERROR, USER, GROUPGLOBAL);
+        merror(USER_ERROR, USER, GROUPGLOBAL, strerror(errno), errno);
         return -1;
     } else {
         return 0;

--- a/src/agentlessd/main.c
+++ b/src/agentlessd/main.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Read config */

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -382,7 +382,7 @@ int main_analysisd(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Found user */

--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Found user */

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Set the group */

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Check client keys */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -60,7 +60,7 @@
 /* COMMON ERRORS */
 #define CONN_ERROR      "(1201): No remote connection configured."
 #define CONFIG_ERROR    "(1202): Configuration error at '%s'."
-#define USER_ERROR      "(1203): Invalid user '%s' or group '%s' given."
+#define USER_ERROR      "(1203): Invalid user '%s' or group '%s' given: %s (%d)"
 #define CONNTYPE_ERROR  "(1204): Invalid connection type: '%s'."
 #define PORT_ERROR      "(1205): Invalid port number: '%d'."
 #define BIND_ERROR      "(1206): Unable to Bind port '%d' due to [(%d)-(%s)]"

--- a/src/headers/privsep_op.h
+++ b/src/headers/privsep_op.h
@@ -21,16 +21,80 @@
 #define w_ctime(x,y,z) ctime_r(x,y)
 #endif
 
+/**
+ * @brief Find a user by name
+ *
+ * This is a wrapper of getpwnam_r().
+ *
+ * @param name Name of the user.
+ * @param pwd Destination password structure.
+ * @param buf Context buffer.
+ * @param buflen Length of buffer.
+ * @return Pointer to pwd, on success.
+ * @retval NULL on failure.
+ * @post errno is set on failure.
+ */
 struct passwd *w_getpwnam(const char *name, struct passwd *pwd, char *buf, size_t buflen);
 
+/**
+ * @brief Find a user by UID
+ *
+ * This is a wrapper of getpwid_r().
+ *
+ * @param name Name of the user.
+ * @param pwd Destination password structure.
+ * @param buf Context buffer.
+ * @param buflen Length of buffer.
+ * @return Pointer to pwd, on success.
+ * @retval NULL on failure.
+ * @post errno is set on failure.
+ */
 struct passwd *w_getpwuid(uid_t  uid, struct  passwd  *pwd, char *buf, int  buflen);
 
-struct group  *w_getgrnam(const  char  *name,  struct group *grp, char *buf, int buflen);
+/**
+ * @brief Find a group by name
+ *
+ * This is a wrapper of getgrnam_r().
+ *
+ * @param name Name of the group.
+ * @param grp Destination group structure.
+ * @param buf Context buffer.
+ * @param buflen Length of buffer.
+ * @return Pointer to grp, on success.
+ * @retval NULL on failure.
+ * @post errno is set on failure.
+ */
+struct group  *w_getgrnam(const char *name, struct group *grp, char *buf, int buflen);
 
+/**
+ * @brief Find a group by GID
+ *
+ * This is a wrapper of getgrid_r().
+ *
+ * @param name Name of the group.
+ * @param grp Destination group structure.
+ * @param buf Context buffer.
+ * @param buflen Length of buffer.
+ * @return Pointer to grp, on success.
+ * @retval NULL on failure.
+ * @post errno is set on failure.
+ */
 struct group *w_getgrgid(gid_t gid, struct group *grp,  char *buf, int buflen);
 
+/**
+ * @brief Find a UID by user name
+ * @param name Name of the user.
+ * @return UID of the user, if found.
+ * @retval -1 user not found.
+ */
 uid_t Privsep_GetUser(const char *name) __attribute__((nonnull));
 
+/**
+ * @brief Find a GID by group name
+ * @param name Name of the group.
+ * @return GID of the group, if found.
+ * @retval -1 group not found.
+ */
 gid_t Privsep_GetGroup(const char *name) __attribute__((nonnull));
 
 int Privsep_SetUser(uid_t uid);

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
     /* Check if the group given is valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, "", group);
+        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
     /* Privilege separation */

--- a/src/monitord/main.c
+++ b/src/monitord/main.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Get config options */

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -244,7 +244,7 @@ int main(int argc, char **argv)
     /* Check if the user/group given are valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, "", group);
+        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
     /* Privilege separation */

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -379,7 +379,7 @@ int main(int argc, char **argv)
     /* Check if the user/group given are valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, "", group);
+        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
     if (!run_foreground) {

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Read configuration */

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Read configuration */

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
     /* Check if the group given is valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, "", group);
+        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
     /* Privilege separation */

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
     gid = Privsep_GetGroup(group);
     if((uid < 0)||(gid < 0))
     {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Reading configuration */

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Read configuration */

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Setup random */

--- a/src/reportd/report.c
+++ b/src/reportd/report.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Exit here if test config is set */
@@ -205,4 +205,3 @@ int main(int argc, char **argv)
 
     exit(0);
 }
-

--- a/src/shared/privsep_op.c
+++ b/src/shared/privsep_op.c
@@ -26,7 +26,13 @@ struct passwd *w_getpwnam(const char *name, struct passwd *pwd, char *buf, size_
     return getpwnam_r(name, pwd, buf, buflen);
 #else
     struct passwd *result = NULL;
-    return (getpwnam_r(name, pwd, buf, buflen, &result) == 0 && result != NULL) ? result : NULL;
+    int retval = getpwnam_r(name, pwd, buf, buflen, &result);
+
+    if (result == NULL) {
+        errno = retval;
+    }
+
+    return result;
 #endif
 }
 
@@ -35,7 +41,13 @@ struct passwd *w_getpwuid(uid_t uid, struct  passwd  *pwd, char *buf, int  bufle
     return getpwuid_r(uid, pwd, buf, buflen);
 #else
     struct passwd *result = NULL;
-    return (getpwuid_r(uid, pwd, buf, buflen, &result) == 0 && result != NULL) ? result : NULL;
+    int retval = getpwuid_r(uid, pwd, buf, buflen, &result);
+
+    if (result == NULL) {
+        errno = retval;
+    }
+
+    return result;
 #endif
 }
 
@@ -44,7 +56,13 @@ struct group *w_getgrnam(const  char  *name,  struct group *grp, char *buf, int 
     return getgrnam_r(name, grp, buf, buflen);
 #else
     struct group *result = NULL;
-    return (getgrnam_r(name, grp, buf, buflen, &result) == 0 && result != NULL) ? result : NULL;
+    int retval = getgrnam_r(name, grp, buf, buflen, &result);
+
+    if (result == NULL) {
+        errno = retval;
+    }
+
+    return result;
 #endif
 }
 
@@ -53,7 +71,13 @@ struct group *w_getgrgid(gid_t gid, struct group *grp,  char *buf, int buflen) {
     return getgrgid_r(gid, grp, buf, buflen);
 #else
     struct group *result = NULL;
-    return (getgrgid_r(gid, grp, buf, buflen, &result) == 0 && result != NULL) ? result : NULL;
+    int retval = getgrgid_r(gid, grp, buf, buflen, &result);
+
+    if (result == NULL) {
+        errno = retval;
+    }
+
+    return result;
 #endif
 }
 
@@ -62,16 +86,16 @@ uid_t Privsep_GetUser(const char *name)
     long int len =  sysconf(_SC_GETGR_R_SIZE_MAX);
     len = len > 0 ? len : 1024;
     struct passwd pw = { .pw_name = NULL };
-    char *buffer;
-    os_malloc(len, buffer);
+    char *buffer = NULL;
     struct passwd *result = NULL;
     uid_t pw_uid;
 
-    if (result = w_getpwnam(name, &pw, buffer, len), result) {
-        pw_uid = result->pw_uid;
-    } else {
-        pw_uid = (uid_t) OS_INVALID;
-    }
+    do {
+        os_realloc(buffer, len, buffer);
+        result = w_getpwnam(name, &pw, buffer, len);
+    } while (result == NULL && errno == ERANGE && (len *= 2) <= OS_MAXSTR);
+
+    pw_uid = result ? result->pw_uid : (uid_t)OS_INVALID;
     os_free(buffer);
 
     return pw_uid;
@@ -83,15 +107,16 @@ gid_t Privsep_GetGroup(const char *name)
     long int len = sysconf(_SC_GETGR_R_SIZE_MAX);
     len = len > 0 ? len : 1024;
     struct group *result = NULL;
-    char *buffer;
-    os_malloc(len, buffer);
+    char *buffer = NULL;
     gid_t gr_gid;
 
-    if (result = w_getgrnam(name, &grp, buffer, len), result) {
-        gr_gid = result->gr_gid;
-    } else {
-        gr_gid = (gid_t) OS_INVALID;
-    }
+
+    do {
+        os_realloc(buffer, len, buffer);
+        result = w_getgrnam(name, &grp, buffer, len);
+    } while (result == NULL && errno == ERANGE && (len *= 2) <= OS_MAXSTR);
+
+    gr_gid = result ? result->gr_gid : (uid_t)OS_INVALID;
     os_free(buffer);
 
     return gr_gid;

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
     /* Check if the group given is valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, "", group);
+        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
     /* Privilege separation */

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -36,6 +36,9 @@ list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wra
                                 -Wl,--wrap,wpopenv -Wl,--wrap,fgets -Wl,--wrap,wpclose -Wl,--wrap,audit_open -Wl,--wrap,audit_add_watch_dir \
                                 -Wl,--wrap,audit_update_watch_perms -Wl,--wrap,audit_errno_to_name -Wl,--wrap,audit_rule_fieldpair_data \
                                 -Wl,--wrap,audit_add_rule_data -Wl,--wrap,audit_delete_rule_data -Wl,--wrap,audit_close")
+
+list(APPEND shared_tests_names "test_privsep_op")
+list(APPEND shared_tests_flags "-Wl,--wrap=sysconf,--wrap=getpwnam_r,--wrap=getgrnam_r")
 endif()
 
 

--- a/src/unit_tests/shared/test_privsep_op.c
+++ b/src/unit_tests/shared/test_privsep_op.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <pwd.h>
+#include <grp.h>
+
+#include "../headers/privsep_op.h"
+
+int __wrap_sysconf(int name) {
+    return mock();
+}
+
+int __wrap_getpwnam_r(const char *name, struct passwd *pwd, char *buf, size_t buflen, struct passwd **result) {
+    *result = NULL;
+
+    if (buflen < 1024) {
+        return ERANGE;
+    }
+
+    if (strcmp(name, "ossec") == 0) {
+        pwd->pw_uid = 1000;
+        *result = pwd;
+    }
+
+    return 0;
+}
+
+int __wrap_getgrnam_r(const char *name, struct group *grp, char *buf, size_t buflen, struct group **result) {
+    *result = NULL;
+
+    if (buflen < 1024) {
+        return ERANGE;
+    }
+
+    if (strcmp(name, "ossec") == 0) {
+        grp->gr_gid = 1000;
+        *result = grp;
+    }
+
+    return 0;
+}
+
+static void test_GetUser_success(void ** state) {
+    will_return(__wrap_sysconf, 1024);
+    uid_t uid = Privsep_GetUser("ossec");
+    assert_int_equal(uid, 1000);
+}
+
+static void test_GetUser_success_extend(void ** state) {
+    will_return(__wrap_sysconf, 512);
+    uid_t uid = Privsep_GetUser("ossec");
+    assert_int_equal(uid, 1000);
+}
+
+static void test_GetUser_failure(void ** state) {
+    will_return(__wrap_sysconf, 1024);
+    uid_t uid = Privsep_GetUser("other");
+    assert_int_equal(uid, (uid_t)-1);
+}
+
+static void test_GetGroup_success(void ** state) {
+    will_return(__wrap_sysconf, 1024);
+    uid_t uid = Privsep_GetGroup("ossec");
+    assert_int_equal(uid, 1000);
+}
+
+static void test_GetGroup_success_extend(void ** state) {
+    will_return(__wrap_sysconf, 512);
+    uid_t uid = Privsep_GetGroup("ossec");
+    assert_int_equal(uid, 1000);
+}
+
+static void test_GetGroup_failure(void ** state) {
+    will_return(__wrap_sysconf, 1024);
+    uid_t uid = Privsep_GetGroup("other");
+    assert_int_equal(uid, (uid_t)-1);
+}
+
+int main() {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_GetUser_success),
+        cmocka_unit_test(test_GetUser_success_extend),
+        cmocka_unit_test(test_GetUser_failure),
+        cmocka_unit_test(test_GetGroup_success),
+        cmocka_unit_test(test_GetGroup_success_extend),
+        cmocka_unit_test(test_GetGroup_failure),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -189,7 +189,7 @@ int main(int argc, char **argv)
     gid = Privsep_GetGroup(group);
     uid = Privsep_GetUser(user);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Set the group */

--- a/src/util/clear_stats.c
+++ b/src/util/clear_stats.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
     gid = Privsep_GetGroup(group);
     uid = Privsep_GetUser(user);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Set the group */

--- a/src/util/list_agents.c
+++ b/src/util/list_agents.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
     gid = Privsep_GetGroup(group);
     uid = Privsep_GetUser(user);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Set the group */

--- a/src/util/rootcheck_control.c
+++ b/src/util/rootcheck_control.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
     gid = Privsep_GetGroup(group);
     uid = Privsep_GetUser(user);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Set the group */

--- a/src/util/syscheck_control.c
+++ b/src/util/syscheck_control.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
     gid = Privsep_GetGroup(group);
     uid = Privsep_GetUser(user);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Set the group */

--- a/src/util/syscheck_update.c
+++ b/src/util/syscheck_update.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
     gid = Privsep_GetGroup(group);
     uid = Privsep_GetUser(user);
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, user, group);
+        merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
     /* Set the group */

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -128,7 +128,7 @@ int main(int argc, char ** argv) {
         gid_t gid = Privsep_GetGroup(GROUPGLOBAL);
 
         if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-            merror_exit(USER_ERROR, USER, GROUPGLOBAL);
+            merror_exit(USER_ERROR, USER, GROUPGLOBAL, strerror(errno), errno);
         }
 
         if (Privsep_SetGroup(gid) < 0) {

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -504,7 +504,7 @@ int wdb_create_file(const char *path, const char *source) {
         gid = Privsep_GetGroup(GROUPGLOBAL);
 
         if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-            merror(USER_ERROR, ROOT, GROUPGLOBAL);
+            merror(USER_ERROR, ROOT, GROUPGLOBAL, strerror(errno), errno);
             return -1;
         }
 

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -335,7 +335,7 @@ int wdb_create_agent_db(int id, const char *name) {
     gid = Privsep_GetGroup(GROUPGLOBAL);
 
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        merror(USER_ERROR, ROOT, GROUPGLOBAL);
+        merror(USER_ERROR, ROOT, GROUPGLOBAL, strerror(errno), errno);
         return -1;
     }
 

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
     /* Check if the group given is valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, "", group);
+        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
     /* Privilege separation */
@@ -149,7 +149,7 @@ void wm_setup()
     // Set group
 
     if (gid = Privsep_GetGroup(GROUPGLOBAL), gid == (gid_t) -1) {
-        merror_exit(USER_ERROR, "", GROUPGLOBAL);
+        merror_exit(USER_ERROR, "", GROUPGLOBAL, strerror(errno), errno);
     }
 
     if (Privsep_SetGroup(gid) < 0) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -383,7 +383,7 @@ int wm_vuldet_create_file(const char *path, const char *source) {
     gid = Privsep_GetGroup(GROUPGLOBAL);
 
     if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
-        mterror(WM_VULNDETECTOR_LOGTAG, USER_ERROR, ROOT, GROUPGLOBAL);
+        mterror(WM_VULNDETECTOR_LOGTAG, USER_ERROR, ROOT, GROUPGLOBAL, strerror(errno), errno);
         return OS_INVALID;
     }
 


### PR DESCRIPTION
This PR aims to fix the following error:

```
2020/04/01 22:29:55 ossec-execd: CRITICAL: (1203): Invalid user '' or group 'ossec' given.
```

According to #4816, it may occur when the internal buffer of `Privsep_GetGroup()` is not long enough to parse the system group database (_/etc/group_).

## Proposed fix

The starting buffer size is 1024 (`sysconf(_SC_GETGR_R_SIZE_MAX)`). If this size is not large enough, duplicate it until 65535 (`OS_MAXSTR`). If this buffer size is still small, return failure with code `ERANGE`.

In addition, we've extended the error message to include a description.

## Error sample

```
2020/04/07 19:15:12 ossec-execd: CRITICAL: (1203): Invalid user '' or group 'ossec' given: Numerical result out of range (34)
```

## Tests

- [X] Compile agent on Debian 10.
- [X] Compile agent on CentOS 8.
- [X] Compile agent on Solaris 10.
- [x] Compile agent on macOS.
- [x] Compile agent for Windows.
- [X] Add unit tests for the functions we've changed: `Privsep_GetUser` and `Privsep_GetGroup`.
- [X] Run unit tests on Valgrind.
- [X] Run Execd on Valgrind.