### PR TITLE
Improving condition selector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -539,20 +539,15 @@ int wm_checks_package_vulnerability(char *version_a, const char *operation, cons
         package_feed_version->version = cversion_it;
         package_feed_version->revision = crelease_it;
 
-        if ((strlen(operation) == strlen(vu_package_comp[VU_COMP_L])) && 
-            !strcmp(operation, vu_package_comp[VU_COMP_L])) {
+        if (!strcmp(operation, vu_package_comp[VU_COMP_L])) {
             feed_condition = PKG_RELATION_LT;
-        } else if ((strlen(operation) == strlen(vu_package_comp[VU_COMP_LE])) && 
-                   !strcmp(operation, vu_package_comp[VU_COMP_LE])) {
+        } else if (!strcmp(operation, vu_package_comp[VU_COMP_LE])) {
             feed_condition = PKG_RELATION_LE;
-        } else if ((strlen(operation) == strlen(vu_package_comp[VU_COMP_G])) && 
-                   !strcmp(operation, vu_package_comp[VU_COMP_G])) {
+        } else if (!strcmp(operation, vu_package_comp[VU_COMP_G])) {
             feed_condition = PKG_RELATION_GT;
-        } else if ((strlen(operation) == strlen(vu_package_comp[VU_COMP_GE])) && 
-                   !strcmp(operation, vu_package_comp[VU_COMP_GE])) {
+        } else if (!strcmp(operation, vu_package_comp[VU_COMP_GE])) {
             feed_condition = PKG_RELATION_GE;
-        } else if ((strlen(operation) == strlen(vu_package_comp[VU_COMP_EQ])) && 
-                   !strcmp(operation, vu_package_comp[VU_COMP_EQ])) {
+        } else if (!strcmp(operation, vu_package_comp[VU_COMP_EQ])) {
             feed_condition = PKG_RELATION_EQ;
         } else {
             ret = VU_ERROR_CMP;


### PR DESCRIPTION
## Description

This is a minor change to improve how the condition to compare versions is selected. This change comes up as a consequence of the changes introduced in the [pull 5026](https://github.com/wazuh/wazuh/pull/5026).

## Tests

Apart from the tests with the tick, the change was verified with the unit test execution. 

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation