### PR TITLE
Remove unnecessary param from curl on rh-generator.sh

### DIFF
--- a/tools/vulnerability-detector/rh-generator.sh
+++ b/tools/vulnerability-detector/rh-generator.sh
@@ -41,7 +41,7 @@ do
     fi
 
     last_page=$page
-    result=$(curl -O assets/content.json $link --output $file --silent -w '%{http_code}')
+    result=$(curl $link --output $file --silent -w '%{http_code}')
 
     if [ $result -ne 200 ]
     then


### PR DESCRIPTION
This PR removes an unnecessary param from a curl call in the helper script `rh-generator.sh`.

## Description
The script `rh-generator.sh` is used for downloading Red Hat feeds for vulnerability-detector. The most common use case for this script is when a user has a manager without direct internet connection and needs to download the feeds to be moved (or served) to the manager.

The curl call has an unnecessary `-O assets/content.json` param since it's already using `--output`

From curl man page:

```
-o, --output <file>
              Write output to <file> instead of stdout. If you are using {} or [] to fetch multiple documents, you can use '#' followed by a number in the <file> specifier. That  variable  will  be  replaced
              with the current string for the URL being fetched. 

-O, --remote-name
              Write output to a local file named like the remote file we get. (Only the file part of the remote file is used, the path is cut off.)

              The  file  will be saved in the current working directory. If you want the file saved in a different directory, make sure you change the current working directory before invoking curl with this
              option.
```


## Tests

```
$ bash rh-generator.sh 2015 redhat/
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=1
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=2
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=3
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=4
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=5
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=6
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=7
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=8
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=9
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=10
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=11
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=12
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=13
Fetching https://access.redhat.com/labs/securitydataapi/cve.json?after=2015-01-01&per_page=1000&page=14
```