### PR TITLE
Let agent auto-enroll when Remoted closes the connection

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -107,7 +107,7 @@ cJSON *getClientConfig(void) {
     if (agt->enrollment_cfg) {
         cJSON *enrollment_cfg = cJSON_CreateObject();
         cJSON_AddStringToObject(enrollment_cfg, "enabled", agt->enrollment_cfg->enabled ? "yes" : "no");
-        cJSON_AddNumberToObject(enrollment_cfg, "wait_time", agt->enrollment_cfg->wait_time);
+        cJSON_AddNumberToObject(enrollment_cfg, "delay_after_enrollment", agt->enrollment_cfg->delay_after_enrollment);
 
         if (agt->enrollment_cfg->target_cfg->manager_name)
             cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg->target_cfg->manager_name);

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -128,7 +128,7 @@ cJSON *getClientConfig(void) {
         if (agt->enrollment_cfg->cert_cfg->agent_key)    
             cJSON_AddStringToObject(enrollment_cfg, "agent_key_path", agt->enrollment_cfg->cert_cfg->agent_key);
         if(agt->enrollment_cfg->cert_cfg->authpass)
-            cJSON_AddStringToObject(enrollment_cfg, "authrization_pass", agt->enrollment_cfg->cert_cfg->authpass);
+            cJSON_AddStringToObject(enrollment_cfg, "authorization_pass_path", agt->enrollment_cfg->cert_cfg->authpass);
         
         cJSON_AddStringToObject(enrollment_cfg,"auto_method",agt->enrollment_cfg->cert_cfg->auto_method ? "yes": "no");
         cJSON_AddItemToObject(client,"auto_enrollment",enrollment_cfg);

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -107,7 +107,8 @@ cJSON *getClientConfig(void) {
     if (agt->enrollment_cfg) {
         cJSON *enrollment_cfg = cJSON_CreateObject();
         cJSON_AddStringToObject(enrollment_cfg, "enabled", agt->enrollment_cfg->enabled ? "yes" : "no");
-        
+        cJSON_AddNumberToObject(enrollment_cfg, "wait_time", agt->enrollment_cfg->wait_time);
+
         if (agt->enrollment_cfg->target_cfg->manager_name)
             cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg->target_cfg->manager_name);
         

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -44,6 +44,13 @@ int ClientConf(const char *cfgfile)
     os_calloc(1, sizeof(wlabel_t), agt->labels);
     modules |= CCLIENT;
 
+    w_enrollment_cert *cert_cfg = w_enrollment_cert_init();
+    w_enrollment_target *target_cfg = w_enrollment_target_init();
+
+    // Initialize enrollment_cfg
+    agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg);
+    agt->enrollment_cfg->allow_localhost = 0; // Localhost not allowed in auto-enrollment
+
     if (ReadConfig(modules, cfgfile, agt, NULL) < 0 ||
         ReadConfig(CLABELS | CBUFFER, cfgfile, &agt->labels, agt) < 0) {
         return (OS_INVALID);
@@ -60,7 +67,7 @@ int ClientConf(const char *cfgfile)
         mwarn("Client buffer throughput too low: set to %d eps", min_eps);
         agt->events_persec = min_eps;
     }
-
+    
     return (1);
 }
 

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -167,8 +167,38 @@ int main(int argc, char **argv)
         merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
+    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
+        // If autoenrollment is enabled, we will avoid exit if there is no valid key
+        OS_PassEmptyKeyfile();
+    }
+    
     /* Check client keys */
     OS_ReadKeys(&keys, 1, 0, 0);
+
+    /* Check if we need to auto-enroll */
+    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
+        int could_register = -1;
+        int rc = 0;
+
+        if (agt->enrollment_cfg->target_cfg->manager_name) {
+            // Configured enrollment server
+            could_register = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
+        } 
+        
+        // Try to enroll to server list
+        while (agt->server[rc].rip && (could_register != 0)) {
+            could_register = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
+            rc++;
+        }
+        
+
+        if(could_register == 0) {
+            // Readkeys again to add obtained key
+            OS_ReadKeys(&keys, 1, 0, 0);
+        } else {
+            merror_exit(AG_ENROLL_FAIL);
+        }
+    }
 
     /* Exit if test config */
     if (test_config) {

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -155,11 +155,6 @@ int main(int argc, char **argv)
         minfo("Max time to reconnect can't be less than notify_time(%d), using notify_time*3 (%d)", agt->notify_time, agt->max_time_reconnect_try);
     }
 
-    /* Check auth keys */
-    if (!OS_CheckKeys()) {
-        merror_exit(AG_NOKEYS_EXIT);
-    }
-
     /* Check if the user/group given are valid */
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
@@ -170,6 +165,11 @@ int main(int argc, char **argv)
     if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
         // If autoenrollment is enabled, we will avoid exit if there is no valid key
         OS_PassEmptyKeyfile();
+    } else {
+        /* Check auth keys */
+        if (!OS_CheckKeys()) {
+            merror_exit(AG_NOKEYS_EXIT);
+        }
     }
     
     /* Check client keys */

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -194,8 +194,8 @@ int main(int argc, char **argv)
 
         if(could_register == 0) {
             // Wait for key update on agent side
-            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->wait_time);
-            sleep(agt->enrollment_cfg->wait_time);
+            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
+            sleep(agt->enrollment_cfg->delay_after_enrollment);
             // Readkeys again to add obtained key
             OS_ReadKeys(&keys, 1, 0, 0);
         } else {

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -177,28 +177,27 @@ int main(int argc, char **argv)
 
     /* Check if we need to auto-enroll */
     if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
-        int could_register = -1;
+        int registration_status = -1;
         int rc = 0;
 
         if (agt->enrollment_cfg->target_cfg->manager_name) {
             // Configured enrollment server
-            could_register = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
+            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
         } 
         
         // Try to enroll to server list
-        while (agt->server[rc].rip && (could_register != 0)) {
-            could_register = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
+        while (agt->server[rc].rip && (registration_status != 0)) {
+            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
             rc++;
         }
         
 
-        if(could_register == 0) {
+        if(registration_status == 0) {
             // Wait for key update on agent side
             mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
             sleep(agt->enrollment_cfg->delay_after_enrollment);
-            // Readkeys again to add obtained key
-            OS_FreeKeys(&keys);
-            OS_ReadKeys(&keys, 1, 0, 0);
+            // Update keys to get obtained key
+            OS_UpdateKeys(&keys);
         } else {
             merror_exit(AG_ENROLL_FAIL);
         }

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -193,6 +193,9 @@ int main(int argc, char **argv)
         
 
         if(could_register == 0) {
+            // Wait for key update on agent side
+            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->wait_time);
+            sleep(agt->enrollment_cfg->wait_time);
             // Readkeys again to add obtained key
             OS_ReadKeys(&keys, 1, 0, 0);
         } else {

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -197,6 +197,7 @@ int main(int argc, char **argv)
             mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
             sleep(agt->enrollment_cfg->delay_after_enrollment);
             // Readkeys again to add obtained key
+            OS_FreeKeys(&keys);
             OS_ReadKeys(&keys, 1, 0, 0);
         } else {
             merror_exit(AG_ENROLL_FAIL);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -221,8 +221,8 @@ void start_agent(int is_startup)
                         int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, agt->server[agt->rip_id].rip);
                         if(enroll_result == 0) {
                             // Wait for key update on agent side
-                            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->wait_time);
-                            sleep(agt->enrollment_cfg->wait_time);
+                            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
+                            sleep(agt->enrollment_cfg->delay_after_enrollment);
                             // Successfull enroll, read keys
                             OS_ReadKeys(&keys, 1, 0, 0);
                         }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -224,6 +224,7 @@ void start_agent(int is_startup)
                             mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
                             sleep(agt->enrollment_cfg->delay_after_enrollment);
                             // Successfull enroll, read keys
+                            OS_FreeKeys(&keys);
                             OS_ReadKeys(&keys, 1, 0, 0);
                         }
                     }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -174,7 +174,6 @@ void start_agent(int is_startup)
         /* Send start up message */
         send_msg(msg, -1);
         attempts = 0;
-
         /* Read until our reply comes back */
         while (attempts <= 5) {
             if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
@@ -195,6 +194,7 @@ void start_agent(int is_startup)
                 recv_b = recv(agt->sock, buffer, OS_MAXSTR, MSG_DONTWAIT);
             }
 
+
             if (recv_b <= 0) {
                 /* Sleep five seconds before trying to get the reply from
                  * the server again
@@ -206,28 +206,27 @@ void start_agent(int is_startup)
                     merror("Corrupt payload (exceeding size) received.");
                     break;
                 case -1:
-#ifdef WIN32
+                    #ifdef WIN32
                     mdebug1("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
-#else
+                    #else
                     mdebug1("Connection socket: %s (%d)", strerror(errno), errno);
-#endif
+                    #endif
                 }
 
                 sleep(attempts);
 
                 /* Send message again (after three attempts) */
                 if (attempts >= 3 || recv_b == OS_SOCKTERR) {
-                    if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
+                    int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, agt->server[agt->rip_id].rip);
+                    if(enroll_result == 0) {
+                        // Successfull enroll, read keys
+                        OS_ReadKeys(&keys, 1, 0, 0);
                         if (!connect_server(agt->rip_id)) {
                             continue;
                         }
-                    } else {
+                        // if enroll is successfull reconnect and re-send message
                         send_msg(msg, -1);
                     }
-                }
-
-                if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
-                    send_msg(msg, -1);
                 }
 
                 continue;

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -232,6 +232,10 @@ void start_agent(int is_startup)
                     }
                     // if enroll is successfull reconnect and re-send message
                     send_msg(msg, -1);
+                    // After sending message wait before response
+                    if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
+                        sleep(attempts);
+                    }
                 }
 
                 continue;

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -224,8 +224,7 @@ void start_agent(int is_startup)
                             mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
                             sleep(agt->enrollment_cfg->delay_after_enrollment);
                             // Successfull enroll, read keys
-                            OS_FreeKeys(&keys);
-                            OS_ReadKeys(&keys, 1, 0, 0);
+                            OS_UpdateKeys(&keys);
                         }
                     }
                     if (!connect_server(agt->rip_id)) {

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -46,7 +46,6 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     logr->notify_time = 0;
     logr->max_time_reconnect_try = 0;
     logr->rip_id = 0;
-    logr->enrollment_cfg = NULL;
 
     for (i = 0; node[i]; i++) {
         rip = NULL;
@@ -303,13 +302,12 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     const char *xml_auto_method = "auto_method";
     char * remote_ip = NULL;
     int port = 0;
-    int enabled = 1;
     int j;
     char f_ip[128];
 
 
-    w_enrollment_cert *cert_cfg = w_enrollment_cert_init();
-    w_enrollment_target *target_cfg = w_enrollment_target_init();
+    w_enrollment_cert *cert_cfg = logr->enrollment_cfg->cert_cfg;
+    w_enrollment_target *target_cfg = logr->enrollment_cfg->target_cfg;
 
     for (j = 0; node[j]; j++) {
         if (!node[j]->element) {
@@ -324,9 +322,9 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             return (OS_INVALID);
         } else if (!strcmp(node[j]->element, xml_enabled)) {
             if (!strcmp(node[j]->content, "yes"))
-                enabled = 1;
+                logr->enrollment_cfg->enabled = 1;
             else if (!strcmp(node[j]->content, "no")) {
-                enabled = 0;
+                logr->enrollment_cfg->enabled = 0;
             } else {
                 merror("Invalid content for tag '%s'.", node[j]->element);
                 w_enrollment_target_destroy(target_cfg);
@@ -411,10 +409,6 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             return (OS_INVALID);
         }
     }
-    // Initialize enrollment_cfg
-    logr->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg);
-    logr->enrollment_cfg->enabled = enabled;
-    logr->enrollment_cfg->allow_localhost = 0; // Localhost not allowed in auto-enrollment
     return 0;
 }
 

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -416,6 +416,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     // Initialize enrollment_cfg
     logr->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg);
     logr->enrollment_cfg->enabled = enabled;
+    logr->enrollment_cfg->allow_localhost = 0; // Localhost not allwoed in auto-enrollment
     return 0;
 }
 

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -301,6 +301,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     const char *xml_auth_password = "authorization_pass_path";
     const char *xml_auto_method = "auto_method";
     const char *xml_delay_after_enrollment = "delay_after_enrollment";
+    const char *xml_use_source_ip = "use_source_ip";
     char * remote_ip = NULL;
     int port = 0;
     int j;
@@ -362,7 +363,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             }
             target_cfg->port = port;
         } else if (strcmp(node[j]->element, xml_agent_name) == 0) {
-            os_free(target_cfg->sender_ip);
+            os_free(target_cfg->agent_name);
             os_strdup(node[j]->content, target_cfg->agent_name);
         } else if (strcmp(node[j]->element, xml_groups) == 0) {
             os_free(target_cfg->centralized_group);
@@ -418,6 +419,17 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
                 return (OS_INVALID);
             } 
             logr->enrollment_cfg->delay_after_enrollment = delay_after_enrollment;
+        } else if (strcmp(node[j]->element, xml_use_source_ip) == 0) {
+            if (!strcmp(node[j]->content, "yes")) {
+                target_cfg->use_src_ip = 1;
+            } else if (!strcmp(node[j]->content, "no")) {
+                target_cfg->use_src_ip = 0;
+            } else {
+                merror("Invalid content for tag '%s'.", node[j]->element);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
+                return OS_INVALID;
+            }
         } else {
             merror(XML_INVELEM, node[j]->element);
             w_enrollment_target_destroy(target_cfg);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -368,8 +368,15 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             os_free(target_cfg->centralized_group);
             os_strdup(node[j]->content, target_cfg->centralized_group);
         } else if (strcmp(node[j]->element, xml_agent_addr) == 0) {
-            os_free(target_cfg->sender_ip);
-            os_strdup(node[j]->content, target_cfg->sender_ip);
+            if (OS_IsValidIP(node[j]->content, NULL) != 0) {
+                os_free(target_cfg->sender_ip);
+                os_strdup(node[j]->content, target_cfg->sender_ip);
+            } else {
+                merror(AG_INV_HOST, node[j]->content);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
+                return (OS_INVALID);
+            }
         } else if (strcmp(node[j]->element, xml_ssl_cipher) == 0) {
             os_free(cert_cfg->ciphers);
             os_strdup(node[j]->content, cert_cfg->ciphers);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -416,7 +416,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     // Initialize enrollment_cfg
     logr->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg);
     logr->enrollment_cfg->enabled = enabled;
-    logr->enrollment_cfg->allow_localhost = 0; // Localhost not allwoed in auto-enrollment
+    logr->enrollment_cfg->allow_localhost = 0; // Localhost not allowed in auto-enrollment
     return 0;
 }
 

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -111,16 +111,14 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             }
             OS_ClearNode(chld_node);
         } else if (strcmp(node[i]->element, xml_client_auto_enrollment) == 0) {
+            if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
+                if (Read_Client_Enrollment(chld_node, logr) < 0) {
+                    OS_ClearNode(chld_node);
+                    return (OS_INVALID);
+                }
 
-            if (!(chld_node = OS_GetElementsbyNode(xml, node[i]))) {
-                merror(XML_INVELEM, node[i]->element);
-                return (OS_INVALID);
-            }
-            if (Read_Client_Enrollment(chld_node, logr) < 0) {
                 OS_ClearNode(chld_node);
-                return (OS_INVALID);
             }
-            OS_ClearNode(chld_node);
         } else if (strcmp(node[i]->element, xml_notify_time) == 0) {
             if (!OS_StrIsNum(node[i]->content)) {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
@@ -308,7 +306,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     int enabled = 1;
     int j;
     char f_ip[128];
-    
+
 
     w_enrollment_cert *cert_cfg = w_enrollment_cert_init();
     w_enrollment_target *target_cfg = w_enrollment_target_init();

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -300,7 +300,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     const char *xml_agent_key_path = "agent_key_path";
     const char *xml_auth_password = "authorization_pass";
     const char *xml_auto_method = "auto_method";
-    const char *xml_wait_time = "wait_time";
+    const char *xml_delay_after_enrollment = "delay_after_enrollment";
     char * remote_ip = NULL;
     int port = 0;
     int j;
@@ -403,21 +403,21 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
                 w_enrollment_cert_destroy(cert_cfg);
                 return OS_INVALID;
             }
-        } else if (strcmp(node[j]->element, xml_wait_time) == 0) {
+        } else if (strcmp(node[j]->element, xml_delay_after_enrollment) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 w_enrollment_target_destroy(target_cfg);
                 w_enrollment_cert_destroy(cert_cfg);
                 return (OS_INVALID);
             }
-            int wait_time;
-            if (wait_time = atoi(node[j]->content), wait_time <= 0) {
+            int delay_after_enrollment;
+            if (delay_after_enrollment = atoi(node[j]->content), delay_after_enrollment <= 0) {
                 merror(PORT_ERROR, port);
                 w_enrollment_target_destroy(target_cfg);
                 w_enrollment_cert_destroy(cert_cfg);
                 return (OS_INVALID);
             } 
-            logr->enrollment_cfg->wait_time = wait_time;
+            logr->enrollment_cfg->delay_after_enrollment = delay_after_enrollment;
         } else {
             merror(XML_INVELEM, node[j]->element);
             w_enrollment_target_destroy(target_cfg);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -300,6 +300,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     const char *xml_agent_key_path = "agent_key_path";
     const char *xml_auth_password = "authorization_pass";
     const char *xml_auto_method = "auto_method";
+    const char *xml_wait_time = "wait_time";
     char * remote_ip = NULL;
     int port = 0;
     int j;
@@ -402,6 +403,21 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
                 w_enrollment_cert_destroy(cert_cfg);
                 return OS_INVALID;
             }
+        } else if (strcmp(node[j]->element, xml_wait_time) == 0) {
+            if (!OS_StrIsNum(node[j]->content)) {
+                merror(XML_VALUEERR, node[j]->element, node[j]->content);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
+                return (OS_INVALID);
+            }
+            int wait_time;
+            if (wait_time = atoi(node[j]->content), wait_time <= 0) {
+                merror(PORT_ERROR, port);
+                w_enrollment_target_destroy(target_cfg);
+                w_enrollment_cert_destroy(cert_cfg);
+                return (OS_INVALID);
+            } 
+            logr->enrollment_cfg->wait_time = wait_time;
         } else {
             merror(XML_INVELEM, node[j]->element);
             w_enrollment_target_destroy(target_cfg);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -298,7 +298,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     const char *xml_server_ca_path = "server_ca_path";
     const char *xml_agent_certif_path = "agent_certificate_path";
     const char *xml_agent_key_path = "agent_key_path";
-    const char *xml_auth_password = "authorization_pass";
+    const char *xml_auth_password = "authorization_pass_path";
     const char *xml_auto_method = "auto_method";
     const char *xml_delay_after_enrollment = "delay_after_enrollment";
     char * remote_ip = NULL;
@@ -390,8 +390,8 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             os_free(cert_cfg->agent_key);
             os_strdup(node[j]->content, cert_cfg->agent_key);
         } else if (strcmp(node[j]->element, xml_auth_password) == 0) {
-            os_free(cert_cfg->authpass);
-            os_strdup(node[j]->content, cert_cfg->authpass);
+            os_free(cert_cfg->authpass_file);
+            os_strdup(node[j]->content, cert_cfg->authpass_file);
         } else if (strcmp(node[j]->element, xml_auto_method) == 0) {
             if (!strcmp(node[j]->content, "yes")) {
                 cert_cfg->auto_method = 1;

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -368,15 +368,8 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             os_free(target_cfg->centralized_group);
             os_strdup(node[j]->content, target_cfg->centralized_group);
         } else if (strcmp(node[j]->element, xml_agent_addr) == 0) {
-            if (OS_IsValidIP(node[j]->content, NULL) == 1) {
-                os_free(target_cfg->sender_ip);
-                os_strdup(node[j]->content, target_cfg->sender_ip);
-            } else {
-                merror(AG_INV_HOST, node[j]->content);
-                w_enrollment_target_destroy(target_cfg);
-                w_enrollment_cert_destroy(cert_cfg);
-                return (OS_INVALID);
-            }
+            os_free(target_cfg->sender_ip);
+            os_strdup(node[j]->content, target_cfg->sender_ip);
         } else if (strcmp(node[j]->element, xml_ssl_cipher) == 0) {
             os_free(cert_cfg->ciphers);
             os_strdup(node[j]->content, cert_cfg->ciphers);

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -254,6 +254,7 @@
 #define AG_MAX_ERROR    "(4110): Maximum number of agents '%d' reached."
 #define AG_AX_AGENTS    "(4111): Maximum number of agents allowed: '%d'."
 #define AG_INV_MNGIP    "(4112): Invalid server address found: '%s'"
+#define AG_ENROLL_FAIL  "(4113): Auto Enrollment configuration failed." 
 
 /* Rules reading errors */
 #define RL_INV_ROOT     "(5101): Invalid root element: '%s'."

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -51,7 +51,8 @@ typedef struct _enrollment_target_cfg {
  */
 typedef struct _enrollment_cert_cfg {
     char *ciphers;     /**> chipers string (default DEFAULT_CIPHERS) */
-    char *authpass;    /**> for password verification */
+    char *authpass_file; /**> password file (default AUTHDPASS_PATH) */
+    char *authpass;    /**> override password file for password verification */
     char *agent_cert;  /**> Agent Certificate (null if not used) */
     char *agent_key;   /**> Agent Key (null if not used) */
     char *ca_cert;     /**> CA Certificate to verificate server (null if not used) */

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -37,6 +37,7 @@ typedef struct _enrollment_target_cfg {
     char *agent_name;         /**> (optional) Name of the agent. In case of NULL enrollment message will send local hostname */
     char *centralized_group;  /**> (optional) In case the agent belong to a group */
     char *sender_ip;          /**> (optional) IP adress or CIDR of the agent. In case of null the manager will use the source ip */
+    int use_src_ip;           /**> (optional) Forces manager to use source ip (-i option in agent_auth)*/
 } w_enrollment_target;
 
 /**

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -64,8 +64,9 @@ typedef struct _enrollment_cert_cfg {
 typedef struct _enrollment_ctx {
     const w_enrollment_target *target_cfg;  /**> for details @see _enrollment_target_cfg */
     const w_enrollment_cert *cert_cfg;      /**> for details @see _enrollment_cert_cfg */
-    SSL *ssl;                                   /**> will hold the connection instance with the manager */
-    unsigned int enabled:1;
+    SSL *ssl;                               /**> will hold the connection instance with the manager */
+    unsigned int enabled:1;                 /**> enabled / disables auto_enrollment */
+    unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
 } w_enrollment_ctx;
 
 /**

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -107,6 +107,7 @@ void w_enrollment_destroy(w_enrollment_ctx *cfg);
  * 
  * @param cfg configuration @see w_enrollment_ctx
  * @param server_adress (optional) If null server_adress will be obtained from cfg
+ * @return 0 if successfull, -1 on error
  * */
 int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address);
 

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -67,7 +67,7 @@ typedef struct _enrollment_ctx {
     SSL *ssl;                               /**> will hold the connection instance with the manager */
     unsigned int enabled:1;                 /**> enabled / disables auto_enrollment */
     unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
-    unsigned int wait_time:30;              /**> 20 by default, number of seconds to wait for enrollment */
+    unsigned int delay_after_enrollment:30;              /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 
 /**

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -67,6 +67,7 @@ typedef struct _enrollment_ctx {
     SSL *ssl;                               /**> will hold the connection instance with the manager */
     unsigned int enabled:1;                 /**> enabled / disables auto_enrollment */
     unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
+    unsigned int wait_time:30;              /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 
 /**

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -62,8 +62,8 @@ typedef struct _enrollment_cert_cfg {
  * @brief Strcture that handles all the enrollment configuration
  * */
 typedef struct _enrollment_ctx {
-    const w_enrollment_target *target_cfg;  /**> for details @see _enrollment_target_cfg */
-    const w_enrollment_cert *cert_cfg;      /**> for details @see _enrollment_cert_cfg */
+    w_enrollment_target *target_cfg;  /**> for details @see _enrollment_target_cfg */
+    w_enrollment_cert *cert_cfg;      /**> for details @see _enrollment_cert_cfg */
     SSL *ssl;                               /**> will hold the connection instance with the manager */
     unsigned int enabled:1;                 /**> enabled / disables auto_enrollment */
     unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
@@ -95,7 +95,7 @@ void w_enrollment_cert_destroy(w_enrollment_cert *cert);
  * Initializes parameters of an w_enrollment_ctx structure based
  * on a target and certificate configurations
  * */
-w_enrollment_ctx * w_enrollment_init(const w_enrollment_target *target, const w_enrollment_cert *cert);
+w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_cert *cert);
 
 /**
  * Frees parameers of an w_enrollment_ctx structure

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -71,21 +71,8 @@ int main(int argc, char **argv)
     gid_t gid = 0;
     const char *group = GROUPGLOBAL;
 #endif
-    w_enrollment_target target_cfg;
-    w_enrollment_cert cert_cfg;
-    target_cfg.port = DEFAULT_PORT;
-    target_cfg.manager_name = NULL;
-    target_cfg.agent_name = NULL;
-    target_cfg.centralized_group = NULL;
-    target_cfg.sender_ip = NULL;
-    cert_cfg.ciphers = strdup(DEFAULT_CIPHERS);
-    cert_cfg.authpass = NULL;
-    cert_cfg.agent_cert = NULL;
-    cert_cfg.agent_key = NULL;
-    cert_cfg.ca_cert = NULL;
-    cert_cfg.auto_method = 0;
-    //char *dir = DEFAULTDIR;
-    int use_src_ip = 0;
+    w_enrollment_target *target_cfg = w_enrollment_target_init();
+    w_enrollment_cert *cert_cfg = w_enrollment_cert_init();
     char *server_address = NULL;
     bio_err = 0;
     int debug_level = 0;
@@ -143,14 +130,14 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-%c needs an argument", c);
                 }
-                target_cfg.agent_name = optarg;
+                target_cfg->agent_name = strdup(optarg);
                 break;
             case 'p':
                 if (!optarg) {
                     merror_exit("-%c needs an argument", c);
                 }
-                target_cfg.port = atoi(optarg);
-                if (target_cfg.port <= 0 || target_cfg.port >= 65536) {
+                target_cfg->port = atoi(optarg);
+                if (target_cfg->port <= 0 || target_cfg->port >= 65536) {
                     merror_exit("Invalid port: %s", optarg);
                 }
                 break;
@@ -158,49 +145,49 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-%c needs an argument", c);
                 }
-                cert_cfg.ciphers = optarg;
+                cert_cfg->ciphers = strdup(optarg);
                 break;
             case 'v':
                 if (!optarg) {
                     merror_exit("-%c needs an argument", c);
                 }
-                cert_cfg.ca_cert = optarg;
+                cert_cfg->ca_cert = strdup(optarg);
                 break;
             case 'x':
                 if (!optarg) {
                     merror_exit("-%c needs an argument", c);
                 }
-                cert_cfg.agent_cert = optarg;
+                cert_cfg->agent_cert = strdup(optarg);
                 break;
             case 'k':
                 if (!optarg) {
                     merror_exit("-%c needs an argument", c);
                 }
-                cert_cfg.agent_key = optarg;
+                cert_cfg->agent_key = strdup(optarg);
                 break;
             case 'P':
                 if (!optarg)
                     merror_exit("-%c needs an argument", c);
 
-                cert_cfg.authpass = strdup(optarg);
+                cert_cfg->authpass = strdup(optarg);
                 break;
             case 'a':
-                cert_cfg.auto_method = 1;
+                cert_cfg->auto_method = 1;
                 break;
             case 'G':
                 if(!optarg){
                     merror_exit("-%c needs an argument",c);
                 }
-                target_cfg.centralized_group = optarg;
+                target_cfg->centralized_group = strdup(optarg);
                 break;
             case 'I':
                 if(!optarg){
                     merror_exit("-%c needs an argument",c);
                 }
-                target_cfg.sender_ip = optarg;
+                target_cfg->sender_ip = strdup(optarg);
                 break;
             case 'i':
-                use_src_ip = 1;
+                target_cfg->use_src_ip = 1;
                 break;
             default:
                 help_agent_auth();
@@ -226,7 +213,7 @@ int main(int argc, char **argv)
         exit(0);
     }
 
-    if (target_cfg.sender_ip && use_src_ip) {
+    if (target_cfg->sender_ip && target_cfg->use_src_ip) {
         merror("Options '-I' and '-i' are uncompatible.");
         exit(1);
     }
@@ -269,8 +256,12 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    w_enrollment_ctx *cfg = w_enrollment_init(&target_cfg, &cert_cfg);
+    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg);
     int ret = w_enrollment_request_key(cfg, server_address); 
+    
+    w_enrollment_target_destroy(target_cfg);
+    w_enrollment_cert_destroy(cert_cfg);
+    w_enrollment_destroy(cfg);
     
     exit((ret == 0) ? 0 : 1);
 }

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -86,7 +86,6 @@ int main(int argc, char **argv)
     cert_cfg.auto_method = 0;
     //char *dir = DEFAULTDIR;
     int use_src_ip = 0;
-    char * buf;
     char *server_address = NULL;
     bio_err = 0;
     int debug_level = 0;
@@ -269,38 +268,9 @@ int main(int argc, char **argv)
         merror("Manager IP not set.");
         exit(1);
     }
-    
-    os_calloc(OS_SIZE_65536 + OS_SIZE_4096 + 1, sizeof(char), buf);
-    buf[OS_SIZE_65536 + OS_SIZE_4096] = '\0';
 
-    /* Checking if there is a custom password file */
-    if (cert_cfg.authpass == NULL) {
-        FILE *fp;
-        fp = fopen(AUTHDPASS_PATH, "r");
-        buf[0] = '\0';
-
-        if (fp) {
-            buf[4096] = '\0';
-            char *ret = fgets(buf, 4095, fp);
-
-            if (ret && strlen(buf) > 2) {
-                /* Remove newline */
-                if (buf[strlen(buf) - 1] == '\n')
-                    buf[strlen(buf) - 1] = '\0';
-
-                cert_cfg.authpass = strdup(buf);
-            }
-
-            fclose(fp);
-            minfo("Using password specified on file: %s", AUTHDPASS_PATH);
-        }
-    }
-    if (!cert_cfg.authpass) {
-        minfo("No authentication password provided.");
-    }
     w_enrollment_ctx *cfg = w_enrollment_init(&target_cfg, &cert_cfg);
     int ret = w_enrollment_request_key(cfg, server_address); 
     
-    free(buf);
     exit((ret == 0) ? 0 : 1);
 }

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -264,6 +264,11 @@ int main(int argc, char **argv)
 
     /* Start up message */
     minfo(STARTUP_MSG, (int)getpid());
+
+    if (!server_address) {
+        merror("Manager IP not set.");
+        exit(1);
+    }
     
     os_calloc(OS_SIZE_65536 + OS_SIZE_4096 + 1, sizeof(char), buf);
     buf[OS_SIZE_65536 + OS_SIZE_4096] = '\0';

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -178,7 +178,17 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     assert(cfg != NULL);
     assert(server_address != NULL);
 
-    char *ip_address = OS_GetHost(server_address, 3);
+    char *ip_address = NULL;
+    char *tmp_str = strchr(server_address, '/'); 
+    if (tmp_str) {
+        // server_address comes in {hostname}/{ip} fomat
+        ip_address = strdup(++tmp_str);
+    }
+    if(!ip_address){
+        // server_address is either a host or a ip
+        ip_address = OS_GetHost(server_address, 3);
+    }
+    
     /* Translate hostname to an ip_adress */
     if (!ip_address) {
         merror("Could not resolve hostname: %s\n", server_address);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -102,13 +102,6 @@ w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_c
 }
 
 void w_enrollment_destroy(w_enrollment_ctx *cfg) {
-    if (cfg->ssl) {
-        BIO *bio = SSL_get_rbio(cfg->ssl);
-        if (bio) {
-            BIO_free(bio);
-        }
-        SSL_free(cfg->ssl);
-    }
     os_free(cfg);
 }
 
@@ -122,6 +115,10 @@ int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address)
             ret = w_enrollment_process_response(cfg->ssl);
         }
         close(socket);
+    }
+    if (cfg->ssl) {
+        SSL_free(cfg->ssl);
+        cfg->ssl = NULL;
     }
     return ret;
 }

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -119,7 +119,7 @@ int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address)
         if (w_enrollment_send_message(cfg) == 0) {
             ret = w_enrollment_process_response(cfg->ssl);
         }
-        close(socket);
+        OS_CloseSocket(socket);
     }
     if (cfg->ssl) {
         SSL_free(cfg->ssl);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -116,6 +116,7 @@ void w_enrollment_destroy(w_enrollment_ctx *cfg) {
 int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address) {
     assert(cfg != NULL);
     int ret = -1;
+    minfo("Starting enrollment process to server: %s", server_address ? server_address : cfg->target_cfg->manager_name);
     int socket = w_enrollment_connect(cfg, server_address ? server_address : cfg->target_cfg->manager_name);
     if ( socket >= 0) {
         if (w_enrollment_send_message(cfg) == 0) {

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -88,15 +88,11 @@ void w_enrollment_cert_destroy(w_enrollment_cert *cert_cfg) {
     os_free(cert_cfg);
 }
 
-w_enrollment_ctx * w_enrollment_init(const w_enrollment_target *target, const w_enrollment_cert *cert) {
+w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_cert *cert) {
     w_enrollment_ctx *cfg;
     os_malloc(sizeof(w_enrollment_ctx), cfg);
-    // Copy constructor for const parameters
-    w_enrollment_ctx init = {
-        .target_cfg = target,
-        .cert_cfg = cert
-    };
-    memcpy(cfg, &init, sizeof(w_enrollment_ctx));
+    cfg->target_cfg = target;
+    cfg->cert_cfg = cert;
     cfg->enabled = 1;
     cfg->ssl = NULL;
     cfg->allow_localhost = 1;

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -96,6 +96,7 @@ w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_c
     cfg->enabled = 1;
     cfg->ssl = NULL;
     cfg->allow_localhost = 1;
+    cfg->wait_time = 20;
     return cfg;
 }
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -97,7 +97,7 @@ w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_c
     cfg->enabled = 1;
     cfg->ssl = NULL;
     cfg->allow_localhost = 1;
-    cfg->wait_time = 20;
+    cfg->delay_after_enrollment = 20;
     return cfg;
 }
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -41,6 +41,7 @@ static void w_enrollment_concat_group(char *buff, const char* centralized_group)
 static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip);
 static int w_enrollment_process_agent_key(char *buffer);
 static int w_enrollment_store_key_entry(const char* keys);
+static char *w_enrollment_extract_agent_name(const w_enrollment_ctx *cfg);
 
 /* Constants */
 static const int ENTRY_ID = 0;
@@ -150,8 +151,10 @@ static char *w_enrollment_extract_agent_name(const w_enrollment_ctx *cfg) {
         lhostname = cfg->target_cfg->agent_name;
     }
 
-    if(!cfg->allow_localhost && strcmp(lhostname, "localhost") == 0) {
-        merror_exit(AG_INV_HOST, lhostname);
+    if(!cfg->allow_localhost && (strcmp(lhostname, "localhost") == 0)) {
+        merror(AG_INV_HOST, lhostname);
+        if(lhostname != cfg->target_cfg->agent_name)
+            os_free(lhostname);
         return NULL;
     }
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -475,16 +475,9 @@ static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip) {
     assert(buff != NULL); // buff should not be NULL.
 
     if(sender_ip){
-		/* Check if this is strictly an IP address using a regex */
-		if (OS_IsValidIP(sender_ip, NULL))
-		{
-			char opt_buf[256] = {0};
-			snprintf(opt_buf,254," IP:'%s'",sender_ip);
-			strncat(buff,opt_buf,254);
-		} else {
-			merror("Invalid IP address provided for sender IP.");
-			return -1;
-		}
+        char opt_buf[256] = {0};
+        snprintf(opt_buf,254," IP:'%s'",sender_ip);
+        strncat(buff,opt_buf,254);		
     } else {
         char opt_buf[10] = {0};
         snprintf(opt_buf,10," IP:'src'");

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -17,7 +17,7 @@ set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwa
                                 -Wl,--wrap=_minfo,--wrap=OS_GetHost,--wrap=os_ssl_keys,--wrap=OS_ConnectTCP \
                                 -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
                                 -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
-                                -Wl,--wrap=BIO_new_socket")
+                                -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS}")
 else()

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -17,7 +17,7 @@ set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwa
                                 -Wl,--wrap=_minfo,--wrap=OS_GetHost,--wrap=os_ssl_keys,--wrap=OS_ConnectTCP \
                                 -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
                                 -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
-                                -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit")
+                                -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS}")
 else()

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -17,7 +17,8 @@ set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwa
                                 -Wl,--wrap=_minfo,--wrap=OS_GetHost,--wrap=os_ssl_keys,--wrap=OS_ConnectTCP \
                                 -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
                                 -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
-                                -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile")
+                                -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile \
+                                -Wl,--wrap=fgets")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS}")
 else()

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -254,6 +254,9 @@ int test_teardown_context(void **state) {
     os_free(cfg->cert_cfg->ca_cert);
     os_free(cfg->cert_cfg->ciphers);
     os_free(cfg->cert_cfg);
+    if(cfg->ssl) {
+        SSL_free(cfg->ssl);
+    }
     w_enrollment_destroy(cfg);
     return 0;
 }

--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -296,8 +296,7 @@ BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam,
                 case UI_MENU_MANAGE_START:
 
                     /* Start OSSEC  -- must have a valid config before */
-                    if ((strcmp(config_inst.key, FL_NOKEY) != 0) &&
-                            (strcmp(config_inst.server, FL_NOSERVER) != 0)) {
+                    if (strcmp(config_inst.server, FL_NOSERVER) != 0) {
                         ret_code = os_start_service();
                     } else {
                         ret_code = 0;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -108,9 +108,14 @@ int local_start()
         merror_exit(CONFIG_ERROR, cfg);
     }
 
-    /* Check auth keys */
-    if (!OS_CheckKeys()) {
-        merror_exit(AG_NOKEYS_EXIT);
+    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
+        // If autoenrollment is enabled, we will avoid exit if there is no valid key
+        OS_PassEmptyKeyfile();
+    } else {
+        /* Check auth keys */
+        if (!OS_CheckKeys()) {
+            merror_exit(AG_NOKEYS_EXIT);
+        }
     }
 
     /* If there is no file to monitor, create a clean entry
@@ -153,6 +158,35 @@ int local_start()
     minfo(ENC_READ);
 
     OS_ReadKeys(&keys, 1, 0, 0);
+
+    /* Check if we need to auto-enroll */
+    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
+        int could_register = -1;
+        int rc = 0;
+
+        if (agt->enrollment_cfg->target_cfg->manager_name) {
+            // Configured enrollment server
+            could_register = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
+        } 
+        
+        // Try to enroll to server list
+        while (agt->server[rc].rip && (could_register != 0)) {
+            could_register = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
+            rc++;
+        }
+        
+
+        if(could_register == 0) {
+            // Wait for key update on agent side
+            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->wait_time);
+            sleep(agt->enrollment_cfg->wait_time);
+            // Readkeys again to add obtained key
+            OS_ReadKeys(&keys, 1, 0, 0);
+        } else {
+            merror_exit(AG_ENROLL_FAIL);
+        }
+    }
+
     OS_StartCounter(&keys);
     os_write_agent_info(keys.keyentries[0]->name, NULL, keys.keyentries[0]->id, agt->profile);
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -181,6 +181,7 @@ int local_start()
             mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
             sleep(agt->enrollment_cfg->delay_after_enrollment);
             // Readkeys again to add obtained key
+            OS_FreeKeys(&keys);
             OS_ReadKeys(&keys, 1, 0, 0);
         } else {
             merror_exit(AG_ENROLL_FAIL);

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -178,8 +178,8 @@ int local_start()
 
         if(could_register == 0) {
             // Wait for key update on agent side
-            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->wait_time);
-            sleep(agt->enrollment_cfg->wait_time);
+            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
+            sleep(agt->enrollment_cfg->delay_after_enrollment);
             // Readkeys again to add obtained key
             OS_ReadKeys(&keys, 1, 0, 0);
         } else {

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -161,28 +161,27 @@ int local_start()
 
     /* Check if we need to auto-enroll */
     if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
-        int could_register = -1;
+        int registration_status = -1;
         int rc = 0;
 
         if (agt->enrollment_cfg->target_cfg->manager_name) {
             // Configured enrollment server
-            could_register = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
+            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
         } 
         
         // Try to enroll to server list
-        while (agt->server[rc].rip && (could_register != 0)) {
-            could_register = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
+        while (agt->server[rc].rip && (registration_status != 0)) {
+            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
             rc++;
         }
         
 
-        if(could_register == 0) {
+        if(registration_status == 0) {
             // Wait for key update on agent side
             mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
             sleep(agt->enrollment_cfg->delay_after_enrollment);
-            // Readkeys again to add obtained key
-            OS_FreeKeys(&keys);
-            OS_ReadKeys(&keys, 1, 0, 0);
+            // Update keys to get obtained key
+            OS_UpdateKeys(&keys);
         } else {
             merror_exit(AG_ENROLL_FAIL);
         }


### PR DESCRIPTION
|Related issue|
|---|
| #4901 |

## Desciption
When auto-enrollment is enabled ossec-agentd should try to enroll automatically.  There are two escenarios taken into account:
1.` ossec-agentd `starts and has no key stored. In this case the agent will try to:
 - Obtain a key from the configure enrollment server defined in `manager_address` tag in `auto-enrollment` stanza
- If failure will try to obtain a key form all servers specified in `ossec.conf` file
2. `ossec-agentd `starts and has a key, but the manager is actively refusing the connection. After 3 retries the agent will try to register to that manager.

## Tests

- Manual test for available enrollment methods:
  1. Simple verification
  2. Simple verification with Password
  3. Manger Verificatiion (CA certificates)  
  4. Manger and Agent Verification (SSL Certificate signed by manager)
- Unit Test for all library methods

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
