### PR TITLE
Audit path removed from audit fields

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -406,11 +406,9 @@ void fim_whodata_event(whodata_evt * w_evt) {
     }
     // Otherwise, it could be a file deleted or a directory moved (or renamed).
     else {
-        #ifdef WIN32
             fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
-        #else
+        #ifndef WIN32
             char** paths = NULL;
-            char *evt_path;
             const unsigned long int inode = strtoul(w_evt->inode,NULL,10);
             const unsigned long int dev = strtoul(w_evt->dev,NULL,10);
 
@@ -418,17 +416,12 @@ void fim_whodata_event(whodata_evt * w_evt) {
             paths = fim_db_get_paths_from_inode(syscheck.database, inode, dev);
             w_mutex_unlock(&syscheck.fim_entry_mutex);
 
-            fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
-
             if(paths) {
-                evt_path = w_evt->path;
                 for(int i = 0; paths[i]; i++) {
-                    w_evt->path = paths[i];
-                    fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
+                    fim_process_missing_entry(paths[i], FIM_WHODATA, w_evt);
                     os_free(paths[i]);
                 }
                 os_free(paths);
-                w_evt->path = evt_path;
             }
         #endif
     }
@@ -1121,7 +1114,6 @@ cJSON * fim_json_compare_attrs(const fim_entry_data * old_data, const fim_entry_
 cJSON * fim_audit_json(const whodata_evt * w_evt) {
     cJSON * fim_audit = cJSON_CreateObject();
 
-    cJSON_AddStringToObject(fim_audit, "path", w_evt->path);
     cJSON_AddStringToObject(fim_audit, "user_id", w_evt->user_id);
     cJSON_AddStringToObject(fim_audit, "user_name", w_evt->user_name);
     cJSON_AddStringToObject(fim_audit, "process_name", w_evt->process_name);

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -643,9 +643,9 @@ static void test_fim_json_event_whodata(void **state) {
     cJSON *audit = cJSON_GetObjectItem(data, "audit");
     assert_non_null(audit);
     #ifdef TEST_WINAGENT
-    assert_int_equal(cJSON_GetArraySize(audit), 5);
+    assert_int_equal(cJSON_GetArraySize(audit), 4);
     #else
-    assert_int_equal(cJSON_GetArraySize(audit), 15);
+    assert_int_equal(cJSON_GetArraySize(audit), 14);
     #endif
     cJSON *diff = cJSON_GetObjectItem(data, "content_changes");
     assert_string_equal(cJSON_GetStringValue(diff), "diff");
@@ -954,13 +954,11 @@ static void test_fim_audit_json(void **state) {
 
     assert_non_null(fim_data->json);
     #ifdef TEST_WINAGENT
-    assert_int_equal(cJSON_GetArraySize(fim_data->json), 5);
+    assert_int_equal(cJSON_GetArraySize(fim_data->json), 4);
     #else
-    assert_int_equal(cJSON_GetArraySize(fim_data->json), 15);
+    assert_int_equal(cJSON_GetArraySize(fim_data->json), 14);
     #endif
 
-    cJSON *path = cJSON_GetObjectItem(fim_data->json, "path");
-    assert_string_equal(cJSON_GetStringValue(path), "./test/test.file");
     cJSON *user_id = cJSON_GetObjectItem(fim_data->json, "user_id");
     assert_string_equal(cJSON_GetStringValue(user_id), "100");
     cJSON *user_name = cJSON_GetObjectItem(fim_data->json, "user_name");


### PR DESCRIPTION
|Related issue|Related QA PR|
|---|---|
|https://github.com/wazuh/wazuh/issues/4864|https://github.com/wazuh/wazuh-qa/pull/731|

## Description
Removed the audit.path field from the alerts. It was being repetitive, since it was the same as data.path. Both variables referred to the same file, and they should never be different.


## Configuration options
`<directories whodata="yes">/test1</directories>`

## Logs/Alerts example
Audit.path no longer appears in the alert:

`
2020/05/25 09:56:10 ossec-syscheckd[2986] run_check.c:114 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/test1/realfile","mode":"whodata","type":"modified","timestamp":1590400570,"attributes":{"type":"file","size":59,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":917506,"mtime":1590400569,"hash_md5":"ef65c759140bdb9dc930ecfa4c94e19b","hash_sha1":"2de2da5ff882abcfc5b1052478cbedc7cab74da5","hash_sha256":"0d3ca30985951bbdbd6d5e3c1334c94752e966c5f591976f72b06d6efc672826","checksum":"aef4da12fbba536bd111966ed4084cf65f149d43"},"changed_attributes":["size","mtime","md5","sha1","sha256"],"old_attributes":{"type":"file","size":42,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":917506,"mtime":1590400491,"hash_md5":"c7b1af3ff2f511b8802b388664b69f6c","hash_sha1":"221995ee43d39dac5113c82856adc8d5772b026d","hash_sha256":"8b97017859fe9fc04dafc329e5a282ba435c5109636120eae7274ae8481bf192","checksum":"69a92216c180a7246b5a6f35c6789f55482ce5c7"},"audit":{"user_id":"0","user_name":"root","process_name":"/usr/bin/bash","process_id":2072,"cwd":"/","group_id":"0","group_name":"root","audit_uid":"1000","audit_name":"vagrant","effective_uid":"0","effective_name":"root","parent_name":"/usr/bin/su","parent_cwd":"/","ppid":2070}}}
`
