### PR TITLE
Update behaviour of filter status in GET /agents/stats/distinct

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1156,11 +1156,9 @@ components:
           description: "Node ID where the agent is reporting to"
         dateAdd:
           type: string
-          format: date-time
           description: "Date when the agent was registered"
         lastKeepAlive:
           type: string
-          format: date-time
           description: "Date when the last keep alive was received from the agent"
 
         os:

--- a/api/test/integration/test_agents_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_GET_endpoints.tavern.yaml
@@ -3553,6 +3553,39 @@ stages:
            - count: !anyint
              os:
                platform: !anystr
+           - count: !anyint
+               os:
+                 platform: unknown
+         failed_items: []
+         total_affected_items: !anyint
+         total_failed_items: 0
+
+ - name: Get the status and os.name
+   request:
+     verify: False
+     <<: *distinct_request
+     params:
+       fields:
+        - os.name
+        - status
+   response:
+     status_code: 200
+     json:
+       data:
+         affected_items:
+           - count: !anyint
+             status: active
+             os:
+               name: Ubuntu
+           - count: !anyint
+             status: disconnected
+             os:
+               name: Ubuntu
+           - count: !anyint
+             status: never_connected
+             os:
+               name: unknown
+
          failed_items: []
          total_affected_items: !anyint
          total_failed_items: 0

--- a/api/test/integration/test_agents_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_GET_endpoints.tavern.yaml
@@ -3553,7 +3553,6 @@ stages:
            - count: !anyint
              os:
                platform: !anystr
-           - count: !anyint
          failed_items: []
          total_affected_items: !anyint
          total_failed_items: 0

--- a/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
@@ -583,7 +583,6 @@ stages:
            - count: 5
              os:
                platform: !anystr
-           - count: !anyint
          failed_items: []
          total_affected_items: !anyint
          total_failed_items: 0

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -586,7 +586,6 @@ stages:
            - count: 6
              os:
                platform: !anystr
-           - count: !anyint
          failed_items: []
          total_affected_items: !anyint
          total_failed_items: 0

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -41,11 +41,26 @@ def get_distinct_agents(agent_list=None, offset=0, limit=common.database_limit, 
                                       some_msg='Some agents information is not shown',
                                       none_msg='No agent information is shown'
                                       )
+
+    if fields is not None:
+        if 'status' in fields:
+            if 'lastKeepAlive' not in fields:
+                fields.append('lastKeepAlive')
+            if 'version' not in fields:
+                fields.append('version')
+
     if len(agent_list) != 0:
-        db_query = WazuhDBQueryGroupByAgents(filter_fields=fields, offset=offset, limit=limit, sort=sort, search=search,
-                                             select=select, query=q, filters={'id': agent_list},
+        db_query = WazuhDBQueryGroupByAgents(filter_fields=fields, offset=offset, limit=limit, sort=sort,
+                                             search=search, select=select, query=q, filters={'id': agent_list},
                                              min_select_fields=set(), count=True, get_data=True)
+
         data = db_query.run()
+
+        # Delete dicts which only have 'count' field
+        for i, dikt in enumerate(data['items']):
+            if len(dikt.keys()) == 1:
+                del data['items'][i]
+
         result.affected_items.extend(data['items'])
         result.total_affected_items = data['totalItems']
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -42,25 +42,12 @@ def get_distinct_agents(agent_list=None, offset=0, limit=common.database_limit, 
                                       none_msg='No agent information is shown'
                                       )
 
-    if fields is not None:
-        if 'status' in fields:
-            if 'lastKeepAlive' not in fields:
-                fields.append('lastKeepAlive')
-            if 'version' not in fields:
-                fields.append('version')
-
     if len(agent_list) != 0:
         db_query = WazuhDBQueryGroupByAgents(filter_fields=fields, offset=offset, limit=limit, sort=sort,
                                              search=search, select=select, query=q, filters={'id': agent_list},
                                              min_select_fields=set(), count=True, get_data=True)
 
         data = db_query.run()
-
-        # Delete dicts which only have 'count' field
-        for i, dikt in enumerate(data['items']):
-            if len(dikt.keys()) == 1:
-                del data['items'][i]
-
         result.affected_items.extend(data['items'])
         result.total_affected_items = data['totalItems']
 

--- a/framework/wazuh/core/core_agent.py
+++ b/framework/wazuh/core/core_agent.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
+import copy
 import fcntl
 import hashlib
 import ipaddress
@@ -87,18 +88,6 @@ class WazuhDBQueryAgents(WazuhDBQuery):
                 else self.search['value']
 
     def _format_data_into_dictionary(self):
-        def format_fields(field_name, value, today, lastKeepAlive=None, version=None):
-            if field_name == 'id':
-                return str(value).zfill(3)
-            elif field_name == 'status':
-                return calculate_status(lastKeepAlive, version is None, today)
-            elif field_name == 'group':
-                return value.split(',')
-            elif field_name in ['dateAdd', 'lastKeepAlive']:
-                return datetime.utcfromtimestamp(value)
-            else:
-                return value
-
         fields_to_nest, non_nested = get_fields_to_nest(self.fields.keys(), ['os'], '.')
 
         today = datetime.utcnow()
@@ -159,10 +148,56 @@ class WazuhDBQueryDistinctAgents(WazuhDBQueryDistinct, WazuhDBQueryAgents):
 
 class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
     def __init__(self, filter_fields, *args, **kwargs):
+        self.real_fields = copy.deepcopy(filter_fields)
+
+        if filter_fields is not None:
+            if 'status' in filter_fields:
+                if 'lastKeepAlive' not in filter_fields:
+                    filter_fields.append('lastKeepAlive')
+                if 'version' not in filter_fields:
+                    filter_fields.append('version')
+
         WazuhDBQueryAgents.__init__(self, *args, **kwargs)
         WazuhDBQueryGroupBy.__init__(self, *args, table=self.table, fields=self.fields, filter_fields=filter_fields,
                                      default_sort_field=self.default_sort_field, backend=self.backend, **kwargs)
         self.remove_extra_fields = True
+
+    def _format_data_into_dictionary(self):
+        if not self.real_fields or self.filter_fields == {'fields': set(self.real_fields)}:
+            return super()._format_data_into_dictionary()
+        else:
+            fields_to_nest, non_nested = get_fields_to_nest(self.fields.keys(), ['os'], '.')
+
+            today = datetime.utcnow()
+
+            # compute 'status' field, format id with zero padding and remove non-user-requested fields.
+            # Also remove, extra fields (internal key and registration IP)
+            selected_fields = self.select - self.extra_fields if self.remove_extra_fields else self.select
+            selected_fields |= {'id'}
+            self._data = [{key: format_fields(key, value, today, item.get('lastKeepAlive'), item.get('version'))
+                           for key, value in item.items() if key in selected_fields} for item in self._data]
+
+            # Create tuples like ({values in self.real_fields}, count) in order to keep the 'count' field and discard
+            # the values not requested by the user.
+            tuples_list = [({k: result[k] if k in result.keys() else 'unknown' for k in self.real_fields},
+                            result['count']) for result in self._data]
+
+            # Sum the 'count' value of all the dictionaries that are equal
+            for i, i_tuple in enumerate(tuples_list):
+                for j, j_tuple in enumerate(tuples_list):
+                    if j_tuple == i_tuple and j > i:
+                        tuples_list[i] = (tuples_list[i][0], tuples_list[i][1] + tuples_list[j][1])
+                        del tuples_list[j]
+
+            # Append 'count' value in each dict
+            self._data = []
+            for dikt in tuples_list:
+                dikt[0].update({'count': dikt[1]})
+                self._data.append(dikt[0])
+
+            self._data = [plain_dict_to_nested_dict(d, fields_to_nest, non_nested, ['os'], '.') for d in self._data]
+
+            return WazuhDBQuery._format_data_into_dictionary(self)
 
 
 class WazuhDBQueryMultigroups(WazuhDBQueryAgents):
@@ -1479,6 +1514,19 @@ class Agent:
             raise WazuhInternalError(1735, extra_message="Minimum required version is " + str(required_version))
 
         return configuration.get_active_configuration(self.id, component, config)
+
+
+def format_fields(field_name, value, today, lastKeepAlive=None, version=None):
+    if field_name == 'id':
+        return str(value).zfill(3)
+    elif field_name == 'status':
+        return calculate_status(lastKeepAlive, version is None, today)
+    elif field_name == 'group':
+        return value.split(',')
+    elif field_name in ['dateAdd', 'lastKeepAlive']:
+        return datetime.utcfromtimestamp(value)
+    else:
+        return value
 
 
 def calculate_status(last_keep_alive, pending, today=datetime.utcnow()):

--- a/framework/wazuh/core/core_agent.py
+++ b/framework/wazuh/core/core_agent.py
@@ -163,7 +163,12 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
         self.remove_extra_fields = True
 
     def _format_data_into_dictionary(self):
+        # Add <field>: 'unknown' when filter field is not within the response.
         if not self.real_fields or self.filter_fields == {'fields': set(self.real_fields)}:
+            for result in self._data:
+                for field in self.filter_fields['fields']:
+                    if field not in result.keys():
+                        result[field] = 'unknown'
             return super()._format_data_into_dictionary()
         else:
             fields_to_nest, non_nested = get_fields_to_nest(self.fields.keys(), ['os'], '.')
@@ -183,15 +188,19 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
                             result['count']) for result in self._data]
 
             # Sum the 'count' value of all the dictionaries that are equal
+            result_list = list()
+            added_dicts = list()
             for i, i_tuple in enumerate(tuples_list):
-                for j, j_tuple in enumerate(tuples_list):
-                    if j_tuple == i_tuple and j > i:
-                        tuples_list[i] = (tuples_list[i][0], tuples_list[i][1] + tuples_list[j][1])
-                        del tuples_list[j]
+                if i not in added_dicts:
+                    for j, j_tuple in enumerate(tuples_list):
+                        if j_tuple[0] == i_tuple[0] and j > i:
+                            tuples_list[i] = (tuples_list[i][0], tuples_list[i][1] + tuples_list[j][1])
+                            added_dicts.append(j)
+                    result_list.append(tuples_list[i])
 
             # Append 'count' value in each dict
             self._data = []
-            for dikt in tuples_list:
+            for dikt in result_list:
                 dikt[0].update({'count': dikt[1]})
                 self._data.append(dikt[0])
 
@@ -1524,7 +1533,7 @@ def format_fields(field_name, value, today, lastKeepAlive=None, version=None):
     elif field_name == 'group':
         return value.split(',')
     elif field_name in ['dateAdd', 'lastKeepAlive']:
-        return datetime.utcfromtimestamp(value)
+        return datetime.utcfromtimestamp(value) if not isinstance(value, str) else value
     else:
         return value
 
@@ -1532,7 +1541,7 @@ def format_fields(field_name, value, today, lastKeepAlive=None, version=None):
 def calculate_status(last_keep_alive, pending, today=datetime.utcnow()):
     """Calculates state based on last keep alive
     """
-    if not last_keep_alive:
+    if not last_keep_alive or last_keep_alive == 'unknown':
         return "never_connected"
     else:
         last_date = datetime.utcfromtimestamp(last_keep_alive)


### PR DESCRIPTION
This PR closes #4047 

# Description 

Hello team. This PR fixes two things:
- Append value 'unknown' to dicts without field in the response. For instance, if we filter by field `os.platform` but some agents do not have that information, the result will now include 'unknown' and the count of agents with no `os.platform` information, as requested in #4047.
- Now when filtering by `status`, the returned result is correct. `lastKeepAlive` and `version` are included, but they are not shown to the user and the result is not grouped by those fields.

The reason lastKeepAlive and version are included is the following. When filtering by status, we expect a query that group the agents based on their status (never_connected, pending, active, disconnected, etc). However, this is not stored in the database but calculated after the request based on the timestamp and the version. You can see some rows of the agent db table here:

```
select * from agent; 
0|wazuh-master|127.0.0.1|127.0.0.1||Ubuntu|18.04.4 LTS|18|04|Bionic Beaver||ubuntu|Linux |wazuh-master |5.4.0-37-generic |#41-Ubuntu SMP Wed Jun 3 18:57:02 UTC 2020 |x86_64|x86_64|Wazuh v4.0.0|||wazuh-master|master-node|1592566486|253402300799|updated|0|0|
1|wazuh-agent1|172.25.0.6|any|b7efaafcde1bb0f3d3cbbf5b32e6335878305f4e6a19bec2d065f5e53e134e65|Ubuntu|16.04.6 LTS|16|04|Xenial Xerus||ubuntu|Linux |wazuh-agent1 |5.4.0-37-generic |#41-Ubuntu SMP Wed Jun 3 18:57:02 UTC 2020 |x86_64|x86_64|Wazuh v3.12.2|29e0926e5a77442212e824868a2a61df|2629b6d310fb8a9f8ad9de7c7842791d|wazuh-worker1|worker1|0|1592566957|empty|0|0|default,group1
```

The status field is always filled with `updated` or `empty`, so no useful information can be grouped based on these values and the real status cannot be calculated. To fix this, we are post-processing the result in order to find out how many times each dict is repeated. 

# Execution examples

> https://localhost:55000/v4/agents/stats/distinct?fields=status&limit=500

```JSON
{
  "data": {
    "affected_items": [
      {
        "status": "active",
        "count": 9
      },
      {
        "status": "disconnected",
        "count": 3
      },
      {
        "status": "never_connected",
        "count": 2
      }
    ],
    "total_affected_items": 14,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information is shown"
}
```

> https://localhost:55000/v4/agents/stats/distinct?wait_for_complete=true&fields=os.name&fields=os.platform&fields=status&limit=500

```JSON
{
  "data": {
    "affected_items": [
      {
        "os": {
          "name": "Ubuntu",
          "platform": "ubuntu"
        },
        "status": "active",
        "count": 9
      },
      {
        "os": {
          "name": "Ubuntu",
          "platform": "ubuntu"
        },
        "status": "disconnected",
        "count": 2
      },
      {
        "os": {
          "name": "unknown",
          "platform": "unknown"
        },
        "status": "never_connected",
        "count": 2
      },
      {
        "os": {
          "name": "Microsoft Windows 7 Ultimate Edition Professional Service Pack 1",
          "platform": "windows"
        },
        "status": "disconnected",
        "count": 1
      }
    ],
    "total_affected_items": 14,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information is shown"
}
```

> https://localhost:55000/v4/agents/stats/distinct?wait_for_complete=true&fields=status&fields=lastKeepAlive&limit=500

```JSON
{
  "data": {
    "affected_items": [
      {
        "status": "active",
        "lastKeepAlive": "9999-12-31T23:59:59Z",
        "count": 1
      },
      {
        "status": "active",
        "lastKeepAlive": "2020-06-23T12:21:01Z",
        "count": 2
      },
      {
        "status": "active",
        "lastKeepAlive": "2020-06-23T12:20:55Z",
        "count": 1
      },
      {
        "status": "active",
        "lastKeepAlive": "2020-06-23T12:21:10Z",
        "count": 1
      },
      {
        "status": "active",
        "lastKeepAlive": "2020-06-23T12:20:54Z",
        "count": 1
      },
      {
        "status": "active",
        "lastKeepAlive": "2020-06-23T12:21:04Z",
        "count": 1
      },
      {
        "status": "active",
        "lastKeepAlive": "2020-06-23T12:21:05Z",
        "count": 1
      },
      {
        "status": "active",
        "lastKeepAlive": "2020-06-23T12:21:06Z",
        "count": 1
      },
      {
        "status": "disconnected",
        "lastKeepAlive": "2020-06-21T09:27:43Z",
        "count": 2
      },
      {
        "status": "never_connected",
        "lastKeepAlive": "unknown",
        "count": 2
      },
      {
        "status": "disconnected",
        "lastKeepAlive": "2020-06-23T11:40:34Z",
        "count": 1
      }
    ],
    "total_affected_items": 14,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information is shown"
}
```

> https://localhost:55000/v4/agents/stats/distinct?wait_for_complete=true&fields=os.name&limit=500

```JSON
{
  "data": {
    "affected_items": [
      {
        "os": {
          "name": "Ubuntu"
        },
        "count": 11
      },
      {
        "os": {
          "name": "unknown"
        },
        "count": 2
      },
      {
        "os": {
          "name": "Microsoft Windows 7 Ultimate Edition Professional Service Pack 1"
        },
        "count": 1
      }
    ],
    "total_affected_items": 14,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information is shown"
}
```

# Integration tests

```
pytest -vv test_agents_GET_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.2.2, cov-2.10.0
collected 90 items                                                                                                                                                                                           

test_agents_GET_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                              [  1%]
test_agents_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                                                                                                         [  2%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                                [  3%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                                     [  4%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                               [  5%]
test_agents_GET_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                              [  6%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                                                                                                             [  7%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                                                                                                            [  8%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                                                                                                          [ 10%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                                                                                                          [ 11%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                                                                                                          [ 12%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                                                                                                          [ 13%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                                                                                                         [ 14%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                                                                                                         [ 15%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                                                                                                        [ 16%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                                                                                                        [ 17%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                                                                                                        [ 18%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                                                                                                        [ 20%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                            [ 21%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED                                                                                                   [ 22%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED                                                                                                     [ 23%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED                                                                                                       [ 24%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                                                                                                          [ 25%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                                                                                                          [ 26%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED                                                                                               [ 27%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED                                                                                                     [ 28%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED                                                                                                   [ 30%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                                                                                                        [ 31%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED                                                                                                   [ 32%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED                                                                                                     [ 33%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED                                                                                                    [ 34%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED                                                                                                 [ 35%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED                                                                                                    [ 36%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED                                                                                                    [ 37%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED                                                                                                     [ 38%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED                                                                                                 [ 40%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED                                                                                                    [ 41%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED                                                                                                  [ 42%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED                                                                                                  [ 43%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED                                                                                                      [ 44%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED                                                                                                     [ 45%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                                     [ 46%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                             [ 47%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                                                                                                            [ 48%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                                                                                                           [ 50%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                                                                                                         [ 51%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                                                                                                         [ 52%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                                                                                                         [ 53%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                                                                                                         [ 54%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                                                                                                        [ 55%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                                                                                                        [ 56%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED                                                                                                       [ 57%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED                                                                                                       [ 58%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED                                                                                                       [ 60%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED                                                                                                       [ 61%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                             [ 62%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                              [ 63%]
test_agents_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                              [ 64%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                                     [ 65%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                                                                                                              [ 66%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                                                                                                                   [ 67%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                                                                                                                   [ 68%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                                                                                                                 [ 70%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                                                                                                            [ 71%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                                                                                                           [ 72%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                                                                                                               [ 73%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                                     [ 74%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                               [ 75%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                                                                                                             [ 76%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                                                                                                                  [ 77%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                                                                                                                  [ 78%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED                                                                                                       [ 80%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                                                                                                             [ 81%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                                                                                                                [ 82%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                                                                                                           [ 83%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                                                                                                             [ 84%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                                                                                                            [ 85%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                                                                                                         [ 86%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                                                                                                            [ 87%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                                                                                                            [ 88%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                                                                                                             [ 90%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                                                                                                         [ 91%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                                                                                                            [ 92%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                                                                                                          [ 93%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                                                                                                          [ 94%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                                                                                                              [ 95%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                                                                                                             [ 96%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                               [ 97%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                                   [ 98%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/upgrade_result PASSED                                                                                                                    [100%]

============================================================================================== warnings summary ==============================================================================================
```

```
pytest -vv test_rbac_black_agents_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.2.2, cov-2.10.0
collected 37 items                                                                                                                                                                                           

test_rbac_black_agents_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                       [  2%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents?list_agents=agent_id PASSED                                                                                                                  [  5%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                         [  8%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                              [ 10%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                        [ 13%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                       [ 16%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                     [ 18%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                              [ 21%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                      [ 24%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                      [ 27%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                       [ 29%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                       [ 32%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                              [ 35%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                              [ 37%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                        [ 40%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                        [ 43%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                            [ 45%]
test_rbac_black_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/upgrade_result PASSED                                                                                                             [ 48%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                        [ 51%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                   [ 54%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents/group?group_id=group_id PASSED                                                                                                            [ 56%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE groups?list_groups=group_id PASSED                                                                                                                [ 59%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                                    [ 62%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents?list_agents=agent_id PASSED                                                                                                               [ 64%]
test_rbac_black_agents_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                    [ 67%]
test_rbac_black_agents_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                      [ 70%]
test_rbac_black_agents_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                               [ 72%]
test_rbac_black_agents_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                         [ 75%]
test_rbac_black_agents_endpoints.tavern.yaml::POST /groups?group_id={group_id} PASSED                                                                                                                  [ 78%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/group?group_id={group_id} PASSED                                                                                                             [ 81%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                              [ 83%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /groups/{group_id}/restart PASSED                                                                                                                    [ 86%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                               [ 89%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                           [ 91%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                    [ 94%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade PASSED                                                                                                                    [ 97%]
test_rbac_black_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED                                                                                                             [100%]

============================================================================================== warnings summary ==============================================================================================
```
```
pytest -vv test_rbac_white_agents_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.2.2, cov-2.10.0
collected 37 items                                                                                                                                                                                           

test_rbac_white_agents_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                       [  2%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents?list_agents=agent_id PASSED                                                                                                                  [  5%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                         [  8%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                              [ 10%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                        [ 13%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                       [ 16%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                     [ 18%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                              [ 21%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                      [ 24%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                      [ 27%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                       [ 29%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                       [ 32%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                              [ 35%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                              [ 37%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                        [ 40%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                        [ 43%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                            [ 45%]
test_rbac_white_agents_endpoints.tavern.yaml::GET /agents/{agent_id}/upgrade_result PASSED                                                                                                             [ 48%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                        [ 51%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                   [ 54%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents/group?group_id={group_id} PASSED                                                                                                          [ 56%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /groups?list_groups={group_id} PASSED                                                                                                             [ 59%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                                    [ 62%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents?list_agents=agent_id PASSED                                                                                                               [ 64%]
test_rbac_white_agents_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                    [ 67%]
test_rbac_white_agents_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                      [ 70%]
test_rbac_white_agents_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                               [ 72%]
test_rbac_white_agents_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                         [ 75%]
test_rbac_white_agents_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                                      [ 78%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                                                 [ 81%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                              [ 83%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /groups/{group_id}/restart PASSED                                                                                                                    [ 86%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                               [ 89%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                           [ 91%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                    [ 94%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade PASSED                                                                                                                    [ 97%]
test_rbac_white_agents_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED                                                                                                             [100%]

============================================================================================== warnings summary ==============================================================================================
```

Kind regards.