### PR TITLE
Fix sort parameter in /mitre endpoint

### DIFF
--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -9,7 +9,7 @@ import more_itertools
 
 from wazuh.common import database_limit
 from wazuh.exception import WazuhException
-from wazuh.utils import WazuhDBBackend, WazuhDBQuery
+from wazuh.utils import WazuhDBBackend, WazuhDBQuery, sort_array
 
 mitre_fields = {'id': 'id', 'json': 'json', 'phase_name': 'phase_name', 'platform_name': 'platform_name'}
 from_fields = "attack LEFT JOIN has_phase ON attack.id = has_phase.attack_id" \
@@ -124,5 +124,8 @@ def get_attack(id: str = None, phase_name: str = None, platform_name: str = None
     # Execute query
     db_query = WazuhDBQueryMitre(offset=offset, limit=limit, query=q, sort=sort, search=search, select=select)
     result = db_query.run()
+
+    if sort and 'json' not in sort['fields']:
+        result['items'] = sort_array(result['items'], sort_by=sort['fields'], order=sort['order'])
 
     return result


### PR DESCRIPTION
Hello team!

# Description 
The behaviour of `sort` parameter in `/mitre` endpoints was different to the behaviour in other endpoints right now. E. g:

If we have this items:

> 1, 2, 3, 4, 5, 6, 7, 8, 9, 10

When specifying sort: -<field>, limit: 3 in /mitre, it was returning items depending on the sort field, but those items wouldn't be sorted:

> 8, 9, 10

While in other endpoints (for instance /rules/requirement/{requirement}), it is sorting the response:

> 10, 9, 8

In both cases it was returning the last 3 elements, but not in the same order, so the current test_mitre_sort function was wrong.

# Fix
We already have this function which aim is sorting an array:
https://github.com/wazuh/wazuh/blob/6d39a077b25c83a63ad0207005062fdadc425b42/framework/wazuh/utils.py#L125

Therefore, we only needed to implement it in the response provided by `get_attack()` (mitre module), just after getting the results from the database.

# Tests performed
## Mocha test

```
mocha test_mitre.js 


  Mitre
    GET/sca/:agent_id
      ✓ Request (219ms)
      ✓ Pagination: limit = 1 (207ms)
      ✓ Pagination: limit = 5 (226ms)
      ✓ Pagination: limit = 10 (221ms)
      ✓ Pagination: limit > 10 (219ms)
      ✓ Retrieve all elements with limit=0 (211ms)
      ✓ Sort: +id (207ms)
      ✓ Sort: -id (226ms)
      ✓ Filters: id (208ms)
      ✓ Filters: id (request returns 0 items) (211ms)
      ✓ Filters: phase_name=initial access (231ms)
      ✓ Filters: phase_name=persistence (208ms)
      ✓ Filters: phase_name (request returns 0 items) (201ms)
      ✓ Filters: platform_name=linux (209ms)
      ✓ Filters: platform_name=macos (217ms)
      ✓ Filters: platform_name=windows (236ms)
      ✓ Filters: platform_name=windows,phase_name=persistence (260ms)
      ✓ Filters: platform_name=linux,phase_name=execution (206ms)
      ✓ Filters: platform_name=macos,phase_name=impact (220ms)
      ✓ Filters: platform_name (request returns 0 items) (219ms)
      ✓ Filters: q=id=T1015 (204ms)
      ✓ Filters: q=platform_name=linux (219ms)
      ✓ Filters: q=phase_name=execution (202ms)
      ✓ Filters: q (request returns 0 items) (203ms)
      ✓ Filters: q (wrong query 1) (217ms)
      ✓ Filters: q (wrong query 2) (204ms)
      ✓ Filters: q (wrong query 3) (199ms)
      ✓ Filters: select=id,phase_name,platform_name (257ms)
      ✓ Filters: select=id,json,platform_name (233ms)
      ✓ Filters: select=platform (wrong field) (228ms)
      ✓ Search (213ms)
      ✓ Search (returns 0 items) (216ms)


  32 passing (7s)
```

Kind regards,
Selu.