### PR TITLE
4.0 - Add new endpoint to restart agents by group_id 

### DIFF
--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -637,7 +637,7 @@ async def get_agents_in_group(request, group_id, pretty=False, wait_for_complete
     :param q: Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
     :return: AllItemsResponseAgents
     """
-    f_kwargs = {'group_id': group_id,
+    f_kwargs = {'group_list': [group_id],
                 'offset': offset,
                 'limit': limit,
                 'sort': parse_api_param(sort, 'sort'),
@@ -846,6 +846,31 @@ async def get_group_file_xml(request, group_id, file_name, pretty=False, wait_fo
     response = ConnexionResponse(body=data["data"], mimetype='application/xml')
 
     return response
+
+
+async def restart_agents_by_group(request, group_id, pretty=False, wait_for_complete=False):
+    """Restart all agents from a group.
+
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param group_id: Group ID.
+    :return: AllItemsResponseAgents
+    """
+    f_kwargs = {'group_id': group_id}
+
+    dapi = DistributedAPI(f=agent.restart_agents,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='distributed_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          pretty=pretty,
+                          logger=logger,
+                          rbac_permissions=request['token_info']['rbac_policies']
+                          )
+
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=dumps)
 
 
 async def insert_agent(request, pretty=False, wait_for_complete=False):

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5840,6 +5840,42 @@ paths:
         default:
           $ref: '#/components/responses/ResponseError'
 
+  /groups/{group_id}/restart:
+    put:
+      tags:
+        - groups
+      summary: 'Restart all agents in a group'
+      description: 'Restart all agents which belong to a given group'
+      operationId: api.controllers.agents_controller.restart_agents_by_group
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/group:read'
+        - $ref: '#/x-rbac-catalog/actions/agent:restart'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/group_id'
+      responses:
+        '200':
+          description: Agents restarted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseAgentIDs'
+                example:
+                  message: Restart command sent to all selected agents
+                  data:
+                    affected_items:
+                      - '002'
+                      - '004'
+                    total_affected_items: 2
+        default:
+          $ref: '#/components/responses/ResponseError'
+
   /agents/insert:
     post:
       tags:

--- a/api/test/integration/test_agentsPUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agentsPUT_endpoints.tavern.yaml
@@ -218,7 +218,7 @@ test_name: PUT /groups/{group_id}/configuration
 
 stages:
 
-    # PUT /group/group2/configuration
+    # PUT /groups/group2/configuration
   - name: Update group2 configuration
     request:
       verify: False
@@ -234,7 +234,7 @@ stages:
       json:
         message: !anystr
 
-    # PUT /group/wrong_group/configuration
+    # PUT /groups/wrong_group/configuration
   - name: Try to update configuration of a non existing group
     request:
       verify: False
@@ -250,7 +250,7 @@ stages:
       json:
         code: 1710
 
-    # PUT /group/group1/configuration
+    # PUT /groups/group1/configuration
   - name: Try to update configuration using an empty file
     request:
       verify: False
@@ -264,7 +264,7 @@ stages:
       json:
         code: 2007
 
-    # PUT /group/group1/configuration
+    # PUT /groups/group1/configuration
   - name: Try to update configuration using an invalid configuration file
     request:
       verify: False
@@ -280,7 +280,7 @@ stages:
       json:
         code: 1113
 
-    # PUT /group/group1/configuration
+    # PUT /groups/group1/configuration
   - name: Try to update configuration using a wrong configuration file
     request:
       verify: False
@@ -295,6 +295,88 @@ stages:
       status_code: 400
       json:
         code: 1114
+
+---
+test_name: PUT /groups/{group_id}/restart
+
+stages:
+
+    # PUT /groups/group1/restart (This group has no agents assigned)
+  - name: Restart all agents from group1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: "application/xml"
+    response:
+      status_code: 400
+      json:
+        title: "Wazuh Error"
+        detail: "The group does not have any agent assigned"
+        status: 400
+        remediation: "Please select another group or assign any agent to it"
+        code: 1755
+        dapi_errors:
+          master-node:
+            error: "The group does not have any agent assigned"
+
+    # PUT /groups/group2/restart (Agents 009 and 010 are disconnected)
+  - name: Restart all agents from group2
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: "application/xml"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - "001"
+            - "002"
+            - "003"
+            - "004"
+            - "005"
+            - "006"
+            - "007"
+            - "008"
+          total_affected_items: 8
+          failed_items:
+            - error:
+                code: 1707
+                message: "Impossible to restart non-active agent: disconnected"
+                remediation: "Please, make sure agent is active before attempting to restart"
+              id:
+                - "009"
+                - "010"
+          total_failed_items: 2
+        message: "Could not send command to some agents"
+    delay_after: 45
+
+  # PUT /groups/not_exists/restart (Group does not exist)
+  - name: Restart all agents from a group which does not exist
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/not_exists/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: "application/xml"
+    response:
+      status_code: 400
+      json:
+        title: "Wazuh Error"
+        detail: "The group does not exist"
+        status: 400
+        remediation: "Please, `GET /agents/groups` to find all available groups"
+        code: 1710
+        dapi_errors:
+          master-node:
+            error: "The group does not exist"
 
 ---
 test_name: PUT /agents/restart

--- a/api/test/integration/test_agentsPUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agentsPUT_endpoints.tavern.yaml
@@ -313,14 +313,7 @@ stages:
     response:
       status_code: 400
       json:
-        title: "Wazuh Error"
-        detail: "The group does not have any agent assigned"
-        status: 400
-        remediation: "Please select another group or assign any agent to it"
         code: 1755
-        dapi_errors:
-          master-node:
-            error: "The group does not have any agent assigned"
 
     # PUT /groups/group2/restart (Agents 009 and 010 are disconnected)
   - name: Restart all agents from group2
@@ -348,8 +341,6 @@ stages:
           failed_items:
             - error:
                 code: 1707
-                message: "Impossible to restart non-active agent: disconnected"
-                remediation: "Please, make sure agent is active before attempting to restart"
               id:
                 - "009"
                 - "010"
@@ -369,14 +360,8 @@ stages:
     response:
       status_code: 400
       json:
-        title: "Wazuh Error"
-        detail: "The group does not exist"
         status: 400
-        remediation: "Please, `GET /agents/groups` to find all available groups"
         code: 1710
-        dapi_errors:
-          master-node:
-            error: "The group does not exist"
 
 ---
 test_name: PUT /agents/restart

--- a/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
@@ -1320,6 +1320,53 @@ stages:
         <<: *permission_denied
 
 ---
+test_name: PUT /groups/{group_id}/restart
+
+stages:
+
+    # PUT /groups/group1/restart
+  - name: Restart all agents from group1 (Denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: "application/xml"
+    response:
+      status_code: 400
+      json:
+        title: "Wazuh Error"
+        detail: "Permission denied: Resource type: group:id"
+        status: 400
+        remediation: "Please, make sure you have permissions to execute current request, for more information on setting up permissions please visit XXXX"
+        code: 4000
+        dapi_errors:
+          master-node:
+            error: "Permission denied: Resource type: group:id"
+
+    # PUT /groups/group2/restart
+  - name: Restart all agents from group2 (Only agent 005 will have both permissions -> group:read & agent:restart)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: "application/xml"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - "005"
+          total_affected_items: 1
+          failed_items: []
+          total_failed_items: 0
+        message: "Restart command sent to all agents"
+    delay_after: 45
+
+---
 test_name: PUT /agents/restart
 
 stages:

--- a/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
@@ -1336,14 +1336,8 @@ stages:
     response:
       status_code: 400
       json:
-        title: "Wazuh Error"
-        detail: "Permission denied: Resource type: group:id"
         status: 400
-        remediation: "Please, make sure you have permissions to execute current request, for more information on setting up permissions please visit XXXX"
         code: 4000
-        dapi_errors:
-          master-node:
-            error: "Permission denied: Resource type: group:id"
 
     # PUT /groups/group2/restart
   - name: Restart all agents from group2 (Only agent 005 will have both permissions -> group:read & agent:restart)

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -1421,6 +1421,41 @@ stages:
         <<: *permission_denied
 
 ---
+test_name: PUT /groups/{group_id}/restart
+
+stages:
+
+    # PUT /groups/default/restart
+  - name: Restart all agents from group default (Partially allowed)
+    delay_before: 20
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/default/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: "application/xml"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - "004"
+          total_affected_items: 1
+          failed_items:
+            - error:
+                code: 4000
+                message: "Permission denied: Resource type: agent:id"
+                remediation: "Please, make sure you have permissions to execute current request, for more information on setting up permissions please visit XXXX"
+              id:
+                - "002"
+                - "006"
+                - "010"
+          total_failed_items: 3
+        message: "Could not send command to some agents"
+    delay_after: 45
+
+---
 test_name: PUT /agents/restart
 
 stages:

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -1445,8 +1445,6 @@ stages:
           failed_items:
             - error:
                 code: 4000
-                message: "Permission denied: Resource type: agent:id"
-                remediation: "Please, make sure you have permissions to execute current request, for more information on setting up permissions please visit XXXX"
               id:
                 - "002"
                 - "006"

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -10,7 +10,7 @@ from shutil import copyfile
 
 from wazuh import common, configuration
 from wazuh.InputValidator import InputValidator
-from wazuh.core.core_agent import WazuhDBQueryAgents, WazuhDBQueryDistinctAgents, WazuhDBQueryGroupByAgents, \
+from wazuh.core.core_agent import WazuhDBQueryAgents, WazuhDBQueryGroupByAgents, \
     WazuhDBQueryMultigroups, Agent
 from wazuh.core.core_utils import get_agents_info, get_groups
 from wazuh.database import Connection
@@ -183,11 +183,12 @@ def get_agent_by_name(name=None, select=None):
         raise e
 
 
-def get_agents_in_group(group_id, offset=0, limit=common.database_limit, sort=None, search=None, select=None,
+@expose_resources(actions=["group:read"], resources=["group:id:{group_list}"], post_proc_func=None)
+def get_agents_in_group(group_list, offset=0, limit=common.database_limit, sort=None, search=None, select=None,
                         filters=None, q=None):
     """Gets a list of available agents with basic attributes.
 
-    :param group_id: Group ID.
+    :param group_list: Group ID.
     :param offset: First item to return.
     :param limit: Maximum number of items to return.
     :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
@@ -197,10 +198,10 @@ def get_agents_in_group(group_id, offset=0, limit=common.database_limit, sort=No
     :param q: Defines query to filter in DB.
     :return: AffectedItemsWazuhResult.
     """
-    if not Agent.group_exists(group_id):
+    if group_list[0] not in get_groups():
         raise WazuhError(1710)
 
-    q = 'group=' + group_id + (';' + q if q else '')
+    q = 'group=' + group_list[0] + (';' + q if q else '')
 
     return get_agents(offset=offset, limit=limit, sort=sort, search=search, select=select, filters=filters, q=q)
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -424,6 +424,18 @@ class DistributedAPI:
             del self.f_kwargs['node_id' if 'node_id' in self.f_kwargs else 'node_list']
             return {node_id: [] for node_id in requested_nodes}
 
+        elif 'group_id' in self.f_kwargs:
+            common.rbac.set(self.rbac_permissions)
+            agents = agent.get_agents_in_group(group_list=[self.f_kwargs['group_id']], select=select_node,
+                                               sort={'fields': ['node_name'], 'order': 'desc'}).affected_items
+            if len(agents) == 0:
+                raise WazuhError(1755)
+            del self.f_kwargs['group_id']
+            node_name = {k: list(map(operator.itemgetter('id'), g)) for k, g in
+                         itertools.groupby(agents, key=operator.itemgetter('node_name'))}
+
+            return node_name
+
         else:
             if self.broadcasting:
                 if 'node_list' in self.f_kwargs:

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -339,6 +339,8 @@ class WazuhException(Exception):
                'remediation': 'Please select another agent or connect your agent before assigning groups'},
         1754: {'message': 'Agent does not exist or you do not have permissions to access it',
                'remediation': 'Try listing all agents with GET /agents endpoint'},
+        1755: {'message': 'The group does not have any agent assigned',
+               'remediation': 'Please select another group or assign any agent to it'},
 
         # CDB List: 1800 - 1899
         1800: {'message': 'Bad format in CDB list {path}'},

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -156,6 +156,7 @@ get_rbac_actions:
         related_endpoints:
           - PUT /agents/{agent_id}/restart
           - PUT /agents/restart
+          - PUT /groups/{group_id}/restart
       agent:upgrade:
         description: Upgrade the version of an agent
         resources:
@@ -199,6 +200,7 @@ get_rbac_actions:
           - GET /groups
           - GET /groups/{group_id}/agents
           - GET /groups/{group_id}/configuration
+          - PUT /groups/{group_id}/restart
           - GET /overview/agents
       group:create:
         description: Create new groups

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -6,8 +6,8 @@
 import os
 import shutil
 import sys
-from pwd import getpwnam
 from grp import getgrnam
+from pwd import getpwnam
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -194,9 +194,9 @@ def test_agent_get_agent_by_name(sqlite_mock, name, expected_id):
 ])
 @patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.agent.get_agents')
-@patch('wazuh.core.core_agent.Agent.group_exists')
+@patch('wazuh.agent.get_groups')
 @patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agents_in_group(sqlite_mock, mock_group_exists, mock_get_agents, group, group_exists,
+def test_agent_get_agents_in_group(sqlite_mock, mock_get_groups, mock_get_agents, group, group_exists,
                                    expected_agents):
     """Test `get_agents_in_group` from agent module.
 
@@ -209,7 +209,7 @@ def test_agent_get_agents_in_group(sqlite_mock, mock_group_exists, mock_get_agen
     expected_agents : List of str
         List of agent ID's that belongs to a given group.
     """
-    mock_group_exists.return_value = group_exists
+    mock_get_groups.return_value = ['default']
     if group_exists:
         # Since the decorator is mocked, pass `agent_list` using `call_args` from mock
         get_agents_in_group(group_list=[group], select=['id'])
@@ -1112,8 +1112,8 @@ def test_agent_get_file_conf(filename, group_list):
     assert isinstance(result, WazuhResult), 'The returned object is not an "WazuhResult" instance.'
     assert 'data' in result.dikt
     assert isinstance(result.dikt['data'], dict)
-    assert 'totalItems' in result.dikt['data']
-    assert result.dikt['data']['totalItems'] == 1
+    assert 'total_affected_items' in result.dikt['data']
+    assert result.dikt['data']['total_affected_items'] == 1
 
 
 @pytest.mark.parametrize('group_list', [
@@ -1131,8 +1131,8 @@ def test_agent_get_agent_conf(group_list):
     """
     result = get_agent_conf(group_list=group_list)
     assert isinstance(result, WazuhResult), 'The returned object is not an "WazuhResult" instance.'
-    assert 'totalItems' in result.dikt
-    assert result.dikt['totalItems'] == 1
+    assert 'total_affected_items' in result.dikt
+    assert result.dikt['total_affected_items'] == 1
 
 
 @pytest.mark.parametrize('group_list', [

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -211,7 +211,7 @@ def test_agent_get_agents_in_group(sqlite_mock, mock_get_groups, mock_get_agents
     """
     mock_get_groups.return_value = ['default']
     if group_exists:
-        # Since the decorator is mocked, pass `agent_list` using `call_args` from mock
+        # Since the decorator is mocked, pass `group_list` using `call_args` from mock
         get_agents_in_group(group_list=[group], select=['id'])
         kwargs = mock_get_agents.call_args[1]
         agents = get_agents(agent_list=short_agent_list, **kwargs)

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -212,7 +212,7 @@ def test_agent_get_agents_in_group(sqlite_mock, mock_group_exists, mock_get_agen
     mock_group_exists.return_value = group_exists
     if group_exists:
         # Since the decorator is mocked, pass `agent_list` using `call_args` from mock
-        get_agents_in_group(group_id=group, select=['id'])
+        get_agents_in_group(group_list=[group], select=['id'])
         kwargs = mock_get_agents.call_args[1]
         agents = get_agents(agent_list=short_agent_list, **kwargs)
         assert agents.affected_items
@@ -222,7 +222,7 @@ def test_agent_get_agents_in_group(sqlite_mock, mock_group_exists, mock_get_agen
     else:
         # If not `group_exists`, expect an error
         with pytest.raises(WazuhError, match='.* 1710 .*'):
-            get_agents_in_group(group_id=group)
+            get_agents_in_group(group_list=[group])
 
 
 @pytest.mark.parametrize('agent_list, expected_items', [


### PR DESCRIPTION
Hello team, this closes #3939 .

A new endpoint has been added to the new API: `PUT /groups/{group_id}/restart`

This endpoint will restart all the agents from the selected group (as long as the user has all the permissions to do it).

This PR also includes the new integration tests for this endpoint and some minor fixes to the unit tests.

## Integration tests
### agentsPUT
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0
collecting ... collected 8 items

test_agentsPUT_endpoints.tavern.yaml::PUT /agents/group PASSED           [ 12%]
test_agentsPUT_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED [ 25%]
test_agentsPUT_endpoints.tavern.yaml::PUT /groups/{group_id}/restart PASSED [ 37%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/restart PASSED         [ 50%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED [ 62%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED [ 75%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade PASSED [ 87%]
test_agentsPUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED [100%]

=============================== warnings summary ===============================
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================== 8 passed, 9 warnings in 339.29s (0:05:39) ===================
```

### RBAC white agents
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0
collecting ... collected 37 items

test_rbac_white_agents_endpoints.tavern.yaml::GET /agents PASSED         [  2%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents?list_agents=agent_id PASSED [  5%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED [  8%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED [ 10%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED [ 13%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups PASSED         [ 16%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED [ 18%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED [ 21%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED [ 24%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED [ 27%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED [ 29%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED [ 32%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/no_group PASSED [ 35%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/outdated PASSED [ 37%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED [ 40%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/summary/status PASSED [ 43%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/summary/os PASSED [ 45%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/upgrade_result PASSED [ 48%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED [ 51%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED [ 54%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents/group?group_id={group_id} PASSED [ 56%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /groups?list_groups={group_id} PASSED [ 59%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /groups PASSED      [ 62%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents?list_agents=agent_id PASSED [ 64%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents PASSED      [ 67%]
test_rbac_white_agents_endpoints.tavern.yaml::POST /agents PASSED        [ 70%]
test_rbac_white_agents_endpoints.tavern.yaml::POST /agents/insert PASSED [ 72%]
test_rbac_white_agents_endpoints.tavern.yaml::POST /agents/insert/quick PASSED [ 75%]
test_rbac_white_agents_endpoints.tavern.yaml::POST /groups PASSED        [ 78%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/group PASSED   [ 81%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED [ 83%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /groups/{group_id}/restart PASSED [ 86%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/restart PASSED [ 89%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED [ 91%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED [ 94%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade PASSED [ 97%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED [100%]

=============================== warnings summary ===============================
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 37 tests with warnings
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================= 37 passed, 38 warnings in 400.78s (0:06:40) ==================
```

### RBAC black agents
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0
collecting ... collected 37 items

test_rbac_black_agents_endpoints.tavern.yaml::GET /agents PASSED         [  2%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents?list_agents=agent_id PASSED [  5%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED [  8%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED [ 10%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED [ 13%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups PASSED         [ 16%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED [ 18%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED [ 21%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED [ 24%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED [ 27%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED [ 29%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED [ 32%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/no_group PASSED [ 35%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/outdated PASSED [ 37%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED [ 40%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/summary/status PASSED [ 43%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/summary/os PASSED [ 45%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/upgrade_result PASSED [ 48%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED [ 51%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED [ 54%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents/group?group_id=group_id PASSED [ 56%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE groups?list_groups=group_id PASSED [ 59%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /groups PASSED      [ 62%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents?list_agents=agent_id PASSED [ 64%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents PASSED      [ 67%]
test_rbac_black_agents_endpoints.tavern.yaml::POST /agents PASSED        [ 70%]
test_rbac_black_agents_endpoints.tavern.yaml::POST /agents/insert PASSED [ 72%]
test_rbac_black_agents_endpoints.tavern.yaml::POST /agents/insert/quick PASSED [ 75%]
test_rbac_black_agents_endpoints.tavern.yaml::POST /groups?group_id={group_id} PASSED [ 78%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/group?group_id={group_id} PASSED [ 81%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED [ 83%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /groups/{group_id}/restart PASSED [ 86%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/restart PASSED [ 89%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED [ 91%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED [ 94%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade PASSED [ 97%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED [100%]

=============================== warnings summary ===============================
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 37 tests with warnings
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================= 37 passed, 38 warnings in 280.44s (0:04:40) ==================
```

### Agent unit tests
```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: tavern-1.0.0
collected 95 items                                                                                                                                                                                          

test_agent.py::test_agent_get_distinct_agents[fields0-expected_items0] PASSED                                                                                                                         [  1%]
test_agent.py::test_agent_get_distinct_agents[fields1-expected_items1] PASSED                                                                                                                         [  2%]
test_agent.py::test_agent_get_distinct_agents[fields2-expected_items2] PASSED                                                                                                                         [  3%]
test_agent.py::test_agent_get_distinct_agents[fields3-expected_items3] PASSED                                                                                                                         [  4%]
test_agent.py::test_agent_get_distinct_agents[fields4-expected_items4] PASSED                                                                                                                         [  5%]
test_agent.py::test_agent_get_agents_summary_status PASSED                                                                                                                                            [  6%]
test_agent.py::test_agent_get_agents_summary_os PASSED                                                                                                                                                [  7%]
test_agent.py::test_agent_restart_agents[agent_list0-expected_items0-None] PASSED                                                                                                                     [  8%]
test_agent.py::test_agent_restart_agents[agent_list1-expected_items1-1703] PASSED                                                                                                                     [  9%]
test_agent.py::test_agent_restart_agents[agent_list2-expected_items2-1701] PASSED                                                                                                                     [ 10%]
test_agent.py::test_agent_get_agents[agent_list0-expected_items0] PASSED                                                                                                                              [ 11%]
test_agent.py::test_agent_get_agents[agent_list1-expected_items1] PASSED                                                                                                                              [ 12%]
test_agent.py::test_agent_get_agent_by_name[agent-1-001] PASSED                                                                                                                                       [ 13%]
test_agent.py::test_agent_get_agent_by_name[nc-agent-003] PASSED                                                                                                                                      [ 14%]
test_agent.py::test_agent_get_agent_by_name[master-000] PASSED                                                                                                                                        [ 15%]
test_agent.py::test_agent_get_agent_by_name[invalid-agent-False] PASSED                                                                                                                               [ 16%]
test_agent.py::test_agent_get_agent_by_name[master-4000] PASSED                                                                                                                                       [ 17%]
test_agent.py::test_agent_get_agent_by_name[master-1000] PASSED                                                                                                                                       [ 18%]
test_agent.py::test_agent_get_agents_in_group[default-True-expected_agents0] PASSED                                                                                                                   [ 20%]
test_agent.py::test_agent_get_agents_in_group[not_exists_group-False-None] PASSED                                                                                                                     [ 21%]
test_agent.py::test_agent_get_agents_keys[agent_list0-expected_items0] PASSED                                                                                                                         [ 22%]
test_agent.py::test_agent_get_agents_keys[agent_list1-expected_items1] PASSED                                                                                                                         [ 23%]
test_agent.py::test_agent_delete_agents[agent_list0-1s-Agent deleted successfully.-None-expected_items0] PASSED                                                                                       [ 24%]
test_agent.py::test_agent_delete_agents[agent_list1-1s-None-1703-expected_items1] PASSED                                                                                                              [ 25%]
test_agent.py::test_agent_delete_agents[agent_list2-1s-Agent deleted successfully.-1701-expected_items2] PASSED                                                                                       [ 26%]
test_agent.py::test_agent_delete_agents[agent_list3-1s-remove_msg3-1700-expected_items3] PASSED                                                                                                       [ 27%]
test_agent.py::test_agent_delete_agents_different_status PASSED                                                                                                                                       [ 28%]
test_agent.py::test_agent_add_agent[agent-1-001-b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f] PASSED                                                                              [ 29%]
test_agent.py::test_agent_add_agent[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-002-f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d] PASSED [ 30%]
test_agent.py::test_agent_get_agent_groups[group_list0-expected_result0] PASSED                                                                                                                       [ 31%]
test_agent.py::test_agent_get_agent_groups[group_list1-expected_result1] PASSED                                                                                                                       [ 32%]
test_agent.py::test_agent_get_agent_groups_exceptions[Invalid path-valid-group-1600] PASSED                                                                                                           [ 33%]
test_agent.py::test_agent_get_agent_groups_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/global.db-valid-group-1000] PASSED                                                 [ 34%]
test_agent.py::test_agent_get_agent_groups_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/global.db-invalid-group-1710] PASSED                                               [ 35%]
test_agent.py::test_agent_get_group_files[group_list0] PASSED                                                                                                                                         [ 36%]
test_agent.py::test_agent_get_group_files[group_list1] PASSED                                                                                                                                         [ 37%]
test_agent.py::test_agent_get_group_files_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/agent/shared-group_list0-False-None-expected_exception0] PASSED                     [ 38%]
test_agent.py::test_agent_get_group_files_exceptions[invalid-path-group_list1-True-None-expected_exception1] PASSED                                                                                   [ 40%]
test_agent.py::test_agent_get_group_files_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/agent/shared-group_list2-True-side_effect2-expected_exception2] PASSED              [ 41%]
test_agent.py::test_agent_get_group_files_exceptions[/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/data/agent/shared-group_list3-True-side_effect3-expected_exception3] PASSED              [ 42%]
test_agent.py::test_create_group[non-existant-group] PASSED                                                                                                                                           [ 43%]
test_agent.py::test_create_group[invalid-group] PASSED                                                                                                                                                [ 44%]
test_agent.py::test_create_group_exceptions[default-WazuhError-1711] PASSED                                                                                                                           [ 45%]
test_agent.py::test_create_group_exceptions[group-1-WazuhError-1711] PASSED                                                                                                                           [ 46%]
test_agent.py::test_create_group_exceptions[invalid!-WazuhError-1722] PASSED                                                                                                                          [ 47%]
test_agent.py::test_create_group_exceptions[delete-me-WazuhInternalError-1005] PASSED                                                                                                                 [ 48%]
test_agent.py::test_agent_delete_groups[group_list0] PASSED                                                                                                                                           [ 49%]
test_agent.py::test_agent_delete_groups[group_list1] PASSED                                                                                                                                           [ 50%]
test_agent.py::test_agent_delete_groups_permission_exception[test_group] PASSED                                                                                                                       [ 51%]
test_agent.py::test_agent_delete_groups_other_exceptions[group_list0-expected_errors0] PASSED                                                                                                         [ 52%]
test_agent.py::test_agent_delete_groups_other_exceptions[group_list1-expected_errors1] PASSED                                                                                                         [ 53%]
test_agent.py::test_agent_delete_groups_other_exceptions[group_list2-expected_errors2] PASSED                                                                                                         [ 54%]
test_agent.py::test_agent_delete_groups_other_exceptions[group_list3-expected_errors3] PASSED                                                                                                         [ 55%]
test_agent.py::test_assign_agents_to_group[group_list0-agent_list0-0] PASSED                                                                                                                          [ 56%]
test_agent.py::test_assign_agents_to_group[group_list1-agent_list1-0] PASSED                                                                                                                          [ 57%]
test_agent.py::test_assign_agents_to_group[group_list2-agent_list2-1] PASSED                                                                                                                          [ 58%]
test_agent.py::test_agent_assign_agents_to_group_exceptions[group_list0-agent_list0-expected_error0-True] PASSED                                                                                      [ 60%]
test_agent.py::test_agent_assign_agents_to_group_exceptions[group_list1-agent_list1-expected_error1-False] PASSED                                                                                     [ 61%]
test_agent.py::test_agent_assign_agents_to_group_exceptions[group_list2-agent_list2-expected_error2-False] PASSED                                                                                     [ 62%]
test_agent.py::test_agent_remove_agent_from_group[default-001] PASSED                                                                                                                                 [ 63%]
test_agent.py::test_agent_remove_agent_from_group[group-1-005] PASSED                                                                                                                                 [ 64%]
test_agent.py::test_agent_remove_agent_from_group_exceptions[any-group-100-expected_error0] PASSED                                                                                                    [ 65%]
test_agent.py::test_agent_remove_agent_from_group_exceptions[any-group-000-expected_error1] PASSED                                                                                                    [ 66%]
test_agent.py::test_agent_remove_agent_from_group_exceptions[group-1-005-expected_error2] PASSED                                                                                                      [ 67%]
test_agent.py::test_agent_remove_agent_from_groups[group_list0-agent_list0] PASSED                                                                                                                    [ 68%]
test_agent.py::test_agent_remove_agent_from_groups_exceptions[group_list0-agent_list0-expected_error0-True] PASSED                                                                                    [ 69%]
test_agent.py::test_agent_remove_agent_from_groups_exceptions[group_list1-agent_list1-expected_error1-True] PASSED                                                                                    [ 70%]
test_agent.py::test_agent_remove_agent_from_groups_exceptions[group_list2-agent_list2-expected_error2-False] PASSED                                                                                   [ 71%]
test_agent.py::test_agent_remove_agents_from_group[group_list0-agent_list0] PASSED                                                                                                                    [ 72%]
test_agent.py::test_agent_remove_agents_from_group_exceptions[group_list0-agent_list0-expected_error0-True] PASSED                                                                                    [ 73%]
test_agent.py::test_agent_remove_agents_from_group_exceptions[group_list1-agent_list1-expected_error1-False] PASSED                                                                                   [ 74%]
test_agent.py::test_agent_remove_agents_from_group_exceptions[group_list2-agent_list2-expected_error2-False] PASSED                                                                                   [ 75%]
test_agent.py::test_agent_get_outdated_agents[agent_list0-outdated_agents0] PASSED                                                                                                                    [ 76%]
test_agent.py::test_agent_upgrade_agents[agent_list0] PASSED                                                                                                                                          [ 77%]
test_agent.py::test_agent_upgrade_agents[agent_list1] PASSED                                                                                                                                          [ 78%]
test_agent.py::test_agent_get_upgrade_result[agent_list0] PASSED                                                                                                                                      [ 80%]
test_agent.py::test_agent_get_upgrade_result[agent_list1] PASSED                                                                                                                                      [ 81%]
test_agent.py::test_agent_upgrade_agents_custom[agent_list0] PASSED                                                                                                                                   [ 82%]
test_agent.py::test_agent_upgrade_agents_custom[agent_list1] PASSED                                                                                                                                   [ 83%]
test_agent.py::test_agent_upgrade_agents_custom_exceptions[None-installer] PASSED                                                                                                                     [ 84%]
test_agent.py::test_agent_upgrade_agents_custom_exceptions[any-path-None] PASSED                                                                                                                      [ 85%]
test_agent.py::test_agent_upgrade_agents_custom_exceptions[None-None] PASSED                                                                                                                          [ 86%]
test_agent.py::test_agent_get_agent_config[agent_list0-logcollector-internal] PASSED                                                                                                                  [ 87%]
test_agent.py::test_agent_get_agent_config_exceptions[agent_list0] PASSED                                                                                                                             [ 88%]
test_agent.py::test_agent_get_agents_sync_group[agent_list0] PASSED                                                                                                                                   [ 89%]
test_agent.py::test_agent_get_agents_sync_group_exceptions[agent_list0-expected_error0] PASSED                                                                                                        [ 90%]
test_agent.py::test_agent_get_agents_sync_group_exceptions[agent_list1-expected_error1] PASSED                                                                                                        [ 91%]
test_agent.py::test_agent_get_file_conf[agent.conf-group_list0] PASSED                                                                                                                                [ 92%]
test_agent.py::test_agent_get_agent_conf[group_list0] PASSED                                                                                                                                          [ 93%]
test_agent.py::test_agent_upload_group_file[group_list0] PASSED                                                                                                                                       [ 94%]
test_agent.py::test_agent_get_full_overview[agent_list0-group_list0-False-001] PASSED                                                                                                                 [ 95%]
test_agent.py::test_agent_get_full_overview[agent_list1-group_list1-False-002] PASSED                                                                                                                 [ 96%]
test_agent.py::test_agent_get_full_overview[agent_list2-group_list2-False-002] PASSED                                                                                                                 [ 97%]
test_agent.py::test_agent_get_full_overview[agent_list3-group_list3-False-004] PASSED                                                                                                                 [ 98%]
test_agent.py::test_agent_get_full_overview[agent_list4-group_list4-True-None] PASSED                                                                                                                 [100%]

============================================================================================= warnings summary ==============================================================================================
/home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/../../wazuh/results.py:19
  /home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/tests/../../wazuh/results.py:19: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    class AbstractWazuhResult(collections.MutableMapping):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================================================= 95 passed, 1 warning in 2.57s =======================================================================================

```

Regards.