### PR TITLE
Refactor get_agent_groups to use WDBQueryAgents

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -11,7 +11,7 @@ from shutil import copyfile
 from wazuh import common, configuration
 from wazuh.InputValidator import InputValidator
 from wazuh.core.core_agent import WazuhDBQueryAgents, WazuhDBQueryGroupByAgents, \
-    WazuhDBQueryMultigroups, Agent
+    WazuhDBQueryMultigroups, Agent, WazuhDBQueryGroup
 from wazuh.core.core_utils import get_agents_info, get_groups
 from wazuh.database import Connection
 from wazuh.exception import WazuhError, WazuhInternalError, WazuhException
@@ -337,8 +337,12 @@ def get_agent_groups(group_list=None, offset=0, limit=None, sort_by=None, sort_a
 
             full_entry = path.join(common.shared_path, group_id)
 
-            # Get agents from the group
-            db_query = WazuhDBQueryAgents(select=['id'], filters={'group': group_id}, min_select_fields=set())
+            # Get ID from group
+            db_query = WazuhDBQueryGroup(select=['name'], filters={'name': group_id})
+            query_data = db_query.run()
+
+            # Group count
+            db_query = WazuhDBQueryAgents(get_data=False, filters={'group': query_data['items'][0]['name']})
             query_data = db_query.run()
 
             # merged.mg and agent.conf sum

--- a/framework/wazuh/core/core_agent.py
+++ b/framework/wazuh/core/core_agent.py
@@ -137,6 +137,22 @@ class WazuhDBQueryAgents(WazuhDBQuery):
             WazuhDBQuery._process_filter(self, field_name, field_filter, q_filter)
 
 
+class WazuhDBQueryGroup(WazuhDBQuery):
+    def __init__(self, offset=0, limit=common.database_limit, sort=None, search=None, select=None, count=True,
+                 get_data=True, query='', filters=None, default_sort_field='id', min_select_fields=None,
+                 remove_extra_fields=True):
+        if filters is None:
+            filters = {}
+        if min_select_fields is None:
+            min_select_fields = {'id'}
+        backend = SQLiteBackend(common.database_path_global)
+        WazuhDBQuery.__init__(self, offset=offset, limit=limit, table='`group`', sort=sort, search=search, select=select,
+                              filters=filters, fields={'id': 'id', 'name': 'name'},
+                              default_sort_field=default_sort_field, default_sort_order='ASC', query=query,
+                              backend=backend, min_select_fields=min_select_fields, count=count, get_data=get_data)
+        self.remove_extra_fields = remove_extra_fields
+
+
 class WazuhDBQueryDistinctAgents(WazuhDBQueryDistinct, WazuhDBQueryAgents):
     pass
 

--- a/framework/wazuh/core/core_utils.py
+++ b/framework/wazuh/core/core_utils.py
@@ -18,12 +18,10 @@ def get_agents_info():
 
     :return: List of agents ids
     """
-    agents = WazuhDBQueryAgents(select=['id']).run()['items']
-    agents_list = set()
-    for agent_info in agents:
-        agents_list.add(str(agent_info['id']).zfill(3))
+    db_query = WazuhDBQueryAgents(select=['id'])
+    query_data = db_query.run()
 
-    return agents_list
+    return {str(agent_info['id']).zfill(3) for agent_info in query_data['items']}
 
 
 @common.context_cached('system_groups')
@@ -34,12 +32,8 @@ def get_groups():
     """
     db_query = WazuhDBQueryGroup(select=['name'], min_select_fields=set())
     query_data = db_query.run()
-    groups = query_data['items']
-    groups_list = set()
-    for group in groups:
-        groups_list.add(group['name'])
 
-    return groups_list
+    return {group['name'] for group in query_data['items']}
 
 
 @common.context_cached('system_files')

--- a/framework/wazuh/core/core_utils.py
+++ b/framework/wazuh/core/core_utils.py
@@ -7,7 +7,7 @@ from os.path import join
 
 from wazuh import common
 from wazuh.common import ossec_path
-from wazuh.core.core_agent import WazuhDBQueryAgents, WazuhDBQueryMultigroups
+from wazuh.core.core_agent import WazuhDBQueryAgents, WazuhDBQueryMultigroups, WazuhDBQueryGroup
 from wazuh.database import Connection
 from wazuh.exception import WazuhInternalError
 
@@ -32,12 +32,9 @@ def get_groups():
 
     :return: List of group names
     """
-    db_global = glob(common.database_path_global)
-    if not db_global:
-        raise WazuhInternalError(1600)
-    conn = Connection(db_global[0])
-    conn.execute("SELECT name FROM `group`")
-    groups = conn.fetch_all()
+    db_query = WazuhDBQueryGroup(select=['name'], min_select_fields=set())
+    query_data = db_query.run()
+    groups = query_data['items']
     groups_list = set()
     for group in groups:
         groups_list.add(group['name'])

--- a/framework/wazuh/core/tests/data/test_core_agent/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_core_agent/schema_global_test.sql
@@ -56,18 +56,18 @@ INSERT INTO agent (id, name, ip, os_name, os_version, os_major, os_minor, os_cod
                    (0,'master','127.0.0.1','Ubuntu','18.04.1 LTS','18','04','Bionic Beaver','ubuntu',
                    'Linux |master |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.9.0','master','node01',strftime('%s','now','-10 days'),253402300799,
-                    'updated',NULL);
+                    'updated','group-1');
 
 -- Connected agent with IP and Registered IP filled
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status) VALUES (1,'agent-1','172.17.0.202','any',
+                   last_keepalive, status, `group`) VALUES (1,'agent-1','172.17.0.202','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-5 seconds'),'updated');
+                    strftime('%s','now','-5 seconds'),'updated', 'group-2');
 
 -- Connected agent with just Registered IP filled
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
@@ -129,3 +129,11 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                    'Wazuh v3.8.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
                     strftime('%s','now','-15 minutes'),'updated');
+
+-- Create group-1 and group-2
+INSERT INTO `group` (id, name) VALUES (1, 'group-1');
+INSERT INTO `group` (id, name) VALUES (2, 'group-2');
+
+-- Add Agent1 to group-1 and agent2 to group-2
+INSERT INTO belongs (id_agent, id_group) VALUES (1, 1);
+INSERT INTO belongs (id_agent, id_group) VALUES (2, 2);

--- a/framework/wazuh/tests/data/schema_global_test.sql
+++ b/framework/wazuh/tests/data/schema_global_test.sql
@@ -145,11 +145,11 @@ INSERT INTO `group` (id, name) VALUES (2, 'group-2');
 INSERT INTO `group` (id, name) VALUES (3, 'group-empty');
 
 
--- agent-6 and agent-7 -> group-1
+-- agent-6 -> group-1 and agent-7 -> group-2
 INSERT INTO belongs (id_agent, id_group) VALUES (6, 1);
-INSERT INTO belongs (id_agent, id_group) VALUES (7, 1);
+INSERT INTO belongs (id_agent, id_group) VALUES (7, 2);
 
 
--- agent-8 -> group-2
+-- agent-8 -> group-1 and group-2
 INSERT INTO belongs (id_agent, id_group) VALUES (8, 2);
 INSERT INTO belongs (id_agent, id_group) VALUES (8, 1);

--- a/framework/wazuh/utils.py
+++ b/framework/wazuh/utils.py
@@ -1157,6 +1157,8 @@ class WazuhDBQuery(object):
         self._add_search_to_query()
         if self.count:
             self._get_total_items()
+            if not self.data:
+                return {'totalItems': self.total_items}
         self._add_sort_to_query()
         self._add_limit_to_query()
         if self.data:


### PR DESCRIPTION
Hello team, this closes #4826 .

This PR refactors the agent SDK to make `get_agents_group` use `WazuhDBQueryAgents` instead of raw SQL queries.

The `core_utils.py` module has been refactored as well since I saw it used a raw SQL query.

New unit tests have been added and the test databases have been updated.

## Tests performed
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 95 items                                                             

wazuh/tests/test_agent.py .............................................. [ 48%]
.................................................                        [100%]

============================== 95 passed in 2.64s ==============================

```
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 184 items                                                            

wazuh/core/tests/test_core_agent.py .................................... [ 19%]
........................................................................ [ 58%]
........................................................................ [ 97%]
....                                                                     [100%]

============================= 184 passed in 0.91s ==============================

```
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 192 items                                                            

wazuh/tests/test_utils.py .............................................. [ 23%]
........................................................................ [ 61%]
........................................................................ [ 98%]
..                                                                       [100%]

============================= 192 passed in 0.33s ==============================


```

Regards.