### PR TITLE
Adding new fields to the elastic search template

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -289,8 +289,6 @@
       "data.virustotal.source.file",
       "data.virustotal.source.md5",
       "data.virustotal.source.sha1",
-      "data.vulnerability.advisories",
-      "data.vulnerability.bugzilla_reference",
       "data.vulnerability.cve",
       "data.vulnerability.cvss.cvss2.base_score",
       "data.vulnerability.cvss.cvss2.exploitability_score",
@@ -317,16 +315,18 @@
       "data.vulnerability.cvss.cvss3.vector.scope",
       "data.vulnerability.cvss.cvss3.vector.user_interaction",
       "data.vulnerability.cwe_reference",
+      "data.vulnerability.package.source",
       "data.vulnerability.package.architecture",
       "data.vulnerability.package.condition",
       "data.vulnerability.package.generated_cpe",
       "data.vulnerability.package.name",
       "data.vulnerability.package.version",
       "data.vulnerability.rationale",
-      "data.vulnerability.reference",
       "data.vulnerability.severity",
       "data.vulnerability.state",
       "data.vulnerability.title",
+      "data.vulnerability.assigner",
+      "data.vulnerability.cve_version",
       "data.win.eventdata.auditPolicyChanges",
       "data.win.eventdata.auditPolicyChangesId",
       "data.win.eventdata.binary",
@@ -1556,12 +1556,6 @@
           },
           "vulnerability": {
             "properties": {
-              "advisories": {
-                "type": "keyword"
-              },
-              "bugzilla_reference": {
-                "type": "keyword"
-              },
               "cve": {
                 "type": "keyword"
               },
@@ -1662,6 +1656,9 @@
               },
               "package": {
                 "properties": {
+                  "source": {
+                    "type": "keyword"
+                  },
                   "architecture": {
                     "type": "keyword"
                   },
@@ -1688,9 +1685,6 @@
               "rationale": {
                 "type": "keyword"
               },
-              "reference": {
-                "type": "keyword"
-              },
               "severity": {
                 "type": "keyword"
               },
@@ -1698,6 +1692,12 @@
                 "type": "keyword"
               },
               "title": {
+                "type": "keyword"
+              },
+              "assigner": {
+                "type": "keyword"
+              },
+              "cve_version": {
                 "type": "keyword"
               }
             }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1117,7 +1117,7 @@ int wm_vuldet_send_cve_report(vu_report *report) {
                 cJSON *j_adv_item = cJSON_CreateString(report->advisories[advcount]);
                 cJSON_AddItemToArray(j_advisories, j_adv_item);
             }
-            cJSON_AddItemToObject(alert_cve, "advisories", j_advisories);
+            cJSON_AddItemToObject(alert_cve, "advisories_ids", j_advisories);
         }
         if (report->bugzilla_references) {
             cJSON *j_bug_references = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|[4958](https://github.com/wazuh/wazuh/issues/4958)|

## Description

This PR implements the necessary changes in the elastic templates in order to be able to display the new alerts data fields.
It takes care of older alerts already indexed by elasticsearch avoiding in this way any possible upgrade issue.

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade