### PR TITLE
5121 dev agent enrollment refactor

### DIFF
--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -92,6 +92,13 @@ void start_agent(int is_startup);
 /* Connect to the server */
 int connect_server(int initial_id);
 
+/** 
+ * Tries to enroll to a server indicated by server_rip
+ * @return 0 on success
+ *         -1 on error
+ * */
+int try_enroll_to_server(const char *server_rip);
+
 /* Notify server */
 void run_notify(void);
 

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -162,47 +162,6 @@ int main(int argc, char **argv)
         merror_exit(USER_ERROR, user, group, strerror(errno), errno);
     }
 
-    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
-        // If autoenrollment is enabled, we will avoid exit if there is no valid key
-        OS_PassEmptyKeyfile();
-    } else {
-        /* Check auth keys */
-        if (!OS_CheckKeys()) {
-            merror_exit(AG_NOKEYS_EXIT);
-        }
-    }
-    
-    /* Check client keys */
-    OS_ReadKeys(&keys, 1, 0, 0);
-
-    /* Check if we need to auto-enroll */
-    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
-        int registration_status = -1;
-        int rc = 0;
-
-        if (agt->enrollment_cfg->target_cfg->manager_name) {
-            // Configured enrollment server
-            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->enrollment_cfg->target_cfg->manager_name);
-        } 
-        
-        // Try to enroll to server list
-        while (agt->server[rc].rip && (registration_status != 0)) {
-            registration_status = w_enrollment_request_key(agt->enrollment_cfg, agt->server[rc].rip);
-            rc++;
-        }
-        
-
-        if(registration_status == 0) {
-            // Wait for key update on agent side
-            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
-            sleep(agt->enrollment_cfg->delay_after_enrollment);
-            // Update keys to get obtained key
-            OS_UpdateKeys(&keys);
-        } else {
-            merror_exit(AG_ENROLL_FAIL);
-        }
-    }
-
     /* Exit if test config */
     if (test_config) {
         exit(0);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -232,12 +232,14 @@ void start_agent(int is_startup)
 
 
 /**
- * Holds the message reception logic for udp
+ * @brief Holds the message reception logic for udp
+ * 
  * @param msg message to be sent
  * @param buffer pointer to buffer where the information will be stored
  * @param max_length size of buffer
- * @return message_size on success
- *         0 when all retries failed
+ * @return Integer value indicating the status code.
+ * @retval message_size on success
+ * @retval 0 when all retries failed
  * */
 static ssize_t receive_message_udp(const char *msg, char *buffer, unsigned int max_lenght) {
     int attempts = 0;
@@ -287,12 +289,14 @@ static ssize_t receive_message_udp(const char *msg, char *buffer, unsigned int m
 }
 
 /**
- * Holds the message reception logic for tcp
+ * @brief Holds the message reception logic for tcp
+ * 
  * @param msg message to be sent
  * @param buffer pointer to buffer where the information will be stored
  * @param max_length size of buffer
- * @return 1 on success
- *         0 when all retries failed
+ * @return Integer value indicating the status code.
+ * @retval message_size on success
+ * @retval 0 when all retries failed
  * */
 static ssize_t receive_message_tcp(const char *msg, char *buffer, unsigned int max_lenght) {
     ssize_t recv_b = 0;

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -154,7 +154,7 @@ int connect_server(int initial_id)
 void start_agent(int is_startup)
 {
     size_t msg_length;
-    int  g_attempts = 1;
+    int delay = 1;
     ssize_t recv_b = 0;
 
     char *tmp_msg;
@@ -218,12 +218,12 @@ void start_agent(int is_startup)
         if (agt->server[agt->rip_id + 1].rip) {
             agt->rip_id++;
             minfo("Trying next server ip in the line: '%s'.", agt->server[agt->rip_id].rip);
-            g_attempts += 5;
-            sleep(g_attempts < agt->notify_time ? g_attempts : agt->notify_time);
+            delay += 5;
+            sleep(delay < agt->notify_time ? delay : agt->notify_time);
         } else {
             agt->rip_id = 0;
-            g_attempts += (5 * 3);
-            sleep(g_attempts < agt->notify_time ? g_attempts : agt->notify_time);
+            delay += (5 * 3);
+            sleep(delay < agt->notify_time ? delay : agt->notify_time);
         }
     }
 

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -14,6 +14,9 @@
 
 int timeout;    //timeout in seconds waiting for a server reply
 
+static ssize_t receive_message_udp(const char *msg, char *buffer, unsigned int max_lenght);
+static ssize_t receive_message_tcp(const char *msg, char *buffer, unsigned int max_lenght);
+
 /* Attempt to connect to all configured servers */
 int connect_server(int initial_id)
 {
@@ -150,9 +153,9 @@ int connect_server(int initial_id)
 /* Send synchronization message to the server and wait for the ack */
 void start_agent(int is_startup)
 {
-    ssize_t recv_b = 0;
     size_t msg_length;
-    int attempts = 0, g_attempts = 1;
+    int  g_attempts = 1;
+    ssize_t recv_b = 0;
 
     char *tmp_msg;
     char msg[OS_MAXSTR + 2];
@@ -166,134 +169,193 @@ void start_agent(int is_startup)
     memset(fmsg, '\0', OS_MAXSTR + 1);
     snprintf(msg, OS_MAXSTR, "%s%s", CONTROL_HEADER, HC_STARTUP);
 
-#ifdef ONEWAY_ENABLED
-    return;
-#endif
+    #ifdef ONEWAY_ENABLED
+        return;
+    #endif
 
     while (1) {
+        connect_server(agt->rip_id);
         /* Send start up message */
         send_msg(msg, -1);
-        attempts = 0;
+
         /* Read until our reply comes back */
-        while (attempts <= 5) {
-            if (agt->server[agt->rip_id].protocol == IPPROTO_TCP) {
-
-                switch (wnet_select(agt->sock, timeout)) {
-                case -1:
-                    merror(SELECT_ERROR, errno, strerror(errno));
-                    break;
-
-                case 0:
-                    // Timeout
-                    break;
-
-                default:
-                    recv_b = OS_RecvSecureTCP(agt->sock, buffer, OS_MAXSTR);
-                }
-            } else {
-                recv_b = recv(agt->sock, buffer, OS_MAXSTR, MSG_DONTWAIT);
-            }
-
-
-            if (recv_b <= 0) {
-                /* Sleep five seconds before trying to get the reply from
-                 * the server again
-                 */
-                attempts++;
-
-                switch (recv_b) {
-                case OS_SOCKTERR:
-                    merror("Corrupt payload (exceeding size) received.");
-                    break;
-                case -1:
-                    #ifdef WIN32
-                    mdebug1("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
-                    #else
-                    mdebug1("Connection socket: %s (%d)", strerror(errno), errno);
-                    #endif
-                }
-
-                sleep(attempts);
-
-                /* Send message again (after three attempts) */
-                if (attempts >= 3 || recv_b == OS_SOCKTERR) {
-                    if (attempts == 3 && agt->enrollment_cfg && agt->enrollment_cfg->enabled) { // Only one enrollment attemp
-                        int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, agt->server[agt->rip_id].rip);
-                        if(enroll_result == 0) {
-                            // Wait for key update on agent side
-                            mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
-                            sleep(agt->enrollment_cfg->delay_after_enrollment);
-                            // Successfull enroll, read keys
-                            OS_UpdateKeys(&keys);
-                        }
-                    }
-                    if (!connect_server(agt->rip_id)) {
-                        continue;
-                    }
-                    // if enroll is successfull reconnect and re-send message
-                    send_msg(msg, -1);
-                    // After sending message wait before response
-                    if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
-                        sleep(attempts);
-                    }
-                }
-
-                continue;
-            }
-
+        if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
+            recv_b = receive_message_udp(msg, buffer, OS_MAXSTR);
+        } else {
+            recv_b = receive_message_tcp(msg, buffer, OS_MAXSTR);
+        }
+        
+        if (recv_b > 0) {
             /* Id of zero -- only one key allowed */
             if (ReadSecMSG(&keys, buffer, cleartext, 0, recv_b - 1, &msg_length, agt->server[agt->rip_id].rip, &tmp_msg) != KS_VALID) {
                 mwarn(MSG_ERROR, agt->server[agt->rip_id].rip);
-                continue;
-            }
+            } else {
+                /* Check for commands */
+                if (IsValidHeader(tmp_msg)) {
+                    /* If it is an ack reply */
+                    if (strcmp(tmp_msg, HC_ACK) == 0) {
+                        available_server = time(0);
 
-            /* Check for commands */
-            if (IsValidHeader(tmp_msg)) {
-                /* If it is an ack reply */
-                if (strcmp(tmp_msg, HC_ACK) == 0) {
-                    available_server = time(0);
+                        minfo(AG_CONNECTED, agt->server[agt->rip_id].rip,
+                                agt->server[agt->rip_id].port, agt->server[agt->rip_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
 
-                    minfo(AG_CONNECTED, agt->server[agt->rip_id].rip,
-                            agt->server[agt->rip_id].port, agt->server[agt->rip_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
-
-                    if (is_startup) {
-                        /* Send log message about start up */
-                        snprintf(msg, OS_MAXSTR, OS_AG_STARTED,
-                                 keys.keyentries[0]->name,
-                                 keys.keyentries[0]->ip->ip);
-                        snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,
-                                 "ossec", msg);
-                        send_msg(fmsg, -1);
+                        if (is_startup) {
+                            /* Send log message about start up */
+                            snprintf(msg, OS_MAXSTR, OS_AG_STARTED,
+                                    keys.keyentries[0]->name,
+                                    keys.keyentries[0]->ip->ip);
+                            snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,
+                                    "ossec", msg);
+                            send_msg(fmsg, -1);
+                        }
+                        return;
                     }
-                    return;
                 }
             }
         }
 
-        /* Wait for server reply */
-        mwarn(AG_WAIT_SERVER, agt->server[agt->rip_id].rip);
-
-        /* If we have more than one server, try all */
-        if (agt->server[1].rip) {
-            int curr_rip = agt->rip_id;
-            minfo("Trying next server ip in the line: '%s'.",
-                   agt->server[agt->rip_id + 1].rip != NULL ? agt->server[agt->rip_id + 1].rip : agt->server[0].rip);
-            connect_server(agt->rip_id + 1);
-
-            if (agt->rip_id == curr_rip) {
-                sleep(g_attempts < agt->notify_time ? g_attempts : agt->notify_time);
-                g_attempts += (attempts * 3);
-            } else {
-                g_attempts += 5;
-                sleep(g_attempts < agt->notify_time ? g_attempts : agt->notify_time);
-            }
-        } else {
+        /* If thre is a next server, try it */
+        if (agt->server[agt->rip_id + 1].rip) {
+            agt->rip_id++;
+            minfo("Trying next server ip in the line: '%s'.", agt->server[agt->rip_id].rip);
+            g_attempts += 5;
             sleep(g_attempts < agt->notify_time ? g_attempts : agt->notify_time);
-            g_attempts += (attempts * 3);
-
-            connect_server(0);
+        } else {
+            agt->rip_id = 0;
+            g_attempts += (5 * 3);
+            sleep(g_attempts < agt->notify_time ? g_attempts : agt->notify_time);
         }
     }
 
     return;
+}
+
+
+/**
+ * Holds the message reception logic for udp
+ * @param msg message to be sent
+ * @param buffer pointer to buffer where the information will be stored
+ * @param max_length size of buffer
+ * @return message_size on success
+ *         0 when all retries failed
+ * */
+static ssize_t receive_message_udp(const char *msg, char *buffer, unsigned int max_lenght) {
+    int attempts = 0;
+    ssize_t recv_b = 0;
+
+    /* Wait for server reply */
+    mwarn(AG_WAIT_SERVER, agt->server[agt->rip_id].rip);
+    sleep(1);
+
+    while (attempts < 5){
+        /* Receive response */
+        recv_b = recv(agt->sock, buffer, max_lenght, MSG_DONTWAIT);
+        
+        if (recv_b <= 0 ) {
+            switch (recv_b) {
+            case OS_SOCKTERR:
+                merror("Corrupt payload (exceeding size) received.");
+                break;
+            case -1:
+            default:
+                #ifdef WIN32
+                    mdebug1("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
+                #else
+                    mdebug1("Connection socket: %s (%d)", strerror(errno), errno);
+                #endif
+                break;
+            }
+            attempts++;
+            sleep(attempts);
+
+            /* Send message again (after three attempts) */
+            if (attempts >= 3 || recv_b == OS_SOCKTERR) {
+                if (attempts == 3 && agt->enrollment_cfg && agt->enrollment_cfg->enabled) { // Only one enrollment attemp
+                    try_enroll_to_server(agt->server[agt->rip_id].rip);
+                }
+                if (connect_server(agt->rip_id)) {
+                    // if enroll is successfull reconnect and re-send message
+                    send_msg(msg, -1);
+                    // After sending message wait before response
+                    sleep(attempts);
+                }
+            }
+        } else {
+            return recv_b;
+        }   
+    }
+    return 0;
+}
+
+/**
+ * Holds the message reception logic for tcp
+ * @param msg message to be sent
+ * @param buffer pointer to buffer where the information will be stored
+ * @param max_length size of buffer
+ * @return 1 on success
+ *         0 when all retries failed
+ * */
+static ssize_t receive_message_tcp(const char *msg, char *buffer, unsigned int max_lenght) {
+    ssize_t recv_b = 0;
+    int attempts = 0;
+    bool enrollment_attemp = false;
+    
+    while ((attempts < 5) && (recv_b <= 0)) {
+        switch (wnet_select(agt->sock, timeout)) {
+            case -1:
+                merror(SELECT_ERROR, errno, strerror(errno));
+                break;
+
+            case 0:
+                // Timeout
+                break;
+
+            default:
+                recv_b = OS_RecvSecureTCP(agt->sock, buffer, max_lenght);
+                break;
+        }
+       
+        attempts++;
+
+        switch (recv_b) {
+            case OS_SOCKTERR:
+                merror("Corrupt payload (exceeding size) received.");
+                break;
+            case 0:
+                // Peer performed orderly shutdown (connection refused by manager)
+                if (agt->enrollment_cfg && agt->enrollment_cfg->enabled && !enrollment_attemp) {
+                    if (try_enroll_to_server(agt->server[agt->rip_id].rip) == 0) {
+                        if (connect_server(agt->rip_id)) {
+                            send_msg(msg, -1);
+                        }
+                    }
+                    enrollment_attemp = true; // Only attemp enrolling once
+                }
+                break;
+            case -1:
+                #ifdef WIN32
+                    mdebug1("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
+                #else
+                    mdebug1("Connection socket: %s (%d)", strerror(errno), errno);
+                #endif
+                // Connection timeout, try to reconnect
+                if (connect_server(agt->rip_id)) {
+                    send_msg(msg, -1);
+                }
+                break;
+        }
+    }
+    return recv_b > 0 ? recv_b : 0;
+}
+
+int try_enroll_to_server(const char * server_rip) {
+    int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, server_rip);
+    if (enroll_result == 0) {
+        // Wait for key update on agent side
+        mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
+        sleep(agt->enrollment_cfg->delay_after_enrollment);
+        // Successfull enroll, read keys
+        OS_UpdateKeys(&keys);
+    }
+    return enroll_result;
 }


### PR DESCRIPTION
|Related issue|
|---|
| #5121 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

`start_agent `method now call two different methods to wait for a startup reply according to the protocol:
- `receive_message_udp`: That handles upd reconnection and enrollment logic
- `receive_message_tcp`: That handles tcp reconnection and enrollment logic
Also, to give further cohesion to the method connection to the server is established inside the method. 

The logic for `start_agent ` method now is the following:
- Connect to a server. In both cases of startup or connection failures we will try to connect to a server. In case the first server fails, it will continue to search on all the available servers until a valid one is reached.
- After connection  sends startup message.
- Receives response (different logic according to protocol)
- If response is valid, tries to decode ACK message, if after all atempts it keeps failiing, move to next server


The recieve logic for the UDP case is:
- Sleep for a few seconds and read from socket. If no response has been found increase attemps
- After 3 attempts, try to enroll to the current server. Connect and send message to see if now there is a response.
- If the 3rd attempt fails, we´ll do 2 more attempts but without registration.

The receive logic for the TCP case is:
- Block on socket recv until message is received or timeout is reached.
- If timeout is reached, try opening a new socket and send the message again (5 attemps)
- If connection is actively closed by the manager, try enrolling to that manager and connecting again. This is only done the first time the manager actively closes the connection.

## Tests

### Suggested scenarios:

Linux agent (repeat for UDP and TCP):
  - [x] Auto-enroll and connect with empty key file.
  - [x] With an existent key, erase the agent from the manager and check for re-registration and re-connection
  - [x] With an existent key, interrupt communication between manager and agent. After a few minutes make it available again. Agent should connect to manager without any attemp of registration.
 - [x] Set multiple servers, where the valid one is not in the first connection and repeate steps above.

Windows agent (repeat for UDP and TCP):
  - [x] Auto-enroll and connect with empty key file.
  - [x] With an existent key, erase the agent from the manager and check for re-registration and re-connection
  - [x] With an existent key, interrupt communication between manager and agent. After a few minutes make it available again. Agent should connect to manager without any attemp of registration.
 - [x] Set multiple servers, where the valid one is not in the first connection and repeate steps above.

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
### Compilation and memory tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory

