### PR TITLE
Fix logbuilder for target 'agent' on <localfile>

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1814,7 +1814,7 @@ void * w_output_thread(void * args){
             // When dealing with this type of messages we don't want any of them to be lost
             // Continuously attempt to reconnect to the queue and send the message.
 
-            if(SendMSG(logr_queue, message->buffer, message->file, message->queue_mq) != 0) {
+            if(SendMSGtoSCK(logr_queue, message->buffer, message->file, message->queue_mq, message->log_target) != 0) {
                 #ifdef CLIENT
                 merror("Unable to send message to '%s' (ossec-agentd might be down). Attempting to reconnect.", DEFAULTQPATH);
                 #else

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -116,77 +116,85 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute
 
     tmpstr[OS_MAXSTR] = '\0';
 
-    int sock_type;
-    const char * strmode;
-
-    switch (target->log_socket->mode) {
-    case IPPROTO_UDP:
-        sock_type = SOCK_DGRAM;
-        strmode = "udp";
-        break;
-    case IPPROTO_TCP:
-        sock_type = SOCK_STREAM;
-        strmode = "tcp";
-        break;
-    default:
-        merror("At %s(): undefined protocol. This shouldn't happen.", __FUNCTION__);
-        free(_message);
-        return -1;
-    }
-
-    // create message and add prefix
-    if (target->log_socket->prefix && *target->log_socket->prefix) {
-        snprintf(tmpstr, OS_MAXSTR, "%s%s", target->log_socket->prefix, _message);
-    } else {
-        snprintf(tmpstr, OS_MAXSTR, "%s", _message);
-    }
-
-    // Connect to socket if disconnected
-    if (target->log_socket->socket < 0) {
-        if (mtime = time(NULL), mtime > target->log_socket->last_attempt + sock_fail_time) {
-            if (target->log_socket->socket = OS_ConnectUnixDomain(target->log_socket->location, sock_type, OS_MAXSTR + 256), target->log_socket->socket < 0) {
-                target->log_socket->last_attempt = mtime;
-                merror("Unable to connect to socket '%s': %s (%s)", target->log_socket->name, target->log_socket->location, strmode);
-                free(_message);
-                return -1;
-            }
-
-            mdebug1("Connected to socket '%s' (%s)", target->log_socket->name, target->log_socket->location);
-        } else {
-            mdebug2("Discarding event from '%s' due to connection issue with '%s'", locmsg, target->log_socket->name);
+    if (strcmp(target->log_socket->name, "agent") == 0) {
+        if(SendMSG(queue, _message, locmsg, loc) != 0) {
             free(_message);
-            return 0;
+            return -1;
         }
-    }
+    }else{
+        int sock_type;
+        const char * strmode;
 
-    // Send msg to socket
-    if (__mq_rcode = OS_SendUnix(target->log_socket->socket, tmpstr, strlen(tmpstr)), __mq_rcode < 0) {
-        if (__mq_rcode == OS_SOCKTERR) {
+        switch (target->log_socket->mode) {
+        case IPPROTO_UDP:
+            sock_type = SOCK_DGRAM;
+            strmode = "udp";
+            break;
+        case IPPROTO_TCP:
+            sock_type = SOCK_STREAM;
+            strmode = "tcp";
+            break;
+        default:
+            merror("At %s(): undefined protocol. This shouldn't happen.", __FUNCTION__);
+            free(_message);
+            return -1;
+        }
+
+        // create message and add prefix
+        if (target->log_socket->prefix && *target->log_socket->prefix) {
+            snprintf(tmpstr, OS_MAXSTR, "%s%s", target->log_socket->prefix, _message);
+        } else {
+            snprintf(tmpstr, OS_MAXSTR, "%s", _message);
+        }
+
+        // Connect to socket if disconnected
+        if (target->log_socket->socket < 0) {
             if (mtime = time(NULL), mtime > target->log_socket->last_attempt + sock_fail_time) {
-                close(target->log_socket->socket);
-
                 if (target->log_socket->socket = OS_ConnectUnixDomain(target->log_socket->location, sock_type, OS_MAXSTR + 256), target->log_socket->socket < 0) {
-                    merror("Unable to connect to socket '%s': %s (%s)", target->log_socket->name, target->log_socket->location, strmode);
                     target->log_socket->last_attempt = mtime;
-                } else {
-                    mdebug1("Connected to socket '%s' (%s)", target->log_socket->name, target->log_socket->location);
-
-                    if (OS_SendUnix(target->log_socket->socket, tmpstr, strlen(tmpstr)), __mq_rcode < 0) {
-                        merror("Cannot send message to socket '%s'. (Retry)", target->log_socket->name);
-                        SendMSG(queue, "Cannot send message to socket.", "logcollector", LOCALFILE_MQ);
-                        target->log_socket->last_attempt = mtime;
-                    }
+                    merror("Unable to connect to socket '%s': %s (%s)", target->log_socket->name, target->log_socket->location, strmode);
+                    free(_message);
+                    return -1;
                 }
+
+                mdebug1("Connected to socket '%s' (%s)", target->log_socket->name, target->log_socket->location);
             } else {
                 mdebug2("Discarding event from '%s' due to connection issue with '%s'", locmsg, target->log_socket->name);
+                free(_message);
+                return 0;
             }
-        } else {
-            merror("Cannot send message to socket '%s'. (Retry)", target->log_socket->name);
-            SendMSG(queue, "Cannot send message to socket.", "logcollector", LOCALFILE_MQ);
         }
-    }
 
-    free(_message);
+        // Send msg to socket
+        if (__mq_rcode = OS_SendUnix(target->log_socket->socket, tmpstr, strlen(tmpstr)), __mq_rcode < 0) {
+            if (__mq_rcode == OS_SOCKTERR) {
+                if (mtime = time(NULL), mtime > target->log_socket->last_attempt + sock_fail_time) {
+                    close(target->log_socket->socket);
+
+                    if (target->log_socket->socket = OS_ConnectUnixDomain(target->log_socket->location, sock_type, OS_MAXSTR + 256), target->log_socket->socket < 0) {
+                        merror("Unable to connect to socket '%s': %s (%s)", target->log_socket->name, target->log_socket->location, strmode);
+                        target->log_socket->last_attempt = mtime;
+                    } else {
+                        mdebug1("Connected to socket '%s' (%s)", target->log_socket->name, target->log_socket->location);
+
+                        if (OS_SendUnix(target->log_socket->socket, tmpstr, strlen(tmpstr)), __mq_rcode < 0) {
+                            merror("Cannot send message to socket '%s'. (Retry)", target->log_socket->name);
+                            SendMSG(queue, "Cannot send message to socket.", "logcollector", LOCALFILE_MQ);
+                            target->log_socket->last_attempt = mtime;
+                        }
+                    }
+                } else {
+                    mdebug2("Discarding event from '%s' due to connection issue with '%s'", locmsg, target->log_socket->name);
+                }
+            } else {
+                merror("Cannot send message to socket '%s'. (Retry)", target->log_socket->name);
+                SendMSG(queue, "Cannot send message to socket.", "logcollector", LOCALFILE_MQ);
+            }
+        }
+
+        free(_message);
+        return (0);
+    }
     return (0);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4877|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The problem was that the `<out_format>` tag didn't work when the `<localfile>` target was "agent". This was caused by a modification that was made in the PR https://github.com/wazuh/wazuh/pull/4696, and it made that the messages that had target agent were sent without being built as a log.

To fix this I have added that the `SendMSGtoSCK()` function considers the target agent and sends it in a normal way after building the log. I have also changed the call to the function to send the log when the target is an agent.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [x] MAC OS X
- [X] Source installation
- [X] Source upgrade

Tests specified here: https://github.com/wazuh/wazuh-qa/issues/656