### PR TITLE
Fix crypto-method unset

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -225,6 +225,8 @@ void start_agent(int is_startup)
                             sleep(agt->enrollment_cfg->delay_after_enrollment);
                             // Successfull enroll, read keys
                             OS_UpdateKeys(&keys);
+                            // Set the crypto method for the agent
+                            os_set_agent_crypto_method(&keys,agt->crypto_method);
                         }
                     }
                     if (!connect_server(agt->rip_id)) {


### PR DESCRIPTION
|Related issue|
|---|
| #5113  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

os_set_agent_crypto_method() must be used after reading keys file in order to set again the cryptografic method using during comunication. This setup is missing when Agent loses comunication with Manager and asks to auto-enroll.

## Configuration options

Default auto-enrollment configuration with valid keys in `client.keys` file.
Manager able to discard comunication with Agent to reproduce the scenario.

## Tests

Changes does not affect Windows agent, so windows case has not been tested

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] MAC OS X
- [X] Source installation
- [X] Review logs syntax and correct language
- [X] Integration tests for agentd 

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer