### PR TITLE
Make new API use a prompt if the private key is encrypted

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -16,7 +16,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 from api.api_exception import APIException
-from api.constants import SECURITY_PATH
 from wazuh import common
 
 
@@ -62,29 +61,11 @@ def fill_dict(default: Dict, config: Dict) -> Dict:
     return {**default, **config}
 
 
-def generate_pem_phrase():
-    """Generate a random PEM phrase for the private key in 'SECURITY_PATH/ssl_secret'.
-
-    Returns
-    -------
-    bytes
-        Encoded PEM phrase.
-    """
-    pem_ssl = str(uuid.uuid4()).replace('-', '')
-    ssl_secret_path = os.path.join(SECURITY_PATH, 'ssl_secret')
-    with open(ssl_secret_path, 'w') as f:
-        f.write(pem_ssl)
-
-    return pem_ssl.encode()
-
-
-def generate_private_key(pem_phrase, private_key_path, public_exponent=65537, key_size=2048):
+def generate_private_key(private_key_path, public_exponent=65537, key_size=2048):
     """Generate a private key in 'CONFIG_PATH/ssl/server.key'.
 
     Parameters
     ----------
-    pem_phrase : bytes
-        Encoded PEM phrase.
     private_key_path : str
         Path where the private key will be generated.
     public_exponent : int, optional
@@ -105,8 +86,8 @@ def generate_private_key(pem_phrase, private_key_path, public_exponent=65537, ke
     with open(private_key_path, 'wb') as f:
         f.write(key.private_bytes(
             encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.BestAvailableEncryption(pem_phrase)
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
         ))
     return key
 


### PR DESCRIPTION
Hello team. 

We were saving the PEM phrase used in the private key in a secret file, but this was not safe enough.

To improve this, we are generating a private key without PEM phrase if the user does not have one and if it does, the API will ask for the PEM phrase in a prompt.

We handle a wrong PEM phrase like this:
```
root@wazuh-master:/# service wazuh-api restart
Restarting Wazuh API
Enter PEM pass phrase:
Traceback (most recent call last):
  File "/var/ossec/api/scripts/wazuh-apid.py", line 83, in start
    keyfile=api_conf['https']['key'])
OSError: [Errno 22] Invalid argument

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/ossec/api/scripts/wazuh-apid.py", line 302, in <module>
    restart(args.foreground, args.root, args.config_file)
  File "/var/ossec/api/scripts/wazuh-apid.py", line 218, in restart
    start(foreground, root, config_file)
  File "/var/ossec/api/scripts/wazuh-apid.py", line 88, in start
    raise APIException(2003, details='PEM phrase is not correct')
api.api_exception.APIException: Error 2003 - Error loading SSL/TLS certificates: PEM phrase is not correct.
```

This was tested both fore and background, using the service and the binary file and having an encrypted private key or generating a new one.

Regards.