### PR TITLE
Fix FIM unit test, check enable_whodata option.

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1183,7 +1183,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
                         return (OS_INVALID);
                     }
-                    
+
                     syscheck->file_limit = atoi(children[j]->content);
 
                     if (syscheck->file_limit > MAX_FILE_LIMIT) {

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -22,6 +22,7 @@ static registry REGISTRY_EMPTY[] = { { NULL, 0, NULL } };
 int Read_Syscheck_Config(const char *cfgfile)
 {
     int modules = 0;
+    int it = 0;
     modules |= CSYSCHECK;
 
     syscheck.rootcheck      = 0;
@@ -80,6 +81,17 @@ int Read_Syscheck_Config(const char *cfgfile)
     modules |= CAGENT_CONFIG;
     ReadConfig(modules, AGENTCONFIG, &syscheck, NULL);
 #endif
+
+    // Check directories options to determine whether to start the whodata thread or not
+    if (syscheck.dir) {
+        for (it = 0; syscheck.dir[it]; it++) {
+            if (syscheck.opts[it] & WHODATA_ACTIVE) {
+                syscheck.enable_whodata = 1;
+
+                break;  // Exit loop with the first whodata directory
+            }
+        }
+    }
 
     switch (syscheck.disabled) {
     case SK_CONF_UNPARSED:

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -240,14 +240,6 @@ int main(int argc, char **argv)
 #endif
             }
 
-            /*
-                Check directories options to determine whether to start
-                the whodata thread or not
-            */
-            if (syscheck.opts[r] & WHODATA_ACTIVE) {
-                syscheck.enable_whodata = 1;
-            }
-
             r++;
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
|No related issue|

This PR fixes an error executing unit test, `test_syscheck_config` should check the whodata_enable value, this option allow executing Who-data thread in the FIM module.

Henceforh, the value must be setted reading FIM configuration.