### PR TITLE
Fixing NVD database removal for local feed update

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6088,15 +6088,17 @@ int wm_vuldet_remove_table(sqlite3 *db, char *table) {
 
 int wm_vuldet_index_nvd(sqlite3 *db, update_node *upd, nvd_vulnerability *nvd_it) {
     time_t index_time = time(NULL);
-    int result;
+    int result = 0;
     int cve_count = 0;
 
     // Clean everything only if there are still residues of an offline update
+    // made by multi_path update. For the cases of multi_url or the online
+    // update, we just need to clean the NVD for the year being indexed.
     if (result = wm_vuldet_has_offline_update(db), result == OS_INVALID) {
         goto error;
-    } else if (result == 1 && wm_vuldet_clean_nvd(db)) {
+    } else if (result == 1 && upd->multi_path && wm_vuldet_clean_nvd(db)) {
         goto error;
-    } else if (!upd->multi_path && !upd->multi_url && wm_vuldet_clean_nvd_year(db, upd->update_it)) {
+    } else if (!upd->multi_path && wm_vuldet_clean_nvd_year(db, upd->update_it)) {
         goto error;
     }
 
@@ -6117,7 +6119,7 @@ int wm_vuldet_index_nvd(sqlite3 *db, update_node *upd, nvd_vulnerability *nvd_it
 
     mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INDEX_TIME, time(NULL) - index_time, "index the NVD");
 
-    return 0;
+    return OS_SUCCESS;
 error:
     wm_vuldet_free_nvd_list(nvd_it);
 


### PR DESCRIPTION
|Related issue|
|---|
| [Issue 5154](https://github.com/wazuh/wazuh/issues/5154) |

## Description

This pull request fixes an issue caused because of the removal mechanism of the NVD database tables. Basically, on each database update, all the NVD related tables were removed. This was causing an issue with the local feed update when the feed files are located in a local server and the tag `<url>` is used.
The usage of the tag `<url>` tells the `wazuh-modulesd` daemon that it has to download a feed file of one specific year, process it, index it, and then continue with the next one until complete all the years defined by the keys `start` and `end` within the `<url>` tag. So, if in all the iterations, all the tables are deleted, as a result, we got a database with only the CVS corresponding to the last indexed year.
As a fix, on each iteration, we only remove the CVEs corresponding to the year that is going to be indexed.
It is important to mention that this was happening only when the `<url>` tag was used. For the `<path>` tag, all the files are processed first and then, all together are indexed. So for this case, we are keeping the original behavior and we delete all the NVD related tables.

## Tests

Apart from the tests described below, I executed some stress tests to ensure that no duplicated data is being add to the database and that the database does not grow deliberately.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade