### PR TITLE
Make pretty parameter usable for the new API

### DIFF
--- a/api/api/controllers/active_response_controller.py
+++ b/api/api/controllers/active_response_controller.py
@@ -38,7 +38,6 @@ async def run_command(request, list_agents='*', pretty=False, wait_for_complete=
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']

--- a/api/api/controllers/active_response_controller.py
+++ b/api/api/controllers/active_response_controller.py
@@ -9,7 +9,7 @@ from aiohttp import web
 
 import wazuh.active_response as active_response
 from api.api_exception import APIError
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.models.active_response_model import ActiveResponse
 from api.util import remove_nones_to_dict, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -45,4 +45,4 @@ async def run_command(request, list_agents='*', pretty=False, wait_for_complete=
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -11,7 +11,7 @@ from connexion.lifecycle import ConnexionResponse
 import wazuh.agent as agent
 from api import configuration
 from api.api_exception import APIError
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.models.agent_added import AgentAdded
 from api.models.agent_inserted import AgentInserted
 from api.models.base_model_ import Data
@@ -53,7 +53,7 @@ async def delete_agents(request, pretty=False, wait_for_complete=False, list_age
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agents(request, pretty=False, wait_for_complete=False, list_agents=None, offset=0, limit=database_limit,
@@ -117,7 +117,7 @@ async def get_agents(request, pretty=False, wait_for_complete=False, list_agents
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def add_agent(request, pretty=False, wait_for_complete=False):
@@ -160,7 +160,7 @@ async def add_agent(request, pretty=False, wait_for_complete=False):
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def restart_agents(request, pretty=False, wait_for_complete=False, list_agents='*'):
@@ -185,7 +185,7 @@ async def restart_agents(request, pretty=False, wait_for_complete=False, list_ag
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_config(request, pretty=False, wait_for_complete=False, agent_id=None, component=None, **kwargs):
@@ -218,7 +218,7 @@ async def get_agent_config(request, pretty=False, wait_for_complete=False, agent
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_single_agent_multiple_groups(request, agent_id, list_groups=None, pretty=False, wait_for_complete=False):
@@ -247,7 +247,7 @@ async def delete_single_agent_multiple_groups(request, agent_id, list_groups=Non
 
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_sync_agent(request, agent_id, pretty=False, wait_for_complete=False):
@@ -274,7 +274,7 @@ async def get_sync_agent(request, agent_id, pretty=False, wait_for_complete=Fals
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_single_agent_single_group(request, agent_id, group_id, pretty=False, wait_for_complete=False):
@@ -303,7 +303,7 @@ async def delete_single_agent_single_group(request, agent_id, group_id, pretty=F
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_agent_single_group(request, agent_id, group_id, force_single_group=False, pretty=False, wait_for_complete=False):
@@ -331,7 +331,7 @@ async def put_agent_single_group(request, agent_id, group_id, force_single_group
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_key(request, agent_id, pretty=False, wait_for_complete=False):
@@ -355,7 +355,7 @@ async def get_agent_key(request, agent_id, pretty=False, wait_for_complete=False
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def restart_agent(request, agent_id, pretty=False, wait_for_complete=False):
@@ -379,7 +379,7 @@ async def restart_agent(request, agent_id, pretty=False, wait_for_complete=False
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_upgrade_agent(request, agent_id, pretty=False, wait_for_complete=False, wpk_repo=None, version=None,
@@ -412,7 +412,7 @@ async def put_upgrade_agent(request, agent_id, pretty=False, wait_for_complete=F
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_upgrade_custom_agent(request, agent_id, pretty=False, wait_for_complete=False, file_path=None,
@@ -442,7 +442,7 @@ async def put_upgrade_custom_agent(request, agent_id, pretty=False, wait_for_com
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def post_new_agent(request, agent_name, pretty=False, wait_for_complete=False):
@@ -469,7 +469,7 @@ async def post_new_agent(request, agent_name, pretty=False, wait_for_complete=Fa
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_upgrade(request, agent_id, timeout=3, pretty=False, wait_for_complete=False):
@@ -495,7 +495,7 @@ async def get_agent_upgrade(request, agent_id, timeout=3, pretty=False, wait_for
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_multiple_agent_single_group(request, group_id, list_agents=None, pretty=False,
@@ -522,7 +522,7 @@ async def delete_multiple_agent_single_group(request, group_id, list_agents=None
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_multiple_agent_single_group(request, group_id, list_agents=None, pretty=False, wait_for_complete=False,
@@ -551,7 +551,7 @@ async def put_multiple_agent_single_group(request, group_id, list_agents=None, p
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_groups(request, list_groups=None, pretty=False, wait_for_complete=False):
@@ -575,7 +575,7 @@ async def delete_groups(request, list_groups=None, pretty=False, wait_for_comple
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_list_group(request, pretty=False, wait_for_complete=False, list_groups=None, offset=0, limit=None,
@@ -617,7 +617,7 @@ async def get_list_group(request, pretty=False, wait_for_complete=False, list_gr
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agents_in_group(request, group_id, pretty=False, wait_for_complete=False, offset=0, limit=database_limit,
@@ -660,7 +660,7 @@ async def get_agents_in_group(request, group_id, pretty=False, wait_for_complete
 
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def post_group(request, group_id, pretty=False, wait_for_complete=False):
@@ -684,7 +684,7 @@ async def post_group(request, group_id, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_group_config(request, group_id, pretty=False, wait_for_complete=False, offset=0, limit=database_limit):
@@ -712,7 +712,7 @@ async def get_group_config(request, group_id, pretty=False, wait_for_complete=Fa
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=Data(data), status=200, dumps=dumps)
+    return web.json_response(data=Data(data), status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_group_config(request, body, group_id, pretty=False, wait_for_complete=False):
@@ -749,7 +749,7 @@ async def put_group_config(request, body, group_id, pretty=False, wait_for_compl
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_group_files(request, group_id, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None,
@@ -787,7 +787,7 @@ async def get_group_files(request, group_id, pretty=False, wait_for_complete=Fal
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_group_file_json(request, group_id, file_name, pretty=False, wait_for_complete=False):
@@ -816,7 +816,7 @@ async def get_group_file_json(request, group_id, file_name, pretty=False, wait_f
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data['data']['affected_items'])
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_group_file_xml(request, group_id, file_name, pretty=False, wait_for_complete=False):
@@ -887,7 +887,7 @@ async def insert_agent(request, pretty=False, wait_for_complete=False):
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_no_group(request, pretty=False, wait_for_complete=False, offset=0, limit=database_limit,
@@ -923,7 +923,7 @@ async def get_agent_no_group(request, pretty=False, wait_for_complete=False, off
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_outdated(request, pretty=False, wait_for_complete=False, offset=0, limit=database_limit, sort=None,
@@ -957,7 +957,7 @@ async def get_agent_outdated(request, pretty=False, wait_for_complete=False, off
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_fields(request, pretty=False, wait_for_complete=False, fields=None, offset=0, limit=database_limit,
@@ -998,7 +998,7 @@ async def get_agent_fields(request, pretty=False, wait_for_complete=False, field
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_summary_status(request, pretty=False, wait_for_complete=False):
@@ -1022,7 +1022,7 @@ async def get_agent_summary_status(request, pretty=False, wait_for_complete=Fals
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_summary_os(request, pretty=False, wait_for_complete=False):
@@ -1045,4 +1045,4 @@ async def get_agent_summary_os(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -47,7 +47,6 @@ async def delete_agents(request, pretty=False, wait_for_complete=False, list_age
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -111,7 +110,6 @@ async def get_agents(request, pretty=False, wait_for_complete=False, list_agents
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -152,7 +150,6 @@ async def add_agent(request, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -178,7 +175,6 @@ async def restart_agents(request, pretty=False, wait_for_complete=False, list_ag
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           broadcasting=list_agents == '*',
                           logger=logger
@@ -211,7 +207,6 @@ async def get_agent_config(request, pretty=False, wait_for_complete=False, agent
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -240,7 +235,6 @@ async def delete_single_agent_multiple_groups(request, agent_id, list_groups=Non
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -268,7 +262,6 @@ async def get_sync_agent(request, agent_id, pretty=False, wait_for_complete=Fals
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -297,7 +290,6 @@ async def delete_single_agent_single_group(request, agent_id, group_id, pretty=F
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -325,7 +317,6 @@ async def put_agent_single_group(request, agent_id, group_id, force_single_group
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -349,7 +340,6 @@ async def get_agent_key(request, agent_id, pretty=False, wait_for_complete=False
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -373,7 +363,6 @@ async def restart_agent(request, agent_id, pretty=False, wait_for_complete=False
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -406,7 +395,6 @@ async def put_upgrade_agent(request, agent_id, pretty=False, wait_for_complete=F
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=True,  # Force wait_for_complete until timeout problems are resolved
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -436,7 +424,6 @@ async def put_upgrade_custom_agent(request, agent_id, pretty=False, wait_for_com
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=True,  # Force wait_for_complete until timeout problems are resolved
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -462,7 +449,6 @@ async def post_new_agent(request, agent_name, pretty=False, wait_for_complete=Fa
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -489,7 +475,6 @@ async def get_agent_upgrade(request, agent_id, timeout=3, pretty=False, wait_for
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -516,7 +501,6 @@ async def delete_multiple_agent_single_group(request, group_id, list_agents=None
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -545,7 +529,6 @@ async def put_multiple_agent_single_group(request, group_id, list_agents=None, p
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -569,7 +552,6 @@ async def delete_groups(request, list_groups=None, pretty=False, wait_for_comple
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -611,7 +593,6 @@ async def get_list_group(request, pretty=False, wait_for_complete=False, list_gr
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -653,7 +634,6 @@ async def get_agents_in_group(request, group_id, pretty=False, wait_for_complete
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -678,7 +658,6 @@ async def post_group(request, group_id, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -706,7 +685,6 @@ async def get_group_config(request, group_id, pretty=False, wait_for_complete=Fa
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -743,7 +721,6 @@ async def put_group_config(request, body, group_id, pretty=False, wait_for_compl
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -781,7 +758,6 @@ async def get_group_files(request, group_id, pretty=False, wait_for_complete=Fal
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -809,7 +785,6 @@ async def get_group_file_json(request, group_id, file_name, pretty=False, wait_f
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -838,7 +813,6 @@ async def get_group_file_xml(request, group_id, file_name, pretty=False, wait_fo
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -880,7 +854,6 @@ async def insert_agent(request, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -917,7 +890,6 @@ async def get_agent_no_group(request, pretty=False, wait_for_complete=False, off
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -951,7 +923,6 @@ async def get_agent_outdated(request, pretty=False, wait_for_complete=False, off
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -992,7 +963,6 @@ async def get_agent_fields(request, pretty=False, wait_for_complete=False, field
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -1015,7 +985,6 @@ async def get_agent_summary_status(request, pretty=False, wait_for_complete=Fals
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -1039,7 +1008,6 @@ async def get_agent_summary_os(request, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/ciscat_controller.py
+++ b/api/api/controllers/ciscat_controller.py
@@ -8,7 +8,7 @@ from typing import List
 from aiohttp import web
 
 import wazuh.ciscat as ciscat
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
@@ -71,4 +71,4 @@ async def get_agents_ciscat_results(request, agent_id: str, pretty: bool = False
                           )
     response = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/ciscat_controller.py
+++ b/api/api/controllers/ciscat_controller.py
@@ -65,7 +65,6 @@ async def get_agents_ciscat_results(request, agent_id: str, pretty: bool = False
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -14,7 +14,7 @@ import wazuh.manager as manager
 import wazuh.stats as stats
 from api import configuration
 from api.api_exception import APIError
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.models.base_model_ import Data
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
 from wazuh.core.cluster.control import get_system_nodes
@@ -45,7 +45,7 @@ async def get_cluster_node(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_cluster_nodes(request, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None,
@@ -87,7 +87,7 @@ async def get_cluster_nodes(request, pretty=False, wait_for_complete=False, offs
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_healthcheck(request, pretty=False, wait_for_complete=False, list_nodes=None):
@@ -117,7 +117,7 @@ async def get_healthcheck(request, pretty=False, wait_for_complete=False, list_n
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_status(request, pretty=False, wait_for_complete=False):
@@ -139,7 +139,7 @@ async def get_status(request, pretty=False, wait_for_complete=False):
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_config(request, pretty=False, wait_for_complete=False):
@@ -163,7 +163,7 @@ async def get_config(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_status_node(request, node_id, pretty=False, wait_for_complete=False):
@@ -188,7 +188,7 @@ async def get_status_node(request, node_id, pretty=False, wait_for_complete=Fals
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_info_node(request, node_id, pretty=False, wait_for_complete=False):
@@ -215,7 +215,7 @@ async def get_info_node(request, node_id, pretty=False, wait_for_complete=False)
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_configuration_node(request, node_id, pretty=False, wait_for_complete=False, section=None, field=None):
@@ -244,7 +244,7 @@ async def get_configuration_node(request, node_id, pretty=False, wait_for_comple
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_node(request, node_id, pretty=False, wait_for_complete=False, date=None):
@@ -278,7 +278,7 @@ async def get_stats_node(request, node_id, pretty=False, wait_for_complete=False
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_hourly_node(request, node_id, pretty=False, wait_for_complete=False):
@@ -307,7 +307,7 @@ async def get_stats_hourly_node(request, node_id, pretty=False, wait_for_complet
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_weekly_node(request, node_id, pretty=False, wait_for_complete=False):
@@ -336,7 +336,7 @@ async def get_stats_weekly_node(request, node_id, pretty=False, wait_for_complet
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_analysisd_node(request, node_id, pretty=False, wait_for_complete=False):
@@ -363,7 +363,7 @@ async def get_stats_analysisd_node(request, node_id, pretty=False, wait_for_comp
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_remoted_node(request, node_id, pretty=False, wait_for_complete=False):
@@ -390,7 +390,7 @@ async def get_stats_remoted_node(request, node_id, pretty=False, wait_for_comple
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_log_node(request, node_id, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None,
@@ -433,7 +433,7 @@ async def get_log_node(request, node_id, pretty=False, wait_for_complete=False, 
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_log_summary_node(request, node_id, pretty=False, wait_for_complete=False):
@@ -458,7 +458,7 @@ async def get_log_summary_node(request, node_id, pretty=False, wait_for_complete
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_files_node(request, node_id, path, pretty=False, wait_for_complete=False):
@@ -485,7 +485,7 @@ async def get_files_node(request, node_id, path, pretty=False, wait_for_complete
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_files_node(request, body, node_id, path, overwrite=False, pretty=False, wait_for_complete=False):
@@ -525,7 +525,7 @@ async def put_files_node(request, body, node_id, path, overwrite=False, pretty=F
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_files_node(request, node_id, path, pretty=False, wait_for_complete=False):
@@ -552,7 +552,7 @@ async def delete_files_node(request, node_id, path, pretty=False, wait_for_compl
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_api_config(request, pretty=False, wait_for_complete=False):
@@ -574,7 +574,7 @@ async def get_api_config(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_api_config(request, pretty=False, wait_for_complete=False):
@@ -600,7 +600,7 @@ async def put_api_config(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_api_config(request, pretty=False, wait_for_complete=False):
@@ -626,7 +626,7 @@ async def delete_api_config(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_restart(request, pretty=False, wait_for_complete=False, list_nodes='*'):
@@ -652,7 +652,7 @@ async def put_restart(request, pretty=False, wait_for_complete=False, list_nodes
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_conf_validation(request, pretty=False, wait_for_complete=False, list_nodes='*'):
@@ -679,7 +679,7 @@ async def get_conf_validation(request, pretty=False, wait_for_complete=False, li
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_node_config(request, node_id, component, wait_for_complete=False, pretty=False, **kwargs):
@@ -708,4 +708,4 @@ async def get_node_config(request, node_id, component, wait_for_complete=False, 
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -38,7 +38,6 @@ async def get_cluster_node(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -79,7 +78,6 @@ async def get_cluster_nodes(request, pretty=False, wait_for_complete=False, offs
                           request_type='local_master',
                           is_async=True,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           local_client_arg='lc',
                           rbac_permissions=request['token_info']['rbac_policies'],
@@ -109,7 +107,6 @@ async def get_healthcheck(request, pretty=False, wait_for_complete=False, list_n
                           request_type='local_master',
                           is_async=True,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           local_client_arg='lc',
                           rbac_permissions=request['token_info']['rbac_policies'],
@@ -132,7 +129,6 @@ async def get_status(request, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -156,7 +152,6 @@ async def get_config(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -181,7 +176,6 @@ async def get_status_node(request, node_id, pretty=False, wait_for_complete=Fals
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -208,7 +202,6 @@ async def get_info_node(request, node_id, pretty=False, wait_for_complete=False)
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -237,7 +230,6 @@ async def get_configuration_node(request, node_id, pretty=False, wait_for_comple
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -271,7 +263,6 @@ async def get_stats_node(request, node_id, pretty=False, wait_for_complete=False
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -299,7 +290,6 @@ async def get_stats_hourly_node(request, node_id, pretty=False, wait_for_complet
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -328,7 +318,6 @@ async def get_stats_weekly_node(request, node_id, pretty=False, wait_for_complet
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -355,7 +344,6 @@ async def get_stats_analysisd_node(request, node_id, pretty=False, wait_for_comp
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -382,7 +370,6 @@ async def get_stats_remoted_node(request, node_id, pretty=False, wait_for_comple
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -426,7 +413,6 @@ async def get_log_node(request, node_id, pretty=False, wait_for_complete=False, 
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -451,7 +437,6 @@ async def get_log_summary_node(request, node_id, pretty=False, wait_for_complete
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -478,7 +463,6 @@ async def get_files_node(request, node_id, path, pretty=False, wait_for_complete
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -518,7 +502,6 @@ async def put_files_node(request, body, node_id, path, overwrite=False, pretty=F
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -545,7 +528,6 @@ async def delete_files_node(request, node_id, path, pretty=False, wait_for_compl
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
@@ -568,7 +550,6 @@ async def get_api_config(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           )
@@ -593,7 +574,6 @@ async def put_api_config(request, pretty=False, wait_for_complete=False):
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=True,
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -619,7 +599,6 @@ async def delete_api_config(request, pretty=False, wait_for_complete=False):
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=True,
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -644,7 +623,6 @@ async def put_restart(request, pretty=False, wait_for_complete=False, list_nodes
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_nodes == '*',
                           rbac_permissions=request['token_info']['rbac_policies'],
@@ -671,7 +649,6 @@ async def get_conf_validation(request, pretty=False, wait_for_complete=False, li
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_nodes == '*',
                           rbac_permissions=request['token_info']['rbac_policies'],
@@ -701,7 +678,6 @@ async def get_node_config(request, node_id, component, wait_for_complete=False, 
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes

--- a/api/api/controllers/decoders_controller.py
+++ b/api/api/controllers/decoders_controller.py
@@ -54,7 +54,6 @@ async def get_decoders(request, decoder_names: list = None, pretty: bool = False
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -98,7 +97,6 @@ async def get_decoders_files(request, pretty: bool = False, wait_for_complete: b
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -122,7 +120,6 @@ async def get_download_file(request, pretty: bool = False, wait_for_complete: bo
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -160,7 +157,6 @@ async def get_decoders_parents(request, pretty: bool = False, wait_for_complete:
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/decoders_controller.py
+++ b/api/api/controllers/decoders_controller.py
@@ -7,7 +7,7 @@ import logging
 from aiohttp import web
 from connexion.lifecycle import ConnexionResponse
 
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh import decoder as decoder_framework
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -60,7 +60,7 @@ async def get_decoders(request, decoder_names: list = None, pretty: bool = False
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_decoders_files(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
@@ -104,7 +104,7 @@ async def get_decoders_files(request, pretty: bool = False, wait_for_complete: b
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_download_file(request, pretty: bool = False, wait_for_complete: bool = False, filename: str = None):
@@ -166,4 +166,4 @@ async def get_decoders_parents(request, pretty: bool = False, wait_for_complete:
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -31,7 +31,6 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -87,7 +86,6 @@ async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, li
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -135,7 +133,6 @@ async def get_hardware_info(request, pretty=False, wait_for_complete=False, list
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -187,7 +184,6 @@ async def get_network_address_info(request, pretty=False, wait_for_complete=Fals
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -242,7 +238,6 @@ async def get_network_interface_info(request, pretty=False, wait_for_complete=Fa
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -291,7 +286,6 @@ async def get_network_protocol_info(request, pretty=False, wait_for_complete=Fal
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -343,7 +337,6 @@ async def get_os_info(request, pretty=False, wait_for_complete=False, list_agent
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -393,7 +386,6 @@ async def get_packages_info(request, pretty=False, wait_for_complete=False, list
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -451,7 +443,6 @@ async def get_ports_info(request, pretty=False, wait_for_complete=False, list_ag
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -522,7 +513,6 @@ async def get_processes_info(request, pretty=False, wait_for_complete=False, lis
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -565,7 +555,6 @@ async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, list
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']

--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -9,7 +9,7 @@ from aiohttp import web
 import wazuh.ciscat as ciscat
 import wazuh.syscheck as syscheck
 import wazuh.syscollector as syscollector
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
@@ -38,7 +38,7 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
@@ -94,7 +94,7 @@ async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, li
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_hardware_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
@@ -142,7 +142,7 @@ async def get_hardware_info(request, pretty=False, wait_for_complete=False, list
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_network_address_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
@@ -194,7 +194,7 @@ async def get_network_address_info(request, pretty=False, wait_for_complete=Fals
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_network_interface_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
@@ -249,7 +249,7 @@ async def get_network_interface_info(request, pretty=False, wait_for_complete=Fa
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_network_protocol_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
@@ -298,7 +298,7 @@ async def get_network_protocol_info(request, pretty=False, wait_for_complete=Fal
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_os_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
@@ -350,7 +350,7 @@ async def get_os_info(request, pretty=False, wait_for_complete=False, list_agent
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_packages_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None, select=None,
@@ -400,7 +400,7 @@ async def get_packages_info(request, pretty=False, wait_for_complete=False, list
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_ports_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
@@ -458,7 +458,7 @@ async def get_ports_info(request, pretty=False, wait_for_complete=False, list_ag
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_processes_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
@@ -529,7 +529,7 @@ async def get_processes_info(request, pretty=False, wait_for_complete=False, lis
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
@@ -572,4 +572,4 @@ async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, list
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/lists_controller.py
+++ b/api/api/controllers/lists_controller.py
@@ -48,7 +48,6 @@ async def get_lists(request, pretty: bool = False, wait_for_complete: bool = Fal
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -92,7 +91,6 @@ async def get_lists_files(request, pretty: bool = False, wait_for_complete: bool
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/lists_controller.py
+++ b/api/api/controllers/lists_controller.py
@@ -7,7 +7,7 @@ import os
 
 from aiohttp import web
 
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh import cdb_list
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -54,7 +54,7 @@ async def get_lists(request, pretty: bool = False, wait_for_complete: bool = Fal
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_lists_files(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
@@ -98,4 +98,4 @@ async def get_lists_files(request, pretty: bool = False, wait_for_complete: bool
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -12,7 +12,7 @@ import wazuh.manager as manager
 import wazuh.stats as stats
 from api import configuration
 from api.api_exception import APIError
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.models.base_model_ import Data
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
 from wazuh import common
@@ -41,7 +41,7 @@ async def get_status(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_info(request, pretty=False, wait_for_complete=False):
@@ -63,7 +63,7 @@ async def get_info(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_configuration(request, pretty=False, wait_for_complete=False, section=None, field=None):
@@ -88,7 +88,7 @@ async def get_configuration(request, pretty=False, wait_for_complete=False, sect
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats(request, pretty=False, wait_for_complete=False, date=None):
@@ -118,7 +118,7 @@ async def get_stats(request, pretty=False, wait_for_complete=False, date=None):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_hourly(request, pretty=False, wait_for_complete=False):
@@ -144,7 +144,7 @@ async def get_stats_hourly(request, pretty=False, wait_for_complete=False):
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_weekly(request, pretty=False, wait_for_complete=False):
@@ -170,7 +170,7 @@ async def get_stats_weekly(request, pretty=False, wait_for_complete=False):
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_analysisd(request, pretty=False, wait_for_complete=False):
@@ -193,7 +193,7 @@ async def get_stats_analysisd(request, pretty=False, wait_for_complete=False):
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_stats_remoted(request, pretty=False, wait_for_complete=False):
@@ -216,7 +216,7 @@ async def get_stats_remoted(request, pretty=False, wait_for_complete=False):
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_log(request, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None,
@@ -253,7 +253,7 @@ async def get_log(request, pretty=False, wait_for_complete=False, offset=0, limi
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_log_summary(request, pretty=False, wait_for_complete=False):
@@ -275,7 +275,7 @@ async def get_log_summary(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_files(request, pretty=False, wait_for_complete=False, path=None):
@@ -298,7 +298,7 @@ async def get_files(request, pretty=False, wait_for_complete=False, path=None):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_files(request, body, overwrite=False, pretty=False, wait_for_complete=False, path=None):
@@ -334,7 +334,7 @@ async def put_files(request, body, overwrite=False, pretty=False, wait_for_compl
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_files(request, pretty=False, wait_for_complete=False, path=None):
@@ -357,7 +357,7 @@ async def delete_files(request, pretty=False, wait_for_complete=False, path=None
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 
@@ -380,7 +380,7 @@ async def get_api_config(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_api_config(request, pretty=False, wait_for_complete=False):
@@ -406,7 +406,7 @@ async def put_api_config(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_api_config(request, pretty=False, wait_for_complete=False):
@@ -432,7 +432,7 @@ async def delete_api_config(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_restart(request, pretty=False, wait_for_complete=False):
@@ -454,7 +454,7 @@ async def put_restart(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_conf_validation(request, pretty=False, wait_for_complete=False):
@@ -476,7 +476,7 @@ async def get_conf_validation(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_manager_config_ondemand(request, component, pretty=False, wait_for_complete=False, **kwargs):
@@ -501,4 +501,4 @@ async def get_manager_config_ondemand(request, component, pretty=False, wait_for
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -35,7 +35,6 @@ async def get_status(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -57,7 +56,6 @@ async def get_info(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -82,7 +80,6 @@ async def get_configuration(request, pretty=False, wait_for_complete=False, sect
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -112,7 +109,6 @@ async def get_stats(request, pretty=False, wait_for_complete=False, date=None):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -137,7 +133,6 @@ async def get_stats_hourly(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -163,7 +158,6 @@ async def get_stats_weekly(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -186,7 +180,6 @@ async def get_stats_analysisd(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -209,7 +202,6 @@ async def get_stats_remoted(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -247,7 +239,6 @@ async def get_log(request, pretty=False, wait_for_complete=False, offset=0, limi
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -269,7 +260,6 @@ async def get_log_summary(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -292,7 +282,6 @@ async def get_files(request, pretty=False, wait_for_complete=False, path=None):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -328,7 +317,6 @@ async def put_files(request, body, overwrite=False, pretty=False, wait_for_compl
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -351,7 +339,6 @@ async def delete_files(request, pretty=False, wait_for_complete=False, path=None
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -374,7 +361,6 @@ async def get_api_config(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -399,7 +385,6 @@ async def put_api_config(request, pretty=False, wait_for_complete=False):
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=True,
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -425,7 +410,6 @@ async def delete_api_config(request, pretty=False, wait_for_complete=False):
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=True,
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -448,7 +432,6 @@ async def put_restart(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -470,7 +453,6 @@ async def get_conf_validation(request, pretty=False, wait_for_complete=False):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -495,7 +477,6 @@ async def get_manager_config_ondemand(request, component, pretty=False, wait_for
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/overview_controller.py
+++ b/api/api/controllers/overview_controller.py
@@ -29,7 +29,6 @@ async def get_overview_agents(request, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/overview_controller.py
+++ b/api/api/controllers/overview_controller.py
@@ -6,7 +6,7 @@ import logging
 
 from aiohttp import web
 
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.models.base_model_ import Data
 from api.util import raise_if_exc, remove_nones_to_dict
 from wazuh.agent import get_full_overview
@@ -36,4 +36,4 @@ async def get_overview_agents(request, pretty=False, wait_for_complete=False):
     data = raise_if_exc(await dapi.distribute_function())
     response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/rules_controller.py
+++ b/api/api/controllers/rules_controller.py
@@ -65,7 +65,6 @@ async def get_rules(request, rule_ids=None, pretty=False, wait_for_complete=Fals
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -101,7 +100,6 @@ async def get_rules_groups(request, pretty=False, wait_for_complete=False, offse
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -136,7 +134,6 @@ async def get_rules_requirement(request, requirement=None, pretty=False, wait_fo
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -177,7 +174,6 @@ async def get_rules_files(request, pretty=False, wait_for_complete=False, offset
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -202,7 +198,6 @@ async def get_download_file(request, pretty: bool = False, wait_for_complete: bo
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/rules_controller.py
+++ b/api/api/controllers/rules_controller.py
@@ -9,7 +9,7 @@ from aiohttp_cache import cache
 from connexion.lifecycle import ConnexionResponse
 
 from api import configuration
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh import rule as rule_framework
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -71,7 +71,7 @@ async def get_rules(request, rule_ids=None, pretty=False, wait_for_complete=Fals
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 @cache(expires=configuration.api_conf['cache']['time'], unless=not configuration.api_conf['cache']['enabled'])
@@ -107,7 +107,7 @@ async def get_rules_groups(request, pretty=False, wait_for_complete=False, offse
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 @cache(expires=configuration.api_conf['cache']['time'], unless=not configuration.api_conf['cache']['enabled'])
@@ -142,7 +142,7 @@ async def get_rules_requirement(request, requirement=None, pretty=False, wait_fo
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 @cache(expires=configuration.api_conf['cache']['time'], unless=not configuration.api_conf['cache']['enabled'])
@@ -183,7 +183,7 @@ async def get_rules_files(request, pretty=False, wait_for_complete=False, offset
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 @cache(expires=configuration.api_conf['cache']['time'], unless=not configuration.api_conf['cache']['enabled'])

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -8,7 +8,7 @@ import logging
 from aiohttp import web
 
 import wazuh.sca as sca
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.common import database_limit
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -58,7 +58,7 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete=False, policy_id=None, title=None,
@@ -122,4 +122,4 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -52,7 +52,6 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -116,7 +115,6 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -10,7 +10,7 @@ from aiohttp import web
 
 from api.api_exception import APIError
 from api.authentication import generate_token
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.models.token_response import TokenResponse
 from api.util import remove_nones_to_dict, raise_if_exc, parse_api_param
 from wazuh import security
@@ -71,7 +71,7 @@ async def get_users(request, usernames: list = None, pretty=False, wait_for_comp
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 def _check_body(f_kwargs, keys: list = None):
@@ -190,7 +190,7 @@ async def get_roles(request, role_ids=None, pretty=False, wait_for_complete=Fals
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def add_role(request, pretty=False, wait_for_complete=False):
@@ -219,7 +219,7 @@ async def add_role(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def remove_roles(request, role_ids=None, pretty=False, wait_for_complete=False):
@@ -243,7 +243,7 @@ async def remove_roles(request, role_ids=None, pretty=False, wait_for_complete=F
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def update_role(request, role_id, pretty=False, wait_for_complete=False):
@@ -274,7 +274,7 @@ async def update_role(request, role_id, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_policies(request, policy_ids=None, pretty=False, wait_for_complete=False, offset=0, limit=None,
@@ -309,7 +309,7 @@ async def get_policies(request, policy_ids=None, pretty=False, wait_for_complete
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def add_policy(request, pretty=False, wait_for_complete=False):
@@ -338,7 +338,7 @@ async def add_policy(request, pretty=False, wait_for_complete=False):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def remove_policies(request, policy_ids=None, pretty=False, wait_for_complete=False):
@@ -362,7 +362,7 @@ async def remove_policies(request, policy_ids=None, pretty=False, wait_for_compl
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def update_policy(request, policy_id, pretty=False, wait_for_complete=False):
@@ -394,7 +394,7 @@ async def update_policy(request, policy_id, pretty=False, wait_for_complete=Fals
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def set_user_role(request, username, role_ids, position=None, pretty=False, wait_for_complete=False):
@@ -430,7 +430,7 @@ async def set_user_role(request, username, role_ids, position=None, pretty=False
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def remove_user_role(request, username, role_ids, pretty=False, wait_for_complete=False):
@@ -455,7 +455,7 @@ async def remove_user_role(request, username, role_ids, pretty=False, wait_for_c
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def set_role_policy(request, role_id, policy_ids, position=None, pretty=False, wait_for_complete=False):
@@ -492,7 +492,7 @@ async def set_role_policy(request, role_id, policy_ids, position=None, pretty=Fa
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def remove_role_policy(request, role_id, policy_ids, pretty=False, wait_for_complete=False):
@@ -517,7 +517,7 @@ async def remove_role_policy(request, role_id, policy_ids, pretty=False, wait_fo
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_rbac_resources(pretty=False, resource: str = None):
@@ -546,7 +546,7 @@ async def get_rbac_resources(pretty=False, resource: str = None):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_rbac_actions(pretty=False, endpoint: str = None):
@@ -574,7 +574,7 @@ async def get_rbac_actions(pretty=False, endpoint: str = None):
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def revoke_all_tokens(request):

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -184,7 +184,6 @@ async def get_roles(request, role_ids=None, pretty=False, wait_for_complete=Fals
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -213,7 +212,6 @@ async def add_role(request, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -237,7 +235,6 @@ async def remove_roles(request, role_ids=None, pretty=False, wait_for_complete=F
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -268,7 +265,6 @@ async def update_role(request, role_id, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -303,7 +299,6 @@ async def get_policies(request, policy_ids=None, pretty=False, wait_for_complete
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -332,7 +327,6 @@ async def add_policy(request, pretty=False, wait_for_complete=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -356,7 +350,6 @@ async def remove_policies(request, policy_ids=None, pretty=False, wait_for_compl
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -388,7 +381,6 @@ async def update_policy(request, policy_id, pretty=False, wait_for_complete=Fals
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -424,7 +416,6 @@ async def set_user_role(request, username, role_ids, position=None, pretty=False
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -449,7 +440,6 @@ async def remove_user_role(request, username, role_ids, pretty=False, wait_for_c
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -486,7 +476,6 @@ async def set_role_policy(request, role_id, policy_ids, position=None, pretty=Fa
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -511,7 +500,6 @@ async def remove_role_policy(request, role_id, policy_ids, pretty=False, wait_fo
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -541,7 +529,6 @@ async def get_rbac_resources(pretty=False, resource: str = None):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=True,
-                          pretty=pretty,
                           logger=logger
                           )
     data = raise_if_exc(await dapi.distribute_function())
@@ -569,7 +556,6 @@ async def get_rbac_actions(pretty=False, endpoint: str = None):
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=True,
-                          pretty=pretty,
                           logger=logger
                           )
     data = raise_if_exc(await dapi.distribute_function())

--- a/api/api/controllers/syscheck_controller.py
+++ b/api/api/controllers/syscheck_controller.py
@@ -30,7 +30,6 @@ async def put_syscheck(request, list_agents='*', pretty=False, wait_for_complete
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           broadcasting=list_agents == '*',
                           rbac_permissions=request['token_info']['rbac_policies']
@@ -92,7 +91,6 @@ async def get_syscheck_agent(request, agent_id, pretty=False, wait_for_complete=
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -117,7 +115,6 @@ async def delete_syscheck_agent(request, agent_id='*', pretty=False, wait_for_co
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -143,7 +140,6 @@ async def get_last_scan_agent(request, agent_id, pretty=False, wait_for_complete
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/syscheck_controller.py
+++ b/api/api/controllers/syscheck_controller.py
@@ -6,7 +6,7 @@ import logging
 
 from aiohttp import web
 
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.syscheck import run, clear, files, last_scan
@@ -37,7 +37,7 @@ async def put_syscheck(request, list_agents='*', pretty=False, wait_for_complete
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_syscheck_agent(request, agent_id, pretty=False, wait_for_complete=False, offset=0,
@@ -98,7 +98,7 @@ async def get_syscheck_agent(request, agent_id, pretty=False, wait_for_complete=
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_syscheck_agent(request, agent_id='*', pretty=False, wait_for_complete=False):
@@ -123,7 +123,7 @@ async def delete_syscheck_agent(request, agent_id='*', pretty=False, wait_for_co
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_last_scan_agent(request, agent_id, pretty=False, wait_for_complete=False):
@@ -149,4 +149,4 @@ async def get_last_scan_agent(request, agent_id, pretty=False, wait_for_complete
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/syscollector_controller.py
+++ b/api/api/controllers/syscollector_controller.py
@@ -31,7 +31,6 @@ async def get_hardware_info(request, agent_id, pretty=False, wait_for_complete=F
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -73,7 +72,6 @@ async def get_hotfix_info(request, agent_id, pretty=False, wait_for_complete=Fal
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -123,7 +121,6 @@ async def get_network_address_info(request, agent_id, pretty=False, wait_for_com
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -177,7 +174,6 @@ async def get_network_interface_info(request, agent_id, pretty=False, wait_for_c
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -223,7 +219,6 @@ async def get_network_protocol_info(request, agent_id, pretty=False, wait_for_co
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -250,7 +245,6 @@ async def get_os_info(request, agent_id, pretty=False, wait_for_complete=False, 
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -298,7 +292,6 @@ async def get_packages_info(request, agent_id, pretty=False, wait_for_complete=F
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -351,7 +344,6 @@ async def get_ports_info(request, agent_id, pretty=False, wait_for_complete=Fals
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
@@ -420,7 +412,6 @@ async def get_processes_info(request, agent_id, pretty=False, wait_for_complete=
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
-                          pretty=pretty,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies']
                           )

--- a/api/api/controllers/syscollector_controller.py
+++ b/api/api/controllers/syscollector_controller.py
@@ -7,7 +7,7 @@ import logging
 from aiohttp import web
 
 import wazuh.syscollector as syscollector
-from api.encoder import dumps
+from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
@@ -37,7 +37,7 @@ async def get_hardware_info(request, agent_id, pretty=False, wait_for_complete=F
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_hotfix_info(request, agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, sort=None,
@@ -79,7 +79,7 @@ async def get_hotfix_info(request, agent_id, pretty=False, wait_for_complete=Fal
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_network_address_info(request, agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None,
@@ -129,7 +129,7 @@ async def get_network_address_info(request, agent_id, pretty=False, wait_for_com
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_network_interface_info(request, agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None,
@@ -183,7 +183,7 @@ async def get_network_interface_info(request, agent_id, pretty=False, wait_for_c
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_network_protocol_info(request, agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None,
@@ -229,7 +229,7 @@ async def get_network_protocol_info(request, agent_id, pretty=False, wait_for_co
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_os_info(request, agent_id, pretty=False, wait_for_complete=False, select=None):
@@ -256,7 +256,7 @@ async def get_os_info(request, agent_id, pretty=False, wait_for_complete=False, 
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_packages_info(request, agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, select=None,
@@ -304,7 +304,7 @@ async def get_packages_info(request, agent_id, pretty=False, wait_for_complete=F
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_ports_info(request, agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None, select=None,
@@ -357,7 +357,7 @@ async def get_ports_info(request, agent_id, pretty=False, wait_for_complete=Fals
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_processes_info(request, agent_id, pretty=False, wait_for_complete=False, offset=0, limit=None,
@@ -426,4 +426,4 @@ async def get_processes_info(request, agent_id, pretty=False, wait_for_complete=
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/encoder.py
+++ b/api/api/encoder.py
@@ -27,7 +27,7 @@ class WazuhJSONEncoder(JSONEncoder):
 
 def dumps(obj: object) -> str:
     """
-    Get a JSON encoded str from an object
+    Get a JSON encoded str from an object.
 
     Parameters
     ----------
@@ -43,3 +43,23 @@ def dumps(obj: object) -> str:
     str
     """
     return json.dumps(obj, cls=WazuhJSONEncoder)
+
+
+def prettify(obj: object) -> str:
+    """
+    Get a prettified JSON encoded str from an object.
+
+    Parameters
+    ----------
+    obj: object
+        Object to be encoded in a JSON string
+
+    Raises
+    ------
+    TypeError
+
+    Returns
+    -------
+    str
+    """
+    return json.dumps(obj, cls=WazuhJSONEncoder, indent=3)

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -30,7 +30,7 @@ class DistributedAPI:
     """
 
     def __init__(self, f: Callable, logger: logging.getLogger, f_kwargs: Dict = None, node: c_common.Handler = None,
-                 debug: bool = False, pretty: bool = False, request_type: str = "local_master",
+                 debug: bool = False, request_type: str = "local_master",
                  wait_for_complete: bool = False, from_cluster: bool = False, is_async: bool = False,
                  broadcasting: bool = False, basic_services: tuple = None, local_client_arg: str = None,
                  rbac_permissions: Dict = None, nodes: list = None):
@@ -42,7 +42,6 @@ class DistributedAPI:
         :param logger: Logging logger to use
         :param node: Asyncio protocol object to use when sending requests to other nodes
         :param debug: Enable debug messages and raise exceptions.
-        :param pretty: Return request result with pretty indent
         :param wait_for_complete: true to disable timeout, false otherwise
         """
         self.logger = logger
@@ -51,7 +50,6 @@ class DistributedAPI:
         self.node = node if node is not None else local_client
         self.cluster_items = wazuh.core.cluster.utils.get_cluster_items() if node is None else node.cluster_items
         self.debug = debug
-        self.pretty = pretty
         self.node_info = wazuh.core.cluster.cluster.get_node() if node is None else node.get_node()
         self.request_id = str(random.randint(0, 2**10 - 1))
         self.request_type = request_type


### PR DESCRIPTION
Hello team, this closes #3117 .

As I added in the issue, the original goal was to completely remove the `pretty` parameter from the new API but we decided to set it to **False** by default and let the user choose whether to get the response 'prettified' or not. This parameter is used on a controller level, so in addition to this change I removed this parameter from the class `DistributedAPI` since it wasn't being used.

## Examples
### Not pretty
`curl -k -X GET "https://localhost:55000/v4/agents?limit=500&status=never_connected" -H "accept: application/json" -H "Authorization: Bearer <TOKEN>"`

```json
{"data": {"affected_items": [{"status": "never_connected", "ip": "10.0.10.11", "name": "NewHost_2", "dateAdd": "2020-04-28T15:23:46Z", "node_name": "unknown", "id": "013", "registerIP": "10.0.10.11"}], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "All selected agents information is shown"}

```

### Pretty
`curl -k -X GET "https://localhost:55000/v4/agents?limit=500&status=never_connected&pretty=true" -H "accept: application/json" -H "Authorization: Bearer <TOKEN>"`

```json
{
   "data": {
      "affected_items": [
         {
            "status": "never_connected",
            "ip": "10.0.10.11",
            "name": "NewHost_2",
            "dateAdd": "2020-04-28T15:23:46Z",
            "node_name": "unknown",
            "id": "013",
            "registerIP": "10.0.10.11"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected agents information is shown"
}
```

Regards.