### PR TITLE
Add mode as dynamic field

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -424,6 +424,7 @@
       "syscheck.md5_after",
       "syscheck.md5_before",
       "syscheck.path",
+      "syscheck.mode",
       "syscheck.perm_after",
       "syscheck.perm_before",
       "syscheck.sha1_after",
@@ -559,6 +560,9 @@
             "type": "keyword"
           },
           "hard_links": {
+            "type": "keyword"
+          },
+          "mode": {
             "type": "keyword"
           },
           "sha1_before": {

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -37,20 +37,28 @@ static int fim_db_search (char *f_name, char *c_sum, char *w_sum, Eventinfo *lf,
 
 // Build FIM alert
 static int fim_alert (char *f_name, sk_sum_t *oldsum, sk_sum_t *newsum, Eventinfo *lf, _sdb *localsdb);
+
 // Build fileds whodata alert
 static void InsertWhodata (const sk_sum_t * sum, _sdb *localsdb);
+
 // Compare the first common fields between sum strings
 static int SumCompare (const char *s1, const char *s2);
+
 // Check for exceed num of changes
 static int fim_check_changes (int saved_frequency, long saved_time, Eventinfo *lf);
+
 // Send control message to wazuhdb
 static int fim_control_msg (char *key, time_t value, Eventinfo *lf, _sdb *sdb);
+
 //Update field date at last event generated
 int fim_update_date (char *file, Eventinfo *lf, _sdb *sdb);
+
 // Clean for old entries
 int fim_database_clean (Eventinfo *lf, _sdb *sdb);
+
 // Clean sdb memory
 void sdb_clean(_sdb *localsdb);
+
 // Get timestamp for last scan from wazuhdb
 int fim_get_scantime (long *ts, Eventinfo *lf, _sdb *sdb, const char *param);
 
@@ -119,6 +127,7 @@ void sdb_init(_sdb *localsdb, OSDecoderInfo *fim_decoder) {
     fim_decoder->fields[FIM_FILE] = "file";
     fim_decoder->fields[FIM_SIZE] = "size";
     fim_decoder->fields[FIM_HARD_LINKS] = "hard_links";
+    fim_decoder->fields[FIM_MODE_FIELD] = "mode";
     fim_decoder->fields[FIM_PERM] = "perm";
     fim_decoder->fields[FIM_UID] = "uid";
     fim_decoder->fields[FIM_GID] = "gid";
@@ -1057,7 +1066,7 @@ int decode_fim_event(_sdb *sdb, Eventinfo *lf) {
      *   data: {
      *     path:                string
      *     hard_links:          array
-     *     mode:                "scheduled"|"real-time"|"whodata"
+     *     mode:                "scheduled"|"realtime"|"whodata"
      *     type:                "added"|"deleted"|"modified"
      *     timestamp:           number
      *     changed_attributes: [
@@ -1194,6 +1203,8 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
                 os_strdup(object->valuestring, lf->fields[FIM_FILE].value);
             } else if (strcmp(object->string, "mode") == 0) {
                 mode = object->valuestring;
+                os_strdup(mode, lf->mode);
+                os_strdup(mode, lf->fields[FIM_MODE_FIELD].value);
             } else if (strcmp(object->string, "type") == 0) {
                 event_type = object->valuestring;
             } else if (strcmp(object->string, "tags") == 0) {

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -66,8 +66,19 @@ int fim_get_scantime (long *ts, Eventinfo *lf, _sdb *sdb, const char *param);
 static int fim_process_alert(_sdb *sdb, Eventinfo *lf, cJSON *event);
 
 // Generate fim alert
-static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
-        cJSON *attributes, cJSON *old_attributes, cJSON *audit);
+
+/**
+ * @brief Generate fim alert
+ * 
+ * @param lf Event information
+ * @param event_type Type of event (added, modified, deleted)
+ * @param attributes New file attributes
+ * @param old_attributes File attributes before the alert
+ * @param audit Audit information
+ * 
+ * @returns 0 on success, -1 on failure
+*/
+static int fim_generate_alert(Eventinfo *lf, char *event_type, cJSON *attributes, cJSON *old_attributes, cJSON *audit);
 
 // Send save query to Wazuh DB
 static void fim_send_db_save(_sdb * sdb, const char * agent_id, cJSON * data);
@@ -127,7 +138,7 @@ void sdb_init(_sdb *localsdb, OSDecoderInfo *fim_decoder) {
     fim_decoder->fields[FIM_FILE] = "file";
     fim_decoder->fields[FIM_SIZE] = "size";
     fim_decoder->fields[FIM_HARD_LINKS] = "hard_links";
-    fim_decoder->fields[FIM_MODE_FIELD] = "mode";
+    fim_decoder->fields[FIM_MODE] = "mode";
     fim_decoder->fields[FIM_PERM] = "perm";
     fim_decoder->fields[FIM_UID] = "uid";
     fim_decoder->fields[FIM_GID] = "gid";
@@ -1187,7 +1198,7 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
     cJSON *old_attributes = NULL;
     cJSON *audit = NULL;
     cJSON *object = NULL;
-    char *mode = NULL;
+    // char *mode = NULL;
     char *event_type = NULL;
 
     cJSON_ArrayForEach(object, event) {
@@ -1202,9 +1213,9 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
                 os_strdup(object->valuestring, lf->filename);
                 os_strdup(object->valuestring, lf->fields[FIM_FILE].value);
             } else if (strcmp(object->string, "mode") == 0) {
-                mode = object->valuestring;
-                os_strdup(mode, lf->mode);
-                os_strdup(mode, lf->fields[FIM_MODE_FIELD].value);
+                // mode = object->valuestring;
+                os_strdup(object->valuestring, lf->mode);
+                os_strdup(lf->mode, lf->fields[FIM_MODE].value);
             } else if (strcmp(object->string, "type") == 0) {
                 event_type = object->valuestring;
             } else if (strcmp(object->string, "tags") == 0) {
@@ -1266,7 +1277,7 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
 
     lf->decoder_syscheck_id = lf->decoder_info->id;
 
-    fim_generate_alert(lf, mode, event_type, attributes, old_attributes, audit);
+    fim_generate_alert(lf, event_type, attributes, old_attributes, audit);
 
     switch (lf->event_type) {
     case FIM_ADDED:
@@ -1352,8 +1363,7 @@ end:
 }
 
 
-static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
-    cJSON *attributes, cJSON *old_attributes, cJSON *audit) {
+static int fim_generate_alert(Eventinfo *lf, char *event_type, cJSON *attributes, cJSON *old_attributes, cJSON *audit) {
 
     cJSON *object = NULL;
     char change_size[OS_FLSIZE + 1] = {'\0'};
@@ -1471,7 +1481,7 @@ static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
             "%s%s%s%s%s%s%s%s%s%s%s%s",
             lf->fields[FIM_FILE].value, event_type,
             lf->fields[FIM_HARD_LINKS].value ? hard_links : "",
-            mode,
+            lf->fields[FIM_MODE].value,
             lf->fields[FIM_CHFIELDS].value ? changed_attributes : "",
             change_size,
             change_perm,

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1198,7 +1198,6 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
     cJSON *old_attributes = NULL;
     cJSON *audit = NULL;
     cJSON *object = NULL;
-    // char *mode = NULL;
     char *event_type = NULL;
 
     cJSON_ArrayForEach(object, event) {
@@ -1213,7 +1212,6 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
                 os_strdup(object->valuestring, lf->filename);
                 os_strdup(object->valuestring, lf->fields[FIM_FILE].value);
             } else if (strcmp(object->string, "mode") == 0) {
-                // mode = object->valuestring;
                 os_strdup(object->valuestring, lf->mode);
                 os_strdup(lf->mode, lf->fields[FIM_MODE].value);
             } else if (strcmp(object->string, "type") == 0) {

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1298,6 +1298,10 @@ void w_copy_event_for_log(Eventinfo *lf,Eventinfo *lf_cpy){
         os_strdup(lf->filename,lf_cpy->filename);
     }
 
+    if (lf->mode) {
+        os_strdup(lf->mode, lf_cpy->mode);
+    }
+
     if (lf->perm_before) {
         os_strdup(lf->perm_before, lf_cpy->perm_before);
     }

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -758,6 +758,7 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->decoder_info = NULL_Decoder;
 
     lf->filename = NULL;
+    lf->mode = NULL;
     lf->perm_before = NULL;
     lf->md5_before = NULL;
     lf->sha1_before = NULL;

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -960,6 +960,9 @@ void Free_Eventinfo(Eventinfo *lf)
     if (lf->filename) {
         free(lf->filename);
     }
+    if (lf->mode) {
+        free(lf->mode);
+    }
     if (lf->sk_tag) {
         free(lf->sk_tag);
     }

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -86,6 +86,7 @@ typedef struct _Eventinfo {
     /* SYSCHECK Results variables */
     syscheck_event_t event_type;
     char *filename;
+    char *mode;
     char *hard_links;
     char *sk_tag;
     char *sym_path;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -173,8 +173,8 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
             cJSON_AddItemToObject(file_diff, "hard_links", cJSON_Parse(lf->fields[FIM_HARD_LINKS].value));
         }
 
-        if (lf->fields[FIM_MODE_FIELD].value) {
-            cJSON_AddStringToObject(file_diff, "mode", lf->fields[FIM_MODE_FIELD].value);
+        if (lf->fields[FIM_MODE].value) {
+            cJSON_AddStringToObject(file_diff, "mode", lf->fields[FIM_MODE].value);
         }
 
         if (lf->sym_path && *lf->sym_path) {

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -173,6 +173,10 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf)
             cJSON_AddItemToObject(file_diff, "hard_links", cJSON_Parse(lf->fields[FIM_HARD_LINKS].value));
         }
 
+        if (lf->fields[FIM_MODE_FIELD].value) {
+            cJSON_AddStringToObject(file_diff, "mode", lf->fields[FIM_MODE_FIELD].value);
+        }
+
         if (lf->sym_path && *lf->sym_path) {
             cJSON_AddStringToObject(file_diff, "symbolic_path", lf->sym_path);
         }

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -82,7 +82,7 @@
 typedef enum fim_fields {
     FIM_FILE,
     FIM_HARD_LINKS,
-    FIM_MODE_FIELD,
+    FIM_MODE,
     FIM_SIZE,
     FIM_PERM,
     FIM_UID,

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -82,6 +82,7 @@
 typedef enum fim_fields {
     FIM_FILE,
     FIM_HARD_LINKS,
+    FIM_MODE_FIELD,
     FIM_SIZE,
     FIM_PERM,
     FIM_UID,

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -39,7 +39,7 @@ static const char *FIM_EVENT_TYPE[] = {
 
 static const char *FIM_EVENT_MODE[] = {
     "scheduled",
-    "real-time",
+    "realtime",
     "whodata"
 };
 

--- a/src/unit_tests/analysisd/test_analysisd_syscheck.c
+++ b/src/unit_tests/analysisd/test_analysisd_syscheck.c
@@ -257,7 +257,9 @@ static int setup_fim_data(void **state) {
         return -1;
     if(data->lf->decoder_info->fields[FIM_HARD_LINKS] = strdup("hard_links"), data->lf->decoder_info->fields[FIM_HARD_LINKS] == NULL)
         return -1;
-    if(data->lf->decoder_info->fields[FIM_MODE] = strdup("mode"), data->lf->decoder_info->fields[FIM_MODE] == NULL)
+    if (data->lf->decoder_info->fields[FIM_MODE] = strdup("mode"), data->lf->decoder_info->fields[FIM_MODE] == NULL)
+        return -1;
+    if (data->lf->fields[FIM_MODE].value = strdup("fim_mode"), data->lf->fields[FIM_MODE].value == NULL)
         return -1;
     if(data->lf->decoder_info->fields[FIM_SIZE] = strdup("size"), data->lf->decoder_info->fields[FIM_SIZE] == NULL)
         return -1;
@@ -1470,6 +1472,8 @@ static void test_fim_generate_alert_null_mode(void **state) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
 
+    input->lf->fields[FIM_MODE].value = NULL;
+
     ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, audit);
 
     assert_int_equal(ret, 0);
@@ -2417,6 +2421,8 @@ static void test_fim_process_alert_no_mode(void **state) {
 
     cJSON *data = cJSON_GetObjectItem(input->event, "data");
     cJSON_DeleteItemFromObject(data, "mode");
+
+    input->lf->fields[FIM_MODE].value = NULL;
 
     if(input->lf->agent_id = strdup("007"), input->lf->agent_id == NULL)
         fail();

--- a/src/unit_tests/analysisd/test_analysisd_syscheck.c
+++ b/src/unit_tests/analysisd/test_analysisd_syscheck.c
@@ -36,8 +36,7 @@ void fim_process_scan_info(_sdb * sdb, const char * agent_id, fim_scan_event eve
 int fim_fetch_attributes_state(cJSON *attr, Eventinfo *lf, char new_state);
 int fim_fetch_attributes(cJSON *new_attrs, cJSON *old_attrs, Eventinfo *lf);
 size_t fim_generate_comment(char * str, long size, const char * format, const char * a1, const char * a2);
-int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
-        cJSON *attributes, cJSON *old_attributes, cJSON *audit);
+int fim_generate_alert(Eventinfo *lf, char *event_type, cJSON *attributes, cJSON *old_attributes, cJSON *audit);
 int fim_process_alert(_sdb *sdb, Eventinfo *lf, cJSON *event);
 int decode_fim_event(_sdb *sdb, Eventinfo *lf);
 void fim_adjust_checksum(sk_sum_t *newsum, char **checksum);
@@ -258,7 +257,7 @@ static int setup_fim_data(void **state) {
         return -1;
     if(data->lf->decoder_info->fields[FIM_HARD_LINKS] = strdup("hard_links"), data->lf->decoder_info->fields[FIM_HARD_LINKS] == NULL)
         return -1;
-    if(data->lf->decoder_info->fields[FIM_MODE_FIELD] = strdup("mode"), data->lf->decoder_info->fields[FIM_MODE_FIELD] == NULL)
+    if(data->lf->decoder_info->fields[FIM_MODE] = strdup("mode"), data->lf->decoder_info->fields[FIM_MODE] == NULL)
         return -1;
     if(data->lf->decoder_info->fields[FIM_SIZE] = strdup("size"), data->lf->decoder_info->fields[FIM_SIZE] == NULL)
         return -1;
@@ -1242,7 +1241,6 @@ static void test_fim_generate_comment_invalid_format(void **state) {
 /* fim_generate_alert */
 static void test_fim_generate_alert_full_alert(void **state) {
     fim_data_t *input = *state;
-    char *mode = "fim_mode";
     char *event_type = "fim_event_type";
     int ret;
 
@@ -1265,8 +1263,7 @@ static void test_fim_generate_alert_full_alert(void **state) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
 
-    ret = fim_generate_alert(input->lf, mode, event_type,
-                             attributes, old_attributes, audit);
+    ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, audit);
 
     assert_int_equal(ret, 0);
 
@@ -1337,7 +1334,6 @@ static void test_fim_generate_alert_full_alert(void **state) {
 
 static void test_fim_generate_alert_type_not_modified(void **state) {
     fim_data_t *input = *state;
-    char *mode = "fim_mode";
     char *event_type = "fim_event_type";
     int ret;
 
@@ -1357,8 +1353,7 @@ static void test_fim_generate_alert_type_not_modified(void **state) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
 
-    ret = fim_generate_alert(input->lf, mode, event_type,
-                             attributes, old_attributes, audit);
+    ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, audit);
 
     assert_int_equal(ret, 0);
 
@@ -1414,7 +1409,6 @@ static void test_fim_generate_alert_type_not_modified(void **state) {
 
 static void test_fim_generate_alert_invalid_element_in_attributes(void **state) {
     fim_data_t *input = *state;
-    char *mode = "fim_mode";
     char *event_type = "fim_event_type";
     int ret;
 
@@ -1429,15 +1423,13 @@ static void test_fim_generate_alert_invalid_element_in_attributes(void **state) 
 
     expect_string(__wrap__mdebug1, formatted_msg, "FIM attribute set contains an item with no key.");
 
-    ret = fim_generate_alert(input->lf, mode, event_type,
-                             attributes, old_attributes, audit);
+    ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, audit);
 
     assert_int_equal(ret, -1);
 }
 
 static void test_fim_generate_alert_invalid_element_in_audit(void **state) {
     fim_data_t *input = *state;
-    char *mode = "fim_mode";
     char *event_type = "fim_event_type";
     int ret;
 
@@ -1452,8 +1444,7 @@ static void test_fim_generate_alert_invalid_element_in_audit(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "FIM audit set contains an item with no key.");
 
-    ret = fim_generate_alert(input->lf, mode, event_type,
-                             attributes, old_attributes, audit);
+    ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, audit);
 
     assert_int_equal(ret, -1);
 }
@@ -1479,8 +1470,7 @@ static void test_fim_generate_alert_null_mode(void **state) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
 
-    ret = fim_generate_alert(input->lf, NULL, event_type,
-                             attributes, old_attributes, audit);
+    ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, audit);
 
     assert_int_equal(ret, 0);
 
@@ -1536,7 +1526,6 @@ static void test_fim_generate_alert_null_mode(void **state) {
 
 static void test_fim_generate_alert_null_event_type(void **state) {
     fim_data_t *input = *state;
-    char *mode = "fim_mode";
     int ret;
 
     cJSON *data = cJSON_GetObjectItem(input->event, "data");
@@ -1555,8 +1544,7 @@ static void test_fim_generate_alert_null_event_type(void **state) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
 
-    ret = fim_generate_alert(input->lf, mode, NULL,
-                             attributes, old_attributes, audit);
+    ret = fim_generate_alert(input->lf, NULL, attributes, old_attributes, audit);
 
     assert_int_equal(ret, 0);
 
@@ -1612,7 +1600,6 @@ static void test_fim_generate_alert_null_event_type(void **state) {
 
 static void test_fim_generate_alert_null_attributes(void **state) {
     fim_data_t *input = *state;
-    char *mode = "fim_mode";
     char *event_type = "fim_event_type";
     int ret;
 
@@ -1631,8 +1618,7 @@ static void test_fim_generate_alert_null_attributes(void **state) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
 
-    ret = fim_generate_alert(input->lf, mode, event_type,
-                             NULL, old_attributes, audit);
+    ret = fim_generate_alert(input->lf, event_type, NULL, old_attributes, audit);
 
     assert_int_equal(ret, 0);
 
@@ -1702,7 +1688,6 @@ static void test_fim_generate_alert_null_attributes(void **state) {
 
 static void test_fim_generate_alert_null_old_attributes(void **state) {
     fim_data_t *input = *state;
-    char *mode = "fim_mode";
     char *event_type = "fim_event_type";
     int ret;
 
@@ -1721,8 +1706,7 @@ static void test_fim_generate_alert_null_old_attributes(void **state) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
 
-    ret = fim_generate_alert(input->lf, mode, event_type,
-                             attributes, NULL, audit);
+    ret = fim_generate_alert(input->lf, event_type, attributes, NULL, audit);
 
     assert_int_equal(ret, 0);
 
@@ -1793,7 +1777,6 @@ static void test_fim_generate_alert_null_old_attributes(void **state) {
 
 static void test_fim_generate_alert_null_audit(void **state) {
     fim_data_t *input = *state;
-    char *mode = "fim_mode";
     char *event_type = "fim_event_type";
     int ret;
 
@@ -1812,8 +1795,7 @@ static void test_fim_generate_alert_null_audit(void **state) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
 
-    ret = fim_generate_alert(input->lf, mode, event_type,
-                             attributes, old_attributes, NULL);
+    ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, NULL);
 
     assert_int_equal(ret, 0);
 
@@ -3151,7 +3133,7 @@ static void test_decode_fim_event_type_event(void **state) {
     if(lf->agent_id = strdup("007"), lf->agent_id == NULL)
         fail();
 
-    lf->decoder_info->fields[FIM_MODE_FIELD] = strdup("mode");
+    lf->decoder_info->fields[FIM_MODE] = strdup("mode");
 
     /* Inside fim_process_alert */
     expect_string(__wrap_wdbc_query_ex, query, "agent 007 syscheck save2 "

--- a/src/unit_tests/analysisd/test_analysisd_syscheck.c
+++ b/src/unit_tests/analysisd/test_analysisd_syscheck.c
@@ -258,6 +258,8 @@ static int setup_fim_data(void **state) {
         return -1;
     if(data->lf->decoder_info->fields[FIM_HARD_LINKS] = strdup("hard_links"), data->lf->decoder_info->fields[FIM_HARD_LINKS] == NULL)
         return -1;
+    if(data->lf->decoder_info->fields[FIM_MODE_FIELD] = strdup("mode"), data->lf->decoder_info->fields[FIM_MODE_FIELD] == NULL)
+        return -1;
     if(data->lf->decoder_info->fields[FIM_SIZE] = strdup("size"), data->lf->decoder_info->fields[FIM_SIZE] == NULL)
         return -1;
     if(data->lf->decoder_info->fields[FIM_PERM] = strdup("perm"), data->lf->decoder_info->fields[FIM_PERM] == NULL)
@@ -3148,6 +3150,8 @@ static void test_decode_fim_event_type_event(void **state) {
 
     if(lf->agent_id = strdup("007"), lf->agent_id == NULL)
         fail();
+
+    lf->decoder_info->fields[FIM_MODE_FIELD] = strdup("mode");
 
     /* Inside fim_process_alert */
     expect_string(__wrap_wdbc_query_ex, query, "agent 007 syscheck save2 "

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -537,7 +537,7 @@ static void test_fim_json_event(void **state) {
     cJSON *path = cJSON_GetObjectItem(data, "path");
     assert_string_equal(cJSON_GetStringValue(path), "test.file");
     cJSON *mode = cJSON_GetObjectItem(data, "mode");
-    assert_string_equal(cJSON_GetStringValue(mode), "real-time");
+    assert_string_equal(cJSON_GetStringValue(mode), "realtime");
     cJSON *data_type = cJSON_GetObjectItem(data, "type");
     assert_string_equal(cJSON_GetStringValue(data_type), "modified");
     cJSON *timestamp = cJSON_GetObjectItem(data, "timestamp");
@@ -675,7 +675,7 @@ static void test_fim_json_event_hardlink_one_path(void **state) {
     cJSON *path = cJSON_GetObjectItem(data, "path");
     assert_string_equal(cJSON_GetStringValue(path), "test.file");
     cJSON *mode = cJSON_GetObjectItem(data, "mode");
-    assert_string_equal(cJSON_GetStringValue(mode), "real-time");
+    assert_string_equal(cJSON_GetStringValue(mode), "realtime");
     cJSON *data_type = cJSON_GetObjectItem(data, "type");
     assert_string_equal(cJSON_GetStringValue(data_type), "modified");
     cJSON *timestamp = cJSON_GetObjectItem(data, "timestamp");
@@ -737,7 +737,7 @@ static void test_fim_json_event_hardlink_two_paths(void **state) {
     cJSON *path = cJSON_GetObjectItem(data, "path");
     assert_string_equal(cJSON_GetStringValue(path), "test.file");
     cJSON *mode = cJSON_GetObjectItem(data, "mode");
-    assert_string_equal(cJSON_GetStringValue(mode), "real-time");
+    assert_string_equal(cJSON_GetStringValue(mode), "realtime");
     cJSON *data_type = cJSON_GetObjectItem(data, "type");
     assert_string_equal(cJSON_GetStringValue(data_type), "modified");
     cJSON *timestamp = cJSON_GetObjectItem(data, "timestamp");


### PR DESCRIPTION
| Related issue  | QA issue                       | Documentation issue                            |
|---------------|-----------------------|--------------------------------------|
| #4799             | wazuh/wazuh-qa#673 | wazuh/wazuh-documentation#2407  |

## Description

This pull request adds the mode field to the FIM alerts. It also makes alerts more consistent deleting the hyphen from the real-time alerts, leaving three possibilities: `scheduled|realtime|whodata`.
This pull request closes #4799.

## Logs/Alerts example

```json
{
    "id": "1587466043.151965",
    "full_log": "File '/test/file_7' added\nMode: realtime\n",
    "syscheck": {
        "path": "/test/file_7",
        "mode": "realtime",
        "size_after": "0",
        "perm_after": "rw-r--r--",
        "uid_after": "0",
        "gid_after": "0",
        "md5_after": "d41d8cd98f00b204e9800998ecf8427e",
        "sha1_after": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
        "sha256_after": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
        "uname_after": "root",
        "gname_after": "root",
        "mtime_after": "2020-04-21T10:47:23",
        "inode_after": 34033987,
        "event": "added"
    },
    "decoder": {
        "name": "syscheck_new_entry"
    },
    "location": "syscheck"
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Dr. Memory
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
