### PR TITLE
Large inode numbers having wrong values in dbs

### DIFF
--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -647,7 +647,7 @@ fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt) {
     entry->data->options = (time_t)sqlite3_column_int(stmt, 6);
     strncpy(entry->data->checksum, (char *)sqlite3_column_text(stmt, 7), sizeof(os_sha1) - 1);
     entry->data->dev = (unsigned long int)sqlite3_column_int(stmt, 8);
-    entry->data->inode = (unsigned long int)sqlite3_column_int(stmt, 9);
+    entry->data->inode = (unsigned long int)sqlite3_column_int64(stmt, 9);
     entry->data->size = (unsigned int)sqlite3_column_int(stmt, 10);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 11), entry->data->perm);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 12), entry->data->attributes);
@@ -670,7 +670,7 @@ fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt) {
 void fim_db_bind_insert_data(fdb_t *fim_sql, fim_entry_data *entry) {
 #ifndef WIN32
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_DATA], 1, entry->dev);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_DATA], 2, entry->inode);
+    sqlite3_bind_int64(fim_sql->stmt[FIMDB_STMT_INSERT_DATA], 2, entry->inode);
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_DATA], 3, entry->size);
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_INSERT_DATA], 4, entry->perm, -1, NULL);
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_INSERT_DATA], 5, entry->attributes, -1, NULL);
@@ -721,7 +721,7 @@ void fim_db_bind_path(fdb_t *fim_sql, int index, const char *file_path) {
 void fim_db_bind_get_inode(fdb_t *fim_sql, int index, const unsigned long int inode, const unsigned long int dev) {
     if (index == FIMDB_STMT_GET_PATHS_INODE || index == FIMDB_STMT_GET_PATHS_INODE_COUNT
         || index == FIMDB_STMT_GET_DATA_ROW) {
-        sqlite3_bind_int(fim_sql->stmt[index], 1, inode);
+        sqlite3_bind_int64(fim_sql->stmt[index], 1, inode);
         sqlite3_bind_int(fim_sql->stmt[index], 2, dev);
     }
 }
@@ -939,7 +939,7 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry) 
             it will delete it and insert the new one.
          */
         if (res_inode == SQLITE_ROW) {
-            inode = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_INODE], 0);
+            inode = sqlite3_column_int64(fim_sql->stmt[FIMDB_STMT_GET_INODE], 0);
 
             if (inode != entry->inode) {
                 fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_INODE_ID);

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -195,7 +195,7 @@ set(FIM_DB_BASE_FLAGS "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2
                        -Wl,--wrap=fim_configuration_directory,--wrap=fim_json_event,--wrap=send_syscheck_msg \
                        -Wl,--wrap=delete_target_file,--wrap=_minfo,--wrap=_mdebug1,--wrap=_mdebug2 \
                        -Wl,--wrap=fseek,--wrap=fclose,--wrap=fopen,--wrap=time,--wrap=getpid,--wrap=fflush \
-                       -Wl,--wrap=fgets,--wrap=wstr_escape_json")
+                       -Wl,--wrap=fgets,--wrap=wstr_escape_json,--wrap=sqlite3_bind_int64,--wrap=sqlite3_column_int64")
 
 list(APPEND syscheckd_tests_names "test_fim_db")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/test_fim_db.c
+++ b/src/unit_tests/syscheckd/test_fim_db.c
@@ -908,7 +908,9 @@ void test_fim_db_insert_data_no_rowid_error(void **state) {
     //Inside fim_db_bind_insert_data
     {
         will_return_always(__wrap_sqlite3_bind_int, 0);
+        #ifndef TEST_WINAGENT
         will_return_always(__wrap_sqlite3_bind_int64, 0);
+        #endif
         will_return_always(__wrap_sqlite3_bind_text, 0);
     }
 
@@ -936,7 +938,9 @@ void test_fim_db_insert_data_no_rowid_success(void **state) {
     //Inside fim_db_bind_insert_data
     {
         will_return_always(__wrap_sqlite3_bind_int, 0);
+        #ifndef TEST_WINAGENT
         will_return_always(__wrap_sqlite3_bind_int64, 0);
+        #endif
         will_return_always(__wrap_sqlite3_bind_text, 0);
     }
 

--- a/src/unit_tests/syscheckd/test_fim_db.c
+++ b/src/unit_tests/syscheckd/test_fim_db.c
@@ -297,6 +297,15 @@ int __wrap_delete_target_file() {
     return 1;
 }
 
+int __wrap_sqlite3_bind_int64(sqlite3_stmt *stmt, int index, sqlite3_int64 value) {
+    return mock();
+}
+
+sqlite3_int64 __wrap_sqlite3_column_int64(sqlite3_stmt* stmt, int iCol) {
+    check_expected(iCol);
+    return mock();
+}
+
 #ifdef TEST_AGENT
 char *_read_file(const char *high_name, const char *low_name, const char *defines_file) __attribute__((nonnull(3)));
 
@@ -413,8 +422,8 @@ static void wraps_fim_db_decode_full_row() {
     will_return(__wrap_sqlite3_column_text, "checksum"); // checksum
     expect_value(__wrap_sqlite3_column_int, iCol, 8);
     will_return(__wrap_sqlite3_column_int, 111); // dev
-    expect_value(__wrap_sqlite3_column_int, iCol, 9);
-    will_return(__wrap_sqlite3_column_int, 1024); // inode
+    expect_value(__wrap_sqlite3_column_int64, iCol, 9);
+    will_return(__wrap_sqlite3_column_int64, 1024); // inode
     expect_value(__wrap_sqlite3_column_int, iCol, 10);
     will_return(__wrap_sqlite3_column_int, 4096); // size
     expect_value_count(__wrap_sqlite3_column_text, iCol, 11, 2);
@@ -443,6 +452,8 @@ static void wraps_fim_db_decode_full_row() {
  * Successfully wrappes a wraps_fim_db_insert_data() call
  * */
 static void wraps_fim_db_insert_data_success(int row_id) {
+    will_return(__wrap_sqlite3_bind_int64, 0);
+
     will_return(__wrap_sqlite3_reset, SQLITE_OK);
     will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
@@ -885,31 +896,55 @@ void test_fim_db_clean_success(void **state) {
 /*----------fim_db_insert_data()---------------*/
 void test_fim_db_insert_data_no_rowid_error(void **state) {
     test_fim_db_insert_data *test_data = *state;
-    will_return(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_int, 0);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
+    int ret;
+    int row_id = 0;
+
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
+
+    //Inside fim_db_bind_insert_data
+    {
+        will_return_always(__wrap_sqlite3_bind_int, 0);
+        will_return_always(__wrap_sqlite3_bind_int64, 0);
+        will_return_always(__wrap_sqlite3_bind_text, 0);
+    }
+
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "SQL ERROR: (1)ERROR MESSAGE");
-    int ret;
-    int row_id = 0;
+
     ret = fim_db_insert_data(test_data->fim_sql, test_data->entry->data, &row_id);
+
     assert_int_equal(row_id, 0);
     assert_int_equal(ret, FIMDB_ERR);
 }
 
 void test_fim_db_insert_data_no_rowid_success(void **state) {
     test_fim_db_insert_data *test_data = *state;
-    will_return(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_int, 0);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_DONE);
-    will_return(__wrap_sqlite3_last_insert_rowid, 1);
     int ret;
     int row_id = 0;
+
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
+
+    //Inside fim_db_bind_insert_data
+    {
+        will_return_always(__wrap_sqlite3_bind_int, 0);
+        will_return_always(__wrap_sqlite3_bind_int64, 0);
+        will_return_always(__wrap_sqlite3_bind_text, 0);
+    }
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+    will_return(__wrap_sqlite3_last_insert_rowid, 1);
+
     ret = fim_db_insert_data(test_data->fim_sql, test_data->entry->data, &row_id);
+
     assert_int_equal(row_id, 1);
     assert_int_equal(ret, FIMDB_OK);
 }
@@ -1003,18 +1038,30 @@ void test_fim_db_insert_path_success(void **state) {
 /*----------fim_db_insert()----------------*/
 void test_fim_db_insert_error(void **state) {
     test_fim_db_insert_data *test_data = *state;
-    will_return(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    int ret;
+
+    // Inside fim_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
+
     #ifdef TEST_WINAGENT
     will_return(__wrap_sqlite3_bind_text, 0);
     #else
-    will_return_always(__wrap_sqlite3_bind_int, 0);
+    // Inside fim_db_bind_get_inode
+    {
+        will_return(__wrap_sqlite3_bind_int64, 0);
+        will_return(__wrap_sqlite3_bind_int, 0);
+    }
     #endif
+
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "SQL ERROR: (1)ERROR MESSAGE");
-    int ret;
+
     ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data);
+
     assert_int_equal(ret, FIMDB_ERR);
 }
 
@@ -1048,6 +1095,7 @@ void test_fim_db_insert_inode_id_null(void **state) {
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_bind_int64, 0);
 
     will_return_count(__wrap_sqlite3_step, SQLITE_DONE, 2);
 
@@ -1069,6 +1117,7 @@ void test_fim_db_insert_inode_id_null_error(void **state) {
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_bind_int64, 0);
 
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
@@ -1087,12 +1136,13 @@ void test_fim_db_insert_inode_id_null_delete(void **state) {
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 4);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_bind_int64, 0);
 
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 1);
+    expect_value(__wrap_sqlite3_column_int64, iCol, 0);
+    will_return(__wrap_sqlite3_column_int64, 1);
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
@@ -1121,12 +1171,13 @@ void test_fim_db_insert_inode_id_null_delete_error(void **state) {
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 4);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_bind_int64, 0);
 
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 1);
+    expect_value(__wrap_sqlite3_column_int64, iCol, 0);
+    will_return(__wrap_sqlite3_column_int64, 1);
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
@@ -1149,12 +1200,13 @@ void test_fim_db_insert_inode_id_null_delete_row_error(void **state) {
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 3);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_bind_int64, 0);
 
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 1);
+    expect_value(__wrap_sqlite3_column_int64, iCol, 0);
+    will_return(__wrap_sqlite3_column_int64, 1);
 
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
 
@@ -1768,6 +1820,7 @@ void test_fim_db_get_paths_from_inode_none_path(void **state) {
     will_return_count(__wrap_sqlite3_reset, SQLITE_OK, 2);
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_int64, 0);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     wraps_fim_db_check_transaction();
     char **paths;
@@ -1781,6 +1834,7 @@ void test_fim_db_get_paths_from_inode_single_path(void **state) {
     will_return_count(__wrap_sqlite3_reset, SQLITE_OK, 2);
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_int64, 0);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, 1);
@@ -1801,6 +1855,7 @@ void test_fim_db_get_paths_from_inode_multiple_path(void **state) {
     will_return_count(__wrap_sqlite3_reset, SQLITE_OK, 2);
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_int64, 0);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, 5);
@@ -1833,6 +1888,7 @@ void test_fim_db_get_paths_from_inode_multiple_unamatched_rows(void **state) {
     will_return_count(__wrap_sqlite3_reset, SQLITE_OK, 2);
     will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_int, 0);
+    will_return_always(__wrap_sqlite3_bind_int64, 0);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, 5);

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -9,7 +9,7 @@ list(APPEND wdb_tests_names "test_wdb_fim")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_begin2 \
                         -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,cJSON_IsNumber \
                         -Wl,--wrap,cJSON_IsObject -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_text \
-                        -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_step")
+                        -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_bind_int")
 
 list(APPEND wdb_tests_names "test_wdb_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/test_wdb_fim.c
+++ b/src/unit_tests/wazuh_db/test_wdb_fim.c
@@ -102,8 +102,11 @@ int __wrap_sqlite3_bind_text()
     return mock();
 }
 
-int __wrap_sqlite3_bind_int64()
+int __wrap_sqlite3_bind_int64(sqlite3_stmt *stmt, int index, sqlite3_int64 value)
 {
+    check_expected(index);
+    check_expected(value);
+
     return mock();
 }
 
@@ -112,7 +115,7 @@ int __wrap_sqlite3_step()
     return mock();
 }
 
-int __wrap_sqlite3_bind_int(sqlite3_stmt* stmt, int index, int value) {
+int __wrap_sqlite3_bind_int(sqlite3_stmt *stmt, int index, int value) {
     check_expected(index);
     check_expected(value);
 
@@ -200,6 +203,8 @@ static void test_wdb_syscheck_save2_success(void **state)
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_wdb_stmt_cache, 1);
     will_return(__wrap_sqlite3_bind_text,1);
+    expect_value(__wrap_sqlite3_bind_int64, index, 3);
+    expect_value(__wrap_sqlite3_bind_int64, value, 10);
     will_return(__wrap_sqlite3_bind_int64,0);
     will_return(__wrap_sqlite3_step,101);
     ret = wdb_syscheck_save2(wdb, VALID_ENTRY);
@@ -310,6 +315,8 @@ static void test_wdb_fim_insert_entry2_fail_element_null(void **state)
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_wdb_stmt_cache, 1);
     will_return(__wrap_sqlite3_bind_text, 1);
+    expect_value(__wrap_sqlite3_bind_int64, index, 3);
+    expect_value(__wrap_sqlite3_bind_int64, value, 10);
     will_return(__wrap_sqlite3_bind_int64,0);
     ret = wdb_fim_insert_entry2(wdb, data);
     cJSON_Delete(data);
@@ -331,6 +338,8 @@ static void test_wdb_fim_insert_entry2_fail_element_string(void **state)
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_wdb_stmt_cache, 1);
     will_return(__wrap_sqlite3_bind_text, 1);
+    expect_value(__wrap_sqlite3_bind_int64, index, 3);
+    expect_value(__wrap_sqlite3_bind_int64, value, 10);
     will_return(__wrap_sqlite3_bind_int64,0);
     expect_string(__wrap__merror, formatted_msg, "DB(000) Invalid attribute name: invalid_attribute");
     ret = wdb_fim_insert_entry2(wdb, data);
@@ -353,6 +362,8 @@ static void test_wdb_fim_insert_entry2_fail_element_number(void **state)
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_wdb_stmt_cache, 1);
     will_return(__wrap_sqlite3_bind_text, 1);
+    expect_value(__wrap_sqlite3_bind_int64, index, 3);
+    expect_value(__wrap_sqlite3_bind_int64, value, 10);
     will_return(__wrap_sqlite3_bind_int64,0);
     expect_string(__wrap__merror, formatted_msg, "DB(000) Invalid attribute name: invalid_attribute");
     ret = wdb_fim_insert_entry2(wdb, data);
@@ -371,6 +382,8 @@ static void test_wdb_fim_insert_entry2_fail_sqlite3_stmt(void **state)
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_wdb_stmt_cache, 1);
     will_return(__wrap_sqlite3_bind_text, 1);
+    expect_value(__wrap_sqlite3_bind_int64, index, 3);
+    expect_value(__wrap_sqlite3_bind_int64, value, 10);
     will_return(__wrap_sqlite3_bind_int64,0);
     will_return(__wrap_sqlite3_step,0);
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) sqlite3_step(): out of memory");
@@ -410,17 +423,20 @@ static void test_wdb_fim_insert_entry2_success(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, 2048);
     expect_value(__wrap_sqlite3_bind_int, index, 12);
     expect_value(__wrap_sqlite3_bind_int, value, 10);
-    expect_value(__wrap_sqlite3_bind_int, index, 13);
-    expect_value(__wrap_sqlite3_bind_int, value, 2);
-    will_return_count(__wrap_sqlite3_bind_int, 0, 3);
+    will_return_count(__wrap_sqlite3_bind_int, 0, 2);
 
     will_return(__wrap_cJSON_GetStringValue, "/test");
     will_return(__wrap_cJSON_IsNumber, true);
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_wdb_stmt_cache, 1);
+    expect_value(__wrap_sqlite3_bind_int64, index, 3);
+    expect_value(__wrap_sqlite3_bind_int64, value, 10);
     will_return(__wrap_sqlite3_bind_int64,0);
     will_return(__wrap_sqlite3_step,SQLITE_DONE);
 
+    expect_value(__wrap_sqlite3_bind_int64, index, 13);
+    expect_value(__wrap_sqlite3_bind_int64, value, 2);
+    will_return(__wrap_sqlite3_bind_int64,0);
     will_return_count(__wrap_sqlite3_bind_text, 1, 13);
     ret = wdb_fim_insert_entry2(wdb, data);
     cJSON_Delete(data);
@@ -457,17 +473,21 @@ static void test_wdb_fim_insert_entry2_large_inode(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, 2048);
     expect_value(__wrap_sqlite3_bind_int, index, 12);
     expect_value(__wrap_sqlite3_bind_int, value, 10);
-    expect_value(__wrap_sqlite3_bind_int, index, 13);
-    expect_value(__wrap_sqlite3_bind_int, value, 2311061769);
-    will_return_count(__wrap_sqlite3_bind_int, 0, 3);
+    will_return_count(__wrap_sqlite3_bind_int, 0, 2);
 
     will_return(__wrap_cJSON_GetStringValue, "/test");
     will_return(__wrap_cJSON_IsNumber, true);
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_wdb_stmt_cache, 1);
-    will_return(__wrap_sqlite3_bind_int64,0);
+    expect_value(__wrap_sqlite3_bind_int64, index, 3);
+    expect_value(__wrap_sqlite3_bind_int64, value, 10);
+    will_return(__wrap_sqlite3_bind_int64, 0);
     will_return(__wrap_sqlite3_step,SQLITE_DONE);
 
+
+    expect_value(__wrap_sqlite3_bind_int64, index, 13);
+    expect_value(__wrap_sqlite3_bind_int64, value, 2311061769);
+    will_return(__wrap_sqlite3_bind_int64, 0);
     will_return_count(__wrap_sqlite3_bind_text, 1, 13);
 
     ret = wdb_fim_insert_entry2(wdb, data);

--- a/src/unit_tests/wazuh_db/test_wdb_fim.c
+++ b/src/unit_tests/wazuh_db/test_wdb_fim.c
@@ -112,6 +112,13 @@ int __wrap_sqlite3_step()
     return mock();
 }
 
+int __wrap_sqlite3_bind_int(sqlite3_stmt* stmt, int index, int value) {
+    check_expected(index);
+    check_expected(value);
+
+    return mock();
+}
+
 /* tests */
 
 static void test_wdb_syscheck_save2_wbs_null(void **state)
@@ -375,12 +382,13 @@ static void test_wdb_fim_insert_entry2_fail_sqlite3_stmt(void **state)
 
 static void test_wdb_fim_insert_entry2_success(void **state)
 {
-    int ret, i;
+    int ret;
 
     wdb_t * wdb = *state;
     wdb->agent_id = strdup("000");
     cJSON* data = cJSON_Parse(VALID_ENTRY);
     cJSON *object = cJSON_CreateObject();
+
     cJSON_AddItemToObject(object, "size", cJSON_CreateNumber(2048));
     cJSON_AddItemToObject(object, "mtime", cJSON_CreateNumber(10));
     cJSON_AddItemToObject(object, "inode", cJSON_CreateNumber(2));
@@ -397,15 +405,71 @@ static void test_wdb_fim_insert_entry2_success(void **state)
     cJSON_AddItemToObject(object, "checksum", cJSON_CreateString("GGGGGGGGGGGG"));
     cJSON_AddItemToObject(object, "attributes", cJSON_CreateString("readonly"));
     cJSON_ReplaceItemInObject(data, "attributes", object);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 2048);
+    expect_value(__wrap_sqlite3_bind_int, index, 12);
+    expect_value(__wrap_sqlite3_bind_int, value, 10);
+    expect_value(__wrap_sqlite3_bind_int, index, 13);
+    expect_value(__wrap_sqlite3_bind_int, value, 2);
+    will_return_count(__wrap_sqlite3_bind_int, 0, 3);
+
     will_return(__wrap_cJSON_GetStringValue, "/test");
     will_return(__wrap_cJSON_IsNumber, true);
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_wdb_stmt_cache, 1);
-    will_return(__wrap_sqlite3_bind_text, 1);
     will_return(__wrap_sqlite3_bind_int64,0);
     will_return(__wrap_sqlite3_step,SQLITE_DONE);
-    for(i=0; i<12; i++)
-        will_return(__wrap_sqlite3_bind_text, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, 1, 13);
+    ret = wdb_fim_insert_entry2(wdb, data);
+    cJSON_Delete(data);
+    assert_int_equal(ret, 0);
+}
+
+static void test_wdb_fim_insert_entry2_large_inode(void **state)
+{
+    int ret;
+
+    wdb_t * wdb = *state;
+    wdb->agent_id = strdup("000");
+    cJSON* data = cJSON_Parse(VALID_ENTRY);
+    cJSON *object = cJSON_CreateObject();
+
+    cJSON_AddItemToObject(object, "size", cJSON_CreateNumber(2048));
+    cJSON_AddItemToObject(object, "mtime", cJSON_CreateNumber(10));
+    cJSON_AddItemToObject(object, "inode", cJSON_CreateNumber(2311061769));
+    cJSON_AddItemToObject(object, "type", cJSON_CreateString("test_type"));
+    cJSON_AddItemToObject(object, "perm", cJSON_CreateString("yes"));
+    cJSON_AddItemToObject(object, "uid", cJSON_CreateString("00000"));
+    cJSON_AddItemToObject(object, "gid", cJSON_CreateString("AAAAA"));
+    cJSON_AddItemToObject(object, "hash_md5", cJSON_CreateString("AAAA23BCD1113A"));
+    cJSON_AddItemToObject(object, "hash_sha1", cJSON_CreateString("AAAA23BCD1113A"));
+    cJSON_AddItemToObject(object, "user_name", cJSON_CreateString("user"));
+    cJSON_AddItemToObject(object, "group_name", cJSON_CreateString("group"));
+    cJSON_AddItemToObject(object, "hash_sha256", cJSON_CreateString("AAAA23BCD1113AASDASDASD"));
+    cJSON_AddItemToObject(object, "symbolic_path", cJSON_CreateString("/path/second-path"));
+    cJSON_AddItemToObject(object, "checksum", cJSON_CreateString("GGGGGGGGGGGG"));
+    cJSON_AddItemToObject(object, "attributes", cJSON_CreateString("readonly"));
+    cJSON_ReplaceItemInObject(data, "attributes", object);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 2048);
+    expect_value(__wrap_sqlite3_bind_int, index, 12);
+    expect_value(__wrap_sqlite3_bind_int, value, 10);
+    expect_value(__wrap_sqlite3_bind_int, index, 13);
+    expect_value(__wrap_sqlite3_bind_int, value, 2311061769);
+    will_return_count(__wrap_sqlite3_bind_int, 0, 3);
+
+    will_return(__wrap_cJSON_GetStringValue, "/test");
+    will_return(__wrap_cJSON_IsNumber, true);
+    will_return(__wrap_cJSON_IsObject, true);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int64,0);
+    will_return(__wrap_sqlite3_step,SQLITE_DONE);
+
+    will_return_count(__wrap_sqlite3_bind_text, 1, 13);
+
     ret = wdb_fim_insert_entry2(wdb, data);
     cJSON_Delete(data);
     assert_int_equal(ret, 0);
@@ -433,6 +497,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wdb_fim_insert_entry2_fail_element_number, setup_wdb_t, teardown_wdb_t),
         cmocka_unit_test_setup_teardown(test_wdb_fim_insert_entry2_fail_sqlite3_stmt, setup_wdb_t, teardown_wdb_t),
         cmocka_unit_test_setup_teardown(test_wdb_fim_insert_entry2_success, setup_wdb_t, teardown_wdb_t),
+        cmocka_unit_test_setup_teardown(test_wdb_fim_insert_entry2_large_inode, setup_wdb_t, teardown_wdb_t),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -535,7 +535,7 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
             } else if (strcmp(element->string, "mtime") == 0) {
                 sqlite3_bind_int(stmt, 12, element->valueint);
             } else if (strcmp(element->string, "inode") == 0) {
-                sqlite3_bind_int(stmt, 13, element->valueint);
+                sqlite3_bind_int64(stmt, 13, element->valuedouble);
             } else {
                 merror("DB(%s) Invalid attribute name: %s", wdb->agent_id, element->string);
                 return -1;


### PR DESCRIPTION
|Related issue|Integration test|
|---|---|
|#4886|[wazuh-qa/657](https://github.com/wazuh/wazuh-qa/pull/657)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
When the `inode` value of files was above the maximum signed 32 bit integer, it's value was being recorded incorrectly inside `fim.db` and the agents db, causing wazuh to generate alerts with incorrect information (such as negative `inodes`).

This PR aims at solving the problem stated above by changing calls to `sqlite` from `int` variants to `int64`, as well as changing `valueint` to `valuedouble` when getting `inode` from a cJSON object.

## Logs/Alerts example

Alert when a modified file has a new, large `inode`
<details>

```
{
    "timestamp": "2020-04-15T10:42:55.605+0000",
    "rule": {
        "level": 7,
        "description": "Integrity checksum changed.",
        "id": "550",
        "firedtimes": 1,
        "mail": false,
        "groups": [
            "ossec",
            "syscheck"
        ],
        "pci_dss": [
            "11.5"
        ],
        "gpg13": [
            "4.11"
        ],
        "gdpr": [
            "II_5.1.f"
        ],
        "hipaa": [
            "164.312.c.1",
            "164.312.c.2"
        ],
        "nist_800_53": [
            "SI.7"
        ]
    },
    "agent": {
        "id": "000",
        "name": "ubuntu1804-FIM"
    },
    "manager": {
        "name": "ubuntu1804-FIM"
    },
    "id": "1586947375.713224",
    "full_log": "File '/home/vagrant/monitored/test' modified\nMode: whodata\nChanged attributes: mtime,inode\nOld modification time was: '1586938964', now it is '1586947320'\nOld inode was: '2646', now it is '2311061769'\n",
    "syscheck": {
        "path": "/home/vagrant/monitored/test",
        "size_after": "0",
        "perm_after": "rw-rw-r--",
        "uid_after": "1000",
        "gid_after": "1000",
        "md5_after": "d41d8cd98f00b204e9800998ecf8427e",
        "sha1_after": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
        "sha256_after": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
        "uname_after": "vagrant",
        "gname_after": "vagrant",
        "mtime_before": "2020-04-15T08:22:44",
        "mtime_after": "2020-04-15T10:42:00",
        "inode_before": 2646,
        "inode_after": 2311061769,
        "changed_attributes": [
            "mtime",
            "inode"
        ],
        "event": "modified",
        "audit": {
            "user": {
                "id": "1000",
                "name": "vagrant"
            },
            "process": {
                "id": "20722",
                "name": "/bin/touch",
                "ppid": "19715"
            },
            "group": {
                "id": "1000",
                "name": "vagrant"
            },
            "login_user": {
                "id": "1000",
                "name": "vagrant"
            },
            "effective_user": {
                "id": "1000",
                "name": "vagrant"
            }
        }
    },
    "decoder": {
        "name": "syscheck_integrity_changed"
    },
    "location": "syscheck"
}
```
</details>

Alert when a modified file has an old, large `inode`

<details>

```
{
    "timestamp": "2020-04-15T10:45:31.573+0000",
    "rule": {
        "level": 7,
        "description": "Integrity checksum changed.",
        "id": "550",
        "firedtimes": 2,
        "mail": false,
        "groups": [
            "ossec",
            "syscheck"
        ],
        "pci_dss": [
            "11.5"
        ],
        "gpg13": [
            "4.11"
        ],
        "gdpr": [
            "II_5.1.f"
        ],
        "hipaa": [
            "164.312.c.1",
            "164.312.c.2"
        ],
        "nist_800_53": [
            "SI.7"
        ]
    },
    "agent": {
        "id": "000",
        "name": "ubuntu1804-FIM"
    },
    "manager": {
        "name": "ubuntu1804-FIM"
    },
    "id": "1586947531.714175",
    "full_log": "File '/home/vagrant/monitored/test' modified\nMode: whodata\nChanged attributes: mtime,inode\nOld modification time was: '1586947320', now it is '1586947465'\nOld inode was: '2311061769', now it is '2646'\n",
    "syscheck": {
        "path": "/home/vagrant/monitored/test",
        "size_after": "0",
        "perm_after": "rw-rw-r--",
        "uid_after": "1000",
        "gid_after": "1000",
        "md5_after": "d41d8cd98f00b204e9800998ecf8427e",
        "sha1_after": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
        "sha256_after": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
        "uname_after": "vagrant",
        "gname_after": "vagrant",
        "mtime_before": "2020-04-15T10:42:00",
        "mtime_after": "2020-04-15T10:44:25",
        "inode_before": 2311061769,
        "inode_after": 2646,
        "changed_attributes": [
            "mtime",
            "inode"
        ],
        "event": "modified",
        "audit": {
            "user": {
                "id": "1000",
                "name": "vagrant"
            },
            "process": {
                "id": "20732",
                "name": "/bin/touch",
                "ppid": "19715"
            },
            "group": {
                "id": "1000",
                "name": "vagrant"
            },
            "login_user": {
                "id": "1000",
                "name": "vagrant"
            },
            "effective_user": {
                "id": "1000",
                "name": "vagrant"
            }
        }
    },
    "decoder": {
        "name": "syscheck_integrity_changed"
    },
    "location": "syscheck"
}
```
</details>

## Tests

Agent db entry when a large inode is stored:
```
sqlite> select inode from fim_entry where file="/home/vagrant/monitored/test";
2311061769
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
