### PR TITLE
Fix /stats on dates whose day has only one digit

### DIFF
--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -37,7 +37,7 @@ def totals(date):
     stat_filename = ""
     try:
         stat_filename = os.path.join(
-            common.stats_path, "totals", str(date.year), MONTHS[date.month-1], f"ossec-totals-{date.day}.log")
+            common.stats_path, "totals", str(date.year), MONTHS[date.month-1], f"ossec-totals-{date.strftime('%d')}.log")
         stats = open(stat_filename, 'r')
     except IOError:
         raise WazuhError(1308, extra_message=stat_filename)


### PR DESCRIPTION
Hello team.

Any endpoint that tried to retrieve stats with `~/stats` on a day with only one digit would not find anything.

This was due to the use of `datetime.day`. Our tests could not catch this because they use two digits days:

### Unit tests
```
@pytest.mark.parametrize('date_, data_list', [
    (date(2019, 8, 13), ['15-571-3-2', '15--107--1483--1257--0']),
    (date(2019, 8, 13), ['15-571-3-2']),
    (date(2019, 8, 13), ['15--107--1483--1257--0']),
    (date(2019, 8, 13), ['15'])
])
@patch('wazuh.stats.common.stats_path', new=test_data_path)
def test_totals(date_, data_list):
```

### Integration tests
```
  - name: Manager stats
    request:
      verify: False
      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
      params:
        date: "2019-08-27"
```

Regards.