### PR TITLE
Add configuration on demand for file_limit

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1163,15 +1163,13 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 continue;
             }
 
-            int file_limit_enabled = true;
-
             for(j = 0; children[j]; j++) {
                 if (strcmp(children[j]->element, xml_file_limit_enabled) == 0) {
                     if (strcmp(children[j]->content, "yes") == 0) {
-                        file_limit_enabled = true;
+                        syscheck->file_limit_enabled = true;
                     }
                     else if (strcmp(children[j]->content, "no") == 0) {
-                        file_limit_enabled = false;
+                        syscheck->file_limit_enabled = false;
                     }
                     else {
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
@@ -1193,7 +1191,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 }
             }
 
-            if (!file_limit_enabled) {
+            if (!syscheck->file_limit_enabled) {
                 syscheck->file_limit = 0;
             }
         }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1194,6 +1194,8 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             if (!syscheck->file_limit_enabled) {
                 syscheck->file_limit = 0;
             }
+
+            OS_ClearNode(children);
         }
 
         /* Get if xml_scan_on_start */

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -287,6 +287,7 @@ typedef struct _config {
     char *scan_time;                /* run syscheck at this time */
 
     unsigned int file_limit;        /* maximum number of files to monitor */
+    unsigned int file_limit_enabled;    /* Enable file_limit option */
 
     char **ignore;                  /* list of files/dirs to ignore */
     OSMatch **ignore_regex;         /* regex of files/dirs to ignore */

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -40,6 +40,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.nodiff_regex   = NULL;
     syscheck.scan_day       = NULL;
     syscheck.scan_time      = NULL;
+    syscheck.file_limit_enabled = true;
     syscheck.file_limit     = 100000;
     syscheck.dir            = NULL;
     syscheck.opts           = NULL;
@@ -170,7 +171,12 @@ cJSON *getSyscheckConfig(void) {
     if (syscheck.scan_on_start) cJSON_AddStringToObject(syscfg,"scan_on_start","yes"); else cJSON_AddStringToObject(syscfg,"scan_on_start","no");
     if (syscheck.scan_day) cJSON_AddStringToObject(syscfg,"scan_day",syscheck.scan_day);
     if (syscheck.scan_time) cJSON_AddStringToObject(syscfg,"scan_time",syscheck.scan_time);
-    cJSON_AddNumberToObject(syscfg,"file_limit",syscheck.file_limit);
+
+    cJSON * file_limit = cJSON_CreateObject();
+    cJSON_AddStringToObject(file_limit, "enabled", syscheck.file_limit_enabled ? "yes" : "no");
+    cJSON_AddNumberToObject(file_limit, "entries", syscheck.file_limit);
+    cJSON_AddItemToObject(syscfg, "file_limit", file_limit);
+
     if (syscheck.dir) {
         cJSON *dirs = cJSON_CreateArray();
         for (i=0;syscheck.dir[i];i++) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -88,7 +88,7 @@ void fim_scan() {
 
     check_deleted_files();
 
-    if (syscheck.file_limit) {
+    if (syscheck.file_limit_enabled) {
         w_mutex_lock(&syscheck.fim_entry_mutex);
         nodes_count = fim_db_get_count_entry_path(syscheck.database);
         w_mutex_unlock(&syscheck.fim_entry_mutex);
@@ -128,12 +128,11 @@ void fim_scan() {
             fim_db_set_all_unscanned(syscheck.database);
             w_mutex_unlock(&syscheck.fim_entry_mutex);
         }
-
     }
 
     gettime(&end);
 
-    if (syscheck.file_limit != 0) {
+    if (syscheck.file_limit_enabled) {
         mdebug2(FIM_FILE_LIMIT_VALUE, syscheck.file_limit);
         fim_check_db_state();
     }

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -913,7 +913,7 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, 
 
     switch (alert_type) {
     case FIM_ADD:
-        if (syscheck.file_limit) {
+        if (syscheck.file_limit_enabled) {
             nodes_count = fim_db_get_count_entry_path(syscheck.database);
             if (nodes_count >= syscheck.file_limit) {
                 mdebug1("Couldn't insert '%s' entry into DB. The DB is full, please check your configuration.", file_path);

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -506,12 +506,14 @@ static int teardown_struct_dirent(void **state) {
 }
 
 static int setup_file_limit(void **state) {
+    syscheck.file_limit_enabled = false;
     syscheck.file_limit = 0;
 
     return 0;
 }
 
 static int teardown_file_limit(void **state) {
+    syscheck.file_limit_enabled = true;
     syscheck.file_limit = 50000;
 
     return 0;

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -237,8 +237,13 @@ void test_getSyscheckConfig(void **state)
     assert_string_equal(cJSON_GetStringValue(disabled), "no");
     cJSON *frequency = cJSON_GetObjectItem(sys_items, "frequency");
     assert_int_equal(frequency->valueint, 43200);
+
     cJSON *file_limit = cJSON_GetObjectItem(sys_items, "file_limit");
-    assert_int_equal(file_limit->valueint, 50000);
+    cJSON *file_limit_enabled = cJSON_GetObjectItem(file_limit, "enabled");
+    assert_string_equal(cJSON_GetStringValue(file_limit_enabled), "yes");
+    cJSON *file_limit_entries = cJSON_GetObjectItem(file_limit, "entries");
+    assert_int_equal(file_limit_entries->valueint, 50000);
+
     cJSON *skip_nfs = cJSON_GetObjectItem(sys_items, "skip_nfs");
     assert_string_equal(cJSON_GetStringValue(skip_nfs), "yes");
     cJSON *skip_dev = cJSON_GetObjectItem(sys_items, "skip_dev");
@@ -347,8 +352,13 @@ void test_getSyscheckConfig_no_audit(void **state)
     assert_string_equal(cJSON_GetStringValue(disabled), "no");
     cJSON *frequency = cJSON_GetObjectItem(sys_items, "frequency");
     assert_int_equal(frequency->valueint, 43200);
+
     cJSON *file_limit = cJSON_GetObjectItem(sys_items, "file_limit");
-    assert_int_equal(file_limit->valueint, 50000);
+    cJSON *file_limit_enabled = cJSON_GetObjectItem(file_limit, "enabled");
+    assert_string_equal(cJSON_GetStringValue(file_limit_enabled), "yes");
+    cJSON *file_limit_entries = cJSON_GetObjectItem(file_limit, "entries");
+    assert_int_equal(file_limit_entries->valueint, 50000);
+
     cJSON *skip_nfs = cJSON_GetObjectItem(sys_items, "skip_nfs");
     assert_string_equal(cJSON_GetStringValue(skip_nfs), "no");
     cJSON *skip_dev = cJSON_GetObjectItem(sys_items, "skip_dev");
@@ -445,8 +455,12 @@ void test_getSyscheckConfig_no_directories(void **state)
     assert_string_equal(cJSON_GetStringValue(disabled), "yes");
     cJSON *frequency = cJSON_GetObjectItem(sys_items, "frequency");
     assert_int_equal(frequency->valueint, 43200);
+    
     cJSON *file_limit = cJSON_GetObjectItem(sys_items, "file_limit");
-    assert_int_equal(file_limit->valueint, 100000);
+    cJSON *file_limit_enabled = cJSON_GetObjectItem(file_limit, "enabled");
+    assert_string_equal(cJSON_GetStringValue(file_limit_enabled), "yes");
+    cJSON *file_limit_entries = cJSON_GetObjectItem(file_limit, "entries");
+    assert_int_equal(file_limit_entries->valueint, 100000);
 
     cJSON *skip_nfs = cJSON_GetObjectItem(sys_items, "skip_nfs");
     assert_string_equal(cJSON_GetStringValue(skip_nfs), "yes");


### PR DESCRIPTION
| Related issue  |
|---------------|
| #5111               |

## Description

This pull request adds the changes in the file_limit configuration to the configuration on demand.

Closes #5111.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
