### PR TITLE
Rootcheck: Memory leak in Windows Server 2016

### DIFF
--- a/src/rootcheck/util/ads_dump.c
+++ b/src/rootcheck/util/ads_dump.c
@@ -90,6 +90,9 @@ int os_get_streams(char *full_path)
         }
     }
 
+    BackupRead(file_h, (LPBYTE)stream_name,
+                       sid.dwStreamNameSize,
+                       &dwRead, TRUE, FALSE, &context);
     CloseHandle(file_h);
     return (0);
 }
@@ -176,4 +179,3 @@ int main(int argc, char **argv)
     }
     return (0);
 }
-

--- a/src/rootcheck/win-common.c
+++ b/src/rootcheck/win-common.c
@@ -103,7 +103,9 @@ int os_check_ads(const char *full_path)
             break;
         }
     }
-
+    BackupRead(file_h, (LPBYTE)stream_name,
+                       sid.dwStreamNameSize,
+                       &dwRead, TRUE, FALSE, &context);
     CloseHandle(file_h);
     return (0);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#4894|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team. 
As described in #4894, a memory leak was found in rootcheck.
This memory leak was an isolated case thas was observed only in Windows 2016. More info can be found in the related issue. 

To fix it, a new call to the function ReadBackup has been added in order to deallocate the memory allocated by this function. 
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```
<ossec_config>
  <client>
    <server>
<address>172.20.1.120</address>
      <port>1514</port>
      <protocol>udp</protocol>
    </server>
    <crypto_method>aes</crypto_method>
    <notify_time>10</notify_time>
    <time-reconnect>60</time-reconnect>
    <auto_restart>yes</auto_restart>
  </client>
  <client_buffer>
    <disabled>no</disabled>
    <queue_size>5000</queue_size>
    <events_per_second>500</events_per_second>
  </client_buffer>

  <rootcheck>
    <disabled>no</disabled>
    <frequency>60</frequency>
    <windows_apps>./shared/win_applications_rcl.txt</windows_apps>
    <windows_malware>./shared/win_malware_rcl.txt</windows_malware>
  </rootcheck>
</ossec_config> 
```
The entire config file can be found in the related issue.
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests
This are the tested Windows versions after the fix: 

1. **Windows Server 2012 after the fix:** 
![image](https://user-images.githubusercontent.com/22987701/80095944-16df1380-8569-11ea-9269-802ad6b5e8ee.png)

2. **Windows Server 2016 after the fix:** 

![image](https://user-images.githubusercontent.com/22987701/80097027-e4ceb100-856a-11ea-8f30-e1827d571eda.png)


3. **Windows Server 2019 after the fix:** 
![image](https://user-images.githubusercontent.com/22987701/80096648-332f8000-856a-11ea-84c6-a94f80037e7d.png)
 
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform

  - [X] Windows
- [X] Source installation

- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [ ] Scan-build report
  - [x] Coverity
  - [ ] Dr. Memory

