### PR TITLE
Add a download timeout for Vulnerability Detector

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -33,6 +33,7 @@ typedef struct provider_options {
     int port;
     time_t update_interval;
     int update_since;
+    long timeout;
 } provider_options;
 
 static int wm_vuldet_get_interval(char *source, time_t *interval);
@@ -71,6 +72,7 @@ static const char *XML_ALLOW = "allow";
 static const char *XML_UPDATE_FROM_YEAR = "update_from_year";
 static const char *XML_PROVIDER = "provider";
 static const char *XML_REPLACED_OS = "replaced_os";
+static const char *XML_TIMEOUT = "download_timeout";
 
 static const char *XML_START = "start";
 static const char *XML_END = "end";
@@ -504,6 +506,8 @@ static int wm_vuldet_read_deprecated_multifeed_tag(xml_node *node, update_node *
             updates[os_index]->interval = interval;
             updates[os_index]->attempted = 0;
             updates[os_index]->old_config = 1;
+            // Deprecated config don't support new option download_timeout
+            updates[os_index]->timeout = 300;
         }
     }
 
@@ -538,6 +542,8 @@ static int wm_vuldet_read_deprecated_feed_tag(const OS_XML *xml, xml_node *node,
     }
 
     updates[os_index]->old_config = 1;
+    // Deprecated config don't support new option download_timeout
+    updates[os_index]->timeout = 300;
 
     if (chld_node = OS_GetElementsbyNode(xml, node), !chld_node) {
         merror(XML_INVELEM, node->element);
@@ -656,6 +662,7 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
                 updates[os_index]->interval = p_options.update_interval;
             }
 
+            updates[os_index]->timeout = p_options.timeout;
             updates[os_index]->url = os_list->url;
             updates[os_index]->path = os_list->path;
             updates[os_index]->port = os_list->port;
@@ -664,12 +671,13 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
                 return OS_INVALID;
             }
 
-            mdebug1("Added %s (%s) feed. Interval: %lus | Path: '%s' | Url: '%s'.",
+            mdebug1("Added %s (%s) feed. Interval: %lus | Path: '%s' | Url: '%s' | Timeout: %lds",
                         pr_name,
                         os_list->version,
                         updates[os_index]->interval,
                         updates[os_index]->path ? updates[os_index]->path : "none",
-                        updates[os_index]->url ? updates[os_index]->url : "none");
+                        updates[os_index]->url ? updates[os_index]->url : "none",
+                        updates[os_index]->timeout);
             flags->update = 1;
 
             os_list = os_list->next;
@@ -693,6 +701,7 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
         updates[os_index]->multi_url_start = p_options.multi_url_start;
         updates[os_index]->multi_url_end = p_options.multi_url_end;
         updates[os_index]->port = p_options.port;
+        updates[os_index]->timeout = p_options.timeout;
 
         if (p_options.multi_allowed_os_name) {
             if (wm_vuldet_add_multi_allow_os(updates[os_index], p_options.multi_allowed_os_name, p_options.multi_allowed_os_ver)) {
@@ -707,12 +716,13 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
             wm_vuldet_release_update_node(updates, CVE_MSU);
         }
 
-        mdebug1("Added %s feed. Interval: %lus | Multi path: '%s' | Multi url: '%s' | Update since: %d.",
+        mdebug1("Added %s feed. Interval: %lus | Multi path: '%s' | Multi url: '%s' | Update since: %d | Timeout: %lds",
             pr_name,
             updates[os_index]->interval,
             updates[os_index]->multi_path ? updates[os_index]->multi_path : "none",
             updates[os_index]->multi_url ? updates[os_index]->multi_url : "none",
-            updates[os_index]->update_from_year);
+            updates[os_index]->update_from_year,
+            updates[os_index]->timeout);
         flags->update = 1;
     }
 
@@ -970,6 +980,10 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
     int elements;
 
     memset(options, '\0', sizeof(provider_options));
+
+    // Set default download timeout
+    options->timeout = WM_VULNDETECTOR_DEFAULT_TIMEOUT;
+
     for (i = 0; node[i]; i++) {
         if (!strcmp(node[i]->element, XML_UPDATE_FROM_YEAR)) {
             if (multi_provider) {
@@ -986,6 +1000,9 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
                 merror("Invalid content for '%s' option at module '%s'.", XML_UPDATE_INTERVAL, WM_VULNDETECTOR_CONTEXT.name);
                 return OS_INVALID;
             }
+        } else if (!strcmp(node[i]->element, XML_TIMEOUT)) {
+            char * end;
+            options->timeout = strtol(node[i]->content, &end, 10);
         } else if (!strcmp(node[i]->element, XML_PATH)) {
             if (multi_provider) {
                 os_free(options->multi_path);
@@ -1085,6 +1102,7 @@ void wm_vuldet_init_provider_options(provider_options *options) {
     options->port = 0;
     options->update_interval = 0;
     options->update_since = 0;
+    options->timeout = 0;
 }
 
 void wm_vuldet_clear_provider_options(provider_options options) {

--- a/src/headers/os_err.h
+++ b/src/headers/os_err.h
@@ -26,6 +26,7 @@
 #define OS_MEMERR       -10 /* Memory Error             */
 #define OS_SOCKBUSY     -11 /* Socket busy -- try again */
 #define OS_MAXLEN       -12 /* Max length               */
+#define OS_TIMEOUT      -13 /* Timeout error            */
 
 #define OS_ENDFILE      -20 /* End of file              */
 #define OS_FINISH       -21 /* Finished this task       */

--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -14,14 +14,15 @@
 
 #include <external/curl/include/curl/curl.h>
 
-#define WURL_WRITE_FILE_ERROR "Cannot open file '%s'."
-#define WURL_DOWNLOAD_FILE_ERROR "Cannot download file '%s' from URL: %s."
+#define WURL_WRITE_FILE_ERROR "Cannot open file '%s'"
+#define WURL_DOWNLOAD_FILE_ERROR "Cannot download file '%s' from URL: '%s'"
+#define WURL_TIMEOUT_ERROR  "Timeout reached when downloading file '%s' from URL: '%s'"
 
-int wurl_get(const char * url, const char * dest, const char * header, const char *data);
+int wurl_get(const char * url, const char * dest, const char * header, const char *data, const long timeout);
 int w_download_status(int status,const char *url,const char *dest);
 // Request download
-int wurl_request(const char * url, const char * dest, const char *header, const char *data);
-int wurl_request_gz(const char * url, const char * dest, const char * header, const char * data);
+int wurl_request(const char * url, const char * dest, const char *header, const char *data, const long timeout);
+int wurl_request_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout);
 char * wurl_http_get(const char * url);
 
 /* Check download module availability */

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -284,7 +284,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                 file_name = SHAREDCFG_FILENAME;
                 snprintf(destination_path, PATH_MAX + 1, "%s/%s", DOWNLOAD_DIR, file_name);
                 mdebug1("Downloading shared file '%s' from '%s'", merged, file_url);
-                downloaded = wurl_request(file_url,destination_path, NULL, NULL);
+                downloaded = wurl_request(file_url,destination_path, NULL, NULL, 0);
                 w_download_status(downloaded,file_url,destination_path);
                 r_group->merged_is_downloaded = !downloaded;
 
@@ -318,7 +318,7 @@ void c_group(const char *group, char ** files, file_sum ***_f_sum,char * sharedc
                         snprintf(destination_path, PATH_MAX + 1, "%s/%s/%s", sharedcfg_dir, group, file_name);
                         snprintf(download_path, PATH_MAX + 1, "%s/%s", DOWNLOAD_DIR, file_name);
                         mdebug1("Downloading shared file '%s' from '%s'", destination_path, file_url);
-                        downloaded = wurl_request(file_url,download_path, NULL, NULL);
+                        downloaded = wurl_request(file_url,download_path, NULL, NULL, 0);
 
                         if (!w_download_status(downloaded, file_url, destination_path)) {
                             OS_MoveFile(download_path, destination_path);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -49,9 +49,10 @@ STATIC int wm_vuldet_remove_target_table(sqlite3 *db, char *TABLE, const char *t
 
 /**
  * @brief Get the Debian status feed to check the status of the vulnerabilities.
+ * @param timeout Timeout for the download request
  * @return Parsed JSON on success, NULL otherwise.
  */
-STATIC cJSON *wm_vuldet_get_debian_status_feed();
+STATIC cJSON *wm_vuldet_get_debian_status_feed(const long timeout);
 
 /**
  * @brief Set the status of the packages. Only for Debian OS.
@@ -59,7 +60,7 @@ STATIC cJSON *wm_vuldet_get_debian_status_feed();
  * @param target Debian OS target.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_debian_set_packages_ignore(sqlite3 *db, const char *target);
+STATIC int wm_vuldet_debian_set_packages_ignore(sqlite3 *db, const char *target, const long timeout);
 
 /**
  * @brief For an specific agent, copy all installed packages' information from SYS_PROGRAM to the AGENTS table.
@@ -2026,12 +2027,12 @@ int wm_vuldet_update_feed(update_node *upd) {
     return 0;
 }
 
-int wm_vuldet_debian_set_packages_ignore(sqlite3 *db, const char *target) {
+int wm_vuldet_debian_set_packages_ignore(sqlite3 *db, const char *target, const long timeout) {
     sqlite3_stmt *stmt = NULL;
     sqlite3_stmt *stmt2 = NULL;
     cJSON *deb_json = NULL;
 
-    if (deb_json = wm_vuldet_get_debian_status_feed(), !deb_json) {
+    if (deb_json = wm_vuldet_get_debian_status_feed(timeout), !deb_json) {
         mtwarn(WM_VULNDETECTOR_LOGTAG, VU_GET_DEB_STATUS_FEED, DEBIAN_REPO_STATUS);
         return 0;
     }
@@ -2427,7 +2428,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     }
 
     // Update the ignore status of the Debian packages
-    if ((update->dist_ref == FEED_DEBIAN) && (wm_vuldet_debian_set_packages_ignore(db, vu_feed_tag[update->dist_tag_ref]) == OS_INVALID)) {
+    if ((update->dist_ref == FEED_DEBIAN) && (wm_vuldet_debian_set_packages_ignore(db, vu_feed_tag[update->dist_tag_ref], update->timeout) == OS_INVALID)) {
         return wm_vuldet_sql_error(db, stmt);
     }
 
@@ -3315,9 +3316,9 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
     for (attempts = 0;; attempts++) {
         int res_url_request;
         if (update->dist_ref == FEED_UBUNTU) {
-            res_url_request = wurl_request(repo, VU_TEMP_FILE_BZ2, NULL, NULL);
+            res_url_request = wurl_request(repo, VU_TEMP_FILE_BZ2, NULL, NULL, update->timeout);
         } else {
-            res_url_request = wurl_request(repo, VU_TEMP_FILE, NULL, NULL);
+            res_url_request = wurl_request(repo, VU_TEMP_FILE, NULL, NULL, update->timeout);
         }
 
         if (!res_url_request) {
@@ -3396,7 +3397,7 @@ int wm_vuldet_fetch_redhat(update_node *update) {
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_DOWNLOAD_START, repo);
     while (1) {
-        if (wurl_request(repo, VU_FIT_TEMP_FILE, NULL, NULL)) {
+        if (wurl_request(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout)) {
             if (attempt == RED_HAT_REPO_MAX_ATTEMPTS) {
                 mtwarn(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV_NEW, repo, RED_HAT_REPO_MAX_ATTEMPTS);
                 update->update_state = VU_TRY_NEXT_PAGE;
@@ -3562,7 +3563,7 @@ int wm_vuldet_fetch_feed(update_node *update, int *need_update) {
             goto end;
         break;
         case FEED_CPED:
-            if (wm_vuldet_fetch_nvd_cpe(repo)) {
+            if (wm_vuldet_fetch_nvd_cpe(update->timeout, repo)) {
                 goto end;
             }
         break;
@@ -3642,7 +3643,7 @@ int wm_vuldet_check_feed(update_node *upd, int *error_code) {
     return 0;
 }
 
-cJSON *wm_vuldet_get_debian_status_feed() {
+cJSON *wm_vuldet_get_debian_status_feed(const long timeout) {
     FILE *deb_file = NULL;
     int attempts;
     int res_url_request;
@@ -3650,7 +3651,7 @@ cJSON *wm_vuldet_get_debian_status_feed() {
     if (deb_file = fopen(VU_DEB_TEMP_FILE, "r"), !deb_file) {
         // Download Debian status feed
         for (attempts = 0;; attempts++) {
-            if (res_url_request = wurl_request(DEBIAN_REPO_STATUS, VU_DEB_TEMP_FILE, NULL, NULL), !res_url_request) {
+            if (res_url_request = wurl_request(DEBIAN_REPO_STATUS, VU_DEB_TEMP_FILE, NULL, NULL, timeout), !res_url_request) {
                 break;
             } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
                 return NULL;
@@ -4566,6 +4567,7 @@ cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
             }
 
             cJSON_AddNumberToObject(provider,"update_interval",vuldet->updates[i]->interval);
+            cJSON_AddNumberToObject(provider,"download_timeout",vuldet->updates[i]->timeout);
 
             // Allowed OS
             if (wm_vuldet_is_single_provider(vuldet->updates[i]->dist_ref)) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -20,6 +20,7 @@
 #define WM_VULNDETECTOR_LOGTAG ARGV0 ":" VU_WM_NAME
 #define WM_VULNDETECTOR_DEFAULT_INTERVAL 300 // 5 minutes
 #define WM_VULNDETECTOR_DEFAULT_UPDATE_INTERVAL 3600 // 1 hour
+#define WM_VULNDETECTOR_DEFAULT_TIMEOUT 300 // 5 minutes
 #define WM_VULNDETECTOR_NVD_UPDATE_INTERVAL 86400 // 1 day
 #define WM_VULNDETECTOR_DEFAULT_CPE_UPDATE_INTERVAL 86400 // 1 day
 #define WM_VULNDETECTOR_RETRY_UPDATE  300 // 5 minutes
@@ -379,6 +380,7 @@ typedef struct update_node {
     in_port_t port;
     char *path;
     char *multi_path;
+    long timeout; // Timeout for download requests
     union { // Supported operating systems
         struct { // Single providers (Debian and Canonical)
             char **allowed_os_name;
@@ -771,7 +773,7 @@ int wm_vuldet_get_min_cpe_index(sqlite3 *db, int *min_index);
 int wm_vuldet_add_cpe(cpe *ncpe, char *cpe_raw, cpe_list *node_list, int index);
 int wm_vuldet_generate_agent_cpes(sqlite3 *db, agent_software *agent, char dic);
 int wm_vuldet_fetch_nvd_cve(update_node *update);
-int wm_vuldet_fetch_nvd_cpe(char *repo);
+int wm_vuldet_fetch_nvd_cpe(const long timeout, char *repo);
 int wm_vuldet_json_nvd_parser(char *json_feed, wm_vuldet_db *parsed_vulnerabilities);
 int wm_vuldet_clean_nvd_metadata(sqlite3 *db, int year);
 int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -788,17 +788,17 @@ void wm_vuldet_free_search_terms(vu_search_terms *s_terms) {
     }
 }
 
-int wm_vuldet_fetch_nvd_cpe(char *repo) {
+int wm_vuldet_fetch_nvd_cpe(const long timeout, char *repo) {
     if (*repo == '\0') {
         snprintf(repo, OS_SIZE_256, NVD_CPE_REPO);
     }
 
     if (wstr_end(repo, ".gz")) {
-        if (wurl_request_gz(repo, VU_TEMP_FILE, NULL, NULL)) {
+        if (wurl_request_gz(repo, VU_TEMP_FILE, NULL, NULL, timeout)) {
             return OS_INVALID;
         }
     } else {
-        if (wurl_request(repo, VU_TEMP_FILE, NULL, NULL)) {
+        if (wurl_request(repo, VU_TEMP_FILE, NULL, NULL, timeout)) {
             return OS_INVALID;
         }
     }
@@ -826,7 +826,7 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
         repo = wstr_replace(update->multi_url, MULTI_URL_TAG, tag);
 
         for (attempt = 0; attempt < NVD_REPO_MAX_ATTEMPTS; attempt++) {
-            if (wurl_request(repo, VU_FIT_TEMP_FILE, NULL, NULL)) {
+            if (wurl_request(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV, repo, attempt * DOWNLOAD_SLEEP_FACTOR);
                 sleep(attempt * DOWNLOAD_SLEEP_FACTOR);
                 continue;
@@ -847,7 +847,7 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
         // Check the metadata feed
         snprintf(repo, OS_SIZE_2048, NVD_CVE_REPO_META, update->update_it);
         for (attempt = 0; attempt < NVD_REPO_MAX_ATTEMPTS; attempt++) {
-            if (wurl_request(repo, VU_TEMP_FILE, NULL, NULL)) {
+            if (wurl_request(repo, VU_TEMP_FILE, NULL, NULL, update->timeout)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV, repo, attempt * DOWNLOAD_SLEEP_FACTOR);
                 sleep(attempt * DOWNLOAD_SLEEP_FACTOR);
                 continue;
@@ -913,7 +913,7 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
         // At this point we know that we must update the feed for this year
         snprintf(repo, OS_SIZE_2048, NVD_CVE_REPO, update->update_it);
         for (attempt = 0; attempt < NVD_REPO_MAX_ATTEMPTS; attempt++) {
-            if (wurl_request_gz(repo, VU_FIT_TEMP_FILE, NULL, NULL)) {
+            if (wurl_request_gz(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV, repo, attempt * DOWNLOAD_SLEEP_FACTOR);
                 sleep(attempt * DOWNLOAD_SLEEP_FACTOR);
                 continue;

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -49,7 +49,7 @@ void * wm_download_main(wm_download_t * data) {
     // If module is disabled, exit
 
     if (data->enabled) {
-        minfo("Module started");
+        minfo("Module started.");
     } else {
         minfo("Module disabled. Exiting.");
         pthread_exit(NULL);
@@ -121,6 +121,8 @@ void wm_download_dispatch(char * buffer) {
     char jpath[PATH_MAX];
     char * next;
     char * buffer_cpy;
+    char * timeout_ptr = NULL;
+    long timeout;
 
     // Copy the command buffer for error messages
 
@@ -129,7 +131,7 @@ void wm_download_dispatch(char * buffer) {
     // Get command
 
     if (next = strchr(buffer, ' '), !(next && *next)) {
-        mdebug1("Empty request command: '%s'.", buffer_cpy);
+        mdebug1("Empty request command: '%s'", buffer_cpy);
         snprintf(buffer, OS_MAXSTR, "err empty command");
         goto end;
     }
@@ -139,7 +141,7 @@ void wm_download_dispatch(char * buffer) {
     // Nowadays we only support the "download" command
 
     if (strcmp(command, "download")) {
-        mdebug1("Invalid request command: '%s'.", buffer_cpy);
+        mdebug1("Invalid request command: '%s'", buffer_cpy);
         snprintf(buffer, OS_MAXSTR, "err invalid command");
         goto end;
     }
@@ -148,7 +150,7 @@ void wm_download_dispatch(char * buffer) {
 
     url = next;
     if (next = wstr_chr(next, '|'), !(next && *next)) {
-        mdebug1("Empty request URL: '%s'.", buffer_cpy);
+        mdebug1("Empty request URL: '%s'", buffer_cpy);
         snprintf(buffer, OS_MAXSTR, "err empty url");
         goto end;
     }
@@ -158,7 +160,7 @@ void wm_download_dispatch(char * buffer) {
 
     fpath = next;
     if (next = wstr_chr(next, '|'), !(next && *next)) {
-        mdebug1("Empty request file: '%s'.", buffer_cpy);
+        mdebug1("Empty request file: '%s'", buffer_cpy);
         snprintf(buffer, OS_MAXSTR, "err empty file name");
         goto end;
     }
@@ -169,7 +171,7 @@ void wm_download_dispatch(char * buffer) {
     header = next;
     if (next = wstr_chr(next, '|'), !(next && *next)) {
         header = NULL;
-        mdebug2("Empty request header: '%s'.", buffer_cpy);
+        mdebug2("Empty request header: '%s'", buffer_cpy);
         goto unsc;
     }
     *(next++) = '\0';
@@ -179,10 +181,21 @@ void wm_download_dispatch(char * buffer) {
     data = next;
     if (next = wstr_chr(next, '|'), !(next && *next)) {
         data = NULL;
-        mdebug2("Empty request data: '%s'.", buffer_cpy);
+        mdebug2("Empty request data: '%s'", buffer_cpy);
         goto unsc;
     }
     *(next++) = '\0';
+
+    // Get request timeout (optional)
+
+    timeout_ptr = next;
+    if (next = wstr_chr(next, '|'), !(next && *next)) {
+        timeout = 0;
+        mdebug2("Empty request timeout: '%s'", buffer_cpy);
+        goto unsc;
+    }
+    *(next++) = '\0';
+    timeout = atol(timeout_ptr);
 
 unsc:
     // Unescape
@@ -198,13 +211,13 @@ unsc:
     // Jail path
 
     if (snprintf(jpath, sizeof(jpath), "%s/%s", DEFAULTDIR, unsc_fpath) >= (int)sizeof(jpath)) {
-        mdebug1("Path too long: '%s'.", buffer_cpy);
+        mdebug1("Path too long: '%s'", buffer_cpy);
         snprintf(buffer, OS_MAXSTR, "err path too long");
         goto end;
     }
 
     if (w_ref_parent_folder(jpath)) {
-        mdebug1("Path references parent folder: '%s'.", buffer_cpy);
+        mdebug1("Path references parent folder: '%s'", buffer_cpy);
         snprintf(buffer, OS_MAXSTR, "err parent folder reference");
         goto end;
     }
@@ -212,7 +225,7 @@ unsc:
     // Run download
     mdebug1("Downloading '%s' to '%s'", url, jpath);
 
-    switch (wurl_get(url, jpath, unsc_header, unsc_data)) {
+    switch (wurl_get(url, jpath, unsc_header, unsc_data, timeout)) {
     case OS_CONNERR:
         mdebug1(WURL_DOWNLOAD_FILE_ERROR, jpath, url);
         snprintf(buffer, OS_MAXSTR, "err connecting to url");
@@ -221,6 +234,11 @@ unsc:
     case OS_FILERR:
         mdebug1(WURL_WRITE_FILE_ERROR, unsc_fpath);
         snprintf(buffer, OS_MAXSTR, "err writing file");
+        break;
+
+    case OS_TIMEOUT:
+        mdebug1(WURL_TIMEOUT_ERROR, jpath, url);
+        snprintf(buffer, OS_MAXSTR, "err timeout");
         break;
 
     default:


### PR DESCRIPTION
## Description

Adding a download timeout to avoid the hanging of the feeds download when Vulnerability Detector updates them.

## Configuration options

```xml
<provider name="test">
  <download_timeout>120</download_timeout>
</provider>
```

## Logs/Alerts example

ToDo

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
