### PR TITLE
Stop analyzing the agent when there is no data in the vendor DB

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -364,6 +364,7 @@
 #define VU_INSERT_PACKAGE_ERROR     "(5572): Couldn't insert the package '%s' into the vulnerability '%s'. Version (%s) '%s' '%s' (feed '%s')."
 #define VU_FILTER_VULN_ERROR        "(5573): Couldn't verify if the vulnerability '%s' of the package '%s' is already patched."
 #define VU_DISCARD_KERNEL_PKG       "(5574): Discarded Linux Kernel package '%s' (not running) for agent '%s'"
+#define VU_OVAL_UNAVAILABLE_DATA    "(5575): Unavailable vulnerability data for the agent '%s' OS. Skipping it."
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1645,7 +1645,7 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents, 
 
         if (agents_it->dist == FEED_WIN) {
             if (wm_vuldet_win_nvd_vulnerabilities(db, agents_it, flags)) {
-                return -1;
+                return OS_INVALID;
             }
 
         } else {
@@ -1654,11 +1654,11 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents, 
             cve_table = OSHash_Create();
             if (!cve_table) {
                 merror(LIST_ERROR);
-                return -1;
+                return OS_INVALID;
             }
             if (!OSHash_setSize(cve_table, VU_CVE_TABLE_SIZE)) {
                 merror(LIST_ERROR);
-                return -1;
+                return OS_INVALID;
             }
 
             int result = 0;
@@ -1666,13 +1666,13 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents, 
                 return result;
             }
             if (wm_vuldet_linux_nvd_vulnerabilities(db, agents_it, cve_table)) {
-                return -1;
+                return OS_INVALID;
             }
             if (wm_vuldet_linux_rm_false_positivies(db, agents_it, cve_table)) {
-                return -1;
+                return OS_INVALID;
             }
             if (wm_vuldet_send_agent_report(db, cve_table, agents_it)) {
-                return -1;
+                return OS_INVALID;
             }
 
             OSHash_Clean(cve_table, wm_vuldet_free_cve_node); // Free the CVE table.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -58,9 +58,9 @@ STATIC int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_
  * @brief Search for known vulnerabilities (NVD and OVAL feeds), and report all found CVEs.
  * @param agent_software Pointer to an agent node.
  * @param max Scan the previous @max agents within the list.
- * @return NULL on success, agent_id otherwise.
+ * @return 0 on success, -1 otherwise.
  */
-STATIC char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents, wm_vuldet_flags *flags, int max);
+STATIC int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents, wm_vuldet_flags *flags, int max);
 
 /**
  * @brief Traverse the agents linked list, gather the installed packages and search
@@ -850,11 +850,11 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
                         const char* condition1 = (pkg->nvd_cond->start_operation == START_INCLUDED) ? "greater or equal than" : "greater than";
                         const char* middle = "and is";
                         const char* condition2 = (pkg->nvd_cond->end_operation == END_INCLUDED) ? "less or equal than" : "less than";
-                        size_t size = strlen(start) + 1 + strlen(condition1) + 1 + strlen(pkg->nvd_cond->start_version) + 1 + 
+                        size_t size = strlen(start) + 1 + strlen(condition1) + 1 + strlen(pkg->nvd_cond->start_version) + 1 +
                                       strlen(middle) + 1 + strlen(condition2) + 1 + strlen(pkg->nvd_cond->end_version);
                         os_calloc(size + 1, sizeof(char), report->condition);
-                        sprintf(report->condition, "%s %s %s %s %s %s", 
-                        start, condition1, pkg->nvd_cond->start_version, 
+                        sprintf(report->condition, "%s %s %s %s %s %s",
+                        start, condition1, pkg->nvd_cond->start_version,
                         middle, condition2, pkg->nvd_cond->end_version);
                     }
                     else if (pkg->nvd_cond->start_version) {
@@ -862,7 +862,7 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
                         const char* condition = (pkg->nvd_cond->start_operation == START_INCLUDED) ? "greater or equal than" : "greater than";
                         size_t size = strlen(start) + 1 + strlen(condition) + 1 + strlen(pkg->nvd_cond->start_version);
                         os_calloc(size + 1, sizeof(char), report->condition);
-                        sprintf(report->condition, "%s %s %s", 
+                        sprintf(report->condition, "%s %s %s",
                         start, condition, pkg->nvd_cond->start_version);
                     }
                     else if (pkg->nvd_cond->end_version) {
@@ -870,7 +870,7 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
                         const char* condition = (pkg->nvd_cond->end_operation == END_INCLUDED) ? "less or equal than" : "less than";
                         size_t size = strlen(start) + 1 + strlen(condition) + 1 + strlen(pkg->nvd_cond->end_version);
                         os_calloc(size + 1, sizeof(char), report->condition);
-                        sprintf(report->condition, "%s %s %s", 
+                        sprintf(report->condition, "%s %s %s",
                         start, condition, pkg->nvd_cond->end_version);
                     }
                     else {
@@ -996,7 +996,7 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
                 if (!report->operation_value) w_strdup(pkg->vuln_cond->operation_value, report->operation_value);
                 if (!report->condition) w_strdup(pkg->vuln_cond->condition, report->condition);
             }
-            
+
             // Adding OVALs information
             if (wm_vuldet_prepare(db, vu_queries[VU_GET_VULN_INFO], -1, &stmt, NULL) != SQLITE_OK) {
                 goto error;
@@ -1515,7 +1515,22 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
     sqlite3_bind_text(stmt, 1, vu_feed_tag[agents_it->dist_ver], -1, NULL);
     sqlite3_bind_int(stmt, 2,  strtol(agents_it->agent_id, NULL, 10));
 
-    while (SQLITE_ROW == wm_vuldet_step(stmt)) {
+    int result = wm_vuldet_step(stmt);
+    switch (result) {
+    case SQLITE_ROW:
+        break;
+    case SQLITE_DONE:
+        // There is no data in the VULNERABILITIES table for this agent
+        // It has to be skipped instead of being scanned agains the NVD to avoid false positives
+        mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UNAVAILABLE_DATA, agents_it->agent_id);
+        wdb_finalize(stmt);
+        return 1;
+    default:
+        return wm_vuldet_sql_error(db, stmt);
+    }
+
+    do {
+
         char condition[OS_SIZE_1024 + 1];
         char state[50];
         char *cve;
@@ -1603,7 +1618,8 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
         default:
             break;
         }
-    }
+
+    } while (SQLITE_ROW == wm_vuldet_step(stmt));
 
     wdb_finalize(stmt);
 
@@ -1613,7 +1629,7 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
     return 0;
 }
 
-char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents, wm_vuldet_flags *flags, int max) {
+int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents, wm_vuldet_flags *flags, int max) {
     OSHash *cve_table = NULL;
     agent_software *agents_it = NULL;
     int agents_count;
@@ -1629,7 +1645,7 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
 
         if (agents_it->dist == FEED_WIN) {
             if (wm_vuldet_win_nvd_vulnerabilities(db, agents_it, flags)) {
-                return agents_it->agent_id;
+                return -1;
             }
 
         } else {
@@ -1638,24 +1654,25 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
             cve_table = OSHash_Create();
             if (!cve_table) {
                 merror(LIST_ERROR);
-                return agents_it->agent_id;
+                return -1;
             }
             if (!OSHash_setSize(cve_table, VU_CVE_TABLE_SIZE)) {
                 merror(LIST_ERROR);
-                return agents_it->agent_id;
+                return -1;
             }
 
-            if (wm_vuldet_linux_nvd_vulnerabilities(db, agents_it, cve_table)) {
-                return agents_it->agent_id;
+            int result = 0;
+            if (result = wm_vuldet_linux_oval_vulnerabilities(db, agents_it, cve_table), result) {
+                return result;
             }
-            if (wm_vuldet_linux_oval_vulnerabilities(db, agents_it, cve_table)) {
-                return agents_it->agent_id;
+            if (wm_vuldet_linux_nvd_vulnerabilities(db, agents_it, cve_table)) {
+                return -1;
             }
             if (wm_vuldet_linux_rm_false_positivies(db, agents_it, cve_table)) {
-                return agents_it->agent_id;
+                return -1;
             }
             if (wm_vuldet_send_agent_report(db, cve_table, agents_it)) {
-                return agents_it->agent_id;
+                return -1;
             }
 
             OSHash_Clean(cve_table, wm_vuldet_free_cve_node); // Free the CVE table.
@@ -1665,14 +1682,13 @@ char *wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agents
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FUNCTION_TIME, time(NULL) - start, "find", agents_it->agent_id);
     }
 
-    return NULL;
+    return 0;
 }
 
 int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuldet_flags *flags, time_t ignore_time) {
     agent_software *agents_it;
     sqlite3 *db;
     sqlite3_stmt *stmt = NULL;
-    char *agent_error;
     int result;
     int i;
 
@@ -1695,8 +1711,8 @@ int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuldet_flag
         if (result != 2) {  // Check that this agent has software to analyze
             if (VU_AGENT_REQUEST_LIMIT && i >= VU_AGENT_REQUEST_LIMIT) {
                 // Report a group of agents
-                if (agent_error = wm_vuldet_report_agent_vulnerabilities(db, agents_it, flags, i), agent_error) {
-                    mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_ERROR, agent_error, sqlite3_errmsg(db));
+                if (wm_vuldet_report_agent_vulnerabilities(db, agents_it, flags, i) < 0) {
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_ERROR, agents_it->agent_id, sqlite3_errmsg(db));
                 }
                 i = 0;
                 // Reset the tables
@@ -1712,8 +1728,8 @@ int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuldet_flag
 
     // Check for unreported agents
     if (!VU_AGENT_REQUEST_LIMIT || (i != VU_AGENT_REQUEST_LIMIT)) {
-        if (agent_error = wm_vuldet_report_agent_vulnerabilities(db, agents_it, flags, i), agent_error) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_ERROR, agent_error, sqlite3_errmsg(db));
+        if (wm_vuldet_report_agent_vulnerabilities(db, agents_it, flags, i) < 0) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_ERROR, agents_it->agent_id, sqlite3_errmsg(db));
         }
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -793,7 +793,7 @@ int wm_vuldet_linux_rm_false_positivies(sqlite3 *db, agent_software *agent, OSHa
  * @param db Vulnerability detector database.
  * @param agent Agent node.
  * @param cve_table CVE hash table for a specific agent.
- * @return 0 on success, -1 otherwise.
+ * @return 0 on success, 1 on silent error, -1 otherwise.
  */
 int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agent, OSHash *cve_table);
 


### PR DESCRIPTION
## Description

This PR replaces #4994. After further discussions, we decided not to add a ignore tag for the NVD provider. When it is enabled, it will try to scan all the supported agents.

In addition, it tries to avoid false positives when the vendor feed is not available for a specific OS. In that case, agents matching with that OS will be skipped when the query for vulnerabilities to the vendor DB returns 0 entries.

It also changes the error propagation between functions to support skipping an agent silently.

## Logs/Alerts example

This is the log shown when an agent is skipped:

```
2020/05/07 10:04:03 wazuh-modulesd:vulnerability-detector: INFO: (5450): Analyzing agent '0' vulnerabilities.
2020/05/07 10:04:03 wazuh-modulesd:vulnerability-detector: WARNING: (5575): Unavailable vulnerability data for the agent '0' OS. Skipping it.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Run a scan without valid data in the DB
- [x] Run a scan with valid data in the DB
