### PR TITLE
[#2552] Fix compilation errors with USE_PRELUDE=1

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1944,7 +1944,9 @@ void * w_writer_log_thread(__attribute__((unused)) void * args ){
     #ifdef PRELUDE_OUTPUT_ENABLED
                 /* Log to prelude */
                 if (Config.prelude) {
-                    if (Config.prelude_log_level <= currently_rule->level) {
+                    RuleInfo *rule = lf->generated_rule;
+
+                    if (rule && Config.prelude_log_level <= rule->level) {
                         OS_PreludeLog(lf);
                     }
                 }

--- a/src/analysisd/output/prelude.c
+++ b/src/analysisd/output/prelude.c
@@ -20,6 +20,7 @@
 
 #include "prelude.h"
 
+#include "syscheck_op.h"
 #include "shared.h"
 #include "rules.h"
 
@@ -193,6 +194,11 @@ static void FileAccess_PreludeLog(idmef_message_t *idmef,
                            const char *gowner,
                            const char *perm)
 {
+    mode_t octal_perms = 0;
+
+    if (perm) {
+      sscanf(perm, "%o", &octal_perms);
+    }
 
     mdebug1("filename = %s.", filename);
     mdebug1("category = %s.", category);
@@ -219,9 +225,23 @@ static void FileAccess_PreludeLog(idmef_message_t *idmef,
         add_idmef_object(idmef, "alert.target(0).file(-1).file_access(>>).user_id.number", owner);
         add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).user_id.type", "user-privs");
 
-        if (perm) {
+        if (octal_perms & S_IRWXU) {
             /* Add the permissions */
-            add_idmef_object(idmef, "alert.target(0).file(-1).file_access(>>).permission", perm);
+            if (octal_perms & S_IWUSR) {
+                add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "write");
+                add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "delete");
+            }
+            if (octal_perms & S_IXUSR) {
+                add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "execute");
+            }
+            if (octal_perms & S_IRUSR ) {
+                add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "read");
+            }
+            if (octal_perms & S_ISUID) {
+                add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "executeAs");
+            }
+        } else if (perm && *perm) {
+            add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "noAccess");
         }
     }
 
@@ -231,38 +251,42 @@ static void FileAccess_PreludeLog(idmef_message_t *idmef,
         add_idmef_object(idmef, "alert.target(0).file(-1).file_access(>>).user_id.number", gowner);
         add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).user_id.type", "group-privs");
 
-        if (perm) {
+        if (octal_perms & S_IRWXG) {
             /* Add the permissions */
-            if (perm & S_IWGRP) {
+            if (octal_perms & S_IWGRP) {
                 add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "write");
                 add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "delete");
             }
-            if (perm & S_IXGRP) {
+            if (octal_perms & S_IXGRP) {
                 add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "execute");
             }
-            if (perm & S_IRGRP ) {
+            if (octal_perms & S_IRGRP ) {
                 add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "read");
             }
-            if (perm & S_ISGID) {
+            if (octal_perms & S_ISGID) {
                 add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "executeAs");
             }
+        } else if (perm && *perm) {
+            add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "noAccess");
         }
     }
 
     add_idmef_object(idmef, "alert.target(0).file(-1).file_access(>>).user_id.type", "other-privs");
 
-    if (perm) {
+    if (octal_perms & S_IRWXO) {
         /* Add the permissions */
-        if (perm & S_IWOTH) {
+        if (octal_perms & S_IWOTH) {
             add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "write");
             add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "delete");
         }
-        if (perm & S_IXOTH) {
+        if (octal_perms & S_IXOTH) {
             add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "execute");
         }
-        if (perm & S_IROTH ) {
+        if (octal_perms & S_IROTH ) {
             add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "read");
         }
+    } else if (perm && *perm) {
+        add_idmef_object(idmef, "alert.target(0).file(-1).file_access(-1).permission(>>)", "noAccess");
     }
     return;
 }
@@ -502,12 +526,12 @@ void OS_PreludeLog(const Eventinfo *lf)
         FileAccess_PreludeLog(idmef,
                               "current",
                               lf->filename,
-                              lf->md5_after,
-                              lf->sha1_after,
-                              lf->sha256_after,
-                              lf->owner_after,
-                              lf->gowner_after,
-                              lf->perm_after);
+                              lf->fields[FIM_MD5].value,
+                              lf->fields[FIM_SHA1].value,
+                              lf->fields[FIM_SHA256].value,
+                              lf->fields[FIM_UID].value,
+                              lf->fields[FIM_GID].value,
+                              lf->fields[FIM_PERM].value);
         mdebug1("Done with alert.target(0).file(1)");
     }
 


### PR DESCRIPTION
|Related issue|
|---|
| #2552 |

## Description

This fixes several errors compilation errors when the Prelude output module is enabled:

* ``currently_rule`` does not exist anymore in ``analysisd/analysisd.c``
* the type for the ``perm`` parameter was changed from an integer to a character string inside ``FileAccess_PreludeLog`` some time ago, but some of the code inside the function had not been migrated following that change. Moreover...
* ...invalid values were being fed to the ``alert.target(*).file(*).file_access(*).permission(*)`` IDMEF path (see the table under https://tools.ietf.org/html/rfc4765#section-4.2.7.6.1 for a list of valid values)
* several ``*_after`` fields have been removed from the ``Eventinfo`` struct in favor of the ``fields`` array