### PR TITLE
Vuln-detector: Discard inactive Linux kernel packages

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -376,6 +376,7 @@
 #define VU_INSERT_PACKAGE_ERROR     "(5590): Agent (%s): Couldn't insert vulnerable package '%s' into CVE '%s' (feed %s)."
 #define VU_GET_CHILDREN_PKG_ID      "(5592): Agent (%s): Couldn't retrieve children IDs from package '%s'."
 #define VU_GET_SIBLINGS_PKG_ID      "(5593): Agent (%s): Couldn't retrieve siblings IDs from package '%s'."
+#define VU_DISCARD_KERNEL_PKG       "(5600): Agent (%s): Discarded Linux Kernel package '%s'(not running)."
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -376,7 +376,7 @@
 #define VU_INSERT_PACKAGE_ERROR     "(5590): Agent (%s): Couldn't insert vulnerable package '%s' into CVE '%s' (feed %s)."
 #define VU_GET_CHILDREN_PKG_ID      "(5592): Agent (%s): Couldn't retrieve children IDs from package '%s'."
 #define VU_GET_SIBLINGS_PKG_ID      "(5593): Agent (%s): Couldn't retrieve siblings IDs from package '%s'."
-#define VU_DISCARD_KERNEL_PKG       "(5600): Agent (%s): Discarded Linux Kernel package '%s'(not running)."
+#define VU_DISCARD_KERNEL_PKG       "(5600): Discarded Linux Kernel package '%s'(not running) for agent '%s'."
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -376,7 +376,7 @@
 #define VU_INSERT_PACKAGE_ERROR     "(5590): Agent (%s): Couldn't insert vulnerable package '%s' into CVE '%s' (feed %s)."
 #define VU_GET_CHILDREN_PKG_ID      "(5592): Agent (%s): Couldn't retrieve children IDs from package '%s'."
 #define VU_GET_SIBLINGS_PKG_ID      "(5593): Agent (%s): Couldn't retrieve siblings IDs from package '%s'."
-#define VU_DISCARD_KERNEL_PKG       "(5600): Discarded Linux Kernel package '%s'(not running) for agent '%s'."
+#define VU_DISCARD_KERNEL_PKG       "(5600): Discarded Linux Kernel package '%s' (not running) for agent '%s'"
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -70,6 +70,7 @@ STATIC char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software 
  */
 STATIC int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuldet_flags *flags, time_t ignore_time);
 
+STATIC int wm_vuldet_match_kernel_package(agent_software *agent, char *name, char *version, char *arch);
 STATIC int wm_vuldet_create_file(const char *path, const char *source);
 STATIC int wm_vuldet_check_update_period(update_node *upd);
 STATIC int wm_vuldet_update_feed(update_node *upd);
@@ -3658,6 +3659,13 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
                     w_strdup(msu_name, s_cpe->msu_name);
                 }
 
+                if (agent->dist != FEED_WIN) {
+                    if (wm_vuldet_match_kernel_package(agent, name, version, architecture)) {
+                        continue;
+                    }
+                }
+
+
                 // Generate the node_list structure with those packages
                 // that have associated CPE
                 if (wm_vuldet_insert_agent_data(db, agent, &min_cpe_index, vendor, name,
@@ -4318,6 +4326,33 @@ int wm_vuldet_generate_win_cpe(agent_software *agent) {
                                                     0,
                                                     vu_feed_ext[agent->dist_ver]);
     }
+    return 0;
+}
+
+int wm_vuldet_match_kernel_package(agent_software *agent, char *name, char *version, char *arch) {
+    char *kernel_uname = NULL;
+
+    if (agent->dist == FEED_REDHAT || agent->dist == FEED_CENTOS) {
+        if (strcmp(name, "kernel")) {
+            return -1;
+        }
+        size_t len = strlen(version) + strlen(arch) + 1;
+        os_calloc(1, len + 1, kernel_uname);
+        snprintf(kernel_uname, len, "%s.%s", version, arch);
+
+    } else { // For Debian family
+        os_calloc(1, strlen(name) + 1, kernel_uname);
+        if (!sscanf(name, "linux-image-%s", kernel_uname)) {
+            return -1;
+        }
+    }
+
+    if (strcmp(kernel_uname, agent->kernel_release)) {
+        minfo("Linux Kernel '%s' discarded", kernel_uname);
+        return -1;
+    }
+
+    minfo("Linux Kernel '%s' accepted", kernel_uname);
     return 0;
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -70,7 +70,16 @@ STATIC char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software 
  */
 STATIC int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuldet_flags *flags, time_t ignore_time);
 
-STATIC int wm_vuldet_match_kernel_package(agent_software *agent, char *name, char *version, char *arch);
+/**
+ * @brief Discard any installed Linux kernel package which is not running.
+ * @param agents_software Agent being analyzed.
+ * @param name Name of the package.
+ * @param version Version of the package.
+ * @param arch Architecture of the package.
+ * @return 0 on success, -1 otherwise.
+ */
+STATIC int wm_vuldet_discard_kernel_package(agent_software *agent, char *name, char *version, char *arch);
+
 STATIC int wm_vuldet_create_file(const char *path, const char *source);
 STATIC int wm_vuldet_check_update_period(update_node *upd);
 STATIC int wm_vuldet_update_feed(update_node *upd);
@@ -3520,7 +3529,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
             break;
         case OS_INVALID:
             goto end;
-    }
+        }
 
     // Request and store packages
     i = 0;
@@ -3660,7 +3669,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
                 }
 
                 if (agent->dist != FEED_WIN) {
-                    if (wm_vuldet_match_kernel_package(agent, name, version, architecture)) {
+                    if (wm_vuldet_discard_kernel_package(agent, name, version, architecture)) {
                         continue;
                     }
                 }
@@ -4329,32 +4338,31 @@ int wm_vuldet_generate_win_cpe(agent_software *agent) {
     return 0;
 }
 
-int wm_vuldet_match_kernel_package(agent_software *agent, char *name, char *version, char *arch) {
+int wm_vuldet_discard_kernel_package(agent_software *agent, char *name, char *version, char *arch) {
     char *kernel_uname = NULL;
 
     if (agent->dist == FEED_REDHAT || agent->dist == FEED_CENTOS) {
         if (strcmp(name, "kernel")) {
-            return -1;
+            return 0;
         }
-        size_t len = strlen(version) + strlen(arch) + 1;
-        os_calloc(1, len + 2, kernel_uname);
+        size_t len = snprintf(kernel_uname, 0, "%s.%s", version, arch);
+        os_calloc(1, len + 1, kernel_uname);
         snprintf(kernel_uname, len + 1, "%s.%s", version, arch);
 
     } else { // For Debian family
         os_calloc(1, strlen(name) + 1, kernel_uname);
         if (!sscanf(name, "linux-image-%s", kernel_uname)) {
             os_free(kernel_uname);
-            return -1;
+            return 0;
         }
     }
 
     if (strcmp(kernel_uname, agent->kernel_release)) {
-        minfo("Linux Kernel '%s' discarded", kernel_uname);
+        mdebug2(VU_DISCARD_KERNEL_PKG, agent->agent_id, kernel_uname);
         os_free(kernel_uname);
         return -1;
     }
 
-    minfo("Linux Kernel '%s' accepted", kernel_uname);
     os_free(kernel_uname);
 
     return 0;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4337,8 +4337,8 @@ int wm_vuldet_match_kernel_package(agent_software *agent, char *name, char *vers
             return -1;
         }
         size_t len = strlen(version) + strlen(arch) + 1;
-        os_calloc(1, len + 1, kernel_uname);
-        snprintf(kernel_uname, len, "%s.%s", version, arch);
+        os_calloc(1, len + 2, kernel_uname);
+        snprintf(kernel_uname, len + 1, "%s.%s", version, arch);
 
     } else { // For Debian family
         os_calloc(1, strlen(name) + 1, kernel_uname);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -78,7 +78,7 @@ STATIC int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuld
  * @param arch Architecture of the package.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_discard_kernel_package(agent_software *agent, char *name, char *version, char *arch);
+STATIC int wm_vuldet_discard_kernel_package(agent_software *agent, const char *name, const char *version, const char *arch);
 
 STATIC int wm_vuldet_create_file(const char *path, const char *source);
 STATIC int wm_vuldet_check_update_period(update_node *upd);
@@ -4338,11 +4338,14 @@ int wm_vuldet_generate_win_cpe(agent_software *agent) {
     return 0;
 }
 
-int wm_vuldet_discard_kernel_package(agent_software *agent, char *name, char *version, char *arch) {
+int wm_vuldet_discard_kernel_package(agent_software *agent, const char *name,
+                                    const char *version, const char *arch) {
     char *kernel_uname = NULL;
 
-    if (agent->dist == FEED_REDHAT || agent->dist == FEED_CENTOS) {
-        if (strcmp(name, "kernel")) {
+    if (agent->dist == FEED_REDHAT) {
+        // Only kernel images have as package name "kernel".
+        // "kernel-rt" is a realtime kernel only available for RedHat.
+        if (strcmp(name, "kernel") && strcmp(name, "kernel-rt")) {
             return 0;
         }
         size_t len = snprintf(kernel_uname, 0, "%s.%s", version, arch);
@@ -4358,7 +4361,7 @@ int wm_vuldet_discard_kernel_package(agent_software *agent, char *name, char *ve
     }
 
     if (strcmp(kernel_uname, agent->kernel_release)) {
-        mdebug2(VU_DISCARD_KERNEL_PKG, agent->agent_id, kernel_uname);
+        mdebug2(VU_DISCARD_KERNEL_PKG, kernel_uname, agent->agent_id);
         os_free(kernel_uname);
         return -1;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4343,16 +4343,20 @@ int wm_vuldet_match_kernel_package(agent_software *agent, char *name, char *vers
     } else { // For Debian family
         os_calloc(1, strlen(name) + 1, kernel_uname);
         if (!sscanf(name, "linux-image-%s", kernel_uname)) {
+            os_free(kernel_uname);
             return -1;
         }
     }
 
     if (strcmp(kernel_uname, agent->kernel_release)) {
         minfo("Linux Kernel '%s' discarded", kernel_uname);
+        os_free(kernel_uname);
         return -1;
     }
 
     minfo("Linux Kernel '%s' accepted", kernel_uname);
+    os_free(kernel_uname);
+
     return 0;
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4376,10 +4376,19 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
 
     // Generate kernel package
     if (agent->kernel_release) {
-        if (wm_vuldet_insert_agent_data(db, agent, NULL, V_KERNEL, PR_KERNEL, NULL, agent->kernel_release, agent->arch, NULL, NULL)) {
+        char *release, *release_end;
+        os_strdup(agent->kernel_release, release);
+        if (release_end = strstr(release, "-"), release_end) {
+            *release_end = '\0';
+        }
+
+        if (wm_vuldet_insert_agent_data(db, agent, NULL, V_KERNEL, PR_KERNEL, NULL, release, agent->arch, NULL, NULL)) {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, PR_KERNEL);
+            os_free(release);
             return OS_INVALID;
         }
+
+        os_free(release);
     }
 
     return 0;
@@ -5327,16 +5336,7 @@ int wm_vuldet_get_oslinux_info(agent_software *agent) {
     }
 
     if ((obj_it = obj->child) && (obj_it = cJSON_GetObjectItem(obj_it, "release")) && obj_it->valuestring) {
-        char *release;
-        w_strdup(obj_it->valuestring, release);
-        if (release) {
-            char *release_end = strstr(release, "-");
-            if (release_end) {
-                *release_end = '\0';
-            }
-        }
-        w_strdup(release, agent->kernel_release);
-        os_free(release);
+        w_strdup(obj_it->valuestring, agent->kernel_release);
     }
 
     retval = 0;


### PR DESCRIPTION
|Related issue|
|---|
|#3635|

## Description

Discard and don't analyze installed but inactive linux kernel packages. Only the package which matches in name with `uname()` will be allowed. 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
