### PR TITLE
Correct typo in default configuration fields

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -23,7 +23,7 @@
         </Property>
         <Property Id="WAZUH_REGISTRATION_CERTIFICATE" Secure="yes">
         </Property>
-        <Property Id="WAZUH_REGISTRARTION_KEY" Secure="yes">
+        <Property Id="WAZUH_REGISTRATION_KEY" Secure="yes">
         </Property>
         <Property Id="WAZUH_AGENT_NAME" Secure="yes">
         </Property>


### PR DESCRIPTION
## Description

Corrects a typo in the W32 installer configuration for the default properties