### PR TITLE
Fix VPC Flow alerts timestamp

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1344,8 +1344,20 @@ class AWSVPCFlowBucket(AWSLogsBucket):
             fieldnames = (
                 "version", "account_id", "interface_id", "srcaddr", "dstaddr", "srcport", "dstport", "protocol",
                 "packets", "bytes", "start", "end", "action", "log_status")
+            unix_fields = ('start', 'end')
+            result = []
+
             tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
-            return [dict(x, source='vpc') for x in tsv_file]
+
+            # Transform UNIX timestamp to ISO8601
+            for row in tsv_file:
+                for key, value in row.items():
+                    if key in unix_fields and value not in unix_fields:
+                        row[key] = datetime.fromtimestamp(int(value)).isoformat()
+
+                result.append(dict(row, source='vpc'))
+
+            return result
 
     def get_ec2_client(self, access_key, secret_key, region, profile_name=None):
         conn_args = {}

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1353,7 +1353,7 @@ class AWSVPCFlowBucket(AWSLogsBucket):
             for row in tsv_file:
                 for key, value in row.items():
                     if key in unix_fields and value not in unix_fields:
-                        row[key] = datetime.fromtimestamp(int(value)).isoformat()
+                        row[key] = datetime.utcfromtimestamp(int(value)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
                 result.append(dict(row, source='vpc'))
 


### PR DESCRIPTION
Hi team, this PR is related to #5201

# Description
As explained in #5201, VPCFlow logs contain two timestamp fields (`start` and `end`). Those timestamps are in UNIX format but Kibana is expecting ISO8601, so the date was incorrect when displayed there.

This PR transforms the UNIX timestamps into ISO8601, so it is correctly displayed as shown below:
![image](https://user-images.githubusercontent.com/23361101/84285317-9d61ab80-ab3d-11ea-9be1-9b76d300a1ca.png)

Kind regards,
Selu.