### PR TITLE
Prevent user self removal when using DELETE /security/users

### DIFF
--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -151,6 +151,7 @@ async def delete_users(request, usernames=None):
                           request_type='local_master',
                           is_async=False,
                           logger=logger,
+                          current_user=request['token_info']['sub'],
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())

--- a/framework/wazuh/common.py
+++ b/framework/wazuh/common.py
@@ -126,6 +126,7 @@ max_groups_per_multigroup = 256
 
 # Context variables
 rbac: ContextVar[Dict] = ContextVar('rbac', default=dict())
+current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[set] = ContextVar('cluster_nodes', default=list())
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -33,7 +33,7 @@ class DistributedAPI:
                  debug: bool = False, request_type: str = "local_master",
                  wait_for_complete: bool = False, from_cluster: bool = False, is_async: bool = False,
                  broadcasting: bool = False, basic_services: tuple = None, local_client_arg: str = None,
-                 rbac_permissions: Dict = None, nodes: list = None):
+                 rbac_permissions: Dict = None, nodes: list = None, current_user: str = ''):
         """
         Class constructor
 
@@ -58,6 +58,7 @@ class DistributedAPI:
         self.is_async = is_async
         self.broadcasting = broadcasting
         self.rbac_permissions = rbac_permissions if rbac_permissions is not None else dict()
+        self.current_user = current_user
         self.nodes = nodes if nodes is not None else list()
         if not basic_services:
             self.basic_services = ('wazuh-modulesd', 'ossec-analysisd', 'ossec-execd', 'wazuh-db')
@@ -177,6 +178,7 @@ class DistributedAPI:
             common.rbac.set(self.rbac_permissions)
             common.broadcast.set(self.broadcasting)
             common.cluster_nodes.set(self.nodes)
+            common.current_user.set(self.current_user)
             data = self.f(**self.f_kwargs)
             common.reset_context_cache()
             self.logger.debug("Finished executing request locally")
@@ -264,6 +266,7 @@ class DistributedAPI:
                 "local_client_arg": self.local_client_arg,
                 "basic_services": self.basic_services,
                 "rbac_permissions": self.rbac_permissions,
+                "current_user": self.current_user,
                 "broadcasting": self.broadcasting,
                 "nodes": self.nodes
                 }

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -119,6 +119,8 @@ def remove_users(username_list):
                                       all_msg='Users deleted correctly')
     with AuthenticationManager() as auth:
         for username in username_list:
+            if username == common.current_user.get():
+                continue
             user = auth.get_user(username)
             query = auth.delete_user(username)
             if not query:


### PR DESCRIPTION
Hi team,

This PR fixes a bug in the security module. Before this fix, **a user could delete himself from the database** by running the `DELETE /security/users` request.

The only users that were not affected by this are the default users: wazuh and wazuh-wui.

Regards