### PR TITLE
Remove seechanges_addfile from fim_json_event to fix an atomicity error

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -359,12 +359,6 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
 
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
-    if (!_base_line && item->configuration & CHECK_SEECHANGES) {
-        // The first backup is created. It should return NULL.
-        char *file_changed = seechanges_addfile(file);
-        os_free(file_changed);
-    }
-
     if (json_event && _base_line && report) {
         json_formated = cJSON_PrintUnformatted(json_event);
         send_syscheck_msg(json_formated);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -416,7 +416,7 @@ void fim_whodata_event(whodata_evt * w_evt) {
             fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
         #else
             char** paths = NULL;
-            char *evt_path = w_evt->path;
+            char *evt_path;
             const unsigned long int inode = strtoul(w_evt->inode,NULL,10);
             const unsigned long int dev = strtoul(w_evt->dev,NULL,10);
 
@@ -425,13 +425,17 @@ void fim_whodata_event(whodata_evt * w_evt) {
             w_mutex_unlock(&syscheck.fim_entry_mutex);
 
             fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
-            for(int i = 0; paths[i]; i++) {
-                w_evt->path = paths[i];
-                fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
-                os_free(paths[i]);
+
+            if(paths) {
+                evt_path = w_evt->path;
+                for(int i = 0; paths[i]; i++) {
+                    w_evt->path = paths[i];
+                    fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
+                    os_free(paths[i]);
+                }
+                os_free(paths);
+                w_evt->path = evt_path;
             }
-            os_free(paths);
-            w_evt->path = evt_path;
         #endif
     }
 }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -128,7 +128,7 @@ void fim_scan() {
             fim_db_set_all_unscanned(syscheck.database);
             w_mutex_unlock(&syscheck.fim_entry_mutex);
         }
-        
+
     }
 
     gettime(&end);
@@ -317,6 +317,7 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
     char *json_formated;
     int alert_type;
     int result;
+    char *diff = NULL;
 
     w_mutex_lock(&syscheck.fim_entry_mutex);
 
@@ -335,9 +336,15 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
         alert_type = FIM_MODIFICATION;
     }
 
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
-    json_event = fim_json_event(file, saved ? saved->data : NULL, new, item->index, alert_type, item->mode, w_evt);
-    w_mutex_lock(&syscheck.fim_entry_mutex);
+    if (item->configuration & CHECK_SEECHANGES) {
+        w_mutex_unlock(&syscheck.fim_entry_mutex);
+        diff = seechanges_addfile(file);
+        w_mutex_lock(&syscheck.fim_entry_mutex);
+    }
+
+    json_event = fim_json_event(file, saved ? saved->data : NULL, new, item->index, alert_type, item->mode, w_evt, diff);
+
+    os_free(diff);
 
     if (json_event) {
         if (result = fim_db_insert(syscheck.database, file, new, alert_type), result < 0) {
@@ -505,7 +512,7 @@ int fim_registry_event(char *key, fim_entry_data *data, int pos) {
         }
         w_mutex_unlock(&syscheck.fim_entry_mutex);
         json_event = fim_json_event(key, saved ? saved->data : NULL, data, pos,
-                                    alert_type, 0, NULL);
+                                    alert_type, 0, NULL, NULL);
     } else {
         fim_db_set_scanned(syscheck.database, key);
         result = 0;
@@ -885,7 +892,7 @@ void check_deleted_files() {
 }
 
 
-cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_data * new_data, int pos, unsigned int type, fim_event_mode mode, whodata_evt * w_evt) {
+cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_data * new_data, int pos, unsigned int type, fim_event_mode mode, whodata_evt * w_evt, const char *diff) {
     cJSON * changed_attributes = NULL;
 
     if (old_data != NULL) {
@@ -949,13 +956,8 @@ cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_da
 
         tags = syscheck.tag[pos];
 
-        if (syscheck.opts[pos] & CHECK_SEECHANGES && type != 1) {
-            char * diff = seechanges_addfile(file_name);
-
-            if (diff != NULL) {
-                cJSON_AddStringToObject(data, "content_changes", diff);
-                os_free(diff);
-            }
+        if (diff != NULL) {
+            cJSON_AddStringToObject(data, "content_changes", diff);
         }
     }
 #ifdef WIN32

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -337,9 +337,7 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
     }
 
     if (item->configuration & CHECK_SEECHANGES) {
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
         diff = seechanges_addfile(file);
-        w_mutex_lock(&syscheck.fim_entry_mutex);
     }
 
     json_event = fim_json_event(file, saved ? saved->data : NULL, new, item->index, alert_type, item->mode, w_evt, diff);

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -1205,7 +1205,7 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
         }
 
         json_event = fim_json_event(entry->path, NULL, entry->data, pos,
-                                                FIM_DELETE, mode, whodata_event);
+                                                FIM_DELETE, mode, whodata_event, NULL);
 
         if (!strcmp(FIM_ENTRY_TYPE[entry->data->entry_type], "file") &&
             syscheck.opts[pos] & CHECK_SEECHANGES) {

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -281,10 +281,11 @@ void check_deleted_files();
  * @param type Type of event: added, deleted or modified.
  * @param mode Event source.
  * @param w_evt Audit data structure.
+ * @param diff File diff if applicable.
  * @return File event JSON object.
  * @retval NULL No changes detected. Do not send an event.
  */
-cJSON *fim_json_event(char *file_name, fim_entry_data *old_data, fim_entry_data *new_data, int pos, unsigned int type, fim_event_mode mode, whodata_evt *w_evt);
+cJSON *fim_json_event(char *file_name, fim_entry_data *old_data, fim_entry_data *new_data, int pos, unsigned int type, fim_event_mode mode, whodata_evt *w_evt, const char *diff);
 
 /**
  * @brief Frees the memory of a FIM entry data structure
@@ -345,7 +346,7 @@ void free_syscheck_dirtb_data(char *data);
 
 /**
  * @brief Deletes subdirectories watches when a folder changes its name
- * 
+ *
  * @param dir Directory whose subdirectories need to delete their watches
  */
 
@@ -353,7 +354,7 @@ void delete_subdirectories_watches(char *dir);
 
 /**
  * @brief Count inotify watches
- * 
+ *
  * @return Number of inotify watches
  */
 unsigned int count_watches();

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1394,9 +1394,6 @@ static void test_fim_file_add(void **state) {
     expect_string(__wrap_fim_db_set_scanned, path, "file");
     will_return(__wrap_fim_db_set_scanned, 0);
 
-    expect_string(__wrap_seechanges_addfile, filename, "file");
-    will_return(__wrap_seechanges_addfile, NULL);
-
     ret = fim_file("file", fim_data->item, NULL, 1);
 
     fim_data->item->configuration &= ~CHECK_SEECHANGES;

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -546,6 +546,7 @@ static void test_fim_json_event(void **state) {
                     1,
                     FIM_MODIFICATION,
                     FIM_REALTIME,
+                    NULL,
                     NULL
                 );
 
@@ -601,9 +602,6 @@ static void test_fim_json_event_whodata(void **state) {
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
     #endif
 
-    expect_string(__wrap_seechanges_addfile, filename, "test.file");
-    will_return(__wrap_seechanges_addfile, strdup("diff"));
-
     fim_data->json = fim_json_event(
         "test.file",
         fim_data->old_data,
@@ -611,7 +609,8 @@ static void test_fim_json_event_whodata(void **state) {
         1,
         FIM_MODIFICATION,
         FIM_WHODATA,
-        fim_data->w_evt
+        fim_data->w_evt,
+        "diff"
     );
 
     syscheck.opts[1] &= ~CHECK_SEECHANGES;
@@ -660,6 +659,7 @@ static void test_fim_json_event_no_changes(void **state) {
                         1,
                         FIM_MODIFICATION,
                         FIM_WHODATA,
+                        NULL,
                         NULL
                     );
 
@@ -688,6 +688,7 @@ static void test_fim_json_event_hardlink_one_path(void **state) {
                     2,
                     FIM_MODIFICATION,
                     FIM_REALTIME,
+                    NULL,
                     NULL
                 );
 
@@ -752,6 +753,7 @@ static void test_fim_json_event_hardlink_two_paths(void **state) {
                     2,
                     FIM_MODIFICATION,
                     FIM_REALTIME,
+                    NULL,
                     NULL
                 );
 
@@ -1381,6 +1383,9 @@ static void test_fim_file_add(void **state) {
     expect_string(__wrap_fim_db_get_path, file_path, "file");
     will_return(__wrap_fim_db_get_path, NULL);
 
+    expect_string(__wrap_seechanges_addfile, filename, "file");
+    will_return(__wrap_seechanges_addfile, strdup("diff"));
+
     expect_value(__wrap_fim_db_insert, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_insert, file_path, "file");
     will_return(__wrap_fim_db_insert, 0);
@@ -1390,7 +1395,7 @@ static void test_fim_file_add(void **state) {
     will_return(__wrap_fim_db_set_scanned, 0);
 
     expect_string(__wrap_seechanges_addfile, filename, "file");
-    will_return(__wrap_seechanges_addfile, strdup("diff"));
+    will_return(__wrap_seechanges_addfile, NULL);
 
     ret = fim_file("file", fim_data->item, NULL, 1);
 


### PR DESCRIPTION
|Related issue|
|---|
|#4829|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims at removing the call to `seechanges_addfile` from `fim_json_event` in order to fix an atomicity error, caused by using a mutexed variable without havig a lock on it.

## Configuration options

This change affects the `report_changes` option of the `<directories>` tag.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
- Memory tests for Windows
  - [x] Scan-build report

