### PR TITLE
logcollector: option for reading files from beginning

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -37,6 +37,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_age = "age";
     const char *xml_localfile_exclude = "exclude";
     const char *xml_localfile_binaries = "ignore_binaries";
+    const char *xml_localfile_fseek = "read-from-end";
 
     logreader *logf;
     logreader_config *log_config;
@@ -81,6 +82,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     logf[pl].exists = 1;
     logf[pl].future = 1;
     logf[pl].reconnect_time = DEFAULT_EVENTCHANNEL_REC_TIME;
+    logf[pl].fseek = 1;
 
     /* Search for entries related to files */
     i = 0;
@@ -359,6 +361,14 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 return (OS_INVALID);
             }
 
+        } else if (strcmp(node[i]->element, xml_localfile_fseek) == 0) {
+            if (strcmp(node[i]->content, "yes") == 0) {
+                logf[pl].fseek = 1;
+            } else if (strcmp(node[i]->content, "no") == 0) {
+                logf[pl].fseek = 0;
+            } else {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            }
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -84,6 +84,7 @@ typedef struct _logreader {
     int exists;
     unsigned int age;
     char *age_str;
+    char fseek;
 
     void *(*read)(struct _logreader *lf, int *rc, int drop_it);
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -878,7 +878,7 @@ int handle_file(int i, int j, int do_fseek, int do_log)
     }
 
     /* Only seek the end of the file if set to */
-    if (do_fseek == 1 && S_ISREG(stat_fd.st_mode)) {
+    if (do_fseek == 1 && S_ISREG(stat_fd.st_mode) && lf->fseek ) {
         /* Windows and fseek causes some weird issues */
 #ifndef WIN32
         if (fseek(lf->fp, 0, SEEK_END) < 0) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5192|
|(loosely) https://github.com/wazuh/wazuh/issues/3368|

This is a contribution.

## Description

When the agent is started, logcollector by default uses `fseek` to start reading from the last line of the file (this behaviour is disabled in windows because of a bug). I've added an option in the `localfile` config to disable this feature in order to read the file from the beginning. This should solve #5192 

Using this option we can force an agent to read all the file every time it is started, this may be a mitigation of issue #3368 since we can "recover" old logs in this way. This would also generate duplicate logs in the `alert.json` and some similiar undesirable behaviour, so deduplication on logstash/elasticsearch and other techniques should be used. It's not a solution, but in some cases it's better to have duplicate events instead of a missing one.

## Configuration options

In `ossec.conf` the `localfile` section will have a new option `read-from-end`. If set to `yes` files will be read from the last line (default), if set to `no` files will be read from the beginning.

I think that in the documentation it should be mentioned that this option won't have any effect on Windows, see [this line](https://github.com/wazuh/wazuh/blob/e423f74d9a2f127e820bd0df2301cd18f15c808c/src/logcollector/logcollector.c#L883) of code for an explanation (this is not a bug introduced by this PR).
