### PR TITLE
[NVD] Improve RHEL regex to parse versions starting with 'v'

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3439,9 +3439,10 @@ end:
 
 const char *wm_vuldet_decode_package_version(char *raw, const char **OS, char **OS_minor, char **package_name, char **package_version) {
     STATIC OSRegex *reg = NULL;
-    STATIC char *package_regex = "(-\\d+:\\d+)|(:v\\d+)|(:\\d+)|(-\\d+-\\d+)|(-\\d+.\\d+-\\d+)|(-\\d+.\\d+.\\d+-\\d+)|(-\\d+.\\d+.\\d+.)|(-\\d+-)|(-\\d+.)";
+    STATIC char *package_regex = "(-\\d+:v\\d+)|(-\\d+:\\d+)|(:v\\d+)|(:\\d+)|(-\\d+-\\d+)|(-\\d+.\\d+-\\d+)|(-\\d+.\\d+.\\d+-\\d+)|(-\\d+.\\d+.\\d+.)|(-\\d+-)|(-\\d+.)";
     const char *retv = NULL;
     char *found;
+    char *aux;
 
     if (!reg) {
         os_calloc(1, sizeof(OSRegex), reg);
@@ -3457,8 +3458,13 @@ const char *wm_vuldet_decode_package_version(char *raw, const char **OS, char **
         if (found = strstr(raw, *reg->d_sub_strings), !found) {
             return NULL;
         }
+        aux = found;
+        if (aux = strstr(aux, "v"), aux) {
+            if (*(aux - 1) == ':') {
+                memmove(aux, aux + 1, strlen(aux + 1) + 1);
+            }
+        }
         *found = '\0';
-        if (found[1] == 'v') found++;
         w_strdup(found + 1, *package_version);
         w_strdup(raw, *package_name);
 


### PR DESCRIPTION
## Description

The purpose of this PR is to add a new regex to parse RHEL package versions that start with a 'v'. Since this character is not necessary to compare versions, it is necesary to remove it when it is present.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation