### PR TITLE
Vulnerability Detector: Fixing minor issues

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -327,7 +327,6 @@
       "data.vulnerability.title",
       "data.vulnerability.assigner",
       "data.vulnerability.cve_version",
-      "data.vulnerability.alert_origin",
       "data.win.eventdata.auditPolicyChanges",
       "data.win.eventdata.auditPolicyChangesId",
       "data.win.eventdata.binary",
@@ -1715,9 +1714,6 @@
                 "type": "keyword"
               },
               "cve_version": {
-                "type": "keyword"
-              },
-              "alert_origin": {
                 "type": "keyword"
               }
             }

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -87,6 +87,7 @@
 #define VU_END_SCAN           "(5472): Vulnerability scan finished."
 #define VU_NO_SRC_VERSION     "(5480): Unable to get the source '%s' version for agent '%.3d'"
 #define VU_NO_SRC_NAME        "(5481): Unable to get the source '%s' name for agent '%.3d'"
+#define VU_VULN_SEND_AG_FEED  "(5482): A total of '%d' vulnerabilities have been reported for agent '%.3d' thanks to the '%s' feed."
 
 /* File integrity monitoring debug messages */
 #define FIM_DIFF_SKIPPED                    "(6200): Diff execution skipped for containing insecure characters."

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -52,7 +52,6 @@ static int build_test_cve_report(vu_report* report, int add_title, int add_condi
     if (1 == add_ip)
         os_strdup("192.168.0.125", report->agent_ip);
 
-    os_strdup("NVD and vendor feeds", report->alert_origin);
     os_strdup("CVE-2016-6489", report->cve);
     os_strdup("The CVE description or rationale.", report->rationale);
     os_strdup("2020-03-05 15:15:00 UTC", report->published);
@@ -2492,6 +2491,10 @@ void test_wm_vuldet_send_agent_report_no_hash_node_rh(void **state)
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'vendor' feed.");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5469): A total of '0' vulnerabilities have been reported for agent '000'");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
@@ -2517,6 +2520,10 @@ void test_wm_vuldet_send_agent_report_no_hash_node_ubuntu(void **state)
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'vendor' feed.");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5469): A total of '0' vulnerabilities have been reported for agent '000'");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
@@ -2888,6 +2895,10 @@ void test_wm_vuldet_send_agent_send_cve_report(void **state)
     expect_string(__wrap__mterror, formatted_msg, "(5559): Could not send the 'CVE-2016-6489' report for 'libhogweed4' in the agent '000'");
     will_return(__wrap_OSHash_Next, NULL);
 
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'vendor' feed.");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5469): A total of '0' vulnerabilities have been reported for agent '000'");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
@@ -3747,8 +3758,6 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "alert_origin");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->alert_origin);
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
@@ -3861,8 +3870,6 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "alert_origin");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->alert_origin);
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
@@ -3980,8 +3987,6 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "alert_origin");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->alert_origin);
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
@@ -4105,8 +4110,6 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "alert_origin");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->alert_origin);
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
@@ -4246,8 +4249,6 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "alert_origin");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->alert_origin);
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
@@ -4387,8 +4388,6 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "alert_origin");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->alert_origin);
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
@@ -4528,8 +4527,6 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "alert_origin");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->alert_origin);
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
@@ -4669,8 +4666,6 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "alert_origin");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->alert_origin);
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
@@ -5558,6 +5553,10 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
     will_return(__wrap_cJSON_CreateObject, NULL);
     will_return(__wrap_OSHash_Next, NULL);
 
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'vendor' feed.");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5469): A total of '0' vulnerabilities have been reported for agent '000'");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -47,7 +47,7 @@ static int build_test_cve_report(vu_report* report, int add_title, int add_condi
         os_strdup("The CVE title.", report->title);
 
     if (1 == add_condition)
-        os_strdup("package is less than 4.3-2", report->condition);
+        os_strdup("Package less than 4.3-2", report->condition);
 
     if (1 == add_ip)
         os_strdup("192.168.0.125", report->agent_ip);
@@ -156,7 +156,7 @@ static int build_test_hash_node(OSHashNode* node, uint8_t feed) {
     os_strdup("Pending confirmation", vuln_cond->state);
     os_strdup("CVE-2016-6489 reports as vulnerable all the versions of this package", vuln_cond->operation);
     os_strdup("4.3-2", vuln_cond->operation_value);
-    os_strdup("package is less than 4.3-2", vuln_cond->condition);
+    os_strdup("Package less than 4.3-2", vuln_cond->condition);
 
     next->vuln_cond = vuln_cond;
 
@@ -1488,7 +1488,7 @@ void test_wm_vuldet_build_nvd_report_condition_both_including(void **state)
 
     wm_vuldet_build_nvd_report_condition(nvd_cond, report);
 
-    assert_string_equal("package is greater or equal than 10.5.0 and is less or equal than 10.7.1", report->condition);
+    assert_string_equal("Package greater or equal than 10.5.0 and less or equal than 10.7.1", report->condition);
 
     os_free(nvd_cond->start_version);
     os_free(nvd_cond->end_version);
@@ -1514,7 +1514,7 @@ void test_wm_vuldet_build_nvd_report_condition_both_excluding(void **state) {
 
     wm_vuldet_build_nvd_report_condition(nvd_cond, report);
 
-    assert_string_equal("package is greater than 10.5.0 and is less than 10.7.1", report->condition);
+    assert_string_equal("Package greater than 10.5.0 and less than 10.7.1", report->condition);
 
     os_free(nvd_cond->start_version);
     os_free(nvd_cond->end_version);
@@ -1538,7 +1538,7 @@ void test_wm_vuldet_build_nvd_report_condition_start_including(void **state) {
 
     wm_vuldet_build_nvd_report_condition(nvd_cond, report);
 
-    assert_string_equal("package is greater or equal than 10.5.0", report->condition);
+    assert_string_equal("Package greater or equal than 10.5.0", report->condition);
 
     os_free(nvd_cond->start_version);
     os_free(nvd_cond->end_version);
@@ -1562,7 +1562,7 @@ void test_wm_vuldet_build_nvd_report_condition_start_excluding(void **state) {
 
     wm_vuldet_build_nvd_report_condition(nvd_cond, report);
 
-    assert_string_equal("package is greater than 10.5.0", report->condition);
+    assert_string_equal("Package greater than 10.5.0", report->condition);
 
     os_free(nvd_cond->start_version);
     os_free(nvd_cond->end_version);
@@ -1586,7 +1586,7 @@ void test_wm_vuldet_build_nvd_report_condition_end_including(void **state) {
 
     wm_vuldet_build_nvd_report_condition(nvd_cond, report);
 
-    assert_string_equal("package is less or equal than 10.7.1", report->condition);
+    assert_string_equal("Package less or equal than 10.7.1", report->condition);
 
     os_free(nvd_cond->start_version);
     os_free(nvd_cond->end_version);
@@ -1610,7 +1610,7 @@ void test_wm_vuldet_build_nvd_report_condition_end_excluding(void **state) {
 
     wm_vuldet_build_nvd_report_condition(nvd_cond, report);
 
-    assert_string_equal("package is less than 10.7.1", report->condition);
+    assert_string_equal("Package less than 10.7.1", report->condition);
 
     os_free(nvd_cond->start_version);
     os_free(nvd_cond->end_version);
@@ -4140,7 +4140,7 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'package is less than 4.3-2'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
 
     will_return(__wrap_SendMSG, OS_SUCCESS);
 
@@ -4418,7 +4418,7 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'package is less than 4.3-2'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
 
     will_return(__wrap_SendMSG, OS_SUCCESS);
 
@@ -4557,7 +4557,7 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (3.4-1) from agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'package is less than 4.3-2'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (3.4-1) from agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
 
     will_return(__wrap_SendMSG, OS_SUCCESS);
 
@@ -4696,7 +4696,7 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (3.4-1) from agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'package is less than 4.3-2'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (3.4-1) from agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
     will_return(__wrap_SendMSG, OS_INVALID);
 
     char* strerr = NULL;
@@ -4960,7 +4960,7 @@ void test_wm_vuldet_add_cve_node(void **state)
     os_strdup("fixed", newPkg->vuln_cond->state);
     os_strdup("less than", newPkg->vuln_cond->operation);
     os_strdup("5.5.2", newPkg->vuln_cond->operation_value);
-    os_strdup("package is less than 5.5.2", newPkg->vuln_cond->condition);
+    os_strdup("Package less than 5.5.2", newPkg->vuln_cond->condition);
 
     char *cve = NULL;
     os_strdup("CVE-2016-6489", cve);
@@ -5059,7 +5059,7 @@ void test_wm_vuldet_free_cve_node(void **state)
     os_strdup("fixed", pkg->vuln_cond->state);
     os_strdup("less than", pkg->vuln_cond->operation);
     os_strdup("1:1.2.3-4.5.7", pkg->vuln_cond->operation_value);
-    os_strdup("package is less than 1:1.2.3-4.5.7", pkg->vuln_cond->condition);
+    os_strdup("Package less than 1:1.2.3-4.5.7", pkg->vuln_cond->condition);
 
     pkg->next = next_pkg;
     next_pkg->nvd_cond = nvd_cond2;
@@ -5075,7 +5075,7 @@ void test_wm_vuldet_free_cve_node(void **state)
     os_strdup("fixed", next_pkg->vuln_cond->state);
     os_strdup("less than", next_pkg->vuln_cond->operation);
     os_strdup("1:1.2.3-4.5.7", next_pkg->vuln_cond->operation_value);
-    os_strdup("package is less than 1:1.2.3-4.5.7", next_pkg->vuln_cond->condition);
+    os_strdup("Package less than 1:1.2.3-4.5.7", next_pkg->vuln_cond->condition);
 
     wm_vuldet_free_cve_node(pkg);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -783,9 +783,9 @@ void wm_vuldet_build_nvd_report_condition(cve_vuln_cond_NVD *nvd_cond, vu_report
     report->pending = nvd_cond->end_version ? 0 : 1;
     // building condition
     if (nvd_cond->start_version && nvd_cond->end_version) {
-        const char* start = "package is";
+        const char* start = "Package";
         const char* condition1 = (nvd_cond->start_operation == START_INCLUDED) ? "greater or equal than" : "greater than";
-        const char* middle = "and is";
+        const char* middle = "and";
         const char* condition2 = (nvd_cond->end_operation == END_INCLUDED) ? "less or equal than" : "less than";
         size_t size = strlen(start) + 1 + strlen(condition1) + 1 + strlen(nvd_cond->start_version) + 1 +
                         strlen(middle) + 1 + strlen(condition2) + 1 + strlen(nvd_cond->end_version);
@@ -795,7 +795,7 @@ void wm_vuldet_build_nvd_report_condition(cve_vuln_cond_NVD *nvd_cond, vu_report
         middle, condition2, nvd_cond->end_version);
     }
     else if (nvd_cond->start_version) {
-        const char* start = "package is";
+        const char* start = "Package";
         const char* condition = (nvd_cond->start_operation == START_INCLUDED) ? "greater or equal than" : "greater than";
         size_t size = strlen(start) + 1 + strlen(condition) + 1 + strlen(nvd_cond->start_version);
         os_calloc(size + 1, sizeof(char), report->condition);
@@ -803,7 +803,7 @@ void wm_vuldet_build_nvd_report_condition(cve_vuln_cond_NVD *nvd_cond, vu_report
         start, condition, nvd_cond->start_version);
     }
     else if (nvd_cond->end_version) {
-        const char* start = "package is";
+        const char* start = "Package";
         const char* condition = (nvd_cond->end_operation == END_INCLUDED) ? "less or equal than" : "less than";
         size_t size = strlen(start) + 1 + strlen(condition) + 1 + strlen(nvd_cond->end_version);
         os_calloc(size + 1, sizeof(char), report->condition);
@@ -811,7 +811,7 @@ void wm_vuldet_build_nvd_report_condition(cve_vuln_cond_NVD *nvd_cond, vu_report
         start, condition, nvd_cond->end_version);
     }
     else {
-        const char* text = "package matches a vulnerable version";
+        const char* text = "Package matches a vulnerable version";
         os_calloc(strlen(text) + 1, sizeof(char), report->condition);
         sprintf(report->condition, "%s", text);
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1785,6 +1785,7 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
             break;
         case 1:
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DUPLICATED_PACKAGE, package, cve, version, operation, operation_value, "OVAL");
+            vuln_count++;
             wm_vuldet_free_cve_node(vuln_pkg);
             break;
         case 0:

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5934,7 +5934,7 @@ int wm_vuldet_get_oslinux_info(agent_software *agent) {
         char *major;
         char *minor;
         w_strdup(obj_it->valuestring, major);
-        if ((obj_it = cJSON_GetObjectItem(obj_it, "os_minor")) && obj_it->valuestring) {
+        if ((obj_it = obj->child) && (obj_it = cJSON_GetObjectItem(obj_it, "os_minor")) && obj_it->valuestring) {
             w_strdup(obj_it->valuestring, minor);
         } else {
             w_strdup("0", minor);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -771,7 +771,6 @@ void wm_vuldet_free_report(vu_report *report) {
     os_free(report->agent_name);
     os_free(report->agent_ip);
     // Metadata
-    os_free(report->alert_origin);
     os_free(report);
 }
 
@@ -1114,6 +1113,8 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
     vu_report *report;
     time_t start_time;
     int vuln_reported = 0;
+    int vuln_reported_nvd = 0;
+    int vuln_reported_vendor = 0;
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_START_VUL_AG_SEND, atoi(agents_it->agent_id));
 
@@ -1162,16 +1163,6 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
             }
             w_strdup(pkg->arch, report->arch);
 
-            if ((pkg->feed & VU_SRC_NVD) && (pkg->feed & VU_SRC_OVAL)) {
-                os_strdup("NVD and vendor feeds", report->alert_origin);
-            }
-            else if (pkg->feed & VU_SRC_NVD) {
-                os_strdup("NVD feed", report->alert_origin);
-            }
-            else if (pkg->feed & VU_SRC_OVAL) {
-                os_strdup("Vendor feed", report->alert_origin);
-            }
-
             // Adding data from NVD
             if (pkg->nvd_cond) wm_vuldet_build_nvd_report_condition(pkg->nvd_cond, report);
 
@@ -1202,6 +1193,12 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
             if (wm_vuldet_send_cve_report(report)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, atoi(agents_it->agent_id));
             } else {
+                if (pkg->feed & VU_SRC_NVD) {
+                    vuln_reported_nvd++;
+                }
+                if (pkg->feed & VU_SRC_OVAL) {
+                    vuln_reported_vendor++;
+                }
                 vuln_reported++;
             }
             wm_vuldet_free_report(report);
@@ -1214,6 +1211,8 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
 
     wdb_finalize(stmt);
 
+    mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_VULN_SEND_AG_FEED, vuln_reported_nvd, atoi(agents_it->agent_id), "NVD");
+    mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_VULN_SEND_AG_FEED, vuln_reported_vendor, atoi(agents_it->agent_id), "vendor");
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_VULN_SEND_AG, vuln_reported, atoi(agents_it->agent_id));
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FUNCTION_TIME, time(NULL) - start_time, "report", atoi(agents_it->agent_id));
 
@@ -1306,7 +1305,6 @@ int wm_vuldet_send_cve_report(vu_report *report) {
             cJSON_AddStringToObject(alert_cve, "title", report->rationale);
         }
         cJSON_AddStringToObject(alert_cve, "severity", wm_vuldet_get_unified_severity(report->severity));
-        cJSON_AddStringToObject(alert_cve, "alert_origin", report->alert_origin);
         if (timestamp = wm_vuldet_normalize_date(&report->published), timestamp) {
             cJSON_AddStringToObject(alert_cve, "published", timestamp);
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1004,7 +1004,15 @@ int wm_vuldet_fill_report_oval_data(sqlite3 *db, sqlite3_stmt *stmt, agent_softw
 
         if (!report->title) w_strdup(title, report->title);
         if (!report->rationale) w_strdup(rationale, report->rationale);
-        if (!report->severity) w_strdup(severity, report->severity);
+        if (severity && agents_it->dist == FEED_REDHAT) {
+            /* For RHEL/CentOS agents we trust in the severity
+            from the vendor feed instead of the NVD.
+            It avoids NULL severity for some vulnerabilities */
+            os_free(report->severity);
+            w_strdup(severity, report->severity);
+        } else if (!report->severity) {
+            w_strdup(severity, report->severity);
+        }
         if (!report->published) w_strdup(published, report->published);
         if (!report->updated && updated) w_strdup(updated, report->updated);
         if (!report->cvss2 && cvss) {
@@ -4708,6 +4716,7 @@ int wm_vuldet_nvd_empty() {
 }
 
 const char *wm_vuldet_get_unified_severity(char *severity) {
+
     if (!severity || strcasestr(severity, vu_severities[VU_UNKNOWN]) || strcasestr(severity, vu_severities[VU_UNTR])) {
         return vu_severities[VU_UNDEFINED_SEV];
     } else if (strcasestr(severity, vu_severities[VU_LOW]) || strcasestr(severity, vu_severities[VU_NEGL])) {
@@ -4720,24 +4729,9 @@ const char *wm_vuldet_get_unified_severity(char *severity) {
         return vu_severities[VU_CRITICAL];
     } else if (strcasestr(severity, vu_severities[VU_NONE])) {
         return vu_severities[VU_NONE];
-    } else {
-        STATIC OSHash *unc_severities = NULL;
-        STATIC int sev_count = 0;
-
-        if (!unc_severities) {
-            if (unc_severities = OSHash_Create(), !unc_severities) {
-                mterror(WM_VULNDETECTOR_LOGTAG, VU_CREATE_HASH_ERRO, "unknown_severities");
-                pthread_exit(NULL);
-            }
-        }
-
-        // In case the feed has been corrupted, we will not insert more than 20 severities
-        if (sev_count < 20 && OSHash_Add(unc_severities, severity, NULL) == 2) {
-            mtwarn(WM_VULNDETECTOR_LOGTAG, VU_UNC_SEVERITY, severity);
-            sev_count++;
-        }
     }
     return vu_severities[VU_UNDEFINED_SEV];
+
 }
 
 void wm_vuldet_get_package_os(const char *version, const char **os_major, char **os_minor)  {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -454,8 +454,6 @@ struct vu_report {
     char *agent_id;
     char *agent_name;
     char *agent_ip;
-    // Metadata
-    char *alert_origin;
 };
 
 typedef struct oval_metadata {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -53,6 +53,7 @@
 #define NVD_CPE_REPO "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz"
 #define NVD_CVE_REPO_META "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%d.meta"
 #define NVD_CVE_REPO "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%d.json.gz"
+#define NVD_CVE_URL "https://nvd.nist.gov/vuln/detail/"
 #define NVD_REPO_MAX_ATTEMPTS 3
 #define DOWNLOAD_SLEEP_FACTOR 5
 #define JSON_FILE_TEST "/tmp/package_test.json"

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2035,7 +2035,6 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
             os_strdup(cve_version, report->cve_version);
             os_strdup(published, report->published);
             os_strdup(last_mod, report->updated);
-            os_strdup("NVD feed", report->alert_origin);
         } else {
             goto error;
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2339,6 +2339,7 @@ int wm_vuldet_check_generic_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_so
                     break;
                 case 1:
                     mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DUPLICATED_PACKAGE, pkg_reference, cve, pkg_version, operation, operation_value, "NVD");
+                    (*vuln_count)++;
                     wm_vuldet_free_cve_node(newPkg);
                     break;
                 case 0:
@@ -2491,6 +2492,7 @@ int wm_vuldet_check_specific_package(sqlite3 *dbCVE, char *pkg_name, char *pkg_s
                     break;
                 case 1:
                     mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DUPLICATED_PACKAGE, pkg_reference, cve, pkg_version, vu_package_comp[PKG_EQUAL], version_cmp, "NVD");
+                    (*vuln_count)++;
                     wm_vuldet_free_cve_node(newPkg);
                     break;
                 case 0:

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -27,7 +27,7 @@ STATIC int wm_vuldet_parse_nvd_impact(cJSON *impact, nvd_vulnerability *data);
 STATIC int wm_vuldet_parse_nvd_cve(cJSON *node, nvd_vulnerability *data);
 STATIC int wm_vuldet_insert_nvd_cve_metric_cvss(sqlite3 *db, cv_scoring_system *nvd_data, int node_id);
 STATIC int wm_vuldet_insert_nvd_cve_configuration(sqlite3 *db, nvd_configuration *nvd_data, int node_id, int parent);
-STATIC int wm_vuldet_insert_nvd_cve_references(sqlite3 *db, nvd_references *nvd_data, int node_id);
+STATIC int wm_vuldet_insert_nvd_cve_references(sqlite3 *db, nvd_references *nvd_data, char *cve, int node_id);
 STATIC int wm_vuldet_insert_nvd_cve_match(sqlite3 *db, nvd_conf_cpe_match *nvd_data, int conf_id);
 STATIC int wm_vuldet_insert_nvd_cve_cpe(sqlite3 *db, cpe *cpe_data);
 STATIC void wm_vuldet_free_nvd_references(nvd_references *data);
@@ -1306,10 +1306,8 @@ int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year)
     wdb_finalize(stmt);
 
     if (id_nvd_cve > 0) {
-        if (nvd_data->references) {
-            if (wm_vuldet_insert_nvd_cve_references(db, nvd_data->references, id_nvd_cve)) {
-                return OS_INVALID;
-            }
+        if (wm_vuldet_insert_nvd_cve_references(db, nvd_data->references, nvd_data->id, id_nvd_cve)) {
+            return OS_INVALID;
         }
         if (nvd_data->configuration) {
             if (wm_vuldet_insert_nvd_cve_configuration(db, nvd_data->configuration, id_nvd_cve, 0)) {
@@ -1335,9 +1333,10 @@ int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year)
     return 0;
 }
 
-int wm_vuldet_insert_nvd_cve_references(sqlite3 *db, nvd_references *nvd_data, int node_id) {
+int wm_vuldet_insert_nvd_cve_references(sqlite3 *db, nvd_references *nvd_data, char *cve, int node_id) {
     nvd_references *node;
     sqlite3_stmt *stmt = NULL;
+    bool nvd_url = false;
     int result;
 
     node = nvd_data;
@@ -1352,8 +1351,37 @@ int wm_vuldet_insert_nvd_cve_references(sqlite3 *db, nvd_references *nvd_data, i
         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
             return wm_vuldet_sql_error(db, stmt);
         }
+
+        // Check if there is included a link to the official NVD website
+        if (!strncmp(node->url, NVD_CVE_URL, 34)) {
+            nvd_url = true;
+        }
         wdb_finalize(stmt);
         node = node->next;
+    }
+
+    // Insert the reference to the NVD if it was not included
+    if (!nvd_url) {
+        char * nvd_cve_ref;
+        size_t url_length = 35 + strlen(cve);
+        os_calloc(url_length, sizeof(char), nvd_cve_ref);
+        snprintf(nvd_cve_ref, url_length, "%s%s", NVD_CVE_URL, cve);
+
+        if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_REFERENCE], -1, &stmt, NULL) != SQLITE_OK) {
+            os_free(nvd_cve_ref);
+            return wm_vuldet_sql_error(db, stmt);
+        }
+        sqlite3_bind_int(stmt, 1, node_id);
+        sqlite3_bind_text(stmt, 2, nvd_cve_ref, -1, NULL);
+        sqlite3_bind_text(stmt, 3, "MISC", -1, NULL);
+
+        if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+            os_free(nvd_cve_ref);
+            return wm_vuldet_sql_error(db, stmt);
+        }
+
+        os_free(nvd_cve_ref);
+        wdb_finalize(stmt);
     }
 
     return 0;


### PR DESCRIPTION
## Description

This PR fixes the following issues:

- Remove the `alert_origin` field from alerts. It is no longer included in the `report` structure. It has been also included a debug log to count how many alerts are generated from each feed. https://github.com/wazuh/wazuh/commit/56193d2d4c3d117f34c8ac25a2ef74f712064e0f

- Unify the `condition` field. The message was a bit different depending on its origin. https://github.com/wazuh/wazuh/commit/fcc7b5971c47dfb022071a09e98833511c8efad2

- Get the `severity` from the vendor feed directly for RHEL based agents. It has been removed a mechanism to store a count of unknown severities in a hash table to fire a warning when it reaches 20. https://github.com/wazuh/wazuh/commit/0293ee4dfea6502c1491b22b12bd40ed6f7aab1f

- Include duplicate vulnerabilities in the absolute count of those detected on each feed. https://github.com/wazuh/wazuh/commit/7f168cd628c1ccc024fa6cc933560cfb883da40f

- Store in the `NVD_REFERENCE` table a link to the NVD itself for each CVE. https://github.com/wazuh/wazuh/commit/f68b90820a2ea6ff4acbf3f26dddb4966e396ded

- Fix the reading of the OS minor when storing the OS information in the vuln-detector DB. It was being stored as 0 always, so it doesn't match correctly when solving dependencies in the NVD. https://github.com/wazuh/wazuh/commit/2e42d860dce17147099848cee6713ff7fda22469

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
- [x] Run unit tests
