### PR TITLE
[3.13 - Filebeat] Add geoip section to GCP

### DIFF
--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -30,6 +30,15 @@
       }
     },
     {
+      "geoip": {
+        "field": "data.gcp.jsonPayload.sourceIP",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
       "date": {
         "field": "timestamp",
         "target_field": "@timestamp",

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -30,6 +30,15 @@
       }
     },
     {
+      "geoip": {
+        "field": "data.gcp.jsonPayload.sourceIP",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
       "date": {
         "field": "timestamp",
         "target_field": "@timestamp",


### PR DESCRIPTION
Hi team,

## Description

In this PR, we are adding a process to generate the GCP GeoPoint from the alert data. With this process, we will be able to see the geolocated alert on the Kibana map.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
