### PR TITLE
Add mutex lock on logging module

### DIFF
--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -68,6 +68,11 @@ void _mtferror(const char *tag, const char * file, int line, const char * func, 
 void _merror_exit(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull)) __attribute__ ((noreturn));
 void _mterror_exit(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull)) __attribute__ ((noreturn));
 
+/**
+ * @brief Logging module initializer
+ */
+void w_logging_init(void);
+
 /* Function to read the logging format configuration */
 void os_logging_config(void);
 cJSON *getLoggingConfig(void);

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -20,11 +20,13 @@ static int chroot_flag = 0;
 static int daemon_flag = 0;
 static int pid;
 
-struct{
+static struct{
   unsigned int log_plain:1;
   unsigned int log_json:1;
-  unsigned int read:1;
+  unsigned int initialized:1;
 } flags;
+
+static pthread_mutex_t logging_mutex;
 
 static void _log(int level, const char *tag, const char * file, int line, const char * func, const char *msg, va_list args) __attribute__((format(printf, 5, 0))) __attribute__((nonnull));
 
@@ -62,8 +64,9 @@ static void _log(int level, const char *tag, const char * file, int line, const 
     va_copy(args2, args);
     va_copy(args3, args);
 
-    if (!flags.read) {
-      os_logging_config();
+    if (!flags.initialized) {
+        w_logging_init();
+        mdebug1("Logging module auto-initialized");  
     }
 
     if (filename = strrchr(file, '/'), filename) {
@@ -122,13 +125,15 @@ static void _log(int level, const char *tag, const char * file, int line, const 
             cJSON_AddStringToObject(json_log, "description", jsonstr);
 
             output = cJSON_PrintUnformatted(json_log);
-
+            
+            w_mutex_lock(&logging_mutex);
             (void)fprintf(fp, "%s", output);
             (void)fprintf(fp, "\n");
+            fflush(fp);
+            w_mutex_unlock(&logging_mutex);
 
             cJSON_Delete(json_log);
             free(output);
-            fflush(fp);
             fclose(fp);
         }
     }
@@ -169,6 +174,7 @@ static void _log(int level, const char *tag, const char * file, int line, const 
 
         /* Maybe log to syslog if the log file is not available */
         if (fp) {
+            w_mutex_lock(&logging_mutex);
             (void)fprintf(fp, "%s ", timestamp);
 
             if (dbg_flag > 0) {
@@ -180,8 +186,9 @@ static void _log(int level, const char *tag, const char * file, int line, const 
             (void)fprintf(fp, "%s: ", strlevel[level]);
             (void)vfprintf(fp, msg, args);
             (void)fprintf(fp, "\n");
-
             fflush(fp);
+            w_mutex_unlock(&logging_mutex);
+
             fclose(fp);
         }
     }
@@ -212,6 +219,12 @@ static void _log(int level, const char *tag, const char * file, int line, const 
     va_end(args3);
 }
 
+void w_logging_init(){
+    flags.initialized = 1;
+    w_mutex_init(&logging_mutex, NULL);
+    os_logging_config();    
+}
+
 void os_logging_config(){
   OS_XML xml;
   const char * xmlf[] = {"ossec_config", "logging", "log_format", NULL};
@@ -220,7 +233,6 @@ void os_logging_config(){
   int i;
 
   pid = (int)getpid();
-  flags.read = 1;
 
   if (OS_ReadXML(chroot_flag ? OSSECCONF : DEFAULTCPATH, &xml) < 0){
     flags.log_plain = 1;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -51,10 +51,7 @@ int local_start()
     w_logging_init();
     
     /* Start agent */
-    agt = (agent *)calloc(1, sizeof(agent));
-    if (!agt) {
-        merror_exit(MEM_ERROR, errno, strerror(errno));
-    }
+    os_calloc(1, sizeof(agent), agt);
 
     /* Configuration file not present */
     if (File_DateofChange(cfg) < 0) {

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -33,7 +33,6 @@ void *skthread()
 /* Locally start (after service/win init) */
 int local_start()
 {
-    int debug_level;
     int rc;
     char *cfg = DEFAULTCPATH;
     WSADATA wsaData;
@@ -41,17 +40,20 @@ int local_start()
     DWORD  threadID2;
     win_debug_level = getDefine_Int("windows", "debug", 0, 2);
 
+    /* Get debug level */
+    int debug_level = win_debug_level;
+    while (debug_level != 0) {
+        nowDebug();
+        debug_level--;
+    }
+    
+    /* Initialize logging module*/
+    w_logging_init();
+    
     /* Start agent */
     agt = (agent *)calloc(1, sizeof(agent));
     if (!agt) {
         merror_exit(MEM_ERROR, errno, strerror(errno));
-    }
-
-    /* Get debug level */
-    debug_level = win_debug_level;
-    while (debug_level != 0) {
-        nowDebug();
-        debug_level--;
     }
 
     /* Configuration file not present */


### PR DESCRIPTION
|Related issue|
|---|
| #5190  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Wazuh logging module didn't handle multi threading access to ossec.log. This leads to missing entries on the log file because EOF pointer can be unupdated on one thread, and both of them ends writing on the same file section.
Now, a mutex lock the access to writing ossec.log to guarantee secuential file writing. 

## Tests

Changes affect Wazuh agents on every OS and Wazuh manager.
Minimal changes where implemented.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] MAC OS X
  - [X] Windows
- [X] Source installation
- [X] Review logs syntax and correct language
- [X] Integration tests for agentd 

## Note
Adding mutex on file write can impact on performance. This fix can be designed using a log buffer and a consuming thread to not block Wazuh operation on each log entry.