### PR TITLE
Fix SCA when special characters are used

### DIFF
--- a/framework/wazuh/security_configuration_assessment.py
+++ b/framework/wazuh/security_configuration_assessment.py
@@ -4,6 +4,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import re
 from itertools import groupby
 from operator import itemgetter
 
@@ -56,6 +57,13 @@ class WazuhDBQuerySCA(WazuhDBQuery):
                  fields=fields_translation_sca, count_field='policy_id'):
         self.default_query = default_query
         self.count_field = count_field
+        self.special_fields = ('title', 'rationale', 'description', 'remediation', 'reason')
+
+        # Replace characters with special meaning in SQL with wildcards.
+        for field in self.special_fields:
+            if field in filters:
+                filters[field] = filters[field].replace("'", "_")
+                filters[field] = filters[field].replace('"', "_")
 
         WazuhDBQuery.__init__(self, offset=offset, limit=limit, table='sca_policy', sort=sort,
                               search=search, select=select, fields=fields, default_sort_field=default_sort_field,
@@ -67,6 +75,59 @@ class WazuhDBQuerySCA(WazuhDBQuery):
 
     def _default_count_query(self):
         return f"SELECT COUNT(DISTINCT {self.count_field})" + " FROM ({0})"
+
+    def _parse_legacy_filters(self):
+        """
+        Parses legacy filters.
+        """
+        # some legacy filters can contain multiple values to filter separated by commas. That must split in a list.
+        legacy_filters_as_list = {}
+
+        # Do not split the value by commas if it is within special_fields.
+        for name, value in self.legacy_filters.items():
+            if isinstance(value, str) and name not in self.special_fields:
+                legacy_filters_as_list.update({name: value.split(',')})
+            else:
+                legacy_filters_as_list.update({name: value if isinstance(value, list) else [value]})
+        # each filter is represented using a dictionary containing the following fields:
+        #   * Value     -> Value to filter by
+        #   * Field     -> Field to filter by. Since there can be multiple filters over the same field, a numeric ID
+        #                  must be added to the field name.
+        #   * Operator  -> Operator to use in the database query. In legacy filters the only available one is =.
+        #   * Separator -> Logical operator used to join queries. In legacy filters, the AND operator is used when
+        #                  different fields are filtered and the OR operator is used when filtering by the same field
+        #                  multiple times.
+        #   * Level     -> The level defines the number of parenthesis the query has. In legacy filters, no
+        #                  parenthesis are used except when filtering over the same field.
+        self.query_filters += [{'value': None if subvalue == "null" else subvalue,
+                                'field': '{}${}'.format(name, i),
+                                'operator': 'LIKE',
+                                'separator': 'OR' if len(value) > 1 else 'AND',
+                                'level': 0 if i == len(value) - 1 else 1}
+                               for name, value in legacy_filters_as_list.items()
+                               for subvalue, i in zip(value, range(len(value))) if not self._pass_filter(subvalue)]
+        if self.query_filters:
+            # if only traditional filters have been defined, remove last AND from the query.
+            self.query_filters[-1]['separator'] = '' if not self.q else 'AND'
+
+    def _process_filter(self, field_name, field_filter, q_filter):
+        if field_name in self.date_fields and re.match(r"^[0-9]+(\.([0-9]+))?$", q_filter['value']) is None:
+            # Filter a date, but only if it is in string (YYYY-MM-DD hh:mm:ss) format.
+            # If it matches the same format as DB (timestamp integer), filter directly by value (next if cond).
+            self._filter_date(q_filter, field_name)
+        else:
+            if q_filter['value'] is not None:
+                self.request[field_filter] = q_filter['value'] if field_name != "version" else re.sub(
+                    r'([a-zA-Z])([v])', r'\1 \2', q_filter['value'])
+                if q_filter['operator'] == 'LIKE':
+                    self.request[field_filter] = "%{}%".format(self.request[field_filter])
+                self.query += '{} {} :{}'.format(self.fields[field_name].split(' as ')[0], q_filter['operator'],
+                                                 field_filter)
+                if not field_filter.isdigit():
+                    # filtering without being uppercase/lowercase sensitive
+                    self.query += ' COLLATE NOCASE'
+            else:
+                self.query += '{} IS null'.format(self.fields[field_name])
 
 
 def get_sca_list(agent_id=None, q="", offset=0, limit=common.database_limit,

--- a/framework/wazuh/security_configuration_assessment.py
+++ b/framework/wazuh/security_configuration_assessment.py
@@ -62,8 +62,7 @@ class WazuhDBQuerySCA(WazuhDBQuery):
         # Replace characters with special meaning in SQL with wildcards.
         for field in self.special_fields:
             if field in filters:
-                filters[field] = filters[field].replace("'", "_")
-                filters[field] = filters[field].replace('"', "_")
+                filters[field] = filters[field].replace("'", "_").replace('"', "_")
 
         WazuhDBQuery.__init__(self, offset=offset, limit=limit, table='sca_policy', sort=sort,
                               search=search, select=select, fields=fields, default_sort_field=default_sort_field,
@@ -119,8 +118,6 @@ class WazuhDBQuerySCA(WazuhDBQuery):
             if q_filter['value'] is not None:
                 self.request[field_filter] = q_filter['value'] if field_name != "version" else re.sub(
                     r'([a-zA-Z])([v])', r'\1 \2', q_filter['value'])
-                if q_filter['operator'] == 'LIKE':
-                    self.request[field_filter] = "%{}%".format(self.request[field_filter])
                 self.query += '{} {} :{}'.format(self.fields[field_name].split(' as ')[0], q_filter['operator'],
                                                  field_filter)
                 if not field_filter.isdigit():


### PR DESCRIPTION
|Related issue|
|---|
|#5312|

# Description

Hello team. This PR fixes some of the bugs reported in #5312 

## 1. Params with special characters.
Now, special characters that can be found within several SCA items are allowed when filtering. New allowed characters include `( ) ' " | < > ! =`. Single and double quotes could lead to SQL injections, so they are replaced by wildcard `_` before reaching the DB. 

Since some fields like **description** or **remediation** are very long, there is no point in looking for strings identical to the one specified. Therefore, the LIKE operator is now used.

Multiple fields apart from `title` had the same problem although they are not mentioned in the issue. Filtering should now work correctly with any of these:
- title
- rationale
- description
- remediation
- reason

```
curl -u foo:bar "https://localhost:55000/sca/000/checks/cis_debian9_L2?pretty&title=Ensure%20system%20administrator%20actions%20(sudolog)%20are%20collected" -k
```

```JSON
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "description": "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log.",
            "condition": "all",
            "id": 3525,
            "policy_id": "cis_debian9_L2",
            "result": "failed",
            "title": "Ensure system administrator actions (sudolog) are collected",
            "status": "",
            "rationale": "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed.",
            "reason": "",
            "directory": "/etc/audit",
            "remediation": "Add the following lines to the /etc/audit/audit.rules file: -w /var/log/sudo.log -p wa -k actions. Notes: The system must be configured with sudisabled (See Item 5.6 Ensure access to the su command is restricted) to force all command execution through sudo. This will not be effective on the console, as administrators can log in as root. Reloading the auditd config to set active settings may require a system reboot.",
            "compliance": [
               {
                  "key": "cis",
                  "value": "4.1.16"
               },
               {
                  "key": "cis_csc",
                  "value": "4.9"
               }
            ],
            "rules": [
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/var/log/sudo.log && r:-p wa && r:-k actions"
               },
               {
                  "type": "directory",
                  "rule": "d:/etc/audit"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules"
               }
            ]
         }
      ]
   }
}
```


Example filtering by **remediation** field with some symbols:
```
curl -u foo:bar "https://localhost:55000/sca/000/checks/cis_debian9_L2?pretty&remediation=For%2032%20bit%20systems%20add%20the%20following%20lines%20to%20the%20%2Fetc%2Faudit%2Faudit.rules%20file%3A%20-w%20%2Fsbin%2Finsmod%20-p%20x%20-k%20modules%20%7C%20-w%20%2Fsbin%2Frmmod%20-p%20x%20-k%20modules%20%7C%20-w%20%2Fsbin%2Fmodprobe%20-p%20x%20-k%20modules%20%7C%20-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20init_module%20-S%20delete_module%20-k%20modules.%20For%2064%20bit%20systems%20add%20the%20following%20lines%20to%20the%20%2Fetc%2Faudit%2Faudit.rules%20file%3A%20-w%20%2Fsbin%2Finsmod%20-p%20x%20-k%20modules%20%7C%20-w%20%2Fsbin%2Frmmod%20-p%20x%20-k%20modules%20%7C%20-w%20%2Fsbin%2Fmodprobe%20-p%20x%20-k%20modules%20%7C%20-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20init_module%20-S%20delete_module%20-k%20modules.%20Notes%3A%20Reloading%20the%20auditd%20config%20to%20set%20active%20settings%20may%20require%20a%20system%20reboot." -k
```
```JSON
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "remediation": "For 32 bit systems add the following lines to the /etc/audit/audit.rules file: -w /sbin/insmod -p x -k modules | -w /sbin/rmmod -p x -k modules | -w /sbin/modprobe -p x -k modules | -a always,exit -F arch=b32 -S init_module -S delete_module -k modules. For 64 bit systems add the following lines to the /etc/audit/audit.rules file: -w /sbin/insmod -p x -k modules | -w /sbin/rmmod -p x -k modules | -w /sbin/modprobe -p x -k modules | -a always,exit -F arch=b64 -S init_module -S delete_module -k modules. Notes: Reloading the auditd config to set active settings may require a system reboot.",
            "id": 3526,
            "description": "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\".",
            "status": "",
            "condition": "all",
            "title": "Ensure kernel module loading and unloading is collected",
            "policy_id": "cis_debian9_L2",
            "result": "failed",
            "reason": "",
            "directory": "/etc/audit",
            "rationale": "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules.",
            "compliance": [
               {
                  "key": "cis_csc",
                  "value": "5.1"
               },
               {
                  "key": "cis",
                  "value": "4.1.17"
               }
            ],
            "rules": [
               {
                  "type": "directory",
                  "rule": "d:/etc/audit"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S init_module && r:-S delete_module && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/insmod && r:-p x && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/rmmod && r:-p x && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules"
               }
            ]
         }
      ]
   }
}
```

## 2. Filtering results by rationale isn't working correctly.
Filtering by the rationale field and others like description had a bug. The commas within these fields were used to divide the value into multiple sub-values. This makes sense in cases like:

> select=id,name,lastKeepAlive

But it does not make sense when searching for a text. It has already been fixed:

```
curl -u foo:bar "https://localhost:55000/sca/000/checks/cis_debian9_L2?pretty&rationale=Changes%20to%20files%20in%20these%20directories%20could%20indicate%20that%20an%20unauthorized%20user%20is%20attempting%20to%20modify%20access%20controls%20and%20change%20security%20contexts%2C%20leading%20to%20a%20compromise%20of%20the%20system." -k
```
```
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "directory": "/etc/audit",
            "remediation": "On systems using AppArmor add the following line to the /etc/audit/audit.rules file: -w /etc/apparmor/ -p wa -k MAC-policy | -w /etc/apparmor.d/ -p wa -k MAC-policy. Notes: Reloading the auditd config to set active settings may require a system reboot.",
            "result": "failed",
            "reason": "",
            "status": "",
            "condition": "all",
            "policy_id": "cis_debian9_L2",
            "description": "Monitor AppArmor mandatory access control. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/apparmor and /etc/apparmor.d directories.",
            "title": "Ensure events that modify the system's Mandatory Access Controls are collected (AppArmor)",
            "id": 3517,
            "rationale": "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system.",
            "compliance": [
               {
                  "key": "cis_csc",
                  "value": "5.5"
               },
               {
                  "key": "cis",
                  "value": "4.1.7"
               }
            ],
            "rules": [
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/etc/apparmor/ && r:-p wa && r:-k MAC-policy"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/etc/apparmor.d/ && r:-p wa && r:-k MAC-policy"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules"
               },
               {
                  "type": "directory",
                  "rule": "d:/etc/audit"
               }
            ]
         }
      ]
   }
}
```

## 3. Some fields cannot be filtered: command, status and reason.
It is now possible to filter by the fields mentioned in the issue #5312.

### Filter by command
```
curl -u foo:bar "https://localhost:55000/sca/000/checks/cis_debian9_L2?pretty&command=dpkg%20-s%20selinux-basics,dpkg%20-s%20apparmor" -k
```
```
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "reason": "",
            "status": "",
            "description": "SELinux and AppArmor provide Mandatory Access Controls.",
            "condition": "any",
            "title": "Ensure SELinux or AppArmor are installed",
            "command": "dpkg -s selinux-basics,dpkg -s apparmor",
            "policy_id": "cis_debian9_L2",
            "id": 3506,
            "result": "failed",
            "rationale": "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available.",
            "remediation": "Run one of the following commands to install SELinux or apparmor: # apt-get install selinux-basics Or: # apt-get install apparmor apparmor-profiles apparmor-utils",
            "compliance": [
               {
                  "key": "cis_csc",
                  "value": "14.6"
               },
               {
                  "key": "cis",
                  "value": "1.6.3"
               }
            ],
            "rules": [
               {
                  "type": "command",
                  "rule": "c:dpkg -s selinux-basics -> r:install ok installed"
               },
               {
                  "type": "command",
                  "rule": "c:dpkg -s apparmor -> r:install ok installed"
               }
            ]
         }
      ]
   }
}
```

### Filter by status
```
curl -u foo:bar "https://localhost:55000/sca/000/checks/cis_debian9_L2?pretty&status=Not%20applicable" -k
```
```
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "result": "",
            "remediation": "Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX: GRUB_CMDLINE_LINUX=\"audit=1\" Run the following command to update the grub2 configuration: # update-grub Notes: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings.",
            "id": 3512,
            "status": "Not applicable",
            "rationale": "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected.",
            "title": "Ensure auditing for processes that start prior to auditd is enabled",
            "condition": "all",
            "file": "/etc/default/grub",
            "description": "Configure grub or lilo so that processes that are capable of being audited can be audited even if they start up prior to auditd startup.",
            "reason": "Could not open file '/etc/default/grub'",
            "policy_id": "cis_debian9_L2",
            "compliance": [
               {
                  "key": "cis_csc",
                  "value": "6.2,6.3"
               },
               {
                  "key": "cis",
                  "value": "4.1.3"
               }
            ],
            "rules": [
               {
                  "type": "file",
                  "rule": "f:/etc/default/grub -> r:^GRUB_CMDLINE_LINUX\\s*=\\s*\\.*audit\\s*=\\s*1\\.*"
               }
            ]
         }
      ]
   }
}
```

### Filter by reason
```
curl -u foo:bar "https://localhost:55000/sca/000/checks/cis_debian9_L2?pretty&wait_for_complete&reason=Could%20not%20open%20file" -k
```
```
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "title": "Ensure auditing for processes that start prior to auditd is enabled",
            "file": "/etc/default/grub",
            "id": 3512,
            "condition": "all",
            "status": "Not applicable",
            "reason": "Could not open file '/etc/default/grub'",
            "policy_id": "cis_debian9_L2",
            "remediation": "Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX: GRUB_CMDLINE_LINUX=\"audit=1\" Run the following command to update the grub2 configuration: # update-grub Notes: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings.",
            "description": "Configure grub or lilo so that processes that are capable of being audited can be audited even if they start up prior to auditd startup.",
            "result": "",
            "rationale": "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected.",
            "compliance": [
               {
                  "key": "cis",
                  "value": "4.1.3"
               },
               {
                  "key": "cis_csc",
                  "value": "6.2,6.3"
               }
            ],
            "rules": [
               {
                  "type": "file",
                  "rule": "f:/etc/default/grub -> r:^GRUB_CMDLINE_LINUX\\s*=\\s*\\.*audit\\s*=\\s*1\\.*"
               }
            ]
         }
      ]
   }
}
```

# Tests performed
## Mocha tests
```
mocha test_sca.js 


  SecurityConfigurationAssessment
    GET/sca/:agent_id
(node:2114) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
      ✓ Request (273ms)
      ✓ Pagination (313ms)
      ✓ Retrieve all elements with limit=0 (294ms)
      ✓ Sort (358ms)
      ✓ Search (263ms)
      ✓ Params: Bad agent id (89ms)
      ✓ Errors: No agent (310ms)
      ✓ Filters: Invalid filter (113ms)
      ✓ Filters: Invalid filter - Extra field (100ms)
      ✓ Filters: query (329ms)
      ✓ Filters: name (260ms)
      ✓ Filters: references (276ms)
      ✓ Retrieve all elements with limit=0 (312ms)
    GET/sca/:agent_id/checks/:policy_id
      ✓ Request (339ms)
      ✓ Pagination (346ms)
      ✓ Retrieve all elements with limit=0 (328ms)
      ✓ Sort (318ms)
      ✓ Search (375ms)
      ✓ Params: Bad agent id (94ms)
      ✓ Errors: No agent (291ms)
      ✓ Check not found (438ms)
      ✓ Retrieve all elements with limit=0 (311ms)
      ✓ Filters: title (307ms)
      ✓ Filters: incomplete title (320ms)
      ✓ Filters: description (287ms)
      ✓ Filters: rationale (321ms)
      ✓ Filters: remediation (303ms)
      ✓ Filters: file (286ms)
      ✓ Filters: references (254ms)
      ✓ Filters: result (256ms)
      ✓ Filters: command (244ms)
      ✓ Filters: status (249ms)
      ✓ Filters: reason (263ms)
      ✓ Filters: condition (261ms)


  34 passing (10s)
```

Best regards,
Selu.