### PR TITLE
Fix unit tests on 3.13

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1454,10 +1454,14 @@ static int fim_generate_alert(Eventinfo *lf, char *mode, char *event_type,
 
     // When full_log field is too long (max 756), it is fixed to show the last part of the path (more relevant)
     char path_splitted[757];
-    int path_log_len = strlen(lf->fields[FIM_FILE].value);
-    if (path_log_len > 756){
-        char * aux = lf->fields[FIM_FILE].value + path_log_len - 30;
-        snprintf(path_splitted, 757, "%.719s [...] %s", lf->fields[FIM_FILE].value, aux);
+    int path_log_len = 0;
+
+    if(lf->fields[FIM_FILE].value != NULL) {
+        path_log_len = strlen(lf->fields[FIM_FILE].value);
+        if (path_log_len > 756){
+            char * aux = lf->fields[FIM_FILE].value + path_log_len - 30;
+            snprintf(path_splitted, 757, "%.719s [...] %s", lf->fields[FIM_FILE].value, aux);
+        }
     }
 
     snprintf(lf->full_log, OS_MAXSTR,

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -390,7 +390,7 @@
 #define FIM_ERROR_REALTIME_MAXNUM_WATCHES           "(6616): Unable to add directory to real time monitoring: '%s' - Maximum size permitted."
 
 #define FIM_ERROR_REALTIME_INITIALIZE               "(6618): Unable to initialize real time file monitoring."
-#define FIM_ERROR_WHODATA_ADD_DIRECTORY             "(6619): Unable to add directory to whodata real time monitoring: '%s'."
+#define FIM_ERROR_WHODATA_ADD_DIRECTORY             "(6619): Unable to add directory to whodata real time monitoring: '%s'. It will be monitored in Realtime"
 #define FIM_ERROR_WHODATA_AUDIT_SUPPORT             "(6620): Audit support not built. Whodata is not available."
 #define FIM_ERROR_WHODATA_EVENTCHANNEL              "(6621): Event Channel subscription could not be made. Whodata scan is disabled."
 #define FIM_ERROR_WHODATA_RESTORE_POLICIES          "(6622): There is no backup of audit policies. Policies will not be restored."

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -43,6 +43,7 @@
 #define GetLastError        wrap_GetLastError
 #undef  sleep
 #define sleep               wrap_Sleep
+#define CreateThread        wrap_run_check_CreateThread
 #endif
 #else
 #define STATIC static

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -459,7 +459,7 @@ int realtime_adddir(const char *dir, int whodata, __attribute__((unused)) int fo
         GetSystemTime(&syscheck.wdata.dirs_status[whodata - 1].last_check);
         if (set_winsacl(dir, whodata - 1)) {
             merror(FIM_ERROR_WHODATA_ADD_DIRECTORY, dir);
-            return 0;
+            return -2;
         }
 
         return 1;

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -318,7 +318,7 @@ int realtime_start(void);
  * @param dir Path to file or directory
  * @param whodata If the path is configured with whodata option
  * @param followsl If the path is configured with follow sym link option
- * @return 0 on success, -1 on error
+ * @return 1 on success, -1 on realtime_start failure, -2 on set_winsacl failure, and 0 on other errors
  */
 int realtime_adddir(const char *dir, int whodata, int followsl) __attribute__((nonnull(1)));
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -2801,7 +2801,7 @@ static void test_fim_whodata_event_file_missing(void **state) {
     // Inside fim_process_missing_entry
         {
             expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-            expect_string(__wrap_fim_db_get_path, file_path, paths[i]);
+            expect_string(__wrap_fim_db_get_path, file_path, "./test/test.file");
             will_return(__wrap_fim_db_get_path, NULL);
 
             expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -258,7 +258,15 @@ static int setup_tmp_file(void **state) {
 /* teardown */
 
 static int teardown_group(void **state) {
-    (void) state;
+    #ifdef TEST_WINAGENT
+    if (syscheck.realtime) {
+        if (syscheck.realtime->dirtb) {
+            OSHash_Free(syscheck.realtime->dirtb);
+        }
+        free(syscheck.realtime);
+        syscheck.realtime = NULL;
+    }
+    #endif
 
     Free_Syscheck(&syscheck);
 
@@ -613,6 +621,8 @@ void test_fim_whodata_initialize_eventchannel(void **state) {
     }
 
     will_return(__wrap_run_whodata_scan, 0);
+
+    will_return(wrap_run_check_CreateThread, (HANDLE)123456);
 
     ret = fim_whodata_initialize();
 

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -1158,8 +1158,12 @@ void test_realtime_adddir_max_limit_reached(void **state) {
 
     syscheck.realtime->fd = 1024;
 
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_string(__wrap__merror, formatted_msg,
         "(6616): Unable to add directory to real time monitoring: 'C:\\a\\path' - Maximum size permitted.");
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 
     ret = realtime_adddir("C:\\a\\path", 0, 0);
 
@@ -1171,10 +1175,14 @@ void test_realtime_adddir_duplicate_entry(void **state) {
 
     syscheck.realtime->fd = 128;
 
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     will_return(__wrap_OSHash_Get_ex, 1);
 
     expect_string(__wrap_w_directory_exists, path, "C:\\a\\path");
     will_return(__wrap_w_directory_exists, 1);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 
     ret = realtime_adddir("C:\\a\\path", 0, 0);
 
@@ -1186,6 +1194,8 @@ void test_realtime_adddir_handle_error(void **state) {
 
     syscheck.realtime->fd = 128;
 
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     will_return(__wrap_OSHash_Get_ex, 0);
 
     expect_string(wrap_run_realtime_CreateFile, lpFileName, "C:\\a\\path");
@@ -1193,6 +1203,8 @@ void test_realtime_adddir_handle_error(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6290): Unable to add directory to real time monitoring: 'C:\\a\\path'");
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 
     ret = realtime_adddir("C:\\a\\path", 0, 0);
 
@@ -1202,10 +1214,14 @@ void test_realtime_adddir_handle_error(void **state) {
 void test_realtime_adddir_out_of_memory_error(void **state) {
     int ret;
 
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     will_return(__wrap_OSHash_Get_ex, 0);
 
     expect_string(wrap_run_realtime_CreateFile, lpFileName, "C:\\a\\path");
     will_return(wrap_run_realtime_CreateFile, (HANDLE)123456);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_OSHash_Add_ex, NULL);
 
@@ -1221,10 +1237,14 @@ void test_realtime_adddir_out_of_memory_error(void **state) {
 void test_realtime_adddir_success(void **state) {
     int ret;
 
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     will_return(__wrap_OSHash_Get_ex, 0);
 
     expect_string(wrap_run_realtime_CreateFile, lpFileName, "C:\\a\\path");
     will_return(wrap_run_realtime_CreateFile, (HANDLE)123456);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_OSHash_Add_ex, 1);
 

--- a/src/unit_tests/syscheckd/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/test_win_whodata.c
@@ -7389,7 +7389,7 @@ void test_set_policies_unable_to_open_new_file(void **state) {
     errno = EACCES;
 
     expect_string(__wrap__merror, formatted_msg,
-        "(6660): 'tmp\\new-policies' could not be removed: 'Permission denied' (13).");
+        "(6661): 'tmp\\new-policies' could not be opened: 'Permission denied' (13).");
 
     expect_value(__wrap_fclose, _File, (FILE*)1234);
     will_return(__wrap_fclose, 0);

--- a/src/unit_tests/wrappers/syscheckd/run_check.c
+++ b/src/unit_tests/wrappers/syscheckd/run_check.c
@@ -34,3 +34,14 @@ DWORD wrap_GetLastError (VOID) {
 VOID wrap_Sleep (DWORD dwMilliseconds) {
     state.sleep_seconds += dwMilliseconds;
 }
+
+HANDLE wrap_run_check_CreateThread(
+    __UNUSED_PARAM(LPSECURITY_ATTRIBUTES   lpThreadAttributes),
+    __UNUSED_PARAM(SIZE_T                  dwStackSize),
+    __UNUSED_PARAM(LPTHREAD_START_ROUTINE  lpStartAddress),
+    __UNUSED_PARAM(PVOID                   lpParameter),
+    __UNUSED_PARAM(DWORD                   dwCreationFlags),
+    __UNUSED_PARAM(LPDWORD                 lpThreadId)
+) {
+    return mock();
+}

--- a/src/unit_tests/wrappers/syscheckd/run_check.h
+++ b/src/unit_tests/wrappers/syscheckd/run_check.h
@@ -20,6 +20,14 @@ WINBOOL wrap_SetThreadPriority (HANDLE hThread, int nPriority);
 HANDLE wrap_GetCurrentThread (VOID);
 DWORD wrap_GetLastError (VOID);
 VOID wrap_Sleep (DWORD dwMilliseconds);
+HANDLE wrap_run_check_CreateThread(
+    LPSECURITY_ATTRIBUTES   lpThreadAttributes,
+    SIZE_T                  dwStackSize,
+    LPTHREAD_START_ROUTINE  lpStartAddress,
+    PVOID                   lpParameter,
+    DWORD                   dwCreationFlags,
+    LPDWORD                 lpThreadId
+);
 
 extern struct state_t state;
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|N/A|

## Description
Some unit tests were failing to compile/run after the lasts merges to 3.13, this PR aims to fix them.

## Tests
### Manager
```
Test project /home/vagrant/git/wazuh/src/unit_tests/build
      Start  1: test_analysisd_syscheck
 1/23 Test  #1: test_analysisd_syscheck ..........   Passed    0.02 sec
      Start  2: test_dbsync
 2/23 Test  #2: test_dbsync ......................   Passed    0.02 sec
      Start  3: test_wdb_integrity
 3/23 Test  #3: test_wdb_integrity ...............   Passed    0.01 sec
      Start  4: test_wdb_fim
 4/23 Test  #4: test_wdb_fim .....................   Passed    0.01 sec
      Start  5: test_wdb_parser
 5/23 Test  #5: test_wdb_parser ..................   Passed    0.01 sec
      Start  6: test_syscom
 6/23 Test  #6: test_syscom ......................   Passed    0.00 sec
      Start  7: test_create_db
 7/23 Test  #7: test_create_db ...................   Passed    0.01 sec
      Start  8: test_syscheck_audit
 8/23 Test  #8: test_syscheck_audit ..............   Passed    0.02 sec
      Start  9: test_seechanges
 9/23 Test  #9: test_seechanges ..................   Passed    0.01 sec
      Start 10: test_run_realtime
10/23 Test #10: test_run_realtime ................   Passed    0.01 sec
      Start 11: test_syscheck_config
11/23 Test #11: test_syscheck_config .............   Passed    0.01 sec
      Start 12: test_syscheck
12/23 Test #12: test_syscheck ....................   Passed    0.00 sec
      Start 13: test_fim_sync
13/23 Test #13: test_fim_sync ....................   Passed    0.01 sec
      Start 14: test_run_check
14/23 Test #14: test_run_check ...................   Passed    0.01 sec
      Start 15: test_fim_db
15/23 Test #15: test_fim_db ......................   Passed    0.02 sec
      Start 16: test_file_op
16/23 Test #16: test_file_op .....................   Passed    0.00 sec
      Start 17: test_integrity_op
17/23 Test #17: test_integrity_op ................   Passed    0.00 sec
      Start 18: test_rbtree_op
18/23 Test #18: test_rbtree_op ...................   Passed    0.01 sec
      Start 19: test_version_op
19/23 Test #19: test_version_op ..................   Passed    0.01 sec
      Start 20: test_bzip2_op
20/23 Test #20: test_bzip2_op ....................   Passed    0.00 sec
      Start 21: test_syscheck_op
21/23 Test #21: test_syscheck_op .................   Passed    0.01 sec
      Start 22: test_audit_op
22/23 Test #22: test_audit_op ....................   Passed    0.01 sec
      Start 23: test_privsep_op
23/23 Test #23: test_privsep_op ..................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 23

Total Test time (real) =   0.25 sec
```

### Linux agent
```
Test project /home/vagrant/git/wazuh/src/unit_tests/build
      Start  1: test_syscom
 1/17 Test  #1: test_syscom ......................   Passed    0.00 sec
      Start  2: test_create_db
 2/17 Test  #2: test_create_db ...................   Passed    0.01 sec
      Start  3: test_syscheck_audit
 3/17 Test  #3: test_syscheck_audit ..............   Passed    0.01 sec
      Start  4: test_seechanges
 4/17 Test  #4: test_seechanges ..................   Passed    0.01 sec
      Start  5: test_run_realtime
 5/17 Test  #5: test_run_realtime ................   Passed    0.01 sec
      Start  6: test_syscheck_config
 6/17 Test  #6: test_syscheck_config .............   Passed    0.01 sec
      Start  7: test_syscheck
 7/17 Test  #7: test_syscheck ....................   Passed    0.00 sec
      Start  8: test_fim_sync
 8/17 Test  #8: test_fim_sync ....................   Passed    0.01 sec
      Start  9: test_run_check
 9/17 Test  #9: test_run_check ...................   Passed    0.01 sec
      Start 10: test_fim_db
10/17 Test #10: test_fim_db ......................   Passed    0.01 sec
      Start 11: test_file_op
11/17 Test #11: test_file_op .....................   Passed    0.00 sec
      Start 12: test_integrity_op
12/17 Test #12: test_integrity_op ................   Passed    0.00 sec
      Start 13: test_rbtree_op
13/17 Test #13: test_rbtree_op ...................   Passed    0.01 sec
      Start 14: test_version_op
14/17 Test #14: test_version_op ..................   Passed    0.00 sec
      Start 15: test_syscheck_op
15/17 Test #15: test_syscheck_op .................   Passed    0.01 sec
      Start 16: test_audit_op
16/17 Test #16: test_audit_op ....................   Passed    0.00 sec
      Start 17: test_privsep_op
17/17 Test #17: test_privsep_op ..................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 17

Total Test time (real) =   0.13 sec
```

### Windows agent
This tests depend on a wrap to `os_random` from PR #4717
```
Test project /home/vagrant/git/wazuh/src/unit_tests/build
      Start  1: test_syscom
 1/19 Test  #1: test_syscom ......................   Passed    1.74 sec
      Start  2: test_create_db
 2/19 Test  #2: test_create_db ...................   Passed    0.18 sec
      Start  3: test_syscheck_audit
 3/19 Test  #3: test_syscheck_audit ..............   Passed    0.06 sec
      Start  4: test_seechanges
 4/19 Test  #4: test_seechanges ..................   Passed    0.17 sec
      Start  5: test_run_realtime
 5/19 Test  #5: test_run_realtime ................   Passed    0.19 sec
      Start  6: test_syscheck_config
 6/19 Test  #6: test_syscheck_config .............   Passed    0.16 sec
      Start  7: test_syscheck
 7/19 Test  #7: test_syscheck ....................   Passed    0.15 sec
      Start  8: test_fim_sync
 8/19 Test  #8: test_fim_sync ....................   Passed    0.16 sec
      Start  9: test_run_check
 9/19 Test  #9: test_run_check ...................   Passed    0.16 sec
      Start 10: test_fim_db
10/19 Test #10: test_fim_db ......................   Passed    0.16 sec
      Start 11: test_win_registry
11/19 Test #11: test_win_registry ................   Passed    0.16 sec
      Start 12: test_run_realtime_event
12/19 Test #12: test_run_realtime_event ..........   Passed    0.17 sec
      Start 13: test_run_check_event
13/19 Test #13: test_run_check_event .............   Passed    0.15 sec
      Start 14: test_win_whodata
14/19 Test #14: test_win_whodata .................   Passed    0.22 sec
      Start 15: test_file_op
15/19 Test #15: test_file_op .....................   Passed    0.17 sec
      Start 16: test_integrity_op
16/19 Test #16: test_integrity_op ................   Passed    0.10 sec
      Start 17: test_rbtree_op
17/19 Test #17: test_rbtree_op ...................   Passed    0.17 sec
      Start 18: test_version_op
18/19 Test #18: test_version_op ..................   Passed    0.05 sec
      Start 19: test_syscheck_op
19/19 Test #19: test_syscheck_op .................   Passed    0.16 sec

100% tests passed, 0 tests failed out of 19

Total Test time (real) =   4.49 sec
```
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

