### PR TITLE
Add mutex lock on logging module.

### DIFF
--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -68,6 +68,11 @@ void _mtferror(const char *tag, const char * file, int line, const char * func, 
 void _merror_exit(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull)) __attribute__ ((noreturn));
 void _mterror_exit(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull)) __attribute__ ((noreturn));
 
+/**
+ * @brief Logging module initializer
+ */
+void w_logging_init(void);
+
 /* Function to read the logging format configuration */
 void os_logging_config(void);
 cJSON *getLoggingConfig(void);


### PR DESCRIPTION
|Related issue|
|---|
| #5114  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Wazuh logging module didn't handle multi threading access to ossec.log. This leads to missing entries on the log file because EOF pointer can be unupdated on one thread, and both of them ends writing on the same file section.
Now, a mutex lock the access to writing ossec.log to guarantee secuential file writing. 

## Tests

Changes affect Wazuh agents on every OS and Wazuh manager.
Minimal changes where implemented.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] MAC OS X
  - [X] Windows
- [X] Source installation
- [X] Review logs syntax and correct language
- [X] Integration tests for agentd 

## Note
Adding mutex on file write can impact on performance. This fix can be designed using a log buffer and a consuming thread to not block Wazuh operation on each log entry.