### PR TITLE
Fix TOCTOU condition in Clusterd when merging agent-info files

### DIFF
--- a/framework/wazuh/cluster/cluster.py
+++ b/framework/wazuh/cluster/cluster.py
@@ -382,10 +382,11 @@ def merge_agent_info(merge_type, node_name, files=None, file_type="", time_limit
             if o_f is None:
                 o_f = open(common.ossec_path + output_file, 'wb')
 
-            header = "{} {} {}".format(stat_data.st_size, filename.replace(common.ossec_path, ''),
-                                       datetime.utcfromtimestamp(stat_data.st_mtime))
             with open(full_path, 'rb') as f:
                 data = f.read()
+
+            header = "{} {} {}".format(len(data), filename.replace(common.ossec_path, ''),
+                                       datetime.utcfromtimestamp(stat_data.st_mtime))
 
             o_f.write((header + '\n').encode() + data)
 


### PR DESCRIPTION
Clusterd was printing this warning in a master node:

```
2020/06/02 08:36:07 wazuh-clusterd: WARNING: [Worker node02] [Main] Malformed agent-info.merged file (invalid literal for int() with base 10: 'Linux'). Parsed line: Linux |centos8 |4.18.0-80.el8.x86_64 |#1 SMP Tue Jun 4 09:19:46 UTC 2019 |x86_64 [CentOS Linux|centos: 8.0] - Wazuh v3.13.0 / ab73af41699f13fdd81903b5f23d8d00
. Some agent statuses won't be synced
```

## Rationale

There is a TOCTOU race condition in [clusterd.py](https://github.com/wazuh/wazuh/blob/c4f7457782312b7d81bf4563060e85e43ef737f7/framework/wazuh/cluster/cluster.py#L385) when merging the _agent-info_ files. 

Clusterd first gets the agent-info file size to build a header, then it copies the source file into the merged file. If the agent sends a notification message (and hence Remoted writes its _agent-info_ file) while Clusterd is merging the files, the size of the file might not match the actual length of the data read. This causes corruption in the merged file.

## Proposed fix

Let the file size in the header be the actual length of the data read from the _agent-info_ file. This will guarantee the integrity of the merged file.

However, Clusterd may read partially an _agent-info_ file. If this occurs, no error should occur; instead, the next sync stage shall update the files successfully.

## Changed artifacts
- cluster.py

## Tests

- [X] Upgrade manager from sources.
- [X] Stress test on an _agent-info_ file. We added a temporal warning log reporting that the file size (`stat`) did not match the actual data length. The warning above must not occur even when this warning happens.

### Stress test

```sh
cd /var/ossec/queue/agent-info
cp -p agent-any ~

while true
do
    cp -p ~/agent-any .
    for i in {1..100}
    do
        echo "#\"label$i\":abc" >> agent-any
    done
done
```