### PR TITLE
Fix agent_upgrade binary

### DIFF
--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -4,13 +4,13 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from sys import exit, path, argv, stdout
-from os.path import dirname
-from signal import signal, SIGINT
-from time import sleep
 import argparse
 import os
 import re
+from os.path import dirname
+from signal import signal, SIGINT
+from sys import exit, path, argv, stdout
+from time import sleep
 
 # Set framework path
 path.append(dirname(argv[0]) + '/../framework')  # It is necessary to import Wazuh package
@@ -18,6 +18,7 @@ path.append(dirname(argv[0]) + '/../framework')  # It is necessary to import Waz
 # Import framework
 try:
     from wazuh import Wazuh
+    import wazuh.agent
     from wazuh.core.agent import Agent
     from wazuh.core.exception import WazuhException
     from wazuh.core import common
@@ -31,19 +32,22 @@ def signal_handler(n_signal, frame):
     print("")
     exit(1)
 
+
 def print_progress(value):
-    stdout.write("Sending WPK: [%-25s] %d%%   \r" % ('='*int(value/4), value))
+    stdout.write("Sending WPK: [%-25s] %d%%   \r" % ('=' * int(value / 4), value))
     stdout.flush()
 
+
 def list_outdated():
-    agents = Agent.get_outdated_agents()
-    if agents['totalItems'] == 0:
+    agents = wazuh.agent.get_outdated_agents()
+    if agents.total_affected_items == 0:
         print("All agents are updated.")
     else:
         print("%-6s%-35s %-25s" % ("ID", "Name", "Version"))
-        for agent in agents['items']:
+        for agent in agents.affected_items:
             print("%-6s%-35s %-25s" % (agent['id'], agent['name'], agent['version']))
-        print("\nTotal outdated agents: {0}".format(agents['totalItems']))
+        print("\nTotal outdated agents: {0}".format(agents.total_affected_items))
+
 
 def main():
     # Capture Ctrl + C
@@ -118,7 +122,8 @@ def main():
                                                force=args.force,
                                                show_progress=print_progress if not args.silent else None,
                                                chunk_size=args.chunk_size,
-                                               rl_timeout=-1 if args.timeout == None else args.timeout, use_http=use_http)
+                                               rl_timeout=-1 if args.timeout == None else args.timeout,
+                                               use_http=use_http)
         if not args.silent:
             if not args.debug:
                 print("\n{0}... Please wait.".format(upgrade_command_result))
@@ -152,15 +157,19 @@ if __name__ == "__main__":
     arg_parser.add_argument("-r", "--repository", type=str, help="Specify a repository URL. [Default: {0}]".format(
         common.wpk_repo_url))
     arg_parser.add_argument("-v", "--version", type=str, help="Version to upgrade. [Default: latest Wazuh version]")
-    arg_parser.add_argument("-F", "--force", action="store_true", help="Allows reinstall same version and downgrade version.")
+    arg_parser.add_argument("-F", "--force", action="store_true",
+                            help="Allows reinstall same version and downgrade version.")
     arg_parser.add_argument("-s", "--silent", action="store_true", help="Do not show output.")
     arg_parser.add_argument("-d", "--debug", action="store_true", help="Debug mode.")
-    arg_parser.add_argument("-l", "--list_outdated", action="store_true", help="Generates a list with all outdated agents.")
-    arg_parser.add_argument("-c", "--chunk_size", type=int, help="Chunk size sending WPK file. Allowed values: [1 - 64000]. [Default: {0}]".format(
-        common.wpk_chunk_size))
+    arg_parser.add_argument("-l", "--list_outdated", action="store_true",
+                            help="Generates a list with all outdated agents.")
+    arg_parser.add_argument("-c", "--chunk_size", type=int,
+                            help="Chunk size sending WPK file. Allowed values: [1 - 64000]. [Default: {0}]".format(
+                                common.wpk_chunk_size))
     arg_parser.add_argument("-t", "--timeout", type=int, help="Timeout until agent restart is unlocked.")
     arg_parser.add_argument("-f", "--file", type=str, help="Custom WPK filename.")
-    arg_parser.add_argument("-x", "--execute", type=str, help="Executable filename in the WPK custom file. [Default: upgrade.sh]")
+    arg_parser.add_argument("-x", "--execute", type=str,
+                            help="Executable filename in the WPK custom file. [Default: upgrade.sh]")
     arg_parser.add_argument("--http", action="store_true", help="Uses http protocol instead of https.")
     args = arg_parser.parse_args()
 


### PR DESCRIPTION
|Related issue|
|---|
|#5394|

This PR closes #5394. The agent_upgrade binary had one error with imports. After fix that error, we have changed the old Agents module format for the new one in 4.0.

```
root@wazuh-master:/# /var/ossec/bin/agent_upgrade -l
ID    Name                                Version                  
001   wazuh-agent1                        Wazuh v3.13.0            
002   wazuh-agent2                        Wazuh v3.13.0            
003   wazuh-agent3                        Wazuh v3.13.0            
004   wazuh-agent4                        Wazuh v3.13.0            
005   wazuh-agent5                        Wazuh v3.13.0            
006   wazuh-agent6                        Wazuh v3.13.0            
007   wazuh-agent7                        Wazuh v3.13.0            
008   wazuh-agent8                        Wazuh v3.13.0            
009   wazuh-agent9                        Wazuh v3.9.2             
010   wazuh-agent10                       Wazuh v3.9.2             

Total outdated agents: 10
```