### PR TITLE
Fixed compilation warnings

### DIFF
--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -340,12 +340,8 @@ int add_agent(int json_output, int no_limit)
                  * Random 5: Final key
                  */
 
-                if (snprintf(str1, STR_SIZE, "%d%s%d", (int)(time3 - time2), name, (int)rand1) >= STR_SIZE) {
-                    mwarn("Add agent: a string used to generate the agent key may be truncated.");
-                }
-                if (snprintf(str2, STR_SIZE, "%d%s%s%d", (int)(time2 - time1), ip, id, (int)rand2) >= STR_SIZE) {
-                    mwarn("Add agent: a string used to generate the agent key may be truncated.");
-                }
+                os_snprintf(str1, STR_SIZE, "%d%s%d", (int)(time3 - time2), name, (int)rand1);
+                os_snprintf(str2, STR_SIZE, "%d%s%s%d", (int)(time2 - time1), ip, id, (int)rand2);
 
                 OS_MD5_Str(str1, -1, md1);
                 OS_MD5_Str(str2, -1, md2);

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -340,8 +340,12 @@ int add_agent(int json_output, int no_limit)
                  * Random 5: Final key
                  */
 
-                snprintf(str1, STR_SIZE, "%d%s%d", (int)(time3 - time2), name, (int)rand1);
-                snprintf(str2, STR_SIZE, "%d%s%s%d", (int)(time2 - time1), ip, id, (int)rand2);
+                if (snprintf(str1, STR_SIZE, "%d%s%d", (int)(time3 - time2), name, (int)rand1) >= STR_SIZE) {
+                    mwarn("Add agent: a string used to generate the agent key may be truncated.");
+                }
+                if (snprintf(str2, STR_SIZE, "%d%s%s%d", (int)(time2 - time1), ip, id, (int)rand2) >= STR_SIZE) {
+                    mwarn("Add agent: a string used to generate the agent key may be truncated.");
+                }
 
                 OS_MD5_Str(str1, -1, md1);
                 OS_MD5_Str(str2, -1, md2);

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -455,8 +455,12 @@ int k_bulkload(const char *cmdbulk)
              * Random 5: Final key
              */
 
-            snprintf(str1, STR_SIZE, "%d%s%d", (int)(time3 - time2), name, (int)rand1);
-            snprintf(str2, STR_SIZE, "%d%s%s%d", (int)(time2 - time1), ip, id, (int)rand2);
+            if (snprintf(str1, STR_SIZE, "%d%s%d", (int)(time3 - time2), name, (int)rand1) >= STR_SIZE) {
+                mwarn("Bulk generate client keys: a string used to generate the client key may be truncated.");
+            }
+            if (snprintf(str2, STR_SIZE, "%d%s%s%d", (int)(time2 - time1), ip, id, (int)rand2) >= STR_SIZE) {
+                mwarn("Bulk generate client keys: a string used to generate the client key may be truncated.");
+            }
 
             OS_MD5_Str(str1, -1, md1);
             OS_MD5_Str(str2, -1, md2);

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -455,12 +455,8 @@ int k_bulkload(const char *cmdbulk)
              * Random 5: Final key
              */
 
-            if (snprintf(str1, STR_SIZE, "%d%s%d", (int)(time3 - time2), name, (int)rand1) >= STR_SIZE) {
-                mwarn("Bulk generate client keys: a string used to generate the client key may be truncated.");
-            }
-            if (snprintf(str2, STR_SIZE, "%d%s%s%d", (int)(time2 - time1), ip, id, (int)rand2) >= STR_SIZE) {
-                mwarn("Bulk generate client keys: a string used to generate the client key may be truncated.");
-            }
+            os_snprintf(str1, STR_SIZE, "%d%s%d", (int)(time3 - time2), name, (int)rand1);
+            os_snprintf(str2, STR_SIZE, "%d%s%s%d", (int)(time2 - time1), ip, id, (int)rand2);
 
             OS_MD5_Str(str1, -1, md1);
             OS_MD5_Str(str2, -1, md2);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -359,7 +359,10 @@ static void send_msg_on_startup(void){
     snprintf(msg, OS_MAXSTR, OS_AG_STARTED,
             keys.keyentries[0]->name,
             keys.keyentries[0]->ip->ip);
-    snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,
-            "ossec", msg);
+    if (snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,
+            "ossec", msg) >= OS_MAXSTR) {
+        mwarn("Message sent to server could not store all information");
+    }
+
     send_msg(fmsg, -1);
 }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -359,10 +359,8 @@ static void send_msg_on_startup(void){
     snprintf(msg, OS_MAXSTR, OS_AG_STARTED,
             keys.keyentries[0]->name,
             keys.keyentries[0]->ip->ip);
-    if (snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,
-            "ossec", msg) >= OS_MAXSTR) {
-        mwarn("Message sent to server could not store all information");
-    }
+    os_snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,
+            "ossec", msg);
 
     send_msg(fmsg, -1);
 }

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -41,4 +41,10 @@
 #define FIM_WARN_WHODATA_ADD_RULE               "(6926): Unable to add audit rule for '%s'"
 #define FIM_DB_FULL_ALERT                       "(6927): Sending DB 100%% full alert."
 
+/* Monitord warning messages */
+#define ROTATE_LOG_LONG_PATH                    "(6928): The path of the rotated log is too long."
+#define ROTATE_JSON_LONG_PATH                   "(6929): The path of the rotated json is too long."
+#define COMPRESSED_LOG_LONG_PATH                "(6930): The path of the compressed log is too long."
+#define COMPRESSED_JSON_LONG_PATH               "(6931): The path of the compressed json is too long."
+
 #endif /* WARN_MESSAGES_H */

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -202,4 +202,15 @@ char * w_tolower_str(const char *string);
 char *decode_base64(const char *src);
 char *encode_base64(int size, const char *src);
 
+/**
+ * @brief Verify the string is not truncated after executing snprintf
+ * 
+ * @param str Pointer to a buffer where the resulting string is stored.
+ * @param size Maximum number of bytes to be used in the buffer.
+ * @param format String that contains a format string that follows the same specifications as format in printf.
+ * @param ... Depending on the format string, the function may expect a sequence of additional arguments.
+ * @return int The number of characters that would have been written if size had been sufficiently large.
+ */
+int os_snprintf(char *str, size_t size, const char *format, ...);
+
 #endif

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1796,14 +1796,22 @@ w_message_t * w_msg_queue_pop(w_msg_queue_t * msg){
     return message;
 }
 
+#ifdef WIN32
+DWORD WINAPI w_output_thread(void * args) {
+#else
 void * w_output_thread(void * args){
+#endif
     char *queue_name = args;
     w_message_t *message;
     w_msg_queue_t *msg_queue;
 
     if (msg_queue = OSHash_Get(msg_queues_table, queue_name), !msg_queue) {
         mwarn("Could not found the '%s'.", queue_name);
+    #ifdef WIN32
+        exit(1);
+    #else
         return NULL;
+    #endif
     }
 
     while(1)
@@ -1864,7 +1872,9 @@ void * w_output_thread(void * args){
         free(message);
     }
 
+#ifndef WIN32
     return NULL;
+#endif
 }
 
 void w_create_output_threads(){
@@ -1882,7 +1892,7 @@ void w_create_output_threads(){
 #else
                 w_create_thread(NULL,
                     0,
-                    (LPTHREAD_START_ROUTINE)w_output_thread,
+                    w_output_thread,
                     curr_node->key,
                     0,
                     NULL);
@@ -1892,7 +1902,11 @@ void w_create_output_threads(){
     }
 }
 
+#ifdef WIN32
+DWORD WINAPI w_input_thread(__attribute__((unused)) void * t_id) {
+#else
 void * w_input_thread(__attribute__((unused)) void * t_id){
+#endif
     logreader *current;
     int i = 0, r = 0, j = -1;
     IT_control f_control = 0;
@@ -2147,7 +2161,9 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
         }
     }
 
+#ifndef WIN32
     return NULL;
+#endif
 }
 
 void w_create_input_threads(){
@@ -2166,7 +2182,7 @@ void w_create_input_threads(){
 #else
         w_create_thread(NULL,
                      0,
-                     (LPTHREAD_START_ROUTINE)w_input_thread,
+                     w_input_thread,
                      NULL,
                      0,
                      NULL);

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -179,13 +179,21 @@ int w_msg_queue_push(w_msg_queue_t * msg, const char * buffer, char *file, unsig
 w_message_t * w_msg_queue_pop(w_msg_queue_t * queue);
 
 /* Output processing thread*/
+#ifdef WIN32
+DWORD WINAPI w_output_thread(void * args);
+#else
 void * w_output_thread(void * args);
+#endif
 
 /* Prepare pool of output threads */
 void w_create_output_threads();
 
 /* Input processing thread */
+#ifdef WIN32
+DWORD WINAPI w_input_thread(__attribute__((unused)) void * t_id);
+#else
 void * w_input_thread(__attribute__((unused)) void * t_id);
+#endif
 
 /* Prepare pool of input threads */
 void w_create_input_threads();

--- a/src/monitord/manage_files.c
+++ b/src/monitord/manage_files.c
@@ -47,13 +47,13 @@ void manage_log(const char * logdir, int cday, int cmon, int cyear, const struct
     OS_SignLog(logfile, logfile_old, ext);
 
     if (mond.compress) {
-        if (snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext) >= OS_FLSIZE) {
+        if (snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext) >= OS_FLSIZE + 1) {
             mwarn("The rotated log's name may be truncated because it is too long.");
         }
         OS_CompressLog(logfile_r);
 
         for (i = 1; !IsFile(logfile_r) && FileSize(logfile_r) > 0; i++) {
-            if (snprintf(logfile_r, OS_FLSIZE + 1, "%s-%.3d.%s", logfile, i, ext) < OS_FLSIZE) {
+            if (snprintf(logfile_r, OS_FLSIZE + 1, "%s-%.3d.%s", logfile, i, ext) < OS_FLSIZE + 1) {
                 OS_CompressLog(logfile_r);
             } else {
                 mwarn("The rotated log's name may be truncated because it is too long.");

--- a/src/monitord/manage_files.c
+++ b/src/monitord/manage_files.c
@@ -47,11 +47,17 @@ void manage_log(const char * logdir, int cday, int cmon, int cyear, const struct
     OS_SignLog(logfile, logfile_old, ext);
 
     if (mond.compress) {
-        snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext);
+        if (snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext) >= OS_FLSIZE) {
+            mwarn("The rotated log's name may be truncated because it is too long.");
+        }
         OS_CompressLog(logfile_r);
 
-        for (i = 1; snprintf(logfile_r, OS_FLSIZE + 1, "%s-%.3d.%s", logfile, i, ext), !IsFile(logfile_r) && FileSize(logfile_r) > 0; i++) {
-            OS_CompressLog(logfile_r);
+        for (i = 1; !IsFile(logfile_r) && FileSize(logfile_r) > 0; i++) {
+            if (snprintf(logfile_r, OS_FLSIZE + 1, "%s-%.3d.%s", logfile, i, ext) < OS_FLSIZE) {
+                OS_CompressLog(logfile_r);
+            } else {
+                mwarn("The rotated log's name may be truncated because it is too long.");
+            }
         }
     }
 }

--- a/src/monitord/manage_files.c
+++ b/src/monitord/manage_files.c
@@ -47,16 +47,12 @@ void manage_log(const char * logdir, int cday, int cmon, int cyear, const struct
     OS_SignLog(logfile, logfile_old, ext);
 
     if (mond.compress) {
-        if (snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext) >= OS_FLSIZE + 1) {
-            mwarn("The rotated log's name may be truncated because it is too long.");
-        }
+        os_snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext);
         OS_CompressLog(logfile_r);
 
         for (i = 1; !IsFile(logfile_r) && FileSize(logfile_r) > 0; i++) {
-            if (snprintf(logfile_r, OS_FLSIZE + 1, "%s-%.3d.%s", logfile, i, ext) < OS_FLSIZE + 1) {
+            if (os_snprintf(logfile_r, OS_FLSIZE + 1, "%s-%.3d.%s", logfile, i, ext) < OS_FLSIZE + 1) {
                 OS_CompressLog(logfile_r);
-            } else {
-                mwarn("The rotated log's name may be truncated because it is too long.");
             }
         }
     }

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -82,21 +82,11 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
     snprintf(base_dir, PATH_MAX, "%s/logs/ossec", isChroot() ? "" : DEFAULTDIR);
 #endif
 
-    if (snprintf(year_dir, PATH_MAX, "%s/%d", base_dir, tm.tm_year + 1900) >= PATH_MAX) {
-        mwarn(ROTATE_LOG_LONG_PATH);
-    }
-    if (snprintf(month_dir, PATH_MAX, "%s/%s", year_dir, MONTHS[tm.tm_mon]) >= PATH_MAX) {
-        mwarn(ROTATE_LOG_LONG_PATH);
-    }
-    if (snprintf(new_path, PATH_MAX, "%s/ossec-%02d.log", month_dir, tm.tm_mday) >= PATH_MAX) {
-        mwarn(ROTATE_LOG_LONG_PATH);
-    }
-    if (snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d.json", month_dir, tm.tm_mday) >= PATH_MAX) {
-        mwarn(ROTATE_JSON_LONG_PATH);
-    }
-    if (snprintf(compressed_path, PATH_MAX, "%s.gz", new_path) >= PATH_MAX) {
-        mwarn(COMPRESSED_LOG_LONG_PATH);
-    }
+    os_snprintf(year_dir, PATH_MAX, "%s/%d", base_dir, tm.tm_year + 1900);
+    os_snprintf(month_dir, PATH_MAX, "%s/%s", year_dir, MONTHS[tm.tm_mon]);
+    os_snprintf(new_path, PATH_MAX, "%s/ossec-%02d.log", month_dir, tm.tm_mday);
+    os_snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d.json", month_dir, tm.tm_mday);
+    os_snprintf(compressed_path, PATH_MAX, "%s.gz", new_path);
 
     // Create folders
 
@@ -113,27 +103,17 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
         /* Count rotated log files of the current day */
         while(!IsFile(compressed_path)){
             counter++;
-            if (snprintf(new_path, PATH_MAX, "%s/ossec-%02d-%03d.log", month_dir, tm.tm_mday, counter) >= PATH_MAX) {
-                mwarn(ROTATE_LOG_LONG_PATH);
-            }
-            if (snprintf(compressed_path, PATH_MAX, "%s.gz", new_path) >= PATH_MAX) {
-                mwarn(COMPRESSED_LOG_LONG_PATH);
-            }
+            os_snprintf(new_path, PATH_MAX, "%s/ossec-%02d-%03d.log", month_dir, tm.tm_mday, counter);
+            os_snprintf(compressed_path, PATH_MAX, "%s.gz", new_path);
         }
 
         /* Rotate compressed logs if needed */
         if (counter == daily_rotations) {
             if (daily_rotations == 1 && counter == 1) {
-                if (snprintf(new_path, PATH_MAX, "%s/ossec-%02d.log", month_dir, tm.tm_mday) >= PATH_MAX) {
-                    mwarn(ROTATE_LOG_LONG_PATH);
-                }
+                os_snprintf(new_path, PATH_MAX, "%s/ossec-%02d.log", month_dir, tm.tm_mday);
             } else {
-                if (snprintf(rename_path, PATH_MAX, "%s/ossec-%02d.log.gz", month_dir, tm.tm_mday) >= PATH_MAX) {
-                    mwarn("The renamed path of the compressed log is too long");
-                }
-                if (snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-001.log.gz", month_dir, tm.tm_mday) >= PATH_MAX) {
-                    mwarn("The old path of the compressed log is too long");
-                }
+                os_snprintf(rename_path, PATH_MAX, "%s/ossec-%02d.log.gz", month_dir, tm.tm_mday);
+                os_snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-001.log.gz", month_dir, tm.tm_mday);
                 counter = 1;
                 while (counter < daily_rotations) {
                     if (rename_ex(old_rename_path, rename_path) != 0) {
@@ -142,13 +122,9 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                     }
                     counter++;
                     snprintf(rename_path, PATH_MAX, "%s", old_rename_path);
-                    if (snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-%03d.log.gz", month_dir, tm.tm_mday, counter) >= PATH_MAX) {
-                        mwarn("The old path of the compressed log is too long");
-                    }
+                    os_snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-%03d.log.gz", month_dir, tm.tm_mday, counter);
                 }
-                if (snprintf(new_path, PATH_MAX, "%s/ossec-%02d-%03d.log", month_dir, tm.tm_mday, counter - 1) >= PATH_MAX) {
-                    mwarn(COMPRESSED_LOG_LONG_PATH);
-                }
+                os_snprintf(new_path, PATH_MAX, "%s/ossec-%02d-%03d.log", month_dir, tm.tm_mday, counter - 1);
             }
         }
 
@@ -166,34 +142,22 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
 
     if (new_day || (!new_day && rotate_json)) {
 
-        if (snprintf(compressed_path, PATH_MAX, "%s.gz", new_path_json) >= PATH_MAX) {
-            mwarn(COMPRESSED_JSON_LONG_PATH);
-        }
+        os_snprintf(compressed_path, PATH_MAX, "%s.gz", new_path_json);
 
         /* Count rotated log files of the current day */
         while(!IsFile(compressed_path)) {
             counter++;
-            if (snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d-%03d.json", month_dir, tm.tm_mday, counter) >= PATH_MAX) {
-                mwarn(ROTATE_JSON_LONG_PATH);
-            }
-            if (snprintf(compressed_path, PATH_MAX, "%s.gz", new_path_json) >= PATH_MAX) {
-                mwarn(COMPRESSED_JSON_LONG_PATH);
-            }
+            os_snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d-%03d.json", month_dir, tm.tm_mday, counter);
+            os_snprintf(compressed_path, PATH_MAX, "%s.gz", new_path_json);
         }
 
         /* Rotate compressed logs if needed */
         if (counter == daily_rotations) {
             if (daily_rotations == 1 && counter == 1) {
-                if (snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d.json", month_dir, tm.tm_mday) >= PATH_MAX) {
-                    mwarn(ROTATE_JSON_LONG_PATH);
-                }
+                os_snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d.json", month_dir, tm.tm_mday);
             } else {
-                if (snprintf(rename_path, PATH_MAX, "%s/ossec-%02d.json.gz", month_dir, tm.tm_mday) >= PATH_MAX) {
-                    mwarn("The renamed path of the compressed json is too long");
-                }
-                if (snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-001.json.gz", month_dir, tm.tm_mday) >= PATH_MAX) {
-                    mwarn("The old path of the compressed json is too long");
-                }
+                os_snprintf(rename_path, PATH_MAX, "%s/ossec-%02d.json.gz", month_dir, tm.tm_mday);
+                os_snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-001.json.gz", month_dir, tm.tm_mday);
                 counter = 1;
                 while (counter < daily_rotations) {
                     if (rename_ex(old_rename_path, rename_path) != 0) {
@@ -202,13 +166,9 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                     }
                     counter++;
                     snprintf(rename_path, PATH_MAX, "%s", old_rename_path);
-                    if (snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-%03d.json.gz", month_dir, tm.tm_mday, counter) >= PATH_MAX) {
-                        mwarn("The old renamed path of the compressed json is too long");
-                    }
+                    os_snprintf(old_rename_path, PATH_MAX, "%s/ossec-%02d-%03d.json.gz", month_dir, tm.tm_mday, counter);
                 }
-                if (snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d-%03d.json", month_dir, tm.tm_mday, counter - 1) >= PATH_MAX) {
-                    mwarn(ROTATE_JSON_LONG_PATH);
-                }
+                os_snprintf(new_path_json, PATH_MAX, "%s/ossec-%02d-%03d.json", month_dir, tm.tm_mday, counter - 1);
             }
         }
 

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -55,9 +55,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     /* Create the checksum file names */
     snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext);
-    if (snprintf(logfilesum, OS_FLSIZE, "%s.sum", logfile_r) >= OS_FLSIZE) {
-        mwarn("The checksum file name may be truncated because it is too long.");
-    }
+    os_snprintf(logfilesum, OS_FLSIZE, "%s.sum", logfile_r);
     snprintf(logfilesum_old, OS_FLSIZE, "%s.%s.sum", logfile_old, ext);
 
     MD5_Init(&md5_ctx);

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -55,7 +55,9 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     /* Create the checksum file names */
     snprintf(logfile_r, OS_FLSIZE + 1, "%s.%s", logfile, ext);
-    snprintf(logfilesum, OS_FLSIZE, "%s.sum", logfile_r);
+    if (snprintf(logfilesum, OS_FLSIZE, "%s.sum", logfile_r) >= OS_FLSIZE) {
+        mwarn("The checksum file name may be truncated because it is too long.");
+    }
     snprintf(logfilesum_old, OS_FLSIZE, "%s.%s.sum", logfile_old, ext);
 
     MD5_Init(&md5_ctx);

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -117,7 +117,9 @@ char *__generatetmppass()
     OS_MD5_Str(rand3, -1, md3);
     OS_MD5_Str(rand4, -1, md4);
 
-    snprintf(str1, STR_SIZE, "%d%d%s%d%s%s",(int)time(0), rand1, getuname(), rand2, md3, md4);
+    if (snprintf(str1, STR_SIZE, "%d%d%s%d%s%s",(int)time(0), rand1, getuname(), rand2, md3, md4) >= STR_SIZE) {
+        mwarn("Temporary shared pass may be truncated because it is too long.");
+    }
     OS_MD5_Str(str1, -1, md1);
     fstring = strdup(md1);
     free(rand3);
@@ -448,7 +450,7 @@ int main(int argc, char **argv)
         exit(1);
     }
     fclose(fp);
-    
+
     /* Start SSL */
     ctx = os_ssl_keys(1, dir, config.ciphers, config.manager_cert, config.manager_key, config.agent_ca, config.flags.auto_negotiate);
     if (!ctx) {
@@ -581,7 +583,7 @@ int main(int argc, char **argv)
     w_cond_signal(&cond_pending);
     w_mutex_unlock(&mutex_keys);
 
-    
+
     pthread_join(thread_dispatcher, NULL);
     if (!config.worker_node) {
         pthread_join(thread_writer, NULL);
@@ -595,7 +597,7 @@ int main(int argc, char **argv)
 
 /* Thread for dispatching connection pool */
 void* run_dispatcher(__attribute__((unused)) void *arg) {
-    char ip[IPSIZE + 1];    
+    char ip[IPSIZE + 1];
     int ret;
     char* buf = NULL;
     SSL *ssl;
@@ -606,7 +608,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
 
     /* Initialize some variables */
     memset(ip, '\0', IPSIZE + 1);
-    
+
     if (!config.worker_node) {
         OS_PassEmptyKeyfile();
         OS_ReadKeys(&keys, 0, !config.flags.clear_removed, 1);
@@ -649,7 +651,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         }
 
         os_calloc(OS_SIZE_65536 + OS_SIZE_4096 + 1, sizeof(char), buf);
-        buf[0] = '\0'; 
+        buf[0] = '\0';
         ret = wrap_SSL_read(ssl, buf, OS_SIZE_65536 + OS_SIZE_4096);
         if (ret <= 0) {
             switch (ssl_error(ssl, ret)) {
@@ -664,9 +666,9 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             os_free(client);
             free(buf);
             continue;
-        }      
-        buf[ret] = '\0';  
-             
+        }
+        buf[ret] = '\0';
+
         mdebug2("Request received: <%s>", buf);
         bool enrollment_ok = FALSE;
         char *agentname = NULL;
@@ -674,20 +676,20 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         char* new_id = NULL;
         char* new_key = NULL;
         if(OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group)){
-            if (config.worker_node) {                
+            if (config.worker_node) {
                 minfo("Dispatching request to master node");
                 if( 0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL) ) {
                     enrollment_ok = TRUE;
-                } 
+                }
             }
             else {
-                w_mutex_lock(&mutex_keys);                
+                w_mutex_lock(&mutex_keys);
                 if(OS_SUCCESS == w_auth_validate_data(response, ip, agentname, centralized_group)){
                     if(OS_SUCCESS == w_auth_add_agent(response, ip, agentname, centralized_group, &new_id, &new_key)){
                         enrollment_ok = TRUE;
                     }
                 }
-                w_mutex_unlock(&mutex_keys); 
+                w_mutex_unlock(&mutex_keys);
             }
         }
 
@@ -700,8 +702,8 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             if (config.worker_node) {
                 if (ret < 0) {
                     merror("SSL write error (%d)", ret);
-                    
-                    ERR_print_errors_fp(stderr);       
+
+                    ERR_print_errors_fp(stderr);
                     if (0 != w_request_agent_remove_clustered(NULL, new_id, TRUE)) {
                         merror("Agent key unable to be shared with %s and unable to delete from master node", agentname);
                     }
@@ -710,7 +712,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                     }
                 }
             }
-            else{     
+            else{
                 if (ret < 0) {
                     merror("SSL write error (%d)", ret);
                     merror("Agent key not saved for %s", agentname);
@@ -722,16 +724,16 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                     write_pending = 1;
                     w_cond_signal(&cond_pending);
                 }
-            }  
+            }
         }
         else {
             SSL_write(ssl, response, strlen(response));
             snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
-            SSL_write(ssl, response, strlen(response));  
+            SSL_write(ssl, response, strlen(response));
         }
-            
+
         SSL_free(ssl);
-        close(client->socket);   
+        close(client->socket);
         os_free(client);
         os_free(buf);
         os_free(agentname);

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -117,9 +117,7 @@ char *__generatetmppass()
     OS_MD5_Str(rand3, -1, md3);
     OS_MD5_Str(rand4, -1, md4);
 
-    if (snprintf(str1, STR_SIZE, "%d%d%s%d%s%s",(int)time(0), rand1, getuname(), rand2, md3, md4) >= STR_SIZE) {
-        mwarn("Temporary shared pass may be truncated because it is too long.");
-    }
+    os_snprintf(str1, STR_SIZE, "%d%d%s%d%s%s",(int)time(0), rand1, getuname(), rand2, md3, md4);
     OS_MD5_Str(str1, -1, md1);
     fstring = strdup(md1);
     free(rand3);

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -27,7 +27,7 @@ extern w_queue_t * winexec_queue;
 OSList *timeout_list;
 OSListNode *timeout_node;
 
-void *win_exec_main(void * args);
+DWORD WINAPI win_exec_main(void * args);
 
 /* Shut down win-execd properly */
 static void WinExecd_Shutdown()
@@ -84,14 +84,14 @@ int WinExecd_Start()
     /* Start up message */
     minfo(STARTUP_MSG, getpid());
 
-    w_create_thread(NULL, 0, (LPTHREAD_START_ROUTINE)win_exec_main,
-            winexec_queue, 0, NULL);
+    w_create_thread(NULL, 0, win_exec_main,
+                    winexec_queue, 0, NULL);
 
     return (1);
 }
 
 // Create a thread to run windows AR simultaneous
-void *win_exec_main(__attribute__((unused)) void * args) {
+DWORD WINAPI win_exec_main(__attribute__((unused)) void * args) {
     while(1) {
         WinExecdRun(queue_pop_ex(winexec_queue));
     }

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -208,14 +208,16 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
              extra_data,
              logs);
 #else
-    snprintf(mail->body, BODY_SIZE - 1, MAIL_BODY,
+    if (snprintf(mail->body, BODY_SIZE - 1, MAIL_BODY,
              al_data->date,
              al_data->location,
              al_data->rule,
              al_data->level,
              al_data->comment,
              extra_data,
-             logs);
+             logs) >= OS_MAXSTR + OS_SIZE_1024 -1) {
+        mwarn("The body of the email could not store all data.");
+    }
 #endif
     mdebug2("OS_RecvMailQ: mail->body[%s]", mail->body);
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -208,16 +208,14 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
              extra_data,
              logs);
 #else
-    if (snprintf(mail->body, BODY_SIZE - 1, MAIL_BODY,
-             al_data->date,
-             al_data->location,
-             al_data->rule,
-             al_data->level,
-             al_data->comment,
-             extra_data,
-             logs) >= BODY_SIZE -1) {
-        mwarn("The body of the email could not store all data.");
-    }
+    os_snprintf(mail->body, BODY_SIZE - 1, MAIL_BODY,
+                al_data->date,
+                al_data->location,
+                al_data->rule,
+                al_data->level,
+                al_data->comment,
+                extra_data,
+                logs);
 #endif
     mdebug2("OS_RecvMailQ: mail->body[%s]", mail->body);
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -215,7 +215,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
              al_data->level,
              al_data->comment,
              extra_data,
-             logs) >= OS_MAXSTR + OS_SIZE_1024 -1) {
+             logs) >= BODY_SIZE -1) {
         mwarn("The body of the email could not store all data.");
     }
 #endif

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1604,7 +1604,7 @@ const char *getuname()
                 }
                 ret_size -= strlen(ret) + 1;
             } else if (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2) {
-                pGNSI = (PGNSI) GetProcAddress(
+                pGNSI = (PGNSI)(LPSYSTEM_INFO)GetProcAddress(
                             GetModuleHandle("kernel32.dll"),
                             "GetNativeSystemInfo");
                 if (NULL != pGNSI) {

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -931,3 +931,19 @@ char * w_tolower_str(const char *string) {
 
     return tolower_str;
 }
+
+// Verify the string is not truncated after executing snprintf
+
+int os_snprintf(char *str, size_t size, const char *format, ...) {
+    size_t ret;
+    va_list args;
+
+    va_start(args, format);
+    ret = vsnprintf(str, size, format, args);
+    if (ret >= size) {
+        mwarn("String may be truncated because it is too long.");
+    }
+    va_end(args);
+
+    return ret;
+}

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -179,7 +179,7 @@ os_info *get_win_version()
                 info->os_name = strdup("Microsoft Windows XP");
             }
             else if (osvi.dwMinorVersion == 2) {
-                pGNSI = (PGNSI) GetProcAddress(GetModuleHandle("kernel32.dll"),"GetNativeSystemInfo");
+                pGNSI = (PGNSI)(LPSYSTEM_INFO)GetProcAddress(GetModuleHandle("kernel32.dll"),"GetNativeSystemInfo");
                 if (NULL != pGNSI) {
                     pGNSI(&si);
                 } else {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -72,8 +72,6 @@ STATIC void fim_link_reload_broken_link(char *path, int index);
 STATIC void fim_delete_realtime_watches(int pos);
 #endif
 
-// Global variables
-static int _base_line = 0;
 
 // Send a message
 STATIC void fim_send_msg(char mq, const char * location, const char * msg) {
@@ -333,6 +331,8 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
 #endif
 
 #if defined INOTIFY_ENABLED || defined WIN32
+
+static int _base_line = 0;
 
 #ifdef WIN32
     set_priority_windows_thread();

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND shared_tests_names "test_rbtree_op")
 list(APPEND shared_tests_flags " ")
 
 list(APPEND shared_tests_names "test_string_op")
-list(APPEND shared_tests_flags "")
+list(APPEND shared_tests_flags "-Wl,--wrap,_mwarn")
 
 list(APPEND shared_tests_names "test_version_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fgets -Wl,--wrap,fclose")

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -1833,7 +1833,7 @@ void sys_network_windows(const char* LOCATION){
     if (checkVista()) {
         sys_library = LoadLibrary("syscollector_win_ext.dll");
         if (sys_library != NULL){
-            _get_network_vista = (CallFunc)GetProcAddress(sys_library, "get_network_vista");
+            _get_network_vista = (CallFunc)(void *)GetProcAddress(sys_library, "get_network_vista");
             if (!_get_network_vista){
                 dwRetVal = GetLastError();
                 mterror(WM_SYS_LOGTAG, "Unable to access 'get_network_vista' on syscollector_win_ext.dll.");

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -18,7 +18,7 @@
 
 static void *wm_control_main();
 static void wm_control_destroy();
-cJSON *wm_control_dump(void);
+cJSON *wm_control_dump();
 
 const wm_context WM_CONTROL_CONTEXT = {
     "control",
@@ -271,7 +271,7 @@ wmodule *wm_control_read(){
     return module;
 }
 
-cJSON *wm_control_dump(void) {
+cJSON *wm_control_dump() {
     cJSON *root = cJSON_CreateObject();
     cJSON *wm_wd = cJSON_CreateObject();
     cJSON_AddStringToObject(wm_wd,"enabled","yes");

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -59,7 +59,11 @@ static int wm_sca_send_alert(wm_sca_t * data,cJSON *json_alert); // Send alert
 static int wm_sca_check_hash(OSHash *cis_db_hash, const char * const result, const cJSON * const check, const cJSON * const event, int check_index, int policy_index);
 static char *wm_sca_hash_integrity(int policy_index);
 static void wm_sca_free_hash_data(cis_db_info_t *event);
+#ifdef WIN32
+static DWORD WINAPI wm_sca_dump_db_thread(wm_sca_t * data);
+#else
 static void * wm_sca_dump_db_thread(wm_sca_t * data);
+#endif
 static void wm_sca_send_policies_scanned(wm_sca_t * data);
 static int wm_sca_send_dump_end(wm_sca_t * data, unsigned int elements_sent,char * policy_id,int scan_id);  // Send dump end event
 static int append_msg_to_vm_scat (wm_sca_t * const data, const char * const msg);
@@ -224,7 +228,7 @@ void * wm_sca_main(wm_sca_t * data) {
 #else
     w_create_thread(NULL,
                     0,
-                    (LPTHREAD_START_ROUTINE)wm_sca_dump_db_thread,
+                    (void *)wm_sca_dump_db_thread,
                     data,
                     0,
                     NULL);
@@ -2764,7 +2768,11 @@ char *wm_sca_hash_integrity_file(const char *file) {
     return hash_file;
 }
 
+#ifdef WIN32
+static DWORD WINAPI wm_sca_dump_db_thread(wm_sca_t * data) {
+#else
 static void *wm_sca_dump_db_thread(wm_sca_t * data) {
+#endif
     int i;
 
     while(1) {
@@ -2862,7 +2870,9 @@ static void *wm_sca_dump_db_thread(wm_sca_t * data) {
         }
     }
 
+#ifndef WIN32
     return NULL;
+#endif
 }
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#5184|

## Description

I added a condition to all the `snprintf` that have string truncation risk to avoid warnings. If the condition is true, it means the string was truncated and a warning/error message will be printed.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Ubuntu 20
  - [x] ArchLinux
  - [x] Centos 8
  - [x] Winagent
  - [x] MacOS
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
