### PR TITLE
Move enrollment process after privilege change

### DIFF
--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -162,47 +162,6 @@ int main(int argc, char **argv)
         merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
-    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
-        // If autoenrollment is enabled, we will avoid exit if there is no valid key
-        OS_PassEmptyKeyfile();
-    } else {
-        /* Check auth keys */
-        if (!OS_CheckKeys()) {
-            merror_exit(AG_NOKEYS_EXIT);
-        }
-    }
-    
-    /* Check client keys */
-    OS_ReadKeys(&keys, 1, 0, 0);
-
-    /* Check if we need to auto-enroll */
-    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
-        int registration_status = -1;
-        int rc = 0;
-
-        if (agt->enrollment_cfg->target_cfg->manager_name) {
-            // Configured enrollment server
-            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
-        } 
-        
-        // Try to enroll to server list
-        while (agt->server[rc].rip && (registration_status != 0)) {
-            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
-            rc++;
-        }
-        
-
-        if(registration_status == 0) {
-            // Wait for key update on agent side
-            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
-            sleep(agt->enrollment_cfg->delay_after_enrollment);
-            // Update keys to get obtained key
-            OS_UpdateKeys(&keys);
-        } else {
-            merror_exit(AG_ENROLL_FAIL);
-        }
-    }
-
     /* Exit if test config */
     if (test_config) {
         exit(0);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -225,6 +225,8 @@ void start_agent(int is_startup)
                             sleep(agt->enrollment_cfg->delay_after_enrollment);
                             // Successfull enroll, read keys
                             OS_UpdateKeys(&keys);
+                            // Set the crypto method for the agent
+                            os_set_agent_crypto_method(&keys,agt->crypto_method);
                         }
                     }
                     if (!connect_server(agt->rip_id)) {

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -217,12 +217,8 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
     __memclear(id, name, ip, key, KEYSIZE + 1);
     memset(buffer, '\0', OS_BUFFER_SIZE + 1);
 
-    if (!fp) {
-        return;
-    }
-
     /* Read each line. Lines are divided as "id name ip key" */
-    while (fgets(buffer, OS_BUFFER_SIZE, fp) != NULL) {
+    while (fp && fgets(buffer, OS_BUFFER_SIZE, fp) != NULL) {
         char *tmp_str;
         char *valid_str;
 
@@ -314,8 +310,10 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
     }
 
     /* Close key file */
-    fclose(fp);
-    fp = NULL;
+    if (fp) {
+        fclose(fp);
+        fp = NULL;
+    }
 
     /* Clear one last time before leaving */
     __memclear(id, name, ip, key, KEYSIZE + 1);

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -217,107 +217,110 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
     __memclear(id, name, ip, key, KEYSIZE + 1);
     memset(buffer, '\0', OS_BUFFER_SIZE + 1);
 
-    /* Read each line. Lines are divided as "id name ip key" */
-    while (fp && fgets(buffer, OS_BUFFER_SIZE, fp) != NULL) {
-        char *tmp_str;
-        char *valid_str;
+    /* Add additional entry for sender == keysize */
+    os_calloc(1, sizeof(keyentry), keys->keyentries[keys->keysize]);
+    w_mutex_init(&keys->keyentries[keys->keysize]->mutex, NULL);
 
-        if ((buffer[0] == '#') || (buffer[0] == ' ')) {
-            continue;
-        }
+    if(fp) {
+        /* Read each line. Lines are divided as "id name ip key" */
+        while (fgets(buffer, OS_BUFFER_SIZE, fp) != NULL) {
+            char *tmp_str;
+            char *valid_str;
 
-        /* Get ID */
-        valid_str = buffer;
-        tmp_str = strchr(buffer, ' ');
-        if (!tmp_str) {
-            merror(INVALID_KEY, buffer);
-            continue;
-        }
+            if ((buffer[0] == '#') || (buffer[0] == ' ')) {
+                continue;
+            }
 
-        *tmp_str = '\0';
-        tmp_str++;
-        strncpy(id, valid_str, KEYSIZE - 1);
+            /* Get ID */
+            valid_str = buffer;
+            tmp_str = strchr(buffer, ' ');
+            if (!tmp_str) {
+                merror(INVALID_KEY, buffer);
+                continue;
+            }
 
-        /* Update counter */
+            *tmp_str = '\0';
+            tmp_str++;
+            strncpy(id, valid_str, KEYSIZE - 1);
 
-        id_number = strtol(id, &end, 10);
+            /* Update counter */
 
-        if (!*end && id_number > keys->id_counter)
-            keys->id_counter = id_number;
+            id_number = strtol(id, &end, 10);
 
-        /* Removed entry */
-        if (*tmp_str == '#' || *tmp_str == '!') {
-            if (save_removed) {
-                tmp_str[-1] = ' ';
-                tmp_str = strchr(tmp_str, '\n');
+            if (!*end && id_number > keys->id_counter)
+                keys->id_counter = id_number;
 
-                if (tmp_str) {
-                    *tmp_str = '\0';
+            /* Removed entry */
+            if (*tmp_str == '#' || *tmp_str == '!') {
+                if (save_removed) {
+                    tmp_str[-1] = ' ';
+                    tmp_str = strchr(tmp_str, '\n');
+
+                    if (tmp_str) {
+                        *tmp_str = '\0';
+                    }
+
+                    save_removed_key(keys, buffer);
                 }
 
-                save_removed_key(keys, buffer);
+                continue;
+            }
+
+            /* Get name */
+            valid_str = tmp_str;
+            tmp_str = strchr(tmp_str, ' ');
+            if (!tmp_str) {
+                merror(INVALID_KEY, buffer);
+                continue;
+            }
+
+            *tmp_str = '\0';
+            tmp_str++;
+            strncpy(name, valid_str, KEYSIZE - 1);
+
+            /* Get IP address */
+            valid_str = tmp_str;
+            tmp_str = strchr(tmp_str, ' ');
+            if (!tmp_str) {
+                merror(INVALID_KEY, buffer);
+                continue;
+            }
+
+            *tmp_str = '\0';
+            tmp_str++;
+            strncpy(ip, valid_str, KEYSIZE - 1);
+
+            /* Get key */
+            valid_str = tmp_str;
+            tmp_str = strchr(tmp_str, '\n');
+            if (tmp_str) {
+                *tmp_str = '\0';
+            }
+
+            strncpy(key, valid_str, KEYSIZE - 1);
+
+            /* Generate the key hash */
+            OS_AddKey(keys, id, name, ip, key);
+
+            /* Clear the memory */
+            __memclear(id, name, ip, key, KEYSIZE + 1);
+
+            /* Check for maximum agent size */
+            if ( !no_limit && keys->keysize >= (MAX_AGENTS - 2) ) {
+                merror(AG_MAX_ERROR, MAX_AGENTS - 2);
+                merror_exit(CONFIG_ERROR, keys_file);
             }
 
             continue;
         }
 
-        /* Get name */
-        valid_str = tmp_str;
-        tmp_str = strchr(tmp_str, ' ');
-        if (!tmp_str) {
-            merror(INVALID_KEY, buffer);
-            continue;
-        }
-
-        *tmp_str = '\0';
-        tmp_str++;
-        strncpy(name, valid_str, KEYSIZE - 1);
-
-        /* Get IP address */
-        valid_str = tmp_str;
-        tmp_str = strchr(tmp_str, ' ');
-        if (!tmp_str) {
-            merror(INVALID_KEY, buffer);
-            continue;
-        }
-
-        *tmp_str = '\0';
-        tmp_str++;
-        strncpy(ip, valid_str, KEYSIZE - 1);
-
-        /* Get key */
-        valid_str = tmp_str;
-        tmp_str = strchr(tmp_str, '\n');
-        if (tmp_str) {
-            *tmp_str = '\0';
-        }
-
-        strncpy(key, valid_str, KEYSIZE - 1);
-
-        /* Generate the key hash */
-        OS_AddKey(keys, id, name, ip, key);
-
-        /* Clear the memory */
-        __memclear(id, name, ip, key, KEYSIZE + 1);
-
-        /* Check for maximum agent size */
-        if ( !no_limit && keys->keysize >= (MAX_AGENTS - 2) ) {
-            merror(AG_MAX_ERROR, MAX_AGENTS - 2);
-            merror_exit(CONFIG_ERROR, keys_file);
-        }
-
-        continue;
-    }
-
-    /* Close key file */
-    if (fp) {
         fclose(fp);
         fp = NULL;
+
+        /* Clear one last time before leaving */
+        __memclear(id, name, ip, key, KEYSIZE + 1);
     }
-
-    /* Clear one last time before leaving */
-    __memclear(id, name, ip, key, KEYSIZE + 1);
-
+    
     /* Check if there are any agents available */
     if (keys->keysize == 0) {
         if (pass_empty_keyfile) {
@@ -326,10 +329,6 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed, int no_limit
             merror_exit(NO_CLIENT_KEYS);
         }
     }
-
-    /* Add additional entry for sender == keysize */
-    os_calloc(1, sizeof(keyentry), keys->keyentries[keys->keysize]);
-    w_mutex_init(&keys->keyentries[keys->keysize]->mutex, NULL);
 
     return;
 }


### PR DESCRIPTION
|Related issue|
|---|
| #5092  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The problem resided in the `OS_UpdateKeys(&keys);` in the `main.c` of agentd. Since this function is called before the privilege changes, the `rids` files are created as root when `ossec-agentd` starts with an empty keys file. This causes issues when the files are opened after privilege changes. The solution is to make sure the enrollment process is done after privilege changes.

## Configuration options

Default auto-enrollment configuration with an empty `client.keys` file.

## Tests

Changes does not affect Windows agent, so windows case has not been tested

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [x] MAC OS X
- [X] Source installation
- [X] Review logs syntax and correct language
- [X] Integration tests for agentd 

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer