### PR TITLE
Avoid duplicate descriptors using wildcards.

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -264,7 +264,6 @@ void LogCollectorStart()
         } else {
             /* On Windows we need to forward the seek for wildcard files */
 #ifdef WIN32
-            set_read(current, i, j);
             minfo(READING_FILE, current->file);
 
             if (current->fp) {


### PR DESCRIPTION
|Related issue|
|---|
|#4920|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
As mentioned in #4920, there was a leak in the windows agent when the files are configured using wildcards in logcollector.
This PR aims to fix this problem by removing this line of code: https://github.com/wazuh/wazuh/blob/e36bb6f1f3b6c6c0ab4423cf2de60c19b0655408/src/logcollector/logcollector.c#L267<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```
<localfile>
    <location>C:\testlog\log*</location>
    <log_format>syslog</log_format>
</localfile>
```
## Descriptors oppened

![image](https://user-images.githubusercontent.com/22987701/80591816-a0398e80-8a1e-11ea-9de6-77183ce16f23.png)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [X] Source installation
- [X] Source upgrade

- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Dr. Memory
