### PR TITLE
Update id_counter when id is defined

### DIFF
--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -48,6 +48,13 @@ int OS_AddNewAgent(keystore *keys, const char *id, const char *name, const char 
         snprintf(_id, 9, "%03d", ++keys->id_counter);
         id = _id;
     }
+    else {
+        char *endptr;
+        int id_number = strtol(id, &endptr, 10);
+
+        if ('\0' == *endptr && id_number > keys->id_counter)
+            keys->id_counter = id_number;
+    }
 
     if (!key) {
         snprintf(str1, STR_SIZE, "%d%s%d%s", (int)time(0), name, os_random(), getuname());


### PR DESCRIPTION
|Related issue|
|---|
|#4980|

## Description
-Fix to possible duplicated ID after adding agents with specific ID.
-Solution: Update id_counter when ID is specified too.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Source upgrade
- [x] QA integrated tests

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [] Coverity
  - [] Valgrind (memcheck and descriptor leaks check)
