### PR TITLE
Added error handling

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -47,23 +47,31 @@ static char *wm_vuldet_clean_version(const char *version);
 
 /**
  * @brief Check if a generic NVD package is vulnerable.
- * @param package Package to check.
  * @param dbCVE Database with NVD information.
+ * @param pkg_name Name of package to check.
+ * @param pkg_source Source of package to check.
+ * @param pkg_version Version of package to check.
+ * @param pkg_arch Architecture of package to check.
  * @param cve_table Vulnerability data hash table.
  * @param name_type Package information: source or name.
- * @return True if vulnerable, false if not.
+ * @param vuln_count Vulnerability counter.
+ * @return 1 vulnerable, 0 no vulnerable, -1 otherwise.
  */
-static bool wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, OSHash *cve_table, int8_t name_type, int *vuln_count);
+static int wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, OSHash *cve_table, int8_t name_type, int *vuln_count);
 
 /**
  * @brief Check if a specific NVD package is vulnerable.
- * @param package Package to check.
  * @param dbCVE Database with NVD information.
+ * @param pkg_name Name of package to check.
+ * @param pkg_source Source of package to check.
+ * @param pkg_version Version of package to check.
+ * @param pkg_arch Architecture of package to check.
  * @param cve_table Vulnerability data hash table.
  * @param name_type Package information: source or name.
- * @return True if vulnerable, false if not.
+ * @param vuln_count Vulnerability counter.
+ * @return 1 vulnerable, 0 no vulnerable, -1 otherwise.
  */
-static bool wm_vuldet_check_specific_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, OSHash *cve_table, int8_t name_type, int *vuln_count);
+static int wm_vuldet_check_specific_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, OSHash *cve_table, int8_t name_type, int *vuln_count);
 
 /**
  * @brief Fill an array with the children's IDs from a package.
@@ -1596,9 +1604,15 @@ void wm_vuldet_free_nvd_list(nvd_vulnerability *nvd_it) {
 
 int wm_vuldet_linux_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, OSHash *cve_table) {
     sqlite3_stmt *stmt = NULL;
-    bool vulnerable = false;
+    int vulnerable_generic = 0;
+    int vulnerable_specific = 0;
     time_t start_time;
     int *vuln_count;
+
+    char *pkg_source = NULL;
+    char *pkg_name = NULL;
+    char *pkg_version = NULL;
+    char *pkg_arch = NULL;
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_START_NVD_AG_AN, agent->agent_id);
 
@@ -1615,10 +1629,6 @@ int wm_vuldet_linux_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, OSHa
     os_calloc(1, sizeof(int), vuln_count);
 
     while(SQLITE_ROW == wm_vuldet_step(stmt)) {
-        char *pkg_source = NULL;
-        char *pkg_name = NULL;
-        char *pkg_version = NULL;
-        char *pkg_arch = NULL;
 
         sqlite_strdup((char *)sqlite3_column_text(stmt, PACKAGE_SOURCE), pkg_source);
         sqlite_strdup((char *)sqlite3_column_text(stmt, PACKAGE_NAME), pkg_name);
@@ -1626,13 +1636,25 @@ int wm_vuldet_linux_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, OSHa
         sqlite_strdup((char *)sqlite3_column_text(stmt, PACKAGE_ARCH), pkg_arch);
 
         if(pkg_source) { //Source
-            vulnerable = wm_vuldet_check_generic_package(db, pkg_name, pkg_source, pkg_version, pkg_arch, cve_table, PACKAGE_SOURCE, vuln_count); //Generic source
-            vulnerable |= wm_vuldet_check_specific_package(db, pkg_name, pkg_source, pkg_version, pkg_arch, cve_table, PACKAGE_SOURCE, vuln_count); //Specific source
+            vulnerable_generic = wm_vuldet_check_generic_package(db, pkg_name, pkg_source, pkg_version, pkg_arch, cve_table, PACKAGE_SOURCE, vuln_count); //Generic source
+            if(vulnerable_generic == OS_INVALID) {
+                goto end;
+            }
+            vulnerable_specific = wm_vuldet_check_specific_package(db, pkg_name, pkg_source, pkg_version, pkg_arch, cve_table, PACKAGE_SOURCE, vuln_count); //Specific source
+            if(vulnerable_generic == OS_INVALID) {
+                goto end;
+            }
         }
 
-        if(pkg_name && !vulnerable) { //Name
-            wm_vuldet_check_generic_package(db, pkg_name, pkg_source, pkg_version, pkg_arch, cve_table, PACKAGE_NAME, vuln_count); //Generic name
-            wm_vuldet_check_specific_package(db, pkg_name, pkg_source, pkg_version, pkg_arch, cve_table, PACKAGE_NAME, vuln_count); //Specific name
+        if(pkg_name && !vulnerable_generic && !vulnerable_specific) { //Name
+            vulnerable_generic = wm_vuldet_check_generic_package(db, pkg_name, pkg_source, pkg_version, pkg_arch, cve_table, PACKAGE_NAME, vuln_count); //Generic name
+            if(vulnerable_generic == OS_INVALID) {
+                goto end;
+            }
+            vulnerable_specific = wm_vuldet_check_specific_package(db, pkg_name, pkg_source, pkg_version, pkg_arch, cve_table, PACKAGE_NAME, vuln_count); //Specific name
+            if(vulnerable_generic == OS_INVALID) {
+                goto end;
+            }
         }
 
         os_free(pkg_source);
@@ -1640,7 +1662,8 @@ int wm_vuldet_linux_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, OSHa
         os_free(pkg_version);
         os_free(pkg_arch);
 
-        vulnerable = false;
+        vulnerable_generic = 0;
+        vulnerable_specific = 0;
     }
 
     wdb_finalize(stmt);
@@ -1651,6 +1674,16 @@ int wm_vuldet_linux_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, OSHa
     os_free(vuln_count);
 
     return 0;
+
+end:
+    os_free(pkg_source);
+    os_free(pkg_name);
+    os_free(pkg_version);
+    os_free(pkg_arch);
+
+    wdb_finalize(stmt);
+    os_free(vuln_count);
+    return OS_INVALID;
 }
 
 int wm_vuldet_win_nvd_vulnerabilities(sqlite3 *db, agent_software *agent, wm_vuldet_flags *flags) {
@@ -2117,7 +2150,7 @@ char *wm_vuldet_clean_version(const char *version) {
     return clean_version;
 }
 
-bool wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, OSHash *cve_table, int8_t name_type, int *vuln_count) {
+int wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, OSHash *cve_table, int8_t name_type, int *vuln_count) {
     sqlite3_stmt *stmt = NULL;
     bool vulnerable_global = false;
     bool vulnerable = false;
@@ -2158,7 +2191,7 @@ bool wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_s
             operation_value = start_including;
         }
 
-        if (start_excluding) {
+        else if (start_excluding) {
             if (wm_checks_package_vulnerability(pkg_version, vu_package_comp[PKG_GREATER_THAN], start_excluding, VER_TYPE_NVD) == VU_VULNERABLE) {
                 search_vulnerabilities = true;
             }
@@ -2166,7 +2199,7 @@ bool wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_s
             operation_value = start_excluding;
         }
 
-        if(!start_including && !start_excluding) {
+        else if(!start_including && !start_excluding) {
             search_vulnerabilities = true;
             operation = vu_package_comp[PKG_EQUAL];
             operation_value = "*";
@@ -2179,7 +2212,7 @@ bool wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_s
                 vulnerable_global = vulnerable = true;
             }
 
-            if (end_including) {
+            else if (end_including) {
                 if (wm_checks_package_vulnerability(pkg_version, vu_package_comp[PKG_LESS_THAN_OR_EQUAL], end_including, VER_TYPE_NVD) == VU_VULNERABLE) {
                     vulnerable_global = vulnerable = true;
                 }
@@ -2187,7 +2220,7 @@ bool wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_s
                 operation_value = end_including;
             }
 
-            if (end_excluding) {
+            else if (end_excluding) {
                 if (wm_checks_package_vulnerability(pkg_version, vu_package_comp[PKG_LESS_THAN], end_excluding, VER_TYPE_NVD) == VU_VULNERABLE) {
                     vulnerable_global = vulnerable = true;
                 }
@@ -2203,11 +2236,17 @@ bool wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_s
 
             // Get dependencies for further study.
             if (parent == 0 && !strcmp(operator, "AND")) { // Get children
-                wm_vuldet_get_children(dbCVE, configuration_id, package_id, newPkg->nvd_cond->children);
+                int vuln_children = wm_vuldet_get_children(dbCVE, configuration_id, package_id, newPkg->nvd_cond->children);
+                if(vuln_children == OS_INVALID) {
+                    goto end;
+                }
             }
 
             else if (parent != 0 && !strcmp(operator, "OR")) { // Get siblings
-                wm_vuldet_get_siblings(dbCVE, parent, configuration_id, newPkg->nvd_cond->siblings);
+                int vuln_siblings = wm_vuldet_get_siblings(dbCVE, parent, configuration_id, newPkg->nvd_cond->siblings);
+                if(vuln_siblings == OS_INVALID) {
+                    goto end;
+                }
             }
 
             sqlite_strdup(pkg_version, newPkg->version);
@@ -2262,10 +2301,16 @@ bool wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_s
 
     wdb_finalize(stmt);
 
-    return vulnerable_global;
+    return(vulnerable_global) ? 1 : 0;
+
+end:
+    wdb_finalize(stmt);
+    os_free(newPkg->nvd_cond);
+    os_free(newPkg);
+    return OS_INVALID;
 }
 
-bool wm_vuldet_check_specific_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, OSHash *cve_table, int8_t name_type, int *vuln_count) {
+int wm_vuldet_check_specific_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, OSHash *cve_table, int8_t name_type, int *vuln_count) {
     sqlite3_stmt *stmt = NULL;
     bool vulnerable = false;
     cve_vuln_pkg *newPkg = NULL;
@@ -2282,6 +2327,7 @@ bool wm_vuldet_check_specific_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_
     len = strlen(clean_version) + 3;
     os_calloc(1, len, sql_version);
     snprintf(sql_version, len, "%%%s%%", clean_version);
+    os_free(clean_version);
 
     if (wm_vuldet_prepare(dbCVE, vu_queries[VU_GET_SPECIFIC_PACKAGE], -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_PACKAGES_VULN_ERROR, "specific", pkg_reference);
@@ -2308,11 +2354,17 @@ bool wm_vuldet_check_specific_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_
 
             // Get dependencies for further study.
             if (parent == 0 && !strcmp(operator, "AND")) { // Get children
-                wm_vuldet_get_children(dbCVE, configuration_id, package_id, newPkg->nvd_cond->children);
+                int vuln_children = wm_vuldet_get_children(dbCVE, configuration_id, package_id, newPkg->nvd_cond->children);
+                if(vuln_children == OS_INVALID) {
+                    goto end;
+                }
             }
 
             else if (parent != 0 && !strcmp(operator, "OR")) { // Get siblings
-                wm_vuldet_get_siblings(dbCVE, parent, configuration_id, newPkg->nvd_cond->siblings);
+                int vuln_siblings = wm_vuldet_get_siblings(dbCVE, parent, configuration_id, newPkg->nvd_cond->siblings);
+                if(vuln_siblings == OS_INVALID) {
+                    goto end;
+                }
             }
 
             sqlite_strdup(pkg_version, newPkg->version);
@@ -2353,10 +2405,16 @@ bool wm_vuldet_check_specific_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_
 
     wdb_finalize(stmt);
 
-    os_free(clean_version);
     os_free(sql_version);
 
-    return vulnerable;
+    return(vulnerable) ? 1 : 0;
+
+end:
+    wdb_finalize(stmt);
+    os_free(sql_version);
+    os_free(newPkg->nvd_cond);
+    os_free(newPkg);
+    return OS_INVALID;
 }
 
 int wm_vuldet_get_children(sqlite3 * dbCVE, int configuration_id, int package_id, int *children) {


### PR DESCRIPTION
|Related issue|
|---|
|[4956](https://github.com/wazuh/wazuh/issues/4956)|

## Description

This PR adds some error handling when SQLite query fails. Furthermore, it simplifies unit tests.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation