### PR TITLE
Fix and refactor get_rules

### DIFF
--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -63,6 +63,8 @@ def get_rules(rule_ids=None, status=None, group=None, pci_dss=None, gpg13=None, 
     original_rules = list(rules)
     no_existent_ids = rule_ids[:]
     for r in original_rules:
+        if r['id'] in no_existent_ids:
+            no_existent_ids.remove(r['id'])
         for key, value in parameters.items():
             if value:
                 if key == 'level' and (len(value) == 1 and int(value[0]) != r['level'] or len(value) == 2
@@ -71,8 +73,6 @@ def get_rules(rule_ids=None, status=None, group=None, pci_dss=None, gpg13=None, 
                         (key == 'filename' and r[key] not in filename) or \
                         (key == 'status' and r[key] not in value) or \
                         (not isinstance(value, list) and value not in r[key]):
-                    if r['id'] in no_existent_ids:
-                        no_existent_ids.remove(r['id'])
                     rules.remove(r)
                     break
 

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -65,21 +65,17 @@ def get_rules(rule_ids=None, status=None, group=None, pci_dss=None, gpg13=None, 
     for r in original_rules:
         for key, value in parameters.items():
             if value:
-                if key == 'level' and r in rules:
-                    if len(value) == 1 and int(value[0]) != r['level'] or len(value) == 2 and \
-                            not int(value[0]) <= r['level'] <= int(value[1]):
-                        rules.remove(r)
-                elif key == 'id':
-                    if r[key] not in value and r in rules:
-                        rules.remove(r)
-                    elif r[key] in no_existent_ids:
-                        no_existent_ids.remove(r[key])
-                elif key == 'filename' and r[key] not in filename and r in rules:
+                if key == 'level' and (len(value) == 1 and int(value[0]) != r['level'] or len(value) == 2
+                                       and not int(value[0]) <= r['level'] <= int(value[1])) or \
+                        (key == 'id' and r[key] not in value) or \
+                        (key == 'filename' and r[key] not in filename) or \
+                        (key == 'status' and r[key] not in value) or \
+                        (not isinstance(value, list) and value not in r[key]):
+                    if r['id'] in no_existent_ids:
+                        no_existent_ids.remove(r['id'])
                     rules.remove(r)
-                elif key == 'status' and r[key] not in value and r in rules:
-                    rules.remove(r)
-                elif not isinstance(value, list) and value not in r[key]:
-                    rules.remove(r)
+                    break
+
     for rule_id in no_existent_ids:
         result.add_failed_item(id_=rule_id, error=WazuhError(1208))
 

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -137,6 +137,8 @@ def test_failed_get_rules_file(mock_config):
 
 
 @pytest.mark.parametrize('arg', [
+    {'group': 'web', 'pci_dss': 'user1'},
+    {'rule_ids': ['31301'], 'filename': '0025-sendmail_rules.xml'},
     {'group': 'user1'},
     {'pci_dss': 'user1'},
     {'gpg13': '10.0'},


### PR DESCRIPTION
Hello team.

An error in the framework was reported when trying to use two filters on `GET /rules`. If there was a rule that could not match any of the filters, an exception would be raised.

This was not detected by our unit tests, so we have added some new ones.

# Test results
## Integration tests
```
Collected tests [1]:
test_rules_endpoints.tavern.yaml


test_rules_endpoints.tavern.yaml 
	 11 passed, 13 warnings
```

## Unit tests
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: tavern-1.0.0
collected 47 items                                                             

wazuh/tests/test_rule.py ............................................... [100%]

=============================== warnings summary ===============================
wazuh/results.py:19
  /home/vicferpoy/Desktop/Git/wazuh/framework/wazuh/results.py:19: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    class AbstractWazuhResult(collections.MutableMapping):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================== 47 passed, 1 warning in 0.29s =========================
```

Regards.
