### PR TITLE
4857 fixing double free issue

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -550,23 +550,22 @@ char *wm_vuldet_build_url(char *pattern, char *value) {
 }
 
 int wm_vuldet_compare_pkg(cve_vuln_pkg *Pkg1, cve_vuln_pkg *Pkg2) {
-    if (!(!Pkg1->src_name && !Pkg2->src_name) &&
-        !(Pkg1->src_name && Pkg2->src_name &&
+    if (!(Pkg1->src_name && Pkg2->src_name &&
         !strcmp(Pkg1->src_name, Pkg2->src_name))) { // Source name
         return -1;
     }
-    if (!(!Pkg1->bin_name && !Pkg2->bin_name) &&
-        !(Pkg1->bin_name && Pkg2->bin_name &&
+
+    if (!(Pkg1->bin_name && Pkg2->bin_name &&
         !strcmp(Pkg1->bin_name, Pkg2->bin_name))) { // Binary name
         return -1;
     }
-    if (!(!Pkg1->version && !Pkg2->version) &&
-        !(Pkg1->version && Pkg2->version &&
+
+    if (!(Pkg1->version && Pkg2->version &&
         !strcmp(Pkg1->version, Pkg2->version))) { // Version
         return -1;
     }
-    if (!(!Pkg1->arch && !Pkg2->arch) &&
-        !(Pkg1->arch && Pkg2->arch &&
+
+    if (!(Pkg1->arch && Pkg2->arch &&
         !strcmp(Pkg1->arch, Pkg2->arch))) { // Archiquitecture
         return -1;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -550,22 +550,26 @@ char *wm_vuldet_build_url(char *pattern, char *value) {
 }
 
 int wm_vuldet_compare_pkg(cve_vuln_pkg *Pkg1, cve_vuln_pkg *Pkg2) {
-    if (!(Pkg1->src_name && Pkg2->src_name &&
+    if (!(!Pkg1->src_name && !Pkg2->src_name) &&
+        !(Pkg1->src_name && Pkg2->src_name &&
         !strcmp(Pkg1->src_name, Pkg2->src_name))) { // Source name
         return -1;
     }
 
-    if (!(Pkg1->bin_name && Pkg2->bin_name &&
+    if (!(!Pkg1->bin_name && !Pkg2->bin_name) &&
+        !(Pkg1->bin_name && Pkg2->bin_name &&
         !strcmp(Pkg1->bin_name, Pkg2->bin_name))) { // Binary name
         return -1;
     }
 
-    if (!(Pkg1->version && Pkg2->version &&
+    if (!(!Pkg1->version && !Pkg2->version) &&
+        !(Pkg1->version && Pkg2->version &&
         !strcmp(Pkg1->version, Pkg2->version))) { // Version
         return -1;
     }
 
-    if (!(Pkg1->arch && Pkg2->arch &&
+    if (!(!Pkg1->arch && !Pkg2->arch) &&
+        !(Pkg1->arch && Pkg2->arch &&
         !strcmp(Pkg1->arch, Pkg2->arch))) { // Archiquitecture
         return -1;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -555,19 +555,16 @@ int wm_vuldet_compare_pkg(cve_vuln_pkg *Pkg1, cve_vuln_pkg *Pkg2) {
         !strcmp(Pkg1->src_name, Pkg2->src_name))) { // Source name
         return -1;
     }
-
     if (!(!Pkg1->bin_name && !Pkg2->bin_name) &&
         !(Pkg1->bin_name && Pkg2->bin_name &&
         !strcmp(Pkg1->bin_name, Pkg2->bin_name))) { // Binary name
         return -1;
     }
-
     if (!(!Pkg1->version && !Pkg2->version) &&
         !(Pkg1->version && Pkg2->version &&
         !strcmp(Pkg1->version, Pkg2->version))) { // Version
         return -1;
     }
-
     if (!(!Pkg1->arch && !Pkg2->arch) &&
         !(Pkg1->arch && Pkg2->arch &&
         !strcmp(Pkg1->arch, Pkg2->arch))) { // Archiquitecture
@@ -595,12 +592,30 @@ int wm_vuldet_add_cve_node(cve_vuln_pkg *newPkg, const char *cve, OSHash *cve_ta
         do {
             if (!wm_vuldet_compare_pkg(tmpPkg, newPkg)) { // Same package?
                 if (!tmpPkg->nvd_cond && newPkg->nvd_cond) {
-                    tmpPkg->nvd_cond = newPkg->nvd_cond;
+                    os_calloc(1, sizeof(cve_vuln_cond_NVD), tmpPkg->nvd_cond);
+
+                    if (newPkg->nvd_cond->vuln_version)
+                        os_strdup(newPkg->nvd_cond->vuln_version, tmpPkg->nvd_cond->vuln_version);
+                    if (newPkg->nvd_cond->fix_version)
+                        os_strdup(newPkg->nvd_cond->fix_version, tmpPkg->nvd_cond->fix_version);
+                    tmpPkg->nvd_cond->start_operation = newPkg->nvd_cond->start_operation;
+                    tmpPkg->nvd_cond->end_operation = newPkg->nvd_cond->end_operation;
                 }
                 if (!tmpPkg->vuln_cond && newPkg->vuln_cond) {
-                    tmpPkg->vuln_cond = newPkg->vuln_cond;
+                    os_calloc(1, sizeof(cve_vuln_cond), tmpPkg->vuln_cond);
+
+                    if (newPkg->vuln_cond->state)
+                        os_strdup(newPkg->vuln_cond->state, tmpPkg->vuln_cond->state);
+                    if (newPkg->vuln_cond->operation)
+                        w_strdup(newPkg->vuln_cond->operation, tmpPkg->vuln_cond->operation);
+                    if (newPkg->vuln_cond->operation_value)
+                        w_strdup(newPkg->vuln_cond->operation_value, tmpPkg->vuln_cond->operation_value);
+                    if (newPkg->vuln_cond->condition)
+                        os_strdup(newPkg->vuln_cond->condition, tmpPkg->vuln_cond->condition);
+                    tmpPkg->vuln_cond->pending = newPkg->vuln_cond->pending;
                 }
                 tmpPkg->feed |= newPkg->feed; // Update the feed field with the new source.
+
                 return 1;
             }
             lastPkg = tmpPkg; // Save last known entry within the linked list.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2064,6 +2064,10 @@ bool wm_vuldet_check_generic_package(char * agent_id, sqlite3_stmt *pStmt, sqlit
 
     int res = sqlite3_prepare_v2(dbCVE, vu_queries[VU_GET_GENERIC_PACKAGE], -1, &pStmt, NULL);
     if (res != SQLITE_OK) {
+        os_free(pkg_source);
+        os_free(pkg_name);
+        os_free(pkg_version);
+        os_free(pkg_arch);
         return wm_vuldet_sql_error(dbCVE, pStmt);
     } else {
         sqlite3_bind_text(pStmt, 1, pkg_reference, -1, NULL);
@@ -2102,10 +2106,11 @@ bool wm_vuldet_check_generic_package(char * agent_id, sqlite3_stmt *pStmt, sqlit
             if (vulnerable == true) {
                 os_calloc(1, sizeof(cve_vuln_pkg), newPkg);
                 os_calloc(1, sizeof(cve_vuln_cond_NVD), newPkg->nvd_cond);
-                newPkg->version = pkg_version;
-                newPkg->bin_name = pkg_name;
-                newPkg->src_name = pkg_source;
-                newPkg->arch = pkg_arch;
+
+                sqlite_strdup(pkg_version, newPkg->version);
+                sqlite_strdup(pkg_name, newPkg->bin_name);
+                sqlite_strdup(pkg_source, newPkg->src_name);
+                sqlite_strdup(pkg_arch, newPkg->arch);
                 newPkg->feed |= VU_SRC_NVD;
 
                 sqlite_strdup((end_including) ? end_including : end_excluding,
@@ -2120,9 +2125,24 @@ bool wm_vuldet_check_generic_package(char * agent_id, sqlite3_stmt *pStmt, sqlit
                     newPkg->nvd_cond->start_operation = (start_including) ? START_INCLUDED : START_EXCLUDED;
                 }
 
-                if (wm_vuldet_add_cve_node(newPkg, cve, cve_table) == -1) {
-                    merror(VU_INSERT_PACKAGE_ERROR, agent_id, pkg_reference, cve, "NVD");
+                int result = wm_vuldet_add_cve_node(newPkg, cve, cve_table);
+
+                switch (result) {
+                case -1:
+                    mterror(WM_VULNDETECTOR_LOGTAG,VU_INSERT_PACKAGE_ERROR, agent_id, pkg_reference, cve, "NVD");
+                    wm_vuldet_free_cve_node(newPkg);
+                    break;
+                case 1:
+                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_DUPLICATED_PACKAGE, agent_id, pkg_reference, cve);
+                    wm_vuldet_free_cve_node(newPkg);
+                    break;
+                case 0:
+                    mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_INSERT, agent_id, pkg_reference, cve);
+                    break;
+                default:
+                    break;
                 }
+
                 newPkg = NULL;
             }
 
@@ -2130,6 +2150,11 @@ bool wm_vuldet_check_generic_package(char * agent_id, sqlite3_stmt *pStmt, sqlit
             vulnerable = false;
         }
     }
+
+    os_free(pkg_source);
+    os_free(pkg_name);
+    os_free(pkg_version);
+    os_free(pkg_arch);
 
     sqlite3_finalize(pStmt);
 
@@ -2162,6 +2187,12 @@ bool wm_vuldet_check_specific_package(char * agent_id, sqlite3_stmt *pStmt, sqli
 
     int res = sqlite3_prepare_v2(dbCVE, vu_queries[VU_GET_SPECIFIC_PACKAGE], -1, &pStmt, NULL);
     if (res != SQLITE_OK) {
+        os_free(pkg_source);
+        os_free(pkg_name);
+        os_free(pkg_version);
+        os_free(pkg_arch);
+        os_free(clean_version);
+        os_free(sql_version);
         return wm_vuldet_sql_error(dbCVE, pStmt);
     } else {
         sqlite3_bind_text(pStmt, 1, pkg_reference, -1, NULL);
@@ -2171,13 +2202,29 @@ bool wm_vuldet_check_specific_package(char * agent_id, sqlite3_stmt *pStmt, sqli
             const char *cve = (const char *)sqlite3_column_text(pStmt, 0);
             if (wm_checks_package_vulnerability((char *)pkg_version, vu_package_comp[PKG_EQUAL], (char *)sqlite3_column_text(pStmt, 1), VER_TYPE_NVD) == VU_VULNERABLE){
                 os_calloc(1, sizeof(cve_vuln_pkg), newPkg);
-                newPkg->version = pkg_version;
-                newPkg->bin_name = pkg_name;
-                newPkg->src_name = pkg_source;
-                newPkg->arch = pkg_arch;
+                
+                sqlite_strdup(pkg_version, newPkg->version);
+                sqlite_strdup(pkg_name, newPkg->bin_name);
+                sqlite_strdup(pkg_source, newPkg->src_name);
+                sqlite_strdup(pkg_arch, newPkg->arch);
                 newPkg->feed |= VU_SRC_NVD;
-                if (wm_vuldet_add_cve_node(newPkg, cve, cve_table) == -1) {
-                    merror(VU_INSERT_PACKAGE_ERROR, agent_id, pkg_reference, cve, "NVD");
+                
+                int result = wm_vuldet_add_cve_node(newPkg, cve, cve_table);
+
+                switch (result) {
+                case -1:
+                    mterror(WM_VULNDETECTOR_LOGTAG,VU_INSERT_PACKAGE_ERROR, agent_id, pkg_reference, cve, "NVD");
+                    wm_vuldet_free_cve_node(newPkg);
+                    break;
+                case 1:
+                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_DUPLICATED_PACKAGE, agent_id, pkg_reference, cve);
+                    wm_vuldet_free_cve_node(newPkg);
+                    break;
+                case 0:
+                    mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_INSERT, agent_id, pkg_reference, cve);
+                    break;
+                default:
+                    break;
                 }
 
                 newPkg = NULL;
@@ -2186,6 +2233,10 @@ bool wm_vuldet_check_specific_package(char * agent_id, sqlite3_stmt *pStmt, sqli
         }
     }
 
+    os_free(pkg_source);
+    os_free(pkg_name);
+    os_free(pkg_version);
+    os_free(pkg_arch);
     os_free(clean_version);
     os_free(sql_version);
     sqlite3_finalize(pStmt);


### PR DESCRIPTION
|Related issue|
|---|
|[4857](https://github.com/wazuh/wazuh/issues/4857)|

## Description

This pull request fixes a "double free" issue caused because of the assignment of some pointer addresses to multiple structures in a list. As a result, when the list was destroyed, some addresses were freed multiple times causing unexpected behaviors. This happened in the method `wm_vuldet_free_cve_node`
In addition, it fixes some memory leaks caused because of some memory not being released.