### PR TITLE
Prevent Agentd from exiting if the enrollment attempt at startup fails

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -54,7 +54,10 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             merror_exit(AG_NOKEYS_EXIT);
         }
     }
-        
+    /* Read private keys  */
+    minfo(ENC_READ);    
+    OS_ReadKeys(&keys, 1, 0, 0); 
+
     // Resolve hostnames
     rc = 0;
     while (rc < agt->rip_id) {
@@ -104,9 +107,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     os_random();
 
     /* Ignore SIGPIPE, it will be detected on recv */
-    signal(SIGPIPE, SIG_IGN);
-
-    start_agent(1);
+    signal(SIGPIPE, SIG_IGN);    
 
     /* Launch rotation thread */
 
@@ -147,6 +148,8 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             agt->execdq = -1;
         }
     }
+    
+    start_agent(1);
 
     os_delwait();
     update_status(GA_STATUS_ACTIVE);

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -54,31 +54,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             merror_exit(AG_NOKEYS_EXIT);
         }
     }
-    
-    /* Check client keys */
-    OS_ReadKeys(&keys, 1, 0, 0);
-
-    /* Check if we need to auto-enroll */
-    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
-        int registration_status = -1;
-        int rc = 0;
-
-        if (agt->enrollment_cfg->target_cfg->manager_name) {
-            // Configured enrollment server
-            registration_status = try_enroll_to_server(agt->enrollment_cfg->target_cfg->manager_name);
-        } 
         
-        // Try to enroll to server list
-        while (agt->server[rc].rip && (registration_status != 0)) {
-            registration_status = try_enroll_to_server(agt->server[rc].rip);
-            rc++;
-        }
-        
-
-        if(registration_status != 0) {
-            merror_exit(AG_ENROLL_FAIL);
-        }
-    }
     // Resolve hostnames
     rc = 0;
     while (rc < agt->rip_id) {
@@ -120,28 +96,6 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     /* Create PID file */
     if (CreatePID(ARGV0, getpid()) < 0) {
         merror_exit(PID_ERROR);
-    }
-
-    /* Read private keys  */
-    minfo(ENC_READ);
-
-    OS_StartCounter(&keys);
-
-    os_write_agent_info(keys.keyentries[0]->name, NULL, keys.keyentries[0]->id,
-                        agt->profile);
-
-    /*Set the crypto method for the agent */
-    os_set_agent_crypto_method(&keys,agt->crypto_method);
-
-    switch (agt->crypto_method) {
-        case W_METH_AES:
-            minfo("Using AES as encryption method.");
-            break;
-        case W_METH_BLOWFISH:
-            minfo("Using Blowfish as encryption method.");
-            break;
-        default:
-            merror("Invalid encryption method.");
     }
 
     /* Start up message */

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -250,9 +250,9 @@ static void w_agentd_keys_init (void) {
         /* Check if we can auto-enroll */
         if (agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
             int registration_status = -1;
+            int delay_sleep = 0;
             while (registration_status != 0) {
-                int rc = 0;
-                int delay_sleep = 0;
+                int rc = 0;                
                 if (agt->enrollment_cfg->target_cfg->manager_name) {
                     // Configured enrollment server
                     registration_status = try_enroll_to_server(agt->enrollment_cfg->target_cfg->manager_name);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -239,7 +239,7 @@ void start_agent(int is_startup)
 }
 
 /**
- * Initialize keys structure, counter, agent info and crypto method.
+ * @brief Initialize keys structure, counter, agent info and crypto method.
  * Keys are read from client.keys. If no valid entry is found:
  *  -If autoenrollment is enabled, a new key is requested to server and execution is blocked until a valid key is received. 
  *  -If autoenrollment is disabled, dameon is stoped

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -12,6 +12,9 @@
 #include "agentd.h"
 #include "os_net/os_net.h"
 
+#define ENROLLMENT_RETRY_TIME_MAX   60
+#define ENROLLMENT_RETRY_TIME_DELTA 5
+
 int timeout;    //timeout in seconds waiting for a server reply
 
 static ssize_t receive_message_udp(const char *msg, char *buffer, unsigned int max_lenght);
@@ -263,8 +266,8 @@ static void w_agentd_keys_init (void) {
 
             //Sleep between retries
             if (registration_status != 0) {
-                if (delay_sleep < 60) {
-                    delay_sleep += 5;
+                if (delay_sleep < ENROLLMENT_RETRY_TIME_MAX) {
+                    delay_sleep += ENROLLMENT_RETRY_TIME_DELTA;
                 }
                 mdebug1("Sleeping %d seconds before trying to enroll again", delay_sleep);
                 sleep(delay_sleep);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -16,6 +16,7 @@ int timeout;    //timeout in seconds waiting for a server reply
 
 static ssize_t receive_message_udp(const char *msg, char *buffer, unsigned int max_lenght);
 static ssize_t receive_message_tcp(const char *msg, char *buffer, unsigned int max_lenght);
+static void w_agentd_keys_init (void);
 
 /* Attempt to connect to all configured servers */
 int connect_server(int initial_id)
@@ -169,6 +170,10 @@ void start_agent(int is_startup)
     memset(fmsg, '\0', OS_MAXSTR + 1);
     snprintf(msg, OS_MAXSTR, "%s%s", CONTROL_HEADER, HC_STARTUP);
 
+    if (is_startup) {
+        w_agentd_keys_init();
+    }
+
     #ifdef ONEWAY_ENABLED
         return;
     #endif
@@ -230,6 +235,59 @@ void start_agent(int is_startup)
     return;
 }
 
+static void w_agentd_keys_init (void) {
+    /* Check client keys */
+    OS_ReadKeys(&keys, 1, 0, 0);
+    int delay_sleep = 0;
+
+    /* Check if we need to auto-enroll */
+    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
+        int registration_status = -1;
+        while (registration_status != 0) {
+            int rc = 0;
+            if (agt->enrollment_cfg->target_cfg->manager_name) {
+                // Configured enrollment server
+                registration_status = try_enroll_to_server(agt->enrollment_cfg->target_cfg->manager_name);
+            } 
+            
+            // Try to enroll to server list
+            while (agt->server[rc].rip && (registration_status != 0)) {
+                registration_status = try_enroll_to_server(agt->server[rc].rip);
+                rc++;
+            }
+
+            //Sleep between retries
+            if (registration_status != 0) {
+                if (delay_sleep < 60) {
+                    delay_sleep += 5;
+                }
+                sleep(delay_sleep);
+            }
+        }        
+    }
+
+    /* Read private keys  */
+    minfo(ENC_READ);
+
+    OS_StartCounter(&keys);
+
+    os_write_agent_info(keys.keyentries[0]->name, NULL, keys.keyentries[0]->id,
+                        agt->profile);
+
+    /*Set the crypto method for the agent */
+    os_set_agent_crypto_method(&keys,agt->crypto_method);
+
+    switch (agt->crypto_method) {
+        case W_METH_AES:
+            minfo("Using AES as encryption method.");
+            break;
+        case W_METH_BLOWFISH:
+            minfo("Using Blowfish as encryption method.");
+            break;
+        default:
+            merror("Invalid encryption method.");
+    }
+}
 
 /**
  * Holds the message reception logic for udp

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -235,16 +235,21 @@ void start_agent(int is_startup)
     return;
 }
 
+/**
+ * Initialize keys structure, counter, agent info and crypto method.
+ * Keys are read from client.keys. If no valid entry is found, a new key is requested to server,
+ * execution is blocked until a valid key is received. 
+ * */
 static void w_agentd_keys_init (void) {
     /* Check client keys */
-    OS_ReadKeys(&keys, 1, 0, 0);
-    int delay_sleep = 0;
+    OS_ReadKeys(&keys, 1, 0, 0);    
 
     /* Check if we need to auto-enroll */
     if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
         int registration_status = -1;
         while (registration_status != 0) {
             int rc = 0;
+            int delay_sleep = 0;
             if (agt->enrollment_cfg->target_cfg->manager_name) {
                 // Configured enrollment server
                 registration_status = try_enroll_to_server(agt->enrollment_cfg->target_cfg->manager_name);
@@ -261,6 +266,7 @@ static void w_agentd_keys_init (void) {
                 if (delay_sleep < 60) {
                     delay_sleep += 5;
                 }
+                mdebug1("Sleeping %d seconds before trying to enroll again", delay_sleep);
                 sleep(delay_sleep);
             }
         }        

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -154,39 +154,6 @@ int local_start()
     /* Initialize sender */
     sender_init();
 
-    /* Read keys */
-    minfo(ENC_READ);
-
-    OS_ReadKeys(&keys, 1, 0, 0);
-
-    /* Check if we need to auto-enroll */
-    if(agt->enrollment_cfg && agt->enrollment_cfg->enabled && keys.keysize == 0) {
-        int registration_status = -1;
-        int rc = 0;
-
-        if (agt->enrollment_cfg->target_cfg->manager_name) {
-            // Configured enrollment server
-            registration_status = try_enroll_to_server(agt->enrollment_cfg->target_cfg->manager_name);
-        } 
-        
-        // Try to enroll to server list
-        while (agt->server[rc].rip && (registration_status != 0)) {
-            registration_status = try_enroll_to_server(agt->server[rc].rip);
-            rc++;
-        }
-        
-
-        if(registration_status != 0) {
-            merror_exit(AG_ENROLL_FAIL);
-        }
-    }
-
-    OS_StartCounter(&keys);
-    os_write_agent_info(keys.keyentries[0]->name, NULL, keys.keyentries[0]->id, agt->profile);
-
-    /*Set the crypto method for the agent */
-    os_set_agent_crypto_method(&keys, agt->crypto_method);
-
     /* Initialize random numbers */
     srandom(time(0));
     os_random();

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -117,6 +117,9 @@ int local_start()
             merror_exit(AG_NOKEYS_EXIT);
         }
     }
+    /* Read keys */
+    minfo(ENC_READ);
+    OS_ReadKeys(&keys, 1, 0, 0);
 
     /* If there is no file to monitor, create a clean entry
      * for the mark messages.
@@ -171,13 +174,6 @@ int local_start()
 
     /* Socket connection */
     agt->sock = -1;
-    
-    /* Check if server is connected */
-    os_setwait();
-    start_agent(1);
-    os_delwait();
-    update_status(GA_STATUS_ACTIVE);
-
 
     /* Start mutex */
     mdebug1("Creating thread mutex.");
@@ -216,6 +212,12 @@ int local_start()
                         (LPDWORD)&threadID);
     }
 
+    /* Check if server is connected */
+    os_setwait();
+    start_agent(1);
+    os_delwait();
+    update_status(GA_STATUS_ACTIVE);
+    
     req_init();
 
     /* Start receiver thread */


### PR DESCRIPTION
|Related issue|
|---|
| #5163  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Agentd first enrollment should be recursive and blocking to guarantee it will retry until a valid key is obteined.
Also, no block or delay must take place prior to Wazuh modules query creation and os_setwait lock logic to guarantee that other Wazuh modules will be able to connect to Agentd even if it takes time to obtain the first key.

## Configuration options

Default auto-enrollment configuration without client keys.

## Tests

New integrated tests case must cover the initialization without keys and check if other modules are loaded.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] MAC OS X
- [X] Source installation
- [X] Review logs syntax and correct language
- [X] Integration tests for agentd 

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer