### PR TITLE
Adapt the configuration to the NVD support for Linux

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1403,9 +1403,13 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
                 merror(LIST_ERROR);
                 return agents_it->agent_id;
             }
-
-            if (wm_vuldet_linux_nvd_vulnerabilities(db, agents_it, cve_table)) {
-                return agents_it->agent_id;
+            if(nvd_version_enabled[agents->dist_ver - FEED_PRECISE]) { // the first os version is FEED_PRECISE in vu_feed
+                if (wm_vuldet_linux_nvd_vulnerabilities(db, agents_it, cve_table)) {
+                    return agents_it->agent_id;
+                }
+            }
+            else {
+                mdebug1("The specified agent %s won't be scan against the NVD.", agents->agent_id);
             }
             if (wm_vuldet_linux_oval_vulnerabilities(db, agents_it, cve_table)) {
                 return agents_it->agent_id;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1391,7 +1391,7 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
                 return agents_it->agent_id;
             }
 
-        } else {
+        } else if (feeds_version_enabled[agents->dist_ver - FEED_PRECISE]) { // the first os version is FEED_PRECISE in vu_feed
             // To add a new node, call wm_vuldet_add_cve_node().
             // @cve_table stores cve_vuln_pkg type nodes.
             cve_table = OSHash_Create();
@@ -1422,10 +1422,12 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
             }
 
             OSHash_Clean(cve_table, wm_vuldet_free_cve_node); // Free the CVE table.
+        } else {
+            mdebug1("Agent %s doesn't have the feeds activated. Your vulnerabilities will not be scanned", agents->agent_id);
         }
-
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_FINISH, agents_it->agent_id);
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_FUNCTION_TIME, time(NULL) - start, "find", agents_it->agent_id);
+
     }
 
     return NULL;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -264,9 +264,10 @@ typedef enum{
     RHEL7,
     RHEL8,
 }os_nvd;
-#define os_nvd_count 13
+#define os_version_count 13
 
-extern int8_t nvd_version_enabled[os_nvd_count];
+extern int8_t nvd_version_enabled[os_version_count];
+extern int8_t feeds_version_enabled[os_version_count];
 
 extern char * linux_version[];
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -246,6 +246,30 @@ typedef enum vu_feed {
     FEED_UNKNOWN
 } vu_feed;
 
+typedef enum{
+    // Ubuntu versions
+    PRECISE,
+    TRUSTY,
+    XENIAL,
+    BIONIC,
+    FOCAL,
+    // Debian versions
+    JESSIE,
+    STRETCH,
+    BUSTER,
+    WHEEZY,
+    // RedHat versions
+    RHEL5,
+    RHEL6,
+    RHEL7,
+    RHEL8,
+}os_nvd;
+#define os_nvd_count 13
+
+extern int8_t nvd_version_enabled[os_nvd_count];
+
+extern char * linux_version[];
+
 typedef enum vu_ver_comp {
     VU_COMP_L,
     VU_COMP_LE,


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4957|

## Description

Since the Vulnerability Detector for Linux agents will support more than one feed simultaneously (NVD and vendor feeds), the module configuration has to be reviewed to adapt it to this new scenario.
- In order to avoid false positives, for Linux agents should not work the NVD feed when the other feeds are not available
- The NVD provider should include a `<ignore_os>` option to ignore the vulnerability scan using the NVD.
- The new options should be available from the remote configuration query
