### PR TITLE
Removed Windows Defender eventchannel block

### DIFF
--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -46,11 +46,6 @@
   </localfile>
 
   <localfile>
-    <location>Microsoft-Windows-Windows Defender/Operational</location>
-    <log_format>eventchannel</log_format>
-  </localfile>
-
-  <localfile>
     <location>active-response\active-responses.log</location>
     <log_format>syslog</log_format>
   </localfile>


### PR DESCRIPTION
|Related issue|
|---|
|#5214|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

This PR removes the configuration block of Windows Defender Eventchannel from the default configuration. The reason for this is an error reported by logcollector in Windows Server 2012 and Windows 8 because it can't subscribe to this channel. 

We will add this configuration by default again once https://github.com/wazuh/wazuh/pull/3967 gets merged.

## Configuration options

NA
## Logs/Alerts example

NA
## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Package installation
- [x] Package upgrade
- [x] Review logs syntax and correct language
