### PR TITLE
Added guarantee that all processes are killed when service stop

### DIFF
--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -235,7 +235,8 @@ stopa()
 
             if ! wait_pid $pid
             then
-                echo "Process ${i} couldn't be killed.";
+                echo "Process ${i} couldn't be terminated. It will be killed.";
+                kill -9 $pid
             fi
         else
             echo "${i} not running...";

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -327,7 +327,8 @@ stopa()
 
             if ! wait_pid $pid
             then
-                echo "Process ${i} couldn't be killed.";
+                echo "Process ${i} couldn't be terminated. It will be killed.";
+                kill -9 $pid
             fi
         else
             echo "${i} not running...";

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -529,7 +529,8 @@ stopa()
                 if [ $USE_JSON = true ]; then
                     echo -n '{"daemon":"'${i}'","status":"failed to kill"}'
                 else
-                    echo "Process ${i} couldn't be killed.";
+                    echo "Process ${i} couldn't be terminated. It will be killed.";
+                    kill -9 $pid
                 fi
             fi
         else


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4928|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
The problem has been solved by adding a _SIGKILL_ after the warning `Process couldn't be killed`. In this way, we ensure that all processes are killed after the execution of `ossec-control stop` 

<!--
Add a clear description of how the problem has been solved.
-->


<!--
When proceed, this section should include new configuration parameters.
-->


<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [X] Source installation
- [X] Source upgrade

- Manager installation
    - [X] Block a demon
    - [X] Kill process
    - [X] Remove PIDfile

- Local installation
    - [X] Block a demon
    - [X] Kill process
    - [X] Remove PIDfile

- Agent installation
    - [X] Block a demon
    - [X] Kill process
    - [X] Remove PIDfile
<!-- Depending on the affected OS -->
<!-- 
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer
-->