### PR TITLE
[4.0] Add RBAC to response error message

### DIFF
--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -14,7 +14,7 @@ def calculate_result(file_name):
     with open(file_name, 'r') as f:
         file = f.read()
     try:
-        result = re.search(r'=+ (.+) in (.*) \(\d+:\d+:\d+\) =+', file).group(1)
+        result = re.search(r'={5,} (.+) in (.*) ={5,}', file).group(1)
         print(f'\t {result}\n')
     except AttributeError:
         print('\tCould not retrieve results from this test')

--- a/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
@@ -1543,3 +1543,25 @@ stages:
       status_code: 400
       json:
         <<: *permission_denied
+
+---
+test_name: GET /agents (allow cluster:read_config)
+
+stages:
+
+  - name: Get unknown-node on failed response
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_agents: '002'
+    response:
+      status_code: 400
+      json:
+        code: 4000
+        dapi_errors:
+          master-node: # We have permission to see node name
+            error: !anystr

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -1723,3 +1723,25 @@ stages:
       status_code: 400
       json:
         <<: *permission_denied
+
+---
+test_name: GET /agents (deny cluster:read_config)
+
+stages:
+
+  - name: Get unknown-node on failed response
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_agents: '001'
+    response:
+      status_code: 400
+      json:
+        code: 4000
+        dapi_errors:
+          unknown-node: # No permissions to see node name
+            error: !anystr

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -12,6 +12,7 @@ from wazuh.InputValidator import InputValidator
 from wazuh.core.core_agent import WazuhDBQueryAgents, WazuhDBQueryGroupByAgents, \
     WazuhDBQueryMultigroups, Agent, WazuhDBQueryGroup
 from wazuh.core.core_utils import get_agents_info, get_groups
+from wazuh.database import Connection
 from wazuh.exception import WazuhError, WazuhInternalError, WazuhException
 from wazuh.rbac.decorators import expose_resources
 from wazuh.results import WazuhResult, AffectedItemsWazuhResult

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -4,7 +4,6 @@
 
 import hashlib
 import operator
-from glob import glob
 from os import chmod, path, listdir
 from shutil import copyfile
 
@@ -13,7 +12,6 @@ from wazuh.InputValidator import InputValidator
 from wazuh.core.core_agent import WazuhDBQueryAgents, WazuhDBQueryGroupByAgents, \
     WazuhDBQueryMultigroups, Agent, WazuhDBQueryGroup
 from wazuh.core.core_utils import get_agents_info, get_groups
-from wazuh.database import Connection
 from wazuh.exception import WazuhError, WazuhInternalError, WazuhException
 from wazuh.rbac.decorators import expose_resources
 from wazuh.results import WazuhResult, AffectedItemsWazuhResult

--- a/framework/wazuh/common.py
+++ b/framework/wazuh/common.py
@@ -125,10 +125,10 @@ def ossec_gid():
 max_groups_per_multigroup = 256
 
 # Context variables
-rbac: ContextVar[Dict] = ContextVar('rbac', default=dict())
+rbac: ContextVar[Dict] = ContextVar('rbac', default={'rbac_mode': 'black'})
 current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
-cluster_nodes: ContextVar[set] = ContextVar('cluster_nodes', default=list())
+cluster_nodes: ContextVar[set] = ContextVar('cluster_nodes', default=set())
 
 _context_cache = dict()
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -326,7 +326,7 @@ class DistributedAPI:
             str
                 Current node name.
             """
-            return filter_node[0]
+            return filter_node[0] if isinstance(filter_node, list) else filter_node
 
         try:
             common.rbac.set(self.rbac_permissions)


### PR DESCRIPTION
Hello team, this closes #5258 .

This PR adds RBAC to the function that generates the `dapi_errors` message whenever we do not have permissions to do a request. Now, if we do not have permissions to read the cluster configuration, we won't be able to see which node the response comes from:

```json
"dapi_errors": {
    "unknown-node": {
      "error": "Permission denied: Resource type: agent:id"
    }
  }
```
New tests for this have been added as well.

# Test results
## Unit tests
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, testinfra-5.0.0, tavern-1.0.0
collected 23 items                                                                                                                                                                                                

wazuh/core/cluster/dapi/tests/test_dapi.py .......................                                                                                                                                          [100%]

========================================================================================= 23 passed, 12 warnings in 0.42s =========================================================================================

```

## Integration tests
```
Collected tests [2]:
test_rbac_black_agents_endpoints.tavern.yaml, test_rbac_white_agents_endpoints.tavern.yaml


test_rbac_black_agents_endpoints.tavern.yaml 
	 38 passed, 40 warnings

test_rbac_white_agents_endpoints.tavern.yaml 
	 38 passed, 40 warnings

```

Regards.