### PR TITLE
Logtest configuration

### DIFF
--- a/src/analysisd/asyscom.c
+++ b/src/analysisd/asyscom.c
@@ -140,6 +140,18 @@ size_t asyscom_getconfig(const char * section, char ** output) {
         } else {
             goto error;
         }
+    }
+    else if(strcmp(section, "rule_test") == 0) {
+        if (cfg = getRuleTestConfig(), cfg) {
+            os_strdup("ok", *output);
+            json_str = cJSON_PrintUnformatted(cfg);
+            wm_strcat(output, json_str, ' ');
+            free(json_str);
+            cJSON_Delete(cfg);
+            return strlen(*output);
+        } else {
+            goto error;
+        }
     } else {
         goto error;
     }

--- a/src/analysisd/asyscom.c
+++ b/src/analysisd/asyscom.c
@@ -141,7 +141,7 @@ size_t asyscom_getconfig(const char * section, char ** output) {
             goto error;
         }
     }
-    else if(strcmp(section, "rule_test") == 0) {
+    else if (strcmp(section, "rule_test") == 0) {
         if (cfg = getRuleTestConfig(), cfg) {
             os_strdup("ok", *output);
             json_str = cJSON_PrintUnformatted(cfg);

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -20,12 +20,12 @@ void *w_logtest_init() {
 
     w_logtest_connection connection;
 
-    if(w_logtest_init_parameters() == OS_INVALID) {
+    if (w_logtest_init_parameters() == OS_INVALID) {
         merror(LOGTEST_ERROR_INV_CONF);
         return NULL;
     }
 
-    if(!strcmp(logtest_conf.enabled, "no")) {
+    if (!strcmp(w_logtest_conf.enabled, "no")) {
         minfo(LOGTEST_DISABLED);
         return NULL;
     }
@@ -44,7 +44,7 @@ void *w_logtest_init() {
 
     minfo(LOGTEST_INITIALIZED);
 
-    for(int i = 1; i < logtest_conf.threads; i++) {
+    for (int i = 1; i < w_logtest_conf.threads; i++) {
         w_create_thread(w_logtest_main, &connection);
     }
 

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -25,7 +25,7 @@ void *w_logtest_init() {
         return NULL;
     }
 
-    if (!strcmp(w_logtest_conf.enabled, "no")) {
+    if (!w_logtest_conf.enabled) {
         minfo(LOGTEST_DISABLED);
         return NULL;
     }
@@ -65,11 +65,10 @@ int w_logtest_init_parameters() {
 
     int modules = CLOGTEST;
 
+    w_logtest_conf.enabled = 1;
     w_logtest_conf.threads = LOGTEST_THREAD;
     w_logtest_conf.max_sessions = LOGTEST_MAX_SESSIONS;
     w_logtest_conf.session_timeout = LOGTEST_SESSION_TIMEOUT;
-
-    os_strdup("yes", w_logtest_conf.enabled);
 
     if (ReadConfig(modules, OSSECCONF, NULL, NULL) < 0) {
         return OS_INVALID;

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -11,11 +11,6 @@
 
 
 /**
- * @brief Internal options configuration
- */
-static logtestConfig config;
-
-/**
  * @brief Mutex to prevent race condition in accept syscall.
  */
 static pthread_mutex_t mutex;
@@ -30,7 +25,7 @@ void *w_logtest_init() {
         return NULL;
     }
 
-    if(!strcmp(config.enabled, "no")) {
+    if(!strcmp(logtest_conf.enabled, "no")) {
         minfo(LOGTEST_DISABLED);
         return NULL;
     }
@@ -49,7 +44,7 @@ void *w_logtest_init() {
 
     minfo(LOGTEST_INITIALIZED);
 
-    for(int i = 1; i < config.threads; i++) {
+    for(int i = 1; i < logtest_conf.threads; i++) {
         w_create_thread(w_logtest_main, &connection);
     }
 
@@ -70,14 +65,14 @@ int w_logtest_init_parameters() {
 
     int modules = CLOGTEST;
 
-    config.threads = LOGTEST_THREAD;
-    config.max_sessions = LOGTEST_MAX_SESSIONS;
-    config.session_timeout = LOGTEST_SESSION_TIMEOUT;
+    logtest_conf.threads = LOGTEST_THREAD;
+    logtest_conf.max_sessions = LOGTEST_MAX_SESSIONS;
+    logtest_conf.session_timeout = LOGTEST_SESSION_TIMEOUT;
 
-    os_calloc(4, sizeof(char), config.enabled);
-    os_strdup("yes", config.enabled);
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_strdup("yes", logtest_conf.enabled);
 
-    if (ReadConfig(modules, OSSECCONF, &config, NULL) < 0) {
+    if (ReadConfig(modules, OSSECCONF, NULL, NULL) < 0) {
         return OS_INVALID;
     }
 

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -65,11 +65,11 @@ int w_logtest_init_parameters() {
 
     int modules = CLOGTEST;
 
-    logtest_conf.threads = LOGTEST_THREAD;
-    logtest_conf.max_sessions = LOGTEST_MAX_SESSIONS;
-    logtest_conf.session_timeout = LOGTEST_SESSION_TIMEOUT;
+    w_logtest_conf.threads = LOGTEST_THREAD;
+    w_logtest_conf.max_sessions = LOGTEST_MAX_SESSIONS;
+    w_logtest_conf.session_timeout = LOGTEST_SESSION_TIMEOUT;
 
-    os_strdup("yes", logtest_conf.enabled);
+    os_strdup("yes", w_logtest_conf.enabled);
 
     if (ReadConfig(modules, OSSECCONF, NULL, NULL) < 0) {
         return OS_INVALID;

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -69,7 +69,6 @@ int w_logtest_init_parameters() {
     logtest_conf.max_sessions = LOGTEST_MAX_SESSIONS;
     logtest_conf.session_timeout = LOGTEST_SESSION_TIMEOUT;
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
     os_strdup("yes", logtest_conf.enabled);
 
     if (ReadConfig(modules, OSSECCONF, NULL, NULL) < 0) {

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -10,12 +10,6 @@
 #include "logtest.h"
 
 
-/**
- * @brief Mutex to prevent race condition in accept syscall.
- */
-static pthread_mutex_t mutex;
-
-
 void *w_logtest_init() {
 
     w_logtest_connection connection;

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -65,7 +65,7 @@ int w_logtest_init_parameters() {
 
     int modules = CLOGTEST;
 
-    w_logtest_conf.enabled = 1;
+    w_logtest_conf.enabled = true;
     w_logtest_conf.threads = LOGTEST_THREAD;
     w_logtest_conf.max_sessions = LOGTEST_MAX_SESSIONS;
     w_logtest_conf.session_timeout = LOGTEST_SESSION_TIMEOUT;

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -87,7 +87,9 @@ void w_logtest_process_log(int token);
 void w_logtest_remove_session(int token);
 
 /**
- * @brief Check all sessions. If session is created and the client has been offline
- * for more than 15 minutes, remove it
+ * @brief Check the active log-test sessions
+ *
+ * Check all sessions. If a session is created and the client has been offline
+ * for more than 15 minutes, remove it.
  */
 void w_logtest_check_active_sessions();

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -16,12 +16,12 @@
 
 
 /**
- * @brief A w_logtest_session_t instance represents a client.
+ * @brief A w_logtest_session_t instance represents a client
  */
 typedef struct w_logtest_session_t {
 
     int token;                              ///< Client ID
-    time_t last_connection;                 ///< Timestamp of the last query.
+    time_t last_connection;                 ///< Timestamp of the last query
 
     RuleNode *rule_list;                    ///< Rule list
     OSDecoderNode *decoderlist_forpname;    ///< Decoder list to match logs which have a program name
@@ -33,7 +33,7 @@ typedef struct w_logtest_session_t {
 } w_logtest_session_t;
 
 /**
- * @brief List of client actives.
+ * @brief List of client actives
  */
 OSHash *w_logtest_sessions;
 
@@ -42,27 +42,27 @@ OSHash *w_logtest_sessions;
  */
 typedef struct w_logtest_connection {
 
-    pthread_mutex_t mutex;      ///< Mutex to prevent race condition in accept syscall.
+    pthread_mutex_t mutex;      ///< Mutex to prevent race condition in accept syscall
     int sock;                   ///< The open connection with logtest queue
 
 } w_logtest_connection;
 
 
 /**
- * @brief Initialize Wazuh Logtest. Initialize the listener and create threads.
- * Then, call function w_logtest_main.
+ * @brief Initialize Wazuh Logtest. Initialize the listener and create threads
+ * Then, call function w_logtest_main
  */
 void *w_logtest_init();
 
 /**
- * @brief Initialize internal options parameters
+ * @brief Initialize logtest configuration. Then, call ReadConfig
  */
 int w_logtest_init_parameters();
 
 /**
- * @brief Main function of Wazuh Logtest module.
+ * @brief Main function of Wazuh Logtest module
  *
- * Listen and treat connections with clients.
+ * Listen and treat connections with clients
  *
  * @param connection The listener where clients connect
  */
@@ -88,6 +88,6 @@ void w_logtest_remove_session(int token);
 
 /**
  * @brief Check all sessions. If session is created and the client has been offline
- * for more than 15 minutes, remove it.
+ * for more than 15 minutes, remove it
  */
 void w_logtest_check_active_sessions();

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -11,6 +11,7 @@
 #include "rules.h"
 #include "decoders/decoder.h"
 #include "eventinfo.h"
+#include "../config/logtest-config.h"
 #include "../os_net/os_net.h"
 
 
@@ -52,6 +53,11 @@ typedef struct w_logtest_connection {
  * Then, call function w_logtest_main.
  */
 void *w_logtest_init();
+
+/**
+ * @brief Initialize internal options parameters
+ */
+int w_logtest_init_parameters();
 
 /**
  * @brief Main function of Wazuh Logtest module.

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -188,7 +188,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
         } else if(chld_node && (strcmp(node[i]->element, wlogtest) == 0)) {
-            if ((modules & CLOGTEST) && (Read_Logtest(chld_node, d1) < 0)) {
+            if ((modules & CLOGTEST) && (Read_Logtest(chld_node) < 0)) {
                 goto fail;
             }
 

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -187,7 +187,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
             if ((modules & CSOCKET) && (Read_Socket(chld_node, d1, d2) < 0)) {
                 goto fail;
             }
-        } else if(chld_node && (strcmp(node[i]->element, wlogtest) == 0)) {
+        } else if (chld_node && (strcmp(node[i]->element, wlogtest) == 0)) {
             if ((modules & CLOGTEST) && (Read_Logtest(chld_node) < 0)) {
                 goto fail;
             }

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -54,6 +54,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
     const char *ossca = "sca";                          /* Security Configuration Assessment */
     const char *osvulndet = "vulnerability-detector";   /* Vulnerability Detector Config */
     const char *osgcp = "gcp-pubsub";                   /* Google Cloud - Wazuh Module */
+    const char *wlogtest = "rule_test";                  /* Wazuh Logtest */
 
 #ifndef WIN32
     const char *osfluent_forward = "fluent-forward";     /* Fluent forwarder */
@@ -186,6 +187,11 @@ static int read_main_elements(const OS_XML *xml, int modules,
             if ((modules & CSOCKET) && (Read_Socket(chld_node, d1, d2) < 0)) {
                 goto fail;
             }
+        } else if(chld_node && (strcmp(node[i]->element, wlogtest) == 0)) {
+            if ((modules & CLOGTEST) && (Read_Logtest(chld_node, d1) < 0)) {
+                goto fail;
+            }
+
         } else {
             merror(XML_INVELEM, node[i]->element);
             goto fail;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -78,7 +78,7 @@ int Read_Authd(XML_NODE node, void *d1, void *d2);
 int Read_Cluster(XML_NODE node, void *d1, void *d2);
 int Read_Socket(XML_NODE node, void *d1, void *d2);
 int Read_Vuln(const OS_XML *xml, xml_node **nodes, void *d1, char d2);
-int Read_Logtest(XML_NODE node, void *config);
+int Read_Logtest(XML_NODE node);
 
 /* Verifies that the configuration for Syscheck is correct. Return 0 on success or -1 on error.  */
 int Test_Syscheck(const char * path);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -33,6 +33,7 @@
 #define CBUFFER       002000000
 #define CCLUSTER      004000000
 #define CSOCKET       010000000
+#define CLOGTEST      020000000
 
 #define MAX_NEEDED_TAGS 4
 
@@ -77,6 +78,7 @@ int Read_Authd(XML_NODE node, void *d1, void *d2);
 int Read_Cluster(XML_NODE node, void *d1, void *d2);
 int Read_Socket(XML_NODE node, void *d1, void *d2);
 int Read_Vuln(const OS_XML *xml, xml_node **nodes, void *d1, char d2);
+int Read_Logtest(XML_NODE node, void *config);
 
 /* Verifies that the configuration for Syscheck is correct. Return 0 on success or -1 on error.  */
 int Test_Syscheck(const char * path);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -78,6 +78,11 @@ int Read_Authd(XML_NODE node, void *d1, void *d2);
 int Read_Cluster(XML_NODE node, void *d1, void *d2);
 int Read_Socket(XML_NODE node, void *d1, void *d2);
 int Read_Vuln(const OS_XML *xml, xml_node **nodes, void *d1, char d2);
+
+/**
+ * @brief Read the configuration for logtest thread
+ * @param node rule_test configuration
+ */
 int Read_Logtest(XML_NODE node);
 
 /* Verifies that the configuration for Syscheck is correct. Return 0 on success or -1 on error.  */

--- a/src/config/logtest-config.c
+++ b/src/config/logtest-config.c
@@ -47,35 +47,45 @@ int Read_Logtest(XML_NODE node) {
 
             char *end;
             long value = strtol(node[i]->content, &end, 10);
+
             if (value < 0 || value > 65534 || *end) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
-            }
-
-            logtest_conf.threads = (unsigned short) value;
-            if(logtest_conf.threads > LOGTEST_MAXTHREAD) {
-                logtest_conf.threads = LOGTEST_MAXTHREAD;
-                mwarn(LOGTEST_INV_NUM_THREADS, LOGTEST_MAXTHREAD);
+            } else if(value > LOGTEST_LIMIT_THREAD) {
+                mdebug2(LOGTEST_INV_NUM_THREADS, LOGTEST_LIMIT_THREAD);
+                logtest_conf.threads = LOGTEST_LIMIT_THREAD;
+            } else {
+                logtest_conf.threads = (unsigned short) value;
             }
         }
 
         else if(!strcmp(node[i]->element, max_sessions)) {
             char *end;
             long value = strtol(node[i]->content, &end, 10);
+
             if (value < 0 || value > 65534 || *end) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
+            } else if (value > LOGTEST_LIMIT_MAX_SESSIONS) {
+                mdebug2(LOGTEST_INV_NUM_USERS, LOGTEST_LIMIT_MAX_SESSIONS);
+                logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
+            } else {
+                logtest_conf.max_sessions = (unsigned short) value;
             }
-            logtest_conf.max_sessions = (unsigned short) value;
         }
 
         else if(!strcmp(node[i]->element, session_timeout)) {
             long value = w_parse_time(node[i]->content);
+
             if (value <= 0) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
+            } else if (value > LOGTEST_LIMIT_SESSION_TIMEOUT) {
+                mdebug2(LOGTEST_INV_NUM_TIMEOUT, LOGTEST_LIMIT_SESSION_TIMEOUT);
+                logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
+            } else {
+                logtest_conf.session_timeout = value;
             }
-            logtest_conf.session_timeout = value;
         }
 
         else {
@@ -93,7 +103,7 @@ cJSON *getRuleTestConfig() {
     cJSON *root = cJSON_CreateObject();
     cJSON *ruletest = cJSON_CreateObject();
 
-    if (logtest_conf.enabled) cJSON_AddStringToObject(ruletest, enabled, logtest_conf.enabled);
+    if (logtest_conf.enabled)cJSON_AddStringToObject(ruletest, enabled, logtest_conf.enabled);
     if (logtest_conf.threads)cJSON_AddNumberToObject(ruletest, threads, logtest_conf.threads);
     if (logtest_conf.max_sessions)cJSON_AddNumberToObject(ruletest, max_sessions, logtest_conf.max_sessions);
     if (logtest_conf.session_timeout)cJSON_AddNumberToObject(ruletest, session_timeout, logtest_conf.session_timeout);

--- a/src/config/logtest-config.c
+++ b/src/config/logtest-config.c
@@ -32,11 +32,14 @@ int Read_Logtest(XML_NODE node) {
         }
 
         else if (!strcmp(node[i]->element, enabled)) {
-            if (strcmp(node[i]->content, "yes") && strcmp(node[i]->content, "no")) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            if (strcmp(node[i]->content, "no") == 0) {
+                w_logtest_conf.enabled = 0;
+            } else if (strcmp(node[i]->content, "yes") == 0) {
+                w_logtest_conf.enabled = 1;
+            } else {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
             }
-            strcpy(w_logtest_conf.enabled, node[i]->content);
         }
 
         else if (!strcmp(node[i]->element, threads)) {
@@ -48,11 +51,11 @@ int Read_Logtest(XML_NODE node) {
             char *end;
             long value = strtol(node[i]->content, &end, 10);
 
-            if (value < 0 || value > 65534 || *end) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            if (value < 0 || value > 65534 || *end != '\0') {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
             } else if (value > LOGTEST_LIMIT_THREAD) {
-                mdebug2(LOGTEST_INV_NUM_THREADS, LOGTEST_LIMIT_THREAD);
+                mwarn(LOGTEST_INV_NUM_THREADS, LOGTEST_LIMIT_THREAD);
                 w_logtest_conf.threads = LOGTEST_LIMIT_THREAD;
             } else {
                 w_logtest_conf.threads = (unsigned short) value;
@@ -63,11 +66,11 @@ int Read_Logtest(XML_NODE node) {
             char *end;
             long value = strtol(node[i]->content, &end, 10);
 
-            if (value < 0 || value > 65534 || *end) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            if (value < 0 || value > 65534 || *end != '\0') {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
             } else if (value > LOGTEST_LIMIT_MAX_SESSIONS) {
-                mdebug2(LOGTEST_INV_NUM_USERS, LOGTEST_LIMIT_MAX_SESSIONS);
+                mwarn(LOGTEST_INV_NUM_USERS, LOGTEST_LIMIT_MAX_SESSIONS);
                 w_logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
             } else {
                 w_logtest_conf.max_sessions = (unsigned short) value;
@@ -78,10 +81,10 @@ int Read_Logtest(XML_NODE node) {
             long value = w_parse_time(node[i]->content);
 
             if (value <= 0) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
             } else if (value > LOGTEST_LIMIT_SESSION_TIMEOUT) {
-                mdebug2(LOGTEST_INV_NUM_TIMEOUT, LOGTEST_LIMIT_SESSION_TIMEOUT);
+                mwarn(LOGTEST_INV_NUM_TIMEOUT, LOGTEST_LIMIT_SESSION_TIMEOUT);
                 w_logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
             } else {
                 w_logtest_conf.session_timeout = value;
@@ -103,7 +106,12 @@ cJSON *getRuleTestConfig() {
     cJSON *root = cJSON_CreateObject();
     cJSON *ruletest = cJSON_CreateObject();
 
-    if (w_logtest_conf.enabled)cJSON_AddStringToObject(ruletest, enabled, w_logtest_conf.enabled);
+    if (w_logtest_conf.enabled) {
+        cJSON_AddStringToObject(ruletest, enabled, "yes");
+    } else {
+        cJSON_AddStringToObject(ruletest, enabled, "no");
+    }
+
     if (w_logtest_conf.threads)cJSON_AddNumberToObject(ruletest, threads, w_logtest_conf.threads);
     if (w_logtest_conf.max_sessions)cJSON_AddNumberToObject(ruletest, max_sessions, w_logtest_conf.max_sessions);
     if (w_logtest_conf.session_timeout)cJSON_AddNumberToObject(ruletest, session_timeout, w_logtest_conf.session_timeout);

--- a/src/config/logtest-config.c
+++ b/src/config/logtest-config.c
@@ -19,7 +19,7 @@ const char *session_timeout = "session_timeout";
 
 int Read_Logtest(XML_NODE node) {
 
-    for(int i = 0; node[i]; i++) {
+    for (int i = 0; node[i]; i++) {
 
         if (!node[i]->element) {
             merror(XML_ELEMNULL);
@@ -51,7 +51,7 @@ int Read_Logtest(XML_NODE node) {
             if (value < 0 || value > 65534 || *end) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
-            } else if(value > LOGTEST_LIMIT_THREAD) {
+            } else if (value > LOGTEST_LIMIT_THREAD) {
                 mdebug2(LOGTEST_INV_NUM_THREADS, LOGTEST_LIMIT_THREAD);
                 w_logtest_conf.threads = LOGTEST_LIMIT_THREAD;
             } else {
@@ -59,7 +59,7 @@ int Read_Logtest(XML_NODE node) {
             }
         }
 
-        else if(!strcmp(node[i]->element, max_sessions)) {
+        else if (!strcmp(node[i]->element, max_sessions)) {
             char *end;
             long value = strtol(node[i]->content, &end, 10);
 
@@ -74,7 +74,7 @@ int Read_Logtest(XML_NODE node) {
             }
         }
 
-        else if(!strcmp(node[i]->element, session_timeout)) {
+        else if (!strcmp(node[i]->element, session_timeout)) {
             long value = w_parse_time(node[i]->content);
 
             if (value <= 0) {

--- a/src/config/logtest-config.c
+++ b/src/config/logtest-config.c
@@ -36,12 +36,12 @@ int Read_Logtest(XML_NODE node) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
             }
-            strcpy(logtest_conf.enabled, node[i]->content);
+            strcpy(w_logtest_conf.enabled, node[i]->content);
         }
 
         else if (!strcmp(node[i]->element, threads)) {
             if (!strcmp(node[i]->content, "auto")) {
-                logtest_conf.threads = get_nprocs();
+                w_logtest_conf.threads = get_nproc();
                 continue;
             }
 
@@ -53,9 +53,9 @@ int Read_Logtest(XML_NODE node) {
                 return OS_INVALID;
             } else if(value > LOGTEST_LIMIT_THREAD) {
                 mdebug2(LOGTEST_INV_NUM_THREADS, LOGTEST_LIMIT_THREAD);
-                logtest_conf.threads = LOGTEST_LIMIT_THREAD;
+                w_logtest_conf.threads = LOGTEST_LIMIT_THREAD;
             } else {
-                logtest_conf.threads = (unsigned short) value;
+                w_logtest_conf.threads = (unsigned short) value;
             }
         }
 
@@ -68,9 +68,9 @@ int Read_Logtest(XML_NODE node) {
                 return OS_INVALID;
             } else if (value > LOGTEST_LIMIT_MAX_SESSIONS) {
                 mdebug2(LOGTEST_INV_NUM_USERS, LOGTEST_LIMIT_MAX_SESSIONS);
-                logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
+                w_logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
             } else {
-                logtest_conf.max_sessions = (unsigned short) value;
+                w_logtest_conf.max_sessions = (unsigned short) value;
             }
         }
 
@@ -82,9 +82,9 @@ int Read_Logtest(XML_NODE node) {
                 return OS_INVALID;
             } else if (value > LOGTEST_LIMIT_SESSION_TIMEOUT) {
                 mdebug2(LOGTEST_INV_NUM_TIMEOUT, LOGTEST_LIMIT_SESSION_TIMEOUT);
-                logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
+                w_logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
             } else {
-                logtest_conf.session_timeout = value;
+                w_logtest_conf.session_timeout = value;
             }
         }
 
@@ -103,10 +103,10 @@ cJSON *getRuleTestConfig() {
     cJSON *root = cJSON_CreateObject();
     cJSON *ruletest = cJSON_CreateObject();
 
-    if (logtest_conf.enabled)cJSON_AddStringToObject(ruletest, enabled, logtest_conf.enabled);
-    if (logtest_conf.threads)cJSON_AddNumberToObject(ruletest, threads, logtest_conf.threads);
-    if (logtest_conf.max_sessions)cJSON_AddNumberToObject(ruletest, max_sessions, logtest_conf.max_sessions);
-    if (logtest_conf.session_timeout)cJSON_AddNumberToObject(ruletest, session_timeout, logtest_conf.session_timeout);
+    if (w_logtest_conf.enabled)cJSON_AddStringToObject(ruletest, enabled, w_logtest_conf.enabled);
+    if (w_logtest_conf.threads)cJSON_AddNumberToObject(ruletest, threads, w_logtest_conf.threads);
+    if (w_logtest_conf.max_sessions)cJSON_AddNumberToObject(ruletest, max_sessions, w_logtest_conf.max_sessions);
+    if (w_logtest_conf.session_timeout)cJSON_AddNumberToObject(ruletest, session_timeout, w_logtest_conf.session_timeout);
 
     cJSON_AddItemToObject(root, "rule_test", ruletest);
 

--- a/src/config/logtest-config.c
+++ b/src/config/logtest-config.c
@@ -1,0 +1,88 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "logtest-config.h"
+
+int Read_Logtest(XML_NODE node, void *config) {
+
+    const char *logtest_enabled = "enabled";
+    const char *logtest_threads = "threads";
+    const char *logtest_users_allowed = "max_sessions";
+    const char *logtest_idle_time_allowed = "session_timeout";
+
+    logtestConfig *logtest_conf = (logtestConfig *) config;
+
+    for(int i = 0; node[i]; i++) {
+
+        if (!node[i]->element) {
+            merror(XML_ELEMNULL);
+            return OS_INVALID;
+        }
+
+        else if (!node[i]->content) {
+            merror(XML_VALUENULL, node[i]->element);
+            return OS_INVALID;
+        }
+
+        else if (!strcmp(node[i]->element, logtest_enabled)) {
+            if (strcmp(node[i]->content, "yes") && strcmp(node[i]->content, "no")) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+                return OS_INVALID;
+            }
+            strcpy(logtest_conf->enabled, node[i]->content);
+        }
+
+        else if (!strcmp(node[i]->element, logtest_threads)) {
+            if (!strcmp(node[i]->content, "auto")) {
+                logtest_conf->threads = get_nprocs();
+                continue;
+            }
+
+            char *end;
+            long value = strtol(node[i]->content, &end, 10);
+            if (value < 0 || value > 65534 || *end) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+                return OS_INVALID;
+            }
+
+            logtest_conf->threads = (unsigned short) value;
+            if(logtest_conf->threads > LOGTEST_MAXTHREAD) {
+                logtest_conf->threads = LOGTEST_MAXTHREAD;
+                mwarn(LOGTEST_INV_NUM_THREADS, LOGTEST_MAXTHREAD);
+            }
+        }
+
+        else if(!strcmp(node[i]->element, logtest_users_allowed)) {
+            char *end;
+            long value = strtol(node[i]->content, &end, 10);
+            if (value < 0 || value > 65534 || *end) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+                return OS_INVALID;
+            }
+            logtest_conf->max_sessions = (unsigned short) value;
+        }
+
+        else if(!strcmp(node[i]->element, logtest_idle_time_allowed)) {
+            long value = w_parse_time(node[i]->content);
+            if (value <= 0) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+                return OS_INVALID;
+            }
+            logtest_conf->session_timeout = value;
+        }
+
+        else {
+            merror(XML_INVELEM, node[i]->element);
+            return OS_INVALID;
+        }
+    }
+
+    return OS_SUCCESS;
+}

--- a/src/config/logtest-config.h
+++ b/src/config/logtest-config.h
@@ -23,9 +23,9 @@
  */
 typedef struct w_logtest_conf_t {
 
-    char *enabled;
-    unsigned short threads;
-    unsigned short max_sessions;
+    bool enabled;
+    int threads;
+    int max_sessions;
     long int session_timeout;
 
 } w_logtest_conf_t;

--- a/src/config/logtest-config.h
+++ b/src/config/logtest-config.h
@@ -9,7 +9,6 @@
  */
 
 #include "shared.h"
-#include <sys/sysinfo.h>
 
 /* Internal options default values */
 #define LOGTEST_THREAD                  1
@@ -22,19 +21,19 @@
 /**
  * @brief Struct to save the wazuh-logtest internal configuration
  */
-typedef struct logtest_config {
+typedef struct w_logtest_conf_t {
 
     char *enabled;
     unsigned short threads;
     unsigned short max_sessions;
     long int session_timeout;
 
-} logtestConfig;
+} w_logtest_conf_t;
 
 /**
  * @brief Global variable to save the configuration
  */
-logtestConfig logtest_conf;
+w_logtest_conf_t w_logtest_conf;
 
 
 /**

--- a/src/config/logtest-config.h
+++ b/src/config/logtest-config.h
@@ -28,3 +28,15 @@ typedef struct logtest_config {
     unsigned int session_timeout;
 
 } logtestConfig;
+
+/**
+ * @brief Global variable to save the configuration
+ */
+logtestConfig logtest_conf;
+
+
+/**
+ * @brief Return the rule_test configuration on demand
+ * @return Configuration in JSON format
+ */
+cJSON *getRuleTestConfig();

--- a/src/config/logtest-config.h
+++ b/src/config/logtest-config.h
@@ -12,10 +12,12 @@
 #include <sys/sysinfo.h>
 
 /* Internal options default values */
-#define LOGTEST_THREAD              1
-#define LOGTEST_MAXTHREAD           128
-#define LOGTEST_MAX_SESSIONS       64
-#define LOGTEST_SESSION_TIMEOUT    900
+#define LOGTEST_THREAD                  1
+#define LOGTEST_LIMIT_THREAD            128
+#define LOGTEST_MAX_SESSIONS            64
+#define LOGTEST_LIMIT_MAX_SESSIONS      500
+#define LOGTEST_SESSION_TIMEOUT         900
+#define LOGTEST_LIMIT_SESSION_TIMEOUT   31536000
 
 /**
  * @brief Struct to save the wazuh-logtest internal configuration
@@ -25,7 +27,7 @@ typedef struct logtest_config {
     char *enabled;
     unsigned short threads;
     unsigned short max_sessions;
-    unsigned int session_timeout;
+    long int session_timeout;
 
 } logtestConfig;
 

--- a/src/config/logtest-config.h
+++ b/src/config/logtest-config.h
@@ -1,0 +1,30 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "shared.h"
+#include <sys/sysinfo.h>
+
+/* Internal options default values */
+#define LOGTEST_THREAD              1
+#define LOGTEST_MAXTHREAD           128
+#define LOGTEST_MAX_SESSIONS       64
+#define LOGTEST_SESSION_TIMEOUT    900
+
+/**
+ * @brief Struct to save the wazuh-logtest internal configuration
+ */
+typedef struct logtest_config {
+
+    char *enabled;
+    unsigned short threads;
+    unsigned short max_sessions;
+    unsigned int session_timeout;
+
+} logtestConfig;

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -237,4 +237,9 @@
 #define FIM_NUM_WATCHES                     "(6345): Folders monitored with real-time engine: %u"
 #define FIM_REALTIME_CALLBACK               "(6346): Realtime watch deleted for '%s'"
 
+/* wazuh-logtest debug messages*/
+#define LOGTEST_INV_NUM_THREADS             "(7000): Number of logtest threads too high. Only creates %d threads"
+#define LOGTEST_INV_NUM_USERS               "(7001): Number of maximum users connected in logtest too high. Only allows %d users"
+#define LOGTEST_INV_NUM_TIMEOUT             "(7002): Number of maximum user timeouts in logtest too high. Only allows %ds maximum timeouts"
+
 #endif /* DEBUG_MESSAGES_H */

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -237,9 +237,4 @@
 #define FIM_NUM_WATCHES                     "(6345): Folders monitored with real-time engine: %u"
 #define FIM_REALTIME_CALLBACK               "(6346): Realtime watch deleted for '%s'"
 
-/* wazuh-logtest debug messages*/
-#define LOGTEST_INV_NUM_THREADS             "(7000): Number of logtest threads too high. Only creates %d threads"
-#define LOGTEST_INV_NUM_USERS               "(7001): Number of maximum users connected in logtest too high. Only allows %d users"
-#define LOGTEST_INV_NUM_TIMEOUT             "(7002): Number of maximum user timeouts in logtest too high. Only allows %ds maximum timeouts"
-
 #endif /* DEBUG_MESSAGES_H */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -494,6 +494,7 @@
 #define LOGTEST_ERROR_ACCEPT_CONN                   "(7301): Failure to accept connection. Errno: %s"
 #define LOGTEST_ERROR_RECV_MSG                      "(7302): Failure to receive message. Errno: %s"
 #define LOGTEST_ERROR_INIT_HASH                     "(7303): Failure to initialize all_sesssions hash"
+#define LOGTEST_ERROR_INV_CONF                      "(7304): Invalid wazuh-logtest configuration"
 
 /* Verbose messages */
 #define STARTUP_MSG "Started (pid: %d)."

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -56,5 +56,6 @@
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"
+#define LOGTEST_DISABLED                    "(7201): Logtest disabled"
 
 #endif /* INFO_MESSAGES_H */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -41,7 +41,4 @@
 #define FIM_WARN_WHODATA_ADD_RULE               "(6926): Unable to add audit rule for '%s'"
 #define FIM_DB_FULL_ALERT                       "(6927): Sending DB 100%% full alert."
 
-/* wazuh-logtest warning messages*/
-#define LOGTEST_INV_NUM_THREADS                 "(7000): Invalid number of wazuh-logtest threads. Only creates %d threads"
-
 #endif /* WARN_MESSAGES_H */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -41,4 +41,9 @@
 #define FIM_WARN_WHODATA_ADD_RULE               "(6926): Unable to add audit rule for '%s'"
 #define FIM_DB_FULL_ALERT                       "(6927): Sending DB 100%% full alert."
 
+/* Wazuh-logtest warning messages*/
+#define LOGTEST_INV_NUM_THREADS             "(7000): Number of logtest threads too high. Only creates %d threads"
+#define LOGTEST_INV_NUM_USERS               "(7001): Number of maximum users connected in logtest too high. Only allows %d users"
+#define LOGTEST_INV_NUM_TIMEOUT             "(7002): Number of maximum user timeouts in logtest too high. Only allows %ds maximum timeouts"
+
 #endif /* WARN_MESSAGES_H */

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -44,7 +44,7 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,mutex_destroy -Wl,--wrap,close")
 
 LIST(APPEND analysisd_names "test_logtest-config")
-LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nprocs")
 
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -44,7 +44,8 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,mutex_destroy -Wl,--wrap,close")
 
 LIST(APPEND analysisd_names "test_logtest-config")
-LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nprocs")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nprocs -Wl,--wrap,cJSON_CreateObject \
+                             -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject -Wl,--wrap,cJSON_AddItemToObject")
 
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -38,6 +38,11 @@ list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,_merror -Wl,--w
 LIST(APPEND analysisd_names "test_same_different_loop")
 LIST(APPEND analysisd_flags "-W")
 
+LIST(APPEND analysisd_names "test_logtest")
+LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap,OS_BindUnixDomain -Wl,--wrap,OSHash_Create \
+                             -Wl,--wrap,pthread_mutex_init -Wl,--wrap,_minfo -Wl,--wrap,_w_mutex_init -Wl,--wrap,w_create_thread \
+                             -Wl,--wrap,mutex_destroy -Wl,--wrap,close")
+
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -44,7 +44,7 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,mutex_destroy -Wl,--wrap,close")
 
 LIST(APPEND analysisd_names "test_logtest-config")
-LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nprocs -Wl,--wrap,cJSON_CreateObject \
+LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject -Wl,--wrap,cJSON_AddItemToObject")
 
 list(LENGTH analysisd_names count)

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -43,6 +43,9 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,pthread_mutex_init -Wl,--wrap,_minfo -Wl,--wrap,_w_mutex_init -Wl,--wrap,w_create_thread \
                              -Wl,--wrap,mutex_destroy -Wl,--wrap,close")
 
+LIST(APPEND analysisd_names "test_logtest-config")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn")
+
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/analysisd/test_logtest-config.c
+++ b/src/unit_tests/analysisd/test_logtest-config.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../headers/shared.h"
+#include "../../analysisd/logtest.h"
+
+void *w_logtest_init();
+
+/* wraps */
+
+void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+/* tests */
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests 
+
+    
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_logtest-config.c
+++ b/src/unit_tests/analysisd/test_logtest-config.c
@@ -17,6 +17,7 @@
 #include "../../analysisd/logtest.h"
 
 int Read_Logtest(XML_NODE node);
+cJSON *getRuleTestConfig();
 
 /* setup/teardown */
 
@@ -61,11 +62,33 @@ int __wrap_get_nprocs (void) {
     return mock();
 }
 
+cJSON * __wrap_cJSON_CreateObject(void) {
+    return mock_type(cJSON *);
+}
+
+cJSON* __wrap_cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string) {
+    if (name) check_expected(name);
+    if (string) check_expected(string);
+    return mock_type(cJSON *);
+}
+
+cJSON* __wrap_cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number) {
+    if (name) check_expected(name);
+    if (number) check_expected(number);
+    return mock_type(cJSON *);
+}
+
+
+void __wrap_cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item) {
+    if (string) check_expected(string);
+    if (item) check_expected(item);
+}
+
 /* tests */
 
 /* Read_Logtest */
 
-void test_Read_Logtest_invalid_element(void **state)
+void test_Read_Logtest_element_NULL(void **state)
 {
     xml_node **nodes;
     nodes = calloc(2, sizeof(xml_node*));
@@ -85,7 +108,7 @@ void test_Read_Logtest_invalid_element(void **state)
     os_free(nodes);
 }
 
-void test_Read_Logtest_invalid_content(void **state)
+void test_Read_Logtest_content_NULL(void **state)
 {
     xml_node **nodes;
     nodes = calloc(2, sizeof(xml_node*));
@@ -485,12 +508,70 @@ void test_Read_Logtest_valid_session_timeout(void **state)
     os_free(logtest_conf.enabled);
 }
 
+void test_Read_Logtest_invalid_element(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("test");
+    nodes[0]->content = strdup("unit_test");
+
+    expect_string(__wrap__merror, formatted_msg, "(1230): Invalid element in the configuration: 'test'.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+/* getRuleTestConfig */
+void test_getRuleTestConfig_OK(void **state)
+{
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+
+    os_strdup("yes", logtest_conf.enabled);
+    logtest_conf.threads = LOGTEST_LIMIT_THREAD;
+    logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
+    logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "enabled");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "yes");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "threads");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 128);
+    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "max_sessions");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 500);
+    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "session_timeout");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 31536000);
+    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddItemToObject, string, "rule_test");
+    expect_value(__wrap_cJSON_AddItemToObject, item, (cJSON *)1);
+
+    cJSON* ret = getRuleTestConfig();
+
+    os_free(logtest_conf.enabled);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         // Tests Read_Logtest
-        cmocka_unit_test(test_Read_Logtest_invalid_element),
-        cmocka_unit_test(test_Read_Logtest_invalid_content),
+        cmocka_unit_test(test_Read_Logtest_element_NULL),
+        cmocka_unit_test(test_Read_Logtest_content_NULL),
         cmocka_unit_test(test_Read_Logtest_invalid_enabled),
         cmocka_unit_test(test_Read_Logtest_valid_enabled),
         cmocka_unit_test(test_Read_Logtest_invalid_threads),
@@ -507,7 +588,10 @@ int main(void)
         cmocka_unit_test(test_Read_Logtest_invalid_session_timeout),
         cmocka_unit_test(test_Read_Logtest_smaller_session_timeout),
         cmocka_unit_test(test_Read_Logtest_limit_session_timeout),
-        cmocka_unit_test(test_Read_Logtest_valid_session_timeout)
+        cmocka_unit_test(test_Read_Logtest_valid_session_timeout),
+        cmocka_unit_test(test_Read_Logtest_invalid_element),
+        // Tests getRuleTestConfig
+        cmocka_unit_test(test_getRuleTestConfig_OK),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_logtest-config.c
+++ b/src/unit_tests/analysisd/test_logtest-config.c
@@ -58,7 +58,7 @@ void __wrap__mdebug2(const char * file, int line, const char * func, const char 
     check_expected(formatted_msg);
 }
 
-int __wrap_get_nprocs (void) {
+int __wrap_get_nproc(void) {
     return mock();
 }
 
@@ -137,10 +137,28 @@ void test_Read_Logtest_invalid_enabled(void **state)
     nodes[0]->element = strdup("enabled");
     nodes[0]->content = strdup("test");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'enabled': test.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'enabled': test.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+}
+
+void test_Read_Logtest_valid_disabled(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    nodes[0]->element = strdup("enabled");
+    nodes[0]->content = strdup("no");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_SUCCESS);
 
     os_free(nodes[0]->element);
     os_free(nodes[0]->content);
@@ -154,8 +172,6 @@ void test_Read_Logtest_valid_enabled(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("enabled");
     nodes[0]->content = strdup("yes");
 
@@ -166,7 +182,6 @@ void test_Read_Logtest_valid_enabled(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_invalid_threads(void **state)
@@ -175,12 +190,10 @@ void test_Read_Logtest_invalid_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("test");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'threads': test.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'threads': test.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -189,7 +202,6 @@ void test_Read_Logtest_invalid_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_auto_threads(void **state)
@@ -198,12 +210,10 @@ void test_Read_Logtest_auto_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("auto");
 
-    will_return(__wrap_get_nprocs, 1);
+    will_return(__wrap_get_nproc, 1);
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_SUCCESS);
@@ -212,7 +222,6 @@ void test_Read_Logtest_auto_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_smaller_threads(void **state)
@@ -221,12 +230,10 @@ void test_Read_Logtest_smaller_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("-1");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'threads': -1.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'threads': -1.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -235,7 +242,6 @@ void test_Read_Logtest_smaller_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_bigger_threads(void **state)
@@ -244,12 +250,10 @@ void test_Read_Logtest_bigger_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("1000000");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'threads': 1000000.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'threads': 1000000.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -258,7 +262,6 @@ void test_Read_Logtest_bigger_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_limit_threads(void **state)
@@ -267,12 +270,10 @@ void test_Read_Logtest_limit_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("256");
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(7000): Number of logtest threads too high. Only creates 128 threads");
+    expect_string(__wrap__mwarn, formatted_msg, "(7000): Number of logtest threads too high. Only creates 128 threads");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_SUCCESS);
@@ -281,7 +282,6 @@ void test_Read_Logtest_limit_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_valid_threads(void **state)
@@ -289,8 +289,6 @@ void test_Read_Logtest_valid_threads(void **state)
     xml_node **nodes;
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
-
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("64");
@@ -302,7 +300,6 @@ void test_Read_Logtest_valid_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_invalid_max_sessions(void **state)
@@ -311,12 +308,10 @@ void test_Read_Logtest_invalid_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("test");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'max_sessions': test.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'max_sessions': test.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -325,7 +320,6 @@ void test_Read_Logtest_invalid_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_smaller_max_sessions(void **state)
@@ -334,12 +328,10 @@ void test_Read_Logtest_smaller_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("-1");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'max_sessions': -1.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'max_sessions': -1.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -348,7 +340,6 @@ void test_Read_Logtest_smaller_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_bigger_max_sessions(void **state)
@@ -357,12 +348,10 @@ void test_Read_Logtest_bigger_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("1000000");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'max_sessions': 1000000.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'max_sessions': 1000000.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -371,7 +360,6 @@ void test_Read_Logtest_bigger_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_limit_max_sessions(void **state)
@@ -380,12 +368,10 @@ void test_Read_Logtest_limit_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("700");
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(7001): Number of maximum users connected in logtest too high. Only allows 500 users");
+    expect_string(__wrap__mwarn, formatted_msg, "(7001): Number of maximum users connected in logtest too high. Only allows 500 users");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_SUCCESS);
@@ -394,7 +380,6 @@ void test_Read_Logtest_limit_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_valid_max_sessions(void **state)
@@ -402,8 +387,6 @@ void test_Read_Logtest_valid_max_sessions(void **state)
     xml_node **nodes;
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
-
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("200");
@@ -415,7 +398,6 @@ void test_Read_Logtest_valid_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_invalid_session_timeout(void **state)
@@ -424,12 +406,10 @@ void test_Read_Logtest_invalid_session_timeout(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("session_timeout");
     nodes[0]->content = strdup("test");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'session_timeout': test.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'session_timeout': test.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -438,7 +418,6 @@ void test_Read_Logtest_invalid_session_timeout(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_smaller_session_timeout(void **state)
@@ -447,12 +426,10 @@ void test_Read_Logtest_smaller_session_timeout(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("session_timeout");
     nodes[0]->content = strdup("-1");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'session_timeout': -1.");
+    expect_string(__wrap__merror, formatted_msg, "(1235): Invalid value for element 'session_timeout': -1.");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -461,7 +438,6 @@ void test_Read_Logtest_smaller_session_timeout(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_limit_session_timeout(void **state)
@@ -470,12 +446,10 @@ void test_Read_Logtest_limit_session_timeout(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
-
     nodes[0]->element = strdup("session_timeout");
     nodes[0]->content = strdup("32000000");
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(7002): Number of maximum user timeouts in logtest too high. Only allows 31536000s maximum timeouts");
+    expect_string(__wrap__mwarn, formatted_msg, "(7002): Number of maximum user timeouts in logtest too high. Only allows 31536000s maximum timeouts");
 
     int ret = Read_Logtest(nodes);
     assert_int_equal(ret, OS_SUCCESS);
@@ -484,7 +458,6 @@ void test_Read_Logtest_limit_session_timeout(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_valid_session_timeout(void **state)
@@ -492,8 +465,6 @@ void test_Read_Logtest_valid_session_timeout(void **state)
     xml_node **nodes;
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
-
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("session_timeout");
     nodes[0]->content = strdup("1000000");
@@ -505,7 +476,6 @@ void test_Read_Logtest_valid_session_timeout(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_invalid_element(void **state)
@@ -513,8 +483,6 @@ void test_Read_Logtest_invalid_element(void **state)
     xml_node **nodes;
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
-
-    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("test");
     nodes[0]->content = strdup("unit_test");
@@ -528,16 +496,48 @@ void test_Read_Logtest_invalid_element(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(w_logtest_conf.enabled);
 }
 
 /* getRuleTestConfig */
-void test_getRuleTestConfig_OK(void **state)
+void test_getRuleTestConfig_disabled(void **state)
 {
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
-    os_strdup("yes", w_logtest_conf.enabled);
+    w_logtest_conf.enabled = false;
+    w_logtest_conf.threads = LOGTEST_LIMIT_THREAD;
+    w_logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
+    w_logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "enabled");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "no");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "threads");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 128);
+    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "max_sessions");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 500);
+    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "session_timeout");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 31536000);
+    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddItemToObject, string, "rule_test");
+    expect_value(__wrap_cJSON_AddItemToObject, item, (cJSON *)1);
+
+    cJSON* ret = getRuleTestConfig();
+
+}
+
+void test_getRuleTestConfig_enabled(void **state)
+{
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+
+    w_logtest_conf.enabled = true;
     w_logtest_conf.threads = LOGTEST_LIMIT_THREAD;
     w_logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
     w_logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
@@ -563,7 +563,6 @@ void test_getRuleTestConfig_OK(void **state)
 
     cJSON* ret = getRuleTestConfig();
 
-    os_free(w_logtest_conf.enabled);
 }
 
 int main(void)
@@ -573,6 +572,7 @@ int main(void)
         cmocka_unit_test(test_Read_Logtest_element_NULL),
         cmocka_unit_test(test_Read_Logtest_content_NULL),
         cmocka_unit_test(test_Read_Logtest_invalid_enabled),
+        cmocka_unit_test(test_Read_Logtest_valid_disabled),
         cmocka_unit_test(test_Read_Logtest_valid_enabled),
         cmocka_unit_test(test_Read_Logtest_invalid_threads),
         cmocka_unit_test(test_Read_Logtest_auto_threads),
@@ -591,7 +591,8 @@ int main(void)
         cmocka_unit_test(test_Read_Logtest_valid_session_timeout),
         cmocka_unit_test(test_Read_Logtest_invalid_element),
         // Tests getRuleTestConfig
-        cmocka_unit_test(test_getRuleTestConfig_OK),
+        cmocka_unit_test(test_getRuleTestConfig_disabled),
+        cmocka_unit_test(test_getRuleTestConfig_enabled)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_logtest-config.c
+++ b/src/unit_tests/analysisd/test_logtest-config.c
@@ -16,7 +16,11 @@
 #include "../../headers/shared.h"
 #include "../../analysisd/logtest.h"
 
-void *w_logtest_init();
+int Read_Logtest(XML_NODE node);
+
+/* setup/teardown */
+
+
 
 /* wraps */
 
@@ -31,14 +35,391 @@ void __wrap__merror(const char * file, int line, const char * func, const char *
     check_expected(formatted_msg);
 }
 
+void __wrap__mwarn(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
 /* tests */
+
+/* Read_Logtest */
+
+void test_Read_Logtest_invalid_element(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    nodes[0]->element = NULL;
+    nodes[0]->content = strdup("yes");
+
+    expect_string(__wrap__merror, formatted_msg, XML_ELEMNULL);
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+}
+
+void test_Read_Logtest_invalid_content(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    nodes[0]->element = strdup("enabled");
+    nodes[0]->content = NULL;
+
+    expect_string(__wrap__merror, formatted_msg, "(1234): Invalid NULL content for element: enabled.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+}
+
+void test_Read_Logtest_invalid_enabled(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    nodes[0]->element = strdup("enabled");
+    nodes[0]->content = strdup("test");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'enabled': test.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+}
+
+void test_Read_Logtest_valid_enabled(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("enabled");
+    nodes[0]->content = strdup("yes");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_invalid_threads(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("threads");
+    nodes[0]->content = strdup("test");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'threads': test.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_smaller_threads(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("threads");
+    nodes[0]->content = strdup("-1");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'threads': -1.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_bigger_threads(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("threads");
+    nodes[0]->content = strdup("1000000");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'threads': 1000000.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_auto_threads(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("threads");
+    nodes[0]->content = strdup("auto");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_valid_threads(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("threads");
+    nodes[0]->content = strdup("64");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_invalid_max_sessions(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("max_sessions");
+    nodes[0]->content = strdup("test");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'max_sessions': test.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_smaller_max_sessions(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("max_sessions");
+    nodes[0]->content = strdup("-1");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'max_sessions': -1.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_bigger_max_sessions(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("max_sessions");
+    nodes[0]->content = strdup("1000000");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'max_sessions': 1000000.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_valid_max_sessions(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("max_sessions");
+    nodes[0]->content = strdup("1000000");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'max_sessions': 1000000.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_invalid_session_timeout(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("session_timeout");
+    nodes[0]->content = strdup("test");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'session_timeout': test.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_smaller_session_timeout(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("session_timeout");
+    nodes[0]->content = strdup("-1");
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1235): Invalid value for element 'session_timeout': -1.");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
+
+void test_Read_Logtest_valid_session_timeout(void **state)
+{
+    xml_node **nodes;
+    nodes = calloc(2, sizeof(xml_node*));
+    nodes[0] = calloc(1, sizeof(xml_node));
+
+    os_calloc(4, sizeof(char), logtest_conf.enabled);
+
+    nodes[0]->element = strdup("session_timeout");
+    nodes[0]->content = strdup("1000000");
+
+    int ret = Read_Logtest(nodes);
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(nodes[0]->element);
+    os_free(nodes[0]->content);
+    os_free(nodes[0]);
+    os_free(nodes);
+    os_free(logtest_conf.enabled);
+}
 
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        // Tests 
-
-    
+        // Tests Read_Logtest
+        cmocka_unit_test(test_Read_Logtest_invalid_element),
+        cmocka_unit_test(test_Read_Logtest_invalid_content),
+        cmocka_unit_test(test_Read_Logtest_invalid_enabled),
+        cmocka_unit_test(test_Read_Logtest_valid_enabled),
+        cmocka_unit_test(test_Read_Logtest_invalid_threads),
+        cmocka_unit_test(test_Read_Logtest_smaller_threads),
+        cmocka_unit_test(test_Read_Logtest_bigger_threads),
+        cmocka_unit_test(test_Read_Logtest_valid_threads),
+        cmocka_unit_test(test_Read_Logtest_invalid_max_sessions),
+        cmocka_unit_test(test_Read_Logtest_smaller_max_sessions),
+        cmocka_unit_test(test_Read_Logtest_bigger_max_sessions),
+        cmocka_unit_test(test_Read_Logtest_valid_max_sessions),
+        cmocka_unit_test(test_Read_Logtest_invalid_session_timeout),
+        cmocka_unit_test(test_Read_Logtest_smaller_session_timeout),
+        cmocka_unit_test(test_Read_Logtest_valid_session_timeout)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_logtest-config.c
+++ b/src/unit_tests/analysisd/test_logtest-config.c
@@ -154,7 +154,7 @@ void test_Read_Logtest_valid_enabled(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("enabled");
     nodes[0]->content = strdup("yes");
@@ -166,7 +166,7 @@ void test_Read_Logtest_valid_enabled(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_invalid_threads(void **state)
@@ -175,7 +175,7 @@ void test_Read_Logtest_invalid_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("test");
@@ -189,7 +189,7 @@ void test_Read_Logtest_invalid_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_auto_threads(void **state)
@@ -198,7 +198,7 @@ void test_Read_Logtest_auto_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("auto");
@@ -212,7 +212,7 @@ void test_Read_Logtest_auto_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_smaller_threads(void **state)
@@ -221,7 +221,7 @@ void test_Read_Logtest_smaller_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("-1");
@@ -235,7 +235,7 @@ void test_Read_Logtest_smaller_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_bigger_threads(void **state)
@@ -244,7 +244,7 @@ void test_Read_Logtest_bigger_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("1000000");
@@ -258,7 +258,7 @@ void test_Read_Logtest_bigger_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_limit_threads(void **state)
@@ -267,7 +267,7 @@ void test_Read_Logtest_limit_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("256");
@@ -281,7 +281,7 @@ void test_Read_Logtest_limit_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_valid_threads(void **state)
@@ -290,7 +290,7 @@ void test_Read_Logtest_valid_threads(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("threads");
     nodes[0]->content = strdup("64");
@@ -302,7 +302,7 @@ void test_Read_Logtest_valid_threads(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_invalid_max_sessions(void **state)
@@ -311,7 +311,7 @@ void test_Read_Logtest_invalid_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("test");
@@ -325,7 +325,7 @@ void test_Read_Logtest_invalid_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_smaller_max_sessions(void **state)
@@ -334,7 +334,7 @@ void test_Read_Logtest_smaller_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("-1");
@@ -348,7 +348,7 @@ void test_Read_Logtest_smaller_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_bigger_max_sessions(void **state)
@@ -357,7 +357,7 @@ void test_Read_Logtest_bigger_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("1000000");
@@ -371,7 +371,7 @@ void test_Read_Logtest_bigger_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_limit_max_sessions(void **state)
@@ -380,7 +380,7 @@ void test_Read_Logtest_limit_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("700");
@@ -394,7 +394,7 @@ void test_Read_Logtest_limit_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_valid_max_sessions(void **state)
@@ -403,7 +403,7 @@ void test_Read_Logtest_valid_max_sessions(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("max_sessions");
     nodes[0]->content = strdup("200");
@@ -415,7 +415,7 @@ void test_Read_Logtest_valid_max_sessions(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_invalid_session_timeout(void **state)
@@ -424,7 +424,7 @@ void test_Read_Logtest_invalid_session_timeout(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("session_timeout");
     nodes[0]->content = strdup("test");
@@ -438,7 +438,7 @@ void test_Read_Logtest_invalid_session_timeout(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_smaller_session_timeout(void **state)
@@ -447,7 +447,7 @@ void test_Read_Logtest_smaller_session_timeout(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("session_timeout");
     nodes[0]->content = strdup("-1");
@@ -461,7 +461,7 @@ void test_Read_Logtest_smaller_session_timeout(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_limit_session_timeout(void **state)
@@ -470,7 +470,7 @@ void test_Read_Logtest_limit_session_timeout(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("session_timeout");
     nodes[0]->content = strdup("32000000");
@@ -484,7 +484,7 @@ void test_Read_Logtest_limit_session_timeout(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_valid_session_timeout(void **state)
@@ -493,7 +493,7 @@ void test_Read_Logtest_valid_session_timeout(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("session_timeout");
     nodes[0]->content = strdup("1000000");
@@ -505,7 +505,7 @@ void test_Read_Logtest_valid_session_timeout(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 void test_Read_Logtest_invalid_element(void **state)
@@ -514,7 +514,7 @@ void test_Read_Logtest_invalid_element(void **state)
     nodes = calloc(2, sizeof(xml_node*));
     nodes[0] = calloc(1, sizeof(xml_node));
 
-    os_calloc(4, sizeof(char), logtest_conf.enabled);
+    os_calloc(4, sizeof(char), w_logtest_conf.enabled);
 
     nodes[0]->element = strdup("test");
     nodes[0]->content = strdup("unit_test");
@@ -528,7 +528,7 @@ void test_Read_Logtest_invalid_element(void **state)
     os_free(nodes[0]->content);
     os_free(nodes[0]);
     os_free(nodes);
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 /* getRuleTestConfig */
@@ -537,10 +537,10 @@ void test_getRuleTestConfig_OK(void **state)
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
-    os_strdup("yes", logtest_conf.enabled);
-    logtest_conf.threads = LOGTEST_LIMIT_THREAD;
-    logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
-    logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
+    os_strdup("yes", w_logtest_conf.enabled);
+    w_logtest_conf.threads = LOGTEST_LIMIT_THREAD;
+    w_logtest_conf.max_sessions = LOGTEST_LIMIT_MAX_SESSIONS;
+    w_logtest_conf.session_timeout = LOGTEST_LIMIT_SESSION_TIMEOUT;
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "enabled");
     expect_string(__wrap_cJSON_AddStringToObject, string, "yes");
@@ -563,7 +563,7 @@ void test_getRuleTestConfig_OK(void **state)
 
     cJSON* ret = getRuleTestConfig();
 
-    os_free(logtest_conf.enabled);
+    os_free(w_logtest_conf.enabled);
 }
 
 int main(void)

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -104,7 +104,7 @@ void test_w_logtest_init_parameters_invalid(void **state)
     will_return(__wrap_ReadConfig, OS_INVALID);
 
     int ret = w_logtest_init_parameters();
-    assert_int_equal(ret, -1);
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_w_logtest_init_parameters_done(void **state)
@@ -112,7 +112,7 @@ void test_w_logtest_init_parameters_done(void **state)
     will_return(__wrap_ReadConfig, 0);
 
     int ret = w_logtest_init_parameters();
-    assert_int_equal(ret, 0);
+    assert_int_equal(ret, OS_SUCCESS);
 }
 
 /* w_logtest_init */

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../headers/shared.h"
+#include "../../analysisd/logtest.h"
+
+int w_logtest_init_parameters();
+void *w_logtest_init();
+
+/* setup/teardown */
+
+
+
+/* wraps */
+
+int __wrap_OS_BindUnixDomain(const char *path, int type, int max_msg_size) {
+    return mock();
+}
+
+int __wrap_accept(int __fd, __SOCKADDR_ARG __addr, socklen_t *__restrict __addr_len) {
+    return mock();
+}
+
+void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+int __wrap_pthread_mutex_init() {
+    return mock();
+}
+
+int __wrap_pthread_mutex_lock() {
+    return mock();
+}
+
+int __wrap_pthread_mutex_unlock() {
+    return mock();
+}
+
+int __wrap_pthread_mutex_destroy() {
+    return mock();
+}
+
+int __wrap_ReadConfig(int modules, const char *cfgfile, void *d1, void *d2) {
+    return mock();
+}
+
+OSHash *__wrap_OSHash_Create() {
+    return mock_type(OSHash *);
+}
+
+void __wrap__minfo(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+void __wrap_w_mutex_init() {
+    return;
+}
+
+void __wrap_w_mutex_destroy() {
+    return;
+}
+
+void __wrap_w_create_thread() {
+    return;
+}
+
+int __wrap_close (int __fd) {
+    return mock();
+}
+
+/* tests */
+
+/* w_logtest_init_parameters */
+
+void test_w_logtest_init_parameters_invalid(void **state)
+{
+    will_return(__wrap_ReadConfig, OS_INVALID);
+
+    int ret = w_logtest_init_parameters();
+    assert_int_equal(ret, -1);
+}
+
+void test_w_logtest_init_parameters_done(void **state)
+{
+    will_return(__wrap_ReadConfig, 0);
+
+    int ret = w_logtest_init_parameters();
+    assert_int_equal(ret, 0);
+}
+
+/* w_logtest_init */
+void test_w_logtest_init_error_parameters(void **state)
+{
+    will_return(__wrap_ReadConfig, OS_INVALID);
+
+    expect_string(__wrap__merror, formatted_msg, "(7104): Invalid wazuh-logtest configuration");
+
+    w_logtest_init();
+}
+
+
+void test_w_logtest_init_logtest_disabled(void **state)
+{
+    strcpy(logtest_conf.enabled, "no");
+
+    will_return(__wrap_ReadConfig, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "(7100): At wazuh_logtest_init(): Unable to bind to socket '/queue/ossec/logtest'. Errno: (2) No such file or directory");
+
+    w_logtest_init();
+}
+
+void test_w_logtest_init_conection_fail(void **state)
+{
+    strcpy(logtest_conf.enabled, "yes");
+
+    will_return(__wrap_ReadConfig, 0);
+
+    will_return(__wrap_OS_BindUnixDomain, OS_SOCKTERR);
+
+    expect_string(__wrap__merror, formatted_msg, "(7100): At wazuh_logtest_init(): Unable to bind to socket '/queue/ossec/logtest'. Errno: (0) Success");
+
+    w_logtest_init();
+}
+
+void test_w_logtest_init_OSHash_create_fail(void **state)
+{
+    strcpy(logtest_conf.enabled, "yes");
+
+    will_return(__wrap_ReadConfig, 0);
+
+    will_return(__wrap_OS_BindUnixDomain, OS_SUCCESS);
+
+    will_return(__wrap_OSHash_Create, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "(7103): Failure to initialize all_sesssions hash");
+
+    w_logtest_init();
+}
+
+// void test_w_logtest_init_done(void **state) -> Needs to implement w_logtest_main
+
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests w_logtest_init_parameters
+        cmocka_unit_test(test_w_logtest_init_parameters_invalid),
+        cmocka_unit_test(test_w_logtest_init_parameters_done),
+        // Tests w_logtest_init
+        cmocka_unit_test(test_w_logtest_init_error_parameters),
+        //cmocka_unit_test(test_w_logtest_init_logtest_disabled),
+        cmocka_unit_test(test_w_logtest_init_conection_fail),
+        cmocka_unit_test(test_w_logtest_init_OSHash_create_fail),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -136,7 +136,7 @@ void test_w_logtest_init_logtest_disabled(void **state)
 {
     will_return(__wrap_ReadConfig, 0);
 
-    // strcpy(logtest_conf.enabled, "no");
+    strcpy(logtest_conf.enabled, "no");
 
     expect_string(__wrap__minfo, formatted_msg, "(7201): Logtest disabled");
 
@@ -184,7 +184,6 @@ int main(void)
         cmocka_unit_test(test_w_logtest_init_parameters_done),
         // Tests w_logtest_init
         cmocka_unit_test(test_w_logtest_init_error_parameters),
-        //cmocka_unit_test(test_w_logtest_init_logtest_disabled),
         cmocka_unit_test(test_w_logtest_init_conection_fail),
         cmocka_unit_test(test_w_logtest_init_OSHash_create_fail),
     };

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -105,6 +105,8 @@ void test_w_logtest_init_parameters_invalid(void **state)
 
     int ret = w_logtest_init_parameters();
     assert_int_equal(ret, OS_INVALID);
+
+    os_free(logtest_conf.enabled);
 }
 
 void test_w_logtest_init_parameters_done(void **state)
@@ -113,6 +115,8 @@ void test_w_logtest_init_parameters_done(void **state)
 
     int ret = w_logtest_init_parameters();
     assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(logtest_conf.enabled);
 }
 
 /* w_logtest_init */
@@ -123,24 +127,26 @@ void test_w_logtest_init_error_parameters(void **state)
     expect_string(__wrap__merror, formatted_msg, "(7104): Invalid wazuh-logtest configuration");
 
     w_logtest_init();
+
+    os_free(logtest_conf.enabled);
 }
 
 
 void test_w_logtest_init_logtest_disabled(void **state)
 {
-    strcpy(logtest_conf.enabled, "no");
-
     will_return(__wrap_ReadConfig, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "(7100): At wazuh_logtest_init(): Unable to bind to socket '/queue/ossec/logtest'. Errno: (2) No such file or directory");
+    // strcpy(logtest_conf.enabled, "no");
+
+    expect_string(__wrap__minfo, formatted_msg, "(7201): Logtest disabled");
 
     w_logtest_init();
+
+    os_free(logtest_conf.enabled);
 }
 
 void test_w_logtest_init_conection_fail(void **state)
 {
-    strcpy(logtest_conf.enabled, "yes");
-
     will_return(__wrap_ReadConfig, 0);
 
     will_return(__wrap_OS_BindUnixDomain, OS_SOCKTERR);
@@ -148,12 +154,12 @@ void test_w_logtest_init_conection_fail(void **state)
     expect_string(__wrap__merror, formatted_msg, "(7100): At wazuh_logtest_init(): Unable to bind to socket '/queue/ossec/logtest'. Errno: (0) Success");
 
     w_logtest_init();
+
+    os_free(logtest_conf.enabled);
 }
 
 void test_w_logtest_init_OSHash_create_fail(void **state)
 {
-    strcpy(logtest_conf.enabled, "yes");
-
     will_return(__wrap_ReadConfig, 0);
 
     will_return(__wrap_OS_BindUnixDomain, OS_SUCCESS);
@@ -163,6 +169,8 @@ void test_w_logtest_init_OSHash_create_fail(void **state)
     expect_string(__wrap__merror, formatted_msg, "(7103): Failure to initialize all_sesssions hash");
 
     w_logtest_init();
+
+    os_free(logtest_conf.enabled);
 }
 
 // void test_w_logtest_init_done(void **state) -> Needs to implement w_logtest_main

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -64,7 +64,7 @@ int __wrap_pthread_mutex_destroy() {
 
 int __wrap_ReadConfig(int modules, const char *cfgfile, void *d1, void *d2) {
     if (!logtest_enabled) {
-        strcpy(w_logtest_conf.enabled,"no");
+        w_logtest_conf.enabled = false;
     }
     return mock();
 }
@@ -110,8 +110,6 @@ void test_w_logtest_init_parameters_invalid(void **state)
 
     int ret = w_logtest_init_parameters();
     assert_int_equal(ret, OS_INVALID);
-
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_w_logtest_init_parameters_done(void **state)
@@ -120,8 +118,6 @@ void test_w_logtest_init_parameters_done(void **state)
 
     int ret = w_logtest_init_parameters();
     assert_int_equal(ret, OS_SUCCESS);
-
-    os_free(w_logtest_conf.enabled);
 }
 
 /* w_logtest_init */
@@ -132,8 +128,6 @@ void test_w_logtest_init_error_parameters(void **state)
     expect_string(__wrap__merror, formatted_msg, "(7304): Invalid wazuh-logtest configuration");
 
     w_logtest_init();
-
-    os_free(w_logtest_conf.enabled);
 }
 
 
@@ -147,7 +141,6 @@ void test_w_logtest_init_logtest_disabled(void **state)
 
     w_logtest_init();
 
-    os_free(w_logtest_conf.enabled);
     logtest_enabled = 1;
 }
 
@@ -160,8 +153,6 @@ void test_w_logtest_init_conection_fail(void **state)
     expect_string(__wrap__merror, formatted_msg, "(7300): Unable to bind to socket '/queue/ossec/logtest'. Errno: (0) Success");
 
     w_logtest_init();
-
-    os_free(w_logtest_conf.enabled);
 }
 
 void test_w_logtest_init_OSHash_create_fail(void **state)
@@ -175,8 +166,6 @@ void test_w_logtest_init_OSHash_create_fail(void **state)
     expect_string(__wrap__merror, formatted_msg, "(7303): Failure to initialize all_sesssions hash");
 
     w_logtest_init();
-
-    os_free(w_logtest_conf.enabled);
 }
 
 // void test_w_logtest_init_done(void **state) -> Needs to implement w_logtest_main

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -63,8 +63,7 @@ int __wrap_pthread_mutex_destroy() {
 }
 
 int __wrap_ReadConfig(int modules, const char *cfgfile, void *d1, void *d2) {
-    if (!logtest_enabled)
-    {
+    if (!logtest_enabled) {
         strcpy(w_logtest_conf.enabled,"no");
     }
     return mock();


### PR DESCRIPTION
|Related issue|
|---|
|[5408](https://github.com/wazuh/wazuh/issues/5408)|

Hello team!

This PR add the configuration for new wazuh-logtest functionality. An example of a valid configuration could be has follow:

```xml
<rule_test>
  <enabled>yes</enabled>
  <threads>auto</threads>
  <max_sessions>200</max_sessions>
  <session_timeout>1h</session_timeout>
</rule_test>
``` 

The following table describe the rule_test options:
| Option | Description | Default value | Values allowed |
| --- | --- | --- | --- |
|`enable`| determine if Logtest is enabled or disabled | yes | yes/no |
|`threads`| number of `wazuh-logtest` threads | 1 | a number between 1 and 128, or `auto` to create one thread per CPU|
|`max_sessions`| number of users connected simultaneously | 64 | a number between 1 and 65534|
|`session_timeout`| time interval in which a client must remain offline to remove the resources associated with their session | 15m | a number to represent seconds, to represent the interval in minutes adds `m`, or `h` to represent the interval in hours. 


Best regards,
Eva

***
## Test

- [x] Compilation without warnings in Linux
- [x] Review logs syntax and correct language
- [x] Scan-build report
- [x] Valgrind (memcheck and descriptor leaks check)
- [x] If the configuration is invalid, Logtest stop but Wazuh still runs
- [x] The configuration options are following the permitted parameters mentioned above
- [x] Wazuh send logtest configuration
- [x] Integration test
- [x] Unit test