### PR TITLE
Do not include the state field in Vulnerability Detector alerts

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -323,7 +323,6 @@
       "data.vulnerability.package.version",
       "data.vulnerability.rationale",
       "data.vulnerability.severity",
-      "data.vulnerability.state",
       "data.vulnerability.title",
       "data.vulnerability.assigner",
       "data.vulnerability.cve_version",
@@ -1702,9 +1701,6 @@
                 "type": "keyword"
               },
               "severity": {
-                "type": "keyword"
-              },
-              "state": {
                 "type": "keyword"
               },
               "title": {

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -65,7 +65,6 @@ static int build_test_cve_report(vu_report* report, int add_title, int add_condi
     os_strdup("The CVE description or rationale.", report->rationale);
     os_strdup("2020-03-05 15:15:00 UTC", report->published);
     os_strdup("2020-05-25 15:15:00 UTC", report->updated);
-    os_strdup("Pending confirmation", report->state);
     os_strdup("cve@mitre.org", report->assigner);
     os_strdup("4.0", report->cve_version);
     report->pending = 1;
@@ -5520,8 +5519,6 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     expect_string(__wrap_cJSON_AddStringToObject, string, "2017-04-14");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2017-07-01");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Pending confirmation");
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, "CWE-502");
     // Adding advisories data
@@ -5810,8 +5807,6 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     expect_string(__wrap_cJSON_AddStringToObject, string, "2017-04-14");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2017-07-01");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Pending confirmation");
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, "CWE-502");
     // Adding advisories data
@@ -6718,8 +6713,6 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->state);
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
     // Adding advisories data
@@ -6830,8 +6823,6 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->state);
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
     // Adding advisories data
@@ -6947,8 +6938,6 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->state);
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
     // Adding advisories data
@@ -7070,8 +7059,6 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->state);
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
     // Adding advisories data
@@ -7209,8 +7196,6 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->state);
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
     // Adding advisories data
@@ -7348,8 +7333,6 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->state);
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
     // Adding advisories data
@@ -7487,8 +7470,6 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->state);
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
     // Adding advisories data
@@ -7626,8 +7607,6 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "state");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->state);
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
     // Adding advisories data

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -758,7 +758,6 @@ void wm_vuldet_free_report(vu_report *report) {
     os_free(report->rationale);
     os_free(report->published);
     os_free(report->updated);
-    os_free(report->state);
     os_free(report->assigner);
     os_free(report->cve_version);
     // Impact
@@ -789,10 +788,6 @@ void wm_vuldet_free_report(vu_report *report) {
 }
 
 void wm_vuldet_build_nvd_report_condition(cve_vuln_cond_NVD *nvd_cond, vu_report *report) {
-    if (nvd_cond->end_version)
-        os_strdup("Fixed", report->state);
-    else
-        os_strdup("Pending confirmation", report->state);
 
     report->pending = nvd_cond->end_version ? 0 : 1;
     // building condition
@@ -990,7 +985,6 @@ int wm_vuldet_fill_report_oval_data(sqlite3 *db, sqlite3_stmt *stmt, agent_softw
     }
 
     if (pkg->vuln_cond) {
-        if (!report->state) w_strdup(pkg->vuln_cond->state, report->state);
         if (!report->operation) w_strdup(pkg->vuln_cond->operation, report->operation);
         if (!report->operation_value) w_strdup(pkg->vuln_cond->operation_value, report->operation_value);
         if (!report->condition) w_strdup(pkg->vuln_cond->condition, report->condition);
@@ -1334,9 +1328,6 @@ int wm_vuldet_send_cve_report(vu_report *report) {
         }
         if (timestamp = wm_vuldet_normalize_date(&report->updated), timestamp) {
             cJSON_AddStringToObject(alert_cve, "updated", timestamp);
-        }
-        if (report->state  && *report->state){
-            cJSON_AddStringToObject(alert_cve, "state", report->state);
         }
         if (report->cwe) cJSON_AddStringToObject(alert_cve, "cwe_reference", report->cwe);
         if (report->advisories) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -434,7 +434,6 @@ struct vu_report {
     char *rationale;
     char *published;
     char *updated;
-    char *state;
     char *assigner;
     char *cve_version;
     char pending;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2173,11 +2173,6 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
         os_strdup(report_node->generated_cpe, report->generated_cpe);
         os_strdup(report_node->raw_arch, report->arch);
         report->pending = report_node->pending;
-        if (report->pending) {
-            os_strdup("Pending confirmation", report->state);
-        } else {
-            os_strdup("Fixed", report->state);
-        }
         wm_vuldet_build_nvd_condition(report_node, &report->condition, &report->is_hotfix);
 
         f_report_node = report_node;


### PR DESCRIPTION
## Description

It has been removed the `state` field from Vulnerability Detector alerts. It was populated by the detector to indicate if there exists a version of the affected package that fixes the CVE. However, it is not clear enough and doesn't provide useful information since it can be guessed by the `condition`.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Added unit tests (for new features)
