### PR TITLE
Improve API integration test script

### DIFF
--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 
 
-RESULTS_PATH = 'test_results'
+RESULTS_PATH = '_test_results'
 PYTEST_COMMAND = 'pytest -vv'
 TESTS_PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -13,28 +13,44 @@ TESTS_PATH = os.path.dirname(os.path.abspath(__file__))
 def calculate_result(file_name):
     with open(file_name, 'r') as f:
         file = f.read()
-    print(f'\t{re.search(r"=+(.*) in (.*)s.*=+", file).group(1)}\n')
+    try:
+        print(f'\t{re.search(r"=+(.*) in (.*)s.*=+", file).group(1)}\n')
+    except AttributeError:
+        print('\tCould not retrieve results from this test')
 
 
-def collect_tests(keyword=None, rbac='both'):
+def collect_tests(test_list=None, keyword=None, rbac='both'):
     os.chdir(TESTS_PATH)
 
-    def filter_tests(kw, rb):
+    def filter_tests(kw, rb, t_list=None):
         kw = kw if kw is not None else ''
-        test_list = []
-        for file in glob.glob('test_*'):
+        t_list = t_list.split(',') if t_list else None
+        collected_items = []
+        candidate_tests = [test for test in glob.glob('test_*') for t in t_list if t in test] if t_list else glob.glob('test_*')
+        for file in candidate_tests:
             if rb == 'yes':
                 if kw in file and 'rbac' in file:
-                    test_list.append(file)
+                    collected_items.append(file)
             elif kw in file and rb == 'no':
                 if 'rbac' not in file:
-                    test_list.append(file)
+                    collected_items.append(file)
             else:
                 if kw in file:
-                    test_list.append(file)
-        return sorted(test_list)
+                    collected_items.append(file)
+        return sorted(collected_items)
 
-    collected_tests = filter_tests(keyword, rbac)
+    collected_tests = filter_tests(keyword, rbac, t_list=test_list)
+    print(f'Collected tests [{len(collected_tests)}]:')
+    print('{}\n\n'.format(", ".join([t for t in collected_tests])))
+
+    return collected_tests
+
+
+def collect_non_excluded_tests():
+    os.chdir(f'{TESTS_PATH}/{RESULTS_PATH}')
+    done_tests = glob.glob(f'test_*')
+    os.chdir(TESTS_PATH)
+    collected_tests = sorted([test for test in glob.glob('test_*') if test.rstrip('.tavern.yaml') not in done_tests])
     print(f'Collected tests [{len(collected_tests)}]:')
     print('{}\n\n'.format(", ".join([t for t in collected_tests])))
 
@@ -42,6 +58,7 @@ def collect_tests(keyword=None, rbac='both'):
 
 
 def run_tests(collected_tests, n_iterations=1):
+    os.chdir(TESTS_PATH)
     for test in collected_tests:
         for i in range(1, n_iterations + 1):
             iteration_info = f'[{i}/{n_iterations}]' if n_iterations > 1 else ''
@@ -50,7 +67,17 @@ def run_tests(collected_tests, n_iterations=1):
             f = open(os.path.join(RESULTS_PATH, test_name), 'w')
             subprocess.call(PYTEST_COMMAND.split(' ') + [test], stdout=f)
             f.close()
-            calculate_result(os.path.join(RESULTS_PATH, test_name))
+            get_results(filename=os.path.join(RESULTS_PATH, test_name))
+
+
+def get_results(filename=None):
+    if filename:
+        calculate_result(filename)
+    else:
+        os.chdir(RESULTS_PATH)
+        for file in glob.glob('test_*'):
+            print(file)
+            calculate_result(file)
 
 
 def get_script_arguments():
@@ -58,6 +85,13 @@ def get_script_arguments():
     parser = argparse.ArgumentParser(usage="%(prog)s [options]",
                                      description="API integration tests",
                                      formatter_class=argparse.RawTextHelpFormatter)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-l', '--list', dest='test_list', default=None,
+                       help='Specify a list of tests separated by a comma.', action='store')
+    group.add_argument('-e', '--exclude', dest='exclude', action='store_true', default=None,
+                       help='Run every test excluding the already saved in the RESULTS_PATH.')
+    group.add_argument('-r', '--results', dest='results', action='store_true', default=None,
+                       help='Get result summary from the already run tests.')
     parser.add_argument('-k', '--keyword', dest='keyword', default=None,
                         help='Specify the keyword to filter tests out. Default None.', action='store')
     parser.add_argument('-rbac', dest='rbac', default='both', choices=rbac_choices,
@@ -73,8 +107,14 @@ if __name__ == '__main__':
     os.makedirs(os.path.join(TESTS_PATH, RESULTS_PATH), exist_ok=True)
     options = get_script_arguments()
     key = options.keyword
+    tl = options.test_list
+    exclude = options.exclude
+    results = options.results
     rbac_arg = options.rbac
     iterations = options.iterations
 
-    tests = collect_tests(keyword=key, rbac=rbac_arg)
-    run_tests(collected_tests=tests, n_iterations=iterations)
+    if results:
+        get_results()
+    else:
+        tests = collect_non_excluded_tests() if exclude else collect_tests(test_list=tl, keyword=key, rbac=rbac_arg)
+        run_tests(collected_tests=tests, n_iterations=iterations)


### PR DESCRIPTION
Hello team.

This PR improves our script for the new API integration tests:
- Fixed a bug where the script would stop if it could not find any results from a test.
- Added param `--list` to run any tests that belong in a list separated by commas. `--keyword` and `--rbac` can be used with this param as well.
- Added param `--exclude` to run all the tests except the ones that have a result already.
- Added param `--results` to show a result summary of every test that has been run.

```
$ python3 run_tests.py -h

usage: run_tests.py [options]

API integration tests

optional arguments:
  -h, --help            show this help message and exit
  -l TEST_LIST, --list TEST_LIST
                        Specify a list of tests separated by a comma.
  -e, --exclude         Run every test excluding the already saved in the RESULTS_PATH.
  -r, --results         Get result summary from the already run tests.
  -k KEYWORD, --keyword KEYWORD
                        Specify the keyword to filter tests out. Default None.
  -rbac {both,yes,no}   Specify what to do with RBAC tests. Run everything, only RBAC ones or no RBAC. Default "both".
  -i ITERATIONS, --iterations ITERATIONS
                        Specify how many times will every test be run. Default 1.

```

# Examples

```
$ python3 run_tests.py -l manager,cluster

Collected tests [6]:
test_cluster_endpoints.tavern.yaml, test_manager_endpoints.tavern.yaml, test_rbac_black_cluster_endpoints.tavern.yaml, test_rbac_black_manager_endpoints.tavern.yaml, test_rbac_white_cluster_endpoints.tavern.yaml, test_rbac_white_manager_endpoints.tavern.yaml

```

```
$ python3 run_tests.py -l agents,security -rbac no -k GET

Collected tests [2]:
test_agents_GET_endpoints.tavern.yaml, test_security_GET_endpoints.tavern.yaml

```

```
$ python3 run_tests.py -r

test_cluster_endpoints
	 72 passed

test_agents_GET_endpoints
	Could not retrieve results from this test
```

```
$ python3 run_tests.py -e

Collected tests [3]:
test_agents_DELETE_endpoints.tavern.yaml, test_lists_endpoints.tavern.yaml, test_overview_endpoints.tavern.yaml

```

Regards.