### PR TITLE
Add integration: gcp to gcp events

### DIFF
--- a/wodles/gcloud/integration.py
+++ b/wodles/gcloud/integration.py
@@ -80,7 +80,7 @@ class WazuhGCloudSubscriber:
         :param msg: Message to be formatted
         """
         # Insert msg as value of self.key_name key.
-        return f'{{"{self.key_name}": {msg}}}'
+        return f'{{"integration": "gcp", "{self.key_name}": {msg}}}'
 
     def process_message(self, ack_id: str, data: bytes):
         """Send a message to Wazuh queue.


### PR DESCRIPTION
Hello team,

This PR adds `integration: gcp` key: value pair to all GCP events generated by the module.

Regards,

David
