### PR TITLE
Fix GET /cluster/status when cluster is disabled

### DIFF
--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -124,8 +124,6 @@ async def get_status(request, pretty=False, wait_for_complete=False):
     :param wait_for_complete: Disable timeout response
     """
     f_kwargs = {}
-
-    nodes = await get_system_nodes()
     dapi = DistributedAPI(f=cluster.get_status_json,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
@@ -133,8 +131,7 @@ async def get_status(request, pretty=False, wait_for_complete=False):
                           wait_for_complete=wait_for_complete,
                           pretty=pretty,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes
+                          rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)


### PR DESCRIPTION
This PR closes #4574.

This fixes a bug in `cluster_controller.py` related to `/cluster/status` endpoint. When having the cluster disabled on `ossec.conf` the endpoint will return an error like the following one instead of the expected response:
```
{
  "code": 3012,
  "dapi_errors": {},
  "detail": "Cluster is not running",
  "status": 500,
  "title": "Wazuh Internal Error",
  "type": "about:blank"
}
```
This was because function `get_system_nodes` was used even when cluster is disabled, raising an error. The fix removes this as its no longer needed.

Here is the output when the endpoint returns now when cluster is disabled:
```
{
  "data": {
    "enabled": "no",
    "running": "no"
  }
}
```

## Test Results

Integration test for the cluster endpoint were executed. Here are the results:
```
============================= test session starts ==============================
platform linux -- Python 3.6.9, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/carlos/GIT/wazuh/api
plugins: tavern-0.34.0, cov-2.8.1
collecting ... collected 53 items

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED     [  1%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED      [  3%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED       [  5%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED            [  7%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED [  9%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED   [ 11%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED   [ 13%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED [ 15%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED           [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[master-node] PASSED [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker1] PASSED [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker2] PASSED [ 33%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[master-node] PASSED [ 35%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker1] PASSED [ 37%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker2] PASSED [ 39%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[master-node] PASSED [ 41%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker1] PASSED [ 43%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker2] PASSED [ 45%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/wrong_node/files PASSED [ 47%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED [ 49%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED [ 50%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED [ 52%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED [ 54%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED [ 56%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED [ 58%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED [ 60%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED [ 62%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED [ 64%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED [ 66%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED [ 84%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED [ 86%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED [ 88%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED [ 90%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED [ 92%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED [ 94%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED [ 96%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED [ 98%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED          [100%]
=================== 53 passed, 1 warnings in 3013.44 seconds ===================
```