### PR TITLE
[Vulnerability-Detector] Support Ubuntu 20.04

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -9,6 +9,7 @@
       <os>trusty</os>
       <os>xenial</os>
       <os>bionic</os>
+      <os>focal</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -158,6 +158,11 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             os_strdup(vu_feed_tag[FEED_BIONIC], upd->version);
             upd->dist_tag_ref = FEED_BIONIC;
             upd->dist_ext = vu_feed_ext[FEED_BIONIC];
+        } else if (!strcmp(version, "20") || strcasestr(version, vu_feed_tag[FEED_FOCAL])) {
+            os_index = CVE_FOCAL;
+            os_strdup(vu_feed_tag[FEED_FOCAL], upd->version);
+            upd->dist_tag_ref = FEED_FOCAL;
+            upd->dist_ext = vu_feed_ext[FEED_FOCAL];
         } else {
             merror("Invalid Ubuntu version '%s'.", version);
             retval = OS_INVALID;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -189,6 +189,7 @@ const char *vu_feed_tag[] = {
     "TRUSTY",
     "XENIAL",
     "BIONIC",
+    "FOCAL",
     // Debian versions
     "JESSIE",
     "STRETCH",
@@ -236,6 +237,7 @@ const char *vu_feed_ext[] = {
     "Ubuntu Trusty",
     "Ubuntu Xenial",
     "Ubuntu Bionic",
+    "Ubuntu Focal",
     // Debian versions
     "Debian Jessie",
     "Debian Stretch",
@@ -3084,7 +3086,8 @@ int wm_vuldet_run_update(update_node **updates) {
         return OS_INVALID;
     }
         // Ubuntu
-    if (wm_vuldet_check_feed(updates[CVE_BIONIC], &error_code)   ||
+    if (wm_vuldet_check_feed(updates[CVE_FOCAL], &error_code)    ||
+        wm_vuldet_check_feed(updates[CVE_BIONIC], &error_code)   ||
         wm_vuldet_check_feed(updates[CVE_XENIAL], &error_code)   ||
         wm_vuldet_check_feed(updates[CVE_TRUSTY], &error_code)   ||
         wm_vuldet_check_feed(updates[CVE_PRECISE], &error_code)  ||
@@ -3667,7 +3670,9 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
         }
 
         if (strcasestr(os_name, vu_feed_ext[FEED_UBUNTU])) {
-            if (strstr(os_version, "18")) {
+            if (strstr(os_version, "20")) {
+                agent_dist_ver = FEED_FOCAL;
+            } else if (strstr(os_version, "18")) {
                 agent_dist_ver = FEED_BIONIC;
             } else if (strstr(os_version, "16")) {
                 agent_dist_ver = FEED_XENIAL;
@@ -4226,6 +4231,7 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
         case FEED_TRUSTY:
         case FEED_XENIAL:
         case FEED_BIONIC:
+        case FEED_FOCAL:
             product_name = PR_UBUNTU;
             vendor = V_UBUNTU;
         break;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -211,6 +211,7 @@ typedef enum vu_feed {
     FEED_TRUSTY,
     FEED_XENIAL,
     FEED_BIONIC,
+    FEED_FOCAL,
     // Debian versions
     FEED_JESSIE,
     FEED_STRETCH,
@@ -340,6 +341,7 @@ typedef enum cve_db{
     CVE_TRUSTY,
     CVE_XENIAL,
     CVE_BIONIC,
+    CVE_FOCAL,
     CVE_JESSIE,
     CVE_STRETCH,
     CVE_BUSTER,


### PR DESCRIPTION
|Related issue|
|---|
|#4960|

## Description

The purpose of this PR it to add support for Ubuntu 20.04 (Focal Fossa) in the vulnerability detector module.

The new feed for Ubuntu 20.04 is downloaded and inserted into the DB, so vulnerabilities in these systems can be detected.

## Configuration

```xml
<provider name="canonical">
    <os>focal</os>
</provider>
```