### PR TITLE
Fix race condition in Analysisd when handling accumulated events

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -224,6 +224,9 @@ static pthread_mutex_t hourly_firewall_mutex = PTHREAD_MUTEX_INITIALIZER;
 /* Do diff mutex */
 static pthread_mutex_t do_diff_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+/* Accumulate mutex */
+static pthread_mutex_t accumulate_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 /* Reported variables */
 static int reported_syscheck = 0;
 static int reported_syscollector = 0;
@@ -710,7 +713,7 @@ int main_analysisd(int argc, char **argv)
 
     // Start com request thread
     w_create_thread(asyscom_main, NULL);
-    
+
     /* Load Mitre JSON File and Mitre hash table */
     mitre_load(NULL);
 
@@ -2356,7 +2359,9 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
 
         /* Run accumulator */
         if ( lf->decoder_info->accumulate == 1 ) {
+            w_mutex_lock(&accumulate_mutex);
             lf = Accumulate(lf);
+            w_mutex_unlock(&accumulate_mutex);
         }
 
         /* Firewall event */


### PR DESCRIPTION
|Related issue|
|---|
|#5068|

This issue aims to fix a race condition in Analysisd when handling events decoded with this option:
```xml
<accumulate />
```

## Change

Enclose the call to `Accumulate()` by `w_process_event_thread()` in a critical section, adding a mutex.

## Affected artifacts

- ossec-analysisd
- ossec-logtest

## Tests

The bug fixed in this PR is related to concurrency and is very hard to be covered by a unit or an integration test. On the other hand, the ruleset test cannot discover this issue since it runs sequentially.

- [X] Compile the manager on CentOS 8.
- [X] Source installation.
- [X] Cannot replicate the issue (see [comment](https://github.com/wazuh/wazuh/issues/5068#issuecomment-632757866)) having this patch applied.
- [X] Valgrind.
- [X] Stress test to the accumulator. Set `OS_ACM_EXPIRE_ELM` to `1`.
- [x] Coverity.
- [x] Scan-build.
- [X] Rules test.