### PR TITLE
Make temporary files created by FIM have unique names

### DIFF
--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -412,9 +412,10 @@ fim_tmp_file *fim_db_create_temp_file(int storage) {
     if (storage == FIM_DB_DISK) {
         os_calloc(PATH_MAX, sizeof(char), file->path);
         //Create random name unique to this thread
-        sprintf(file->path, "%stmp_%lu%d", FIM_DB_TMPDIR,
+        sprintf(file->path, "%stmp_%lu%d%u", FIM_DB_TMPDIR,
                     (unsigned long)time(NULL),
-                    getpid());
+                    getpid(),
+                    os_random());
 
         file->fd = fopen(file->path, "w+");
         if (file->fd == NULL) {

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -197,7 +197,8 @@ set(FIM_DB_BASE_FLAGS "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2
                        -Wl,--wrap=fim_configuration_directory,--wrap=fim_json_event,--wrap=send_syscheck_msg \
                        -Wl,--wrap=delete_target_file,--wrap=_minfo,--wrap=_mdebug1,--wrap=_mdebug2 \
                        -Wl,--wrap=fseek,--wrap=fclose,--wrap=fopen,--wrap=getpid,--wrap=fflush \
-                       -Wl,--wrap=fgets,--wrap=wstr_escape_json,--wrap=sqlite3_bind_int64,--wrap=sqlite3_column_int64")
+                       -Wl,--wrap=fgets,--wrap=wstr_escape_json,--wrap=sqlite3_bind_int64,--wrap=sqlite3_column_int64 \
+                       -Wl,--wrap=os_random")
 
 list(APPEND syscheckd_tests_names "test_fim_db")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/test_fim_db.c
+++ b/src/unit_tests/syscheckd/test_fim_db.c
@@ -320,6 +320,10 @@ int __wrap_sqlite3_bind_int64(sqlite3_stmt *stmt, int index, sqlite3_int64 value
     return mock();
 }
 
+int __wrap_os_random(void) {
+    return 123456;
+}
+
 sqlite3_int64 __wrap_sqlite3_column_int64(sqlite3_stmt* stmt, int iCol) {
     check_expected(iCol);
     return mock();
@@ -1664,9 +1668,9 @@ void test_fim_db_get_path_range_failed(void **state) {
 
     will_return(__wrap_fopen, 0);
     #ifndef TEST_WINAGENT
-    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_1928374652345'");
+    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_1928374652345123456'");
     #else
-    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage 'tmp/tmp_1928374652345'");
+    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage 'tmp/tmp_1928374652345123456'");
     #endif
 
     int ret = fim_db_get_path_range(test_data->fim_sql, "start", "stop", &file, syscheck.database_store);
@@ -1687,9 +1691,9 @@ void test_fim_db_get_path_range_success(void **state) {
     wraps_fim_db_check_transaction();
 
     #ifndef TEST_WINAGENT
-    expect_string(__wrap_remove, filename, "/var/ossec/tmp/tmp_1928374652345");
+    expect_string(__wrap_remove, filename, "/var/ossec/tmp/tmp_1928374652345123456");
     #else
-    expect_string(__wrap_remove, filename, "tmp/tmp_1928374652345");
+    expect_string(__wrap_remove, filename, "tmp/tmp_1928374652345123456");
     #endif
     will_return(__wrap_remove, 0);
 
@@ -1707,9 +1711,9 @@ void test_fim_db_get_not_scanned_failed(void **state) {
 
     will_return(__wrap_fopen, 0);
     #ifndef TEST_WINAGENT
-    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_1928374652345'");
+    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_1928374652345123456'");
     #else
-    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage 'tmp/tmp_1928374652345'");
+    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage 'tmp/tmp_1928374652345123456'");
     #endif
 
     int ret = fim_db_get_not_scanned(test_data->fim_sql, &file, syscheck.database_store);
@@ -1726,9 +1730,9 @@ void test_fim_db_get_not_scanned_success(void **state) {
     wraps_fim_db_check_transaction();
 
     #ifndef TEST_WINAGENT
-    expect_string(__wrap_remove, filename, "/var/ossec/tmp/tmp_1928374652345");
+    expect_string(__wrap_remove, filename, "/var/ossec/tmp/tmp_1928374652345123456");
     #else
-    expect_string(__wrap_remove, filename, "tmp/tmp_1928374652345");
+    expect_string(__wrap_remove, filename, "tmp/tmp_1928374652345123456");
     #endif
     will_return(__wrap_remove, 0);
 
@@ -2686,15 +2690,15 @@ void test_fim_db_create_temp_file_disk(void **state) {
 
     assert_non_null(ret);
     assert_non_null(ret->fd);
-    assert_string_equal(ret->path, FIM_DB_TMPDIR"tmp_1928374652345");
+    assert_string_equal(ret->path, FIM_DB_TMPDIR"tmp_1928374652345123456");
 }
 
 void test_fim_db_create_temp_file_disk_error(void **state) {
     will_return(__wrap_fopen, 0);
     #ifdef TEST_WINAGENT
-    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage 'tmp/tmp_1928374652345'");
+    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage 'tmp/tmp_1928374652345123456'");
     #else
-    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_1928374652345'");
+    expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_1928374652345123456'");
     #endif
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#5213|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In order to prevent temporal files created by FIM, a randomly generated number will be added to the file name.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer
