### PR TITLE
DBSync contexts locking and lifecycle handling refactor.

### DIFF
--- a/src/dbsync/example/main.cpp
+++ b/src/dbsync/example/main.cpp
@@ -30,7 +30,7 @@ int main()
       if(0 == dbsync_insert_data(handle, json_insert)) { 
         do {
           auto t_start {std::chrono::high_resolution_clock::now()};
-          //if(update_with_snapshot_cb(handle, json_update, (void *)&callback)) {
+          //dbsync_update_with_snapshot_cb(handle, json_update, (void *)&callback);
           if(0 == dbsync_update_with_snapshot(handle, json_update, &json_result)) {   
             auto t_end {std::chrono::high_resolution_clock::now()};
             std::cout << "duration: "<<std::chrono::duration_cast<std::chrono::microseconds>(t_end-t_start).count()<<std::endl;

--- a/src/dbsync/include/dbsync.h
+++ b/src/dbsync/include/dbsync.h
@@ -50,9 +50,9 @@ extern "C" {
  * @param path Path of local db.
  * @param sql_statement sql sentence to create tables in a SQL engine
  *
- * @return return a instance number to be used in the future.
+ * @return return a handle to be used in the future (cannot be used by more than 1 thread).
  */
-  EXPORTED unsigned long long dbsync_initialize(
+  EXPORTED DBSYNC_HANDLE dbsync_initialize(
     const HostType host_type, 
     const DbEngineType db_type,
     const char* path, 
@@ -67,7 +67,7 @@ extern "C" {
  * @return return 0 if the operations is success, otherwise an error code will vary depending on the operating system.
  */
   EXPORTED int dbsync_insert_data(
-    const unsigned long long handle,
+    const DBSYNC_HANDLE handle,
     const cJSON* json_insert);
 
 /**
@@ -80,7 +80,7 @@ extern "C" {
  * @return return 0 if the operations is success, otherwise an error code will vary depending on the operating system.
  */
   EXPORTED int dbsync_update_with_snapshot(
-    const unsigned long long handle,
+    const DBSYNC_HANDLE handle,
     const cJSON* json_snapshot,
     cJSON** json_return_modifications);
 
@@ -94,7 +94,7 @@ extern "C" {
  * @return return 0 if the operations is success, otherwise an error code will vary depending on the operating system.
  */
   EXPORTED int dbsync_update_with_snapshot_cb(
-    const unsigned long long handle,
+    const DBSYNC_HANDLE handle,
     const cJSON* json_snapshot,
     void* callback);
 
@@ -108,7 +108,7 @@ extern "C" {
  * @return return 0 if the operations is success, otherwise an error code will vary depending on the operating system.
  */
   EXPORTED int dbsync_select_rows(
-    const unsigned long long handle,
+    const DBSYNC_HANDLE handle,
     const cJSON* json_data_input,
     cJSON** json_return_rows);
 
@@ -122,7 +122,7 @@ extern "C" {
  * @return return 0 if the operations is success, otherwise an error code will vary depending on the operating system.
  */
   EXPORTED int dbsync_set_max_rows(
-    const unsigned long long handle,
+    const DBSYNC_HANDLE handle,
     const char* table,
     const unsigned long long max_rows);
 

--- a/src/dbsync/include/typedef.h
+++ b/src/dbsync/include/typedef.h
@@ -36,6 +36,7 @@ typedef enum {
     INSERTED = 2
 }ReturnTypeCallback;
 
+typedef void* DBSYNC_HANDLE;
 
 /**
  * \brief Callback function for results

--- a/src/dbsync/src/dbengine_context.h
+++ b/src/dbsync/src/dbengine_context.h
@@ -15,8 +15,6 @@
 #include "dbengine.h"
 #include "typedef.h"
 
-static std::atomic_ullong g_handler = { 0ull };
-
 class DbEngineContext {
 public:
   DbEngineContext(
@@ -25,16 +23,13 @@ public:
     const DbEngineType db_type) : 
     m_dbengine(std::move(dbengine)),
     m_host_type(host_type),
-    m_dbengine_type(db_type),
-    m_handler(++g_handler) {}
+    m_dbengine_type(db_type) {}
 
-  const std::unique_ptr<DbEngine>& GetDbEngine() { return m_dbengine; }
-  const HostType& GetHostType() { return m_host_type; }
-  const DbEngineType& GetDbEngineType() { return m_dbengine_type; }
-  const uint64_t& GetHandler() { return m_handler; }
+  const std::unique_ptr<DbEngine>& GetDbEngine() const { return m_dbengine; }
+  const HostType& GetHostType() const { return m_host_type; }
+  const DbEngineType& GetDbEngineType() const { return m_dbengine_type; }
 private:
-  std::unique_ptr<DbEngine> m_dbengine;
-  HostType m_host_type;
-  DbEngineType m_dbengine_type;
-  uint64_t m_handler;
+  const std::unique_ptr<DbEngine> m_dbengine;
+  const HostType m_host_type;
+  const DbEngineType m_dbengine_type;
 };

--- a/src/dbsync/src/dbsync.cpp
+++ b/src/dbsync/src/dbsync.cpp
@@ -80,9 +80,7 @@ int dbsync_update_with_snapshot_cb(
 }
 
 void dbsync_teardown(void) {
-  if(!DBSyncImplementation::getInstance().release()) {
-    std::cout << "Error when release DBSyncImplementation" << std::endl;
-  }
+  DBSyncImplementation::getInstance().release();
 }
 
 #ifdef __cplusplus

--- a/src/dbsync/src/dbsync_implementation.cpp
+++ b/src/dbsync/src/dbsync_implementation.cpp
@@ -36,12 +36,10 @@ DBSYNC_HANDLE DBSyncImplementation::initialize(const HostType hostType,
     return retVal;
 }
 
-bool DBSyncImplementation::release()
+void DBSyncImplementation::release()
 {
-    const auto retVal { true };
     std::lock_guard<std::mutex> lock{m_mutex};
     m_dbSyncContexts.clear();
-    return retVal;
 }
 
 int32_t DBSyncImplementation::insertBulkData(const DBSYNC_HANDLE handle,
@@ -144,9 +142,9 @@ std::shared_ptr<DbEngineContext> DBSyncImplementation::getDbEngineContext(const 
     {
         std::find_if(m_dbSyncContexts.begin(),
                      m_dbSyncContexts.end(),
-                     [handle](const std::shared_ptr<DbEngineContext>& handle_param)
+                     [handle](const std::shared_ptr<DbEngineContext>& context)
                      {
-                        return handle_param.get() == handle;
+                        return context.get() == handle;
                      })
     };
     if (it == m_dbSyncContexts.end())

--- a/src/dbsync/src/dbsync_implementation.h
+++ b/src/dbsync/src/dbsync_implementation.h
@@ -19,25 +19,33 @@
 #include "typedef.h"
 #include "json.hpp"
 
-class DBSyncImplementation {
+class DBSyncImplementation
+{
 public:
-  static DBSyncImplementation& getInstance() {
-    static DBSyncImplementation instance;
-    return instance;
-  }
-  int32_t InsertBulkData(const uint64_t handle, const char* json_raw);
-  int32_t UpdateSnapshotData(const uint64_t handle, const char* json_snapshot, std::string& result);
-  int32_t UpdateSnapshotData(const uint64_t handle, const char* json_snapshot, void* callback);
-  uint64_t Initialize(const HostType host_type, const DbEngineType db_type, const std::string& path, const std::string& sql_statement);
-  bool Release();
+    static DBSyncImplementation& getInstance()
+    {
+        static DBSyncImplementation s_instance;
+        return s_instance;
+    }
+    int32_t insertBulkData(const DBSYNC_HANDLE handle,
+                           const char* jsonRaw);
+    int32_t updateSnapshotData(const DBSYNC_HANDLE handle,
+                               const char* jsonSnapshot,
+                               std::string& result);
+    int32_t updateSnapshotData(const DBSYNC_HANDLE handle,
+                               const char* jsonSnapshot,
+                               void* callback);
+    DBSYNC_HANDLE initialize(const HostType hostType,
+                             const DbEngineType dbType,
+                             const std::string& path,
+                             const std::string& sqlStatement);
+    bool release();
 private:
-  std::vector<std::unique_ptr<DbEngineContext>>::iterator GetDbEngineContext(const uint64_t handler);
-
-  DBSyncImplementation() = default;
-  ~DBSyncImplementation() = default;
-  DBSyncImplementation(const DBSyncImplementation&) = delete;
-  DBSyncImplementation& operator=(const DBSyncImplementation&) = delete;
-
-  std::vector<std::unique_ptr<DbEngineContext>> m_dbsync_list;
-  std::mutex m_mutex;
+    std::shared_ptr<DbEngineContext> getDbEngineContext(const DBSYNC_HANDLE handle);
+    DBSyncImplementation() = default;
+    ~DBSyncImplementation() = default;
+    DBSyncImplementation(const DBSyncImplementation&) = delete;
+    DBSyncImplementation& operator=(const DBSyncImplementation&) = delete;
+    std::vector<std::shared_ptr<DbEngineContext>> m_dbSyncContexts;
+    std::mutex m_mutex;
 };

--- a/src/dbsync/src/dbsync_implementation.h
+++ b/src/dbsync/src/dbsync_implementation.h
@@ -39,7 +39,7 @@ public:
                              const DbEngineType dbType,
                              const std::string& path,
                              const std::string& sqlStatement);
-    bool release();
+    void release();
 private:
     std::shared_ptr<DbEngineContext> getDbEngineContext(const DBSYNC_HANDLE handle);
     DBSyncImplementation() = default;


### PR DESCRIPTION
Changed mutex lock scope to improve locking granularity.
Changed usage of global counter as handle id to object's address as handle value.
Added unique_ptr+deleter to enforce RAII and avoid the use of raw pointers.
Fixed memory leak in dbsync_update_with_snapshot_cb.

Because of the lack of the UT framework I tested the correctness of the objects lifecycle adding a call to dbsync_teardown
in the callback defined in example/main.cpp. In that way the callback caller object was removed from the contexts list
while it was notifiying the changes in the db and it was destroyed through the shared_ptr when it finished and returned.
Further attemps to use the handle throwed exceptions of invalid handle value in cout.

|Related issue|
|---|
||
https://github.com/wazuh/wazuh/issues/5294
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
