### PR TITLE
Refactor receive_message_udp and receive_message_tcp to wait  5 connection attempts pre enrollment

### DIFF
--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -463,7 +463,7 @@ static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_ce
         }
     }
     else {
-        mwarn("Registering agent to unverified manager.");
+        minfo("Registering agent to unverified manager.");
     }
 }
 

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -463,7 +463,7 @@ void test_w_enrollment_verify_ca_certificate_null_connection(void **state) {
 
 void test_w_enrollment_verify_ca_certificate_no_certificate(void **state) {
     SSL *ssl = *state;
-    expect_string(__wrap__mwarn, formatted_msg, "Registering agent to unverified manager.");
+    expect_string(__wrap__minfo, formatted_msg, "Registering agent to unverified manager.");
     w_enrollment_verify_ca_certificate(ssl, NULL, "hostname");
 }
 


### PR DESCRIPTION
|Related issue|
|---|
| #5216 #5217 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

`receive_message_udp()` and `receive_message_tcp()`, methods used by `start_agent()` after first **start_up** command to read the expected **remoted** **ACK** and retry in case of error, were refactored to guarantee no enrollment until the fifth attempt of communication with delays between each attempt.

The logic for the UDP case is:
- Sleep for a few seconds and read from socket. 
- If no response has been found increase attempts and increase sleep time.
- After 3rd attempt, start re-connecting and re-sending **start-up** message.
- If the 5th attempt fails, try enrolling to that manager

The receive logic for the TCP case is:
- Sleep for a few seconds and block on socket recv until message is received or timeout is reached. 
- If no succesful response has been found increase attemps and increase sleep time.
- If timeout is reached, try opening a new socket and send the message again.
- If connection is actively closed by the manager try opening a new socket and send the message again in case **remoted** is rejecting connection due to keys update delay. On 5th attempt try enrolling to that manager too. 

On both protocols, this logic will be executed 6 times, allowing one extra connection attempt after the enrollment. Now, having 5 delayed attempts previous to enrollment, any possible delay on **remoted** to update keys is contemplated, even if keys are generated via an external process as **agent-auth**

In addition, warnings and undefined behaviour conditions on **connect_server** from #5217 were fixed.

## Tests

### Suggested scenarios:

Linux agent (repeat for UDP and TCP):
  - [x] Auto-enroll and connect with empty key file.
  - [x] With an existent key, erase the agent from the manager and check for re-registration and re-connection
  - [x] With an existent key, interrupt communication between manager and agent. After a few minutes make it available again. Agent should connect to manager without any attemp of registration.
 - [x] Set multiple servers, where the valid one is not in the first connection and repeate steps above.

Windows agent (repeat for UDP and TCP):
  - [x] Auto-enroll and connect with empty key file.
  - [x] With an existent key, erase the agent from the manager and check for re-registration and re-connection
  - [x] With an existent key, interrupt communication between manager and agent. After a few minutes make it available again. Agent should connect to manager without any attemp of registration.
 - [x] Set multiple servers, where the valid one is not in the first connection and repeate steps above.

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
### Compilation and memory tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [ ] Scan-build report

