### PR TITLE
Avoid scanning Amazon Linux agents with the RHEL7 feed by default

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -205,9 +205,7 @@ const char *vu_package_dist[] = {
     ".el8",
     ".el7",
     ".el6",
-    ".el5",
-    "ubuntu",
-    ".amzn"
+    ".el5"
 };
 
 const char *vu_feed_tag[] = {
@@ -216,7 +214,6 @@ const char *vu_feed_tag[] = {
     "DEBIAN",
     "REDHAT",
     "CENTOS",
-    "AMAZLINUX",
     "WIN",
     // Ubuntu versions
     "PRECISE",
@@ -264,7 +261,6 @@ const char *vu_feed_ext[] = {
     "Debian",
     "Red Hat Enterprise Linux",
     "CentOS",
-    "Amazon Linux",
     "Microsoft Windows",
     // Ubuntu versions
     "Ubuntu Precise",
@@ -4250,9 +4246,6 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             } else {
                 dist_error = FEED_CENTOS;
             }
-            agent_dist = FEED_REDHAT;
-        } else if (strcasestr(os_name, vu_feed_ext[FEED_AMAZL])) {
-            agent_dist_ver = FEED_RHEL7;
             agent_dist = FEED_REDHAT;
         } else if (strcasestr(os_name, vu_feed_ext[FEED_WIN])) {
             agent_dist_ver = wm_vuldet_decode_win_os(os_name);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -162,9 +162,7 @@ typedef enum vu_package_dist_id {
     VU_RH_EXT_8,
     VU_RH_EXT_7,
     VU_RH_EXT_6,
-    VU_RH_EXT_5,
-    VU_UB_EXT,
-    VU_AMAZ_EXT
+    VU_RH_EXT_5
 } vu_package_dist_id;
 
 typedef enum pkg_logic {
@@ -207,7 +205,6 @@ typedef enum vu_feed {
     FEED_DEBIAN,
     FEED_REDHAT,
     FEED_CENTOS,
-    FEED_AMAZL,
     FEED_WIN,
     // Ubuntu versions
     FEED_PRECISE,


### PR DESCRIPTION
## Description

As reported at #3952, the Amazon Linux agents were being scanned based on the RHEL CVE vulnerabilities by default. That leads to many false positives since they don't follow the same naming convention.

This PR removes the Amazon Linux agents from the list of supported agents until the ALAS feed is available for Vulnerability Detector.

However, it is still possible to scan Amazon Linux packages by configuring them explicitly by following this guide: https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/allow_os.html

## Configuration options

To enable the Vulnerability Detector for Amazon Linux systems you would have to set the following configuration:

```xml
<provider name="redhat">
    <enabled>yes</enabled>
    <allow replaced_os="Red Hat-7">Amazon Linux-2</allow>
    <update_interval>1h</update_interval>
    <update_from_year>2010</update_from_year>
</provider>
```

## Logs/Alerts example

The behavior by default shows the following log:

```
2020/05/22 05:02:33 wazuh-modulesd:vulnerability-detector[43504] wm_vuln_detector.c:4262 at wm_vuldet_set_agents_info(): DEBUG: (5433): Agent '005' has an unsupported Wazuh version: '1-5fbd89db-amzn2'
```

When it is configured, the scan runs for that agent:

```
2020/05/22 05:33:50 wazuh-modulesd:vulnerability-detector[46213] wm_vuln_detector.c:1789 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5450): Analyzing agent '005' vulnerabilities.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] Amazon Linux agent is skipped by default
- [x] Amazon Linux agent is scanned when configuring it