### PR TITLE
Fix defect reported by Coverity on Vulnerability Detector

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -16063,7 +16063,7 @@ void test_wm_vuldet_index_json_multipath_error(void **state)
     }
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5551): Invalid multi_path 'tmp/vuln-temp-deb': 'it is not an absolute path'");
+    expect_string(__wrap__mterror, formatted_msg, "(5551): Invalid multi_path 'tmp/vuln-temp-deb': 'relative path'");
 
     int ret = wm_vuldet_index_json(parsed_vulnerabilities, update, path, multi_path);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6137,11 +6137,13 @@ int wm_vuldet_index_json(wm_vuldet_db *parsed_vulnerabilities, update_node *upda
         os_strdup(path, path_cpy);
 
         if (*path_cpy != '/') {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_MULTIPATH_ERROR, path_cpy, "it is not an absolute path");
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_MULTIPATH_ERROR, path_cpy, "relative path");
             goto end;
         }
 
         directory = strrchr(path_cpy, '/');
+
+        assert(directory != NULL);
 
         *directory = '\0';
         pattern = directory + 1;


### PR DESCRIPTION
## Description

Fixing the following potential bug reported by Coverity:

```
________________________________________________________________________________________________________
*** CID 204340:  Null pointer dereferences  (NULL_RETURNS)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 6159 in wm_vuldet_index_json()
6153                 mterror(WM_VULNDETECTOR_LOGTAG, VU_MULTIPATH_ERROR, path_cpy, "it is not an absolute path");
6154                 goto end;
6155             }
6156     
6157             directory = strrchr(path_cpy, '/');
6158     
>>>     CID 204340:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing "directory", which is known to be "NULL".
6159             *directory = '\0';
6160             pattern = directory + 1;
6161     
6162             if (upd_dir = opendir(path_cpy == directory ? "/" : path_cpy), !upd_dir) {
6163                 mterror(WM_VULNDETECTOR_LOGTAG, VU_MULTIPATH_ERROR, path_cpy == directory ? "/" : path_cpy, strerror(errno));
6164                 goto end;
```

It was controlled since the function ends if `path_cpy` does not contain a slash. However, it has been included an assertion as a precaution. 

## Logs/Alerts example

Simplified a log message from:

```
(5551): Invalid multi_path 'tmp/vuln-temp-deb': 'it is not an absolute path'
```

to

```
(5551): Invalid multi_path 'tmp/vuln-temp-deb': 'relative path'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
- [x] Added unit tests (for new features)
