### PR TITLE
Improve parameter 'q' (query) for the new API

### DIFF
--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -9,6 +9,7 @@
 a human readable message is shown, the new field `message` will be used instead.
 * Changed search negation from `!` to `-`.
 * Changed nested fields from `a_b` to `a.b`
+* Changed parameter **query** to allow reserved characters.
 
 ## Active Response
 ### PUT /active-response
@@ -38,6 +39,9 @@ a human readable message is shown, the new field `message` will be used instead.
 * Endpoint deleted, use `POST /groups?group_id=group_id`
 * In response, `msg` key is now moved to new `message` key
 * Verb changed to POST
+
+### PUT /agents/groups/:group_id/restart
+* Endpoint deleted, use `PUT /groups/{group_id}/restart`
 
 ### POST /agents
 * Changed parameter **force** name to **force_time**

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3666,7 +3666,7 @@ components:
       description: Query to filter results by. For example q=&quot;status=active&quot;
       schema:
         type: string
-        format: query
+      allowReserved: true
     rationale:
       in: query
       name: rationale

--- a/framework/wazuh/exception.py
+++ b/framework/wazuh/exception.py
@@ -144,11 +144,11 @@ class WazuhException(Exception):
         1406: {'message': '0 is not a valid limit',
                'remediation': 'Please select a limit between 1 and 1000'
                },
-        1407: 'query does not match expected format',
+        1407: 'Query does not match expected format',
         1408: 'Field does not exist.',
         1409: 'Invalid query operator.',
         1410: 'Selecting more than one field in distinct mode',
-        1411: 'Timeframe is not valid',
+        1411: 'TimeFrame is not valid',
         1412: 'Date filter not valid. Valid formats are timeframe or YYYY-MM-DD HH:mm:ss',
         1413: {'message': 'Error reading rules file'},
         1414: {'message': 'Error reading rules file',

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -717,7 +717,7 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
         if op == '~':
             # value1 should be str if operator is '~'
             value1 = str(value1) if type(value1) == int else value1
-            if value1.startswith(value2, 0):
+            if value2 in value1:
                 return True
             else:
                 return False
@@ -727,7 +727,7 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
             return operators[op](value1, value2)
 
     # compile regular expression only one time when function is called
-    re_get_elements = re.compile(r'([\w\-.]+)(=|!=|<|>|~)([\w\-.]+)')  # regex for getting elements in a clause
+    re_get_elements = re.compile(r'([\w\-.]+)(=|!=|<|>|~)([\w\-./]+)')  # regex for getting elements in a clause
     # get a list with OR clauses
     or_clauses = q.split(',')
     output_array = []

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -714,17 +714,20 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
                      '!=': operator.ne,
                      '<': operator.lt,
                      '>': operator.gt}
-        if op == '~':
-            # value1 should be str if operator is '~'
-            value1 = str(value1) if type(value1) == int else value1
-            if value2 in value1:
-                return True
+        value1 = [value1] if not isinstance(value1, list) else value1
+        for val in value1:
+            if op == '~':
+                # value1 should be str if operator is '~'
+                val = str(val) if type(val) == int else val
+                if value2 in val:
+                    return True
             else:
-                return False
+                # cast value2 to integer if value1 is integer
+                value2 = int(value2) if type(val) == int else value2
+                if operators[op](val, value2):
+                    return True
         else:
-            # cast value2 to integer if value1 is integer
-            value2 = int(value2) if type(value1) == int else value2
-            return operators[op](value1, value2)
+            return False
 
     # compile regular expression only one time when function is called
     re_get_elements = re.compile(r'([\w\-.]+)(=|!=|<|>|~)([\w\-./]+)')  # regex for getting elements in a clause
@@ -740,7 +743,11 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
             match = True  # flag for checking clauses
             for and_clause in and_clauses:
                 # get elements in a clause
-                field_name, op, value = re_get_elements.match(and_clause).groups()
+                try:
+                    field_name, op, value = re_get_elements.match(and_clause).groups()
+                except AttributeError:
+                    raise WazuhError(1407, extra_message=f"Parameter 'q' is not valid: '{and_clause}'")
+
                 # check if a clause is satisfied
                 if field_name in elem and check_clause(elem[field_name], op, value):
                     continue


### PR DESCRIPTION
Hello team. As it was reported in #4379 , there were some combinations with the parameter `q` that did not work in `3.x`. We have fixed this for the new API, making this parameter more flexible and adding some troubleshooting in case of bad queries.

### The "Like" (~) operator does not work
`curl -X GET "https://localhost:55001/v4/rules?limit=500&q=filename~rules" -H "accept: application/json" -H "Authorization: Bearer <TOKEN>"`
```json
{
  "data": {
    "affected_items": [
      {
        "filename": "0010-rules_config.xml",
        "relative_dirname": "ruleset/rules",
        "id": 1,
        "level": 0,
        "status": "enabled",
        "details": {
          "noalert": "1",
          "category": "syslog"
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "groups": [
          "syslog"
        ],
        "description": "Generic template for all syslog rules."
      },
      {
        "filename": "0010-rules_config.xml",
        "relative_dirname": "ruleset/rules",
        "id": 2,
        "level": 0,
        "status": "enabled",
        "details": {
          "noalert": "1",
          "category": "firewall"
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "groups": [
          "firewall"
        ],
        "description": "Generic template for all firewall rules."
      },
[ ... ]
```
In addition to this, this operator is more accurate now to what it means in other languages. It would only match those results that started with the same pattern. It will now match every result with the pattern within.

`curl -X GET "https://localhost:55001/v4/rules?limit=500&q=filename~10" -H "accept: application/json" -H "Authorization: Bearer <TOKEN>"`
```json
{
  "data": {
    "affected_items": [
      {
        "filename": "0010-rules_config.xml",
        "relative_dirname": "ruleset/rules",
        "id": 1,
        "level": 0,
        "status": "enabled",
        "details": {
          "noalert": "1",
          "category": "syslog"
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "groups": [
          "syslog"
        ],
        "description": "Generic template for all syslog rules."
      },
      {
        "filename": "0010-rules_config.xml",
        "relative_dirname": "ruleset/rules",
        "id": 2,
        "level": 0,
        "status": "enabled",
        "details": {
          "noalert": "1",
          "category": "firewall"
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "groups": [
          "firewall"
        ],
        "description": "Generic template for all firewall rules."
      },
[ ... ]
```

### All requests to path field return error when using slash
`curl -X GET "https://localhost:55001/v4/rules?limit=500&q=relative_dirname=ruleset/rules" -H "accept: application/json" -H "Authorization: Bearer <TOKEN>"`
```json
{
  "data": {
    "affected_items": [
      {
        "filename": "0010-rules_config.xml",
        "relative_dirname": "ruleset/rules",
        "id": 1,
        "level": 0,
        "status": "enabled",
        "details": {
          "noalert": "1",
          "category": "syslog"
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "groups": [
          "syslog"
        ],
        "description": "Generic template for all syslog rules."
      },
[ ... ]
```

### Requests to regulatory compliance fields do not work (PCI, HIPAA, GPG13, GDPR, NIST-800-53)
`curl -X GET "https://localhost:55001/v4/rules?limit=500&q=gpg13=10.1" -H "accept: application/json" -H "Authorization: Bearer <TOKEN>"`
```json
{
  "data": {
    "affected_items": [
      {
        "filename": "0015-ossec_rules.xml",
        "relative_dirname": "ruleset/rules",
        "id": 501,
        "level": 3,
        "status": "enabled",
        "details": {
          "if_sid": "500",
          "if_fts": "",
          "options": "alert_by_email",
          "match": "Agent started"
        },
        "pci_dss": [
          "10.6.1"
        ],
        "gpg13": [
          "10.1"
        ],
        "gdpr": [
          "IV_35.7.d"
        ],
        "hipaa": [
          "164.312.b"
        ],
        "nist_800_53": [
          "AU.6"
        ],
        "groups": [
          "ossec"
        ],
        "description": "New ossec agent connected."
      },
[ ... ]
```

### Requests to group field do not work
`curl -X GET "https://localhost:55001/v4/rules?limit=500&q=groups=syslog" -H "accept: application/json" -H "Authorization: Bearer <TOKEN>"`
```json
{
  "data": {
    "affected_items": [
      {
        "filename": "0010-rules_config.xml",
        "relative_dirname": "ruleset/rules",
        "id": 1,
        "level": 0,
        "status": "enabled",
        "details": {
          "noalert": "1",
          "category": "syslog"
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "groups": [
          "syslog"
        ],
        "description": "Generic template for all syslog rules."
      },
      {
        "filename": "0020-syslog_rules.xml",
        "relative_dirname": "ruleset/rules",
        "id": 1001,
        "level": 2,
        "status": "enabled",
        "details": {
          "match": "^Couldn't open /etc/securetty"
        },
        "pci_dss": [
          "10.2.4"
        ],
        "gpg13": [
          "4.1"
        ],
        "gdpr": [
          "IV_35.7.d"
        ],
        "hipaa": [
          "164.312.b"
        ],
        "nist_800_53": [
          "AU.14",
          "AC.7"
        ],
        "groups": [
          "syslog",
          "errors"
        ],
        "description": "File missing. Root access unrestricted."
      },
[ ... ]
```

## Integration tests
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0
collecting ... collected 11 items

test_rules_endpoints.tavern.yaml::GET /rules PASSED                      [  9%]
test_rules_endpoints.tavern.yaml::GET /rules filters PASSED              [ 18%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/pci_dss PASSED  [ 27%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/gdpr PASSED     [ 36%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/gpg13 PASSED    [ 45%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/hipaa PASSED    [ 54%]
test_rules_endpoints.tavern.yaml::GET /rules/requirement/nist-800-53 PASSED [ 63%]
test_rules_endpoints.tavern.yaml::GET /rules/groups PASSED               [ 72%]
test_rules_endpoints.tavern.yaml::GET /rules/files PASSED                [ 81%]
test_rules_endpoints.tavern.yaml::GET /rules/files/{filename}/download PASSED [ 90%]
test_rules_endpoints.tavern.yaml::GET /rules?rule_ids PASSED             [100%]

=============================== warnings summary ===============================
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 11 tests with warnings
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================= 11 passed, 12 warnings in 123.15s (0:02:03) ==================
```

```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0
collecting ... collected 5 items

test_rbac_white_rules_endpoints.tavern.yaml::GET RULES RBAC PASSED       [ 20%]
test_rbac_white_rules_endpoints.tavern.yaml::GET RULES FILES RBAC PASSED [ 40%]
test_rbac_white_rules_endpoints.tavern.yaml::GET RULES FILES RBAC (Download) PASSED [ 60%]
test_rbac_white_rules_endpoints.tavern.yaml::GET RULES GROUPS RBAC PASSED [ 80%]
test_rbac_white_rules_endpoints.tavern.yaml::GET pci_dss REQUIREMENT RBAC PASSED [100%]

=============================== warnings summary ===============================
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================== 5 passed, 6 warnings in 34.15s ========================

```

```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0
collecting ... collected 5 items

test_rbac_black_rules_endpoints.tavern.yaml::GET RULES RBAC PASSED       [ 20%]
test_rbac_black_rules_endpoints.tavern.yaml::GET RULES FILES RBAC PASSED [ 40%]
test_rbac_black_rules_endpoints.tavern.yaml::GET RULES FILES RBAC (Download) PASSED [ 60%]
test_rbac_black_rules_endpoints.tavern.yaml::GET RULES GROUPS RBAC PASSED [ 80%]
test_rbac_black_rules_endpoints.tavern.yaml::GET pci_dss REQUIREMENT RBAC PASSED [100%]

=============================== warnings summary ===============================
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
  /home/vicferpoy/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================== 5 passed, 6 warnings in 672.70s (0:11:12) ===================

```

## Unit tests
```
======================================== test session starts ========================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: tavern-1.0.0
collected 45 items                                                                                  

wazuh/tests/test_rule.py .............................................                        [100%]

========================================= warnings summary ==========================================
wazuh/results.py:19
  /home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/results.py:19: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    class AbstractWazuhResult(collections.MutableMapping):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 45 passed, 1 warning in 0.26s ===================================
```

```
======================================== test session starts ========================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: tavern-1.0.0
collected 21 items                                                                                  

wazuh/core/tests/test_rule.py .....................                                           [100%]

========================================= warnings summary ==========================================
wazuh/results.py:19
  /home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/results.py:19: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    class AbstractWazuhResult(collections.MutableMapping):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 21 passed, 1 warning in 0.13s ===================================
```