### PR TITLE
Fixing memory leak in function wm_vuldet_normalize_date

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6088,10 +6088,15 @@ int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, c
 
         retval = 0;
 free_mem:
-        free(part);
-        free(op);
-        free(check);
-        free(op_value);
+        os_free(part);
+        os_free(op);
+        os_free(check);
+        os_free(op_value);
+    }
+
+    if (regex) {
+        regfree(regex);
+        os_free(regex);
     }
 
     return retval;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1194,7 +1194,7 @@ int wm_vuldet_send_cve_report(vu_report *report) {
     char alert_msg[OS_MAXSTR + 1];
     // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
-    char *timestamp;
+    char *timestamp = NULL;
 
     if (alert = cJSON_CreateObject(), !alert) {
         return retval;
@@ -6523,6 +6523,19 @@ end:
         if (!*date || !w_str_is_number(*date)) {
            os_free(*date);
         }
+    }
+
+    if (r_timestap) {
+        regfree(r_timestap);
+        os_free(r_timestap);
+    }
+    if (r_utc) {
+        regfree(r_utc);
+        os_free(r_utc);
+    }
+    if (r_only_date) {
+        regfree(r_only_date);
+        os_free(r_only_date);
     }
 
     return *date;


### PR DESCRIPTION
## Description

This issue was discovered during the development of [4956](https://github.com/wazuh/wazuh/issues/4956). It is a memory leak caused because the precompiled pattern buffer of the regex was not properly freed as described [here](https://linux.die.net/man/3/regcomp).

## Tests

This change was also validated by running the unit tests generated executable with `valgrind`.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation