### PR TITLE
Fix some warnings IDs to maintain continuity

### DIFF
--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -36,9 +36,9 @@
 #define FIM_WARN_FILE_REALTIME                  "(6921): Unable to configure real-time option for file: '%s'"
 #define FIM_PATH_NOT_OPEN                       "(6922): Cannot open '%s': %s"
 #define FIM_WARN_SKIP_EVENT                     "(6923): Unable to process file '%s'"
-#define FIM_AUDIT_NORUNNING                     "(6224): Who-data engine cannot start because Auditd is not running."
-#define FIM_INVALID_OPTION_SKIP                 "(6225): Invalid option '%s' for attribute '%s'. The paths '%s' not be monitored."
-#define FIM_WARN_WHODATA_ADD_RULE               "(6226): Unable to add audit rule for '%s'"
-#define FIM_DB_FULL_ALERT                       "(6227): Sending DB 100%% full alert."
+#define FIM_AUDIT_NORUNNING                     "(6924): Who-data engine cannot start because Auditd is not running."
+#define FIM_INVALID_OPTION_SKIP                 "(6925): Invalid option '%s' for attribute '%s'. The paths '%s' not be monitored."
+#define FIM_WARN_WHODATA_ADD_RULE               "(6926): Unable to add audit rule for '%s'"
+#define FIM_DB_FULL_ALERT                       "(6927): Sending DB 100%% full alert."
 
 #endif /* WARN_MESSAGES_H */

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1975,7 +1975,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
 
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6227): Sending DB 100% full alert.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
@@ -2026,7 +2026,7 @@ static void test_fim_scan_no_realtime(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6227): Sending DB 100% full alert.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
 
     expect_function_call(__wrap_count_watches);
@@ -2637,7 +2637,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6227): Sending DB 100% full alert.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
@@ -2924,7 +2924,7 @@ static void test_fim_check_db_state_empty_to_full(void **state) {
 
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6227): Sending DB 100% full alert.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
 
     assert_int_equal(_db_state, FIM_STATE_DB_EMPTY);
@@ -3038,7 +3038,7 @@ static void test_fim_check_db_state_normal_to_full(void **state) {
 
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6227): Sending DB 100% full alert.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
 
     assert_int_equal(_db_state, FIM_STATE_DB_NORMAL);
@@ -3125,7 +3125,7 @@ static void test_fim_check_db_state_80_percentage_to_full(void **state) {
 
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6227): Sending DB 100% full alert.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
 
     assert_int_equal(_db_state, FIM_STATE_DB_80_PERCENTAGE);
@@ -3182,7 +3182,7 @@ static void test_fim_check_db_state_90_percentage_to_full(void **state) {
 
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6227): Sending DB 100% full alert.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
 
     assert_int_equal(_db_state, FIM_STATE_DB_90_PERCENTAGE);

--- a/src/unit_tests/syscheckd/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/test_syscheck_audit.c
@@ -945,7 +945,7 @@ void test_add_audit_rules_syscheck_not_added_error(void **state)
     // Add rule
     will_return(__wrap_audit_add_rule, -1);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6226): Unable to add audit rule for '/var/test'");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6926): Unable to add audit rule for '/var/test'");
 
     int ret;
     ret = add_audit_rules_syscheck(0);
@@ -984,7 +984,7 @@ void test_add_audit_rules_syscheck_not_added_first_error(void **state)
     // Add rule
     will_return(__wrap_audit_add_rule, -1);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6226): Unable to add audit rule for '/var/test'");
+    expect_string(__wrap__mwarn, formatted_msg, "(6926): Unable to add audit rule for '/var/test'");
 
     int ret;
     ret = add_audit_rules_syscheck(1);


### PR DESCRIPTION

## Description
Hi team,
I have found some small errors in the IDs related to the warnings messages, I have fixed them and changed everything related to them in unit tests, so that the continuity of these IDs is maintained.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

