### PR TITLE
Fix memory leak in Logcollector when formatting a message

### DIFF
--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -195,6 +195,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute
         free(_message);
         return (0);
     }
+    free(_message);
     return (0);
 }
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Memory leak detected in a stress test in Ubuntu agent. It is caused by a change in this PR https://github.com/wazuh/wazuh/pull/4942. To fix this, a memory free has been added in the modified code.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [X] Windows
  - [x] MAC OS X
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

- Memory tests for Windows
  - [X] Scan-build report
  - [x] Coverity

- Memory tests for macOS
  - [x] Scan-build report


