### PR TITLE
Fix Wazuh-api service (systemd)

### DIFF
--- a/api/service/wazuh-api.service
+++ b/api/service/wazuh-api.service
@@ -18,6 +18,7 @@ Environment=
 ExecStart=/usr/bin/env ${APP_PATH} start
 ExecStop=/usr/bin/env ${APP_PATH} stop
 KillMode=none
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
|Related issue|
|---|
|#5228|

## Description
Hello team. This PR fixes the bug in `wazuh-api.service`. Right now, as explained in the issue #5228, it is stopped right after being started. The problem happens no more after adding the option RemainAfterExit (as set in other wazuh services).

## Logs/Alerts example
```
ps aux | grep ossec
ossec     1123  9.7 14.2 280624 71244 ?        Sl   11:55   0:05 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py start
```

Best regards,
Selu.