### PR TITLE
Integrator: Create a file per alert and integration type

### DIFF
--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -243,8 +243,8 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 }
             }
 
-            /* Create temp file once per alert. */
-            if(temp_file_created == 0)
+            /* Create temp file once per alert and integration type. */
+            if(temp_file_created == 0 || strstr(exec_tmp_file, integrator_config[s]->name) == NULL)
             {
                 snprintf(exec_tmp_file, 2048, "/tmp/%s-%d-%ld.alert",
                          integrator_config[s]->name, (int)time(0), (long int)os_random());


### PR DESCRIPTION
|Related issue|
|---|
|#4264|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to fix #4264  by creating a file per alert and integration type.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```
<integration>
        <name>pagerduty</name>
        <api_key>api_key</api_key>
        <rule_id>5402</rule_id>
        <alert_format>json</alert_format>
</integration>

<integration>
        <name>slack</name>
        <hook_url>slack_hook</hook_url>
        <rule_id>5402</rule_id>
        <alert_format>json</alert_format>
</integration>
```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

`integrator.c:391 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/pagerduty /tmp/pagerduty-1588676293--1846142022.alert `

`integrator.c:391 at OS_IntegratorD(): DEBUG: Running: /var/ossec/integrations/slack /tmp/slack-1588676293-1756984807.alert`
<!--
Paste here related logs and alerts
-->
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
