### PR TITLE
Fixed wm vuldet index json condition

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6163,9 +6163,7 @@ int wm_vuldet_index_json(wm_vuldet_db *parsed_vulnerabilities, update_node *upda
             goto end;
         }
 
-        if (directory = strrchr(path_cpy, '/'), !directory) {
-            goto end;
-        }
+        directory = strrchr(path_cpy, '/');
 
         *directory = '\0';
         pattern = directory + 1;


### PR DESCRIPTION
This PR removes a condition in function ` wm vuldet index json` that can never be given.

In the following code:
``` c
if (*path_cpy != '/') {
    mterror(WM_VULNDETECTOR_LOGTAG, VU_MULTIPATH_ERROR, path_cpy, "it is not an absolute path");
    goto end;
}
if (directory = strrchr(path_cpy, '/'), !directory) {
    goto end;
}
```
It is impossible that the condition of the second if statement occurs. In the case the `path` variable does not have `/`, the error will be handled with the `goto end`, jumping to the function's end.

Therefore the variable `directory` will never be `NULL` because to execute the second if statement the path variable must have `/`.`