### PR TITLE
Declare main functions and structures for wazuh-logtest

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -713,6 +713,9 @@ int main_analysisd(int argc, char **argv)
     /* Load Mitre JSON File and Mitre hash table */
     mitre_load(NULL);
 
+    /* Initialize Logtest */
+    w_create_thread(w_logtest_init, NULL);
+
     /* Going to main loop */
     OS_ReadMSG(m_queue);
 

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -16,6 +16,7 @@
 #include "decoders/decoder.h"
 #include "rules.h"
 #include "eventinfo.h"
+#include "logtest.h"
 
 /* Time structures */
 extern int today;

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -1,0 +1,87 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "logtest.h"
+
+void *w_logtest_init() {
+
+    int connection = 0;
+
+    if (connection = OS_BindUnixDomain(LOGTEST_SOCK, SOCK_STREAM, OS_MAXSTR), connection < 0) {
+        merror(LOGTEST_ERROR_BIND_SOCK, LOGTEST_SOCK, errno, strerror(errno));
+        return NULL;
+    }
+
+    if(all_sessions = OSHash_Create(), !all_sessions) {
+        merror(LOGTEST_ERROR_INIT_HASH);
+        return NULL;
+    }
+
+    w_mutex_init(&logtest_mutex, NULL);
+
+    minfo(LOGTEST_INITIALIZED);
+
+    w_logtest_main(&connection);
+
+    close(connection);
+    w_mutex_destroy(&logtest_mutex);
+
+    return NULL;
+}
+
+
+void *w_logtest_main(int *connection) {
+
+    int client;
+    char msg_received[OS_MAXSTR];
+    int size_msg_received;
+
+    while(1) {
+
+        w_mutex_lock(&logtest_mutex);
+
+        if(client = accept(*connection, (struct sockaddr *)NULL, NULL), client < 0) {
+            merror(LOGTEST_ERROR_ACCEPT_CONN, strerror(errno));
+            continue;
+        }
+
+        w_mutex_unlock(&logtest_mutex);
+
+        if(size_msg_received = recv(client, msg_received, OS_MAXSTR, 0), size_msg_received < 0) {
+            merror(LOGTEST_ERROR_RECV_MSG, strerror(errno));
+            close(client);
+            continue;
+        }
+
+        close(client);
+    }
+
+    return NULL;
+}
+
+
+void w_logtest_initialize_session(int token) {
+
+}
+
+
+void w_logtest_process_log(int token) {
+
+}
+
+
+void w_logtest_remove_session(int token) {
+
+}
+
+
+void w_logtest_check_active_sessions() {
+
+}

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -1,0 +1,84 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "shared.h"
+#include "rules.h"
+#include "decoders/decoder.h"
+#include "eventinfo.h"
+#include "../headers/pthreads_op.h"
+#include "../headers/defs.h"
+#include "../headers/validate_op.h"
+#include "../os_net/os_net.h"
+
+
+/**
+ * @brief A sessionLogtest instance represents a client.
+*/
+typedef struct sessionLogtest {
+
+    int token;
+    time_t last_connection;
+
+    RuleNode *rulelist;
+    OSDecoderNode *decoderlist_forpname;
+    OSDecoderNode *decoderlist_nopname;
+    ListNode *cdblistnode;
+    ListRule *cdblistrule;
+    EventList *eventlist;
+
+} sessionLogtest;
+
+/**
+ * @brief List of client actives.
+ */
+OSHash *all_sessions;
+
+/**
+ * @brief Mutex to prevent race condition in accept syscall.
+ */
+pthread_mutex_t logtest_mutex;
+
+
+/**
+ * @brief Initialize Wazuh Logtest. Initialize the listener and creat threads.
+ * Then, call function wazuh_logtest_init.
+ */
+void *w_logtest_init();
+
+
+/**
+ * @brief Main function of Wazuh Logtest module. Listen and treat conexions with clients.
+ * @param connection The listener where clients connect
+ */
+void *w_logtest_main(int * connection);
+
+/**
+ * @brief Create resources necessaries to service client
+ * @param fd File descriptor which represents the client
+ */
+void w_logtest_initialize_session(int token);
+
+/**
+ * @brief Process client's request
+ * @param fd File descriptor which represents the client
+ */
+void w_logtest_process_log(int token);
+
+/**
+ * @brief Free resources after client close connection
+ * @param fd File descriptor which represents the client
+ */
+void w_logtest_remove_session(int token);
+
+/**
+ * @brief Check all sessions. If session is created and the client has been offline
+ * for more than 15 minutes, remove it.
+ */
+void w_logtest_check_active_sessions();

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -490,10 +490,10 @@
 #define FIM_ERROR_WHODATA_INIT                      "(6710): Failed to start the Whodata engine. Directories/files will be monitored in Realtime mode"
 
 /* Wazuh Logtest error messsages */
-#define LOGTEST_ERROR_BIND_SOCK                     "(7100): At wazuh_logtest_init(): Unable to bind to socket '%s'. Errno: (%d) %s"
-#define LOGTEST_ERROR_ACCEPT_CONN                   "(7101): At wazuh_logtest_main(): Failure to accept connection. Errno: %s"
-#define LOGTEST_ERROR_RECV_MSG                      "(7102): At wazuh_logtest_main(): Failure to receive message. Errno: %s"
-#define LOGTEST_ERROR_INIT_HASH                     "(7103): Failure to initialize all_sesssions hash"
+#define LOGTEST_ERROR_BIND_SOCK                     "(7300): Unable to bind to socket '%s'. Errno: (%d) %s"
+#define LOGTEST_ERROR_ACCEPT_CONN                   "(7301): Failure to accept connection. Errno: %s"
+#define LOGTEST_ERROR_RECV_MSG                      "(7302): Failure to receive message. Errno: %s"
+#define LOGTEST_ERROR_INIT_HASH                     "(7303): Failure to initialize all_sesssions hash"
 
 /* Verbose messages */
 #define STARTUP_MSG "Started (pid: %d)."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -489,6 +489,12 @@
 #define FIM_DB_ERROR_RM_NOT_SCANNED                 "(6709): Failed to delete from db all unscanned files."
 #define FIM_ERROR_WHODATA_INIT                      "(6710): Failed to start the Whodata engine. Directories/files will be monitored in Realtime mode"
 
+/* Wazuh Logtest error messsages */
+#define LOGTEST_ERROR_BIND_SOCK                     "(7100): At wazuh_logtest_init(): Unable to bind to socket '%s'. Errno: (%d) %s"
+#define LOGTEST_ERROR_ACCEPT_CONN                   "(7101): At wazuh_logtest_main(): Failure to accept connection. Errno: %s"
+#define LOGTEST_ERROR_RECV_MSG                      "(7102): At wazuh_logtest_main(): Failure to receive message. Errno: %s"
+#define LOGTEST_ERROR_INIT_HASH                     "(7103): Failure to initialize all_sesssions hash"
+
 /* Verbose messages */
 #define STARTUP_MSG "Started (pid: %d)."
 #define PRIVSEP_MSG "Chrooted to directory: %s, using user: %s"

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -54,4 +54,7 @@
 #define FIM_DB_80_PERCENTAGE_ALERT          "(6039): Sending DB 80%% full alert."
 #define FIM_DB_90_PERCENTAGE_ALERT          "(6039): Sending DB 90%% full alert."
 
+/* wazuh-logtest information messages */
+#define LOGTEST_INITIALIZED                 "(7200): Logtest started"
+
 #endif /* INFO_MESSAGES_H */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -41,4 +41,7 @@
 #define FIM_WARN_WHODATA_ADD_RULE               "(6926): Unable to add audit rule for '%s'"
 #define FIM_DB_FULL_ALERT                       "(6927): Sending DB 100%% full alert."
 
+/* wazuh-logtest warning messages*/
+#define LOGTEST_INV_NUM_THREADS                 "(7000): Invalid number of wazuh-logtest threads. Only creates %d threads"
+
 #endif /* WARN_MESSAGES_H */

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -145,6 +145,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define MON_LOCAL_SOCK  "/queue/ossec/monitor"
 #define CLUSTER_SOCK "/queue/cluster/c-internal.sock"
 #define CONTROL_SOCK "/queue/ossec/control"
+#define LOGTEST_SOCK "/queue/ossec/logtest"
 
 // Absolute path local requests socket
 #define CONTROL_SOCK_PATH DEFAULTDIR CONTROL_SOCK


### PR DESCRIPTION
|Related issue|
|---|
|[5360](https://github.com/wazuh/wazuh/issues/5360)|

Hello team!

This PR contains the structure of the new Logtest.

**Struct and functions:**
An instance of the following structure represents a client active:
```c
typedef struct sessionLogtest {

    int token;
    time_t last_connection;

    RuleNode *rulelist;
    OSDecoderNode *decoderlist_forpname;
    OSDecoderNode *decoderlist_nopname;
    ListNode *cdblistnode;
    ListRule *cdblistrule;
    EventList *eventlist;

} sessionLogtest;
```

The main functions are:

```c
void *w_logtest_init();
void *w_logtest_main(int * connection);
void w_logtest_initialize_session(int token);
void w_logtest_process_log(int token);
void w_logtest_remove_session(int token);
void w_logtest_check_active_sessions();
```

**Flow:**

1. Analysisd main function creates a thread to execute `w_logtest_init`.
2. `w_logtest_init` creates the listener, the clients' list, and mutex necessary to syscall `accept`. Then, create the number of threads specified in `internal_option.conf`(if there are more than one), and call `w_logtest_main`.
3. `w_logtest_main` waiting for new connections.

The rest of the functions will implement in the next PRs.

**Test:**

To test it, you can use command `nc` with option `-U` as shown below:
`sudo nc -U /var/ossec/queue/ossec/logtest`

To check Logtest receive the messages, you should add `minfo` messages in `w_logtest_main` function.


**Test:**
- [x] Logtest receive messages
- [x] Scan-build on Linux

Regards,
Eva
