### PR TITLE
Fixed static filters related to the system_name field

### DIFF
--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -191,7 +191,7 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         "same_data",
         "same_extra_data",
         "same_status",
-        "same_systemname",
+        "same_system_name",
         "same_srcgeoip",
         "same_dstgeoip",
         "same_location"
@@ -211,7 +211,7 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         "different_data",
         "different_extra_data",
         "different_status",
-        "different_systemname",
+        "different_system_name",
         "different_srcgeoip",
         "different_dstgeoip",
         "different_location"

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -136,7 +136,7 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_same_data = "same_data";
     const char *xml_same_extra_data = "same_extra_data";
     const char *xml_same_status = "same_status";
-    const char *xml_same_systemname = "same_systemname";
+    const char *xml_same_systemname = "same_system_name";
     const char *xml_same_dstgeoip = "same_dstgeoip";
 
     const char *xml_different_url = "different_url";
@@ -156,7 +156,7 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_different_data = "different_data";
     const char *xml_different_extra_data = "different_extra_data";
     const char *xml_different_status = "different_status";
-    const char *xml_different_systemname = "different_systemname";
+    const char *xml_different_systemname = "different_system_name";
     const char *xml_different_dstgeoip = "different_dstgeoip";
     const char *xml_different_field = "different_field";
 

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -105,7 +105,7 @@ int OS_ReadXMLRules(const char *rulefile,
     const char *xml_same_data = "same_data";
     const char *xml_same_extra_data = "same_extra_data";
     const char *xml_same_status = "same_status";
-    const char *xml_same_systemname = "same_systemname";
+    const char *xml_same_systemname = "same_system_name";
     const char *xml_same_dstgeoip = "same_dstgeoip";
 
     const char *xml_different_url = "different_url";
@@ -125,7 +125,7 @@ int OS_ReadXMLRules(const char *rulefile,
     const char *xml_different_data = "different_data";
     const char *xml_different_extra_data = "different_extra_data";
     const char *xml_different_status = "different_status";
-    const char *xml_different_systemname = "different_systemname";
+    const char *xml_different_systemname = "different_system_name";
     const char *xml_different_dstgeoip = "different_dstgeoip";
     const char *xml_different_field = "different_field";
 


### PR DESCRIPTION
|Related issue|
|---|
| #5128 |

## Description

I renamed the static filters related to system_name. Now the filters' names are:
- same_system_name
- different_system_name

## Configuration options
```
<same_system_name />
<different_system_name />
```
## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

### Ruleset test
All the tests passed

![image](https://user-images.githubusercontent.com/24528466/83137608-bd2eb380-a0e9-11ea-9b3e-4737e852dd96.png)

