### PR TITLE
Logcollector: enabled mysql5.7 log format #4056 and minor bug fix

### DIFF
--- a/etc/rules/0295-mysql_rules.xml
+++ b/etc/rules/0295-mysql_rules.xml
@@ -24,7 +24,7 @@
   </rule>
 
   <rule id="50106" level="9">
-    <if_sid>50105</if_sid>
+    <if_sid>50100</if_sid>
     <match>Access denied for user</match>
     <description>MySQL: authentication failure.</description>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SC.2,</group>
@@ -86,4 +86,29 @@
     <group>service_availability,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
   </rule>
 
+  <rule id="50181" level="5">
+    <if_sid>50100</if_sid>
+    <regex>^MySQL log: \d+-\d+-\d+T\d+:\d+:\d+.\d+\.+ \d+ [ERROR]</regex>
+    <description>MySQL: error.</description>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="50182" level="12">
+    <if_sid>50181</if_sid>
+    <match>Fatal error:</match>
+    <description>MySQL: fatal error.</description>
+    <mitre>
+      <id>T1499</id>
+    </mitre>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
+  </rule>
+
+  <rule id="50183" level="10" frequency="8" timeframe="120" ignore="60">
+    <if_matched_sid>50181</if_matched_sid>
+    <description>MySQL: Multiple errors.</description>
+    <mitre>
+      <id>T1499</id>
+    </mitre>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
+  </rule>
 </group>

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -14,7 +14,7 @@
 #include "logcollector.h"
 
 /* Starting last time */
-static char __mysql_last_time[18] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+static char __mysql_last_time[36] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 
 void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
@@ -95,6 +95,107 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
             snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
                      __mysql_last_time, p);
         }
+
+       /* MySQL 5.7 messages have the following format(in case of NOT utc):
+        * YYYY-MM-DDThh:mm:ss.uuuuuu±hh:mm XX
+        * ref: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_log_timestamps
+        */
+       else if ((str_len > 35) &&
+               (str[4] == '-') &&
+               (str[7] == '-') &&
+               (str[10] == 'T') &&
+               (str[13] == ':') &&
+               (str[16] == ':') &&
+               (str[19] == '.') &&
+               ((str[26] == '-') || (str[26] == '+')) &&
+               (str[29] == ':') &&
+               (str[32] == ' ') &&
+               isdigit((int)str[0]) &&
+               isdigit((int)str[1]) &&
+               isdigit((int)str[2]) &&
+               isdigit((int)str[3]) &&
+               isdigit((int)str[5]) &&
+               isdigit((int)str[6]) &&
+               isdigit((int)str[8]) &&
+               isdigit((int)str[9]) &&
+               isdigit((int)str[11]) &&
+               isdigit((int)str[12]) &&
+               isdigit((int)str[14]) &&
+               isdigit((int)str[15]) &&
+               isdigit((int)str[17]) &&
+               isdigit((int)str[18]) &&
+               isdigit((int)str[20]) &&
+               isdigit((int)str[21]) &&
+               isdigit((int)str[22]) &&
+               isdigit((int)str[23]) &&
+               isdigit((int)str[24]) &&
+               isdigit((int)str[25]) &&
+               isdigit((int)str[27]) &&
+               isdigit((int)str[28]) &&
+               isdigit((int)str[30]) &&
+               isdigit((int)str[31])) {
+           /* Save last time */
+           strncpy(__mysql_last_time, str, 33);
+           __mysql_last_time[32] = '\0';
+
+           /* Remove spaces and tabs */
+           p = str + 32;
+           while (*p == ' ' || *p == '\t') {
+               p++;
+           }
+
+           /* Valid MySQL message */
+           snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
+                    __mysql_last_time, p);
+       }
+       
+      /* MySQL 5.7 messages have the following format(in case of utc):
+       * YYYY-MM-DDThh:mm:ss.uuuuuuZ XX
+       * ref: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_log_timestamps
+       */
+      else if ((str_len > 30) &&
+              (str[4] == '-') &&
+              (str[7] == '-') &&
+              (str[10] == 'T') &&
+              (str[13] == ':') &&
+              (str[16] == ':') &&
+              (str[19] == '.') &&
+              (str[26] == 'Z') &&
+              (str[27] == ' ') &&
+              isdigit((int)str[0]) &&
+              isdigit((int)str[1]) &&
+              isdigit((int)str[2]) &&
+              isdigit((int)str[3]) &&
+              isdigit((int)str[5]) &&
+              isdigit((int)str[6]) &&
+              isdigit((int)str[8]) &&
+              isdigit((int)str[9]) &&
+              isdigit((int)str[11]) &&
+              isdigit((int)str[12]) &&
+              isdigit((int)str[14]) &&
+              isdigit((int)str[15]) &&
+              isdigit((int)str[17]) &&
+              isdigit((int)str[18]) &&
+              isdigit((int)str[20]) &&
+              isdigit((int)str[21]) &&
+              isdigit((int)str[22]) &&
+              isdigit((int)str[23]) &&
+              isdigit((int)str[24]) &&
+              isdigit((int)str[25])) {
+          /* Save last time */
+          strncpy(__mysql_last_time, str, 28);
+          __mysql_last_time[27] = '\0';
+
+          /* Remove spaces and tabs */
+          p = str + 27;
+          while (*p == ' ' || *p == '\t') {
+              p++;
+          }
+
+          /* Valid MySQL message */
+          snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
+                   __mysql_last_time, p);
+      }
 
         /* Multiple events at the same second share the same timestamp:
          * 0909 2020 2020 2020 20


### PR DESCRIPTION
|Related issue|
|---|
|Logcollector - Some log_format values don't work #4056|

contribution

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The issue #4056 is caused because current [read_mysq_log](https://github.com/wazuh/wazuh/blob/master/src/logcollector/read_mysql_log.c) and [0295-mysql_rules.xml](https://github.com/wazuh/wazuh/blob/master/etc/rules/0295-mysql_rules.xml) intends the log format of MySQL 5.6 [(_**ref**_)](https://mariadb.com/kb/en/error-log/#format).
I edited `read_mysql_log.c` and `0295-mysql_rules.xml` to collect logs in the format of MySQL 5.7.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

Logs in the format of MySQL 5.7 are collected as below:

### in the case of NOT UTC

- rule id: 50106 : bug fix

```
# /var/log/mysqld.log 
2020-05-13T17:21:24.096968+09:00 26 [Note] Access denied for user 'dbadmin'@'localhost' (using password: NO)

# /var/ossec/logs/alerts/alerts.log
** Alert 1589358085.320045: - mysql_log,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SC.2,
2020 May 13 17:21:25 (wazuh-test-agent) 10.0.1.173->/var/log/mysqld.log
Rule: 50106 (level 9) -> 'MySQL: authentication failure.'
MySQL log: 2020-05-13T17:21:24.096968+09:00 26 [Note] Access denied for user 'dbadmin'@'localhost' (using password: NO)
```

- rule id: 50181, 50182: added

```
# /var/log/mysqld.log 
2020-05-13T17:30:40.230187+09:00 4 [ERROR] Fatal error: Cant open and lock privilege tables: Table mysql.host doesnt exist

# /var/ossec/logs/alerts/alerts.log
** Alert 1589359232.329273: mail  - mysql_log,service_availability,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,
2020 May 13 17:40:32 (wazuh-test-agent) 10.0.1.173->/var/log/mysqld.log
Rule: 50182 (level 12) -> 'MySQL: fatal error.'
MySQL log: 2020-05-13T17:30:40.230187+09:00 4 [ERROR] Fatal error: Cant open and lock privilege tables: Table mysql.host doesnt exist
```

- rule id: 50183: added

```
# /var/log/mysqld.log 
2020-05-13T18:32:46.904753+09:00 4 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T18:32:49.924352+09:00 5 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T18:32:52.944335+09:00 6 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T18:32:55.964244+09:00 7 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T18:32:58.986045+09:00 8 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T18:33:02.013211+09:00 9 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T18:33:05.049485+09:00 10 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T18:33:08.068079+09:00 11 [ERROR] Plugin InnoDB init function returned error.

# /var/ossec/logs/alerts/alerts.log
** Alert 1589362389.450428: - mysql_log,service_availability,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,
2020 May 13 18:33:09 (wazuh-test-agent) 10.0.1.173->/var/log/mysqld.log
Rule: 50183 (level 10) -> 'MySQL: Multiple errors.'
MySQL log: 2020-05-13T18:33:08.068079+09:00 11 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T18:33:05.049485+09:00 10 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T18:33:02.013211+09:00 9 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T18:32:58.986045+09:00 8 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T18:32:55.964244+09:00 7 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T18:32:52.944335+09:00 6 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T18:32:49.924352+09:00 5 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T18:32:46.904753+09:00 4 [ERROR] Plugin InnoDB init function returned error.
```

### in the case of UTC

- rule id: 50106 : bug fix

```
# /var/log/mysqld.log 
2020-05-13T10:17:58.141628Z 9 [Note] Access denied for user 'test'@'localhost' (using password: NO)

# /var/ossec/logs/alerts/alerts.log
** Alert 1589365078.336776: - mysql_log,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SC.2,
2020 May 13 19:17:58 (wazuh-test-agent) 10.0.1.173->/var/log/mysqld.log
Rule: 50106 (level 9) -> 'MySQL: authentication failure.'
MySQL log: 2020-05-13T10:17:58.141628Z 9 [Note] Access denied for user 'test'@'localhost' (using password: NO)
```

- rule id: 50181, 50182: added

```
# /var/log/mysqld.log 
2020-05-13T19:20:13.532491Z 10 [ERROR] Fatal error: Cant open and lock privilege tables: Table mysql.host doesnt exist

# /var/ossec/logs/alerts/alerts.log
** Alert 1589365214.339938: mail  - mysql_log,service_availability,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,
2020 May 13 19:20:14 (wazuh-test-agent) 10.0.1.173->/var/log/mysqld.log
Rule: 50182 (level 12) -> 'MySQL: fatal error.'
MySQL log: 2020-05-13T19:20:13.532491Z 10 [ERROR] Fatal error: Cant open and lock privilege tables: Table mysql.host doesnt exist
```

- rule id: 50183: added

```
# /var/log/mysqld.log 
2020-05-13T19:23:04.882671Z 15 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T19:23:07.901442Z 16 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T19:23:10.919219Z 17 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T19:23:13.939306Z 18 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T19:23:16.959903Z 19 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T19:23:19.983365Z 20 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T19:23:23.025015Z 21 [ERROR] Plugin InnoDB init function returned error.
2020-05-13T19:23:50.374815Z 22 [ERROR] Plugin InnoDB init function returned error.

# /var/ossec/logs/alerts/alerts.log
** Alert 1589365430.354115: - mysql_log,service_availability,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,
2020 May 13 19:23:50 (wazuh-test-agent) 10.0.1.173->/var/log/mysqld.log
Rule: 50183 (level 10) -> 'MySQL: Multiple errors.'
MySQL log: 2020-05-13T19:23:50.374815Z 22 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T19:23:23.025015Z 21 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T19:23:19.983365Z 20 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T19:23:16.959903Z 19 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T19:23:13.939306Z 18 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T19:23:10.919219Z 17 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T19:23:07.901442Z 16 [ERROR] Plugin InnoDB init function returned error.
MySQL log: 2020-05-13T19:23:04.882671Z 15 [ERROR] Plugin InnoDB init function returned error.
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components