### PR TITLE
Vulnerability-detector: Remove unused code from xml parser

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2824,7 +2824,6 @@ void wm_vuldet_adapt_title(char *title, char *cve) {
 int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_oval, update_node *update, vu_logic condition) {
     int i, j;
     int retval = 0;
-    int check = 0;
     vulnerability *vuln;
     XML_NODE chld_node = NULL;
     vu_feed dist = update->dist_ref;
@@ -3148,10 +3147,6 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                                 retval = OS_INVALID;
                                 goto end;
                             }
-                            if (result == VU_TRUE) {
-                                retval = VU_TRUE;
-                                check = 1;
-                            }
 
                         } else if (!strcmp(node[i]->values[j], XML_AND)) {
                             if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
@@ -3160,19 +3155,11 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                                 retval = OS_INVALID;
                                 goto end;
                             }
+
                         } else {
                             mterror(WM_VULNDETECTOR_LOGTAG, VU_INVALID_OPERATOR, node[i]->values[j]);
                             retval = OS_INVALID;
                             goto end;
-                        }
-
-                        if (result == VU_FALSE) {
-                            if (condition == VU_AND) {
-                                retval = VU_FALSE;
-                                goto end;
-                            } else if (condition == VU_OR && !check) {
-                                retval = VU_FALSE;
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Remove unused lines which where ignored when parsing and OVAL XML file.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
