### PR TITLE
Add sleep when run on start is set to no

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6774,7 +6774,6 @@ void wm_vuldet_run_sleep(wm_vuldet_t * vuldet) {
 
 void wm_vuldet_init(wm_vuldet_t * vuldet) {
     wm_vuldet_flags *flags = &vuldet->flags;
-    update_node **updates = vuldet->updates;
     int i;
 
     if (!flags->enabled) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6808,12 +6808,14 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     }
 
     if (!flags->run_on_start) {
-        vuldet->last_detection = time(NULL);
+        time_t time_sleep = vuldet->detection_interval;
         for (i = 0; i < OS_SUPP_SIZE; i++) {
-            if (updates[i]) {
-                updates[i]->last_update = time(NULL);
+            if (vuldet->updates[i] && (vuldet->updates[i]->interval < time_sleep)) {
+                time_sleep = vuldet->updates[i]->interval;
             }
         }
+        // Initial sleep
+        sleep(time_sleep);
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#5261|

## Description

The purpose of this PR is to solve a problem related to the `run_on_start` option of the vulnerability detector module.

If this option is set to `no`, the initial database update is not performed. There was a problem leading to not populating the `MSU` and `WCPE` related tables, which are populated only when Wazuh starts.

To fix this problem, an initial sleep is performed instead of updating the detection times and starting the module.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities