### PR TITLE
Reduce Framework Python file permissions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1562,7 +1562,7 @@ install_dependencies: install_python
 install_framework: install_python
 	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET}
 	chown -R root:${OSSEC_GROUP} ${WPYTHON_DIR}
-	chmod -R o=- ${WPYTHON_DIR}/*
+	chmod -R o=- ${WPYTHON_DIR}
 
 install_mitre: install_python
 	cd ../tools/mitre && ${WPYTHON_DIR}/bin/python3 mitredb.py -d ${PREFIX}/var/db/mitre.db

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -121,7 +121,7 @@ WazuhUpgrade()
     rm -f $DIRECTORY/queue/vulnerabilities/cve.db
 
     # Remove OpenSCAP policies if the module is disabled
-    if stat $DIRECTORY/wodles/oscap/content/* > /dev/null ; then
+    if stat $DIRECTORY/wodles/oscap/content/* 2> /dev/null ; then
 
         is_disabled="$(CheckModuleIsEnabled '<wodle name="open-scap">' '</wodle>' 'disabled')"
 


### PR DESCRIPTION
Hello team, this PR aims to fix some Python permissions that are too open.

## Description
There is a '*'' wildcard that applies some permissions to all the files inside the framework Python directory. We've removed it to avoid that such chmod affect those files. Also, we want to have the same permissions in both Debian and RPM systems. 


## Tests

### Rpm from sources
- [x] Tested
```
[root@55494868681e wazuh-fix-python-permissions]# ls /var/ossec/framework/ -l
total 12
drwxr-x--- 6 root ossec 4096 May 28 11:18 python
drwxr-x--- 2 root ossec 4096 May 28 11:18 scripts
drwxr-x--- 3 root ossec 4096 May 28 11:18 wazuh

[root@55494868681e wazuh-fix-python-permissions]# ls /var/ossec/framework/python/ -l
total 16
drwxr-x--- 3 root ossec 4096 May 28 11:18 bin
drwxr-x--- 3 root ossec 4096 May 28 11:18 include
drwxr-x--- 4 root ossec 4096 May 28 11:18 lib
drwxr-x--- 3 root ossec 4096 May 28 11:18 share
```

### Debian from sources
- [x] Tested
```
root@db182f57170b:/wazuh-fix-python-permissions# ls /var/ossec/framework/ -l
total 12
drwxr-x--- 6 root ossec 4096 May 28 11:24 python
drwxr-x--- 2 root ossec 4096 May 28 11:24 scripts
drwxr-x--- 3 root ossec 4096 May 28 11:24 wazuh

root@db182f57170b:/wazuh-fix-python-permissions# ls /var/ossec/framework/python/ -l
total 16
drwxr-x--- 3 root ossec 4096 May 28 11:24 bin
drwxr-x--- 3 root ossec 4096 May 28 11:24 include
drwxr-x--- 4 root ossec 4096 May 28 11:24 lib
drwxr-x--- 3 root ossec 4096 May 28 11:24 share
```

## Current permissions (packages)
Notice that Debian package generation procedure doesn't modify the permissions generated during compilation. Rpm does based on his SPECs. 
### Debian
```
root@1069998f13b8:/# ls -l /var/ossec/framework/      
total 12
drwxr-xr-x 6 root ossec 4096 May 28 09:58 python
drwxr-x--- 2 root ossec 4096 May 28 09:58 scripts
drwxr-x--- 3 root ossec 4096 May 28 09:58 wazuh
root@1069998f13b8:/# 
```
### Centos
```
[root@434ea545435e /]# ls -l /var/ossec/framework/      
total 16
drwxr-x--- 2 root ossec 4096 May 28 09:58 lib
drwxr-x--- 6 root ossec 4096 May 28 09:58 python
drwxr-x--- 2 root ossec 4096 May 28 09:58 scripts
drwxr-x--- 3 root ossec 4096 May 28 09:58 wazu
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows [not affected] [test on jenkins]
  - [x] MAC OS X [not affected] [test on jenkins]
- [x] Source installation [on centos and debian]
- [x] Package installation [test on jenkins]
- [x] Source upgrade [on centos and debian]
- [x] Package upgrade [test on jenkins]
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities


