### PR TITLE
Fixes in delete_subdirectories_watches function

### DIFF
--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -233,26 +233,22 @@ void delete_subdirectories_watches(char *dir) {
     char *dir_slash = NULL;
     int dir_len = strlen(dir) + 1;
 
-    /*
-        If the directory already ends with an slash, there is no need for adding
-        an extra one
-     */
+
+    // If the directory already ends with an slash, there is no need for adding an extra one
     if (dir[dir_len - 1] != '/') {
         os_calloc(dir_len + 2, sizeof(char), dir_slash);  // Length of dir plus an extra slash
 
-        /*
-            Copy the content of dir into dir_slash and add an extra slash
-        */
-        strncpy(dir_slash, dir, dir_len);
-        strncat(dir_slash, "/", strlen(dir_slash) + 1);
+    
+        // Copy the content of dir into dir_slash and add an extra slash
+        snprintf(dir_slash, dir_len + 2, "%s/", dir);
     }
     else {
         os_calloc(dir_len, sizeof(char), dir_slash);
-        strncpy(dir_slash, dir, dir_len);
+        snprintf(dir_slash, dir_len, "%s", dir);
     }
 
     if(syscheck.realtime->fd) {
-        w_mutex_lock(&syscheck.fim_entry_mutex);
+        w_mutex_lock(&syscheck.fim_realtime_mutex);
         hash_node = OSHash_Begin(syscheck.realtime->dirtb, &inode_it);
 
         while(hash_node) {
@@ -274,7 +270,7 @@ void delete_subdirectories_watches(char *dir) {
             hash_node = OSHash_Next(syscheck.realtime->dirtb, &inode_it, hash_node);
         }
 
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
+        w_mutex_unlock(&syscheck.fim_realtime_mutex);
     }
 
     os_free(dir_slash);


### PR DESCRIPTION
| Related issue  |
|---------------|
| #5125              |

## Description

This pull request changes the mutex used for the `delete_subdirectories_watches` and substitutes `strcpy` and strcat with `snprintf`.

This pull request closes #5125.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

