### PR TITLE
[NVD] Change NVD filter query

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1605,7 +1605,7 @@ int wm_vuldet_linux_rm_false_positivies(sqlite3 *db, agent_software *agent, OSHa
                     sqlite3_bind_text(stmt, 1, cve, -1, NULL);
                     sqlite3_bind_text(stmt, 2, pkg->bin_name, -1, NULL);
 
-                    if ((SQLITE_ROW == wm_vuldet_step(stmt)) && sqlite3_column_int(stmt, 0)) {
+                    if ((SQLITE_ROW == wm_vuldet_step(stmt)) && !sqlite3_column_int(stmt, 0)) {
                         // We can discard this vulnerability if the NVD says that this version is not affected
                         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_NOT_AFF, pkg->bin_name, cve, "NVD");
                         pkg->discard = 1;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1577,43 +1577,28 @@ int wm_vuldet_linux_rm_false_positivies(sqlite3 *db, agent_software *agent, OSHa
 
             if ((pkg->feed == VU_SRC_OVAL) && !pkg->discard && pkg->vuln_cond && !strcmp(pkg->vuln_cond->state, "Unfixed")) {
 
+                if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_MATCHES_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_ERROR, cve, pkg->bin_name);
+                    return wm_vuldet_sql_error(db, stmt);
+                }
+
+                sqlite3_bind_text(stmt, 1, cve, -1, NULL);
+                sqlite3_bind_text(stmt, 2, pkg->bin_name, -1, NULL);
+
                 if (pkg->src_name) {
-                    if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_MATCHES_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
-                        mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_ERROR, cve, pkg->bin_name);
-                        return wm_vuldet_sql_error(db, stmt);
-                    }
-
-                    sqlite3_bind_text(stmt, 1, cve, -1, NULL);
-                    sqlite3_bind_text(stmt, 2, pkg->src_name, -1, NULL);
-
-                    if ((SQLITE_ROW == wm_vuldet_step(stmt)) && sqlite3_column_int(stmt, 0)) {
-                        // We can discard this vulnerability if the NVD says that this version is not affected
-                        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_NOT_AFF, pkg->bin_name, cve, "NVD");
-                        pkg->discard = 1;
-                        vuln_discarded++;
-                    }
-
-                    wdb_finalize(stmt);
+                    sqlite3_bind_text(stmt, 3, pkg->src_name, -1, NULL);
+                } else {
+                    sqlite3_bind_text(stmt, 3, pkg->bin_name, -1, NULL);
                 }
 
-                if (!pkg->discard) {
-                    if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_MATCHES_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
-                        mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_ERROR, cve, pkg->bin_name);
-                        return wm_vuldet_sql_error(db, stmt);
-                    }
-
-                    sqlite3_bind_text(stmt, 1, cve, -1, NULL);
-                    sqlite3_bind_text(stmt, 2, pkg->bin_name, -1, NULL);
-
-                    if ((SQLITE_ROW == wm_vuldet_step(stmt)) && !sqlite3_column_int(stmt, 0)) {
-                        // We can discard this vulnerability if the NVD says that this version is not affected
-                        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_NOT_AFF, pkg->bin_name, cve, "NVD");
-                        pkg->discard = 1;
-                        vuln_discarded++;
-                    }
-
-                    wdb_finalize(stmt);
+                if ((SQLITE_ROW == wm_vuldet_step(stmt)) && !sqlite3_column_int(stmt, 0)) {
+                    // We can discard this vulnerability if the NVD says that this version is not affected
+                    mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_NOT_AFF, pkg->bin_name, cve, "NVD");
+                    pkg->discard = 1;
+                    vuln_discarded++;
                 }
+
+                wdb_finalize(stmt);
 
                 if (pkg->discard) {
                     cve_vuln_pkg *tmp = first;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
@@ -296,11 +296,11 @@ static const char *vu_queries[] = {
             FROM NVD_CPE INNER JOIN NVD_CVE_MATCH ON NVD_CPE.ID = NVD_CVE_MATCH.ID_CPE \
                          INNER JOIN NVD_CVE_CONFIGURATION ON NVD_CVE_CONFIGURATION.ID = NVD_CVE_MATCH.NVD_CVE_CONFIGURATION_ID \
                          INNER JOIN NVD_CVE ON NVD_CVE_CONFIGURATION.NVD_CVE_ID = NVD_CVE.ID \
-                         WHERE ((NVD_CPE.VERSION != '*' AND NVD_CPE.VERSION != '-') \
-                                OR NVD_CVE_MATCH.VERSION_START_INCLUDING IS NOT NULL \
-                                OR NVD_CVE_MATCH.VERSION_START_EXCLUDING IS NOT NULL \
-                                OR NVD_CVE_MATCH.VERSION_END_INCLUDING IS NOT NULL \
-                                OR NVD_CVE_MATCH.VERSION_END_EXCLUDING IS NOT NULL) \
+                         WHERE ((NVD_CPE.VERSION == '*' OR NVD_CPE.VERSION == '-') \
+                                AND NVD_CVE_MATCH.VERSION_START_INCLUDING IS NULL \
+                                AND NVD_CVE_MATCH.VERSION_START_EXCLUDING IS NULL \
+                                AND NVD_CVE_MATCH.VERSION_END_INCLUDING IS NULL \
+                                AND NVD_CVE_MATCH.VERSION_END_EXCLUDING IS NULL) \
                                AND NVD_CVE.CVE_ID = ? AND NVD_CPE.PRODUCT = ?",
     // SQL OPERATIONS
     "DELETE FROM SQLITE_SEQUENCE WHERE NAME = ?;",

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
@@ -296,12 +296,12 @@ static const char *vu_queries[] = {
             FROM NVD_CPE INNER JOIN NVD_CVE_MATCH ON NVD_CPE.ID = NVD_CVE_MATCH.ID_CPE \
                          INNER JOIN NVD_CVE_CONFIGURATION ON NVD_CVE_CONFIGURATION.ID = NVD_CVE_MATCH.NVD_CVE_CONFIGURATION_ID \
                          INNER JOIN NVD_CVE ON NVD_CVE_CONFIGURATION.NVD_CVE_ID = NVD_CVE.ID \
-                         WHERE ((NVD_CPE.VERSION == '*' OR NVD_CPE.VERSION == '-') \
+                         WHERE ((NVD_CPE.VERSION = '*' OR NVD_CPE.VERSION = '-') \
                                 AND NVD_CVE_MATCH.VERSION_START_INCLUDING IS NULL \
                                 AND NVD_CVE_MATCH.VERSION_START_EXCLUDING IS NULL \
                                 AND NVD_CVE_MATCH.VERSION_END_INCLUDING IS NULL \
                                 AND NVD_CVE_MATCH.VERSION_END_EXCLUDING IS NULL) \
-                               AND NVD_CVE.CVE_ID = ? AND NVD_CPE.PRODUCT = ?",
+                               AND NVD_CVE.CVE_ID = ? AND (NVD_CPE.PRODUCT = ? OR NVD_CPE.PRODUCT = ?)",
     // SQL OPERATIONS
     "DELETE FROM SQLITE_SEQUENCE WHERE NAME = ?;",
     // WAZUH CPE DICTIONARY


### PR DESCRIPTION
## Description

The purpose of this PR is to modify the NVD filter query to reduce false positives.

Now, with this new query, the engine will discard all unfixed OVAL vulnerabilities that the NVD doesn't consider as unfixed.


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation