### PR TITLE
Update URL library error log messages

### DIFF
--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -14,9 +14,8 @@
 
 #include <external/curl/include/curl/curl.h>
 
-#define WURL_WRITE_FILE_ERROR "Failed opening file '%s'"
-#define WURL_DOWNLOAD_FILE_ERROR "Failed to download file '%s' from url: %s"
-#define WURL_HTTP_GET_ERROR "Failed to get a response from '%s'"
+#define WURL_WRITE_FILE_ERROR "Cannot open file '%s'."
+#define WURL_DOWNLOAD_FILE_ERROR "Cannot download file '%s' from URL: %s."
 
 int wurl_get(const char * url, const char * dest, const char * header, const char *data);
 int w_download_status(int status,const char *url,const char *dest);


### PR DESCRIPTION
This PR changes the messages that the URL library may print on the log.

## Log example

### Changed logs

```
ossec-remoted: WARN: Cannot open file '/tmp/example.txt'.
ossec-remoted: WARN: Cannot download file '%s' from URL: 'https://example.com/myfile.txt'.
```

### Removed log message

This log was unused

```
Failed to get a response from 'https://example.com/myfile.txt'
```

## Tests

- [X] Compile manager on Linux.
- [x] Compile agent for Windows.