### PR TITLE
Fixed query for wm_vuldet_get_vuln_nvd_cpe

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -1846,8 +1846,10 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db, agent_software *agent, wm_vuldet_fla
     sqlite3_bind_text(stmt, 3, agent_cpe->product, -1, NULL);
     sqlite3_bind_text(stmt, 4, agent_cpe->version, -1, NULL);
     sqlite3_bind_text(stmt, 5, agent_cpe->update ? agent_cpe->update : "", -1, NULL);
-    sqlite3_bind_text(stmt, 6, agent_cpe->sw_edition ? agent_cpe->sw_edition : "", -1, NULL);
-    sqlite3_bind_text(stmt, 7, agent_cpe->target_hw ? agent_cpe->target_hw : "", -1, NULL);
+    sqlite3_bind_text(stmt, 6, agent_cpe->edition ? agent_cpe->edition : "", -1, NULL);
+    sqlite3_bind_text(stmt, 7, agent_cpe->language ? agent_cpe->language : "", -1, NULL);
+    sqlite3_bind_text(stmt, 8, agent_cpe->sw_edition ? agent_cpe->sw_edition : "", -1, NULL);
+    sqlite3_bind_text(stmt, 9, agent_cpe->target_hw ? agent_cpe->target_hw : "", -1, NULL);
 
     while(result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
         if (result == SQLITE_ROW) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5161|

This PR solve the problem occurring within the function `wm_vuldet_get_vuln_nvd_cpe`:
```c
if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_CPE], -1, &stmt, NULL) != SQLITE_OK) {
        return wm_vuldet_sql_error(db, stmt);
    }
    sqlite3_bind_text(stmt, 1, agent_cpe->part, -1, NULL);
    sqlite3_bind_text(stmt, 2, agent_cpe->vendor, -1, NULL);
    sqlite3_bind_text(stmt, 3, agent_cpe->product, -1, NULL);
    sqlite3_bind_text(stmt, 4, agent_cpe->version, -1, NULL);
    sqlite3_bind_text(stmt, 5, agent_cpe->update ? agent_cpe->update : "", -1, NULL);
    sqlite3_bind_text(stmt, 6, agent_cpe->sw_edition ? agent_cpe->sw_edition : "", -1, NULL);
    sqlite3_bind_text(stmt, 7, agent_cpe->target_hw ? agent_cpe->target_hw : "", -1, NULL);
    while(result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
        .
        .
    }
   .
   .
}
```
Looking at the sql query:
```sqlite
SELECT NVD_CPE.ID FROM NVD_CPE WHERE NVD_CPE.PART = ? AND NVD_CPE.VENDOR = ? AND NVD_CPE.PRODUCT = ? AND (NVD_CPE.VERSION = ? OR NVD_CPE.VERSION = '*' OR NVD_CPE.VERSION = '-') AND (NVD_CPE.UPDATED = '*' OR NVD_CPE.UPDATED = ?) AND (NVD_CPE.EDITION = '*' OR NVD_CPE. EDITION = ? OR NVD_CPE.EDITION = '') AND (NVD_CPE.LANGUAGE = '*' OR NVD_CPE.LANGUAGE = ? OR NVD_CPE.LANGUAGE = '') AND (NVD_CPE.SW_EDITION = '*' OR NVD_CPE.SW_EDITION = ? OR NVD_CPE.SW_EDITION = '') AND (NVD_CPE.TARGET_SW = '*' OR NVD_CPE.TARGET_SW = '-' OR NVD_CPE.TARGET_SW = '') AND (NVD_CPE.TARGET_HW = '*' OR NVD_CPE.TARGET_HW = '-' OR NVD_CPE.TARGET_HW = ?);
```

We see that the number of parameters is incorrect. Because of this, the architecture is being inserted in an incorrect field. When calling the function `wm_vuldet_step(stmt)`, it returns SQLITE_DONE, skipping all checks.

Seven out of nine fields were successfully inserted. although two of them were shifted.
The following fields of the query:
```c
sqlite3_bind_text(stmt, 6, agent_cpe->sw_edition ? agent_cpe->sw_edition : "", -1, NULL);
sqlite3_bind_text(stmt, 7, agent_cpe->target_hw ? agent_cpe->target_hw : "", -1, NULL);
```
should be:
```c
sqlite3_bind_text(stmt, 8, agent_cpe->sw_edition ? agent_cpe->sw_edition : "", -1, NULL);
sqlite3_bind_text(stmt, 9, agent_cpe->target_hw ? agent_cpe->target_hw : "", -1, NULL);
```

On the other hand, we should complete the `NVD_CPE. EDITION` and `NVD_CPE.LANGUAGE` field:
```c
sqlite3_bind_text(stmt, 6, agent_cpe->edition ? agent_cpe->edition : "", -1, NULL);
sqlite3_bind_text(stmt, 7, agent_cpe->language ? agent_cpe->language : "", -1, NULL);
```