### PR TITLE
Add WazuhDBQueryGroupByAgents unit tests

### DIFF
--- a/framework/wazuh/core/tests/test_core_agent.py
+++ b/framework/wazuh/core/tests/test_core_agent.py
@@ -442,12 +442,12 @@ def test_WazuhDBQueryGroupByAgents_format_data_into_dictionary_status(mock_socke
 
     query_group.select = {'os.name', 'count', 'status', 'lastKeepAlive', 'version'}
     query_group._data = [
-        {'os.name': 'Ubuntu', 'count': 1, 'version': 'Wazuh v4.0.0', 'status': 'updated', 'lastKeepAlive': 253402300799},
+        {'os.name': 'Ubuntu', 'count': 1, 'version': 'Wazuh v4.0.0', 'status': 'updated', 'lastKeepAlive': 1593093968},
         {'os.name': 'Ubuntu', 'count': 2, 'version': 'Wazuh v3.13.0', 'status': 'empty', 'lastKeepAlive': 1593093968},
         {'os.name': 'Ubuntu', 'count': 1, 'version': 'Wazuh v3.13.0', 'status': 'empty', 'lastKeepAlive': 1593093976}]
 
     result = query_group._format_data_into_dictionary()
-    assert result == {'items': [{'os': {'name': 'Ubuntu'}, 'status': 'active', 'count': 4}], 'totalItems': 0}
+    assert result == {'items': [{'os': {'name': 'Ubuntu'}, 'status': 'disconnected', 'count': 4}], 'totalItems': 0}
 
 
 @patch('wazuh.utils.glob.glob', return_value=True)


### PR DESCRIPTION
Hello team,

# Description

I forgot to add the corresponding unit tests in `test_core_agent.py` for the new methods of this PR #5260. Now the coverage is back to 100%.

I have also modified the code so that the `global.db` database used (and created) in the tests is deleted after the execution of all of them.

# Tests

```
python3 -m pytest wazuh/core/tests/test_core_agent.py -vv
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/framework
plugins: tavern-1.2.2, cov-2.10.0
collected 186 items                                                                                                                                                                                          

wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents__init__[True] PASSED                                                                                                                      [  0%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents__init__[False] PASSED                                                                                                                     [  1%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status[active-(last_keepalive >= :time_active AND version IS NOT NULL) or id = 0] PASSED                                           [  1%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status[disconnected-last_keepalive < :time_active] PASSED                                                                          [  2%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status[never_connected-last_keepalive IS NULL AND id != 0] PASSED                                                                  [  2%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status[pending-last_keepalive IS NOT NULL AND version IS NULL] PASSED                                                              [  3%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_status_ko PASSED                                                                                                                   [  3%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_filter_date PASSED                                                                                                                        [  4%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_sort_query[status-last_keepAlive asc] PASSED                                                                                              [  4%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_sort_query[os.version-CAST(os_major AS INTEGER) asc, CAST(os_minor AS INTEGER) asc] PASSED                                                [  5%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_sort_query[id-id asc] PASSED                                                                                                              [  5%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_add_search_to_query PASSED                                                                                                                [  6%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_format_data_into_dictionary PASSED                                                                                                        [  6%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_parse_legacy_filters PASSED                                                                                                               [  7%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_process_filter[group-field-q_filter0] PASSED                                                                                              [  8%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_process_filter[group-test-q_filter1] PASSED                                                                                               [  8%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryAgents_process_filter[os.name-field-q_filter2] PASSED                                                                                            [  9%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup__init__[True] PASSED                                                                                                                       [  9%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup__init__[False] PASSED                                                                                                                      [ 10%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup_select[select0] PASSED                                                                                                                     [ 10%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup_select[select1] PASSED                                                                                                                     [ 11%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup_select[select2] PASSED                                                                                                                     [ 11%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup_select[None] PASSED                                                                                                                        [ 12%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup_filters[filters0] PASSED                                                                                                                   [ 12%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup_filters[filters1] PASSED                                                                                                                   [ 13%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroup_filters[filters2] PASSED                                                                                                                   [ 13%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroupByAgents__init__ PASSED                                                                                                                     [ 14%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroupByAgents_format_data_into_dictionary PASSED                                                                                                 [ 15%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryGroupByAgents_format_data_into_dictionary_status PASSED                                                                                          [ 15%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups__init__ PASSED                                                                                                                       [ 16%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups_default_query[null] PASSED                                                                                                           [ 16%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups_default_query[test] PASSED                                                                                                           [ 17%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups_default_count_query PASSED                                                                                                           [ 17%]
wazuh/core/tests/test_core_agent.py::test_WazuhDBQueryMultigroups_get_total_items PASSED                                                                                                               [ 18%]
wazuh/core/tests/test_core_agent.py::test_agent__init__[1-127.0.0.1-test_agent-b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747D] PASSED                                                [ 18%]
wazuh/core/tests/test_core_agent.py::test_agent__str__ PASSED                                                                                                                                          [ 19%]
wazuh/core/tests/test_core_agent.py::test_agent_to_dict PASSED                                                                                                                                         [ 19%]
wazuh/core/tests/test_core_agent.py::test_agent_load_info_from_db[000-127.0.0.1-master-Bionic Beaver] PASSED                                                                                           [ 20%]
wazuh/core/tests/test_core_agent.py::test_agent_load_info_from_db[001-172.17.0.202-agent-1-Bionic Beaver] PASSED                                                                                       [ 20%]
wazuh/core/tests/test_core_agent.py::test_agent_load_info_from_db[002-172.17.0.201-agent-2-Xenial] PASSED                                                                                              [ 21%]
wazuh/core/tests/test_core_agent.py::test_agent_load_info_from_db_ko PASSED                                                                                                                            [ 22%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[0-None] PASSED                                                                                                                   [ 22%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[3-None] PASSED                                                                                                                   [ 23%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[0-select2] PASSED                                                                                                                [ 23%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[5-select3] PASSED                                                                                                                [ 24%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[0-select4] PASSED                                                                                                                [ 24%]
wazuh/core/tests/test_core_agent.py::test_agent_get_basic_information[2-select5] PASSED                                                                                                                [ 25%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[0-MCBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                         [ 25%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[1-MSBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                         [ 26%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[2-MiBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                         [ 26%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[3-MyBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                         [ 27%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[4-NCBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                         [ 27%]
wazuh/core/tests/test_core_agent.py::test_agent_compute_key[5-NSBOb25lIE5vbmUgTm9uZQ==] PASSED                                                                                                         [ 28%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[1-MDAxIGFnZW50LTEgYW55IGIzNjUwZTExZWJhMmYyN2VyNGQxNjBjNjlkZTUzM2VlN2VlZDYwMTYzNmE4NWJhMjQ1NWQ1M2E5MDkyNzc0N2Y=] PASSED                         [ 29%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[2-MDAyIGFnZW50LTIgMTcyLjE3LjAuMjAxIGIzNjUwZTExZWJhMmYyN2VyNGQxNjBjNjlkZTUzM2VlN2VlZDYwMTZmZ2E4NWJhMjQ1NWQ1M2E5MDkyNzc0N2Y=] PASSED             [ 29%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[3-MDAzIG5jLWFnZW50IGFueSBmMzA0ZjU4MmYyNDE3YTNmZGRhZDY5ZDlhZTJiNGYzYjZlNmZkYTc4ODIyOTY2OGFmOWE2OTM0ZDQ1NGVmNDRk] PASSED                         [ 30%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[4-MDA0IHBlbmRpbmctYWdlbnQgYW55IDI4NTViY2Y0OTI3M2M3NTllZjViMTE2ODI5Y2M1ODJmMTUzYzZjMTk5ZGY3Njc2ZTUzZDU5Mzc4NTVmZjU5MDI=] PASSED                 [ 30%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key[5-MDA1IGFnZW50LTUgMTcyLjE3LjAuMzAwIGIzNjUwZTExZWJhMmYyN2VyNGQxNjBjNjlkZTUzM2VlN2VlZDYwMTYzNmE0MmJhMjQ1NWQ1M2E5MDkyNzc0N2Y=] PASSED             [ 31%]
wazuh/core/tests/test_core_agent.py::test_agent_get_key_ko PASSED                                                                                                                                      [ 31%]
wazuh/core/tests/test_core_agent.py::test_agent_restart PASSED                                                                                                                                         [ 32%]
wazuh/core/tests/test_core_agent.py::test_agent_restart_ko PASSED                                                                                                                                      [ 32%]
wazuh/core/tests/test_core_agent.py::test_agent_remove[stopped] PASSED                                                                                                                                 [ 33%]
wazuh/core/tests/test_core_agent.py::test_agent_remove[running] PASSED                                                                                                                                 [ 33%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_ko PASSED                                                                                                                                       [ 34%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_authd PASSED                                                                                                                                    [ 34%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual[False-False] PASSED                                                                                                                      [ 35%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual[True-False] PASSED                                                                                                                       [ 36%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual[True-True] PASSED                                                                                                                        [ 36%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[001-1746] PASSED                                                                                                                      [ 37%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[006-1701] PASSED                                                                                                                      [ 37%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[001-1600] PASSED                                                                                                                      [ 38%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[001-1748] PASSED                                                                                                                      [ 38%]
wazuh/core/tests/test_core_agent.py::test_agent_remove_manual_ko[001-1747] PASSED                                                                                                                      [ 39%]
wazuh/core/tests/test_core_agent.py::test_agent_add[192.168.0.0-None-None--1-running] PASSED                                                                                                           [ 39%]
wazuh/core/tests/test_core_agent.py::test_agent_add[192.168.0.0-None-None--1-stopped] PASSED                                                                                                           [ 40%]
wazuh/core/tests/test_core_agent.py::test_agent_add[192.168.0.0/28-002-None--1-running] PASSED                                                                                                         [ 40%]
wazuh/core/tests/test_core_agent.py::test_agent_add[192.168.0.0/28-002-None--1-stopped] PASSED                                                                                                         [ 41%]
wazuh/core/tests/test_core_agent.py::test_agent_add[any-002-WMPlw93l2PnwQMN--1-running] PASSED                                                                                                         [ 41%]
wazuh/core/tests/test_core_agent.py::test_agent_add[any-002-WMPlw93l2PnwQMN--1-stopped] PASSED                                                                                                         [ 42%]
wazuh/core/tests/test_core_agent.py::test_agent_add[any-003-WMPlw93l2PnwQMN-1-running] PASSED                                                                                                          [ 43%]
wazuh/core/tests/test_core_agent.py::test_agent_add[any-003-WMPlw93l2PnwQMN-1-stopped] PASSED                                                                                                          [ 43%]
wazuh/core/tests/test_core_agent.py::test_agent_add_ko PASSED                                                                                                                                          [ 44%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd[test_agent-172.19.0.100-None-None] PASSED                                                                                                    [ 44%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd[test_agent-172.19.0.100-002-MDAyIHdpbmRvd3MtYWdlbnQyIGFueSAzNDA2MjgyMjEwYmUwOWVlMWViNDAyZTYyODZmNWQ2OTE5MjBkODNjNTVjZDE5N2YyMzk3NzA0YWRhNjg1YzQz] PASSED [ 45%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[None-None] PASSED                                                                                                                         [ 45%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[mocked_exception1-.* 1705 .*] PASSED                                                                                                      [ 46%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[mocked_exception2-.* 1706 .*] PASSED                                                                                                      [ 46%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[mocked_exception3-.* 1708 .*] PASSED                                                                                                      [ 47%]
wazuh/core/tests/test_core_agent.py::test_agent_add_authd_ko[mocked_exception4-.* None] PASSED                                                                                                         [ 47%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual[192.168.0.0-002-None--1] PASSED                                                                                                             [ 48%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual[192.168.0.0/28-002-None--1] PASSED                                                                                                          [ 48%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual[any-002-WMPlw93l2PnwQMN--1] PASSED                                                                                                          [ 49%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual[any-003-WMPlw93l2PnwQMN-1] PASSED                                                                                                           [ 50%]
wazuh/core/tests/test_core_agent.py::test_agent_add_manual_ko PASSED                                                                                                                                   [ 50%]
wazuh/core/tests/test_core_agent.py::test_agent_delete_single_group PASSED                                                                                                                             [ 51%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[0-os_name-Ubuntu] PASSED                                                                                                                [ 51%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[7-os_name-Windows] PASSED                                                                                                               [ 52%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[5-status-updated] PASSED                                                                                                                [ 52%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[2-register_ip-172.17.0.201] PASSED                                                                                                      [ 53%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr[1-os_arch-x86_64] PASSED                                                                                                                [ 53%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agent_attr_ko PASSED                                                                                                                               [ 54%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_default PASSED                                                                                                                     [ 54%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select0-all-None-0] PASSED                                                                                                  [ 55%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select1-all-None-1] PASSED                                                                                                  [ 55%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select2-all-None-1] PASSED                                                                                                  [ 56%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select3-active,pending-None-0] PASSED                                                                                       [ 56%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select4-disconnected-None-1] PASSED                                                                                         [ 57%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select5-disconnected-1s-1] PASSED                                                                                           [ 58%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select6-disconnected-2h-0] PASSED                                                                                           [ 58%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select7-all-15m-2] PASSED                                                                                                   [ 59%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select8-active-15m-0] PASSED                                                                                                [ 59%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select9-active,pending-15m-1] PASSED                                                                                        [ 60%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_select[select10-status10-15m-1] PASSED                                                                                             [ 60%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search0-3] PASSED                                                                                                           [ 61%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search1-6] PASSED                                                                                                           [ 61%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search2-1] PASSED                                                                                                           [ 62%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search3-8] PASSED                                                                                                           [ 62%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_search[search4-2] PASSED                                                                                                           [ 63%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[ip=172.17.0.201-1] PASSED                                                                                                    [ 63%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[ip=172.17.0.202-1] PASSED                                                                                                    [ 64%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[ip=172.17.0.202;registerIP=any-1] PASSED                                                                                     [ 65%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[status=disconnected;lastKeepAlive>34m-1] PASSED                                                                              [ 65%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_query[(status=active,status=pending);lastKeepAlive>5m-4] PASSED                                                                    [ 66%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_status_olderthan[active-9m-4-None] PASSED                                                                                          [ 66%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_status_olderthan[all-1s-8-None] PASSED                                                                                             [ 67%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_status_olderthan[pending,never_connected-30m-1-None] PASSED                                                                        [ 67%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_status_olderthan[55-30m-0-1729] PASSED                                                                                             [ 68%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_sort[sort0-000] PASSED                                                                                                             [ 68%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_overview_sort[sort1-004] PASSED                                                                                                             [ 69%]
wazuh/core/tests/test_core_agent.py::test_agent_add_group_to_agent[002-test_group-False-False-None] PASSED                                                                                             [ 69%]
wazuh/core/tests/test_core_agent.py::test_agent_add_group_to_agent[002-test_group-True-False-None] PASSED                                                                                              [ 70%]
wazuh/core/tests/test_core_agent.py::test_agent_add_group_to_agent[002-test_group-False-True-replace_list2] PASSED                                                                                     [ 70%]
wazuh/core/tests/test_core_agent.py::test_agent_add_group_to_agent_ko PASSED                                                                                                                           [ 71%]
wazuh/core/tests/test_core_agent.py::test_agent_check_if_delete_agent[002-10-True] PASSED                                                                                                              [ 72%]
wazuh/core/tests/test_core_agent.py::test_agent_check_if_delete_agent[002-700-False] PASSED                                                                                                            [ 72%]
wazuh/core/tests/test_core_agent.py::test_agent_check_if_delete_agent_ko PASSED                                                                                                                        [ 73%]
wazuh/core/tests/test_core_agent.py::test_agent_group_exists[True] PASSED                                                                                                                              [ 73%]
wazuh/core/tests/test_core_agent.py::test_agent_group_exists[False] PASSED                                                                                                                             [ 74%]
wazuh/core/tests/test_core_agent.py::test_agent_group_exists_ko PASSED                                                                                                                                 [ 74%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_group_file[True] PASSED                                                                                                                     [ 75%]
wazuh/core/tests/test_core_agent.py::test_agent_get_agents_group_file[False] PASSED                                                                                                                    [ 75%]
wazuh/core/tests/test_core_agent.py::test_agent_set_agent_group_file PASSED                                                                                                                            [ 76%]
wazuh/core/tests/test_core_agent.py::test_agent_set_agent_group_file_ko PASSED                                                                                                                         [ 76%]
wazuh/core/tests/test_core_agent.py::test_agent_check_multigroup_limit[default0,default1,default2,default3-True] PASSED                                                                                [ 77%]
wazuh/core/tests/test_core_agent.py::test_agent_check_multigroup_limit[default0,default1-False] PASSED                                                                                                 [ 77%]
wazuh/core/tests/test_core_agent.py::test_agent_check_multigroup_limit[-False] PASSED                                                                                                                  [ 78%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent[002-test_group-False-default,test_group,another_test-False] PASSED                                                            [ 79%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent[002-test_group-True-default,test_group,another_test-False] PASSED                                                             [ 79%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent[002-test_group-False-test_group-True] PASSED                                                                                  [ 80%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent[002-test_group-False-test_group,another_test-False] PASSED                                                                    [ 80%]
wazuh/core/tests/test_core_agent.py::test_agent_unset_single_group_agent_ko PASSED                                                                                                                     [ 81%]
wazuh/core/tests/test_core_agent.py::test_agent_get_protocol[packages.wazuh.com/wpk/linux/x86_64/wazuh_agent_v3.11.4_linux_x86_64.wpk-False-https://] PASSED                                           [ 81%]
wazuh/core/tests/test_core_agent.py::test_agent_get_protocol[packages.wazuh.com/wpk/linux/x86_64/wazuh_agent_v3.11.4_linux_x86_64.wpk-True-http://] PASSED                                             [ 82%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions[001-ubuntu-None-https://packages.wazuh.com/wpk/linux/x86_64/versions] PASSED                                                              [ 82%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions[002-ubuntu-v3.3.0-https://packages.wazuh.com/wpk/ubuntu/16.04/x86_64/versions] PASSED                                                     [ 83%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions[002-windows-v3.3.0-https://packages.wazuh.com/wpk/windows/versions] PASSED                                                                [ 83%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions[002-debian-v3.3.0-https://packages.wazuh.com/wpk/debian/16/x86_64/versions] PASSED                                                        [ 84%]
wazuh/core/tests/test_core_agent.py::test_agent_get_versions_ko PASSED                                                                                                                                 [ 84%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[001-None-ubuntu-False-False] PASSED                                                                                                       [ 85%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[001-v3.9.0-ubuntu-False-False] PASSED                                                                                                     [ 86%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[002-v3.9.0-windows-False-False] PASSED                                                                                                    [ 86%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[002-v3.3.9-debian-True-True] PASSED                                                                                                       [ 87%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file[002-v3.3.9-ubuntu-True-True] PASSED                                                                                                       [ 87%]
wazuh/core/tests/test_core_agent.py::test_agent_get_wpk_file_ko PASSED                                                                                                                                 [ 88%]
wazuh/core/tests/test_core_agent.py::test_agent_send_wpk_file[001] PASSED                                                                                                                              [ 88%]
wazuh/core/tests/test_core_agent.py::test_agent_send_wpk_file[002] PASSED                                                                                                                              [ 89%]
wazuh/core/tests/test_core_agent.py::test_agent_send_wpk_file_ko PASSED                                                                                                                                [ 89%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade[001-Ubuntu] PASSED                                                                                                                             [ 90%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade[002-Ubuntu] PASSED                                                                                                                             [ 90%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade[008-Windows] PASSED                                                                                                                            [ 91%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_ko PASSED                                                                                                                                      [ 91%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_result[001] PASSED                                                                                                                             [ 92%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_result[002] PASSED                                                                                                                             [ 93%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_result_ko PASSED                                                                                                                               [ 93%]
wazuh/core/tests/test_core_agent.py::test_agent_send_custom_wpk_file[001] PASSED                                                                                                                       [ 94%]
wazuh/core/tests/test_core_agent.py::test_agent_send_custom_wpk_file[002] PASSED                                                                                                                       [ 94%]
wazuh/core/tests/test_core_agent.py::test_agent_send_custom_wpk_file_ko PASSED                                                                                                                         [ 95%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_custom[001] PASSED                                                                                                                             [ 95%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_custom[002] PASSED                                                                                                                             [ 96%]
wazuh/core/tests/test_core_agent.py::test_agent_upgrade_custom_ko PASSED                                                                                                                               [ 96%]
wazuh/core/tests/test_core_agent.py::test_agent_getconfig PASSED                                                                                                                                       [ 97%]
wazuh/core/tests/test_core_agent.py::test_agent_getconfig_ko PASSED                                                                                                                                    [ 97%]
wazuh/core/tests/test_core_agent.py::test_calculate_status[10-False-active] PASSED                                                                                                                     [ 98%]
wazuh/core/tests/test_core_agent.py::test_calculate_status[1900-False-disconnected] PASSED                                                                                                             [ 98%]
wazuh/core/tests/test_core_agent.py::test_calculate_status[10-True-pending] PASSED                                                                                                                     [ 99%]
wazuh/core/tests/test_core_agent.py::test_send_restart_command PASSED                                                                                                                                  [100%]

============================================================================================ 186 passed in 1.05s =============================================================================================
```

## Coverage

```
----------- coverage: platform linux, python 3.8.2-final-0 -----------
Name                                             Stmts   Miss  Cover
--------------------------------------------------------------------
wazuh/core/core_agent.py                           975      0   100%
```

Kind regards,
Selu.