### PR TITLE
Set C standard to C11 on unit tests

### DIFF
--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.10)
 
 PROJECT(UnitTests C)
 
-# message("${TARGET}")
+set(CMAKE_C_STANDARD 11)
 get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
 
 message(Source folder: ${SRC_FOLDER})


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Unit tests compilation was failing under CentOS 7 with the `cmake3` package. The cause was that the C standard version was defaulted to C90. By setting `CMAKE_C_STANDARD` to 11, all generated targets will default to C11 if available and cascade down to C99 and C90.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests
Before setting `CMAKE_C_STANDARD`:
```
[ 64%] Building C object syscheckd/CMakeFiles/test_run_check.dir/test_run_check.c.o
/home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_run_check.c: In function ‘test_fim_send_sync_msg_10_eps’:
/home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_run_check.c:641:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 1; i < syscheck.sync_max_eps; i++) {
     ^
/home/vagrant/git/wazuh/src/unit_tests/syscheckd/test_run_check.c:641:5: note: use option -std=c99 or -std=gnu99 to compile your code
```
After setting `CMAKE_C_STANDARD`:
```
Scanning dependencies of target test_run_check
[ 62%] Building C object syscheckd/CMakeFiles/test_run_check.dir/test_run_check.c.o
[ 64%] Linking C executable test_run_check
[ 64%] Built target test_run_check
```