### PR TITLE
Optimized get default gateway in big routing tables

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -1407,7 +1407,11 @@ char* get_default_gateway(char *ifa_name){
         while (fgets(string, OS_MAXSTR, fp) != NULL){
 
             if (sscanf(string, "%s %8x %8x %d %d %d %d", if_name, &destination, &gateway, &flags, &ref, &use, &metric) == 7){
-                if (destination == 00000000 && !strcmp(if_name, interface)){
+                if (destination != 00000000) {
+                    break;
+                }
+
+                if (!strcmp(if_name, interface)) {
                     address.s_addr = gateway;
                     snprintf(def_gateway, V_LENGTH, "%s|%d", inet_ntoa(*(struct in_addr *) &address), metric);
                     fclose(fp);


### PR DESCRIPTION
|Related issue|
|---|
| #4890 |

## Description
The file /proc/net/route is opened and read to get the default gateway. We found out that the first lines of the file have the default gateway information so it is not necessary to read the entire file. 
With this we avoid reading thousands of lines in case of big routing tables.

In the Linux repository we found the function that fills/proc/net/route file:
https://github.com/torvalds/linux/blob/v3.17/net/ipv4/fib_trie.c#L2498-L2521

_prefix = htonl(l->key);_ Prefix is the Destination IP and it is store from _l->key_. The first key is 0.0.0.0/24 (default):
https://github.com/torvalds/linux/blob/v3.17/net/ipv4/fib_trie.c#L1905-L1916

## Logs/Alerts example

`# ip route show default`
> default via 10.0.2.2 dev eth0 
> default via 172.16.1.23 dev eth1 metric 100

I added a line to show the output of get_default_gateway:
> 2020/05/22 12:44:14 wazuh-modulesd: INFO: The default gateway is 10.0.2.2|0
> 2020/05/22 12:44:14 wazuh-modulesd: INFO: The default gateway is 172.16.1.23|100

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Stress test for affected components
