### PR TITLE
Fix API integration tests after 3.13 merge

### DIFF
--- a/api/test/integration/env/configurations/rbac/cluster/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/cluster/white_config.txt
@@ -15,3 +15,4 @@
 | cluster:delete_file      | node:id&file:path | master-node,worker2 | ruleset/decoders/0005-wazuh_decoders.xml                                                    |                     |
 | cluster:read_api_config  | *:*               | *                                                                                                                 |                     |
 | cluster:update_api_config| *:*               | *                                                                                                                 |                     |
+

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -124,8 +124,8 @@ stages:
             - error:
                 code: 4000
                 message: 'Permission denied: Resource type: user:id'
-                remediation: Please, make sure you have permissions to execute current request,
-                  for more information on setting up permissions please visit XXXX
+                remediation: "Please, make sure you have permissions to execute the current request.
+                For more information on how to set up permissions, please visit XXXX"
               id:
                 - administrator
                 - guest
@@ -679,8 +679,8 @@ stages:
             - error:
                 code: 4000
                 message: 'Permission denied: Resource type: policy:id'
-                remediation: Please, make sure you have permissions to execute current request,
-                  for more information on setting up permissions please visit XXXX
+                remediation: "Please, make sure you have permissions to execute the current request.
+                For more information on how to set up permissions, please visit XXXX"
               id:
                 - '15'
         message: Some policies could not be linked to role 12

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -631,23 +631,6 @@ stages:
         message: !anystr
 
 ---
-test_name: DELETE /cluster/api/config
-
-stages:
-
-  - name: Restore API config (Allowed)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
-      method: DELETE
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        <<: *update_api_config_ok
-
----
 test_name: PUT /cluster/restart
 
 stages:
@@ -869,3 +852,20 @@ stages:
         path: etc/ossec.conf
     response:
       status_code: 200
+
+---
+test_name: DELETE /cluster/api/config
+
+stages:
+
+  - name: Restore API config (Allowed)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        <<: *update_api_config_ok

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -697,8 +697,8 @@ stages:
             - error:
                 code: 4000
                 message: 'Permission denied: Resource type: policy:id'
-                remediation: Please, make sure you have permissions to execute current request,
-                  for more information on setting up permissions please visit XXXX
+                remediation: "Please, make sure you have permissions to execute the current request.
+                For more information on how to set up permissions, please visit XXXX"
               id:
                 - '16'
                 - '17'
@@ -872,8 +872,8 @@ stages:
             - error:
                 code: 4000
                 message: 'Permission denied: Resource type: user:id'
-                remediation: Please, make sure you have permissions to execute current request,
-                  for more information on setting up permissions please visit XXXX
+                remediation: "Please, make sure you have permissions to execute the current request.
+                For more information on how to set up permissions, please visit XXXX"
               id:
                 - wazuh
             - error:

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -522,10 +522,7 @@ stages:
               roles: []
             - username: python
               roles: []
-            - username: testing
-              roles: []
           failed_items: []
-          total_affected_items: 5
+          total_affected_items: 4
           total_failed_items: 0
         message: Users deleted correctly
-

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -987,29 +987,28 @@ stages:
       status_code: 200
       json:
         "*:*":
-          description: 'Resource applied in functions acting on resources that do not yet
-            exist in the system. We call these functions, resourceless functions. Example:
-            agent:create'
+          description: 'Resource applied in functions which take part in the creation of a specific resource.
+          We call these functions, resourceless functions. Example: agent:create'
         agent:id:
           description: Reference agents via agent ID (i.e. agent:id:001)
         group:id:
           description: Reference agent groups via group ID (i.e. group:id:default)
         node:id:
-          description: Reference cluster node via node ID (i.e. node:id:worker1)
+          description: Reference cluster nodes via node ID (i.e. node:id:worker1)
         file:path:
-          description: Reference file via its path (i.e. file:path:etc/rules/new_rule.xml)
+          description: Reference files via its path (i.e. file:path:etc/rules/new_rule.xml)
         decoder:file:
-          description: Reference decoder file via its path (i.e. decoder:file:0005-wazuh_decoders.xml)
+          description: Reference decoder files via its path (i.e. decoder:file:0005-wazuh_decoders.xml)
         lists:path:
-          description: Reference list file via its path (i.e. lists:path:etc/lists/audit-keys)
+          description: Reference list files via its path (i.e. lists:path:etc/lists/audit-keys)
         rules:file:
-          description: Reference rule file via its path (i.e. rules:file:0610-win-ms_logs_rules.xml)
+          description: Reference rule files via its path (i.e. rules:file:0610-win-ms_logs_rules.xml)
         policy:id:
-          description: Reference security policy via its id (i.e. policy:id:1)
+          description: Reference security policies via its id (i.e. policy:id:1)
         role:id:
-          description: Reference security role via its id (i.e. role:id:1)
+          description: Reference security roles via its id (i.e. role:id:1)
         user:id:
-          description: Reference security user via its username (i.e. user:id:wazuh)
+          description: Reference security users via its username (i.e. user:id:wazuh)
 
   - name: Testing RBAC's actions catalog
     request:


### PR DESCRIPTION
Hello team.

This PR fixes all our API integration tests after merging 3.13 into `dev-aiohttp-poc`. These are minor changes.

# Test results

```
test_experimental_endpoints
	 11 passed, 13 warnings

test_security_DELETE_endpoints
	 8 passed, 10 warnings

test_rbac_white_cluster_endpoints
	 21 passed, 23 warnings

test_rbac_white_security_endpoints
	 17 passed, 19 warnings

test_rbac_white_experimental_endpoints
	 11 passed, 13 warnings

test_rbac_black_security_endpoints
	 16 passed, 18 warnings

test_security_GET_endpoints
	 12 passed, 15 warnings
```

Regards.