### PR TITLE
Use the proper algorithm name for SHA-256 inside prelude output

### DIFF
--- a/src/analysisd/output/prelude.c
+++ b/src/analysisd/output/prelude.c
@@ -209,7 +209,7 @@ static void FileAccess_PreludeLog(idmef_message_t *idmef,
         add_idmef_object(idmef, "alert.target(0).file(-1).checksum(-1).value", sha1);
     }
     if (sha256) {
-        add_idmef_object(idmef, "alert.target(0).file(-1).checksum(>>).algorithm", "SHA256");
+        add_idmef_object(idmef, "alert.target(0).file(-1).checksum(>>).algorithm", "SHA2-256");
         add_idmef_object(idmef, "alert.target(0).file(-1).checksum(-1).value", sha256);
     }
 


### PR DESCRIPTION
As per RFC 4765, section 4.2.7.6.4, "SHA256" must be represented using the "SHA2-256" keyword when used inside an IDMEF message [1].

[1] See the table under https://tools.ietf.org/html/rfc4765#section-4.2.7.6.4 for the mapping between algorithms and keywords.