### PR TITLE
Adding new dbsync APIs exposure for FIM use cases purpose

### DIFF
--- a/src/dbsync/dbsync_doxygen.conf
+++ b/src/dbsync/dbsync_doxygen.conf
@@ -2214,7 +2214,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: YES.
 
-HAVE_DOT               = YES
+HAVE_DOT               = NO
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of

--- a/src/dbsync/include/dbsync.h
+++ b/src/dbsync/include/dbsync.h
@@ -73,10 +73,10 @@ EXPORTED void dbsync_teardown(void);
  * @details If the max queue size is reached then this will be processed synchronously.
  */
 EXPORTED TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE handle,
-                                              const char**        tables,
-                                              const int           thread_number,
-                                              const int           max_queue_size,
-                                              void*               callback);
+                                      const char**        tables,
+                                      const int           thread_number,
+                                      const int           max_queue_size,
+                                      void*               callback);
 
 /**
  * @brief Closes the \p txn database transaction.

--- a/src/dbsync/include/dbsync.h
+++ b/src/dbsync/include/dbsync.h
@@ -61,50 +61,52 @@ EXPORTED void dbsync_teardown(void);
 /**
  * @brief Creates a database transaction based on the supplied information.
  *
- * @param handle         Handle assigned as part of the \ref dbsync_create method.
+ * @param handle         Handle obtained from the \ref dbsync_create method call.
  * @param tables         Tables to be created in the transaction.
- * @param thread_number  Number of worker threads for processing data.
- * @param max_queue_size Max data number to hold/queue to be processed. If 0 hardware concurrency
+ * @param thread_number  Number of worker threads for processing data. If 0 hardware concurrency
  *                       value will be used.
- * @param callback       Associated function callback with the results.
+ * @param max_queue_size Max data number to hold/queue to be processed.
+ * @param callback       This callback will be called for each result.
  *
- * @return Resulting database transaction after tables creation.
+ * @return Handle instance to be used in transacted operations.
+ *
+ * @details If the max queue size is reached then this will be processed synchronously.
  */
-EXPORTED TXN_HANDLE dbsync_create_transaction(const DBSYNC_HANDLE handle,
+EXPORTED TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE handle,
                                               const char**        tables,
                                               const int           thread_number,
                                               const int           max_queue_size,
                                               void*               callback);
 
 /**
- * @brief Closes the \ref txn database transaction.
+ * @brief Closes the \p txn database transaction.
  *
  * @param txn Database transaction to be closed.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
  */
-EXPORTED int dbsync_close_transaction(const TXN_HANDLE txn);
+EXPORTED int dbsync_close_txn(const TXN_HANDLE txn);
 
 /**
- * @brief Synchronizes the \ref js_input data using the \ref txn current
+ * @brief Synchronizes the \p js_input data using the \p txn current
  *  database transaction.
  *
  * @param txn      Database transaction to be used for \ref js_input data sync.
- * @param js_input JSON information to be inserted.
+ * @param js_input JSON information to be synchronized.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
  */
 EXPORTED int dbsync_sync_txn_row(const TXN_HANDLE txn,
-                                 const cJSON*    js_input);
+                                 const cJSON*     js_input);
 
 /**
  * @brief Inserts into an auxiliary table the information to be associated accordingly.
  *
  * @param handle        Handle assigned as part of the \ref dbsync_create method.
  * @param table         Table to be added.
- * @param parent_table  Parent table to be associated with \ref table one.
+ * @param parent_table  Parent table to be associated with \p table one.
  * @param key_base      Unique key to be assigned.
  * @param parent_field  Parent table field to be associated.
  *
@@ -118,10 +120,10 @@ EXPORTED int dbsync_add_table_relationship(const DBSYNC_HANDLE handle,
                                            const char*         parent_field);
 
 /**
- * @brief Insert the \ref js_insert data in the database.
+ * @brief Insert the \p js_insert data in the database.
  *
  * @param handle    Handle assigned as part of the \ref dbsync_create method().
- * @param js_insert JSON information with snapshot values.
+ * @param js_insert JSON information with values to be inserted.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
@@ -130,11 +132,11 @@ EXPORTED int dbsync_insert_data(const DBSYNC_HANDLE handle,
                                 const cJSON*        js_insert);
 
 /**
- * @brief Sets the max rows in the \ref table table.
+ * @brief Sets the max rows in the \p table table.
  *
  * @param handle   Handle assigned as part of the \ref dbsync_create method().
  * @param table    Table name to apply the max rows configuration.
- * @param max_rows Max rows number to be applied in the table \ref table table.
+ * @param max_rows Max rows number to be applied in the table \p table table.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
@@ -150,7 +152,7 @@ EXPORTED int dbsync_set_table_max_rows(const DBSYNC_HANDLE      handle,
  *
  * @param handle    Handle instance assigned as part of the \ref dbsync_create method().
  * @param input     JSON information used to add/modified a database record.
- * @param callback  Associated function callback with the results.
+ * @param callback  This callback will be called for each result.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
@@ -160,11 +162,11 @@ EXPORTED int dbsync_sync_row(const DBSYNC_HANDLE handle,
                              void*               callback);
 
 /**
- * @brief Select data, based in \ref json_data_input data, from the database table.
+ * @brief Select data, based in \p json_data_input data, from the database table.
  *
  * @param handle        Handle assigned as part of the \ref dbsync_create method().
  * @param js_data_input JSON with table name, fields and filters to apply in the query.
- * @param callback      Associated function callback with the results.
+ * @param callback      This callback will be called for each result.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
@@ -174,7 +176,7 @@ EXPORTED int dbsync_select_rows(const DBSYNC_HANDLE handle,
                                 void*               callback);
 
 /**
- * @brief Deletes a database table record and its relationships based on \ref js_key_values value.
+ * @brief Deletes a database table record and its relationships based on \p js_key_values value.
  *
  * @param handle        Handle instance assigned as part of the \ref dbsync_create method().
  * @param js_key_values JSON information to be applied/deleted in the database.
@@ -189,7 +191,7 @@ EXPORTED int dbsync_delete_rows(const DBSYNC_HANDLE handle,
  * @brief Gets the deleted rows (diff) from the database.
  *
  * @param txn      Database transaction to be used.
- * @param callback Associated function callback with the results.
+ * @param callback This callback will be called for each result.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
@@ -198,7 +200,7 @@ EXPORTED int dbsync_get_deleted_rows(const TXN_HANDLE txn,
                                      void*            callback);
 
 /**
- * @brief Updates data table with \ref js_snapshot information. \ref js_result value will
+ * @brief Updates data table with \p js_snapshot information. \p js_result value will
  *  hold/contain the results of this operation (rows insertion, modification and/or deletion).
  *
  * @param handle      Handle instance assigned as part of the \ref dbsync_create method().
@@ -207,6 +209,8 @@ EXPORTED int dbsync_get_deleted_rows(const TXN_HANDLE txn,
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
+ *
+ * @details The \p js_result resulting data should be freed using the \ref dbsync_free_result function.
  */
 EXPORTED int dbsync_update_with_snapshot(const DBSYNC_HANDLE handle,
                                          const cJSON*        js_snapshot,
@@ -217,7 +221,7 @@ EXPORTED int dbsync_update_with_snapshot(const DBSYNC_HANDLE handle,
  *
  * @param handle      Handle assigned as part of the \ref dbsync_create method().
  * @param js_snapshot JSON with snapshot values.
- * @param callback    Associated function callback with the results.
+ * @param callback    This callback will be called for each result.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
@@ -230,6 +234,9 @@ EXPORTED int dbsync_update_with_snapshot(const DBSYNC_HANDLE handle,
  * @brief Deallocate cJSON result data.
  *
  * @param js_data JSON information be be deallocated.
+ *
+ * @details This function should only be used to free result objects obtained
+ *  from the interface.
  */
   EXPORTED void dbsync_free_result(cJSON** js_data);
 

--- a/src/dbsync/include/dbsync.h
+++ b/src/dbsync/include/dbsync.h
@@ -76,7 +76,7 @@ EXPORTED TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE handle,
                                       const char**        tables,
                                       const int           thread_number,
                                       const int           max_queue_size,
-                                      void*               callback);
+                                      result_callback_t   callback);
 
 /**
  * @brief Closes the \p txn database transaction.
@@ -159,7 +159,7 @@ EXPORTED int dbsync_set_table_max_rows(const DBSYNC_HANDLE      handle,
  */
 EXPORTED int dbsync_sync_row(const DBSYNC_HANDLE handle,
                              const cJSON*        js_input,
-                             void*               callback);
+                             result_callback_t   callback);
 
 /**
  * @brief Select data, based in \p json_data_input data, from the database table.
@@ -173,7 +173,7 @@ EXPORTED int dbsync_sync_row(const DBSYNC_HANDLE handle,
  */
 EXPORTED int dbsync_select_rows(const DBSYNC_HANDLE handle,
                                 const cJSON*        js_data_input,
-                                void*               callback);
+                                result_callback_t   callback);
 
 /**
  * @brief Deletes a database table record and its relationships based on \p js_key_values value.
@@ -196,8 +196,8 @@ EXPORTED int dbsync_delete_rows(const DBSYNC_HANDLE handle,
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
  */
-EXPORTED int dbsync_get_deleted_rows(const TXN_HANDLE txn,
-                                     void*            callback);
+EXPORTED int dbsync_get_deleted_rows(const TXN_HANDLE  txn,
+                                     result_callback_t callback);
 
 /**
  * @brief Updates data table with \p js_snapshot information. \p js_result value will

--- a/src/dbsync/include/typedef.h
+++ b/src/dbsync/include/typedef.h
@@ -9,46 +9,64 @@
  * Foundation.
  */
 
-/**
- * @file typedef.h
- * @author Dwordcito
- * @date 17 May 2020
- * @brief File containing declaration for common types for the usage of this module
- *
- */
-
-#pragma once
+#ifndef _DBSYNC_TYPEDEF_H_
+#define _DBSYNC_TYPEDEF_H_
 
 #include "cJSON.h"
 
+/**
+ * @brief Represents the different host types to be used.
+ */
 typedef enum 
 {
-    MANAGER = 0,
-    AGENT = 1
+    MANAGER = 0,    /*< Manager host type. */
+    AGENT   = 1     /*< Agent host type.   */
 }HostType;
 
+/**
+ * @brief Represents the database type to be used.
+ */
 typedef enum 
 {
-    UNDEFINED = 0,
-    SQLITE3 = 1,
+    UNDEFINED = 0,  /*< Undefined database. */
+    SQLITE3   = 1,  /*< SQLite3 database.   */
 }DbEngineType;
 
+/**
+ * @brief Represents the database operation events.
+ */
 typedef enum 
 {
-    MODIFIED = 0,
-    DELETED = 1,
-    INSERTED = 2
+    MODIFIED = 0,   /*< Database modificaton operation. */
+    DELETED  = 1,   /*< Database deletion operation.    */
+    INSERTED = 2    /*< Database insertion operation.   */
 }ReturnTypeCallback;
 
+/**
+ * @brief Represents the handle associated with database creation.
+ */
 typedef void* DBSYNC_HANDLE;
 
 /**
- * \brief Callback function for results
+ * @brief Represents the transaction handle associated with database instance.
+ */
+typedef void* TXN_HANDLE;
+
+/**
+ * @brief Callback function for results
  *
- * This callback is called for each result obtained, after evaluating changes between two snapshots.
- * \param result_type Enumeration value indicating what action was taken.
- * \param result_json Json which describe the change.
+ * Callback called for each result obtained, after evaluating changes between two snapshots.
+ * @param result_type Enumeration value indicating what action was taken.
+ * @param result_json Json which describe the change.
  */
 typedef void((*result_callback)(ReturnTypeCallback result_type, cJSON* result_json));
 
+/**
+ * @brief Callback function for user defined logging.
+ *
+ * Callback called to get deeper information during the dbsync interaction.
+ * @param msg Message to be logged.
+ */
 typedef void((*log_fnc_t)(const char* msg));
+
+#endif // _DBSYNC_TYPEDEF_H_

--- a/src/dbsync/include/typedef.h
+++ b/src/dbsync/include/typedef.h
@@ -19,8 +19,8 @@
  */
 typedef enum 
 {
-    MANAGER = 0,    /*< Manager host type. */
-    AGENT   = 1     /*< Agent host type.   */
+    MANAGER = 0,
+    AGENT   = 1
 }HostType;
 
 /**
@@ -48,24 +48,26 @@ typedef enum
 typedef void* DBSYNC_HANDLE;
 
 /**
- * @brief Represents the transaction handle associated with database instance.
+ * @brief Represents the transaction handle associated with a database instance.
  */
 typedef void* TXN_HANDLE;
 
 /**
  * @brief Callback function for results
  *
- * Callback called for each result obtained, after evaluating changes between two snapshots.
  * @param result_type Enumeration value indicating what action was taken.
  * @param result_json Json which describe the change.
+ *
+ * @details Callback called for each obtained result, after evaluating changes between two snapshots.
  */
-typedef void((*result_callback)(ReturnTypeCallback result_type, cJSON* result_json));
+typedef void((*result_callback_t)(ReturnTypeCallback result_type, cJSON* result_json));
 
 /**
  * @brief Callback function for user defined logging.
  *
- * Callback called to get deeper information during the dbsync interaction.
  * @param msg Message to be logged.
+ *
+ * @details Useful to get deeper information during the dbsync interaction.
  */
 typedef void((*log_fnc_t)(const char* msg));
 

--- a/src/dbsync/src/dbsync.cpp
+++ b/src/dbsync/src/dbsync.cpp
@@ -92,7 +92,7 @@ TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE /*handle*/,
                              const char**        /*tables*/,
                              const int           /*thread_number*/,
                              const int           /*max_queue_size*/,
-                             void*               /*callback*/)
+                             result_callback_t   /*callback*/)
 {
     // Dummy function for now.
     return nullptr;
@@ -168,7 +168,7 @@ int dbsync_set_table_max_rows(const DBSYNC_HANDLE      /*handle*/,
 
 int dbsync_sync_row(const DBSYNC_HANDLE /*handle*/,
                     const cJSON*        /*js_input*/,
-                    void*               /*callback*/)
+                    result_callback_t   /*callback*/)
 {
     // Dummy function for now.
     return 0;
@@ -176,7 +176,7 @@ int dbsync_sync_row(const DBSYNC_HANDLE /*handle*/,
 
 int dbsync_select_rows(const DBSYNC_HANDLE /*handle*/,
                        const cJSON*        /*js_data_input*/,
-                       void*               /*callback*/)
+                       result_callback_t   /*callback*/)
 {
     // Dummy function for now.
     return 0;
@@ -189,8 +189,8 @@ int dbsync_delete_rows(const DBSYNC_HANDLE /*handle*/,
     return 0;
 }
 
-int dbsync_get_deleted_rows(const TXN_HANDLE /*txn*/,
-                            void*           /*callback*/)
+int dbsync_get_deleted_rows(const TXN_HANDLE  /*txn*/,
+                            result_callback_t /*callback*/)
 {
     // Dummy function for now.
     return 0;

--- a/src/dbsync/src/dbsync.cpp
+++ b/src/dbsync/src/dbsync.cpp
@@ -88,17 +88,17 @@ void dbsync_teardown(void)
     DBSyncImplementation::instance().release();
 }
 
-TXN_HANDLE dbsync_create_transaction(const DBSYNC_HANDLE /*handle*/,
-                                    const char**         /*tables*/,
-                                    const int            /*thread_number*/,
-                                    const int            /*max_queue_size*/,
-                                    void*                /*callback*/)
+TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE /*handle*/,
+                             const char**        /*tables*/,
+                             const int           /*thread_number*/,
+                             const int           /*max_queue_size*/,
+                             void*               /*callback*/)
 {
     // Dummy function for now.
     return nullptr;
 }
 
-int dbsync_close_transaction(const TXN_HANDLE /*txn*/)
+int dbsync_close_txn(const TXN_HANDLE /*txn*/)
 {
     // Dummy function for now.
     return 0;

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -15,13 +15,13 @@
 #include <fstream>
 
 void SQLiteDBEngine::execute(
-    const std::string& query) {
-}
+    const std::string& /*query*/)
+{}
 
 void SQLiteDBEngine::select(
-    const std::string& query, 
-    nlohmann::json& result) {
-}
+    const std::string& /*query*/,
+    nlohmann::json& /*result*/)
+{}
 
 
 SQLiteDBEngine::SQLiteDBEngine(

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -274,7 +274,7 @@ bool SQLiteDBEngine::removeNotExistsRows(
         }
         auto callback { std::get<ResponseType::RT_CALLBACK>(delta) };
         if (nullptr != callback) {
-          result_callback Notify = reinterpret_cast<result_callback>(callback);
+          result_callback_t Notify = reinterpret_cast<result_callback_t>(callback);
           cJSON* json_result { cJSON_Parse(object.dump().c_str()) };
           Notify(ReturnTypeCallback::DELETED, json_result);
           cJSON_Delete(json_result);
@@ -532,7 +532,7 @@ bool SQLiteDBEngine::insertNewRows(
         }
         auto callback { std::get<ResponseType::RT_CALLBACK>(delta) };
         if (nullptr != callback) {
-          result_callback Notify = reinterpret_cast<result_callback>(callback);
+          result_callback_t Notify = reinterpret_cast<result_callback_t>(callback);
           cJSON* json_result { cJSON_Parse(object.dump().c_str()) };
           Notify(ReturnTypeCallback::INSERTED, json_result);
           cJSON_Delete(json_result);
@@ -591,7 +591,7 @@ int SQLiteDBEngine::changeModifiedRows(
         }
         auto callback { std::get<ResponseType::RT_CALLBACK>(delta) };
         if (nullptr != callback) {
-          result_callback Notify = reinterpret_cast<result_callback>(callback);
+          result_callback_t Notify = reinterpret_cast<result_callback_t>(callback);
           cJSON* json_result { cJSON_Parse(object.dump().c_str()) };
           Notify(ReturnTypeCallback::MODIFIED, json_result);
           cJSON_Delete(json_result);

--- a/src/dbsync/testtool/cmdArgsHelper.h
+++ b/src/dbsync/testtool/cmdArgsHelper.h
@@ -49,7 +49,7 @@ public:
                   << "\t-c JSON_CONFIG_FILE\tSpecifies the json config file to initialize the database.\n"
                   << "\t-s SNAPSHOT_LIST\tSpecifies the list of snapshots to exercise the dabase.\n"
                   << "\t-o OUTPUT_FOLDER\tSpecifies the output folder path where the results will be generated.\n"         
-                  << "\n Example:"
+                  << "\nExample:"
                   << "\n\t./dbsync_test_tool -c config.json -s input1.json,input2.json,input3.json -o ./output\n"
                   << std::endl;
     }


### PR DESCRIPTION
|Related issue|
|---|
|[5414](https://github.com/wazuh/wazuh/issues/5414)|
## Description

Adding the proposed interface dbsync APIs to cover FIM uses cases. Right now all new APIs have dummy implementation but complete doxygen documentation ([Here](https://github.com/wazuh/wazuh/issues/5414#issuecomment-655062196) for more details). The main idea of doing it on this wait it to have better control and granularity in near future changes. 

