### PR TITLE
4.0 - Improve API status when the service has never started

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -225,11 +225,14 @@ def status():
     if get_wazuh_apid_pids():
         print("Wazuh API is running")
     else:
-        print("Wazuh API is stopped.")
-        with open(API_LOG_FILE_PATH, 'r') as log:
-            for line in deque(log, 20):
-                print(line)
-        print(f"Full log in {API_LOG_FILE_PATH}")
+        print("Wazuh API is stopped")
+        try:
+            with open(API_LOG_FILE_PATH, 'r') as log:
+                for line in deque(log, 20):
+                    print(line)
+            print(f"Full log in {API_LOG_FILE_PATH}")
+        except FileNotFoundError:
+            print(f"Could not find API log in '{os.path.dirname(API_LOG_FILE_PATH)}'")
 
 
 def get_wazuh_apid_pids():


### PR DESCRIPTION
Hello team.

If we tried to use `service wazuh-api status` when the API had never started or the `api.log` had been removed, this was the output:

```
root@wazuh-master:/# service wazuh-api status
Wazuh API is stopped.
Traceback (most recent call last):
  File "/var/ossec/api/scripts/wazuh-apid.py", line 303, in <module>
    status()
  File "/var/ossec/api/scripts/wazuh-apid.py", line 229, in status
    with open(API_LOG_FILE_PATH, 'r') as log:
FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/logs/api.log'
```

This is what we see after this change:

```
root@wazuh-master:/# service wazuh-api status
Wazuh API is stopped
Could not find API log in '/var/ossec/logs'

```

Regards.