### PR TITLE
Change JSON schema of vulnerability detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -52,8 +52,8 @@
 #define RED_HAT_REPO_REQ_SIZE 1000
 #define RED_HAT_REPO "https://access.redhat.com/labs/securitydataapi/cve.json?after=%d-01-01&per_page=%d&page=%d"
 #define NVD_CPE_REPO "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz"
-#define NVD_CVE_REPO_META "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%d.meta"
-#define NVD_CVE_REPO "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%d.json.gz"
+#define NVD_CVE_REPO_META "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.meta"
+#define NVD_CVE_REPO "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz"
 #define NVD_CVE_URL "https://nvd.nist.gov/vuln/detail/"
 #define NVD_REPO_MAX_ATTEMPTS 3
 #define DOWNLOAD_SLEEP_FACTOR 5


### PR DESCRIPTION
Currently, version 1.0 of the JSON NVD schema is used by the vulnerability detector. This PR switches the JSON schema version from 1.0 to 1.1.

This new version requires less disk space and downloads the NVD feed faster.