### PR TITLE
Fixed CPython build in ArchLinux host

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1568,7 +1568,7 @@ install_dependencies: install_python
 install_framework: install_python
 	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET}
 	chown -R root:${OSSEC_GROUP} ${WPYTHON_DIR}
-	chmod -R o=- ${WPYTHON_DIR}/*
+	chmod -R o=- ${WPYTHON_DIR}
 
 install_mitre: install_python
 	cd ../tools/mitre && ${WPYTHON_DIR}/bin/python3 mitredb.py -d ${PREFIX}/var/db/mitre.db

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,8 @@ uname_P := $(shell sh -c 'uname -p 2>/dev/null || echo not')
 uname_R := $(shell sh -c 'uname -r 2>/dev/null || echo not')
 HAS_CHECKMODULE = $(shell command -v checkmodule > /dev/null && echo YES)
 HAS_SEMODULE_PACKAGE = $(shell command -v semodule_package > /dev/null && echo YES)
+CHECK_ARCHLINUX := $(shell sh -c 'grep "Arch Linux" /etc/os-release > /dev/null && echo YES || echo not')
+ARCH_FLAGS =
 
 ROUTE_PATH := $(shell pwd)
 EXTERNAL_JSON=external/cJSON/
@@ -95,6 +97,9 @@ ifeq (${uname_S},Linux)
 		USE_AUDIT=yes
 ifneq (,$(filter ${USE_AUDIT},YES yes y Y 1))
 		OSSEC_CFLAGS+=-I$(EXTERNAL_AUDIT)lib
+endif
+ifeq (${CHECK_ARCHLINUX},YES)
+		ARCH_FLAGS+=-lnghttp2 -lbrotlidec -lpsl
 endif
 else
 ifeq (${uname_S},AIX)
@@ -1542,7 +1547,7 @@ ifeq (,$(wildcard ${EXTERNAL_CPYTHON}/python.exe))
 endif
 else
 ifeq (,$(wildcard ${EXTERNAL_CPYTHON}/python))
-	export WPATH_LIB="'\$$\$$ORIGIN/../../../lib'" && export SOURCE_PATH=${ROUTE_PATH} && export WAZUH_FFI_PATH=${EXTERNAL_LIBFFI} && export LD_LIBRARY_PATH=${ROUTE_PATH} && cd ${EXTERNAL_CPYTHON} && ./configure --prefix="${WPYTHON_DIR}" --libdir="${WPYTHON_DIR}/lib" --enable-shared --with-openssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LDFLAGS="-L${ROUTE_PATH} -lwazuhext -Wl,-rpath,'\$$\$$ORIGIN/../../../lib',--disable-new-dtags" CPPFLAGS="-I${ROUTE_PATH}/${EXTERNAL_OPENSSL}" $(CPYTHON_FLAGS) && ${MAKE}
+	export WPATH_LIB="'\$$\$$ORIGIN/../../../lib'" && export SOURCE_PATH=${ROUTE_PATH} && export WAZUH_FFI_PATH=${EXTERNAL_LIBFFI} && export LD_LIBRARY_PATH=${ROUTE_PATH} && cd ${EXTERNAL_CPYTHON} && ./configure --prefix="${WPYTHON_DIR}" --libdir="${WPYTHON_DIR}/lib" --enable-shared --with-openssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LDFLAGS="${ARCH_FLAGS} -L${ROUTE_PATH} -lwazuhext -Wl,-rpath,'\$$\$$ORIGIN/../../../lib',--disable-new-dtags" CPPFLAGS="-I${ROUTE_PATH}/${EXTERNAL_OPENSSL}" $(CPYTHON_FLAGS) && ${MAKE}
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,6 +100,7 @@ ifneq (,$(filter ${USE_AUDIT},YES yes y Y 1))
 endif
 ifeq (${CHECK_ARCHLINUX},YES)
 		ARCH_FLAGS+=-lnghttp2 -lbrotlidec -lpsl
+		OSSEC_LDFLAGS+=-lnghttp2 -lbrotlidec -lpsl
 endif
 else
 ifeq (${uname_S},AIX)

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -121,7 +121,7 @@ WazuhUpgrade()
     rm -f $DIRECTORY/queue/vulnerabilities/cve.db
 
     # Remove OpenSCAP policies if the module is disabled
-    if stat $DIRECTORY/wodles/oscap/content/* > /dev/null ; then
+    if stat $DIRECTORY/wodles/oscap/content/* 2> /dev/null ; then
 
         is_disabled="$(CheckModuleIsEnabled '<wodle name="open-scap">' '</wodle>' 'disabled')"
 


### PR DESCRIPTION
Previously, to build the CPython interpreter in ArchLinux we need to run
the Makefile as follows `LIBS="-lnghttp2 -lbrotlidec -lpsl" make -C src
TARGET=server`

This commit fix this issue by checking in the Makefile if the host is
ArchLinux or not.

|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3012|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

This PR makes it easier to build the wazuh-manager on ArchLinux. To do so, previously you need to build it as follows in order to build the CPython interpreter correctly:
```
LIBS="-lnghttp2 -lbrotlidec -lpsl" make -C src TARGET=server
```

Now, the Makefile will check if the host is ArchLinux or not and will add automatically this flags to the `build_python` target.

## Configuration options
NA

## Logs/Alerts example
NA

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
