### PR TITLE
Windows unit test compile fix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -963,16 +963,28 @@ os_net/%.o: os_net/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
 #### Shared ##########
+# Unit tests wrappers
+wrappers_common_c := $(wildcard unit_tests/wrappers/*.c)
+wrappers_common_o := $(wrappers_common_c:.c=.o)
 
+wrappers_syscheck_c := $(wildcard unit_tests/wrappers/syscheckd/*.c)
+wrappers_syscheck_o := $(wrappers_syscheck_c:.c=.o)
 
 wrappers_shared_c := $(wildcard unit_tests/wrappers/shared/*.c)
 wrappers_shared_o := $(wrappers_shared_c:.c=.o)
 
 ifneq (,$(filter ${TEST},YES yes y Y 1))
+	OSSEC_CFLAGS+=${CFLAGS_TEST}
+	# OSSEC_CFLAGS+=${CFLAGS_TEST} -Itests
+	OSSEC_LDFLAGS+=${CFLAGS_TEST}
+	OSSEC_LIBS+=${LIBS_TEST}
+
+UNIT_TEST_WRAPPERS:=${wrappers_common_o}
 ifeq (${TARGET},winagent)
-	WINDOWS_SHARED_WRAPPERS:=${wrappers_syscheck_o}
+	UNIT_TEST_WRAPPERS+=${wrappers_shared_o}
+	UNIT_TEST_WRAPPERS+=${wrappers_syscheck_o}
 endif
-endif
+endif #TEST
 
 shared_c := $(wildcard shared/*.c)
 shared_o := $(shared_c:.c=.o)
@@ -1120,7 +1132,7 @@ crypto_o := ${crypto_blowfish_o} \
 
 #### libwazuh #########
 
-libwazuh.a: ${config_o} ${wmodules_dep} ${crypto_o} ${shared_o} ${os_net_o} ${os_regex_o} ${os_xml_o} ${os_zlib_o} ${WINDOWS_SHARED_WRAPPERS}
+libwazuh.a: ${config_o} ${wmodules_dep} ${crypto_o} ${shared_o} ${os_net_o} ${os_regex_o} ${os_xml_o} ${os_zlib_o} ${UNIT_TEST_WRAPPERS}
 	${OSSEC_LINK} $@ $^
 	${OSSEC_RANLIB} $@
 
@@ -1576,21 +1588,10 @@ LIBS_TEST=-lcmocka
 
 # LIBS_TEST = -lcheck -lm -lrt -lsubunit
 
-# Unit tests wrappers
-wrappers_syscheck_c := $(wildcard unit_tests/wrappers/syscheckd/*.c)
-wrappers_syscheck_o := $(wrappers_syscheck_c:.c=.o)
 
-ifneq (,$(filter ${TEST},YES yes y Y 1))
-	OSSEC_CFLAGS+=${CFLAGS_TEST}
-	# OSSEC_CFLAGS+=${CFLAGS_TEST} -Itests
-	OSSEC_LDFLAGS+=${CFLAGS_TEST}
-	OSSEC_LIBS+=${LIBS_TEST}
 
-ifeq (${TARGET},winagent)
-	WINDOWS_UNIT_TEST_WRAPPERS:=${wrappers_syscheck_o}
-	WINDOWS_UNIT_TEST_WRAPPERS+=${wrappers_shared_o}
-endif
-endif #TEST
+unit_tests/wrappers/%.o: unit_tests/wrappers/%.c
+	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -c $^ -o $@
 
 unit_tests/wrappers/syscheckd/%.o: unit_tests/wrappers/syscheckd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -c $^ -o $@
@@ -1689,10 +1690,10 @@ win32_ui_o := $(win32_ui_c:.c=.o)
 win32/ui/%.o: win32/ui/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -UOSSECHIDS -DARGV0=\"ossec-win32ui\" -c $^ -o $@
 
-win32/ossec-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll ${WINDOWS_UNIT_TEST_WRAPPERS}
+win32/ossec-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll ${UNIT_TEST_WRAPPERS}
 	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/ossec-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o $(filter-out syscheckd/main-event.o, ${syscheck_eventchannel_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll ${WINDOWS_UNIT_TEST_WRAPPERS}
+win32/ossec-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o $(filter-out syscheckd/main-event.o, ${syscheck_eventchannel_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} monitord/rotate_log.o monitord/compress_log.o wazuh_modules/syscollector/syscollector_win_ext.dll ${UNIT_TEST_WRAPPERS}
 	${OSSEC_CCBIN} -DARGV0=\"ossec-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 win32/ossec-rootcheck.exe: win32/icon.o win32/win_service_rk.o ${rootcheck_rk_o}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1767,7 +1767,7 @@ endif
 clean-deps:
 	rm -rf $(EXTERNAL_DIR) $(EXTERNAL_CPYTHON) $(MSU_JSON_GZ)
 
-clean-internals:
+clean-internals: clean-unit-tests
 	rm -f $(BUILD_SERVER)
 	rm -f $(BUILD_AGENT)
 	rm -f $(BUILD_LIBS)
@@ -1799,8 +1799,11 @@ clean-internals:
 	rm -f ${wdb_o}
 	rm -f ${SELINUX_MODULE}
 	rm -f ${SELINUX_POLICY}
+	
+clean-unit-tests:
 	rm -f ${wrappers_syscheck_o}
 	rm -f ${wrappers_shared_o}
+	rm -f ${wrappers_common_o}
 
 clean-framework:
 	${MAKE} -C ../framework clean

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -207,6 +207,12 @@ extern const char *__local_name;
 #define isAgent 0
 #endif
 
+#ifndef UNIT_TESTING
+#define FOREVER() 1
+#else
+#include "unit_tests/wrappers/common.h"
+#endif
+
 #include "debug_op.h"
 #include "wait_op.h"
 #include "agent_op.h"
@@ -260,5 +266,6 @@ extern const char *__local_name;
 #include "os_utils.h"
 #include "schedule_scan.h"
 #include "bzip2_op.h"
+
 
 #endif /* SHARED_H */

--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -37,9 +37,6 @@
 // Remove static qualifier when unit testing
 #define STATIC
 
-// Control infinite loops during unit tests
-int FOREVER();
-
 #undef OpenProcessToken
 #define OpenProcessToken wrap_win_whodata_OpenProcessToken
 #undef GetLastError
@@ -87,7 +84,6 @@ int FOREVER();
 #define ConvertSidToStringSid wrap_win_whodata_ConvertSidToStringSid
 #else
 #define STATIC static
-#define FOREVER() 1
 #endif
 
 // Variables whodata

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -44,6 +44,9 @@ if(NOT WAZUHEXT)
   message(FATAL_ERROR "libwazuhext not found! Aborting...")
 endif()
 
+add_subdirectory(syscheckd)
+add_subdirectory(shared)
+
 # Config files
 if(${TARGET} STREQUAL "winagent")
   configure_file("test_syscheck_win.conf" "syscheckd/test_syscheck.conf" NEWLINE_STYLE WIN32)

--- a/src/unit_tests/server.cmake
+++ b/src/unit_tests/server.cmake
@@ -12,8 +12,6 @@ add_compile_options(-ggdb -O0 -g -coverage -DTEST_SERVER -DENABLE_AUDIT -DINOTIF
 set(TEST_DEPS ${WAZUHLIB} ${WAZUHEXT} -lpthread -lcmocka -fprofile-arcs -ftest-coverage)
 
 add_subdirectory(analysisd)
-add_subdirectory(shared)
-add_subdirectory(syscheckd)
 add_subdirectory(wazuh_db)
 add_subdirectory(wazuh_modules)
 add_subdirectory(wazuh_modules/gcp)

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -13,8 +13,6 @@
 #include <cmocka.h>
 #include <stdio.h>
 
-#include "../wazuh_modules/wmodules.h"
-#include "../wazuh_modules/vulnerability_detector/wm_vuln_detector.h"
 #include "../headers/shared.h"
 
 char * w_tolower_str(const char *string);

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -221,7 +221,7 @@ if(${TARGET} STREQUAL "winagent")
                                            -Wl,--wrap=OSHash_Delete_ex,--wrap=_mterror,--wrap=check_path_type,--wrap=_minfo \
                                            -Wl,--wrap=OSHash_Create,--wrap=OSHash_SetFreeDataPointer,--wrap=fim_whodata_event \
                                            -Wl,--wrap=fim_configuration_directory,--wrap=fim_checker,--wrap=OSHash_Get \
-                                           -Wl,--wrap=convert_windows_string,--wrap=OSHash_Get_ex")
+                                           -Wl,--wrap=convert_windows_string,--wrap=OSHash_Get_ex,--wrap=FOREVER")
 endif()
 
 # Compiling tests

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -438,7 +438,7 @@ void test_fim_whodata_initialize_fail_set_policies(void **state)
 
         str_lowercase(expanded_dirs[i]);
         expect_string(__wrap_realtime_adddir, dir, expanded_dirs[i]);
-        expect_value(__wrap_realtime_adddir, whodata, 9);
+        expect_value(__wrap_realtime_adddir, whodata, 10);
         will_return(__wrap_realtime_adddir, 0);
     }
 

--- a/src/unit_tests/syscheckd/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/test_win_whodata.c
@@ -4569,7 +4569,7 @@ void test_whodata_callback_event_4656_canceled(void **state){
     buffer[5].Type = EvtVarTypeHexInt64;
     buffer[6].Type = EvtVarTypeHexInt32;
     buffer[7].Type = EvtVarTypeNull;
-    const char* win_path = syscheck.dir[0];
+    const char* win_path = syscheck.dir[1];
     buffer[0].Int16Val = 4656;
     buffer[1].XmlVal = L"USERNAME";
     buffer[2].XmlVal = (const short unsigned int *) win_path;
@@ -4588,13 +4588,13 @@ void test_whodata_callback_event_4656_canceled(void **state){
 
     //Whodata path
     {
-        expect_string(wrap_win_whodata_WideCharToMultiByte, lpWideCharStr, syscheck.dir[0]);
+        expect_string(wrap_win_whodata_WideCharToMultiByte, lpWideCharStr, syscheck.dir[1]);
         expect_value(wrap_win_whodata_WideCharToMultiByte, cchWideChar, -1);
         will_return(wrap_win_whodata_WideCharToMultiByte, 21);
 
-        expect_string(wrap_win_whodata_WideCharToMultiByte, lpWideCharStr, syscheck.dir[0]);
+        expect_string(wrap_win_whodata_WideCharToMultiByte, lpWideCharStr, syscheck.dir[1]);
         expect_value(wrap_win_whodata_WideCharToMultiByte, cchWideChar, -1);
-        will_return(wrap_win_whodata_WideCharToMultiByte, syscheck.dir[0]);
+        will_return(wrap_win_whodata_WideCharToMultiByte, syscheck.dir[1]);
         will_return(wrap_win_whodata_WideCharToMultiByte, 21);
     }
 
@@ -4612,7 +4612,7 @@ void test_whodata_callback_event_4656_canceled(void **state){
     will_return(__wrap_fim_configuration_directory, 8);
 
     char debug_msg[OS_MAXSTR];
-    snprintf(debug_msg, OS_MAXSTR, "(6240): The monitoring of '%s' in whodata mode has been canceled. Added to the ignore list.", syscheck.dir[0]);
+    snprintf(debug_msg, OS_MAXSTR, "(6240): The monitoring of '%s' in whodata mode has been canceled. Added to the ignore list.", syscheck.dir[1]);
     expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
     int ret = whodata_callback(action, NULL, event);
@@ -4648,7 +4648,7 @@ void test_whodata_callback_event_4656_handler_not_removed(void **state) {
     buffer[6].Type = EvtVarTypeHexInt32;
     buffer[7].Type = EvtVarTypeNull;
     char win_path[OS_MAXSTR] = {0};
-    strcat(win_path, syscheck.dir[1]);
+    strcat(win_path, syscheck.dir[2]);
     strcat(win_path, "\\sasa.exe");
     buffer[0].Int16Val = 4656;
     buffer[1].XmlVal = L"USERNAME";
@@ -5677,6 +5677,8 @@ void test_whodata_callback_event_4663_invalid_param(void **state){
     whodata_evt *w_evt = *state;
     whodata_directory w_dir;
 
+    w_evt->scan_directory = (char)2;
+
     /* EvtRender first call */
     expect_value(wrap_win_whodata_EvtRender, Context, context);
     expect_value(wrap_win_whodata_EvtRender, Fragment, event);
@@ -5736,7 +5738,7 @@ void test_whodata_callback_event_4663_invalid_param(void **state){
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.fd);
     expect_string(__wrap_OSHash_Get, key, "1234567890123456789");
-    will_return(__wrap_OSHash_Get, &w_evt);
+    will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.wdata.directories);
     expect_string(__wrap_OSHash_Get_ex, key, "c:\\another\\path.file");
@@ -5821,7 +5823,7 @@ void test_whodata_callback_event_4663_wrong_event_time_param(void **state){
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.fd);
     expect_string(__wrap_OSHash_Get, key, "1234567890123456789");
-    will_return(__wrap_OSHash_Get, &w_evt);
+    will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.wdata.directories);
     expect_string(__wrap_OSHash_Get_ex, key, "c:\\another\\path.file");
@@ -5929,7 +5931,7 @@ void test_whodata_callback_event_4663_file_time_error(void **state){
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.fd);
     expect_string(__wrap_OSHash_Get, key, "1234567890123456789");
-    will_return(__wrap_OSHash_Get, &w_evt);
+    will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.wdata.directories);
     expect_string(__wrap_OSHash_Get_ex, key, "c:\\another\\path.file");
@@ -6036,7 +6038,7 @@ void test_whodata_callback_event_4663_timestamp_ok(void **state){
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.fd);
     expect_string(__wrap_OSHash_Get, key, "1234567890123456789");
-    will_return(__wrap_OSHash_Get, &w_evt);
+    will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.wdata.directories);
     expect_string(__wrap_OSHash_Get_ex, key, "c:\\another\\path.file");
@@ -6121,7 +6123,7 @@ void test_whodata_callback_event_4663_no_event(void **state){
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.fd);
     expect_string(__wrap_OSHash_Get, key, "1234567890123456789");
-    will_return(__wrap_OSHash_Get, &w_evt);
+    will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.wdata.directories);
     expect_string(__wrap_OSHash_Get_ex, key, "c:\\another\\path.file");
@@ -6147,6 +6149,7 @@ void test_whodata_callback_event_4663_no_dir(void **state){
     EVT_VARIANT buffer[NUM_EVENTS];
     whodata_evt *w_evt = *state;
     whodata_directory w_dir;
+    w_evt->scan_directory = (char)2;
 
     /* EvtRender first call */
     expect_value(wrap_win_whodata_EvtRender, Context, context);
@@ -6209,7 +6212,7 @@ void test_whodata_callback_event_4663_no_dir(void **state){
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.fd);
     expect_string(__wrap_OSHash_Get, key, "1234567890123456789");
-    will_return(__wrap_OSHash_Get, &w_evt);
+    will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.wdata.directories);
     expect_string(__wrap_OSHash_Get_ex, key, "c:\\another\\path.file");
@@ -6243,6 +6246,7 @@ void test_whodata_callback_event_4663_dir(void **state){
     EVT_VARIANT buffer[NUM_EVENTS];
     whodata_evt *w_evt = *state;
     whodata_directory w_dir;
+    w_evt->scan_directory = (char)2;
 
     /* EvtRender first call */
     expect_value(wrap_win_whodata_EvtRender, Context, context);
@@ -6305,7 +6309,7 @@ void test_whodata_callback_event_4663_dir(void **state){
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.fd);
     expect_string(__wrap_OSHash_Get, key, "1234567890123456789");
-    will_return(__wrap_OSHash_Get, &w_evt);
+    will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.wdata.directories);
     expect_string(__wrap_OSHash_Get_ex, key, "c:\\another\\path.file");
@@ -6401,7 +6405,7 @@ void test_whodata_callback_event_4663_dir_removed(void **state){
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.fd);
     expect_string(__wrap_OSHash_Get, key, "1234567890123456789");
-    will_return(__wrap_OSHash_Get, &w_evt);
+    will_return(__wrap_OSHash_Get, w_evt);
 
     int ret = whodata_callback(action, NULL, event);
     assert_int_equal(ret, 0);
@@ -7783,8 +7787,8 @@ void test_state_checker_no_files_to_check(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
-    will_return(FOREVER, 1);
-    will_return(FOREVER, 0);
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_FOREVER, 0);
 
     expect_value(wrap_win_whodata_Sleep, dwMilliseconds, WDATA_DEFAULT_INTERVAL_SCAN * 1000);
 
@@ -7808,8 +7812,8 @@ void test_state_checker_file_not_whodata(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
-    will_return(FOREVER, 1);
-    will_return(FOREVER, 0);
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_FOREVER, 0);
 
     expect_value(wrap_win_whodata_Sleep, dwMilliseconds, WDATA_DEFAULT_INTERVAL_SCAN * 1000);
 
@@ -7840,8 +7844,8 @@ void test_state_checker_file_does_not_exist(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
-    will_return(FOREVER, 1);
-    will_return(FOREVER, 0);
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_FOREVER, 0);
 
     expect_value(wrap_win_whodata_Sleep, dwMilliseconds, WDATA_DEFAULT_INTERVAL_SCAN * 1000);
 
@@ -7883,8 +7887,8 @@ void test_state_checker_file_with_invalid_sacl(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
-    will_return(FOREVER, 1);
-    will_return(FOREVER, 0);
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_FOREVER, 0);
 
     expect_value(wrap_win_whodata_Sleep, dwMilliseconds, WDATA_DEFAULT_INTERVAL_SCAN * 1000);
 
@@ -7992,8 +7996,8 @@ void test_state_checker_file_with_valid_sacl(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
-    will_return(FOREVER, 1);
-    will_return(FOREVER, 0);
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_FOREVER, 0);
 
     expect_value(wrap_win_whodata_Sleep, dwMilliseconds, WDATA_DEFAULT_INTERVAL_SCAN * 1000);
 
@@ -8097,8 +8101,8 @@ void test_state_checker_dir_readded_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
-    will_return(FOREVER, 1);
-    will_return(FOREVER, 0);
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_FOREVER, 0);
 
     expect_value(wrap_win_whodata_Sleep, dwMilliseconds, WDATA_DEFAULT_INTERVAL_SCAN * 1000);
 
@@ -8164,8 +8168,8 @@ void test_state_checker_dir_readded_succesful(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
-    will_return(FOREVER, 1);
-    will_return(FOREVER, 0);
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_FOREVER, 0);
 
     expect_value(wrap_win_whodata_Sleep, dwMilliseconds, WDATA_DEFAULT_INTERVAL_SCAN * 1000);
 
@@ -8503,8 +8507,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_whodata_callback_event_4658_new_file_added, setup_win_whodata_evt, teardown_win_whodata_evt),
         cmocka_unit_test_setup_teardown(test_whodata_callback_event_4658_no_new_files, setup_win_whodata_evt, teardown_win_whodata_evt),
         cmocka_unit_test_setup_teardown(test_whodata_callback_event_4658_scan_aborted, setup_win_whodata_evt, teardown_win_whodata_evt),
-        cmocka_unit_test_setup_teardown(test_whodata_callback_event_4663_no_dir, setup_whodata_callback, teardown_whodata_callback),
-        cmocka_unit_test(test_whodata_callback_event_4663_invalid_param),
+        cmocka_unit_test_setup_teardown(test_whodata_callback_event_4663_no_dir, setup_event_4663_dir, teardown_event_4663_dir),
+        cmocka_unit_test_setup_teardown(test_whodata_callback_event_4663_invalid_param, setup_event_4663_dir, teardown_event_4663_dir),
         cmocka_unit_test_setup_teardown(test_whodata_callback_event_4663_wrong_event_time_param, setup_win_whodata_evt, teardown_win_whodata_evt),
         cmocka_unit_test_setup_teardown(test_whodata_callback_event_4663_file_time_error, setup_win_whodata_evt, teardown_win_whodata_evt),
         cmocka_unit_test_setup_teardown(test_whodata_callback_event_4663_timestamp_ok, setup_win_whodata_evt, teardown_win_whodata_evt),

--- a/src/unit_tests/wazuh_modules/gcp/test_wm_gcp.c
+++ b/src/unit_tests/wazuh_modules/gcp/test_wm_gcp.c
@@ -126,10 +126,6 @@ void __wrap__mterror(const char *tag, const char * file, int line, const char * 
     check_expected(formatted_msg);
 }
 
-int __wrap_FOREVER() {
-    return mock();
-}
-
 /* setup/teardown */
 static int setup_group(void **state) {
     wm_gcp *gcp_config = calloc(1, sizeof(wm_gcp));

--- a/src/unit_tests/wazuh_modules/scheduling/test_aws_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_aws_scheduling.c
@@ -27,10 +27,6 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     time_t current_time = time(NULL);
     struct tm *date = localtime(&current_time);
     test_aws_date_storage[test_aws_date_counter++] = *date;
-    if(test_aws_date_counter >= TEST_MAX_DATES) {
-        // Break infinite loop
-        will_return(__wrap_FOREVER, 0);
-    }
 }
 /****************************************************************/
 
@@ -74,7 +70,6 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_aws_date_counter = 0;
     return 0;
@@ -113,6 +108,8 @@ void test_interval_execution(void **state) {
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 600; // 10min
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     aws_module->context->start(module_data);
     check_time_interval( &module_data->scan_config, &test_aws_date_storage[0], TEST_MAX_DATES);
 }
@@ -126,6 +123,8 @@ void test_day_of_month(void **state) {
     module_data->scan_config.scan_time =strdup("00:00");
     module_data->scan_config.interval = 1; // 1 month
     module_data->scan_config.month_interval = true;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     aws_module->context->start(module_data);
     check_day_of_month( &module_data->scan_config, &test_aws_date_storage[0], TEST_MAX_DATES);  
 }
@@ -139,6 +138,8 @@ void test_day_of_week(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 604800;  // 1 week
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     aws_module->context->start(module_data);
     check_day_of_week( &module_data->scan_config, &test_aws_date_storage[0], TEST_MAX_DATES);  
 }
@@ -152,6 +153,8 @@ void test_time_of_day(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = WM_DEF_INTERVAL;  // 1 day
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     aws_module->context->start(module_data);
     check_time_of_day( &module_data->scan_config, &test_aws_date_storage[0], TEST_MAX_DATES);
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_aws_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_aws_scheduling.c
@@ -29,7 +29,7 @@ void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     test_aws_date_storage[test_aws_date_counter++] = *date;
     if(test_aws_date_counter >= TEST_MAX_DATES) {
         // Break infinite loop
-        disable_forever_loop();
+        will_return(__wrap_FOREVER, 0);
     }
 }
 /****************************************************************/
@@ -74,7 +74,7 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    enable_forever_loop();
+    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_aws_date_counter = 0;
     return 0;

--- a/src/unit_tests/wazuh_modules/scheduling/test_azure_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_azure_scheduling.c
@@ -27,7 +27,7 @@ int __wrap_wm_exec(char *command, char **output, int *exitcode, int secs, const 
     test_azure_date_storage[test_azure_date_counter++] = *date;
     if(test_azure_date_counter >= TEST_MAX_DATES){
         // Break infinite loop
-        disable_forever_loop();
+        will_return(__wrap_FOREVER, 0);
     }
     *exitcode = 0;
     return 0;
@@ -89,7 +89,7 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    enable_forever_loop();
+    will_return(__wrap_FOREVER, 1);
     test_azure_date_counter = 0;
     return 0;
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_azure_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_azure_scheduling.c
@@ -25,10 +25,6 @@ int __wrap_wm_exec(char *command, char **output, int *exitcode, int secs, const 
     time_t current_time = time(NULL);
     struct tm *date = localtime(&current_time);
     test_azure_date_storage[test_azure_date_counter++] = *date;
-    if(test_azure_date_counter >= TEST_MAX_DATES){
-        // Break infinite loop
-        will_return(__wrap_FOREVER, 0);
-    }
     *exitcode = 0;
     return 0;
 }
@@ -89,7 +85,6 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    will_return(__wrap_FOREVER, 1);
     test_azure_date_counter = 0;
     return 0;
 }
@@ -127,6 +122,8 @@ void test_interval_execution(void **state) {
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 1200; // 20min
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     azure_module->context->start(module_data);
     check_time_interval( &module_data->scan_config, &test_azure_date_storage[0], TEST_MAX_DATES);
 }
@@ -140,6 +137,8 @@ void test_day_of_month(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 1; // 1 month
     module_data->scan_config.month_interval = true;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     azure_module->context->start(module_data);
     check_day_of_month( &module_data->scan_config, &test_azure_date_storage[0], TEST_MAX_DATES);
 }
@@ -153,6 +152,8 @@ void test_day_of_week(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 604800;  // 1 week
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     azure_module->context->start(module_data);
     check_day_of_week( &module_data->scan_config, &test_azure_date_storage[0], TEST_MAX_DATES);
 }
@@ -166,6 +167,8 @@ void test_time_of_day(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = WM_DEF_INTERVAL;  // 1 day
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     azure_module->context->start(module_data);
     check_time_of_day( &module_data->scan_config, &test_azure_date_storage[0], TEST_MAX_DATES);
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_ciscat_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_ciscat_scheduling.c
@@ -26,10 +26,6 @@ int __wrap_os_random() {
     time_t current_time = time(NULL);
     struct tm *date = localtime(&current_time);
     test_ciscat_date_storage[test_ciscat_date_counter++] = *date;
-    if(test_ciscat_date_counter >= TEST_MAX_DATES){
-        // Break infinite loop
-        will_return(__wrap_FOREVER, 0);
-    }
     return 0;
 }
 
@@ -83,7 +79,6 @@ static int teardown_module(){
 }
 
 static int setup_test_executions() {
-    will_return(__wrap_FOREVER, 1);
     test_ciscat_date_counter = 0;
     return 0;
 }
@@ -121,6 +116,8 @@ void test_interval_execution(void **state) {
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 120; // 2min
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     ciscat_module->context->start(module_data);
     check_time_interval( &module_data->scan_config, &test_ciscat_date_storage[0], TEST_MAX_DATES);
 }
@@ -134,6 +131,8 @@ void test_day_of_month(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 1; // 1 month
     module_data->scan_config.month_interval = true;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     ciscat_module->context->start(module_data);
     check_day_of_month( &module_data->scan_config, &test_ciscat_date_storage[0], TEST_MAX_DATES);
 }
@@ -147,6 +146,8 @@ void test_day_of_week(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 604800;  // 1 week
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     ciscat_module->context->start(module_data);
     check_day_of_week( &module_data->scan_config, &test_ciscat_date_storage[0], TEST_MAX_DATES);
 }
@@ -160,6 +161,8 @@ void test_time_of_day(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = WM_DEF_INTERVAL;  // 1 day
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     ciscat_module->context->start(module_data);
     check_time_of_day( &module_data->scan_config, &test_ciscat_date_storage[0], TEST_MAX_DATES);
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_ciscat_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_ciscat_scheduling.c
@@ -28,7 +28,7 @@ int __wrap_os_random() {
     test_ciscat_date_storage[test_ciscat_date_counter++] = *date;
     if(test_ciscat_date_counter >= TEST_MAX_DATES){
         // Break infinite loop
-        disable_forever_loop();
+        will_return(__wrap_FOREVER, 0);
     }
     return 0;
 }
@@ -83,7 +83,7 @@ static int teardown_module(){
 }
 
 static int setup_test_executions() {
-    enable_forever_loop();
+    will_return(__wrap_FOREVER, 1);
     test_ciscat_date_counter = 0;
     return 0;
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_command_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_command_scheduling.c
@@ -27,7 +27,7 @@ int __wrap_wm_exec(char *command, char **output, int *exitcode, int secs, const 
     test_command_date_storage[test_command_date_counter++] = *date;
     if(test_command_date_counter >= TEST_MAX_DATES){
         // Break infinite loop
-        disable_forever_loop();
+        will_return(__wrap_FOREVER, 0);
     }
     *exitcode = 0;
     return 0;
@@ -76,7 +76,7 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state){
-    enable_forever_loop();
+    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_command_date_counter = 0;
     return 0;

--- a/src/unit_tests/wazuh_modules/scheduling/test_command_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_command_scheduling.c
@@ -25,10 +25,6 @@ int __wrap_wm_exec(char *command, char **output, int *exitcode, int secs, const 
     time_t current_time = time(NULL);
     struct tm *date = localtime(&current_time);
     test_command_date_storage[test_command_date_counter++] = *date;
-    if(test_command_date_counter >= TEST_MAX_DATES){
-        // Break infinite loop
-        will_return(__wrap_FOREVER, 0);
-    }
     *exitcode = 0;
     return 0;
 }
@@ -76,7 +72,6 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state){
-    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_command_date_counter = 0;
     return 0;
@@ -115,6 +110,8 @@ void test_interval_execution(void **state) {
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 60; // 1min
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     command_module->context->start(module_data);
     check_time_interval( &module_data->scan_config, &test_command_date_storage[0], TEST_MAX_DATES);     
 }
@@ -128,6 +125,8 @@ void test_day_of_month(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 1; // 1 month
     module_data->scan_config.month_interval = true;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     command_module->context->start(module_data);
     check_day_of_month( &module_data->scan_config, &test_command_date_storage[0], TEST_MAX_DATES);
 }
@@ -141,6 +140,8 @@ void test_day_of_week(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 604800;  // 1 week
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     command_module->context->start(module_data);
     check_day_of_week( &module_data->scan_config, &test_command_date_storage[0], TEST_MAX_DATES);
 }
@@ -154,6 +155,8 @@ void test_time_of_day(void **state) {
     module_data->scan_config.scan_time = strdup("05:25");
     module_data->scan_config.interval = WM_DEF_INTERVAL;  // 1 day
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     command_module->context->start(module_data);
     check_time_of_day( &module_data->scan_config, &test_command_date_storage[0], TEST_MAX_DATES);
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_docker_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_docker_scheduling.c
@@ -28,10 +28,6 @@ int __wrap_wpclose(wfd_t * wfd) {
     time_t current_time = time(NULL);
     struct tm *date = localtime(&current_time);
     test_docker_date_storage[test_docker_date_counter++] = *date;
-    if(test_docker_date_counter >= TEST_MAX_DATES){
-        // Break infinite loop
-        will_return(__wrap_FOREVER, 0);
-    }
     return 0;
 }
 
@@ -75,7 +71,6 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_docker_date_counter = 0;
     return 0;
@@ -116,6 +111,8 @@ void test_interval_execution(void **state) {
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 60 * 25; // 25min
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     docker_module->context->start(module_data);
     check_time_interval( &module_data->scan_config, &test_docker_date_storage[0], TEST_MAX_DATES);   
 }
@@ -129,6 +126,8 @@ void test_day_of_month(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 1; // 1 month
     module_data->scan_config.month_interval = true;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     docker_module->context->start(module_data);
     check_day_of_month( &module_data->scan_config, &test_docker_date_storage[0], TEST_MAX_DATES); 
 }
@@ -142,6 +141,8 @@ void test_day_of_week(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 604800;  // 1 week
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     docker_module->context->start(module_data);
     check_day_of_week( &module_data->scan_config, &test_docker_date_storage[0], TEST_MAX_DATES);
 }
@@ -155,6 +156,8 @@ void test_time_of_day(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = WM_DEF_INTERVAL;  // 1 day
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     docker_module->context->start(module_data);
     check_time_of_day( &module_data->scan_config, &test_docker_date_storage[0], TEST_MAX_DATES);
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_docker_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_docker_scheduling.c
@@ -30,7 +30,7 @@ int __wrap_wpclose(wfd_t * wfd) {
     test_docker_date_storage[test_docker_date_counter++] = *date;
     if(test_docker_date_counter >= TEST_MAX_DATES){
         // Break infinite loop
-        disable_forever_loop();
+        will_return(__wrap_FOREVER, 0);
     }
     return 0;
 }
@@ -75,7 +75,7 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    enable_forever_loop();
+    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_docker_date_counter = 0;
     return 0;

--- a/src/unit_tests/wazuh_modules/scheduling/test_gcp_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_gcp_scheduling.c
@@ -35,10 +35,6 @@ void wm_gcp_run(const wm_gcp *data) {
     time_t current_time = time(NULL);
     struct tm *date = localtime(&current_time);
     test_gcp_date_storage[test_gcp_date_counter++] = *date;
-    if(test_gcp_date_counter >= TEST_MAX_DATES){
-        // Break infinite loop
-        will_return(__wrap_FOREVER, 0);
-    }
 }
 
 static void wmodule_cleanup(wmodule *module){
@@ -79,7 +75,6 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    will_return(__wrap_FOREVER, 1);
     test_gcp_date_counter = 0;
     return 0;
 }
@@ -118,6 +113,8 @@ void test_interval_execution(void **state) {
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 60; // 1min
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     gcp_module->context->start(module_data);
     check_time_interval( &module_data->scan_config, &test_gcp_date_storage[0], TEST_MAX_DATES);   
 }
@@ -131,6 +128,8 @@ void test_day_of_month(void **state){
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 1; // 1 month
     module_data->scan_config.month_interval = true;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     gcp_module->context->start(module_data);
     check_day_of_month( &module_data->scan_config, &test_gcp_date_storage[0], TEST_MAX_DATES);  
 }
@@ -144,6 +143,8 @@ void test_day_of_week(void **state){
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 604800;  // 1 week
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     gcp_module->context->start(module_data);
     check_day_of_week( &module_data->scan_config, &test_gcp_date_storage[0], TEST_MAX_DATES);    
 }
@@ -157,6 +158,8 @@ void test_time_of_day(void **state){
     module_data->scan_config.scan_time = strdup("05:25");
     module_data->scan_config.interval = WM_DEF_INTERVAL;  // 1 day
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     gcp_module->context->start(module_data);
     check_time_of_day( &module_data->scan_config, &test_gcp_date_storage[0], TEST_MAX_DATES);
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_gcp_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_gcp_scheduling.c
@@ -37,7 +37,7 @@ void wm_gcp_run(const wm_gcp *data) {
     test_gcp_date_storage[test_gcp_date_counter++] = *date;
     if(test_gcp_date_counter >= TEST_MAX_DATES){
         // Break infinite loop
-        disable_forever_loop();
+        will_return(__wrap_FOREVER, 0);
     }
 }
 
@@ -79,7 +79,7 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    enable_forever_loop();
+    will_return(__wrap_FOREVER, 1);
     test_gcp_date_counter = 0;
     return 0;
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_oscap_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_oscap_scheduling.c
@@ -27,7 +27,7 @@ int __wrap_wm_exec(char *command, char **output, int *exitcode, int secs, const 
     test_oscap_date_storage[test_oscap_date_counter++] = *date;
     if(test_oscap_date_counter >= TEST_MAX_DATES){
         // Break infinite loop
-        disable_forever_loop();
+        will_return(__wrap_FOREVER, 0);
     }
     *exitcode = 0;
     *output = strdup("TEST_STRING");
@@ -86,7 +86,7 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    enable_forever_loop();
+    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_oscap_date_counter = 0;
     return 0;

--- a/src/unit_tests/wazuh_modules/scheduling/test_oscap_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_oscap_scheduling.c
@@ -25,10 +25,6 @@ int __wrap_wm_exec(char *command, char **output, int *exitcode, int secs, const 
     time_t current_time = time(NULL);
     struct tm *date = localtime(&current_time);
     test_oscap_date_storage[test_oscap_date_counter++] = *date;
-    if(test_oscap_date_counter >= TEST_MAX_DATES){
-        // Break infinite loop
-        will_return(__wrap_FOREVER, 0);
-    }
     *exitcode = 0;
     *output = strdup("TEST_STRING");
     return 0;
@@ -86,7 +82,6 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_oscap_date_counter = 0;
     return 0;
@@ -127,6 +122,8 @@ void test_interval_execution(void **state) {
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 60; // 1min
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     oscap_module->context->start(module_data);
     check_time_interval( &module_data->scan_config, &test_oscap_date_storage[0], TEST_MAX_DATES);
 }
@@ -140,6 +137,8 @@ void test_day_of_month(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 1; // 1 month
     module_data->scan_config.month_interval = true;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     oscap_module->context->start(module_data);
     check_day_of_month( &module_data->scan_config, &test_oscap_date_storage[0], TEST_MAX_DATES);
 }
@@ -153,6 +152,8 @@ void test_day_of_week(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 604800;  // 1 week
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     oscap_module->context->start(module_data);
     check_day_of_week( &module_data->scan_config, &test_oscap_date_storage[0], TEST_MAX_DATES);
 }
@@ -166,6 +167,8 @@ void test_time_of_day(void **state) {
     module_data->scan_config.scan_time = strdup("05:25");
     module_data->scan_config.interval = WM_DEF_INTERVAL;  // 1 day
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     oscap_module->context->start(module_data);
     check_time_of_day( &module_data->scan_config, &test_oscap_date_storage[0], TEST_MAX_DATES);
 }

--- a/src/unit_tests/wazuh_modules/scheduling/test_sca_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_sca_scheduling.c
@@ -64,7 +64,7 @@ void wm_sca_send_policies_scanned(wm_sca_t * data)
     test_sca_date_storage[test_sca_date_counter++] = *date;
     if(test_sca_date_counter >= TEST_MAX_DATES){
         // Break infinite loop
-        disable_forever_loop();
+        will_return(__wrap_FOREVER, 0);
     }
     
 }
@@ -110,7 +110,7 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    enable_forever_loop();
+    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_sca_date_counter = 0;
     return 0;

--- a/src/unit_tests/wazuh_modules/scheduling/test_sca_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_sca_scheduling.c
@@ -62,11 +62,6 @@ void wm_sca_send_policies_scanned(wm_sca_t * data)
     time_t current_time = time(NULL);
     struct tm *date = localtime(&current_time);
     test_sca_date_storage[test_sca_date_counter++] = *date;
-    if(test_sca_date_counter >= TEST_MAX_DATES){
-        // Break infinite loop
-        will_return(__wrap_FOREVER, 0);
-    }
-    
 }
 
 /******* Helpers **********/
@@ -110,7 +105,6 @@ static int teardown_module(){
 }
 
 static int setup_test_executions(void **state) {
-    will_return(__wrap_FOREVER, 1);
     wm_max_eps = 1;
     test_sca_date_counter = 0;
     return 0;
@@ -160,6 +154,8 @@ void test_interval_execution(void **state) {
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 60; // 1min
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     sca_module->context->start(module_data);
     check_time_interval( &module_data->scan_config, &test_sca_date_storage[0], TEST_MAX_DATES);   
 }
@@ -173,6 +169,8 @@ void test_day_of_month(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 1; // 1 month
     module_data->scan_config.month_interval = true;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     sca_module->context->start(module_data);
     check_day_of_month( &module_data->scan_config, &test_sca_date_storage[0], TEST_MAX_DATES);   
 }
@@ -186,6 +184,8 @@ void test_day_of_week(void **state) {
     module_data->scan_config.scan_time = strdup("00:00");
     module_data->scan_config.interval = 604800;  // 1 week
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     sca_module->context->start(module_data);
     check_day_of_week( &module_data->scan_config, &test_sca_date_storage[0], TEST_MAX_DATES);
 }
@@ -199,6 +199,8 @@ void test_time_of_day(void **state) {
     module_data->scan_config.scan_time = strdup("05:25");
     module_data->scan_config.interval = WM_DEF_INTERVAL;  // 1 day
     module_data->scan_config.month_interval = false;
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    will_return(__wrap_FOREVER, 0);
     sca_module->context->start(module_data);
     check_time_of_day( &module_data->scan_config, &test_sca_date_storage[0], TEST_MAX_DATES);
 }

--- a/src/unit_tests/wazuh_modules/scheduling/wmodules_scheduling_helpers.c
+++ b/src/unit_tests/wazuh_modules/scheduling/wmodules_scheduling_helpers.c
@@ -2,23 +2,9 @@
 #include <time.h> 
 
 static time_t current_time = 0;
-static int FOREVER_LOOP = 1;
 extern time_t __real_time(time_t *_time);
 /**************** Mocked functions *************/
 /**     Mocked functions       **/
-
-//Function that defines the ending of the module main loop
-int __wrap_FOREVER(){
-    return FOREVER_LOOP;
-}
-
-void disable_forever_loop(){
-    FOREVER_LOOP = 0;
-}
-
-void enable_forever_loop(){
-    FOREVER_LOOP = 1;
-}
 
 time_t __wrap_time(time_t *_time){
     if(!current_time){

--- a/src/unit_tests/wazuh_modules/scheduling/wmodules_scheduling_helpers.h
+++ b/src/unit_tests/wazuh_modules/scheduling/wmodules_scheduling_helpers.h
@@ -17,9 +17,6 @@ typedef struct test_structure {
 const XML_NODE string_to_xml_node(const char * string, OS_XML *_lxml);
 sched_scan_config init_config_from_string(const char* string);
 
-void disable_forever_loop();
-void enable_forever_loop();
-
 /* Sets current simulation time */
 void set_current_time(time_t _time);
 

--- a/src/unit_tests/wrappers/common.c
+++ b/src/unit_tests/wrappers/common.c
@@ -1,0 +1,26 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "common.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+
+int FOREVER() {
+    return 1;
+}
+
+
+int __wrap_FOREVER() {
+    return mock();
+}
+

--- a/src/unit_tests/wrappers/common.h
+++ b/src/unit_tests/wrappers/common.h
@@ -1,0 +1,21 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef COMMON_H
+#define COMMON_H
+
+int FOREVER();
+
+int __wrap_FOREVER();
+
+
+#endif /* COMMON_H */
+

--- a/src/unit_tests/wrappers/syscheckd/run_check.c
+++ b/src/unit_tests/wrappers/syscheckd/run_check.c
@@ -13,8 +13,6 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "./run_check.h"
-
 struct state_t state;
 
 WINBOOL wrap_SetThreadPriority (HANDLE hThread, int nPriority) {

--- a/src/unit_tests/wrappers/syscheckd/run_check.c
+++ b/src/unit_tests/wrappers/syscheckd/run_check.c
@@ -41,5 +41,5 @@ HANDLE wrap_run_check_CreateThread(
     __UNUSED_PARAM(DWORD                   dwCreationFlags),
     __UNUSED_PARAM(LPDWORD                 lpThreadId)
 ) {
-    return mock();
+    return mock_type(HANDLE);
 }

--- a/src/unit_tests/wrappers/syscheckd/win_whodata.c
+++ b/src/unit_tests/wrappers/syscheckd/win_whodata.c
@@ -410,10 +410,6 @@ char * wrap_win_whodata_fgets (char * __s, int __n, FILE * __stream) {
   return NULL;
 }
 
-int FOREVER() {
-  return mock();
-}
-
 VOID wrap_win_whodata_Sleep (DWORD dwMilliseconds) {
     check_expected(dwMilliseconds);
 }

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -20,9 +20,6 @@ int wm_max_eps;             // Maximum events per second sent by OpenScap and CI
 int wm_kill_timeout;        // Time for a process to quit before killing it
 int wm_debug_level;
 
-int FOREVER() {
-    return 1;
-}
 
 // Read XML configuration and internal options
 

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -101,9 +101,6 @@ extern int wm_max_eps;          // Maximum events per second sent by OpenScap Wa
 extern int wm_kill_timeout;     // Time for a process to quit before killing it
 extern int wm_debug_level;
 
-// Wrappable function to determine infinite loop
-int FOREVER();
-
 
 // Read XML configuration and internal options
 int wm_config();


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5132|

## Description
- Windows unit test compile fixed.
- Declaration of FOREVER function changed.
- Fixed some tests of windows `test_run_check.c` and `test_win_whodata.c` because of some problems with changes in the windows configuration code (reordering of the array where the monitored directories syscheck.dir were saved) and because of other problems related to some unset variables.
- Created new files (`common.h` and `common.c`) to start organizing the wrappers in a more orderly way, instead of creating them all in the same test where they are used. 