### PR TITLE
Fix infinite loop on syscollector.

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -931,8 +931,6 @@ void list_hotfixes(HKEY hKey, int usec, const char *timestamp, int ID, const cha
     FILETIME ftLastWriteTime;      // last write time
     long unsigned int i, result;
 
-    // Remove unused variables
-
     result = RegQueryInfoKey(
         hKey,                    // key handle
         achClass,                // buffer for class name
@@ -947,7 +945,8 @@ void list_hotfixes(HKEY hKey, int usec, const char *timestamp, int ID, const cha
         &cbSecurityDescriptor,   // security descriptor
         &ftLastWriteTime);       // last write time
 
-    if (!cSubKeys) {
+    // Exit if the number of subkeys is 0 or if not success
+    if (cSubKeys == 0 || result != ERROR_SUCCESS) {
         return;
     }
 
@@ -1018,6 +1017,9 @@ void list_hotfixes(HKEY hKey, int usec, const char *timestamp, int ID, const cha
             }
         } else {
             mterror(WM_SYS_LOGTAG, "Error reading key '%s'. Error code: %lu", achKey, result);
+            // Avoid infinite loops
+            break;
+
         }
     }
 }


### PR DESCRIPTION
|Related issue|
|#4853|


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As mentioned in #4853, it's needed to check the output of the function `RegQueryInfoKey`. 
It was assumed that in case this function fails, the variable `cSubKeys` remain the same, this could cause an infinite loop. 
If there is any failure reading any sub-key, the execution will be interrupted.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Windows
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language

