### PR TITLE
Fix q parameter for Windows files in FIM

### DIFF
--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -863,7 +863,7 @@ class WazuhDBQuery(object):
             r'(\()?' +  # A ( character.
             r'([\w.]+)' +  # Field name: name of the field to look on DB
             '([' + ''.join(self.query_operators.keys()) + "]{1,2})" +  # Operator: looks for =, !=, <, > or ~.
-            r"([\[\]\w _\-\.:/']+)" +  # Value: A string.
+            r"([\[\]\w _\-\.:\\/']+)" +  # Value: A string.
             r"(\))?" +  # A ) character
             "([" + ''.join(self.query_separators.keys()) + "])?"  # Separator: looks for ;, , or nothing.
         )


### PR DESCRIPTION
This PR closes #4872, specifically the problem described here https://github.com/wazuh/wazuh/issues/4872#issuecomment-643095237

# Description

Hello team. It turns out that, after fixing and allowing special symbols like  `\`, `[`, `]`, `{`, `}` to be able to query Windows files, nothing was ever returned when performing this kind of requests:

```
root@7429ca762e39:/wazuh-api/test# curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscheck/000?pretty&q=file=c:\windows\sysnative\wbem\wmic.exe"
```
```JSON
{
   "error": 0,
   "data": {
      "items": [],
      "totalItems": 0
   }
}
```

The problem is that the backslash was not included in the query_regex.
https://github.com/wazuh/wazuh/blob/e378b3ccf4f22f5bf3b1663435b11e505cef59db/framework/wazuh/utils.py#L862-L869

Therefore when trying to find this file for example:
```
file=c:\windows\sysnative\wbem\wmic.exe
```
the query was finally like this
```
file=c:
```

# Requests after fix
example requests:

```
curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscheck/001?pretty&q=file=c:\\users\\jmv74211\\desktop\\realtime\\archivo2.txt" 
{
   "error": 0,
   "data": {
      "items": [
         {
            "perm": "SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administradores (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, jmv74211 (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes",
            "md5": "d41d8cd98f00b204e9800998ecf8427e",
            "type": "file",
            "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
            "file": "c:\\users\\jmv74211\\desktop\\realtime\\archivo2.txt",
            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "size": 0,
            "date": "2020-06-15 10:18:09",
            "uname": "Administradores",
            "uid": "S-1-5-32-544",
            "mtime": "2020-06-15 09:47:32",
            "inode": 0
         }
      ],
      "totalItems": 1
   }
}

curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscheck/001?pretty&q=file=c:\\users\\jmv74211\\desktop\\realtime\\nuevo%20documento%20de%20texto.txt" {
   "error": 0,
   "data": {
      "items": [
         {
            "size": 0,
            "file": "c:\\users\\jmv74211\\desktop\\realtime\\nuevo documento de texto.txt",
            "uid": "S-1-5-32-544",
            "inode": 0,
            "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "uname": "Administradores",
            "md5": "d41d8cd98f00b204e9800998ecf8427e",
            "perm": "SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administradores (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, jmv74211 (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes",
            "mtime": "2020-06-15 09:44:01",
            "date": "2020-06-15 10:18:09",
            "type": "file"
         }
      ],
      "totalItems": 1
   }
}
```

Best regards,
Selu.