### PR TITLE
Vulnerability detector: Fixing RHEL version extractor. Null pointer checking.

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2382,7 +2382,7 @@ end:
 
 const char *wm_vuldet_decode_package_version(char *raw, const char **OS, char **OS_minor, char **package_name, char **package_version) {
     static OSRegex *reg = NULL;
-    static char *package_regex = "(-\\d+:)|(-\\d+.)|(-\\d+\\w+)";
+    static char *package_regex = "(:v\\d+:)|(:v\\d+.)|(:v\\d+\\w+)|(:\\d+:)|(:\\d+.)|(:\\d+\\w+)|(-\\d+:)|(-\\d+.)|(-\\d+\\w+)";
     const char *retv = NULL;
     char *found;
 
@@ -2401,6 +2401,7 @@ const char *wm_vuldet_decode_package_version(char *raw, const char **OS, char **
             return NULL;
         }
         *found = '\0';
+        if (found[1] == 'v') found++;
         w_strdup(found + 1, *package_version);
         w_strdup(raw, *package_name);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2394,6 +2394,9 @@ const char *wm_vuldet_decode_package_version(char *raw, const char **OS, char **
     }
 
     if (retv = OSRegex_Execute(raw, reg), retv) {
+        if(*reg->d_sub_strings == NULL){
+            return NULL;
+        }
         if (found = strstr(raw, *reg->d_sub_strings), !found) {
             return NULL;
         }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4884|

## Description

The current regex being used is not capturing the _substrings_ properly causing a null pointer return which later produces de segfault.

The issue is located in the following source code lines:

https://github.com/wazuh/wazuh/blob/3.12/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c#L2396-L2398 

```
if (retv = OSRegex_Execute(raw, reg), retv) {
   if (found = strstr(raw, *reg->d_sub_strings), !found) {
   return NULL;
}
...
```

GDB Output (segfault)

```
#1  0x0000000000478100 in wm_vuldet_decode_package_version (raw=0x7ff78004f000 "openstack-rabbitmq-container:13.0-57",
    OS=0x7ff7800864e8, OS_minor=0x7ff7800864f0, package_name=0x7ff7800864f8, package_version=0x7ff780086500)
    at wazuh_modules/vulnerability_detector/wm_vuln_detector.c:2380
2380	        if (found = strstr(raw, *reg->d_sub_strings), !found) {
(gdb) print found
$7 = 0x7ff785ff5aaa <strdup+26> "H\205\300t\031H\203\304\bH\211\336H\211\352[]H\211\307\351-\200"
(gdb) print raw
$8 = 0x7ff78004f000 "openstack-rabbitmq-container:13.0-57"
(gdb) print *reg->d_sub_strings
$9 = 0x0
(gdb) print reg->d_sub_strings
$10 = (char **) 0x7ff780022cc0
```

GDB Output (no segfault)
```
Breakpoint 1, wm_vuldet_decode_package_version (raw=0x7f8bf8022680 "chromium-browser-77.0.3865.120-2.el6_10", OS=0x7f8bf8022978,
    OS_minor=0x7f8bf8022980, package_name=0x7f8bf8022988, package_version=0x7f8bf8022990)
    at wazuh_modules/vulnerability_detector/wm_vuln_detector.c:2380
2380	        if (found = strstr(raw, *reg->d_sub_strings), !found) {
(gdb) print found
$11 = 0x7f8bfec43aaa <strdup+26> "H\205\300t\031H\203\304\bH\211\336H\211\352[]H\211\307\351-\200"
(gdb) print raw
$12 = 0x7f8bf8022680 "chromium-browser-77.0.3865.120-2.el6_10"
(gdb) print *reg->d_sub_strings
$13 = 0x7f8bf828b290 "-77."
(gdb) print reg->d_sub_strings
$14 = (char **) 0x7f8bf824cb10
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [ ] Stress test for affected components
