### PR TITLE
Extend agent service configuration

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -96,6 +96,27 @@ cJSON *getClientConfig(void) {
         }
         cJSON_AddItemToObject(client,"server",servers);
     }
+
+    if (agt->enrollment_cfg.enabled) {
+        cJSON *enrollment_cfg = cJSON_CreateObject();
+        cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg.target.manager_name);
+        cJSON_AddNumberToObject(enrollment_cfg, "port", agt->enrollment_cfg.target.port);
+        cJSON_AddStringToObject(enrollment_cfg, "agent_name", agt->enrollment_cfg.target.agent_name);
+        cJSON_AddStringToObject(enrollment_cfg, "group", agt->enrollment_cfg.target.centralized_group);
+        cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg.target.manager_name);
+
+        cJSON_AddStringToObject(enrollment_cfg, "ssl_cipher", agt->enrollment_cfg.certificates.ciphers);
+        cJSON_AddStringToObject(enrollment_cfg, "server_certificate_path", agt->enrollment_cfg.certificates.ca_cert);
+        cJSON_AddStringToObject(enrollment_cfg, "agent_certificate_path", agt->enrollment_cfg.certificates.agent_cert);
+        cJSON_AddStringToObject(enrollment_cfg, "agent_key_path", agt->enrollment_cfg.certificates.agent_key);
+        cJSON_AddStringToObject(enrollment_cfg, "authrization_pass", agt->enrollment_cfg.certificates.authpass);
+        if (agt->enrollment_cfg.certificates.auto_method)
+            cJSON_AddStringToObject(enrollment_cfg,"auto_method","yes");
+        else
+            cJSON_AddStringToObject(enrollment_cfg,"auto_method","no");
+
+        cJSON_AddItemToObject(client,"auto_enrollment",enrollment_cfg);
+    }
     cJSON_AddItemToObject(root,"client",client);
 
     return root;
@@ -139,7 +160,7 @@ cJSON *getLabelsConfig(void) {
             cJSON_AddItemToObject(labels, "", label);
         }
     }
-    
+
     cJSON_AddItemToObject(root, "labels", labels);
 
     return root;

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -97,24 +97,32 @@ cJSON *getClientConfig(void) {
         cJSON_AddItemToObject(client,"server",servers);
     }
 
-    if (agt->enrollment_cfg.enabled) {
+    if (agt->enrollment_cfg) {
         cJSON *enrollment_cfg = cJSON_CreateObject();
-        cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg.target.manager_name);
-        cJSON_AddNumberToObject(enrollment_cfg, "port", agt->enrollment_cfg.target.port);
-        cJSON_AddStringToObject(enrollment_cfg, "agent_name", agt->enrollment_cfg.target.agent_name);
-        cJSON_AddStringToObject(enrollment_cfg, "group", agt->enrollment_cfg.target.centralized_group);
-        cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg.target.manager_name);
-
-        cJSON_AddStringToObject(enrollment_cfg, "ssl_cipher", agt->enrollment_cfg.certificates.ciphers);
-        cJSON_AddStringToObject(enrollment_cfg, "server_certificate_path", agt->enrollment_cfg.certificates.ca_cert);
-        cJSON_AddStringToObject(enrollment_cfg, "agent_certificate_path", agt->enrollment_cfg.certificates.agent_cert);
-        cJSON_AddStringToObject(enrollment_cfg, "agent_key_path", agt->enrollment_cfg.certificates.agent_key);
-        cJSON_AddStringToObject(enrollment_cfg, "authrization_pass", agt->enrollment_cfg.certificates.authpass);
-        if (agt->enrollment_cfg.certificates.auto_method)
-            cJSON_AddStringToObject(enrollment_cfg,"auto_method","yes");
-        else
-            cJSON_AddStringToObject(enrollment_cfg,"auto_method","no");
-
+        cJSON_AddStringToObject(enrollment_cfg, "enabled", agt->enrollment_cfg->enabled ? "yes" : "no");
+        
+        if (agt->enrollment_cfg->target_cfg->manager_name)
+            cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg->target_cfg->manager_name);
+        
+        cJSON_AddNumberToObject(enrollment_cfg, "port", agt->enrollment_cfg->target_cfg->port);
+        
+        if (agt->enrollment_cfg->target_cfg->agent_name)
+            cJSON_AddStringToObject(enrollment_cfg, "agent_name", agt->enrollment_cfg->target_cfg->agent_name);
+        if (agt->enrollment_cfg->target_cfg->centralized_group)   
+            cJSON_AddStringToObject(enrollment_cfg, "group", agt->enrollment_cfg->target_cfg->centralized_group);
+        
+        cJSON_AddStringToObject(enrollment_cfg, "ssl_cipher", agt->enrollment_cfg->cert_cfg->ciphers);
+        
+        if (agt->enrollment_cfg->cert_cfg->ca_cert)
+            cJSON_AddStringToObject(enrollment_cfg, "server_certificate_path", agt->enrollment_cfg->cert_cfg->ca_cert);
+        if (agt->enrollment_cfg->cert_cfg->agent_cert)
+            cJSON_AddStringToObject(enrollment_cfg, "agent_certificate_path", agt->enrollment_cfg->cert_cfg->agent_cert);
+        if (agt->enrollment_cfg->cert_cfg->agent_key)    
+            cJSON_AddStringToObject(enrollment_cfg, "agent_key_path", agt->enrollment_cfg->cert_cfg->agent_key);
+        if(agt->enrollment_cfg->cert_cfg->authpass)
+            cJSON_AddStringToObject(enrollment_cfg, "authrization_pass", agt->enrollment_cfg->cert_cfg->authpass);
+        
+        cJSON_AddStringToObject(enrollment_cfg,"auto_method",agt->enrollment_cfg->cert_cfg->auto_method ? "yes": "no");
         cJSON_AddItemToObject(client,"auto_enrollment",enrollment_cfg);
     }
     cJSON_AddItemToObject(root,"client",client);

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -44,6 +44,13 @@ int ClientConf(const char *cfgfile)
     os_calloc(1, sizeof(wlabel_t), agt->labels);
     modules |= CCLIENT;
 
+    w_enrollment_cert *cert_cfg = w_enrollment_cert_init();
+    w_enrollment_target *target_cfg = w_enrollment_target_init();
+
+    // Initialize enrollment_cfg
+    agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg);
+    agt->enrollment_cfg->allow_localhost = 0; // Localhost not allowed in auto-enrollment
+
     if (ReadConfig(modules, cfgfile, agt, NULL) < 0 ||
         ReadConfig(CLABELS | CBUFFER, cfgfile, &agt->labels, agt) < 0) {
         return (OS_INVALID);
@@ -60,7 +67,7 @@ int ClientConf(const char *cfgfile)
         mwarn("Client buffer throughput too low: set to %d eps", min_eps);
         agt->events_persec = min_eps;
     }
-
+    
     return (1);
 }
 
@@ -100,7 +107,8 @@ cJSON *getClientConfig(void) {
     if (agt->enrollment_cfg) {
         cJSON *enrollment_cfg = cJSON_CreateObject();
         cJSON_AddStringToObject(enrollment_cfg, "enabled", agt->enrollment_cfg->enabled ? "yes" : "no");
-        
+        cJSON_AddNumberToObject(enrollment_cfg, "delay_after_enrollment", agt->enrollment_cfg->delay_after_enrollment);
+
         if (agt->enrollment_cfg->target_cfg->manager_name)
             cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg->target_cfg->manager_name);
         
@@ -120,7 +128,7 @@ cJSON *getClientConfig(void) {
         if (agt->enrollment_cfg->cert_cfg->agent_key)    
             cJSON_AddStringToObject(enrollment_cfg, "agent_key_path", agt->enrollment_cfg->cert_cfg->agent_key);
         if(agt->enrollment_cfg->cert_cfg->authpass)
-            cJSON_AddStringToObject(enrollment_cfg, "authrization_pass", agt->enrollment_cfg->cert_cfg->authpass);
+            cJSON_AddStringToObject(enrollment_cfg, "authorization_pass_path", agt->enrollment_cfg->cert_cfg->authpass);
         
         cJSON_AddStringToObject(enrollment_cfg,"auto_method",agt->enrollment_cfg->cert_cfg->auto_method ? "yes": "no");
         cJSON_AddItemToObject(client,"auto_enrollment",enrollment_cfg);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -46,7 +46,6 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     logr->notify_time = 0;
     logr->max_time_reconnect_try = 0;
     logr->rip_id = 0;
-    logr->enrollment_cfg = NULL;
 
     for (i = 0; node[i]; i++) {
         rip = NULL;

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -111,16 +111,14 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             }
             OS_ClearNode(chld_node);
         } else if (strcmp(node[i]->element, xml_client_auto_enrollment) == 0) {
+            if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
+                if (Read_Client_Enrollment(chld_node, logr) < 0) {
+                    OS_ClearNode(chld_node);
+                    return (OS_INVALID);
+                }
 
-            if (!(chld_node = OS_GetElementsbyNode(xml, node[i]))) {
-                merror(XML_INVELEM, node[i]->element);
-                return (OS_INVALID);
-            }
-            if (Read_Client_Enrollment(chld_node, logr) < 0) {
                 OS_ClearNode(chld_node);
-                return (OS_INVALID);
             }
-            OS_ClearNode(chld_node);
         } else if (strcmp(node[i]->element, xml_notify_time) == 0) {
             if (!OS_StrIsNum(node[i]->content)) {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
@@ -301,17 +299,18 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     const char *xml_server_ca_path = "server_ca_path";
     const char *xml_agent_certif_path = "agent_certificate_path";
     const char *xml_agent_key_path = "agent_key_path";
-    const char *xml_auth_password = "authorization_pass";
+    const char *xml_auth_password = "authorization_pass_path";
     const char *xml_auto_method = "auto_method";
+    const char *xml_delay_after_enrollment = "delay_after_enrollment";
+    const char *xml_use_source_ip = "use_source_ip";
     char * remote_ip = NULL;
     int port = 0;
-    int enabled = 1;
     int j;
     char f_ip[128];
-    
 
-    w_enrollment_cert *cert_cfg = w_enrollment_cert_init();
-    w_enrollment_target *target_cfg = w_enrollment_target_init();
+
+    w_enrollment_cert *cert_cfg = logr->enrollment_cfg->cert_cfg;
+    w_enrollment_target *target_cfg = logr->enrollment_cfg->target_cfg;
 
     for (j = 0; node[j]; j++) {
         if (!node[j]->element) {
@@ -326,9 +325,9 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             return (OS_INVALID);
         } else if (!strcmp(node[j]->element, xml_enabled)) {
             if (!strcmp(node[j]->content, "yes"))
-                enabled = 1;
+                logr->enrollment_cfg->enabled = 1;
             else if (!strcmp(node[j]->content, "no")) {
-                enabled = 0;
+                logr->enrollment_cfg->enabled = 0;
             } else {
                 merror("Invalid content for tag '%s'.", node[j]->element);
                 w_enrollment_target_destroy(target_cfg);
@@ -365,13 +364,13 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             }
             target_cfg->port = port;
         } else if (strcmp(node[j]->element, xml_agent_name) == 0) {
-            os_free(target_cfg->sender_ip);
+            os_free(target_cfg->agent_name);
             os_strdup(node[j]->content, target_cfg->agent_name);
         } else if (strcmp(node[j]->element, xml_groups) == 0) {
             os_free(target_cfg->centralized_group);
             os_strdup(node[j]->content, target_cfg->centralized_group);
         } else if (strcmp(node[j]->element, xml_agent_addr) == 0) {
-            if (OS_IsValidIP(node[j]->content, NULL) == 1) {
+            if (OS_IsValidIP(node[j]->content, NULL) != 0) {
                 os_free(target_cfg->sender_ip);
                 os_strdup(node[j]->content, target_cfg->sender_ip);
             } else {
@@ -393,13 +392,39 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             os_free(cert_cfg->agent_key);
             os_strdup(node[j]->content, cert_cfg->agent_key);
         } else if (strcmp(node[j]->element, xml_auth_password) == 0) {
-            os_free(cert_cfg->authpass);
-            os_strdup(node[j]->content, cert_cfg->authpass);
+            os_free(cert_cfg->authpass_file);
+            os_strdup(node[j]->content, cert_cfg->authpass_file);
         } else if (strcmp(node[j]->element, xml_auto_method) == 0) {
             if (!strcmp(node[j]->content, "yes")) {
                 cert_cfg->auto_method = 1;
             } else if (!strcmp(node[j]->content, "no")) {
                 cert_cfg->auto_method = 0;
+            } else {
+                merror("Invalid content for tag '%s'.", node[j]->element);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
+                return OS_INVALID;
+            }
+        } else if (strcmp(node[j]->element, xml_delay_after_enrollment) == 0) {
+            if (!OS_StrIsNum(node[j]->content)) {
+                merror(XML_VALUEERR, node[j]->element, node[j]->content);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
+                return (OS_INVALID);
+            }
+            int delay_after_enrollment;
+            if (delay_after_enrollment = atoi(node[j]->content), delay_after_enrollment <= 0) {
+                merror(PORT_ERROR, port);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
+                return (OS_INVALID);
+            } 
+            logr->enrollment_cfg->delay_after_enrollment = delay_after_enrollment;
+        } else if (strcmp(node[j]->element, xml_use_source_ip) == 0) {
+            if (!strcmp(node[j]->content, "yes")) {
+                target_cfg->use_src_ip = 1;
+            } else if (!strcmp(node[j]->content, "no")) {
+                target_cfg->use_src_ip = 0;
             } else {
                 merror("Invalid content for tag '%s'.", node[j]->element);
                 w_enrollment_target_destroy(target_cfg);
@@ -413,9 +438,6 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             return (OS_INVALID);
         }
     }
-    // Initialize enrollment_cfg
-    logr->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg);
-    logr->enrollment_cfg->enabled = enabled;
     return 0;
 }
 

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -316,9 +316,13 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     for (j = 0; node[j]; j++) {
         if (!node[j]->element) {
             merror(XML_ELEMNULL);
+            w_enrollment_target_destroy(target_cfg);
+            w_enrollment_cert_destroy(cert_cfg);
             return (OS_INVALID);
         } else if (!node[j]->content) {
             merror(XML_VALUENULL, node[j]->element);
+            w_enrollment_target_destroy(target_cfg);
+            w_enrollment_cert_destroy(cert_cfg);
             return (OS_INVALID);
         } else if (!strcmp(node[j]->element, xml_enabled)) {
             if (!strcmp(node[j]->content, "yes"))
@@ -327,6 +331,8 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
                 enabled = 0;
             } else {
                 merror("Invalid content for tag '%s'.", node[j]->element);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
                 return OS_INVALID;
             }
         }
@@ -338,6 +344,8 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
                 remote_ip = f_ip;
             } else {
                 merror(AG_INV_HOST, node[j]->content);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
                 return (OS_INVALID);
             }
             os_free(target_cfg->manager_name);
@@ -345,10 +353,14 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
         } else if (strcmp(node[j]->element, xml_port) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
                 return (OS_INVALID);
             }
             if (port = atoi(node[j]->content), port <= 0 || port > 65535) {
                 merror(PORT_ERROR, port);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
                 return (OS_INVALID);
             }
             target_cfg->port = port;
@@ -364,6 +376,8 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
                 os_strdup(node[j]->content, target_cfg->sender_ip);
             } else {
                 merror(AG_INV_HOST, node[j]->content);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[j]->element, xml_ssl_cipher) == 0) {
@@ -388,10 +402,14 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
                 cert_cfg->auto_method = 0;
             } else {
                 merror("Invalid content for tag '%s'.", node[j]->element);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
                 return OS_INVALID;
             }
         } else {
             merror(XML_INVELEM, node[j]->element);
+            w_enrollment_target_destroy(target_cfg);
+            w_enrollment_cert_destroy(cert_cfg);
             return (OS_INVALID);
         }
     }

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -22,6 +22,29 @@ typedef struct agent_server {
     int protocol;
 } agent_server;
 
+typedef struct w_enrollment_target {
+    char *manager_name;
+    int port;
+    char *agent_name;
+    char *centralized_group;
+    char *sender_ip;
+} w_enrollment_target;
+
+typedef struct w_enrollment_cert {
+    char *ciphers;
+    char *authpass;
+    char *agent_cert;
+    char *agent_key;
+    char *ca_cert;
+    unsigned int auto_method:1;
+} w_enrollment_cert;
+
+typedef struct w_enrollment_cfg {
+    w_enrollment_target target;
+    w_enrollment_cert certificates;
+    unsigned int enabled:1;
+} w_enrollment_cfg;
+
 /* Configuration structure */
 typedef struct _agent {
     agent_server * server;
@@ -40,6 +63,7 @@ typedef struct _agent {
     int crypto_method;
     wlabel_t *labels; /* null-ended label set */
     agent_flags_t flags;
+    w_enrollment_cfg enrollment_cfg;
 } agent;
 
 /* Frees the Client struct  */

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -11,6 +11,8 @@
 #ifndef CAGENTD_H
 #define CAGENTD_H
 
+#include "shared.h"
+
 typedef struct agent_flags_t {
     unsigned int auto_restart:1;
     unsigned int remote_conf:1;
@@ -21,29 +23,6 @@ typedef struct agent_server {
     int port;
     int protocol;
 } agent_server;
-
-typedef struct w_enrollment_target {
-    char *manager_name;
-    int port;
-    char *agent_name;
-    char *centralized_group;
-    char *sender_ip;
-} w_enrollment_target;
-
-typedef struct w_enrollment_cert {
-    char *ciphers;
-    char *authpass;
-    char *agent_cert;
-    char *agent_key;
-    char *ca_cert;
-    unsigned int auto_method:1;
-} w_enrollment_cert;
-
-typedef struct w_enrollment_cfg {
-    w_enrollment_target target;
-    w_enrollment_cert certificates;
-    unsigned int enabled:1;
-} w_enrollment_cfg;
 
 /* Configuration structure */
 typedef struct _agent {
@@ -63,7 +42,7 @@ typedef struct _agent {
     int crypto_method;
     wlabel_t *labels; /* null-ended label set */
     agent_flags_t flags;
-    w_enrollment_cfg enrollment_cfg;
+    w_enrollment_ctx *enrollment_cfg;
 } agent;
 
 /* Frees the Client struct  */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -254,6 +254,7 @@
 #define AG_MAX_ERROR    "(4110): Maximum number of agents '%d' reached."
 #define AG_AX_AGENTS    "(4111): Maximum number of agents allowed: '%d'."
 #define AG_INV_MNGIP    "(4112): Invalid server address found: '%s'"
+#define AG_ENROLL_FAIL  "(4113): Auto Enrollment configuration failed." 
 
 /* Rules reading errors */
 #define RL_INV_ROOT     "(5101): Invalid root element: '%s'."

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -75,10 +75,20 @@ typedef struct _enrollment_ctx {
 w_enrollment_target *w_enrollment_target_init();
 
 /**
+ * Frees enrollment_target structure
+ * */
+void w_enrollment_target_destroy(w_enrollment_target *target);
+
+/**
  * Default initialization of w_enrollment_cert
  * structure
  * */
 w_enrollment_cert *w_enrollment_cert_init();
+
+/**
+ * Frees enrollment_cert structure
+ * */
+void w_enrollment_cert_destroy(w_enrollment_cert *cert);
 
 /**
  * Initializes parameters of an w_enrollment_ctx structure based

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -69,6 +69,18 @@ typedef struct _enrollment_ctx {
 } w_enrollment_ctx;
 
 /**
+ * Default initialization of w_enrollment_target
+ * structure
+ * */
+w_enrollment_target *w_enrollment_target_init();
+
+/**
+ * Default initialization of w_enrollment_cert
+ * structure
+ * */
+w_enrollment_cert *w_enrollment_cert_init();
+
+/**
  * Initializes parameters of an w_enrollment_ctx structure based
  * on a target and certificate configurations
  * */

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -37,6 +37,7 @@ typedef struct _enrollment_target_cfg {
     char *agent_name;         /**> (optional) Name of the agent. In case of NULL enrollment message will send local hostname */
     char *centralized_group;  /**> (optional) In case the agent belong to a group */
     char *sender_ip;          /**> (optional) IP adress or CIDR of the agent. In case of null the manager will use the source ip */
+    int use_src_ip;           /**> (optional) Forces manager to use source ip (-i option in agent_auth)*/
 } w_enrollment_target;
 
 /**
@@ -51,7 +52,8 @@ typedef struct _enrollment_target_cfg {
  */
 typedef struct _enrollment_cert_cfg {
     char *ciphers;     /**> chipers string (default DEFAULT_CIPHERS) */
-    char *authpass;    /**> for password verification */
+    char *authpass_file; /**> password file (default AUTHDPASS_PATH) */
+    char *authpass;    /**> override password file for password verification */
     char *agent_cert;  /**> Agent Certificate (null if not used) */
     char *agent_key;   /**> Agent Key (null if not used) */
     char *ca_cert;     /**> CA Certificate to verificate server (null if not used) */
@@ -62,10 +64,12 @@ typedef struct _enrollment_cert_cfg {
  * @brief Strcture that handles all the enrollment configuration
  * */
 typedef struct _enrollment_ctx {
-    const w_enrollment_target *target_cfg;  /**> for details @see _enrollment_target_cfg */
-    const w_enrollment_cert *cert_cfg;      /**> for details @see _enrollment_cert_cfg */
-    SSL *ssl;                                   /**> will hold the connection instance with the manager */
-    unsigned int enabled:1;
+    w_enrollment_target *target_cfg;  /**> for details @see _enrollment_target_cfg */
+    w_enrollment_cert *cert_cfg;      /**> for details @see _enrollment_cert_cfg */
+    SSL *ssl;                               /**> will hold the connection instance with the manager */
+    unsigned int enabled:1;                 /**> enabled / disables auto_enrollment */
+    unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
+    unsigned int delay_after_enrollment:30;              /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 
 /**
@@ -94,7 +98,7 @@ void w_enrollment_cert_destroy(w_enrollment_cert *cert);
  * Initializes parameters of an w_enrollment_ctx structure based
  * on a target and certificate configurations
  * */
-w_enrollment_ctx * w_enrollment_init(const w_enrollment_target *target, const w_enrollment_cert *cert);
+w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_cert *cert);
 
 /**
  * Frees parameers of an w_enrollment_ctx structure
@@ -107,6 +111,7 @@ void w_enrollment_destroy(w_enrollment_ctx *cfg);
  * 
  * @param cfg configuration @see w_enrollment_ctx
  * @param server_adress (optional) If null server_adress will be obtained from cfg
+ * @return 0 if successfull, -1 on error
  * */
 int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address);
 

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -84,7 +84,6 @@ int main(int argc, char **argv)
     cert_cfg.agent_key = NULL;
     cert_cfg.ca_cert = NULL;
     cert_cfg.auto_method = 0;
-    //char *dir = DEFAULTDIR;
     int use_src_ip = 0;
     char * buf;
     char *server_address = NULL;
@@ -128,7 +127,7 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-g needs an argument");
                 }
-                // dir = optarg; (NEVER USED)
+                mwarn(DEPRECATED_OPTION_WARN,"-D");
                 break;
 #endif
             case 't':

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -48,6 +48,29 @@ static const int ENTRY_NAME = 1;
 static const int ENTRY_IP = 2;
 static const int ENTRY_KEY = 3; 
 
+w_enrollment_target *w_enrollment_target_init() {
+    w_enrollment_target *target_cfg;
+    os_malloc(sizeof(w_enrollment_target), target_cfg);
+    target_cfg->port = DEFAULT_PORT;
+    target_cfg->manager_name = NULL;
+    target_cfg->agent_name = NULL;
+    target_cfg->centralized_group = NULL;
+    target_cfg->sender_ip = NULL;
+    return target_cfg;
+}
+
+w_enrollment_cert *w_enrollment_cert_init(){
+    w_enrollment_cert *cert_cfg;
+    os_malloc(sizeof(w_enrollment_cert), cert_cfg);
+    cert_cfg->ciphers = strdup(DEFAULT_CIPHERS);
+    cert_cfg->authpass = NULL;
+    cert_cfg->agent_cert = NULL;
+    cert_cfg->agent_key = NULL;
+    cert_cfg->ca_cert = NULL;
+    cert_cfg->auto_method = 0;
+    return cert_cfg;
+}
+
 w_enrollment_ctx * w_enrollment_init(const w_enrollment_target *target, const w_enrollment_cert *cert) {
     assert(target != NULL);
     assert(cert != NULL);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -59,6 +59,14 @@ w_enrollment_target *w_enrollment_target_init() {
     return target_cfg;
 }
 
+void w_enrollment_target_destroy(w_enrollment_target *target_cfg) {
+    os_free(target_cfg->manager_name);
+    os_free(target_cfg->agent_name);
+    os_free(target_cfg->centralized_group);
+    os_free(target_cfg->sender_ip);
+    os_free(target_cfg);
+}
+
 w_enrollment_cert *w_enrollment_cert_init(){
     w_enrollment_cert *cert_cfg;
     os_malloc(sizeof(w_enrollment_cert), cert_cfg);
@@ -69,6 +77,15 @@ w_enrollment_cert *w_enrollment_cert_init(){
     cert_cfg->ca_cert = NULL;
     cert_cfg->auto_method = 0;
     return cert_cfg;
+}
+
+void w_enrollment_cert_destroy(w_enrollment_cert *cert_cfg) {
+    os_free(cert_cfg->ciphers);
+    os_free(cert_cfg->authpass);
+    os_free(cert_cfg->agent_cert);
+    os_free(cert_cfg->agent_key);
+    os_free(cert_cfg->ca_cert);
+    os_free(cert_cfg);
 }
 
 w_enrollment_ctx * w_enrollment_init(const w_enrollment_target *target, const w_enrollment_cert *cert) {
@@ -246,7 +263,7 @@ static int w_enrollment_send_message(w_enrollment_ctx *cfg) {
 
     os_free(buf);
     if(lhostname != cfg->target_cfg->agent_name)
-            os_free(lhostname);
+        os_free(lhostname);
     return 0;
 }
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -49,6 +49,8 @@ static const int ENTRY_IP = 2;
 static const int ENTRY_KEY = 3; 
 
 w_enrollment_ctx * w_enrollment_init(const w_enrollment_target *target, const w_enrollment_cert *cert) {
+    assert(target != NULL);
+    assert(cert != NULL);
     w_enrollment_ctx *cfg;
     os_malloc(sizeof(w_enrollment_ctx), cfg);
     // Copy constructor for const parameters
@@ -63,6 +65,7 @@ w_enrollment_ctx * w_enrollment_init(const w_enrollment_target *target, const w_
 }
 
 void w_enrollment_destroy(w_enrollment_ctx *cfg) {
+    assert(cfg != NULL);
     if (cfg->ssl) {
         BIO *bio = SSL_get_rbio(cfg->ssl);
         if (bio) {

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -38,9 +38,11 @@ static int w_enrollment_process_response(SSL *ssl);
 /* Auxiliary */
 static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);
 static void w_enrollment_concat_group(char *buff, const char* centralized_group);
-static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip);
+static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const int use_src_ip);
 static int w_enrollment_process_agent_key(char *buffer);
 static int w_enrollment_store_key_entry(const char* keys);
+static char *w_enrollment_extract_agent_name(const w_enrollment_ctx *cfg);
+static void w_enrollment_load_pass(w_enrollment_cert *cert_cfg);
 
 /* Constants */
 static const int ENTRY_ID = 0;
@@ -56,6 +58,7 @@ w_enrollment_target *w_enrollment_target_init() {
     target_cfg->agent_name = NULL;
     target_cfg->centralized_group = NULL;
     target_cfg->sender_ip = NULL;
+    target_cfg->use_src_ip = 0;
     return target_cfg;
 }
 
@@ -71,6 +74,7 @@ w_enrollment_cert *w_enrollment_cert_init(){
     w_enrollment_cert *cert_cfg;
     os_malloc(sizeof(w_enrollment_cert), cert_cfg);
     cert_cfg->ciphers = strdup(DEFAULT_CIPHERS);
+    cert_cfg->authpass_file = strdup(AUTHDPASS_PATH);
     cert_cfg->authpass = NULL;
     cert_cfg->agent_cert = NULL;
     cert_cfg->agent_key = NULL;
@@ -81,6 +85,7 @@ w_enrollment_cert *w_enrollment_cert_init(){
 
 void w_enrollment_cert_destroy(w_enrollment_cert *cert_cfg) {
     os_free(cert_cfg->ciphers);
+    os_free(cert_cfg->authpass_file);
     os_free(cert_cfg->authpass);
     os_free(cert_cfg->agent_cert);
     os_free(cert_cfg->agent_key);
@@ -88,45 +93,83 @@ void w_enrollment_cert_destroy(w_enrollment_cert *cert_cfg) {
     os_free(cert_cfg);
 }
 
-w_enrollment_ctx * w_enrollment_init(const w_enrollment_target *target, const w_enrollment_cert *cert) {
+w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_cert *cert) {
     assert(target != NULL);
     assert(cert != NULL);
     w_enrollment_ctx *cfg;
     os_malloc(sizeof(w_enrollment_ctx), cfg);
-    // Copy constructor for const parameters
-    w_enrollment_ctx init = {
-        .target_cfg = target,
-        .cert_cfg = cert
-    };
-    memcpy(cfg, &init, sizeof(w_enrollment_ctx));
+    cfg->target_cfg = target;
+    cfg->cert_cfg = cert;
     cfg->enabled = 1;
     cfg->ssl = NULL;
+    cfg->allow_localhost = 1;
+    cfg->delay_after_enrollment = 20;
     return cfg;
 }
 
 void w_enrollment_destroy(w_enrollment_ctx *cfg) {
     assert(cfg != NULL);
-    if (cfg->ssl) {
-        BIO *bio = SSL_get_rbio(cfg->ssl);
-        if (bio) {
-            BIO_free(bio);
-        }
-        SSL_free(cfg->ssl);
-    }
     os_free(cfg);
 }
 
 int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address) {
     assert(cfg != NULL);
     int ret = -1;
+    minfo("Starting enrollment process to server: %s", server_address ? server_address : cfg->target_cfg->manager_name);
     int socket = w_enrollment_connect(cfg, server_address ? server_address : cfg->target_cfg->manager_name);
     if ( socket >= 0) {
+        w_enrollment_load_pass(cfg->cert_cfg);
         if (w_enrollment_send_message(cfg) == 0) {
             ret = w_enrollment_process_response(cfg->ssl);
         }
-        close(socket);
+        OS_CloseSocket(socket);
+    }
+    if (cfg->ssl) {
+        SSL_free(cfg->ssl);
+        cfg->ssl = NULL;
     }
     return ret;
+}
+
+/**
+ * @brief Retrieves agent name. If no agent_name has been extracted it will 
+ * be obtained by obtaining hostname
+ * 
+ * @param cfg configuration structure
+ * @param allow_localhost 1 will allow localhost as name, 0 will throw an merror_exit
+ * @return agent_name on succes
+ *         NULL on errors
+ * */
+static char *w_enrollment_extract_agent_name(const w_enrollment_ctx *cfg) {
+    char *lhostname = NULL;
+    /* agent_name extraction */
+    if (cfg->target_cfg->agent_name == NULL) {
+        os_malloc(513, lhostname);
+        lhostname[512] = '\0';
+        if (gethostname(lhostname, 512 - 1) != 0) {
+            merror("Unable to extract hostname. Custom agent name not set.");
+            os_free(lhostname);
+            return NULL;
+        }
+        OS_ConvertToValidAgentName(lhostname);
+    } else {
+        lhostname = cfg->target_cfg->agent_name;
+    }
+
+    if(!cfg->allow_localhost && (strcmp(lhostname, "localhost") == 0)) {
+        merror(AG_INV_HOST, lhostname);
+        if(lhostname != cfg->target_cfg->agent_name)
+            os_free(lhostname);
+        return NULL;
+    }
+
+    if (!OS_IsValidName(lhostname)) {
+        merror("Invalid agent name \"%s\". Please pick a valid name.", lhostname);
+        if(lhostname != cfg->target_cfg->agent_name)
+            os_free(lhostname);
+        return NULL;
+    }
+    return lhostname;
 }
 
 /**
@@ -143,7 +186,17 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     assert(cfg != NULL);
     assert(server_address != NULL);
 
-    char *ip_address = OS_GetHost(server_address, 3);
+    char *ip_address = NULL;
+    char *tmp_str = strchr(server_address, '/'); 
+    if (tmp_str) {
+        // server_address comes in {hostname}/{ip} fomat
+        ip_address = strdup(++tmp_str);
+    }
+    if(!ip_address){
+        // server_address is either a host or a ip
+        ip_address = OS_GetHost(server_address, 3);
+    }
+    
     /* Translate hostname to an ip_adress */
     if (!ip_address) {
         merror("Could not resolve hostname: %s\n", server_address);
@@ -202,27 +255,11 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
  */
 static int w_enrollment_send_message(w_enrollment_ctx *cfg) {
     assert(cfg != NULL);
-    char *lhostname = NULL;
-    /* agent_name extraction */
-    if (cfg->target_cfg->agent_name == NULL) {
-        os_malloc(513, lhostname);
-        lhostname[512] = '\0';
-        if (gethostname(lhostname, 512 - 1) != 0) {
-            merror("Unable to extract hostname. Custom agent name not set.");
-            os_free(lhostname);
-            return -1;
-        }
-        OS_ConvertToValidAgentName(lhostname);
-    } else {
-        lhostname = cfg->target_cfg->agent_name;
-    }
-
-    if (!OS_IsValidName(lhostname)) {
-        merror("Invalid agent name \"%s\". Please pick a valid name.", lhostname);
-        if(lhostname != cfg->target_cfg->agent_name)
-            os_free(lhostname);
+    char *lhostname = w_enrollment_extract_agent_name(cfg);
+    if (!lhostname) {
         return -1;
     }
+    
     minfo("Using agent name as: %s", lhostname);
 
     /* Message formation */
@@ -240,7 +277,7 @@ static int w_enrollment_send_message(w_enrollment_ctx *cfg) {
         w_enrollment_concat_group(buf, cfg->target_cfg->centralized_group);
     }
 
-    if(w_enrollment_concat_src_ip(buf, cfg->target_cfg->sender_ip)) {
+    if(w_enrollment_concat_src_ip(buf, cfg->target_cfg->sender_ip, cfg->target_cfg->use_src_ip)) {
         os_free(buf);
         if(lhostname != cfg->target_cfg->agent_name)
             os_free(lhostname);
@@ -333,16 +370,36 @@ static int w_enrollment_process_response(SSL *ssl) {
  * */
 static int w_enrollment_store_key_entry(const char* keys) {
     assert(keys != NULL);
+
+#ifdef WIN32
     FILE *fp;
-    umask(0026);
     fp = fopen(KEYSFILE_PATH, "w");
 
     if (!fp) {
-        merror("Unable to open key file: %s", KEYSFILE_PATH);
+        merror(FOPEN_ERROR, KEYSFILE_PATH, errno, strerror(errno));
         return -1;
     }
     fprintf(fp, "%s\n", keys);
     fclose(fp);
+
+#else /* !WIN32 */
+    File file;
+
+    if (TempFile(&file, isChroot() ? AUTH_FILE : KEYSFILE_PATH, 0) < 0) {        
+        merror(FOPEN_ERROR, isChroot() ? AUTH_FILE : KEYSFILE_PATH, errno, strerror(errno));
+        return -1;
+    }
+    fprintf(file.fp, "%s\n", keys);    
+    fclose(file.fp);
+    
+    if (OS_MoveFile(file.name, isChroot() ? AUTH_FILE : KEYSFILE_PATH) < 0) {
+        free(file.name);
+        return -1;
+    }
+    free(file.name);
+
+#endif /* !WIN32 */
+
     return 0;
 }
 
@@ -435,25 +492,62 @@ static void w_enrollment_concat_group(char *buff, const char* centralized_group)
  * @return 0 on success
  *        -1 if ip is invalid 
  */
-static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip) {
+static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const int use_src_ip) {
     assert(buff != NULL); // buff should not be NULL.
 
-    if(sender_ip){
-		/* Check if this is strictly an IP address using a regex */
-		if (OS_IsValidIP(sender_ip, NULL))
-		{
-			char opt_buf[256] = {0};
-			snprintf(opt_buf,254," IP:'%s'",sender_ip);
-			strncat(buff,opt_buf,254);
-		} else {
-			merror("Invalid IP address provided for sender IP.");
-			return -1;
-		}
-    } else {
+    if(sender_ip && !use_src_ip) { // Force an IP  
+        /* Check if this is strictly an IP address using a regex */
+        if (OS_IsValidIP(sender_ip, NULL))
+        {
+            char opt_buf[256] = {0};
+            snprintf(opt_buf,254," IP:'%s'",sender_ip);
+            strncat(buff,opt_buf,254);
+        } else {
+            merror("Invalid IP address provided for sender IP.");
+            return -1;
+        }
+    } else if (!sender_ip && use_src_ip){ // Force src IP
         char opt_buf[10] = {0};
         snprintf(opt_buf,10," IP:'src'");
         strncat(buff,opt_buf,10);
+    } else if (sender_ip && use_src_ip) { // Incompatible options
+        merror("Incompatible sender_ip options: Forcing IP while using use_source_ip flag.");
+        return -1;
     }
 
     return 0;
+}
+
+/**
+ * Loads enrollment password
+ * If no override pass is set checks in authpass_file
+ * @param cert_cfg certificate configuration
+ * */
+static void w_enrollment_load_pass(w_enrollment_cert *cert_cfg) {
+    assert(cert_cfg != NULL);
+    /* Checking if there is a custom password file */
+    if (cert_cfg->authpass == NULL) {
+        FILE *fp;
+        fp = fopen(cert_cfg->authpass_file, "r");
+
+        if (fp) {
+            char buf[4096];
+            char *ret = fgets(buf, 4095, fp);
+
+            if (ret && strlen(buf) > 2) {
+                /* Remove newline */
+                if (buf[strlen(buf) - 1] == '\n')
+                    buf[strlen(buf) - 1] = '\0';
+
+                cert_cfg->authpass = strdup(buf);
+            }
+
+            fclose(fp);
+            minfo("Using password specified on file: %s", cert_cfg->authpass_file);
+        }
+
+        if (!cert_cfg->authpass) {
+            minfo("No authentication password provided.");
+        }
+    }
 }

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -17,7 +17,8 @@ set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwa
                                 -Wl,--wrap=_minfo,--wrap=OS_GetHost,--wrap=os_ssl_keys,--wrap=OS_ConnectTCP \
                                 -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
                                 -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
-                                -Wl,--wrap=BIO_new_socket")
+                                -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile \
+                                -Wl,--wrap=fgets")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS}")
 else()

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -200,13 +200,13 @@ int test_teardown_concats(void **state) {
 
 // Setup
 int test_setup_context(void **state) {
-    os_malloc(sizeof(w_enrollment_target), local_target);
+    local_target = w_enrollment_target_init();
     local_target->manager_name = strdup("valid_hostname");
     local_target->agent_name = NULL;
     local_target->sender_ip = NULL;
     local_target->port = 1234; 
     local_target->centralized_group = NULL;
-    os_malloc(sizeof(w_enrollment_cert), local_cert);
+    local_cert = w_enrollment_cert_init();
     local_cert->ciphers = DEFAULT_CIPHERS;
     local_cert->auto_method = 0;
     local_cert->authpass = NULL;
@@ -234,13 +234,13 @@ int test_teardown_context(void **state) {
 
 //Setup
 int test_setup_context_2(void **state) {
-    os_malloc(sizeof(w_enrollment_target), local_target);
+    local_target = w_enrollment_target_init();
     local_target->manager_name = strdup("valid_hostname");
     local_target->agent_name = strdup("test_agent");
     local_target->sender_ip = "192.168.1.1";
     local_target->port = 1234; 
     local_target->centralized_group = "test_group";
-    os_malloc(sizeof(w_enrollment_cert), local_cert);
+    local_cert = w_enrollment_cert_init();
     local_cert->ciphers = DEFAULT_CIPHERS;
     local_cert->auto_method = 0;
     local_cert->authpass = "test_password";
@@ -274,13 +274,13 @@ int test_setup_context_3(void **state) {
 
 //Setup
 int test_setup_w_enrolment_request_key(void **state) {
-    os_malloc(sizeof(w_enrollment_target), local_target);
+    local_target = w_enrollment_target_init();
     local_target->manager_name = strdup("valid_hostname");
     local_target->agent_name = "test_agent";
     local_target->sender_ip = "192.168.1.1";
     local_target->port = 1234; 
     local_target->centralized_group = "test_group";
-    os_malloc(sizeof(w_enrollment_cert), local_cert);
+    local_cert = w_enrollment_cert_init();
     local_cert->ciphers = DEFAULT_CIPHERS;
     local_cert->auto_method = 0;
     local_cert->authpass = "test_password";

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -15,7 +15,7 @@
     static int flag_fopen = 0;
 #endif
 
-extern int w_enrollment_concat_src_ip(char *buff, const char* sender_ip);
+extern int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const int use_src_ip);
 extern void w_enrollment_concat_group(char *buff, const char* centralized_group);
 extern void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);
 extern int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_address);
@@ -23,9 +23,9 @@ extern int w_enrollment_send_message(w_enrollment_ctx *cfg);
 extern int w_enrollment_store_key_entry(const char* keys);
 extern int w_enrollment_process_agent_key(char *buffer);
 extern int w_enrollment_process_response(SSL *ssl);
+extern char *w_enrollment_extract_agent_name(const w_enrollment_ctx *cfg);
+extern void w_enrollment_load_pass(w_enrollment_cert *cert_cfg);
 
-static w_enrollment_target* local_target;
-static w_enrollment_cert* local_cert;
 /*************** WRAPS ************************/
 void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
     char formatted_msg[OS_MAXSTR];
@@ -58,6 +58,19 @@ void __wrap__minfo(const char * file, int line, const char * func, const char *m
     va_end(args);
 
     check_expected(formatted_msg);
+}
+
+void __wrap__merror_exit(const char * file, int line, const char * func, const char *msg, ...) 
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+    return;
 }
 
 int __wrap_OS_IsValidIP(const char *ip_address, os_ip *final_ip) {
@@ -142,6 +155,16 @@ FILE * __wrap_fopen ( const char * filename, const char * mode ) {
     return mock_ptr_type(FILE *);
 }
 
+extern char * __real_fgets(char * buf, int size, FILE *stream);
+char * __wrap_fgets(char * buf, int size, FILE *stream) {
+    if(!flag_fopen)
+        return __real_fgets(buf, size, stream);
+    snprintf(buf, size, "%s", mock_ptr_type(char*));
+    check_expected(size);
+    check_expected(stream);
+    return mock_ptr_type(char *);
+}
+
 extern int __real_fclose ( FILE * stream );
 int __wrap_fclose ( FILE * stream ) {
     if(!flag_fopen)
@@ -150,7 +173,21 @@ int __wrap_fclose ( FILE * stream ) {
 }
 
 int __wrap_gethostname(char *name, int len) {
-    snprintf(name, len, "%s",mock_ptr_type(char*));
+    snprintf(name, len, "%s",mock_type(char*));
+    return mock_type(int);
+}
+
+int __wrap_TempFile(File *file, const char *source, int copy) {
+    file->name = mock_type(char *);
+    file->fp = mock_type(FILE *);
+    check_expected(source);
+    check_expected(copy);
+    return mock_type(int);
+}
+
+int __wrap_OS_MoveFile(const char *src, const char *dst) {
+    check_expected(src);
+    check_expected(dst);
     return mock_type(int);
 }
 
@@ -200,16 +237,15 @@ int test_teardown_concats(void **state) {
 
 // Setup
 int test_setup_context(void **state) {
+    w_enrollment_target* local_target; 
     local_target = w_enrollment_target_init();
     local_target->manager_name = strdup("valid_hostname");
     local_target->agent_name = NULL;
     local_target->sender_ip = NULL;
     local_target->port = 1234; 
     local_target->centralized_group = NULL;
+    w_enrollment_cert* local_cert;
     local_cert = w_enrollment_cert_init();
-    local_cert->ciphers = DEFAULT_CIPHERS;
-    local_cert->auto_method = 0;
-    local_cert->authpass = NULL;
     local_cert->agent_cert = strdup("CERT");
     local_cert->agent_key = strdup("KEY");
     local_cert->ca_cert = strdup("CA_CERT");
@@ -221,28 +257,32 @@ int test_setup_context(void **state) {
 //Teardown 
 int test_teardown_context(void **state) {
     w_enrollment_ctx *cfg = *state;
-    os_free(local_target->manager_name);
-    os_free(local_target->agent_name);
-    os_free(local_target);
-    os_free(local_cert->agent_cert);
-    os_free(local_cert->agent_key);
-    os_free(local_cert->ca_cert);
-    os_free(local_cert);
+    os_free(cfg->target_cfg->manager_name);
+    os_free(cfg->target_cfg->agent_name);
+    os_free(cfg->target_cfg);
+    os_free(cfg->cert_cfg->agent_cert);
+    os_free(cfg->cert_cfg->agent_key);
+    os_free(cfg->cert_cfg->ca_cert);
+    os_free(cfg->cert_cfg->ciphers);
+    os_free(cfg->cert_cfg);
+    if(cfg->ssl) {
+        SSL_free(cfg->ssl);
+    }
     w_enrollment_destroy(cfg);
     return 0;
 }
 
 //Setup
 int test_setup_context_2(void **state) {
+    w_enrollment_target* local_target;
     local_target = w_enrollment_target_init();
     local_target->manager_name = strdup("valid_hostname");
     local_target->agent_name = strdup("test_agent");
     local_target->sender_ip = "192.168.1.1";
     local_target->port = 1234; 
     local_target->centralized_group = "test_group";
+    w_enrollment_cert* local_cert;
     local_cert = w_enrollment_cert_init();
-    local_cert->ciphers = DEFAULT_CIPHERS;
-    local_cert->auto_method = 0;
     local_cert->authpass = "test_password";
     local_cert->agent_cert = strdup("CERT");
     local_cert->agent_key = strdup("KEY");
@@ -254,16 +294,15 @@ int test_setup_context_2(void **state) {
 
 //Setup 
 int test_setup_context_3(void **state) {
-    os_malloc(sizeof(w_enrollment_target), local_target);
+    w_enrollment_target* local_target;
+    local_target = w_enrollment_target_init();
     local_target->manager_name = strdup("valid_hostname");
     local_target->agent_name = strdup("Invalid\'!@Hostname\'");
     local_target->sender_ip = NULL;
     local_target->port = 1234; 
     local_target->centralized_group = NULL;
-    os_malloc(sizeof(w_enrollment_cert), local_cert);
-    local_cert->ciphers = DEFAULT_CIPHERS;
-    local_cert->auto_method = 0;
-    local_cert->authpass = NULL;
+    w_enrollment_cert* local_cert;
+    local_cert = w_enrollment_cert_init();
     local_cert->agent_cert = strdup("CERT");
     local_cert->agent_key = strdup("KEY");
     local_cert->ca_cert = strdup("CA_CERT");
@@ -274,14 +313,15 @@ int test_setup_context_3(void **state) {
 
 //Setup
 int test_setup_w_enrolment_request_key(void **state) {
+    w_enrollment_target* local_target;
     local_target = w_enrollment_target_init();
     local_target->manager_name = strdup("valid_hostname");
     local_target->agent_name = "test_agent";
     local_target->sender_ip = "192.168.1.1";
     local_target->port = 1234; 
     local_target->centralized_group = "test_group";
+    w_enrollment_cert* local_cert;
     local_cert = w_enrollment_cert_init();
-    local_cert->ciphers = DEFAULT_CIPHERS;
     local_cert->auto_method = 0;
     local_cert->authpass = "test_password";
     local_cert->agent_cert = strdup("CERT");
@@ -296,12 +336,13 @@ int test_setup_w_enrolment_request_key(void **state) {
 //Teardown
 int test_teardown_w_enrolment_request_key(void **state){
     w_enrollment_ctx *cfg = *state;
-    os_free(local_target->manager_name);
-    os_free(local_target);
-    os_free(local_cert->agent_cert);
-    os_free(local_cert->agent_key);
-    os_free(local_cert->ca_cert);
-    os_free(local_cert);
+    os_free(cfg->target_cfg->manager_name);
+    os_free(cfg->target_cfg);
+    os_free(cfg->cert_cfg->agent_cert);
+    os_free(cfg->cert_cfg->agent_key);
+    os_free(cfg->cert_cfg->ca_cert);
+    os_free(cfg->cert_cfg->ciphers);
+    os_free(cfg->cert_cfg);
     w_enrollment_destroy(cfg);
     flag_fopen = 0;
     return 0;
@@ -322,6 +363,23 @@ int test_teardow_ssl_context(void **state) {
     teardown_file_ops(state);
     return 0;
 }
+
+int test_setup_enrollment_load_pass(void **state) {
+    w_enrollment_cert *cert_cfg = w_enrollment_cert_init();
+    *state = cert_cfg;
+    flag_fopen = 1;
+    return 0;
+}
+
+int test_teardown_enrollment_load_pass(void **state) {
+    w_enrollment_cert *cert_cfg;
+    cert_cfg = *state;
+    os_free(cert_cfg->authpass);
+    os_free(cert_cfg->authpass_file);
+    os_free(cert_cfg);
+    flag_fopen = 0;
+    return 0;
+}
 /**********************************************/
 /************* w_enrollment_concat_src_ip ****************/
 void test_w_enrollment_concat_src_ip_invalid_ip(void **state) {
@@ -332,7 +390,7 @@ void test_w_enrollment_concat_src_ip_invalid_ip(void **state) {
     will_return(__wrap_OS_IsValidIP, 0);
 
     expect_string(__wrap__merror, formatted_msg, "Invalid IP address provided for sender IP.");
-    int ret = w_enrollment_concat_src_ip(buf, sender_ip);
+    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 0);
     assert_int_equal(ret, -1);
 }
 
@@ -343,7 +401,7 @@ void test_w_enrollment_concat_src_ip_valid_ip(void **state) {
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
 
-    int ret = w_enrollment_concat_src_ip(buf, sender_ip);
+    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(buf, " IP:'192.168.1.1'");
 }
@@ -352,13 +410,33 @@ void test_w_enrollment_concat_src_ip_empty_ip(void **state) {
     char *buf = *state;
     const char* sender_ip = NULL;
 
-    int ret = w_enrollment_concat_src_ip(buf, sender_ip);
+    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 1);
     assert_int_equal(ret, 0);
     assert_string_equal(buf, " IP:'src'");
 }
 
+void test_w_enrollment_concat_src_ip_incomaptible_opt(void **state) {
+    char *buf = *state;
+    const char* sender_ip ="192.168.1.1";
+
+    expect_string(__wrap__merror, formatted_msg, "Incompatible sender_ip options: Forcing IP while using use_source_ip flag.");
+    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 1);
+    assert_int_equal(ret, -1);
+   
+}
+
+void test_w_enrollment_concat_src_ip_default(void **state) {
+    char *buf = *state;
+    const char* sender_ip = NULL;
+
+    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal(buf, "");
+   
+}
+
 void test_w_enrollment_concat_src_ip_empty_buff(void **state) {
-    expect_assert_failure(w_enrollment_concat_src_ip(NULL, NULL));
+    expect_assert_failure(w_enrollment_concat_src_ip(NULL, NULL, 0));
 }
 /**********************************************/
 /************* w_enrollment_concat_group ****************/
@@ -593,7 +671,7 @@ void test_w_enrollment_send_message_fix_invalid_hostname(void **state) {
     // If gethostname returns an invalid string should be fixed by OS_ConvertToValidAgentName
     expect_string(__wrap__minfo, formatted_msg, "Using agent name as: InvalidHostname");
     expect_value(__wrap_SSL_write, ssl, cfg->ssl);
-    expect_string(__wrap_SSL_write, buf, "OSSEC A:'InvalidHostname' IP:'src'\n");
+    expect_string(__wrap_SSL_write, buf, "OSSEC A:'InvalidHostname'\n");
     will_return(__wrap_SSL_write, -1);
     expect_string(__wrap__merror, formatted_msg, "SSL write error (unable to send message.)");
     expect_string(__wrap__merror, formatted_msg, "If Agent verification is enabled, agent key and certifiates are required!");
@@ -612,7 +690,7 @@ void test_w_enrollment_send_message_ssl_error(void **state) {
     #endif
     expect_string(__wrap__minfo, formatted_msg, "Using agent name as: host.name");
     expect_value(__wrap_SSL_write, ssl, cfg->ssl);
-    expect_string(__wrap_SSL_write, buf, "OSSEC A:'host.name' IP:'src'\n");
+    expect_string(__wrap_SSL_write, buf, "OSSEC A:'host.name'\n");
     will_return(__wrap_SSL_write, -1);
     expect_string(__wrap__merror, formatted_msg, "SSL write error (unable to send message.)");
     expect_string(__wrap__merror, formatted_msg, "If Agent verification is enabled, agent key and certifiates are required!");
@@ -643,10 +721,18 @@ void test_w_enrollment_store_key_entry_null_key(void **state) {
 void test_w_enrollment_store_key_entry_cannot_open(void **state) {
     const char* key_string = "KEY EXAMPLE STRING";
     char key_file[1024];
+    #ifdef WIN32
     expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 0);
-    snprintf(key_file, 1024, "Unable to open key file: %s", KEYSFILE_PATH);
+    #else
+    expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+    expect_value(__wrap_TempFile, copy, 0);
+    will_return(__wrap_TempFile, NULL);
+    will_return(__wrap_TempFile, NULL);
+    will_return(__wrap_TempFile, -1);
+    #endif
+    snprintf(key_file, 1024, "(1103): Could not open file '%s' due to [(2)-(No such file or directory)].", KEYSFILE_PATH);
     expect_string(__wrap__merror, formatted_msg, key_file);
     int ret = w_enrollment_store_key_entry(key_string);
     assert_int_equal(ret, -1);
@@ -655,15 +741,26 @@ void test_w_enrollment_store_key_entry_cannot_open(void **state) {
 void test_w_enrollment_store_key_entry_success(void **state) {
     FILE file;
     const char* key_string = "KEY EXAMPLE STRING";
-    expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, &file);
     #ifdef WIN32 
+        expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+        expect_string(__wrap_fopen, mode, "w");
+        will_return(__wrap_fopen, &file);
+    
         expect_value(wrap_enrollment_op_fprintf, stream, &file);
         expect_string(wrap_enrollment_op_fprintf, formatted_msg, "KEY EXAMPLE STRING\n");
     #else
-        expect_value(__wrap_fprintf, stream, &file);
-        expect_string(__wrap_fprintf, formatted_msg, "KEY EXAMPLE STRING\n"); 
+        expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+        expect_value(__wrap_TempFile, copy, 0);
+        will_return(__wrap_TempFile, strdup("client.keys.temp"));
+        will_return(__wrap_TempFile, 6);
+        will_return(__wrap_TempFile, 0);
+
+        expect_value(__wrap_fprintf, stream, 6);
+        expect_string(__wrap_fprintf, formatted_msg, "KEY EXAMPLE STRING\n");
+
+        expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
+        expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
+        will_return(__wrap_OS_MoveFile, 0);
     #endif
     int ret = w_enrollment_store_key_entry(key_string);
     assert_int_equal(ret, 0);
@@ -699,15 +796,26 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     expect_string(__wrap_OS_IsValidIP, ip_address, "192.168.1.1");
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
-    expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 4);
-    #ifdef WIN32
+    #ifdef WIN32 
+        expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+        expect_string(__wrap_fopen, mode, "w");
+        will_return(__wrap_fopen, 4);
+    
         expect_value(wrap_enrollment_op_fprintf, stream, 4);
         expect_string(wrap_enrollment_op_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
     #else
+        expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+        expect_value(__wrap_TempFile, copy, 0);
+        will_return(__wrap_TempFile, strdup("client.keys.temp"));
+        will_return(__wrap_TempFile, 4);
+        will_return(__wrap_TempFile, 0);
+
         expect_value(__wrap_fprintf, stream, 4);
         expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
+
+        expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
+        expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
+        will_return(__wrap_OS_MoveFile, 0);
     #endif
     expect_string(__wrap__minfo, formatted_msg, "Valid key created. Finished.");
     int ret = w_enrollment_process_agent_key(key);
@@ -763,15 +871,26 @@ void test_w_enrollment_process_response_success(void **state) {
         expect_string(__wrap_OS_IsValidIP, ip_address, "192.168.1.1");
         expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
         will_return(__wrap_OS_IsValidIP, 1);
-        expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
-        expect_string(__wrap_fopen, mode, "w");
-        will_return(__wrap_fopen, 4);
-        #ifdef WIN32
+        #ifdef WIN32 
+            expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+            expect_string(__wrap_fopen, mode, "w");
+            will_return(__wrap_fopen, 4);
+        
             expect_value(wrap_enrollment_op_fprintf, stream, 4);
             expect_string(wrap_enrollment_op_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
-        #else 
+        #else
+            expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+            expect_value(__wrap_TempFile, copy, 0);
+            will_return(__wrap_TempFile, strdup("client.keys.temp"));
+            will_return(__wrap_TempFile, 4);
+            will_return(__wrap_TempFile, 0);
+
             expect_value(__wrap_fprintf, stream, 4);
             expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
+
+            expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
+            expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
+            will_return(__wrap_OS_MoveFile, 0);
         #endif
         expect_string(__wrap__minfo, formatted_msg, "Valid key created. Finished.");
     }
@@ -792,6 +911,8 @@ void test_w_enrollment_request_key(void **state) {
     w_enrollment_ctx *cfg = *state; 
     SSL_CTX *ctx = get_ssl_context(DEFAULT_CIPHERS, 0);
     
+    expect_string(__wrap__minfo, formatted_msg, "Starting enrollment process to server: valid_hostname");
+
     // w_enrollment_connect
     {
         // GetHost
@@ -847,19 +968,29 @@ void test_w_enrollment_request_key(void **state) {
         expect_string(__wrap__minfo, formatted_msg, "Received response with agent key");
         // w_enrollment_process_agent_key
         {
-            FILE file;
             expect_string(__wrap_OS_IsValidIP, ip_address, "192.168.1.1");
             expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
             will_return(__wrap_OS_IsValidIP, 1);
-            expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
-            expect_string(__wrap_fopen, mode, "w");
-            will_return(__wrap_fopen, &file);
-            #ifdef WIN32
-                expect_value(wrap_enrollment_op_fprintf, stream, &file);
+            #ifdef WIN32 
+                expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+                expect_string(__wrap_fopen, mode, "w");
+                will_return(__wrap_fopen, 4);
+            
+                expect_value(wrap_enrollment_op_fprintf, stream, 4);
                 expect_string(wrap_enrollment_op_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
             #else
-                expect_value(__wrap_fprintf, stream, &file);
+                expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+                expect_value(__wrap_TempFile, copy, 0);
+                will_return(__wrap_TempFile, strdup("client.keys.temp"));
+                will_return(__wrap_TempFile, 4);
+                will_return(__wrap_TempFile, 0);
+
+                expect_value(__wrap_fprintf, stream, 4);
                 expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
+
+                expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
+                expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
+                will_return(__wrap_OS_MoveFile, 0);
             #endif
             expect_string(__wrap__minfo, formatted_msg, "Valid key created. Finished.");
         }
@@ -871,6 +1002,85 @@ void test_w_enrollment_request_key(void **state) {
     assert_int_equal(ret, 0);
 }
 /**********************************************/
+/******* w_enrollment_extract_agent_name ********/
+
+void test_w_enrollment_extract_agent_name_localhost_allowed(void **state) {
+    w_enrollment_ctx *cfg = *state; 
+    cfg->allow_localhost = 1; // Allow localhost
+    #ifdef WIN32
+        will_return(wrap_enrollment_op_gethostname, "localhost");
+        will_return(wrap_enrollment_op_gethostname, 0);
+    #else 
+        will_return(__wrap_gethostname, "localhost");
+        will_return(__wrap_gethostname, 0);
+    #endif
+    char *lhostname = w_enrollment_extract_agent_name(cfg);
+    assert_string_equal( lhostname, "localhost");
+    os_free(lhostname);
+}
+
+void test_w_enrollment_extract_agent_name_localhost_not_allowed(void **state) {
+    w_enrollment_ctx *cfg = *state; 
+    cfg->allow_localhost = 0; // Do not allow localhost
+    #ifdef WIN32
+        will_return(wrap_enrollment_op_gethostname, "localhost");
+        will_return(wrap_enrollment_op_gethostname, 0);
+    #else 
+        will_return(__wrap_gethostname, "localhost");
+        will_return(__wrap_gethostname, 0);
+    #endif
+    expect_string(__wrap__merror, formatted_msg, "(4104): Invalid hostname: 'localhost'.");
+
+    char *lhostname = w_enrollment_extract_agent_name(cfg);
+    assert_int_equal( lhostname, NULL);
+}
+/******* w_enrollment_load_pass ********/
+void test_w_enrollment_load_pass_null_cert(void **state) {
+    expect_assert_failure(w_enrollment_load_pass(NULL));
+}
+
+void test_w_enrollment_load_pass_empty_file(void **state) {
+    w_enrollment_cert *cert = *state; 
+    
+    expect_string(__wrap_fopen, filename, AUTHDPASS_PATH);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 4);
+
+    expect_value(__wrap_fgets, size, 4095);
+    expect_value(__wrap_fgets, stream, 4);
+    will_return(__wrap_fgets, "");
+    will_return(__wrap_fgets, NULL);
+    
+    char buff[1024];
+    snprintf(buff, 1024, "Using password specified on file: %s", AUTHDPASS_PATH);
+    expect_string(__wrap__minfo, formatted_msg, buff);
+    expect_string(__wrap__minfo, formatted_msg, "No authentication password provided.");
+    
+    w_enrollment_load_pass(cert);
+    assert_int_equal(cert->authpass, NULL);
+}
+
+void test_w_enrollment_load_pass_file_with_content(void **state) {
+    w_enrollment_cert *cert = *state; 
+    
+    expect_string(__wrap_fopen, filename, AUTHDPASS_PATH);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 4);
+
+    expect_value(__wrap_fgets, size, 4095);
+    expect_value(__wrap_fgets, stream, 4);
+    will_return(__wrap_fgets, "content_password");
+    will_return(__wrap_fgets, "content_password");
+    
+    char buff[1024];
+    snprintf(buff, 1024, "Using password specified on file: %s", AUTHDPASS_PATH);
+    expect_string(__wrap__minfo, formatted_msg, buff);
+    
+    w_enrollment_load_pass(cert);
+    assert_string_equal(cert->authpass, "content_password");
+}
+
+/**********************************************/
 int main()
 {
     const struct CMUnitTest tests[] = 
@@ -879,6 +1089,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_w_enrollment_concat_src_ip_invalid_ip, test_setup_concats, test_teardown_concats),
         cmocka_unit_test_setup_teardown(test_w_enrollment_concat_src_ip_valid_ip, test_setup_concats, test_teardown_concats),
         cmocka_unit_test_setup_teardown(test_w_enrollment_concat_src_ip_empty_ip, test_setup_concats, test_teardown_concats),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_concat_src_ip_incomaptible_opt, test_setup_concats, test_teardown_concats),
         cmocka_unit_test(test_w_enrollment_concat_src_ip_empty_buff),
         // w_enrollment_concat_group
         cmocka_unit_test(test_w_enrollment_concat_group_empty_buff),
@@ -921,7 +1132,14 @@ int main()
         cmocka_unit_test_setup_teardown(test_w_enrollment_process_response_success, test_setup_ssl_context, test_teardow_ssl_context),
         // w_enrollment_request_key (wrapper)
         cmocka_unit_test(test_w_enrollment_request_key_null_cfg),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_request_key, test_setup_w_enrolment_request_key, test_teardown_w_enrolment_request_key)  
+        cmocka_unit_test_setup_teardown(test_w_enrollment_request_key, test_setup_w_enrolment_request_key, test_teardown_w_enrolment_request_key),  
+        // w_enrollment_extract_agent_name
+        cmocka_unit_test_setup_teardown(test_w_enrollment_extract_agent_name_localhost_allowed, test_setup_context, test_teardown_context),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_extract_agent_name_localhost_not_allowed, test_setup_context, test_teardown_context),
+        // w_enrollment_load_pass
+        cmocka_unit_test(test_w_enrollment_load_pass_null_cert),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_load_pass_empty_file, test_setup_enrollment_load_pass, test_teardown_enrollment_load_pass),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_load_pass_file_with_content, test_setup_enrollment_load_pass, test_teardown_enrollment_load_pass),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -296,8 +296,7 @@ BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam,
                 case UI_MENU_MANAGE_START:
 
                     /* Start OSSEC  -- must have a valid config before */
-                    if ((strcmp(config_inst.key, FL_NOKEY) != 0) &&
-                            (strcmp(config_inst.server, FL_NOSERVER) != 0)) {
+                    if (strcmp(config_inst.server, FL_NOSERVER) != 0) {
                         ret_code = os_start_service();
                     } else {
                         ret_code = 0;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -108,9 +108,14 @@ int local_start()
         merror_exit(CONFIG_ERROR, cfg);
     }
 
-    /* Check auth keys */
-    if (!OS_CheckKeys()) {
-        merror_exit(AG_NOKEYS_EXIT);
+    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
+        // If autoenrollment is enabled, we will avoid exit if there is no valid key
+        OS_PassEmptyKeyfile();
+    } else {
+        /* Check auth keys */
+        if (!OS_CheckKeys()) {
+            merror_exit(AG_NOKEYS_EXIT);
+        }
     }
 
     /* If there is no file to monitor, create a clean entry
@@ -153,6 +158,35 @@ int local_start()
     minfo(ENC_READ);
 
     OS_ReadKeys(&keys, 1, 0, 0);
+
+    /* Check if we need to auto-enroll */
+    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
+        int registration_status = -1;
+        int rc = 0;
+
+        if (agt->enrollment_cfg->target_cfg->manager_name) {
+            // Configured enrollment server
+            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
+        } 
+        
+        // Try to enroll to server list
+        while (agt->server[rc].rip && (registration_status != 0)) {
+            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
+            rc++;
+        }
+        
+
+        if(registration_status == 0) {
+            // Wait for key update on agent side
+            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
+            sleep(agt->enrollment_cfg->delay_after_enrollment);
+            // Update keys to get obtained key
+            OS_UpdateKeys(&keys);
+        } else {
+            merror_exit(AG_ENROLL_FAIL);
+        }
+    }
+
     OS_StartCounter(&keys);
     os_write_agent_info(keys.keyentries[0]->name, NULL, keys.keyentries[0]->id, agt->profile);
 


### PR DESCRIPTION
|Related issue|
|---|
| #4899 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds the code for reading all auto-enrollment section variables and integrates changes with the newly created Enrollment Library

## Configuration options

Available configurations are: 

|Option|Values|Required|Default Value|Description|
|---|---|---|---|--|
|`enabled`|`yes` or `no`|`no`|`yes`|Enables/Disables agent auto-enrollment|
|`manager_address`| `string` - Should be valid IP/Hostname |`no`|-|Hostname or IP of the manager where the agent will be enrolled. If no value is set, the agent will try enrolling to the same manager that was specified for connection|
|`port`| `0`...`65535`|`no`|1515|Manager port|
|`agent_name`| `string` - Registration name for the agent|`no`| Hostname of the machine | Agent name that will be used for enrollment|
|`groups`| `string` - Name of one or many valid groups |`no`| NULL | Agent name that will be used for enrollment|
|`agent_address`| `string` - Valid IP | `no` | `src` | Force IP adress from agent. If this is not set manager will extract source IP from enrollment message |
|`ssl_cipher`|`valid ssl ciphers`|`no`| DEFAULT_CIPHERS | Override SSL used ciphers |
|`server_ca_path`| Path to a valid CA certificate | `no` | NULL | Used for manager verification. If no CA certificate is set server will not be verified |
|`agent_certificate_path`| Path to a valid agent certificate file | `no` | NULL | Required when agent verification is enabled in manager | 
|`agent_key_path`| Path to a valid agent key file | `no` |  NULL | Required when agent verification is enabled in manager |
|`authorization_pass_path`| Password file path | `no` | /var/ossec/etc/atuhd.pass (UNIX) aurthd.pass (Windows) | Set a different path to search for password |
|`auto_method`| `yes`, `no` | `no` | `no` | `no` for TLS v1.2 only, `yes` for Auto negotiate the most secure common SSL/TLS method with the manager. | 
|`delay_after_enrollment`|  number of seconds | `no` | `20` | Wait time agentd should wait after a successfull registration | 
|`use_source_ip`|  `yes`, `no`   | `no` | `no` | Forces manager to compute IP from agent message | 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)