### PR TITLE
Added MITRE technique name to the alerts

### DIFF
--- a/extensions/elasticsearch/6.x/wazuh-template.json
+++ b/extensions/elasticsearch/6.x/wazuh-template.json
@@ -308,10 +308,14 @@
                   "type": "keyword",
                   "doc_values": "true"
                 },
-                "tactics": {
+                "tactic": {
                   "type": "keyword",
                   "doc_values": "true"
-                }   
+                },
+                "technique": {
+                  "type": "keyword",
+                  "doc_values": "true"
+                }
               }
             }
           }

--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -400,7 +400,8 @@
       "rule.id",
       "rule.info",
       "rule.mitre.id",
-      "rule.mitre.tactics",
+      "rule.mitre.tactic",
+      "rule.mitre.technique",
       "rule.pci_dss",
       "rule.hipaa",
       "rule.nist_800_53",
@@ -764,7 +765,10 @@
               "id": {
                 "type": "keyword"
               },
-              "tactics": {
+              "tactic": {
+                "type": "keyword"
+              },
+              "technique": {
                 "type": "keyword"
               }
             }

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -97,11 +97,12 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log)
         }
         if(lf->generated_rule->mitre_id) {
             const char **mitre_cpy = (const char**)lf->generated_rule->mitre_id;
+            cJSON * name = NULL;
             cJSON * mitre = NULL;
-            cJSON *tactics = NULL;
             cJSON * tactic = NULL;
             cJSON * element = NULL;
             int tactic_array_size;
+            mitre_data * data_mitre = NULL;
 
             cJSON_AddItemToObject(rule, "mitre", mitre = cJSON_CreateObject());
             /* Creating id array */
@@ -111,11 +112,14 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log)
             cJSON_AddItemToObject(mitre, "id", mitre_id_array);
             /* Creating tactics array */
             cJSON *mitre_tactic_array = cJSON_CreateArray();
+            /* Creating names array */
+            cJSON *mitre_technique_array = cJSON_CreateArray();
             for (i = 0; lf->generated_rule->mitre_id[i] != NULL; i++){
-                if (tactics = mitre_get_attack(lf->generated_rule->mitre_id[i]), tactics == NULL) {
+                if (data_mitre = mitre_get_attack(lf->generated_rule->mitre_id[i]), !data_mitre) {
                     mwarn("Mitre Technique ID '%s' not found in database.", lf->generated_rule->mitre_id[i]);
                 } else {
-                    cJSON_ArrayForEach(tactic, tactics){
+                    /* Filling tactic array */
+                    cJSON_ArrayForEach(tactic, data_mitre->tactics_array) {
                         int inarray = 0;
                         /* Check if the element is already in the array */
                         cJSON_ArrayForEach(element, mitre_tactic_array){
@@ -124,15 +128,20 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log)
                             }
                         }
                         if (!inarray) {
-                            cJSON_AddItemToArray(mitre_tactic_array, cJSON_Duplicate(tactic,0));
+                            cJSON_AddItemToArray(mitre_tactic_array, cJSON_Duplicate(tactic, 0));
                         }
                     }
+                    /* Filling technique array */
+                    name = cJSON_CreateString(data_mitre->technique_name);
+                    cJSON_AddItemToArray(mitre_technique_array, cJSON_Duplicate(name, 0));
                 }
             }
             if (tactic_array_size = cJSON_GetArraySize(mitre_tactic_array), tactic_array_size > 0) {
-                cJSON_AddItemToObject(mitre, "tactics", mitre_tactic_array);
+                cJSON_AddItemToObject(mitre, "tactic", mitre_tactic_array);
+                cJSON_AddItemToObject(mitre, "technique", mitre_technique_array);
             } else {
                 cJSON_Delete(mitre_tactic_array);
+                cJSON_Delete(mitre_technique_array);
             }
         }
         if(lf->generated_rule->cve) {

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -97,7 +97,6 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log)
         }
         if(lf->generated_rule->mitre_id) {
             const char **mitre_cpy = (const char**)lf->generated_rule->mitre_id;
-            cJSON * name = NULL;
             cJSON * mitre = NULL;
             cJSON * tactic = NULL;
             cJSON * element = NULL;
@@ -132,8 +131,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log)
                         }
                     }
                     /* Filling technique array */
-                    name = cJSON_CreateString(data_mitre->technique_name);
-                    cJSON_AddItemToArray(mitre_technique_array, cJSON_Duplicate(name, 0));
+                    cJSON_AddItemToArray(mitre_technique_array, cJSON_CreateString(data_mitre->technique_name));
                 }
             }
             if (tactic_array_size = cJSON_GetArraySize(mitre_tactic_array), tactic_array_size > 0) {

--- a/src/analysisd/mitre.c
+++ b/src/analysisd/mitre.c
@@ -61,7 +61,7 @@ int mitre_load(char * mode){
         if (id = cJSON_GetObjectItem(ids,"id"), id == NULL) {
             merror("It was not possible to get Mitre techniques information.");
             result = -1;
-            goto end; 
+            goto end;
         }
         ext_id = id->valuestring;
 
@@ -119,7 +119,7 @@ int mitre_load(char * mode){
         }
 
         os_malloc(sizeof(mitre_data), data_mitre);
-        data_mitre->tactics_array = cJSON_Duplicate(tactics_array, 1);
+        data_mitre->tactics_array = tactics_array;
         data_mitre->technique_name = strdup(response+3);
 
         /* Filling Hash table with Mitre's information */
@@ -130,7 +130,6 @@ int mitre_load(char * mode){
         }
 
         if (mode != NULL && !strcmp(mode,"test")) {
-            cJSON_Delete(tactics_array);
             cJSON_Delete(data_mitre->tactics_array);
             os_free(data_mitre->technique_name);
             os_free(data_mitre);

--- a/src/analysisd/mitre.c
+++ b/src/analysisd/mitre.c
@@ -136,6 +136,9 @@ int mitre_load(char * mode){
 
         if (mode != NULL && !strcmp(mode,"test")) {
             cJSON_Delete(tactics_array);
+            cJSON_Delete(data_mitre->tactics_array);
+            os_free(data_mitre->technique_name);
+            os_free(data_mitre);
         }
     }
 

--- a/src/analysisd/mitre.h
+++ b/src/analysisd/mitre.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2019, Wazuh Inc.
+/* Copyright (C) 2015-2020, Wazuh Inc.
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
@@ -15,6 +15,11 @@
 #include "os_net/os_net.h"
 #include "headers/wazuhdb_op.h"
 
+typedef struct mitre_data {
+    cJSON * tactics_array;
+    char * technique_name;
+} mitre_data;
+
 /**
  * @brief This function fills Hash Table using Mitre technique ID as Key and technique's tactics as info.
  * 
@@ -27,9 +32,9 @@ int mitre_load(char *mode);
 /**
  * @brief This function gets a Mitre technique ID's tactics from Hash Table 'mitre table'.
  * 
- * @param mitre_id Input parameter, Mitre technique ID (e.g. T1168). 
- * @return cJSON*, a cJSON array with tactic(s) or NULL if cJSON array is not found.   
+ * @param mitre_id Input parameter, Mitre technique ID (e.g. T1168).
+ * @return mitre_data*, struct that stores a MITRE tactics array and technique's name.
  */
-cJSON * mitre_get_attack(const char * mitre_id);
+mitre_data * mitre_get_attack(const char * mitre_id);
 
 #endif /* MITRE_H */

--- a/src/analysisd/output/jsonout.c
+++ b/src/analysisd/output/jsonout.c
@@ -22,6 +22,9 @@ void jsonout_output_event(const Eventinfo *lf)
     if (strstr(json_alert,"gcp")) {
         mdebug2("Sending gcp event: %s", json_alert);
     }
+    if (strstr(json_alert,"mitre")) {
+        mdebug2("Sending mitre event: %s", json_alert);
+    }
     free(json_alert);
     return;
 }

--- a/src/headers/wazuhdb_op.h
+++ b/src/headers/wazuhdb_op.h
@@ -18,3 +18,4 @@ int wdbc_connect();
 int wdbc_query(const int sock, const char *query, char *response, const int len);
 int wdbc_query_ex(int *sock, const char *query, char *response, const int len);
 int wdbc_parse_result(char *result, char **payload);
+cJSON * wdbc_query_parse_json(int *sock, const char *query, char *response, const int len);

--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -189,3 +189,42 @@ int wdbc_parse_result(char *result, char **payload) {
 
     return retval;
 }
+
+
+/**
+ * @brief Combine wdbc_query_ex and wdbc_parse_result functions and return a JSON item.
+ * 
+ * @param[in] sock Pointer to the client socket descriptor.
+ * @param[in] query Query to be sent to Wazuh-DB.
+ * @param[out] response Char pointer where the response from Wazuh-DB will be stored.
+ * @param[in] len Lenght of the response param.
+ * @return cJSON* on success or NULL on failure.
+ */
+cJSON * wdbc_query_parse_json(int *sock, const char *query, char *response, const int len) {
+    int result;
+    char * arg;
+    cJSON * root = NULL;
+
+    result = wdbc_query_ex(sock, query, response, len);
+    switch (result) {
+    case -2:
+        merror("Unable to connect to socket '%s'", WDB_LOCAL_SOCK);
+        return NULL;
+    case -1:
+        merror("No response from wazuh-db.");
+        return NULL;
+    }
+
+    switch (wdbc_parse_result(response, &arg)) {
+    case WDBC_OK:
+        break;
+    case WDBC_ERROR:
+        merror("Bad response from wazuh-db: %s", arg);
+        // Fallthrough
+    default:
+        return NULL;
+    }
+
+    root = cJSON_Parse(arg);
+    return root;
+}

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -32,7 +32,7 @@ list(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,OS_ConnectUnixDomain 
                          -Wl,--wrap,wdbc_parse_result")
 
 list(APPEND analysisd_names "test_mitre")
-list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,_merror")
+list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,_merror -Wl,--wrap,wdbc_query_parse_json")
 
 LIST(APPEND analysisd_names "test_same_different_loop")
 LIST(APPEND analysisd_flags "-W")

--- a/src/unit_tests/analysisd/test_mitre.c
+++ b/src/unit_tests/analysisd/test_mitre.c
@@ -31,6 +31,29 @@ int __wrap_wdbc_query_ex(int *sock, const char *query, char *response, const int
     return mock();
 }
 
+cJSON* __wrap_wdbc_query_parse_json(int *sock, const char *query, char *response, const int len)
+{
+    int option;
+
+    option = mock_type(int);
+    switch (option) {
+    case -2:
+        merror("Unable to connect to socket '%s'", WDB_LOCAL_SOCK);
+        break;
+    case -1:
+        merror("No response from wazuh-db.");
+        break;
+    case 0:
+        break;
+    case 1:
+        snprintf(response, OS_SIZE_6144, "%s", mock_ptr_type(char*));
+        merror("Bad response from wazuh-db: %s", response+4);
+        break;
+    }
+
+    return mock_ptr_type(cJSON *);
+}
+
 void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
     char formatted_msg[OS_MAXSTR];
     va_list args;
@@ -48,24 +71,30 @@ void test_queryid_error_socket(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = NULL;
 
-    will_return(__wrap_wdbc_query_ex, -2);
-    will_return(__wrap_wdbc_query_ex, -2);
+    will_return(__wrap_wdbc_query_parse_json, -2);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
+
     expect_string(__wrap__merror, formatted_msg, "Unable to connect to socket '/queue/db/wdb'");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
-    assert_int_equal(-2, ret);
+    assert_int_equal(-1, ret);
 }
 
 void test_queryid_no_response(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = NULL;
 
-    will_return(__wrap_wdbc_query_ex, -1);
-    will_return(__wrap_wdbc_query_ex, -1);
+    will_return(__wrap_wdbc_query_parse_json, -1);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
+
     expect_string(__wrap__merror, formatted_msg, "No response from wazuh-db.");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -76,13 +105,15 @@ void test_queryid_bad_response(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = NULL;
 
     char *response_ids = "err not found";
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 1);
+    will_return(__wrap_wdbc_query_parse_json, response_ids);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     expect_string(__wrap__merror, formatted_msg, "Bad response from wazuh-db: not found");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -93,13 +124,12 @@ void test_queryid_error_parse(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":}]");
 
-    char *response_ids = "ok [";
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
-    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed: 'ok'");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -110,11 +140,10 @@ void test_queryid_empty_array(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[ ]");
 
-    char *response_ids = "ok []";
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database has 0 elements.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
@@ -127,11 +156,10 @@ void test_queryid_error_parse_ids(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"ids\":\"T1001\"},{\"ids\":\"T1002\"}]");
 
-    char *response_ids = "ok [{\"ids\":\"T1001\"},{\"ids\":\"T1002\"}]";
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     expect_string(__wrap__merror, formatted_msg, "It was not possible to get Mitre techniques information.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
@@ -144,41 +172,42 @@ void test_querytactics_error_socket(void **state)
 {
     (void) state;
     int ret;
-
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1002\"}]");
+    cJSON * tactic_array = NULL;
 
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, -2);
-    will_return(__wrap_wdbc_query_ex, -2);
+    will_return(__wrap_wdbc_query_parse_json, -2);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     expect_string(__wrap__merror, formatted_msg, "Unable to connect to socket '/queue/db/wdb'");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
-    assert_int_equal(-2, ret);
+    assert_int_equal(-1, ret);
 }
 
 void test_querytactics_no_response(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1002\"}]");
+    cJSON * tactic_array = NULL;
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, -1);
-    will_return(__wrap_wdbc_query_ex, -1);
+    will_return(__wrap_wdbc_query_parse_json, -1);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     expect_string(__wrap__merror, formatted_msg, "No response from wazuh-db.");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -189,20 +218,21 @@ void test_querytactics_bad_response(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1002\"}]");
+    cJSON * tactic_array = NULL;
+    char * response_tactics = "err not found";
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
-    char *response_tactics = "err not found";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_tactics);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 1);
+    will_return(__wrap_wdbc_query_parse_json, response_tactics);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     expect_string(__wrap__merror, formatted_msg, "Bad response from wazuh-db: not found");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -213,20 +243,18 @@ void test_querytactics_error_parse(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1002\"}]");
+    cJSON * tactic_array = cJSON_Parse("[{\"phase_name\":}]");
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
-    char *response_tactics = "ok [";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_tactics);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
-    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed: 'ok'");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -237,18 +265,16 @@ void test_querytactics_empty_array(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1002\"}]");
+    cJSON * tactic_array = cJSON_Parse("[ ]");
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
-    char *response_tactics = "ok [ ]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
     
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_tactics);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database has 0 elements.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
@@ -261,18 +287,16 @@ void test_querytactics_error_parse_tactics(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1002\"}]");
+    cJSON * tactic_array = cJSON_Parse("[{\"phase\":\"Discovery\"}]");
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
-    char *response_tactics = "ok [{\"phase\":\"Discovery\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_tactics);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     expect_string(__wrap__merror, formatted_msg, "It was not possible to get MITRE tactics information.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
@@ -284,17 +308,16 @@ void test_querytactics_error_parse_tactics(void **state)
 void test_queryname_error_socket(void **state) {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1001\"}]");
+    cJSON * tactic_array = cJSON_Parse("[{\"phase_name\":\"Command And Control\"}]");
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1001\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, -2);
@@ -311,17 +334,16 @@ void test_queryname_error_socket(void **state) {
 void test_queryname_no_response(void **state) {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1001\"}]");
+    cJSON * tactic_array = cJSON_Parse("[{\"phase_name\":\"Command And Control\"}]");
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1001\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, -1);
@@ -337,17 +359,16 @@ void test_queryname_no_response(void **state) {
 void test_queryname_bad_response(void **state) {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1001\"}]");
+    cJSON * tactic_array = cJSON_Parse("[{\"phase_name\":\"Command And Control\"}]");
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1001\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
@@ -365,17 +386,17 @@ void test_querytactics_repeated_id(void **state)
 {
     (void) state;
     int ret;
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1001\"}]");
+    cJSON * tactic_array = cJSON_Parse("[{\"phase_name\":\"Command And Control\"}]");
+    cJSON * tactic_array_2 = cJSON_Parse("[{\"phase_name\":\"Command And Control\"}]");
 
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1001\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
@@ -383,9 +404,8 @@ void test_querytactics_repeated_id(void **state)
     will_return(__wrap_wdbc_query_ex, 0);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array_2);
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
@@ -400,26 +420,25 @@ void test_querytactics_success(void **state)
 {
     (void) state;
     int ret;
-    
-    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
+    cJSON * id_array = cJSON_Parse("[{\"id\":\"T1001\"},{\"id\":\"T1002\"}]");
+    cJSON * tactic_array = cJSON_Parse("[{\"phase_name\":\"Command And Control\"}]");
+    cJSON * tactic_array_2 = cJSON_Parse("[{\"phase_name\":\"Exfiltration\"}]");
+
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, id_array);
 
     /* Mitre's tactics query */
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array);
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, "ok Data Obfuscation");
     will_return(__wrap_wdbc_query_ex, 0);
 
-    will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Exfiltration\"}]");
-    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, tactic_array_2);
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);

--- a/src/unit_tests/analysisd/test_mitre.c
+++ b/src/unit_tests/analysisd/test_mitre.c
@@ -65,7 +65,7 @@ void test_queryid_no_response(void **state)
 
     will_return(__wrap_wdbc_query_ex, -1);
     will_return(__wrap_wdbc_query_ex, -1);
-    expect_string(__wrap__merror, formatted_msg, "No response or bad response from wazuh-db: ''");
+    expect_string(__wrap__merror, formatted_msg, "No response from wazuh-db.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -77,12 +77,12 @@ void test_queryid_bad_response(void **state)
     (void) state;
     int ret;
 
-    char *response_ids = "Bad response";
+    char *response_ids = "err not found";
     will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
-    will_return(__wrap_wdbc_query_ex, -1);
+    will_return(__wrap_wdbc_query_ex, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "No response or bad response from wazuh-db: 'Bad response'");
+    expect_string(__wrap__merror, formatted_msg, "Bad response from wazuh-db: not found");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -94,12 +94,12 @@ void test_queryid_error_parse(void **state)
     (void) state;
     int ret;
 
-    char *response_ids = " ";
+    char *response_ids = "ok [";
     will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed: ' '");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed: 'ok'");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -178,7 +178,7 @@ void test_querytactics_no_response(void **state)
     will_return(__wrap_wdbc_query_ex, -1);
     will_return(__wrap_wdbc_query_ex, -1);
 
-    expect_string(__wrap__merror, formatted_msg, "No response or bad response from wazuh-db: 'ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]'");
+    expect_string(__wrap__merror, formatted_msg, "No response from wazuh-db.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -191,7 +191,7 @@ void test_querytactics_bad_response(void **state)
     int ret;
 
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
-    char *response_tactics = "Bad response";
+    char *response_tactics = "err not found";
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
@@ -200,9 +200,9 @@ void test_querytactics_bad_response(void **state)
     /* Mitre's tactics query */
     will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_tactics);
-    will_return(__wrap_wdbc_query_ex, -1);
+    will_return(__wrap_wdbc_query_ex, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "No response or bad response from wazuh-db: 'Bad response'");
+    expect_string(__wrap__merror, formatted_msg, "Bad response from wazuh-db: not found");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -215,7 +215,7 @@ void test_querytactics_error_parse(void **state)
     int ret;
 
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
-    char *response_tactics = " ";
+    char *response_tactics = "ok [";
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
@@ -226,7 +226,7 @@ void test_querytactics_error_parse(void **state)
     will_return(__wrap_wdbc_query_ex, response_tactics);
     will_return(__wrap_wdbc_query_ex, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "It was not possible to get MITRE tactics information.");
+    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed: 'ok'");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -327,7 +327,7 @@ void test_queryname_no_response(void **state) {
     will_return(__wrap_wdbc_query_ex, -1);
     will_return(__wrap_wdbc_query_ex, -1);
 
-    expect_string(__wrap__merror, formatted_msg, "No response or bad response from wazuh-db: 'ok [{\"phase_name\":\"Command And Control\"}]'");
+    expect_string(__wrap__merror, formatted_msg, "No response from wazuh-db.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -351,10 +351,10 @@ void test_queryname_bad_response(void **state) {
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "Bad response");
-    will_return(__wrap_wdbc_query_ex, -1);
+    will_return(__wrap_wdbc_query_ex, "err not found");
+    will_return(__wrap_wdbc_query_ex, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "No response or bad response from wazuh-db: 'Bad response'");
+    expect_string(__wrap__merror, formatted_msg, "Bad response from wazuh-db: not found");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load("test");
@@ -379,7 +379,7 @@ void test_querytactics_repeated_id(void **state)
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "Data Obfuscation");
+    will_return(__wrap_wdbc_query_ex, "ok Data Obfuscation");
     will_return(__wrap_wdbc_query_ex, 0);
 
     /* Mitre's tactics query */
@@ -389,7 +389,7 @@ void test_querytactics_repeated_id(void **state)
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "Data Obfuscation");
+    will_return(__wrap_wdbc_query_ex, "ok Data Obfuscation");
     will_return(__wrap_wdbc_query_ex, 0);
 
     ret = mitre_load("test");
@@ -414,7 +414,7 @@ void test_querytactics_success(void **state)
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "Data Obfuscation");
+    will_return(__wrap_wdbc_query_ex, "ok Data Obfuscation");
     will_return(__wrap_wdbc_query_ex, 0);
 
     will_return(__wrap_wdbc_query_ex, 0);
@@ -423,7 +423,7 @@ void test_querytactics_success(void **state)
 
     /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "Data Compressed");
+    will_return(__wrap_wdbc_query_ex, "ok Data Compressed");
     will_return(__wrap_wdbc_query_ex, 0);
 
     ret = mitre_load("test");

--- a/src/unit_tests/analysisd/test_mitre.c
+++ b/src/unit_tests/analysisd/test_mitre.c
@@ -95,7 +95,7 @@ void test_queryid_error_parse(void **state)
     int ret;
 
     char *response_ids = " ";
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
@@ -112,7 +112,7 @@ void test_queryid_empty_array(void **state)
     int ret;
 
     char *response_ids = "ok []";
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
@@ -129,7 +129,7 @@ void test_queryid_error_parse_ids(void **state)
     int ret;
 
     char *response_ids = "ok [{\"ids\":\"T1001\"},{\"ids\":\"T1002\"}]";
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
@@ -148,7 +148,7 @@ void test_querytactics_error_socket(void **state)
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
 
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
@@ -170,7 +170,7 @@ void test_querytactics_no_response(void **state)
 
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
@@ -193,7 +193,7 @@ void test_querytactics_bad_response(void **state)
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
     char *response_tactics = "Bad response";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
@@ -217,7 +217,7 @@ void test_querytactics_error_parse(void **state)
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
     char *response_tactics = " ";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
@@ -241,7 +241,7 @@ void test_querytactics_empty_array(void **state)
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
     char *response_tactics = "ok [ ]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
     
@@ -265,7 +265,7 @@ void test_querytactics_error_parse_tactics(void **state)
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
     char *response_tactics = "ok [{\"phase\":\"Discovery\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
@@ -281,6 +281,86 @@ void test_querytactics_error_parse_tactics(void **state)
     assert_int_equal(-1, ret);
 }
 
+void test_queryname_error_socket(void **state) {
+    (void) state;
+    int ret;
+
+    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1001\"}]";
+    /* Mitre's techniques IDs query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, response_ids);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre's tactics query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre technique's name query */
+    will_return(__wrap_wdbc_query_ex, -2);
+    will_return(__wrap_wdbc_query_ex, -2);
+
+    expect_string(__wrap__merror, formatted_msg, "Unable to connect to socket '/queue/db/wdb'");
+    expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
+
+    ret = mitre_load("test");
+    assert_int_equal(-2, ret);
+}
+
+
+void test_queryname_no_response(void **state) {
+    (void) state;
+    int ret;
+
+    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1001\"}]";
+    /* Mitre's techniques IDs query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, response_ids);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre's tactics query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre technique's name query */
+    will_return(__wrap_wdbc_query_ex, -1);
+    will_return(__wrap_wdbc_query_ex, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "No response or bad response from wazuh-db: 'ok [{\"phase_name\":\"Command And Control\"}]'");
+    expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
+
+    ret = mitre_load("test");
+    assert_int_equal(-1, ret);
+}
+
+void test_queryname_bad_response(void **state) {
+    (void) state;
+    int ret;
+
+    char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1001\"}]";
+    /* Mitre's techniques IDs query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, response_ids);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre's tactics query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre technique's name query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, "Bad response");
+    will_return(__wrap_wdbc_query_ex, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "No response or bad response from wazuh-db: 'Bad response'");
+    expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
+
+    ret = mitre_load("test");
+    assert_int_equal(-1, ret);
+}
+
 void test_querytactics_repeated_id(void **state)
 {
     (void) state;
@@ -288,17 +368,28 @@ void test_querytactics_repeated_id(void **state)
 
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1001\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
     /* Mitre's tactics query */
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Discovery\"}]");
+    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
     will_return(__wrap_wdbc_query_ex, 0);
 
+    /* Mitre technique's name query */
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Lateral Movement\"}]");
+    will_return(__wrap_wdbc_query_ex, "Data Obfuscation");
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre's tactics query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre technique's name query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, "Data Obfuscation");
     will_return(__wrap_wdbc_query_ex, 0);
 
     ret = mitre_load("test");
@@ -312,17 +403,27 @@ void test_querytactics_success(void **state)
     
     char *response_ids = "ok [{\"id\":\"T1001\"},{\"id\":\"T1002\"}]";
     /* Mitre's techniques IDs query */
-    will_return(__wrap_wdbc_query_ex, 0);    
+    will_return(__wrap_wdbc_query_ex, 0);
     will_return(__wrap_wdbc_query_ex, response_ids);
     will_return(__wrap_wdbc_query_ex, 0);
 
     /* Mitre's tactics query */
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Discovery\"}]");
+    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Command And Control\"}]");
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre technique's name query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, "Data Obfuscation");
     will_return(__wrap_wdbc_query_ex, 0);
 
     will_return(__wrap_wdbc_query_ex, 0);
-    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Lateral Movement\"}]");
+    will_return(__wrap_wdbc_query_ex, "ok [{\"phase_name\":\"Exfiltration\"}]");
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    /* Mitre technique's name query */
+    will_return(__wrap_wdbc_query_ex, 0);
+    will_return(__wrap_wdbc_query_ex, "Data Compressed");
     will_return(__wrap_wdbc_query_ex, 0);
 
     ret = mitre_load("test");
@@ -344,6 +445,9 @@ int main(void) {
         cmocka_unit_test(test_querytactics_error_parse),
         cmocka_unit_test(test_querytactics_empty_array),
         cmocka_unit_test(test_querytactics_error_parse_tactics),
+        cmocka_unit_test(test_queryname_error_socket),
+        cmocka_unit_test(test_queryname_no_response),
+        cmocka_unit_test(test_queryname_bad_response),
         cmocka_unit_test(test_querytactics_repeated_id),
         cmocka_unit_test(test_querytactics_success),
     };

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -99,6 +99,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_FIM_CLEAR] = "DELETE FROM fim_entry;",
     [WDB_STMT_SYNC_UPDATE_ATTEMPT] = "UPDATE sync_info SET last_attempt = ?, n_attempts = n_attempts + 1 WHERE component = ?;",
     [WDB_STMT_SYNC_UPDATE_COMPLETION] = "UPDATE sync_info SET last_attempt = ?, last_completion = ?, n_attempts = n_attempts + 1, n_completions = n_completions + 1 WHERE component = ?;",
+    [WDB_STMT_MITRE_NAME_GET] = "SELECT name FROM attack WHERE id = ?;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",
 };
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -121,6 +121,7 @@ typedef enum wdb_stmt {
     WDB_STMT_FIM_CLEAR,
     WDB_STMT_SYNC_UPDATE_ATTEMPT,
     WDB_STMT_SYNC_UPDATE_COMPLETION,
+    WDB_STMT_MITRE_NAME_GET,
     WDB_STMT_SIZE,
     WDB_STMT_PRAGMA_JOURNAL_WAL,
 } wdb_stmt;
@@ -570,6 +571,18 @@ int wdb_parse_ciscat(wdb_t * wdb, char * input, char * output);
 
 int wdb_parse_sca(wdb_t * wdb, char * input, char * output);
 
+/**
+ * @brief Function to get values from MITRE database.
+ * 
+ * @param wdb the MITRE struct database.
+ * @param input query to get a value.
+ * @param output response of the query.
+ * @retval 1 Success: response contains the value.
+ * @retval 0 On error: the value was not found.
+ * @retval -1 On error: invalid DB query syntax.
+ */
+int wdb_parse_mitre_get(wdb_t * wdb, char * input, char * output);
+
 int wdbi_checksum_range(wdb_t * wdb, wdb_component_t component, const char * begin, const char * end, os_sha1 hexdigest);
 
 int wdbi_delete(wdb_t * wdb, wdb_component_t component, const char * begin, const char * end, const char * tail);
@@ -632,6 +645,18 @@ int wdbi_query_clear(wdb_t * wdb, wdb_component_t component, const char * payloa
  * @retval -1 On error.
  */
 int wdb_journal_wal(sqlite3 *db);
+
+/**
+ * @brief Function to get a MITRE technique's name.
+ * 
+ * @param wdb the MITRE struct database.
+ * @param id MITRE technique's ID.
+ * @param output MITRE technique's name.
+ * @retval 1 Sucess: name found on MITRE database.
+ * @retval 0 On error: name not found on MITRE database.
+ * @retval -1 On error: invalid DB query syntax.
+ */
+int wdb_mitre_name_get(wdb_t *wdb, char *id, char *output);
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }

--- a/src/wazuh_db/wdb_mitre.c
+++ b/src/wazuh_db/wdb_mitre.c
@@ -1,0 +1,49 @@
+/*
+ * Wazuh SQLite integration
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * June 06, 2016.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wdb.h"
+
+// Function to get a MITRE technique's name.
+
+int wdb_mitre_name_get(wdb_t *wdb, char *id, char *output) {
+    
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("cannot begin transaction");
+        return -1;
+    }
+
+    sqlite3_stmt *stmt = NULL;
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_MITRE_NAME_GET) < 0) {
+        mdebug1("at wdb_mitre_name_get(): cannot cache statement");
+        return -1;
+    }
+
+    stmt = wdb->stmt[WDB_STMT_MITRE_NAME_GET];
+
+    if (sqlite3_bind_text(stmt, 1, id, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return -1;
+    }
+
+    switch (wdb_step(stmt)) {
+    case SQLITE_ROW:
+        snprintf(output, OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE, "%s", sqlite3_column_text(stmt, 0));
+        return 1;
+        break;
+    case SQLITE_DONE:
+        return 0;
+        break;
+    default:
+        mdebug1("SQLite: %s", sqlite3_errmsg(wdb->db));
+        return -1;
+    }
+}

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -375,6 +375,15 @@ int wdb_parse(char * input, char * output) {
                     result = -1;
                 }
             }
+        } else if (strcmp(query, "get") == 0) {
+            if (!next) {
+                mdebug1("Mitre DB Invalid DB query syntax.");
+                mdebug2("Mitre DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = -1;
+            } else {
+                result = wdb_parse_mitre_get(wdb, next, output);
+            }
         } else {
             mdebug1("Invalid DB query syntax.");
             mdebug2("DB query error near: %s", query);
@@ -3742,6 +3751,53 @@ int wdb_parse_ciscat(wdb_t * wdb, char * input, char * output) {
         mdebug1("Invalid CISCAT query syntax.");
         mdebug2("DB query error near: %s", curr);
         snprintf(output, OS_MAXSTR + 1, "err Invalid CISCAT query syntax, near '%.32s'", curr);
+        return -1;
+    }
+}
+
+// Function to get values from MITRE database
+
+int wdb_parse_mitre_get(wdb_t * wdb, char * input, char * output) {
+    char * next;
+    char * id;
+    int result;
+
+    if (next = wstr_chr(input, ' '), !next) {
+        mdebug1("Invalid DB query syntax.");
+        mdebug2("DB query error near: %s", input);
+        snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", input);
+        return -1;
+    }
+    *next++ = '\0';
+
+    if (strcmp(input, "name") == 0) {
+        if (!next) {
+            mdebug1("Mitre DB Invalid DB query syntax.");
+            mdebug2("Mitre DB query error near: %s", input);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", input);
+            return -1;
+        } else {
+            id = next;
+            char result_found[OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE] = {0};
+            result = wdb_mitre_name_get(wdb, id, result_found);
+            switch (result) {
+                case 0:
+                    snprintf(output, OS_MAXSTR + 1, "err not found");
+                    break;
+                case 1:
+                    snprintf(output, OS_MAXSTR + 1, "ok %s", result_found);
+                    break;
+                default:
+                    mdebug1("Cannot query MITRE technique's name.");
+                    snprintf(output, OS_MAXSTR + 1, "err Cannot query name of MITRE technique '%s'", id);
+            }
+
+            return result;
+        }
+    } else {
+        mdebug1("Invalid DB query syntax.");
+        mdebug2("DB query error near: %s", input);
+        snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", input);
         return -1;
     }
 }

--- a/tools/mitre/mitredb.py
+++ b/tools/mitre/mitredb.py
@@ -65,7 +65,8 @@ def create_delete_tables(conn):
  
     sql_create_attack = """CREATE TABLE IF NOT EXISTS attack (
                                     id TEXT PRIMARY KEY, 
-                                    json TEXT
+                                    json TEXT,
+                                    name TEXT
                                 );"""
  
     sql_create_has_phase = """CREATE TABLE IF NOT EXISTS has_phase (
@@ -100,7 +101,8 @@ def create_delete_tables(conn):
     # Create has_platform table
     table_stmt(conn, sql_create_has_platform)
 
-def insert_attack_table(conn, id, json_object, database):
+
+def insert_attack_table(conn, id, json_object, name, database):
     """ 
     Insert to Mitre 'attack' table from Mitre ID technique and its JSON object. 
 
@@ -109,9 +111,9 @@ def insert_attack_table(conn, id, json_object, database):
     :param json_object: JSON object with ID 'id' taken from the JSON file
     :return:
     """
-    attack_sql = """INSERT INTO attack ('id', 'json') VALUES (?, ?);"""
-    args = (id, json_object)
-    
+    attack_sql = """INSERT INTO attack ('id', 'json', 'name') VALUES (?, ?, ?);"""
+    args = (id, json_object, name)
+
     try:
         c = conn.cursor()
         c.execute(attack_sql, args)
@@ -197,9 +199,10 @@ def parse_json(pathfile, conn, database):
                 if data_object['type'] == 'attack-pattern' and data_object['external_references'][0]['source_name'] == 'mitre-attack':
                     string_id = json.dumps(data_object['external_references'][0]['external_id']).replace('"', '')
                     string_object = json.dumps(data_object)
+                    string_name = json.dumps(data_object['name']).replace('"', '')
 
                     # Fill the attack table 
-                    insert_attack_table(conn, string_id, string_object, database)
+                    insert_attack_table(conn, string_id, string_object, string_name, database)
                     
                     # Fill the phase table
                     n = len(data_object['kill_chain_phases'])

--- a/tools/mitre/mitredb.py
+++ b/tools/mitre/mitredb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 #
@@ -15,11 +15,11 @@ import sqlite3
 from sqlite3 import Error
 import os
 import pwd
-import grp 
+import grp
 import argparse
 import sys
- 
- 
+
+
 def create_connection(db_file):
     """ 
     Create a database connection to the SQLite database specified by db_file.
@@ -33,10 +33,10 @@ def create_connection(db_file):
         return conn
     except Error as e:
         print(e)
- 
+
     return conn
- 
- 
+
+
 def table_stmt(conn, sql_stmt):
     """ 
     Create or delete a table from the sql statement.
@@ -51,6 +51,7 @@ def table_stmt(conn, sql_stmt):
     except Error as e:
         print(e)
 
+
 def create_delete_tables(conn):
     """ 
     First it deletes attack, has_phase and has_platform tables and then it creates them.
@@ -58,31 +59,31 @@ def create_delete_tables(conn):
     :return:
     """
     sql_delete_attack = """DROP TABLE IF EXISTS attack;"""
- 
+
     sql_delete_has_phase = """DROP TABLE IF EXISTS has_phase;"""
 
     sql_delete_has_platform = """DROP TABLE IF EXISTS has_platform;"""
- 
+
     sql_create_attack = """CREATE TABLE IF NOT EXISTS attack (
-                                    id TEXT PRIMARY KEY, 
+                                    id TEXT PRIMARY KEY,
                                     json TEXT,
                                     name TEXT
                                 );"""
- 
+
     sql_create_has_phase = """CREATE TABLE IF NOT EXISTS has_phase (
-                                    attack_id TEXT, 
+                                    attack_id TEXT,
                                     phase_name TEXT,
                                     FOREIGN KEY(attack_id) REFERENCES attack(id),
                                     PRIMARY KEY (attack_id, phase_name)
                                 );"""
 
     sql_create_has_platform = """CREATE TABLE IF NOT EXISTS has_platform (
-                                    attack_id TEXT, 
+                                    attack_id TEXT,
                                     platform_name TEXT,
                                     FOREIGN KEY(attack_id) REFERENCES attack(id),
                                     PRIMARY KEY (attack_id, platform_name)
-                                );"""                            
- 
+                                );"""
+
     # Delete attack table if exists
     table_stmt(conn, sql_delete_attack)
 
@@ -109,6 +110,8 @@ def insert_attack_table(conn, id, json_object, name, database):
     :param conn: Connection object
     :param id: Mitre ID technique (e.g. 'T1122')
     :param json_object: JSON object with ID 'id' taken from the JSON file
+    :param name: MITRE Technique's name
+    :param database: path of MITRE database
     :return:
     """
     attack_sql = """INSERT INTO attack ('id', 'json', 'name') VALUES (?, ?, ?);"""
@@ -120,18 +123,20 @@ def insert_attack_table(conn, id, json_object, name, database):
         conn.commit()
     except Error as e:
         print(e)
-        print("Deleting "+database)
+        print("Deleting " + database)
         conn.close()
         os.remove(database)
         sys.exit(1)
+
 
 def insert_phase_table(conn, attack_id, phase_name, database):
     """ 
     Insert to Mitre 'phase' table from Mitre ID technique and its phase/tactic. It is posible that one ID has more than one phase/tactic associated.
 
     :param conn: Connection object
-    :param id: Mitre ID technique (e.g. 'T1122')
+    :param attack_id: Mitre ID technique (e.g. 'T1122')
     :param phase_name: A phase/tactic name ('persistence ', 'privilege-escalation', etc)
+    :param database: path of MITRE database
     :return:
     """
     phase_sql = """INSERT INTO has_phase ('attack_id', 'phase_name') VALUES (?, ?);"""
@@ -143,18 +148,20 @@ def insert_phase_table(conn, attack_id, phase_name, database):
         conn.commit()
     except Error as e:
         print(e)
-        print("Deleting "+database)
+        print("Deleting " + database)
         conn.close()
         os.remove(database)
         sys.exit(1)
-        
+
+
 def insert_platform_table(conn, attack_id, platform_name, database):
     """ 
     Insert to Mitre 'plaftform' table from Mitre ID technique and its platform. It is posible that one ID has more than one platform associated.
 
     :param conn: Connection object
-    :param id: Mitre ID technique (e.g. 'T1122')
+    :param attack_id: Mitre ID technique (e.g. 'T1122')
     :param platform_name: A platform name (e.g. Windows, Linux, macOs)
+    :param database: path of MITRE database
     :return:
     """
     platform_sql = """INSERT INTO has_platform ('attack_id', 'platform_name') VALUES (?, ?);"""
@@ -166,19 +173,22 @@ def insert_platform_table(conn, attack_id, platform_name, database):
         conn.commit()
     except Error as e:
         print(e)
-        print("Deleting "+database)
+        print("Deleting " + database)
         conn.close()
         os.remove(database)
         sys.exit(1)
+
 
 def parse_json(pathfile, conn, database):
     """ 
     Parse enterprise-attack.json and fill mitre.db's tables.
 
     :param pathfile: Path directory where enterprise-attack.json file is
+    :param conn: SQLite connection
+    :param database: path of MITRE database
     :return:
     """
-    try: 
+    try:
         with open(pathfile) as json_file:
             datajson = json.load(json_file)
             data = json.dumps(datajson)
@@ -196,49 +206,52 @@ def parse_json(pathfile, conn, database):
             data = data.replace(': "impact"', ': "Impact"')
             datajson = json.loads(data)
             for data_object in datajson['objects']:
-                if data_object['type'] == 'attack-pattern' and data_object['external_references'][0]['source_name'] == 'mitre-attack':
+                if data_object['type'] == 'attack-pattern' and \
+                        data_object['external_references'][0]['source_name'] == 'mitre-attack':
                     string_id = json.dumps(data_object['external_references'][0]['external_id']).replace('"', '')
                     string_object = json.dumps(data_object)
                     string_name = json.dumps(data_object['name']).replace('"', '')
 
-                    # Fill the attack table 
+                    # Fill the attack table
                     insert_attack_table(conn, string_id, string_object, string_name, database)
-                    
+
                     # Fill the phase table
                     n = len(data_object['kill_chain_phases'])
-                    for i in range (0,n):
+                    for i in range(0, n):
                         string_phase = json.dumps(data_object['kill_chain_phases'][i]['phase_name']).replace('"', '')
                         insert_phase_table(conn, string_id, string_phase, database)
-                    
+
                     # Fill the platform table
                     for platform in data_object['x_mitre_platforms']:
                         string_platform = json.dumps(platform).replace('"', '')
-                        insert_platform_table(conn,string_id, string_platform, database)
+                        insert_platform_table(conn, string_id, string_platform, database)
 
     except TypeError as t_e:
         print(t_e)
-        print("Deleting "+database)
+        print("Deleting " + database)
         conn.close()
         os.remove(database)
         sys.exit(1)
     except KeyError as k_e:
         print(k_e)
-        print("Deleting "+database)
+        print("Deleting " + database)
         conn.close()
         os.remove(database)
         sys.exit(1)
     except NameError as n_e:
         print(n_e)
-        print("Deleting "+database)
+        print("Deleting " + database)
         conn.close()
         os.remove(database)
         sys.exit(1)
+
 
 def find(name, path):
     for root, dirs, files in os.walk(path):
         if name in files:
             return os.path.join(root, name)
- 
+
+
 def main(database=None):
     """
     Main function that creates the mitre database in a chosen directory. It deletes, creates and fills the mitre tables.
@@ -251,9 +264,9 @@ def main(database=None):
     else:
         if not os.path.isdir('/'.join((str(database).split('/')[0:-1]))):
             raise Exception('Error: Directory not found.')
-    
-    pathfile = find('enterprise-attack.json', '../..')                            
- 
+
+    pathfile = find('enterprise-attack.json', '../..')
+
     # Create a database connection
     conn = create_connection(database)
 
@@ -262,7 +275,7 @@ def main(database=None):
         create_delete_tables(conn)
     else:
         print("Error! Cannot create the database connection.")
-    
+
     # Parse enterprise-attack.json file:
     parse_json(pathfile, conn, database)
 
@@ -273,6 +286,7 @@ def main(database=None):
     os.chown(database, uid, gid)
 
     conn.close()
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='This script installs mitre.db in a directory.')


### PR DESCRIPTION
|Related issue|
|---|
|#5203|

## Description

I added MITRE technique's name to the alerts. For that, I added a column in the attack table in mitre.db. Then I created a end-point in the Wazuh-DB to query a technique's name. This name is included in a Hash table with the MITRE tactics. Finally, the names and tactics are included in MITRE JSON object after consulting the Hash table.

## Configuration options

```
  <rule id="5712" level="10" frequency="8" timeframe="120" ignore="60">
    <if_matched_sid>5710</if_matched_sid>
    <description>sshd: brute force trying to get access to </description>
    <description>the system.</description>
    <mitre>
      <id>T1110</id>
    </mitre>
    <same_source_ip />
    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
  </rule>
```

## Logs/Alerts example

```
{
   "timestamp":"2020-06-10T18:27:22.815+0200",
   "rule":{
      "level":10,
      "description":"sshd: brute force trying to get access to the system.",
      "id":"5712",
      "mitre":{
         "id":[
            "T1110",
            "T1021"
         ],
         "tactic":[
            "Credential Access",
            "Lateral Movement"
         ],
         "technique":[
            "Brute Force",
            "Remote Services"
         ]
      },
...
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- [x] Source installation
- [x] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] The data flow works as expected (agent-manager-api)
- [x] Added unit tests (for new features)
- [x] Integration tests