### PR TITLE
Vulnerability detector: fixing bugs reported by Coverity

### DIFF
--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -333,7 +333,7 @@ static void readJSON (cJSON *logJSON, char *parent, Eventinfo *lf)
                     value = cJSON_Print(logJSON);
                 }
 
-                if (*value) {
+                if (value && *value != '\0') {
                     fillData(lf, key, value);
                 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1590,7 +1590,7 @@ int wm_vuldet_linux_rm_false_positivies(sqlite3 *db, agent_software *agent, OSHa
                     wdb_finalize(stmt);
                 }
 
-                if (pkg->bin_name && !pkg->discard) {
+                if (!pkg->discard) {
                     if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_MATCHES_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
                         mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_ERROR, cve, pkg->bin_name);
                         return wm_vuldet_sql_error(db, stmt);
@@ -2070,18 +2070,23 @@ int wm_vuldet_debian_set_packages_ignore(sqlite3 *db, const char *target) {
         target_lower = w_tolower_str(target);
 
         if (package_json = cJSON_GetObjectItem(deb_json, package), !package_json) {
+            os_free(target_lower);
             continue;
         }
         if (cve_json = cJSON_GetObjectItem(package_json, cve), !cve_json) {
+            os_free(target_lower);
             continue;
         }
         if (releases_json = cJSON_GetObjectItem(cve_json, "releases"), !releases_json) {
+            os_free(target_lower);
             continue;
         }
         if (target_json = cJSON_GetObjectItem(releases_json, target_lower), !target_json) {
+            os_free(target_lower);
             continue;
         }
         if (status_json = cJSON_GetObjectItem(target_json, "status"), !status_json) {
+            os_free(target_lower);
             continue;
         }
         urgency_json = cJSON_GetObjectItem(target_json, "urgency");
@@ -3989,7 +3994,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
     unsigned int i;
     int size;
     char buffer[OS_SIZE_6144];
-    char json_str[OS_SIZE_6144];
+    char json_str[OS_SIZE_6144 + 10];
     char scan_id[OS_SIZE_128];
     int request;
     int retval = OS_INVALID;
@@ -6814,7 +6819,7 @@ end:
 
 int wm_vuldet_get_last_software_scan(char *agent_id, char scan_id[OS_SIZE_128]) {
     char buffer[OS_SIZE_6144];
-    char json_str[OS_SIZE_6144];
+    char json_str[OS_SIZE_6144 + 10];
     int retval = OS_INVALID;
     cJSON *obj = NULL;
     const char *jsonErrPtr;


### PR DESCRIPTION
## Description
 
The following errors reported by Coverity have been solved:

**Memory leak**

```
** CID 210510:    (RESOURCE_LEAK)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 2076 in wm_vuldet_debian_set_packages_ignore()
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 2079 in wm_vuldet_debian_set_packages_ignore()
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 2073 in wm_vuldet_debian_set_packages_ignore()

*** CID 210510:    (RESOURCE_LEAK)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 2076 in wm_vuldet_debian_set_packages_ignore()
2070             target_lower = w_tolower_str(target);
2071     
2072             if (package_json = cJSON_GetObjectItem(deb_json, package), !package_json) {
2073                 continue;
2074             }
2075             if (cve_json = cJSON_GetObjectItem(package_json, cve), !cve_json) {
>>>     CID 210510:    (RESOURCE_LEAK)
>>>     Variable "target_lower" going out of scope leaks the storage it points to.
2076                 continue;
```

**Overrun**

```
________________________________________________________________________________________________________
*** CID 210509:  Memory - corruptions  (OVERRUN)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 4064 in wm_vuldet_get_software_info()
4058             if (size > 0) {
4059                 if (size < 10) {
4060                     break;
4061                 }
4062                 if (wm_vuldet_wdb_valid_answ(buffer)) {
4063                     buffer[0] = buffer[1] = ' ';
>>>     CID 210509:  Memory - corruptions  (OVERRUN)
>>>     Overrunning array "json_str" of 6144 bytes by passing it to a function which accesses it at byte offset 6153 using argument "6154UL".
4064                     snprintf(json_str, OS_SIZE_6144 + 10, "{\"data\":%s}", buffer);
4065                 } else {
4066                     goto end;
4067                 }
4068                 if (obj) {
4069                     cJSON *new_obj;

** CID 210508:  Memory - corruptions  (OVERRUN)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 6838 in wm_vuldet_get_last_software_scan()
```

Same bug:
```
** CID 210508:  Memory - corruptions  (OVERRUN)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 6838 in wm_vuldet_get_last_software_scan()
```

**Null pointer dereferences**

```
** CID 210507:  Null pointer dereferences  (FORWARD_NULL)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 1623 in wm_vuldet_linux_rm_false_positivies()


________________________________________________________________________________________________________
*** CID 210507:  Null pointer dereferences  (FORWARD_NULL)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 1623 in wm_vuldet_linux_rm_false_positivies()
1617                             if ((tmp->feed == VU_SRC_OVAL) && !tmp->discard) {
1618     
1619                                 if (pkg->src_name && tmp->src_name && !strcmp(pkg->src_name, tmp->src_name)) {
1620                                     discard = true;
1621                                 } else if (pkg->src_name && !strcmp(pkg->src_name, tmp->bin_name)) {
1622                                     discard = true;
>>>     CID 210507:  Null pointer dereferences  (FORWARD_NULL)
>>>     Passing null pointer "pkg->bin_name" to "strcmp", which dereferences it.
1623                                 } else if (tmp->src_name && !strcmp(pkg->bin_name, tmp->src_name)) {
1624                                     discard = true;
1625                                 }
1626     
1627                                 if (discard) {
1628                                     // If the NVD says that this package isn't vulnerable,
```

**Null pointer dereferences**

```
** CID 210254:  Null pointer dereferences  (FORWARD_NULL)
/analysisd/decoders/plugins/json_decoder.c: 336 in readJSON()


________________________________________________________________________________________________________
*** CID 210254:  Null pointer dereferences  (FORWARD_NULL)
/analysisd/decoders/plugins/json_decoder.c: 336 in readJSON()
330                             }
331                         }
332                     } else if (lf->decoder_info->flags & JSON_ARRAY) {
333                         value = cJSON_Print(logJSON);
334                     }
335     
>>>     CID 210254:  Null pointer dereferences  (FORWARD_NULL)
>>>     Dereferencing null pointer "value".
336                     if (*value) {
337                         fillData(lf, key, value);
338                     }
339     
340                     os_free(value);
341                     break;
```

Passed a scan after applying the fixes to confirm they are solved.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
