### PR TITLE
Disable WAL mode in Wazuh DB

### DIFF
--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -321,11 +321,9 @@ CREATE TABLE IF NOT EXISTS sync_info (
 
 BEGIN;
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '4');
+INSERT INTO metadata (key, value) VALUES ('db_version', '5');
 INSERT INTO scan_info (module) VALUES ('fim');
 INSERT INTO scan_info (module) VALUES ('syscollector');
 INSERT INTO sync_info (component) VALUES ('fim');
 
 COMMIT;
-
-PRAGMA journal_mode=WAL;

--- a/src/wazuh_db/schema_upgrade_v5.sql
+++ b/src/wazuh_db/schema_upgrade_v5.sql
@@ -1,0 +1,13 @@
+/*
+ * SQL Schema for upgrading databases
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * April 23, 2020.
+ *
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+*/
+
+PRAGMA journal_mode=DELETE;
+
+INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 5);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -121,7 +121,8 @@ typedef enum wdb_stmt {
     WDB_STMT_FIM_CLEAR,
     WDB_STMT_SYNC_UPDATE_ATTEMPT,
     WDB_STMT_SYNC_UPDATE_COMPLETION,
-    WDB_STMT_SIZE
+    WDB_STMT_SIZE,
+    WDB_STMT_PRAGMA_JOURNAL_WAL,
 } wdb_stmt;
 
 typedef struct wdb_t {
@@ -613,6 +614,15 @@ int wdbi_query_checksum(wdb_t * wdb, wdb_component_t component, const char * com
  * @retval -1 On error.
  */
 int wdbi_query_clear(wdb_t * wdb, wdb_component_t component, const char * payload);
+
+/**
+ * @brief Set the database journal mode to write-ahead logging
+ *
+ * @param db Pointer to an open database.
+ * @retval 0 On success.
+ * @retval -1 On error.
+ */
+int wdb_journal_wal(sqlite3 *db);
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -158,6 +158,7 @@ extern char *schema_upgrade_v1_sql;
 extern char *schema_upgrade_v2_sql;
 extern char *schema_upgrade_v3_sql;
 extern char *schema_upgrade_v4_sql;
+extern char *schema_upgrade_v5_sql;
 
 extern wdb_config config;
 extern pthread_mutex_t pool_mutex;

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -25,7 +25,8 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
         schema_upgrade_v1_sql,
         schema_upgrade_v2_sql,
         schema_upgrade_v3_sql,
-        schema_upgrade_v4_sql
+        schema_upgrade_v4_sql,
+        schema_upgrade_v5_sql,
     };
 
     char db_version[OS_SIZE_256 + 2];


### PR DESCRIPTION
|Related issue|
|---|
|#4411|

This PR aims to set the journaling mode to _DELETE_ in Wazuh DB while leaving _WAL_ in the legacy database module.

That will make the journal mode length depend on the transaction size, which is bounded between `wazuh_db.commit_time_min` and `wazuh_db.commit_time_max` since Wazuh 3.12.0.

## Affected artifacts

- wazuh-db binary.
- wazuh-modulesd binary: database synchronization database.
- Agent database template (removed at Wazuh DB startup and exit).

## Tests

- [X] Compile manager on Ubuntu 19.10.
- [X] Source installation.
- [X] Source upgrade.
- [X] Update a database from v3 (3.11) to v5 (current).
- [X] Run Valgrind on Wazuh DB and Modulesd.
- [X] Run unit tests for the manager.
- [X] Check that _var/db/agents/*_ have `journal_mode=WAL` and _queue/db/*_ have `journal_mode=DELETE`.
- [X] Review logs syntax and correct language.

### Valgrind on Wazuh DB

- Run a Syscollector and an SCA scan.
- Upgrade a database from v3 to v4 and v5.

```
==9609== HEAP SUMMARY:
==9609==     in use at exit: 0 bytes in 0 blocks
==9609==   total heap usage: 224,417 allocs, 224,417 frees, 367,127,009 bytes allocated
==9609==
==9609== All heap blocks were freed -- no leaks are possible
```

### Valgrind on Wazuh Modulesd

- Synchronize the agent 000 database.

```
==7590== LEAK SUMMARY:
==7590==    definitely lost: 0 bytes in 0 blocks
==7590==    indirectly lost: 0 bytes in 0 blocks
==7590==      possibly lost: 6,824 bytes in 11 blocks
==7590==    still reachable: 755,026 bytes in 7,431 blocks
```

### Unit tests result

```
100% tests passed, 0 tests failed out of 23
```