### PR TITLE
Vulnerability-detector: Minor fix for RHEL source packages parser

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3927,7 +3927,6 @@ int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities,
     return retval;
 }
 
-
 void wm_parse_rpm_source_package(agent_software *agent, const char *product, char **source, const char *version, char **src_version) {
     char *tok = NULL;
     char *src_name = NULL;
@@ -3944,14 +3943,14 @@ void wm_parse_rpm_source_package(agent_software *agent, const char *product, cha
     os_strdup(*source, tmp_src);
 
     tok = strtok_r(tmp_src, "-", &saved);
-    if (tok == NULL) {
+    if (tok == NULL || saved == NULL || strlen(saved) == 0) {
         mdebug2(VU_NO_SRC_NAME, *source, atoi(agent->agent_id));
         goto clean;
     }
 
     // Parse and retrieve the sources's full package name.
     os_calloc(1, OS_SIZE_256 + 1, src_name);
-    while(tok != NULL && len < OS_SIZE_256) {
+    while (tok != NULL && len < OS_SIZE_256) {
         len = strlen(src_name);
         if (len) {
             strncat(src_name, "-", OS_SIZE_256 - len);
@@ -3963,22 +3962,23 @@ void wm_parse_rpm_source_package(agent_software *agent, const char *product, cha
     }
 
     // Parse the source's version.
-    tok = strtok(saved, "src");
+    tok = strstr(saved, ".src.rpm");
     if (tok == NULL) {
         mdebug2(VU_NO_SRC_VERSION, *source, atoi(agent->agent_id));
         goto clean;
     }
+    *tok = '\0';
 
     /* If the binary's version is equal to the one within the source,
     but also includes an epoch, use it as the source's version. Otherwise,
     set the source's epoch to -1. */
-    len = strlen(tok) - 1;
-    tok[len] = '\0'; // remove final dot
-    if (strstr(version, tok)) {
+    len = strlen(saved);
+    if (strstr(version, saved)) {
         os_strdup(version, *src_version);
-    } else {
+    }
+    else {
         os_calloc(1, len + 5, *src_version);
-        snprintf(*src_version, len + 4, "-1:%s", tok);
+        snprintf(*src_version, len + 4, "-1:%s", saved);
     }
 
 clean:


### PR DESCRIPTION

## Description

This PR fixes some minor bugs that happened when parsing a RHEL source package.
For instance: `wazuh-testing-3.12.sample.src.rpm`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

