### PR TITLE
Fixing version type selector error

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -858,9 +858,11 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
 
     if (agents_it->dist != FEED_REDHAT) {
         query = vu_queries[VU_JOIN_QUERY];
+        vertype = VER_TYPE_DEB;
     }
     else {
         query = vu_queries[VU_JOIN_RH_QUERY];
+        vertype = VER_TYPE_RPM;
     }
 
     if (sqlite3_prepare_v2(db, query, -1, &stmt, NULL) != SQLITE_OK) {


### PR DESCRIPTION
For some reason like a branch merge, the [pull 4866](https://github.com/wazuh/wazuh/pull/4866) introduced an error in the version type selector during the vulnerability check process. This resulted in a big number of failures in the version comparison.
This pull request restores the original behavior.