### PR TITLE
Fix a typo in FIM's Audit rule management log on UNIX

### DIFF
--- a/src/shared/audit_op.c
+++ b/src/shared/audit_op.c
@@ -270,7 +270,7 @@ int audit_manage_rules(int action, const char *path, const char *key) {
     }
 
     if (retval <= 0) {
-        mdebug2("audit_manage_rules(): Cann't adding/deleting rule (%d) = %s", retval, audit_errno_to_name(abs(retval)));
+        mdebug2("Can't add or delete a rule (%d) = %s", retval, audit_errno_to_name(abs(retval)));
     }
 
 end:

--- a/src/unit_tests/shared/test_audit_op.c
+++ b/src/unit_tests/shared/test_audit_op.c
@@ -490,7 +490,7 @@ static void test_audit_delete_rule(void **state) {
 
     will_return(__wrap_audit_errno_to_name, "AUDIT ERROR");
 
-    expect_string(__wrap__mdebug2, formatted_msg, "audit_manage_rules(): Cann't adding/deleting rule (-1) = AUDIT ERROR");
+    expect_string(__wrap__mdebug2, formatted_msg, "Can't add or delete a rule (-1) = AUDIT ERROR");
 
     will_return(__wrap_audit_close, 1);
 


### PR DESCRIPTION
This PR fixes a typo in a debugging log printed by FIM.

- The name of the function is duplicate
- Replace "cann't" with "can't".
- Replace "adding" and "deleting" with "add" and "delete" as "can" is a modal verb.

### Before

```
2020/07/02 16:47:56 ossec-syscheckd[15301] audit_op.c:273 at audit_manage_rules(): DEBUG: audit_manage_rules(): Cann't adding/deleting rule (-1) = EPERM
```

### After

```
2020/07/02 17:02:51 ossec-syscheckd[15630] audit_op.c:273 at audit_manage_rules(): DEBUG: Can't add or delete a rule (-1) = EPERM
```

## Tests

- [X] Compile manager in CentOS 8.
- [X] Review log syntax.
- [X] Unit tests for UNIX (agent and manager).