### PR TITLE
Adding version comparator for NVD versions

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -319,6 +319,22 @@ void test_pkg_version_relate_epoch_LT(void **state)
     assert_int_equal(ret, 0);
 }
 
+void test_pkg_version_relate_epoch_negative_nvd(void **state)
+{
+    struct pkg_version *version_a = state[0];
+    struct pkg_version *version_b = state[1];
+
+    version_a->epoch = -1;
+    version_a->version = "1";
+    version_a->revision = "";
+    version_b->epoch = -1;
+    version_b->version = "2";
+    version_b->revision = "";
+
+    int ret = pkg_version_relate(version_a, PKG_RELATION_EQ, version_b, VER_TYPE_NVD);
+    assert_int_equal(ret, 0);
+}
+
 void test_pkg_version_relate_version_deb_GT(void **state)
 {
     struct pkg_version *version_a = state[0];
@@ -495,6 +511,38 @@ void test_pkg_version_relate_version_rpm_LE(void **state)
     assert_int_equal(ret, 0);
 }
 
+void test_pkg_version_relate_version_nvd_GE(void **state)
+{
+    struct pkg_version *version_a = state[0];
+    struct pkg_version *version_b = state[1];
+
+    version_a->epoch = 0;
+    version_a->version = "t32.10";
+    version_a->revision = "";
+    version_b->epoch = 0;
+    version_b->version = "t5.10";
+    version_b->revision = "";
+
+    int ret = pkg_version_relate(version_a, PKG_RELATION_GE, version_b, VER_TYPE_NVD);
+    assert_int_equal(ret, 1);
+}
+
+void test_pkg_version_relate_version_nvd_LE(void **state)
+{
+    struct pkg_version *version_a = state[0];
+    struct pkg_version *version_b = state[1];
+
+    version_a->epoch = 0;
+    version_a->version = "6.3.0";
+    version_a->revision = "";
+    version_b->epoch = 0;
+    version_b->version = "6.3.0r1";
+    version_b->revision = "";
+
+    int ret = pkg_version_relate(version_a, PKG_RELATION_LE, version_b, VER_TYPE_NVD);
+    assert_int_equal(ret, 1);
+}
+
 void test_pkg_version_relate_version_rpm_LT(void **state)
 {
     struct pkg_version *version_a = state[0];
@@ -669,6 +717,22 @@ void test_pkg_version_relate_revision_rpm_LT(void **state)
 
     int ret = pkg_version_relate(version_a, PKG_RELATION_LT, version_b, VER_TYPE_RPM);
     assert_int_equal(ret, 0);
+}
+
+void test_pkg_version_relate_revision_nvd_null(void **state)
+{
+    struct pkg_version *version_a = state[0];
+    struct pkg_version *version_b = state[1];
+
+    version_a->epoch = 0;
+    version_a->version = "1";
+    version_a->revision = NULL;
+    version_b->epoch = 0;
+    version_b->version = "1";
+    version_b->revision = NULL;
+
+    int ret = pkg_version_relate(version_a, PKG_RELATION_EQ, version_b, VER_TYPE_NVD);
+    assert_int_equal(ret, 1);
 }
 
 void test_wm_vuldet_get_oslinux_info(void **state)
@@ -1168,6 +1232,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_epoch_EQ, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_epoch_LE, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_epoch_LT, setup_versions, teardown_versions),
+        cmocka_unit_test_setup_teardown(test_pkg_version_relate_epoch_negative_nvd, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_deb_GT, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_deb_GT_zero_ending, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_deb_GE, setup_versions, teardown_versions),
@@ -1179,6 +1244,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_rpm_GE, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_rpm_EQ, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_rpm_LE, setup_versions, teardown_versions),
+        cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_nvd_GE, setup_versions, teardown_versions),
+        cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_nvd_LE, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_version_rpm_LT, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_revision_deb_GT, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_revision_deb_GE, setup_versions, teardown_versions),
@@ -1189,7 +1256,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_revision_rpm_GE, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_revision_rpm_EQ, setup_versions, teardown_versions),
         cmocka_unit_test_setup_teardown(test_pkg_version_relate_revision_rpm_LE, setup_versions, teardown_versions),
-        cmocka_unit_test_setup_teardown(test_pkg_version_relate_revision_rpm_LT, setup_versions, teardown_versions)
+        cmocka_unit_test_setup_teardown(test_pkg_version_relate_revision_rpm_LT, setup_versions, teardown_versions),
+        cmocka_unit_test_setup_teardown(test_pkg_version_relate_revision_nvd_null, setup_versions, teardown_versions)
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -28,8 +28,8 @@ static int setup_versions(void **state) {
     struct pkg_version *version_a;
     struct pkg_version *version_b;
 
-    os_calloc(1, sizeof(version_a), version_a);
-    os_calloc(1, sizeof(version_b), version_b);
+    os_calloc(1, sizeof(struct pkg_version), version_a);
+    os_calloc(1, sizeof(struct pkg_version), version_b);
 
     if(!version_a || !version_b) {
         return -1;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -458,7 +458,10 @@ int wm_vuldet_step(sqlite3_stmt *stmt) {
     return result;
 }
 
-int wm_checks_package_vulnerability(char *version, const char *operation, const char *operation_value, version_type vertype) {
+/*
+* This function should be taken as the version comparison entry point
+*/
+int wm_checks_package_vulnerability(char *version_a, const char *operation, const char *version_b, version_type vertype) {
     int size;
     int epoch, c_epoch;
     char version_cl[KEY_SIZE];
@@ -469,29 +472,31 @@ int wm_checks_package_vulnerability(char *version, const char *operation, const 
     struct pkg_version *package_feed_version;
     enum pkg_relation feed_condition;
 
-    if (operation_value) {
+    if (version_b) {
         // Copy the original values
-        if (size = snprintf(version_cl, KEY_SIZE, "%s", version), size >= KEY_SIZE) {
+        if (size = snprintf(version_cl, KEY_SIZE, "%s", version_a), size >= KEY_SIZE) {
             return OS_INVALID;
         }
-        if (size = snprintf(cversion_cl, KEY_SIZE, "%s", operation_value), size >= KEY_SIZE) {
+        if (size = snprintf(cversion_cl, KEY_SIZE, "%s", version_b), size >= KEY_SIZE) {
             return OS_INVALID;
         }
 
         // Check EPOCH
+        // If the epoch is not present in the version and we are comparing NVD versions
+        // we assign -1 to indicate that it shouldn't be compared
         if (version_it = strchr(version_cl, ':'), version_it) {
             *(version_it++) = '\0';
             epoch = strtol(version_cl, NULL, 10);
         } else {
             version_it = version_cl;
-            epoch = 0;
+            epoch = (VER_TYPE_NVD != vertype) ? 0 : -1;
         }
         if (cversion_it = strchr(cversion_cl, ':'), cversion_it) {
             *(cversion_it++) = '\0';
             c_epoch = strtol(cversion_cl, NULL, 10);
         } else {
             cversion_it = cversion_cl;
-            c_epoch = 0;
+            c_epoch = (VER_TYPE_NVD != vertype) ? 0 : -1;
         }
 
         // Separate the version from the revision

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -747,7 +747,7 @@ int wm_vuldet_linux_rm_false_positivies(sqlite3 *db, agent_software *agent, OSHa
 int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agent, OSHash *cve_table);
 int wm_vuldet_linux_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, wm_vuldet_flags *flags, OSHash *cve_table);
 int wm_vuldet_win_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, wm_vuldet_flags *flags);
-int wm_checks_package_vulnerability(char *version, const char *operation, const char *operation_value, version_type vertype);
+int wm_checks_package_vulnerability(char *version_a, const char *operation, const char *version_b, version_type vertype);
 
 /**
  * @brief Send a report for a specific CVE and the affected packages.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.c
@@ -287,98 +287,98 @@ static int rpm_vercmp(const char * a, const char * b)
 
     /* loop through each version segment of str1 and str2 and compare them */
     while (*one || *two) {
-    while (*one && !(c_isalpha(*one) || c_isdigit(*one)) && *one != '~' && *one != '^') one++;
-    while (*two && !(c_isalpha(*two) || c_isdigit(*two)) && *two != '~' && *two != '^') two++;
+        while (*one && !(c_isalpha(*one) || c_isdigit(*one)) && *one != '~' && *one != '^') one++;
+        while (*two && !(c_isalpha(*two) || c_isdigit(*two)) && *two != '~' && *two != '^') two++;
 
-    /* handle the tilde separator, it sorts before everything else */
-    if (*one == '~' || *two == '~') {
-        if (*one != '~') return 1;
-        if (*two != '~') return -1;
-        one++;
-        two++;
-        continue;
-    }
+        /* handle the tilde separator, it sorts before everything else */
+        if (*one == '~' || *two == '~') {
+            if (*one != '~') return 1;
+            if (*two != '~') return -1;
+            one++;
+            two++;
+            continue;
+        }
 
-    /*
-     * Handle caret separator. Concept is the same as tilde,
-     * except that if one of the strings ends (base version),
-     * the other is considered as higher version.
-     */
-    if (*one == '^' || *two == '^') {
-        if (!*one) return -1;
-        if (!*two) return 1;
-        if (*one != '^') return 1;
-        if (*two != '^') return -1;
-        one++;
-        two++;
-        continue;
-    }
+        /*
+        * Handle caret separator. Concept is the same as tilde,
+        * except that if one of the strings ends (base version),
+        * the other is considered as higher version.
+        */
+        if (*one == '^' || *two == '^') {
+            if (!*one) return -1;
+            if (!*two) return 1;
+            if (*one != '^') return 1;
+            if (*two != '^') return -1;
+            one++;
+            two++;
+            continue;
+        }
 
-    /* If we ran to the end of either, we are finished with the loop */
-    if (!(*one && *two)) break;
+        /* If we ran to the end of either, we are finished with the loop */
+        if (!(*one && *two)) break;
 
-    str1 = one;
-    str2 = two;
+        str1 = one;
+        str2 = two;
 
-    /* grab first completely alpha or completely numeric segment */
-    /* leave one and two pointing to the start of the alpha or numeric */
-    /* segment and walk str1 and str2 to end of segment */
-    if (c_isdigit(*str1)) {
-        while (*str1 && c_isdigit(*str1)) str1++;
-        while (*str2 && c_isdigit(*str2)) str2++;
-        isnum = 1;
-    } else {
-        while (*str1 && c_isalpha(*str1)) str1++;
-        while (*str2 && c_isalpha(*str2)) str2++;
-        isnum = 0;
-    }
+        /* grab first completely alpha or completely numeric segment */
+        /* leave one and two pointing to the start of the alpha or numeric */
+        /* segment and walk str1 and str2 to end of segment */
+        if (c_isdigit(*str1)) {
+            while (*str1 && c_isdigit(*str1)) str1++;
+            while (*str2 && c_isdigit(*str2)) str2++;
+            isnum = 1;
+        } else {
+            while (*str1 && c_isalpha(*str1)) str1++;
+            while (*str2 && c_isalpha(*str2)) str2++;
+            isnum = 0;
+        }
 
-    /* save character at the end of the alpha or numeric segment */
-    /* so that they can be restored after the comparison */
-    oldch1 = *str1;
-    *str1 = '\0';
-    oldch2 = *str2;
-    *str2 = '\0';
+        /* save character at the end of the alpha or numeric segment */
+        /* so that they can be restored after the comparison */
+        oldch1 = *str1;
+        *str1 = '\0';
+        oldch2 = *str2;
+        *str2 = '\0';
 
-    /* this cannot happen, as we previously tested to make sure that */
-    /* the first string has a non-null segment */
-    if (one == str1) return -1;   /* arbitrary */
+        /* this cannot happen, as we previously tested to make sure that */
+        /* the first string has a non-null segment */
+        if (one == str1) return -1;   /* arbitrary */
 
-    /* take care of the case where the two version segments are */
-    /* different types: one numeric, the other alpha (i.e. empty) */
-    /* numeric segments are always newer than alpha segments */
-    /* XXX See patch #60884 (and details) from bugzilla #50977. */
-    if (two == str2) return (isnum ? 1 : -1);
+        /* take care of the case where the two version segments are */
+        /* different types: one numeric, the other alpha (i.e. empty) */
+        /* numeric segments are always newer than alpha segments */
+        /* XXX See patch #60884 (and details) from bugzilla #50977. */
+        if (two == str2) return (isnum ? 1 : -1);
 
-    if (isnum) {
-        size_t onelen, twolen;
-        /* this used to be done by converting the digit segments */
-        /* to ints using atoi() - it's changed because long  */
-        /* digit segments can overflow an int - this should fix that. */
+        if (isnum) {
+            size_t onelen, twolen;
+            /* this used to be done by converting the digit segments */
+            /* to ints using atoi() - it's changed because long  */
+            /* digit segments can overflow an int - this should fix that. */
 
-        /* throw away any leading zeros - it's a number, right? */
-        while (*one == '0') one++;
-        while (*two == '0') two++;
+            /* throw away any leading zeros - it's a number, right? */
+            while (*one == '0') one++;
+            while (*two == '0') two++;
 
-        /* whichever number has more digits wins */
-        onelen = strlen(one);
-        twolen = strlen(two);
-        if (onelen > twolen) return 1;
-        if (twolen > onelen) return -1;
-    }
+            /* whichever number has more digits wins */
+            onelen = strlen(one);
+            twolen = strlen(two);
+            if (onelen > twolen) return 1;
+            if (twolen > onelen) return -1;
+        }
 
-    /* strcmp will return which one is greater - even if the two */
-    /* segments are alpha or if they are numeric.  don't return  */
-    /* if they are equal because there might be more segments to */
-    /* compare */
-    rc = strcmp(one, two);
-    if (rc) return (rc < 1 ? -1 : 1);
+        /* strcmp will return which one is greater - even if the two */
+        /* segments are alpha or if they are numeric.  don't return  */
+        /* if they are equal because there might be more segments to */
+        /* compare */
+        rc = strcmp(one, two);
+        if (rc) return (rc < 1 ? -1 : 1);
 
-    /* restore character that was replaced by null above */
-    *str1 = oldch1;
-    one = str1;
-    *str2 = oldch2;
-    two = str2;
+        /* restore character that was replaced by null above */
+        *str1 = oldch1;
+        one = str1;
+        *str2 = oldch2;
+        two = str2;
     }
 
     /* this catches the case where all numeric and alpha segments have */
@@ -388,6 +388,54 @@ static int rpm_vercmp(const char * a, const char * b)
 
     /* whichever version still has characters left over wins */
     if (!*one) return -1; else return 1;
+}
+
+/*
+* Compare alpha and numeric segments of two NVD versions
+* return > 0: a is newer than b
+*          0: a and b are the same version
+*        < 0: b is newer than a
+*/
+static int nvd_verrevcmp(const char *a, const char *b)
+{
+    // In the NVD version comparison, we avoid the revision
+    // comparison if any of them is not present. 
+    if ((a == NULL) || (b == NULL))
+        return 0;
+
+    while (*a || *b) {
+        int first_diff = 0;
+
+        while ((*a && !c_isdigit(*a)) || (*b && !c_isdigit(*b))) {
+            int ac = order(*a);
+            int bc = order(*b);
+
+            if (ac != bc)
+                return ac - bc;
+
+            a++;
+            b++;
+        }
+        while (*a == '0')
+            a++;
+        while (*b == '0')
+            b++;
+        while (c_isdigit(*a) && c_isdigit(*b)) {
+            if (!first_diff)
+                first_diff = *a - *b;
+            a++;
+            b++;
+        }
+
+        if (c_isdigit(*a))
+            return 1;
+        if (c_isdigit(*b))
+            return -1;
+        if (first_diff)
+            return first_diff;
+    }
+
+    return 0;
 }
 
 /**
@@ -408,10 +456,16 @@ int pkg_version_compare(const struct pkg_version *a, const struct pkg_version *b
 {
     int rc;
 
-    if (a->epoch > b->epoch)
-        return 1;
-    if (a->epoch < b->epoch)
-        return -1;
+    // We will compare the epoch only if both values are >= 0. If any of the values
+    // is < 0, it means that we are comparing NVD versions and that the epoch is not
+    // present. In this case we avoid the epoch comparison.
+    if (a->epoch >= 0 && b->epoch >= 0)
+    {
+        if (a->epoch > b->epoch)
+            return 1;
+        if (a->epoch < b->epoch)
+            return -1;
+    }
 
     rc = comparator(a->version, b->version);
     if (rc)
@@ -430,7 +484,7 @@ int pkg_version_compare(const struct pkg_version *a, const struct pkg_version *b
  * @param type The package type of the versions being compared.
  *
  * @retval 1 If the expression “a rel b” is true.
- * @retval 1 If rel is #PKG_RELATION_NONE.
+ * @retval 1 If rel is PKG_RELATION_NONE or vertype is VER_TYPE_NONE
  * @retval 0 Otherwise.
  *
  */
@@ -449,7 +503,7 @@ bool pkg_version_relate(const struct pkg_version *a, enum pkg_relation rel, cons
     case VER_TYPE_RPM:
         comparator = rpm_vercmp; break;
     case VER_TYPE_NVD:
-        comparator = deb_verrevcmp; break; // TODO: Temporary assigning the debian comparator until having the one for NVD
+        comparator = nvd_verrevcmp; break;
     default:
         mterror(WM_VULNDETECTOR_LOGTAG, "unknown version_type %d", vertype);
         return false;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.c
@@ -402,40 +402,8 @@ static int nvd_verrevcmp(const char *a, const char *b)
     // comparison if any of them is not present. 
     if ((a == NULL) || (b == NULL))
         return 0;
-
-    while (*a || *b) {
-        int first_diff = 0;
-
-        while ((*a && !c_isdigit(*a)) || (*b && !c_isdigit(*b))) {
-            int ac = order(*a);
-            int bc = order(*b);
-
-            if (ac != bc)
-                return ac - bc;
-
-            a++;
-            b++;
-        }
-        while (*a == '0')
-            a++;
-        while (*b == '0')
-            b++;
-        while (c_isdigit(*a) && c_isdigit(*b)) {
-            if (!first_diff)
-                first_diff = *a - *b;
-            a++;
-            b++;
-        }
-
-        if (c_isdigit(*a))
-            return 1;
-        if (c_isdigit(*b))
-            return -1;
-        if (first_diff)
-            return first_diff;
-    }
-
-    return 0;
+    else
+        return deb_verrevcmp(a, b);
 }
 
 /**

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.h
@@ -63,7 +63,7 @@ typedef enum {
  */
 struct pkg_version {
     /** The epoch. It will be zero if no epoch is present. */
-    unsigned int epoch;
+    int epoch;
     /** The upstream part of the version. */
     const char *version;
     /** The revision part of the version. */


### PR DESCRIPTION
|Related issue|
|---|
|[4858](https://github.com/wazuh/wazuh/issues/4858)|

## Description

This PR introduces a new function to compare versions coming from the NVD feed. In addition, it modifies a bit the current logic in order to avoid comparing `epoch` and `revision` when they are not present **only in the NVD version comparison**.

## Tests

Some new unit tests were added in order to cover the special cases mentioned for the absence of the `epoch` and `revision`. Also, I add some new tests to cover the cases where the version contains some alpha characters apart from numbers.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [*] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [*] Source installation
- [*] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities