### PR TITLE
Simplify audit healthcheck in order to make it less likely to fail

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -143,12 +143,12 @@
 #define FIM_HEALTHCHECK_CREATE              "(6252): Whodata health-check: Detected file creation event (%s)"
 #define FIM_HEALTHCHECK_DELETE              "(6253): Whodata health-check: Detected file deletion event (%s)"
 #define FIM_HEALTHCHECK_UNRECOGNIZED_EVENT  "(6254): Whodata health-check: Unrecognized event (%s)"
-#define FIM_HEALTHCHECK_THREAD_ATIVE        "(6255): Whodata health-check: Reading thread active."
-#define FIM_HEALTHCHECK_THREAD_FINISED      "(6256): Whodata health-check: Reading thread finished."
-#define FIM_HEALTHCHECK_WAIT_CREATE         "(6257): Whodata health-check: Waiting creation event."
-#define FIM_HEALTHCHECK_CREATE_RECEIVE      "(6258): Whodata health-check: Creation event received."
-#define FIM_HEALTHCHECK_WAIT_DELETE         "(6259): Whodata health-check: Waiting deletion event."
-#define FIM_HEALTHCHECK_DELETE_RECEIVE      "(6260): Whodata health-check: Deletion event received."
+#define FIM_HEALTHCHECK_THREAD_ACTIVE       "(6255): Whodata health-check: Reading thread active."
+#define FIM_HEALTHCHECK_THREAD_FINISHED     "(6256): Whodata health-check: Reading thread finished."
+#define FIM_HEALTHCHECK_CREATE_ERROR        "(6257): Whodata health-check: Failed to receive creation event."
+
+
+
 #define FIM_HEALTHCHECK_SUCCESS             "(6261): Whodata health-check: Success."
 #define FIM_HEALTHCHECK_CHECK_RULE          "(6262): Couldn't delete audit health check rule."
 #define FIM_SACL_CHECK_CONFIGURE            "(6263): Setting up SACL for '%s'"

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -1472,7 +1472,7 @@ int audit_health_check(int audit_socket) {
     unlink(AUDIT_HEALTHCHECK_FILE);
 
     if(retval = audit_delete_rule(AUDIT_HEALTHCHECK_DIR, AUDIT_HEALTHCHECK_KEY), retval <= 0){
-        mdebug1(FIM_HEALTHCHECK_CHECK_RULE);
+        mdebug1(FIM_HEALTHCHECK_CHECK_RULE);    // LCOV_EXCL_LINE
     }
     hc_thread_active = 0;
 
@@ -1482,7 +1482,7 @@ int audit_health_check(int audit_socket) {
 
 exit_err:
     if(retval = audit_delete_rule(AUDIT_HEALTHCHECK_DIR, AUDIT_HEALTHCHECK_KEY), retval <= 0){
-        mdebug1(FIM_HEALTHCHECK_CHECK_RULE);
+        mdebug1(FIM_HEALTHCHECK_CHECK_RULE);    // LCOV_EXCL_LINE
     }
     hc_thread_active = 0;
     return -1;

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -1422,7 +1422,6 @@ int filterkey_audit_events(char *buffer) {
 }
 
 
-// LCOV_EXCL_START
 // Audit healthcheck before starting the main thread
 int audit_health_check(int audit_socket) {
     int retval;
@@ -1488,7 +1487,6 @@ exit_err:
     hc_thread_active = 0;
     return -1;
 }
-// LCOV_EXCL_STOP
 
 #endif
 #endif

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -1446,21 +1446,19 @@ int audit_health_check(int audit_socket) {
         w_cond_wait(&audit_hc_started, &audit_hc_mutex);
     w_mutex_unlock(&audit_hc_mutex);
 
-    // Create a file
-    fp = fopen(AUDIT_HEALTHCHECK_FILE, "w");
+    // Generate open events until they get picked up
+    do {
+        fp = fopen(AUDIT_HEALTHCHECK_FILE, "w");
 
-    if(!fp) {
-        mdebug1(FIM_AUDIT_HEALTHCHECK_FILE);
-        goto exit_err;
-    }
-    fclose(fp);
+        if(!fp) {
+            mdebug1(FIM_AUDIT_HEALTHCHECK_FILE);
+            goto exit_err;
+        }
+        fclose(fp);
 
-    sleep(1);
-
-    while (!audit_health_check_creation && timer > 0) {
         sleep(1);
-        timer--;
-    }
+    } while (!audit_health_check_creation && --timer > 0);
+
     if (!audit_health_check_creation) {
         mdebug1("error: audit_health_check_creation");
         goto exit_err;

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -86,10 +86,8 @@ else()
   list(APPEND syscheckd_tests_flags "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches")
 endif()
 
-list(APPEND syscheckd_tests_names "test_syscheck_audit")
-if(${TARGET} STREQUAL "winagent")
-  list(APPEND syscheckd_tests_flags " ")
-else()
+if(NOT ${TARGET} STREQUAL "winagent")
+  list(APPEND syscheckd_tests_names "test_syscheck_audit")
   list(APPEND syscheckd_tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,IsSocket -Wl,--wrap,IsFile -Wl,--wrap,IsDir -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,audit_restart \
                        -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,fopen -Wl,--wrap,fwrite -Wl,--wrap,fprintf -Wl,--wrap,fclose -Wl,--wrap,symlink -Wl,--wrap,unlink \
                        -Wl,--wrap,audit_open -Wl,--wrap,audit_get_rule_list -Wl,--wrap,audit_close -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,W_Vector_length -Wl,--wrap,search_audit_rule \

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -91,9 +91,10 @@ if(NOT ${TARGET} STREQUAL "winagent")
   list(APPEND syscheckd_tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,IsSocket -Wl,--wrap,IsFile -Wl,--wrap,IsDir -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,audit_restart \
                        -Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,fopen -Wl,--wrap,fwrite -Wl,--wrap,fprintf -Wl,--wrap,fclose -Wl,--wrap,symlink -Wl,--wrap,unlink \
                        -Wl,--wrap,audit_open -Wl,--wrap,audit_get_rule_list -Wl,--wrap,audit_close -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,W_Vector_length -Wl,--wrap,search_audit_rule \
-                       -Wl,--wrap,audit_add_rule -Wl,--wrap,W_Vector_insert_unique -Wl,--wrap,SendMSG -Wl,--wrap,fim_whodata_event \
+                       -Wl,--wrap,audit_add_rule -Wl,--wrap,W_Vector_insert_unique -Wl,--wrap,SendMSG -Wl,--wrap,fim_whodata_event -Wl,--wrap,audit_delete_rule \
                        -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc -Wl,--wrap,closeproc -Wl,--wrap,_mdebug2 -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,realpath \
-                       -Wl,--wrap,readlink")
+                       -Wl,--wrap,pthread_cond_init -Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,CreateThread \
+                       -Wl,--wrap,sleep -Wl,--wrap,readlink")
 endif()
 
 set(SEECHANGES_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,lstat -Wl,--wrap,stat -Wl,--wrap,abspath -Wl,--wrap,fopen -Wl,--wrap,fread \

--- a/src/unit_tests/syscheckd/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/test_syscheck_audit.c
@@ -17,8 +17,7 @@
 #include "syscheckd/syscheck.h"
 #include "external/procps/readproc.h"
 
-#if defined(TEST_SERVER) || defined(TEST_AGENT)
-extern volatile int audit_health_check_deletion;
+extern volatile int hc_thread_active;
 
 int test_mode = 0;
 
@@ -1868,11 +1867,7 @@ void test_audit_parse_rm_hc(void **state)
     expect_string(__wrap__mdebug2, msg, FIM_HEALTHCHECK_DELETE);
     expect_string(__wrap__mdebug2, formatted_msg, "(6253): Whodata health-check: Detected file deletion event (263)");
 
-    audit_health_check_deletion = 0;
-
     audit_parse(buffer);
-
-    assert_int_equal(audit_health_check_deletion, 1);
 }
 
 
@@ -2222,13 +2217,3 @@ int main(void) {
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }
-
-#elif defined(TEST_WINAGENT)
-
-int main(void) {
-    const struct CMUnitTest tests[] = {
-    };
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
-
-#endif

--- a/src/unit_tests/syscheckd/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/test_syscheck_audit.c
@@ -2280,11 +2280,11 @@ void test_audit_health_check_no_creation_event_detected(void **state)
     expect_function_call(__wrap_pthread_cond_wait);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap_fopen, filename, "/var/ossec/tmp/audit_hc");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string_count(__wrap_fopen, filename, "/var/ossec/tmp/audit_hc", 10);
+    expect_string_count(__wrap_fopen, mode, "w", 10);
+    will_return_count(__wrap_fopen, 1, 10);
 
-    will_return(__wrap_fclose, 0);
+    will_return_count(__wrap_fclose, 0, 10);
 
     expect_string(__wrap__mdebug1, formatted_msg, "error: audit_health_check_creation");
 

--- a/src/unit_tests/syscheckd/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/test_syscheck_audit.c
@@ -18,8 +18,10 @@
 #include "external/procps/readproc.h"
 
 extern volatile int hc_thread_active;
+extern volatile int audit_health_check_creation;
 
 int test_mode = 0;
+int hc_success = 0;
 
 /* redefinitons/wrapping */
 
@@ -306,6 +308,10 @@ int __wrap_CreateThread(void * (*function_pointer)(void *), void *data) {
 }
 
 unsigned int __wrap_sleep(unsigned int seconds) {
+    if(hc_success) {
+        audit_health_check_creation = 1;
+    }
+
     return 0;
 }
 
@@ -328,6 +334,18 @@ static int free_string(void **state)
 {
     char * string = *state;
     free(string);
+    return 0;
+}
+
+static int setup_hc_success(void **state)
+{
+    hc_success = 1;
+    return 0;
+}
+
+static int teardown_hc_success(void **state)
+{
+    hc_success = 0;
     return 0;
 }
 
@@ -2197,6 +2215,127 @@ void test_audit_parse_delete_folder_hex5_error(void **state)
     audit_parse(buffer);
 }
 
+/* audit_health_check() tests */
+void test_audit_health_check_fail_to_add_rule(void **state)
+{
+    int ret;
+
+    will_return(__wrap_audit_add_rule, -1);
+
+    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_RULE);
+
+    expect_string(__wrap_audit_delete_rule, path, "/var/ossec/tmp");
+    expect_string(__wrap_audit_delete_rule, key, "wazuh_hc");
+    will_return(__wrap_audit_delete_rule, 1);
+
+    ret = audit_health_check(123456);
+
+    assert_int_equal(ret, -1);
+    assert_int_equal(hc_thread_active, 0);
+}
+
+void test_audit_health_check_fail_to_create_hc_file(void **state)
+{
+    int ret;
+
+    hc_thread_active = 0;
+
+    will_return(__wrap_audit_add_rule, -17);
+
+    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_START);
+
+    expect_function_call(__wrap_pthread_cond_init);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_cond_wait);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/tmp/audit_hc");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_FILE);
+
+    expect_string(__wrap_audit_delete_rule, path, "/var/ossec/tmp");
+    expect_string(__wrap_audit_delete_rule, key, "wazuh_hc");
+    will_return(__wrap_audit_delete_rule, 1);
+
+    ret = audit_health_check(123456);
+
+    assert_int_equal(ret, -1);
+    assert_int_equal(hc_thread_active, 0);
+}
+
+void test_audit_health_check_no_creation_event_detected(void **state)
+{
+    int ret;
+
+    hc_thread_active = 0;
+
+    will_return(__wrap_audit_add_rule, -17);
+
+    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_START);
+
+    expect_function_call(__wrap_pthread_cond_init);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_cond_wait);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/tmp/audit_hc");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fclose, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "error: audit_health_check_creation");
+
+    expect_string(__wrap_audit_delete_rule, path, "/var/ossec/tmp");
+    expect_string(__wrap_audit_delete_rule, key, "wazuh_hc");
+    will_return(__wrap_audit_delete_rule, 1);
+
+    ret = audit_health_check(123456);
+
+    assert_int_equal(ret, -1);
+    assert_int_equal(hc_thread_active, 0);
+}
+
+void test_audit_health_check_success(void **state)
+{
+    int ret;
+
+    hc_thread_active = 0;
+
+    will_return(__wrap_audit_add_rule, 1);
+
+    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_START);
+
+    expect_function_call(__wrap_pthread_cond_init);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_cond_wait);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_string(__wrap_fopen, filename, "/var/ossec/tmp/audit_hc");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fclose, 0);
+
+    expect_string(__wrap__mdebug2, msg, FIM_HEALTHCHECK_CREATE_RECEIVE);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_HEALTHCHECK_CREATE_RECEIVE);
+
+    will_return(__wrap_unlink, 0);
+
+    expect_string(__wrap_audit_delete_rule, path, "/var/ossec/tmp");
+    expect_string(__wrap_audit_delete_rule, key, "wazuh_hc");
+    will_return(__wrap_audit_delete_rule, 1);
+
+    expect_string(__wrap__mdebug2, msg, FIM_HEALTHCHECK_SUCCESS);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_HEALTHCHECK_SUCCESS);
+
+    ret = audit_health_check(123456);
+
+    assert_int_equal(ret, 0);
+    assert_int_equal(hc_thread_active, 0);
+}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
@@ -2260,6 +2399,10 @@ int main(void) {
         cmocka_unit_test(test_audit_parse_delete_folder_hex3_error),
         cmocka_unit_test(test_audit_parse_delete_folder_hex4_error),
         cmocka_unit_test(test_audit_parse_delete_folder_hex5_error),
+        cmocka_unit_test(test_audit_health_check_fail_to_add_rule),
+        cmocka_unit_test(test_audit_health_check_fail_to_create_hc_file),
+        cmocka_unit_test(test_audit_health_check_no_creation_event_detected),
+        cmocka_unit_test_setup_teardown(test_audit_health_check_success, setup_hc_success, teardown_hc_success),
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#4689|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims at decreasing the likelihood of the audit healthcheck routine to fail at random times, by simplifying it to only wait for an initial creation event and discarding the delete event.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

- [x] Added unit tests (for new features)
