### PR TITLE
Fix same output in archives.json and alert.json.

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -22,7 +22,7 @@
 void add_json_attrs(const char *attrs_str, cJSON *file_diff, char after);
 
 /* Convert Eventinfo to json */
-char* Eventinfo_to_jsonstr(const Eventinfo* lf)
+char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log)
 {
     cJSON* root;
     cJSON* rule = NULL;
@@ -157,7 +157,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
     if(lf->dstuser) {
         cJSON_AddStringToObject(data, "dstuser", lf->dstuser);
     }
-    if(lf->full_log && !(lf->generated_rule && lf->generated_rule->alert_opts & NO_FULL_LOG)) {
+    if(lf->full_log && (force_full_log || !(lf->generated_rule && lf->generated_rule->alert_opts & NO_FULL_LOG))) {
         cJSON_AddStringToObject(root, "full_log", lf->full_log);
     }
     if (lf->agent_id) {

--- a/src/analysisd/format/to_json.h
+++ b/src/analysisd/format/to_json.h
@@ -13,5 +13,5 @@
 
 #include "eventinfo.h"
 #define add_json_field(obj, name, string, filter) if (string && strcmp(string, filter)) { if (!obj) obj = cJSON_CreateObject(); cJSON_AddStringToObject(obj, name, string); }
-char *Eventinfo_to_jsonstr(const Eventinfo *lf);
+char *Eventinfo_to_jsonstr(const Eventinfo *lf, bool force_full_log);
 #endif /* TO_JSON_H */

--- a/src/analysisd/output/jsonout.c
+++ b/src/analysisd/output/jsonout.c
@@ -14,7 +14,7 @@
 
 void jsonout_output_event(const Eventinfo *lf)
 {
-    char *json_alert = Eventinfo_to_jsonstr(lf);
+    char *json_alert = Eventinfo_to_jsonstr(lf, false);
 
     fprintf(_jflog,
             "%s\n",
@@ -28,7 +28,7 @@ void jsonout_output_archive(const Eventinfo *lf)
     char *json_alert;
 
     if (strcmp(lf->location, "ossec-keepalive") && !strstr(lf->location, "->ossec-keepalive")) {
-        json_alert = Eventinfo_to_jsonstr(lf);
+        json_alert = Eventinfo_to_jsonstr(lf, true);
         fprintf(_ejflog, "%s\n", json_alert);
         free(json_alert);
     }
@@ -41,4 +41,3 @@ void jsonout_output_archive_flush(){
 void jsonout_output_event_flush(){
     fflush(_jflog);
 }
-


### PR DESCRIPTION
|Related issue|
|---|
|#4891|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes the problem described in #4891.

<!--
Add a clear description of how the problem has been solved.
-->
Now the function `json_output_archive` calls `Eventinfo_to_json_archive` instead of `Eventinfo_to_jsonstr`. 
New functions has been added in order to reuse the common code between this two functions.  
## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)