### PR TITLE
Fix high impact issues reported by Coverity

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1821,7 +1821,7 @@ void * w_output_thread(void * args){
                 #endif
 
                 while(1) {
-                    if(logr_queue = StartMQ(DEFAULTQPATH, WRITE), logr_queue > 0) {
+                    if(logr_queue = StartMQ(DEFAULTQPATH, WRITE), logr_queue >= 0) {
                         if (SendMSG(logr_queue, message->buffer, message->file, message->queue_mq) == 0) {
                             minfo("Successfully reconnected to '%s'", DEFAULTQPATH);
                             break;  //  We sent the message successfully, we can go on.

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -229,7 +229,6 @@ wdb_t * wdb_open_agent2(int agent_id) {
     char path[PATH_MAX + 1];
     sqlite3 * db;
     wdb_t * wdb = NULL;
-    wdb_t * new_wdb = NULL;
 
     snprintf(sagent_id, sizeof(sagent_id), "%03d", agent_id);
 
@@ -268,11 +267,10 @@ wdb_t * wdb_open_agent2(int agent_id) {
     else {
         wdb = wdb_init(db, sagent_id);
         wdb_pool_append(wdb);
+        wdb = wdb_upgrade(wdb);
 
-        if (new_wdb = wdb_upgrade(wdb), new_wdb != wdb) {
-            // If I had to generate backup and change DB
-            wdb = new_wdb;
-            wdb_pool_append(wdb);
+        if (wdb == NULL) {
+            goto end;
         }
     }
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -172,10 +172,10 @@ int wdb_open_global();
 
 /**
  * @brief Open mitre database and store in DB poll.
- * 
+ *
  * It is opened every time a query to Mitre database is done.
- * 
- * @return wdb_t* Database Structure that store mitre database or NULL on failure. 
+ *
+ * @return wdb_t* Database Structure that store mitre database or NULL on failure.
  */
 wdb_t * wdb_open_mitre();
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4991|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Fixed resource leak in logcollector and "read/use after free" bugs in wazuh_db, that had been reported by Coverity.
<!--
Add a clear description of how the problem has been solved.
-->



<!--
When proceed, this section should include new configuration parameters.
-->



<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [x] MAC OS X
- [X] Source installation
- [X] Source upgrade

- [X] Test upgrade old db.

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)

- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity

- Memory tests for macOS
  - [x] Scan-build report
