### PR TITLE
Active Response: Fixed remote restart of Windows agents

### DIFF
--- a/src/analysisd/active-response.c
+++ b/src/analysisd/active-response.c
@@ -48,7 +48,7 @@ int AR_ReadConfig(const char *cfgfile)
         merror(FOPEN_ERROR, DEFAULTARPATH, errno, strerror(errno));
         return (OS_INVALID);
     }
-    fprintf(fp, "restart-ossec0 - restart-ossec.sh - 0\n restart-ossec0 - restart-ossec.cmd - 0\n");
+    fprintf(fp, "restart-ossec0 - restart-ossec.sh - 0\nrestart-ossec0 - restart-ossec.cmd - 0\n");
     fclose(fp);
 
 #ifndef WIN32


### PR DESCRIPTION
|Related issue|
|---|
|#5196|

## Description

Fixed a small typo when generating the `ar.conf` file.

## Tests
Whether it's by using the API or the `agent_control` binary , all the methods require for the agent to read and parse `ar.conf`. 

Having that in mind, the chosen one to test this PR is:
`/var/ossec/bin/agent_control -R -u 001`
And in the agent's side:
`cat ossec.log | Select-String Exiting...`

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [ ] Package installation