### PR TITLE
Fixing memory leaks

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2215,8 +2215,9 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 return wm_vuldet_sql_error(db, stmt);
             }
             wdb_finalize(stmt);
-            free(info_it->refs->values[j]);
         }
+
+        free_strarray(info_it->refs->values);
 
         // Saving the bugzilla references corresponding to the current CVE
         for (j = 0; info_it->bugzilla_references && (j < info_it->bugzilla_references->elements) && info_it->bugzilla_references->values[j]; j++) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2231,8 +2231,9 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 return wm_vuldet_sql_error(db, stmt);
             }
             wdb_finalize(stmt);
-            free(info_it->bugzilla_references->values[j]);
         }
+
+        free_strarray(info_it->bugzilla_references->values);
 
         // Saving the advisories corresponding to the current CVE
         for (j = 0; info_it->advisories && (j < info_it->advisories->elements) && info_it->advisories->values[j]; j++) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1007,7 +1007,11 @@ int wm_vuldet_fill_report_oval_data(sqlite3 *db, sqlite3_stmt *stmt, agent_softw
         sqlite3_bind_text(stmt, 1, report->cve, -1, NULL);
         sqlite3_bind_text(stmt, 2, target, -1, NULL);
 
-        ref_count = 0;
+        for (ref_count = 0; report->references && report->references[ref_count]; ++ref_count) {
+            // Do nothing. Just counting the number of references just
+            // in case the NVD could have add some references URLs.
+        }
+
         while (SQLITE_ROW == wm_vuldet_step(stmt)) {
             reference = (char *)sqlite3_column_text(stmt, 0);
 
@@ -1038,6 +1042,11 @@ int wm_vuldet_fill_report_oval_data(sqlite3 *db, sqlite3_stmt *stmt, agent_softw
         sqlite3_bind_text(stmt, 1, report->cve, -1, NULL);
         sqlite3_bind_text(stmt, 2, target, -1, NULL);
 
+        for (bugref_count = 0; report->bugzilla_references && report->bugzilla_references[bugref_count]; ++bugref_count) {
+            // Do nothing. Just counting the number of references just
+            // in case the NVD could have add some bugzilla URLs.
+        }
+
         while (SQLITE_ROW == wm_vuldet_step(stmt)) {
             bugzilla_reference = (char *)sqlite3_column_text(stmt, 0);
             os_realloc(report->bugzilla_references, (bugref_count + 2) * sizeof(char *), report->bugzilla_references);
@@ -1054,6 +1063,11 @@ int wm_vuldet_fill_report_oval_data(sqlite3 *db, sqlite3_stmt *stmt, agent_softw
 
         sqlite3_bind_text(stmt, 1, report->cve, -1, NULL);
         sqlite3_bind_text(stmt, 2, target, -1, NULL);
+
+        for (adv_count = 0; report->advisories && report->advisories[adv_count]; ++adv_count) {
+            // Do nothing. Just counting the number of references just
+            // in case the NVD could have add some advisories.
+        }
 
         while (SQLITE_ROW == wm_vuldet_step(stmt)) {
             advisory = (char *)sqlite3_column_text(stmt, 0);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2231,7 +2231,8 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
             wdb_finalize(stmt);
         }
 
-        free_strarray(info_it->refs->values);
+        if (info_it->refs)
+            free_strarray(info_it->refs->values);
 
         // Saving the bugzilla references corresponding to the current CVE
         for (j = 0; info_it->bugzilla_references && (j < info_it->bugzilla_references->elements) && info_it->bugzilla_references->values[j]; j++) {
@@ -2247,7 +2248,8 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
             wdb_finalize(stmt);
         }
 
-        free_strarray(info_it->bugzilla_references->values);
+        if (info_it->bugzilla_references)
+            free_strarray(info_it->bugzilla_references->values);
 
         // Saving the advisories corresponding to the current CVE
         for (j = 0; info_it->advisories && (j < info_it->advisories->elements) && info_it->advisories->values[j]; j++) {
@@ -2263,7 +2265,8 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
             wdb_finalize(stmt);
         }
 
-        free_strarray(info_it->advisories->values);
+        if (info_it->advisories)
+            free_strarray(info_it->advisories->values);
 
         info_cve *info_aux = info_it;
         info_it = info_it->prev;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2247,8 +2247,9 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 return wm_vuldet_sql_error(db, stmt);
             }
             wdb_finalize(stmt);
-            free(info_it->advisories->values[j]);
         }
+
+        free_strarray(info_it->advisories->values);
 
         info_cve *info_aux = info_it;
         info_it = info_it->prev;


### PR DESCRIPTION
|Related issue|
|---|
|[Issue 675](https://github.com/wazuh/wazuh-qa/issues/675)|

## Description

This PR fixes some memory leaks discovered during the performance analysis of the overall implementation of the NVD support for Linux agents in Vulnerability Detector.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
