### PR TITLE
4962 Fix start index in X509_NAME_get_index_by_NID call

### DIFF
--- a/src/os_auth/check_cert.c
+++ b/src/os_auth/check_cert.c
@@ -107,7 +107,7 @@ int check_subject_cn(X509 *cert, const char *manager)
 {
     X509_NAME *name = NULL;
     int result = VERIFY_FALSE;
-    int i = 0;
+    int i = -1;
 
     if ((name = X509_get_subject_name(cert))) {
         while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0 && result == VERIFY_FALSE) {


### PR DESCRIPTION
|Related issue|
|---|
| #4962 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Current implementation of function `check_subject_cn` skips the first index when searching for the certificate subject common name.

### Steps to reproduce:
1. Create a file named `req.conf` with the manager information: 
```
[req]
distinguished_name = req_distinguished_name
req_extensions = req_ext
prompt = no
[req_distinguished_name]
C = US
CN = 192.168.1.2
[req_ext]
subjectAltName = @alt_names
[alt_names]
DNS.1 = wazuh
DNS.2 = wazuh.com
```
2. Issue and sign a certificate for the manager:
```
openssl req -new -nodes -newkey rsa:4096 -keyout sslmanager.key -out sslmanager.csr -config req.conf
openssl x509 -req -days 365 -in sslmanager.csr -CA rootCA.pem -CAkey rootCA.key -out sslmanager.cert -CAcreateserial -extfile req.conf -extensions req_ext
```
3. Copy the newly created certificate and its key to the `/var/ossec/etc`
```
cp sslmanager.cert sslmanager.key /var/ossec/etc
```

4 .Issue and sign a certificate for the agent, entering its hostname or IP address into the common name field. For example, if the agent’s IP is 192.168.1.3: (**IMPORTANT TO REPRODUCE**, CN should go before C)
```
openssl req -new -nodes -newkey rsa:4096 -keyout sslagent.key -out sslagent.csr -subj '/CN=192.168.1.3/C=US'
openssl x509 -req -days 365 -in sslagent.csr -CA rootCA.pem -CAkey rootCA.key -out sslagent.cert -CAcreateserial
```

5. Copy the CA (.pem file) to the /var/ossec/etc folder:
```
cp rootCA.pem /var/ossec/etc
```

6. Modify the /var/ossec/etc/ossec.conf file to enable the host verification. You will need to modify the <auth><ssl_agent_ca> section by uncommenting it (remove the <!- and -->) and by adding the path to the CA file. You also need to set the field <ssl_verify_host> to yes:
```
<auth>
  ...
  <ssl_agent_ca>/var/ossec/etc/rootCA.pem</ssl_agent_ca>
  <ssl_verify_host>yes</ssl_verify_host>
  ...
</auth>
```

7. Restart wazuh manager
8. Copy sslagent.cert and sslagent.key files to the agent to the /var/ossec/etc folder and run the agent-auth program.

```
cp sslagent.cert sslagent.key /var/ossec/etc
/var/ossec/bin/agent-auth -m 192.168.1.2 -x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key
```

## Output

### Before change

Manger 
```
2020/04/30 20:00:09 ossec-authd[7990] config.c:22 at authd_read_config(): DEBUG: Reading configuration '/var/ossec/etc/ossec.conf'
2020/04/30 20:00:09 ossec-authd[7990] main-server.c:377 at main(): DEBUG: Starting ...
2020/04/30 20:00:09 ossec-authd[7990] main-server.c:412 at main(): INFO: Started (pid: 7990).
2020/04/30 20:00:09 ossec-authd[7990] main-server.c:442 at main(): INFO: Accepting connections on port 1515. No password required.
2020/04/30 20:00:09 ossec-authd[7990] ssl.c:47 at os_ssl_keys(): DEBUG: Peer verification requested.
2020/04/30 20:00:09 ossec-authd[7990] ssl.c:75 at os_ssl_keys(): DEBUG: Returning CTX for server.
2020/04/30 20:00:09 ossec-authd[7990] main-server.c:488 at main(): INFO: Setting network timeout to 1.000000 sec.
2020/04/30 20:00:09 ossec-authd[7990] main-server.c:622 at run_dispatcher(): DEBUG: Dispatch thread ready
2020/04/30 20:00:09 ossec-authd[7990] local-server.c:74 at run_local_server(): DEBUG: Local server thread ready.
2020/04/30 20:00:29 ossec-authd[7990] main-server.c:649 at run_dispatcher(): INFO: New connection from 172.16.1.10
2020/04/30 20:00:29 ossec-authd[7990] check_cert.c:52 at check_x509_cert(): DEBUG: Checking certificate's subject alternative names.
2020/04/30 20:00:29 ossec-authd[7990] check_cert.c:58 at check_x509_cert(): DEBUG: No matching subject alternative names found. Checking common name.
2020/04/30 20:00:29 ossec-authd[7990] main-server.c:655 at run_dispatcher(): ERROR: Unable to verify client certificate.
```

Agent 
```
sudo /var/ossec/bin/agent-auth -m 172.16.1.16 -x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key
2020/04/30 19:52:03 agent-auth: INFO: Started (pid: 22129).
2020/04/30 19:52:03 agent-auth: INFO: No authentication password provided.
2020/04/30 19:52:03 agent-auth: INFO: Connected to 172.16.1.16:1515
2020/04/30 19:52:03 agent-auth: WARNING: Registering agent to unverified manager.
2020/04/30 19:52:03 agent-auth: INFO: Using agent name as: ubuntu1610
2020/04/30 19:52:03 agent-auth: INFO: Send request to manager. Waiting for reply.
2020/04/30 19:52:03 agent-auth: ERROR: Unable to create key. Either wrong password or connection not accepted by the manager.
2020/04/30 19:52:03 agent-auth: INFO: Connection closed.
```
### After changes

Manger:
```
sudo /var/ossec/bin/ossec-authd -f -dd
2020/04/30 20:04:13 ossec-authd[8172] config.c:22 at authd_read_config(): DEBUG: Reading configuration '/var/ossec/etc/ossec.conf'
2020/04/30 20:04:13 ossec-authd[8172] main-server.c:377 at main(): DEBUG: Starting ...
2020/04/30 20:04:13 ossec-authd[8172] main-server.c:412 at main(): INFO: Started (pid: 8172).
2020/04/30 20:04:13 ossec-authd[8172] main-server.c:442 at main(): INFO: Accepting connections on port 1515. No password required.
2020/04/30 20:04:13 ossec-authd[8172] ssl.c:47 at os_ssl_keys(): DEBUG: Peer verification requested.
2020/04/30 20:04:13 ossec-authd[8172] ssl.c:75 at os_ssl_keys(): DEBUG: Returning CTX for server.
2020/04/30 20:04:13 ossec-authd[8172] main-server.c:488 at main(): INFO: Setting network timeout to 1.000000 sec.
2020/04/30 20:04:13 ossec-authd[8172] local-server.c:74 at run_local_server(): DEBUG: Local server thread ready.
2020/04/30 20:04:13 ossec-authd[8172] main-server.c:622 at run_dispatcher(): DEBUG: Dispatch thread ready
2020/04/30 20:04:32 ossec-authd[8172] main-server.c:649 at run_dispatcher(): INFO: New connection from 172.16.1.10
2020/04/30 20:04:32 ossec-authd[8172] check_cert.c:52 at check_x509_cert(): DEBUG: Checking certificate's subject alternative names.
2020/04/30 20:04:32 ossec-authd[8172] check_cert.c:58 at check_x509_cert(): DEBUG: No matching subject alternative names found. Checking common name.
2020/04/30 20:04:32 ossec-authd[8172] main-server.c:685 at run_dispatcher(): DEBUG: Request received: <OSSEC A:'ubuntu1610'
>
2020/04/30 20:04:32 ossec-authd[8172] main-server.c:722 at run_dispatcher(): INFO: Received request for a new agent (ubuntu1610) from: 172.16.1.10
2020/04/30 20:04:32 ossec-authd[8172] main-server.c:1005 at run_dispatcher(): INFO: Duplicated name 'ubuntu1610' (002). Saving backup.
2020/04/30 20:04:32 ossec-authd[8172] main-server.c:1087 at run_dispatcher(): INFO: Agent key generated for 'ubuntu1610' (requested by any)
2020/04/30 20:04:32 ossec-authd[8172] validate.c:692 at OS_BackupAgentInfo(): DEBUG: Couldn't create some backup files.
```

Agent:
```
sudo /var/ossec/bin/agent-auth -m 172.16.1.16 -x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key
2020/04/30 19:56:06 agent-auth: INFO: Started (pid: 22149).
2020/04/30 19:56:06 agent-auth: INFO: No authentication password provided.
2020/04/30 19:56:06 agent-auth: INFO: Connected to 172.16.1.16:1515
2020/04/30 19:56:06 agent-auth: WARNING: Registering agent to unverified manager.
2020/04/30 19:56:06 agent-auth: INFO: Using agent name as: ubuntu1610
2020/04/30 19:56:06 agent-auth: INFO: Send request to manager. Waiting for reply.
2020/04/30 19:56:06 agent-auth: INFO: Received response with agent key
2020/04/30 19:56:06 agent-auth: INFO: Valid key created. Finished.
2020/04/30 19:56:06 agent-auth: INFO: Connection closed.
```

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

## Memcheck

### Valgrind

```
2020/04/30 20:11:00 ossec-authd[19545] main-server.c:596 at main(): INFO: Exiting...
==19545== 
==19545== HEAP SUMMARY:
==19545==     in use at exit: 1,814 bytes in 22 blocks
==19545==   total heap usage: 16,380 allocs, 16,358 frees, 4,885,666 bytes allocated
==19545== 
==19545== LEAK SUMMARY:
==19545==    definitely lost: 0 bytes in 0 blocks
==19545==    indirectly lost: 0 bytes in 0 blocks
==19545==      possibly lost: 0 bytes in 0 blocks
==19545==    still reachable: 1,814 bytes in 22 blocks
==19545==         suppressed: 0 bytes in 0 blocks
==19545== Reachable blocks (those to which a pointer was found) are not shown.
==19545== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==19545== 
==19545== For lists of detected and suppressed errors, rerun with: -s
==19545== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
