### PR TITLE
Fix invalid socket on the UDP connection in Remoted

### DIFF
--- a/src/remoted/netcounter.c
+++ b/src/remoted/netcounter.c
@@ -29,6 +29,8 @@ void rem_initList(size_t initial_size) {
 
 
 void rem_setCounter(int fd, size_t counter) {
+    assert(fd >= 0);
+
     w_mutex_lock(&lock);
     while (fd >= connections.size) {
         os_realloc(connections.list, sizeof(int) * (connections.size + SIZE_BLOCK), connections.list);
@@ -41,6 +43,8 @@ void rem_setCounter(int fd, size_t counter) {
 
 
 size_t rem_getCounter(int fd) {
+    assert(fd >= 0);
+
     w_mutex_lock(&lock);
     size_t counter = (fd >= connections.size) ? 0 : connections.list[fd];
     w_mutex_unlock(&lock);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -243,8 +243,7 @@ void * rem_handler_main(__attribute__((unused)) void * args) {
 
     while (1) {
         message = rem_msgpop();
-        size_t fd_list_counter = rem_getCounter(message->sock);
-        if (message->counter > fd_list_counter) {
+        if (message->sock == -1 || message->counter > rem_getCounter(message->sock)) {
             memcpy(buffer, message->buffer, message->size);
             HandleSecureMessage(buffer, message->size, &message->addr, message->sock);
         } else {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4832|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description


The failure was caused by a problem in the UDP connection, this was due to underflow buffer caused by improper management of an invalid socket. To fix this, a check has been added to the network counter to avoid the case of a invalid socket.



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [x] Windows
  - [x] MAC OS X
- [X] Source installation
- [X] Source upgrade
- [X] Ubuntu x64 TCP without a key.
- [X] Ubuntu x64 TCP with a key.
- [X] Ubuntu x64 UDP without a key.
- [X] Ubuntu x64 UDP with a key.
- [X] Ubuntu x32 TCP without a key.
- [X] Ubuntu x32 TCP with a key.
- [X] Ubuntu x32 UDP without a key.
- [X] Ubuntu x32 UDP with a key.

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Coverity
  - [X] UDP x64 Valgrind.
  - [X] UDP x32 Valgrind.