### PR TITLE
Disconnected time in ossec-agentd.state (max_time_reconnect_try)

### DIFF
--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -132,7 +132,7 @@ int write_state() {
         "\n"
         "# Number of messages (events + control messages) sent to the manager\n"
         "msg_sent='%u'\n"
-        , __local_name, agt->notify_time, agt->notify_time, status, last_keepalive, last_ack, agent_state.msg_count, agent_state.msg_sent);
+        , __local_name, agt->notify_time, agt->max_time_reconnect_try, status, last_keepalive, last_ack, agent_state.msg_count, agent_state.msg_sent);
 
     fclose(fp);
 


### PR DESCRIPTION

|Related issue|
|---|
|#5138|

## Description
After replacing the `notify_time` variable with `max_time_reconnect_try`, it is possible to note that the file ` ossec-agentd.state` is displaying the correct disconnected time.

Closes #5138 

###  ossec-agentd.state file

This is an example of the file `ossec-agentd.state` when the bug appeared. It can be noted that both **connected** and **disconnected** time have the same value

```
# Agent status:
# - pending:      waiting for get connected.
# - connected:    connection established with manager in the last 5 seconds.
# - disconnected: connection lost or no ACK received in the last 5 seconds. 
```
After replacing the variable, the  `ossec-agentd.state` file show the correct values for both times

```
# Agent status:
# - pending:      waiting to get connected.
# - connected:    connection established with manager in the last 10 seconds.
# - disconnected: connection lost or no ACK received in the last 60 seconds.
```


## Tests


<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

