### PR TITLE
[NVD] Remove false positives ubuntu

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1427,31 +1427,50 @@ int wm_vuldet_linux_rm_false_positivies(sqlite3 *db, agent_software *agent, OSHa
 
             if (pkg->feed == VU_SRC_NVD && strcmp(pkg->bin_name, PR_KERNEL) && strcmp(pkg->bin_name, PR_UBUNTU) && strcmp(pkg->bin_name, PR_DEBIAN) && strcmp(pkg->bin_name, PR_REDHAT)) {
 
-                if (wm_vuldet_prepare(db, vu_queries[VU_GET_VULN_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
-                    mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_ERROR, cve, pkg->bin_name);
-                    return wm_vuldet_sql_error(db, stmt);
-                }
+                vu_feed feed = agent->dist_ver;
 
-                sqlite3_bind_text(stmt, 1, cve, -1, NULL);
-                sqlite3_bind_text(stmt, 2, vu_feed_tag[agent->dist_ver], -1, NULL);
-                sqlite3_bind_text(stmt, 3, version_null, -1, NULL);
+                do {
+                    if (wm_vuldet_prepare(db, vu_queries[VU_GET_VULN_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
+                        mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_ERROR, cve, pkg->bin_name);
+                        return wm_vuldet_sql_error(db, stmt);
+                    }
 
-                if (agent->dist == FEED_DEBIAN && pkg->src_name) {
-                    sqlite3_bind_text(stmt, 4, pkg->src_name, -1, NULL);
-                } else {
-                    sqlite3_bind_text(stmt, 4, pkg->bin_name, -1, NULL);
-                }
+                    sqlite3_bind_text(stmt, 1, cve, -1, NULL);
+                    sqlite3_bind_text(stmt, 2, vu_feed_tag[feed], -1, NULL);
+                    sqlite3_bind_text(stmt, 3, version_null, -1, NULL);
 
-                if ((SQLITE_ROW == wm_vuldet_step(stmt)) && sqlite3_column_int(stmt, 0)) {
-                    // We can discard NVD vulnerabilities in two cases:
-                    // - The OVAL says that this package is patched or is not vulnerable.
-                    // - The OVAL says that this binary is not affected.
-                    mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_NOT_AFF, pkg->bin_name, cve, "OVAL");
-                    pkg->discard = 1;
-                    vuln_discarded++;
-                }
+                    if (agent->dist == FEED_DEBIAN && pkg->src_name) {
+                        sqlite3_bind_text(stmt, 4, pkg->src_name, -1, NULL);
+                    } else {
+                        sqlite3_bind_text(stmt, 4, pkg->bin_name, -1, NULL);
+                    }
 
-                wdb_finalize(stmt);
+                    if ((SQLITE_ROW == wm_vuldet_step(stmt)) && sqlite3_column_int(stmt, 0)) {
+                        // We can discard NVD vulnerabilities in two cases:
+                        // - The OVAL says that this package is patched or is not vulnerable.
+                        // - The OVAL says that this binary is not affected.
+                        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_NOT_AFF, pkg->bin_name, cve, "OVAL");
+                        pkg->discard = 1;
+                        vuln_discarded++;
+                        feed = FEED_UNKNOWN;
+                    }
+
+                    wdb_finalize(stmt);
+
+                    switch (feed) {
+                    case FEED_FOCAL:
+                        feed = FEED_BIONIC;
+                        break;
+                    case FEED_BIONIC:
+                        feed = FEED_XENIAL;
+                        break;
+                    case FEED_XENIAL:
+                        feed = FEED_TRUSTY;
+                        break;
+                    default:
+                        feed = FEED_UNKNOWN;
+                    }
+                } while ((feed == FEED_BIONIC) || (feed == FEED_XENIAL) || (feed == FEED_TRUSTY));
             }
 
             pkg = next;
@@ -4022,7 +4041,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
             }
             if (wm_vuldet_wdb_valid_answ(buffer)) {
                 buffer[0] = buffer[1] = ' ';
-                snprintf(json_str, OS_SIZE_6144, "{\"data\":%s}", buffer);
+                snprintf(json_str, OS_SIZE_6144 + 10, "{\"data\":%s}", buffer);
             } else {
                 goto end;
             }
@@ -6789,7 +6808,7 @@ int wm_vuldet_get_last_software_scan(char *agent_id, char scan_id[OS_SIZE_128]) 
             goto end;
         }
         buffer[0] = buffer[1] = ' ';
-        snprintf(json_str, OS_SIZE_6144, "{\"data\":%s}", buffer);
+        snprintf(json_str, OS_SIZE_6144 + 10, "{\"data\":%s}", buffer);
     } else {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_INV_WAZUHDB_RES, buffer);
         goto end;


### PR DESCRIPTION
## Description

This PR solves a problem with Canonical feed that was leading to report false positives.
When a vulnerability is fixed in a version of Ubuntu earlier than the one analized, the feed doesn't report the fix for the latest versions. To solve this, for the latest version of Ubuntu it is necesary to repeat the filter query to also check the vulnerabilities fixed in previous releases.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation