### PR TITLE
Fix unexpected stop in Windows agent

### DIFF
--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -230,7 +230,9 @@ void start_daemon()
 #endif
 
     // Launch Whodata real-time thread
-    fim_whodata_initialize();
+    if(syscheck.enable_whodata) {
+        fim_whodata_initialize();
+    }
 
     // Before entering in daemon mode itself
     prev_time_sk = time(0);


### PR DESCRIPTION
# Description

Hello team,

Windows agent stops when receive Windows event 4658 (close FD) if there aren't directories to monitor in whodata mode.

There is a segmentation fault in `whodata_callback` function:

```c 
// Close fd
case 4658:
    os_calloc(1, sizeof(fim_element), item);
    item->mode = FIM_WHODATA;
    if (w_evt = OSHash_Delete_ex(syscheck.wdata.fd, hash_id), w_evt && w_evt->path) {
        ...
    }
``` 

If there aren't files/directories to monitor in whodata mode variable `syscheck.wdata.fd` doesn't initialize.

To solve it, this PR doesn't start whodata engine if there aren't directories configured on whodata.

Regards,
Eva

# Test

- [x] Windows agent doesn't stop when  4658 event is generated by Windows System
- [x] Scan-build
- [x] Integration test