### PR TITLE
Fix syntax of mkfifo in Oscap script

### DIFF
--- a/wodles/oscap/oscap.py
+++ b/wodles/oscap/oscap.py
@@ -107,7 +107,12 @@ def oscap(profile=None):
         pass
 
     # Create an unique FIFO file
-    mkfifo(FIFO_PATH, 0666)
+    try:
+        perm = eval('0666')
+    except SyntaxError:
+        perm = eval('0o666')
+
+    mkfifo(FIFO_PATH, perm)
 
     try:
         cmd = [OSCAP_BIN, arg_module, 'eval', '--results', FIFO_PATH]


### PR DESCRIPTION
## Description

This PR fixes an error when running the OpenScap integration over Python 3 due to a syntax error on the function `mkfifo`.

```
File "/var/ossec/wodles/oscap/oscap.py", line 110
    mkfifo(FIFO_PATH, 0666)
                         ^
SyntaxError: invalid token
```

Thanks to the users that reported the bug at https://github.com/wazuh/wazuh/issues/5297 and the mailing lists.


## Tests

It has been tested that the syntax change does not affect the correct behavior when running the script with Python 2 and Python 3:

Running the following script:

```
from os import mkfifo

FIFO_PATH = "test.fifo"

try:
    perm = eval('0600')
except SyntaxError:
    perm = eval('0o600')

mkfifo(FIFO_PATH, perm)

print("SUCCESS!")
```

With python2:

```
root@ubuntu:~/devel/test-python# python2 fifo.py
SUCCESS!
root@ubuntu:~/devel/test-python# ls -lah test.fifo
prw------- 1 root root    0 Jun 25 00:33 test.fifo|
```

And python3:

```
root@ubuntu:~/devel/test-python# python3 fifo.py
SUCCESS!
root@ubuntu:~/devel/test-python# ls -lah test.fifo
prw------- 1 root root    0 Jun 25 00:33 test.fifo|
```

In both cases, the FIFO pipe is created with the correct mode.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
