### PR TITLE
Changes in decoder functions, rules and CDBlist for wazuh-Logtest

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -499,9 +499,9 @@ int main_analysisd(int argc, char **argv)
 
     Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", MIN_ORDER_SIZE, MAX_DECODER_ORDER_SIZE);
 
-    if (!last_events_list) {
-        os_calloc(1, sizeof(EventList), last_events_list);
-        OS_CreateEventList(Config.memorysize, last_events_list);
+    if (!os_analysisd_last_events) {
+        os_calloc(1, sizeof(EventList), os_analysisd_last_events);
+        OS_CreateEventList(Config.memorysize, os_analysisd_last_events);
     }
 
     /*
@@ -585,7 +585,7 @@ int main_analysisd(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading rules file: '%s'", *rulesfiles);
                     }
-                    if (Rules_OP_ReadRules(*rulesfiles, &rulenode, &global_listnode) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists) < 0) {
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }
 
@@ -602,7 +602,7 @@ int main_analysisd(int argc, char **argv)
              * search thought the list of lists for the correct file during
              * rule evaluation.
              */
-            OS_ListLoadRules(&global_listnode);
+            OS_ListLoadRules(&os_analysisd_cdblists);
         }
     }
 
@@ -1339,7 +1339,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->srcip) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->srcip, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->srcip, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1347,7 +1347,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->srcport) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->srcport, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->srcport, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1355,7 +1355,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->dstip) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->dstip, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->dstip, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1363,17 +1363,17 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->dstport) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->dstport, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->dstport, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
                 case RULE_USER:
                     if (lf->srcuser) {
-                        if (!OS_DBSearch(list_holder, lf->srcuser, global_listnode)) {
+                        if (!OS_DBSearch(list_holder, lf->srcuser, os_analysisd_cdblists)) {
                             return (NULL);
                         }
                     } else if (lf->dstuser) {
-                        if (!OS_DBSearch(list_holder, lf->dstuser, global_listnode)) {
+                        if (!OS_DBSearch(list_holder, lf->dstuser, os_analysisd_cdblists)) {
                             return (NULL);
                         }
                     } else {
@@ -1384,7 +1384,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->url) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->url, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->url, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1392,7 +1392,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->id) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->id, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->id, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1400,7 +1400,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->hostname) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->hostname, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->hostname, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1408,7 +1408,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->program_name) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->program_name, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->program_name, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1416,7 +1416,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->status) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->status, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->status, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1424,7 +1424,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->action) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->action, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->action, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1432,7 +1432,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->systemname) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->systemname, global_listnode)){
+                    if (!OS_DBSearch(list_holder, lf->systemname, os_analysisd_cdblists)){
                         return (NULL);
                     }
                     break;
@@ -1440,7 +1440,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->protocol) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->protocol, global_listnode)){
+                    if (!OS_DBSearch(list_holder, lf->protocol, os_analysisd_cdblists)){
                         return (NULL);
                     }
                     break;
@@ -1448,7 +1448,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->data) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->data, global_listnode)){
+                    if (!OS_DBSearch(list_holder, lf->data, os_analysisd_cdblists)){
                         return (NULL);
                     }
                     break;
@@ -1456,14 +1456,14 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->extra_data) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->extra_data, global_listnode)) {
+                    if (!OS_DBSearch(list_holder, lf->extra_data, os_analysisd_cdblists)) {
                         return (NULL);
                     }
                     break;
                 case RULE_DYNAMIC:
                     field = FindField(lf, list_holder->dfield);
 
-                    if (!(field &&OS_DBSearch(list_holder, (char*)field, global_listnode)))
+                    if (!(field &&OS_DBSearch(list_holder, (char*)field, os_analysisd_cdblists)))
                         return NULL;
 
                     break;
@@ -2581,7 +2581,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
             os_calloc(1, sizeof(Eventinfo), lf_logall);
             w_copy_event_for_log(lf, lf_logall);
             w_free_event_info(lf);
-            OS_AddEvent(lf, last_events_list);
+            OS_AddEvent(lf, os_analysisd_last_events);
             break;
 
         } while ((rulenode_pt = rulenode_pt->next) != NULL);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -57,7 +57,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
 static void LoopRule(RuleNode *curr_node, FILE *flog);
 
 /* For decoders */
-void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match);
+void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *node);
 int DecodeSyscheck(Eventinfo *lf, _sdb *sdb);
 // Decode events in json format
 int decode_fim_event(_sdb *sdb, Eventinfo *lf);
@@ -585,7 +585,7 @@ int main_analysisd(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading rules file: '%s'", *rulesfiles);
                     }
-                    if (Rules_OP_ReadRules(*rulesfiles) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, rulenode, &global_listnode) < 0) {
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }
 
@@ -602,7 +602,7 @@ int main_analysisd(int argc, char **argv)
              * search thought the list of lists for the correct file during
              * rule evaluation.
              */
-            OS_ListLoadRules();
+            OS_ListLoadRules(&global_listnode);
         }
     }
 
@@ -1339,7 +1339,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->srcip) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->srcip)) {
+                    if (!OS_DBSearch(list_holder, lf->srcip, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1347,7 +1347,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->srcport) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->srcport)) {
+                    if (!OS_DBSearch(list_holder, lf->srcport, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1355,7 +1355,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->dstip) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->dstip)) {
+                    if (!OS_DBSearch(list_holder, lf->dstip, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1363,17 +1363,17 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->dstport) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->dstport)) {
+                    if (!OS_DBSearch(list_holder, lf->dstport, global_listnode)) {
                         return (NULL);
                     }
                     break;
                 case RULE_USER:
                     if (lf->srcuser) {
-                        if (!OS_DBSearch(list_holder, lf->srcuser)) {
+                        if (!OS_DBSearch(list_holder, lf->srcuser, global_listnode)) {
                             return (NULL);
                         }
                     } else if (lf->dstuser) {
-                        if (!OS_DBSearch(list_holder, lf->dstuser)) {
+                        if (!OS_DBSearch(list_holder, lf->dstuser, global_listnode)) {
                             return (NULL);
                         }
                     } else {
@@ -1384,7 +1384,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->url) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->url)) {
+                    if (!OS_DBSearch(list_holder, lf->url, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1392,7 +1392,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->id) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->id)) {
+                    if (!OS_DBSearch(list_holder, lf->id, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1400,7 +1400,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->hostname) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->hostname)) {
+                    if (!OS_DBSearch(list_holder, lf->hostname, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1408,7 +1408,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->program_name) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->program_name)) {
+                    if (!OS_DBSearch(list_holder, lf->program_name, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1416,7 +1416,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->status) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->status)) {
+                    if (!OS_DBSearch(list_holder, lf->status, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1424,7 +1424,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->action) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->action)) {
+                    if (!OS_DBSearch(list_holder, lf->action, global_listnode)) {
                         return (NULL);
                     }
                     break;
@@ -1432,7 +1432,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->systemname) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->systemname)){
+                    if (!OS_DBSearch(list_holder, lf->systemname, global_listnode)){
                         return (NULL);
                     }
                     break;
@@ -1440,7 +1440,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->protocol) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->protocol)){
+                    if (!OS_DBSearch(list_holder, lf->protocol, global_listnode)){
                         return (NULL);
                     }
                     break;
@@ -1448,7 +1448,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->data) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->data)){
+                    if (!OS_DBSearch(list_holder, lf->data, global_listnode)){
                         return (NULL);
                     }
                     break;
@@ -1456,14 +1456,14 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->extra_data) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->extra_data)) {
+                    if (!OS_DBSearch(list_holder, lf->extra_data, global_listnode)) {
                         return (NULL);
                     }
                     break;
                 case RULE_DYNAMIC:
                     field = FindField(lf, list_holder->dfield);
 
-                    if (!(field &&OS_DBSearch(list_holder, (char*)field)))
+                    if (!(field &&OS_DBSearch(list_holder, (char*)field, global_listnode)))
                         return NULL;
 
                     break;
@@ -2194,6 +2194,7 @@ void * w_decode_hostinfo_thread(__attribute__((unused)) void * args){
 
 void * w_decode_event_thread(__attribute__((unused)) void * args){
     Eventinfo *lf = NULL;
+    OSDecoderNode *node;
     char * msg = NULL;
     regex_matching decoder_match;
     memset(&decoder_match, 0, sizeof(regex_matching));
@@ -2223,7 +2224,12 @@ void * w_decode_event_thread(__attribute__((unused)) void * args){
                     continue;
                 }
             } else {
-                DecodeEvent(lf, &decoder_match);
+                node = OS_GetFirstOSDecoder(lf->program_name);
+
+                if (!node) {
+                    return (NULL);
+                }
+                DecodeEvent(lf, &decoder_match, node);
             }
 
             free(msg);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -585,7 +585,7 @@ int main_analysisd(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading rules file: '%s'", *rulesfiles);
                     }
-                    if (Rules_OP_ReadRules(*rulesfiles, rulenode, &global_listnode) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, &rulenode, &global_listnode) < 0) {
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }
 
@@ -2225,10 +2225,6 @@ void * w_decode_event_thread(__attribute__((unused)) void * args){
                 }
             } else {
                 node = OS_GetFirstOSDecoder(lf->program_name);
-
-                if (!node) {
-                    return (NULL);
-                }
                 DecodeEvent(lf, &decoder_match, node);
             }
 

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -40,24 +40,28 @@ extern time_t current_time;
 
 /**
  * @brief We have two internal lists for decoders. One with the program_name
- * and one without. This is going to improve greatly the
- * performance of our decoder matching.
+ * and one without.
+ *
+ * This is going to improve greatly the performance of our decoder matching.
  */
-
 OSDecoderNode *osdecodernode_forpname;
 OSDecoderNode *osdecodernode_nopname;
+
 /**
  * @brief Structure to save all rules read in starting.
  */
 RuleNode *rulenode;
+
 /**
  * @brief Structure to save the last list of events.
  */
 EventList *last_events_list;
+
 /**
  * @brief Structure to save a node in a list of lists.
  */
 ListNode *global_listnode;
+
 /**
  * @brief Structure to save a list of rules.
  */

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -33,14 +33,35 @@ extern struct timespec c_timespec; /* Current time of event. Used everywhere */
 extern char __shost[512];
 
 extern OSDecoderInfo *NULL_Decoder;
-extern OSDecoderNode *osdecodernode_forpname;
-extern OSDecoderNode *osdecodernode_nopname;
-extern RuleNode *rulenode;
 extern rlim_t nofile;
 extern int sys_debug_level;
 extern OSDecoderInfo *fim_decoder;
-extern EventList *last_events_list;
 extern time_t current_time;
+
+/**
+ * @brief We have two internal lists for decoders. One with the program_name
+ * and one without. This is going to improve greatly the
+ * performance of our decoder matching.
+ */
+
+OSDecoderNode *osdecodernode_forpname;
+OSDecoderNode *osdecodernode_nopname;
+/**
+ * @brief Structure to save all rules read in starting.
+ */
+RuleNode *rulenode;
+/**
+ * @brief Structure to save the last list of events.
+ */
+EventList *last_events_list;
+/**
+ * @brief Structure to save a node in a list of lists.
+ */
+ListNode *global_listnode;
+/**
+ * @brief Structure to save a list of rules.
+ */
+ListRule *global_listrule;
 
 // Com request thread dispatcher
 void * asyscom_main(__attribute__((unused)) void * arg) ;

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -39,38 +39,55 @@ extern OSDecoderInfo *fim_decoder;
 extern time_t current_time;
 
 /**
- * @brief We have two internal lists for decoders. One with the program_name
- * and one without.
- *
- * This is going to improve greatly the performance of our decoder matching.
+ * @brief Structure to save decoders which have program_name or parent with program_name
  */
-OSDecoderNode *osdecodernode_forpname;
-OSDecoderNode *osdecodernode_nopname;
+OSDecoderNode *os_analysisd_decoderlist_pn;
+
+/**
+ * @brief Structure to save decoders which haven't program_name or parent without program_name
+ */
+OSDecoderNode *os_analysisd_decoderlist_nopn;
 
 /**
  * @brief Structure to save all rules read in starting.
  */
-RuleNode *rulenode;
+RuleNode *os_analysisd_rulelist;
 
 /**
  * @brief Structure to save the last list of events.
  */
-EventList *last_events_list;
+EventList *os_analysisd_last_events;
 
 /**
- * @brief Structure to save a node in a list of lists.
+ * @brief Structure to save all CDB lists.
  */
-ListNode *global_listnode;
+ListNode *os_analysisd_cdblists;
 
 /**
- * @brief Structure to save a list of rules.
+ * @brief Structure to save rules wich depends on a CDB list.
  */
-ListRule *global_listrule;
+ListRule *os_analysisd_cdbrules;
 
-// Com request thread dispatcher
+
+/**
+ * @brief Listen to analysisd socket for new requests
+ */
 void * asyscom_main(__attribute__((unused)) void * arg) ;
+
+/**
+ * @brief Check that request is to get a configuration
+ * @param command message received from api
+ * @param output the configuration to send
+ */
 size_t asyscom_dispatch(char * command, char ** output);
+
+/**
+ * @brief Process the message received to send the configuration requested
+ * @param section contains the name of configuration requested
+ * @param output the configuration to send
+ */
 size_t asyscom_getconfig(const char * section, char ** output);
+
 
 #define WM_ANALYSISD_LOGTAG ARGV0 "" // Tag for log messages
 

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -276,9 +276,9 @@ cJSON *getDecodersConfig(void) {
     cJSON *root = cJSON_CreateObject();
     cJSON *list = cJSON_CreateArray();
 
-    if (osdecodernode_forpname) {
-        _getDecodersListJSON(osdecodernode_forpname, list);
-        _getDecodersListJSON(osdecodernode_nopname, list);
+    if (os_analysisd_decoderlist_pn) {
+        _getDecodersListJSON(os_analysisd_decoderlist_pn, list);
+        _getDecodersListJSON(os_analysisd_decoderlist_nopn, list);
     }
 
     cJSON_AddItemToObject(root,"decoders",list);
@@ -292,8 +292,8 @@ cJSON *getRulesConfig(void) {
     cJSON *root = cJSON_CreateObject();
     cJSON *list = cJSON_CreateArray();
 
-    if (rulenode) {
-        _getRulesListJSON(rulenode, list);
+    if (os_analysisd_rulelist) {
+        _getRulesListJSON(os_analysisd_rulelist, list);
     }
 
     cJSON_AddItemToObject(root,"rules",list);

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -756,7 +756,7 @@ int ReadDecodeXML(const char *file)
         }
 
         /* Add osdecoder to the list */
-        if (!OS_AddOSDecoder(pi, &osdecodernode_forpname, &osdecodernode_nopname)) {
+        if (!OS_AddOSDecoder(pi, &os_analysisd_decoderlist_pn, &os_analysisd_decoderlist_nopn)) {
             merror(DECODER_ERROR);
             goto cleanup;
         }

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -756,7 +756,7 @@ int ReadDecodeXML(const char *file)
         }
 
         /* Add osdecoder to the list */
-        if (!OS_AddOSDecoder(pi)) {
+        if (!OS_AddOSDecoder(pi, &osdecodernode_forpname, &osdecodernode_nopname)) {
             merror(DECODER_ERROR);
             goto cleanup;
         }

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -28,6 +28,10 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *no
     const char *regex_prev = NULL;
     const char *result = NULL;
 
+    if (!node) {
+        return;
+    }
+
 #ifdef TESTRULE
     if (!alert_only) {
         print_out("\n**Phase 2: Completed decoding.");

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -17,9 +17,8 @@
 
 
 /* Use the osdecoders to decode the received event */
-void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
+void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *node)
 {
-    OSDecoderNode *node;
     OSDecoderNode *child_node;
     OSDecoderInfo *nnode;
 
@@ -28,12 +27,6 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
     const char *cmatch = NULL;
     const char *regex_prev = NULL;
     const char *result = NULL;
-
-    node = OS_GetFirstOSDecoder(lf->program_name);
-
-    if (!node) {
-        return;
-    }
 
 #ifdef TESTRULE
     if (!alert_only) {

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -79,7 +79,7 @@ typedef struct dbsync_context_t {
  * list and to get the first osdecoder
  */
 void OS_CreateOSDecoderList(void);
-int OS_AddOSDecoder(OSDecoderInfo *pi);
+int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode);
 OSDecoderNode *OS_GetFirstOSDecoder(const char *pname);
 int getDecoderfromlist(const char *name);
 char *GetGeoInfobyIP(char *ip_addr);

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -16,13 +16,7 @@
 #include "decoder.h"
 #include "error_messages/error_messages.h"
 #include "error_messages/debug_messages.h"
-
-/* We have two internal lists. One with the program_name
- * and one without. This is going to improve greatly the
- * performance of our decoder matching.
- */
-OSDecoderNode *osdecodernode_forpname;
-OSDecoderNode *osdecodernode_nopname;
+#include "analysisd.h"
 
 static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi);
 
@@ -134,7 +128,7 @@ error:
     return (NULL);
 }
 
-int OS_AddOSDecoder(OSDecoderInfo *pi)
+int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode)
 {
     int added = 0;
     OSDecoderNode *osdecodernode;
@@ -143,14 +137,14 @@ int OS_AddOSDecoder(OSDecoderInfo *pi)
      * name and the other without.
      */
     if (pi->program_name) {
-        osdecodernode = osdecodernode_forpname;
+        osdecodernode = *pn_osdecodernode;
     } else {
-        osdecodernode = osdecodernode_nopname;
+        osdecodernode = *npn_osdecodernode;
     }
 
     /* Search for parent on both lists */
     if (pi->parent) {
-        OSDecoderNode *tmp_node = osdecodernode_forpname;
+        OSDecoderNode *tmp_node = *pn_osdecodernode;
 
         /* List with p_name */
         while (tmp_node) {
@@ -166,7 +160,7 @@ int OS_AddOSDecoder(OSDecoderInfo *pi)
         }
 
         /* List without p name */
-        tmp_node = osdecodernode_nopname;
+        tmp_node = *npn_osdecodernode;
         while (tmp_node) {
             if (strcmp(tmp_node->osdecoder->name, pi->parent) == 0) {
                 tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi);
@@ -195,9 +189,9 @@ int OS_AddOSDecoder(OSDecoderInfo *pi)
 
         /* Update global decoder pointers */
         if (pi->program_name) {
-            osdecodernode_forpname = osdecodernode;
+            *pn_osdecodernode = osdecodernode;
         } else {
-            osdecodernode_nopname = osdecodernode;
+            *npn_osdecodernode = osdecodernode;
         }
     }
     return (1);

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -23,8 +23,8 @@ static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi)
 /* Create the Event List */
 void OS_CreateOSDecoderList()
 {
-    osdecodernode_forpname = NULL;
-    osdecodernode_nopname = NULL;
+    os_analysisd_decoderlist_pn = NULL;
+    os_analysisd_decoderlist_nopn = NULL;
 
     return;
 }
@@ -34,10 +34,10 @@ OSDecoderNode *OS_GetFirstOSDecoder(const char *p_name)
 {
     /* If program name is set, we return the forpname list */
     if (p_name) {
-        return (osdecodernode_forpname);
+        return (os_analysisd_decoderlist_pn);
     }
 
-    return (osdecodernode_nopname);
+    return (os_analysisd_decoderlist_nopn);
 }
 
 /* Add an osdecoder to the list */

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -21,7 +21,6 @@ int alert_only;
 
 #define OS_COMMENT_MAX 1024
 
-EventList *last_events_list;
 time_t current_time = 0;
 
 size_t field_offset[] = {

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -458,7 +458,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
     w_mutex_lock(&rule->mutex);
 
     /* Get the first event */
-    if (first_pt = OS_GetFirstEvent(last_events_list), !first_pt) {
+    if (first_pt = OS_GetFirstEvent(os_analysisd_last_events), !first_pt) {
         /* Nothing found */
         goto end;
     }

--- a/src/analysisd/lists.h
+++ b/src/analysisd/lists.h
@@ -55,15 +55,15 @@ int Lists_OP_LoadList(char *listfile);
 
 int OS_DBSearchKey(ListRule *lrule, char *key);
 
-int OS_DBSearch(ListRule *lrule, char *key);
+int OS_DBSearch(ListRule *lrule, char *key, ListNode *l_node);
 
-void OS_ListLoadRules(void);
+void OS_ListLoadRules(ListNode **l_node);
 
-ListRule *OS_AddListRule(ListRule *first_rule_list, int lookup_type, int field, const char *dfield, char *listname, OSMatch *matcher);
+ListRule *OS_AddListRule(ListRule *first_rule_list, int lookup_type, int field, const char *dfield, char *listname, OSMatch *matcher, ListNode *l_node);
 
 ListNode *OS_GetFirstList(void);
 
-ListNode *OS_FindList(const char *listname);
+ListNode *OS_FindList(const char *listname, ListNode *l_node);
 
 void Lists_OP_CreateLists(void);
 

--- a/src/analysisd/lists_list.c
+++ b/src/analysisd/lists_list.c
@@ -22,8 +22,8 @@
 /* Create the ListRule */
 void OS_CreateListsList()
 {
-    global_listnode = NULL;
-    global_listrule = NULL;
+    os_analysisd_cdblists = NULL;
+    os_analysisd_cdbrules = NULL;
 
     return;
 }
@@ -31,14 +31,14 @@ void OS_CreateListsList()
 /* Get first listnode  */
 ListNode *OS_GetFirstList()
 {
-    ListNode *listnode_pt = global_listnode;
+    ListNode *listnode_pt = os_analysisd_cdblists;
 
     return (listnode_pt);
 }
 
 void OS_ListLoadRules(ListNode **l_node)
 {
-    ListRule *lrule = global_listrule;
+    ListRule *lrule = os_analysisd_cdbrules;
     while (lrule != NULL) {
         if (!lrule->loaded) {
             lrule->db = OS_FindList(lrule->filename, *l_node);
@@ -51,12 +51,12 @@ void OS_ListLoadRules(ListNode **l_node)
 /* External AddList */
 int OS_AddList(ListNode *new_listnode)
 {
-    if (global_listnode == NULL) {
+    if (os_analysisd_cdblists == NULL) {
         /* First list */
-        global_listnode = new_listnode;
+        os_analysisd_cdblists = new_listnode;
     } else {
         /* Add new list to the end */
-        ListNode *last_list_node = global_listnode;
+        ListNode *last_list_node = os_analysisd_cdblists;
 
         while (last_list_node->next != NULL) {
             last_list_node = last_list_node->next;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -46,7 +46,7 @@ void Rules_OP_CreateRules()
 }
 
 /* Read the log rules */
-int Rules_OP_ReadRules(const char *rulefile, RuleNode *r_node, ListNode **l_node)
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node)
 {
     OS_XML xml;
     XML_NODE node = NULL;
@@ -1706,16 +1706,16 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode *r_node, ListNode **l_node
              * will be a "child" of someone.
              */
             if (config_ruleinfo->sigid < 10) {
-                OS_AddRule(config_ruleinfo, &r_node);
+                OS_AddRule(config_ruleinfo, r_node);
             } else if (config_ruleinfo->alert_opts & DO_OVERWRITE) {
-                if (!OS_AddRuleInfo(r_node, config_ruleinfo,
+                if (!OS_AddRuleInfo(*r_node, config_ruleinfo,
                                     config_ruleinfo->sigid)) {
                     merror("Overwrite rule '%d' not found.",
                            config_ruleinfo->sigid);
                     goto cleanup;
                 }
             } else {
-                OS_AddChild(config_ruleinfo, &r_node);
+                OS_AddChild(config_ruleinfo, r_node);
             }
 
             /* Clean what we do not need */

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -46,7 +46,7 @@ void Rules_OP_CreateRules()
 }
 
 /* Read the log rules */
-int Rules_OP_ReadRules(const char *rulefile)
+int Rules_OP_ReadRules(const char *rulefile, RuleNode *r_node, ListNode **l_node)
 {
     OS_XML xml;
     XML_NODE node = NULL;
@@ -331,7 +331,7 @@ int Rules_OP_ReadRules(const char *rulefile)
                     goto cleanup;
                 }
 
-                if (overwrite != 1 && doesRuleExist(id, NULL)) {
+                if (overwrite != 1 && doesRuleExist(id, rulenode)) {
                     merror("Duplicate rule ID:%d", id);
                     goto cleanup;
                 }
@@ -817,7 +817,8 @@ int Rules_OP_ReadRules(const char *rulefile)
                                                                     rule_type,
                                                                     rule_dfield,
                                                                     rule_opt[k]->content,
-                                                                    matcher);
+                                                                    matcher,
+                                                                    *l_node);
                             if (config_ruleinfo->lists == NULL) {
                                 merror("List error: Could not load %s", rule_opt[k]->content);
                                 goto cleanup;
@@ -1101,7 +1102,7 @@ int Rules_OP_ReadRules(const char *rulefile)
                         if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                         }
-                    } else if (strcmp(rule_opt[k]->element, xml_different_id) == 0 || 
+                    } else if (strcmp(rule_opt[k]->element, xml_different_id) == 0 ||
                                strcmp(rule_opt[k]->element, xml_notsame_id) == 0) {
                         config_ruleinfo->different_field |= FIELD_ID;
 
@@ -1169,7 +1170,7 @@ int Rules_OP_ReadRules(const char *rulefile)
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_different_user) == 0 ||
-                               strcasecmp(rule_opt[k]->element, 
+                               strcasecmp(rule_opt[k]->element,
                                           xml_notsame_user) == 0) {
                         config_ruleinfo->different_field |= FIELD_USER;
 
@@ -1185,7 +1186,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
-                        } 
+                        }
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_global_frequency) == 0) {
                         config_ruleinfo->context_opts |= FIELD_GFREQUENCY;
@@ -1427,7 +1428,7 @@ int Rules_OP_ReadRules(const char *rulefile)
                 }
 
                 /* Check for valid use of frequency */
-                if ((config_ruleinfo->context_opts || config_ruleinfo->same_field || 
+                if ((config_ruleinfo->context_opts || config_ruleinfo->same_field ||
                         config_ruleinfo->different_field ||
                         config_ruleinfo->frequency) &&
                         !config_ruleinfo->context) {
@@ -1705,16 +1706,16 @@ int Rules_OP_ReadRules(const char *rulefile)
              * will be a "child" of someone.
              */
             if (config_ruleinfo->sigid < 10) {
-                OS_AddRule(config_ruleinfo);
+                OS_AddRule(config_ruleinfo, &r_node);
             } else if (config_ruleinfo->alert_opts & DO_OVERWRITE) {
-                if (!OS_AddRuleInfo(NULL, config_ruleinfo,
+                if (!OS_AddRuleInfo(r_node, config_ruleinfo,
                                     config_ruleinfo->sigid)) {
                     merror("Overwrite rule '%d' not found.",
                            config_ruleinfo->sigid);
                     goto cleanup;
                 }
             } else {
-                OS_AddChild(config_ruleinfo);
+                OS_AddChild(config_ruleinfo, &r_node);
             }
 
             /* Clean what we do not need */

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -331,7 +331,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     goto cleanup;
                 }
 
-                if (overwrite != 1 && doesRuleExist(id, rulenode)) {
+                if (overwrite != 1 && doesRuleExist(id, os_analysisd_rulelist)) {
                     merror("Duplicate rule ID:%d", id);
                     goto cleanup;
                 }
@@ -1910,8 +1910,8 @@ RuleInfo *zerorulemember(int id, int level,
     ruleinfo_pt->firedtimes = 0;
     ruleinfo_pt->maxsize = maxsize;
     ruleinfo_pt->frequency = frequency;
-    if (ruleinfo_pt->frequency > last_events_list->_max_freq) {
-        last_events_list->_max_freq = ruleinfo_pt->frequency;
+    if (ruleinfo_pt->frequency > os_analysisd_last_events->_max_freq) {
+        os_analysisd_last_events->_max_freq = ruleinfo_pt->frequency;
     }
     ruleinfo_pt->ignore_time = ignore_time;
     ruleinfo_pt->timeframe = timeframe;

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -231,10 +231,10 @@ RuleInfo *zerorulemember(int id,
 void OS_CreateRuleList(void);
 
 /* Add rule information to the list */
-int OS_AddRule(RuleInfo *read_rule);
+int OS_AddRule(RuleInfo *read_rule, RuleNode **r_node);
 
 /* Add rule information as a child */
-int OS_AddChild(RuleInfo *read_rule);
+int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node);
 
 /* Add an overwrite rule */
 int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid);
@@ -250,7 +250,7 @@ RuleNode *OS_GetFirstRule(void);
 
 void Rules_OP_CreateRules(void);
 
-int Rules_OP_ReadRules(const char *rulefile);
+int Rules_OP_ReadRules(const char *rulefile, RuleNode *r_node, ListNode **l_node);
 
 int AddHash_Rule(RuleNode *node);
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -250,7 +250,7 @@ RuleNode *OS_GetFirstRule(void);
 
 void Rules_OP_CreateRules(void);
 
-int Rules_OP_ReadRules(const char *rulefile, RuleNode *r_node, ListNode **l_node);
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node);
 
 int AddHash_Rule(RuleNode *node);
 

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -11,9 +11,8 @@
 #include "shared.h"
 #include "rules.h"
 #include "eventinfo.h"
+#include "analysisd.h"
 
-/* Rulenode local  */
-RuleNode *rulenode;
 
 /* _OS_Addrule: Internal AddRule */
 static RuleNode *_OS_AddRule(RuleNode *_rulenode, RuleInfo *read_rule);
@@ -115,7 +114,7 @@ static int _AddtoRule(int sid, int level, int none, const char *group,
 }
 
 /* Add a child */
-int OS_AddChild(RuleInfo *read_rule)
+int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node)
 {
     if (!read_rule) {
         merror("rules_list: Passing a NULL rule. Inconsistent state");
@@ -138,7 +137,7 @@ int OS_AddChild(RuleInfo *read_rule)
             } else if ((isdigit((int)*sid)) || (*sid == '\0')) {
                 if (val == 0) {
                     rule_id = atoi(sid);
-                    if (!_AddtoRule(rule_id, 0, 0, NULL, NULL, read_rule)) {
+                    if (!_AddtoRule(rule_id, 0, 0, NULL, *r_node, read_rule)) {
                         merror_exit("rules_list: Signature ID '%d' not "
                                   "found. Invalid 'if_sid'.", rule_id);
                     }
@@ -163,7 +162,7 @@ int OS_AddChild(RuleInfo *read_rule)
 
         ilevel *= 100;
 
-        if (!_AddtoRule(0, ilevel, 0, NULL, NULL, read_rule)) {
+        if (!_AddtoRule(0, ilevel, 0, NULL, r_node, read_rule)) {
             merror_exit("rules_list: Level ID '%d' not "
                       "found. Invalid 'if_level'.", ilevel);
         }
@@ -171,7 +170,7 @@ int OS_AddChild(RuleInfo *read_rule)
 
     /* Adding for if_group */
     else if (read_rule->if_group) {
-        if (!_AddtoRule(0, 0, 0, read_rule->if_group, NULL, read_rule)) {
+        if (!_AddtoRule(0, 0, 0, read_rule->if_group, r_node, read_rule)) {
             merror_exit("rules_list: Group '%s' not "
                       "found. Invalid 'if_group'.", read_rule->if_group);
         }
@@ -179,7 +178,7 @@ int OS_AddChild(RuleInfo *read_rule)
 
     /* Just add based on the category */
     else {
-        if (!_AddtoRule(0, 0, 0, NULL, NULL, read_rule)) {
+        if (!_AddtoRule(0, 0, 0, NULL, r_node, read_rule)) {
             merror_exit("rules_list: Category '%d' not "
                       "found. Invalid 'category'.", read_rule->category);
         }
@@ -245,9 +244,9 @@ static RuleNode *_OS_AddRule(RuleNode *_rulenode, RuleInfo *read_rule)
 }
 
 /* External AddRule */
-int OS_AddRule(RuleInfo *read_rule)
+int OS_AddRule(RuleInfo *read_rule, RuleNode **r_node)
 {
-    rulenode = _OS_AddRule(rulenode, read_rule);
+    rulenode = _OS_AddRule(*r_node, read_rule);
 
     return (0);
 }

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -23,14 +23,14 @@ static int _AddtoRule(int sid, int level, int none, const char *group,
 /* Create the RuleList */
 void OS_CreateRuleList()
 {
-    rulenode = NULL;
+    os_analysisd_rulelist = NULL;
     return;
 }
 
 /* Get first node from rule */
 RuleNode *OS_GetFirstRule()
 {
-    RuleNode *rulenode_pt = rulenode;
+    RuleNode *rulenode_pt = os_analysisd_rulelist;
     return (rulenode_pt);
 }
 

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -44,7 +44,7 @@ static int _AddtoRule(int sid, int level, int none, const char *group,
      * the beginning of the list
      */
     if (!r_node) {
-        r_node = OS_GetFirstRule();
+        return r_code;
     }
 
     while (r_node) {
@@ -162,7 +162,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node)
 
         ilevel *= 100;
 
-        if (!_AddtoRule(0, ilevel, 0, NULL, r_node, read_rule)) {
+        if (!_AddtoRule(0, ilevel, 0, NULL, *r_node, read_rule)) {
             merror_exit("rules_list: Level ID '%d' not "
                       "found. Invalid 'if_level'.", ilevel);
         }
@@ -170,7 +170,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node)
 
     /* Adding for if_group */
     else if (read_rule->if_group) {
-        if (!_AddtoRule(0, 0, 0, read_rule->if_group, r_node, read_rule)) {
+        if (!_AddtoRule(0, 0, 0, read_rule->if_group, *r_node, read_rule)) {
             merror_exit("rules_list: Group '%s' not "
                       "found. Invalid 'if_group'.", read_rule->if_group);
         }
@@ -178,7 +178,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node)
 
     /* Just add based on the category */
     else {
-        if (!_AddtoRule(0, 0, 0, NULL, r_node, read_rule)) {
+        if (!_AddtoRule(0, 0, 0, NULL, *r_node, read_rule)) {
             merror_exit("rules_list: Category '%d' not "
                       "found. Invalid 'category'.", read_rule->category);
         }
@@ -246,7 +246,7 @@ static RuleNode *_OS_AddRule(RuleNode *_rulenode, RuleInfo *read_rule)
 /* External AddRule */
 int OS_AddRule(RuleInfo *read_rule, RuleNode **r_node)
 {
-    rulenode = _OS_AddRule(*r_node, read_rule);
+    *r_node = _OS_AddRule(*r_node, read_rule);
 
     return (0);
 }

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -36,7 +36,7 @@ void OS_ReadMSG(char *ut_str);
 /* Analysisd function */
 RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching *rule_match);
 
-void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match);
+void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *node);
 
 // Cleanup at exit
 static void onexit();
@@ -302,7 +302,7 @@ int main(int argc, char **argv)
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
-                    if (Rules_OP_ReadRules(*rulesfiles, rulenode, global_listnode) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, &rulenode, &global_listnode) < 0) {
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }
 
@@ -405,6 +405,7 @@ void OS_ReadMSG(char *ut_str)
 
     RuleInfoDetail *last_info_detail;
     Eventinfo *lf;
+    OSDecoderNode *node = NULL;
 
     RuleInfo * currently_rule;
     /* Null global pointer to current rule */
@@ -484,7 +485,8 @@ void OS_ReadMSG(char *ut_str)
             lf->size = strlen(lf->log);
 
             /* Decode event */
-            DecodeEvent(lf, &decoder_match);
+            node = OS_GetFirstOSDecoder(lf->program_name);
+            DecodeEvent(lf, &decoder_match, node);
 
             /* Run accumulator */
             if ( lf->decoder_info->accumulate == 1 ) {

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
     struct sigaction action = { .sa_handler = onsignal };
     int quiet = 0;
     num_rule_matching_threads = 1;
-    last_events_list = NULL;
+    os_analysisd_last_events = NULL;
 
     /* Set the name */
     OS_SetName(ARGV0);
@@ -200,9 +200,9 @@ int main(int argc, char **argv)
 
     Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", MIN_ORDER_SIZE, MAX_DECODER_ORDER_SIZE);
 
-    if (!last_events_list) {
-        os_calloc(1, sizeof(EventList), last_events_list);
-        OS_CreateEventList(Config.memorysize, last_events_list);
+    if (!os_analysisd_last_events) {
+        os_calloc(1, sizeof(EventList), os_analysisd_last_events);
+        OS_CreateEventList(Config.memorysize, os_analysisd_last_events);
     }
 
     /*
@@ -302,7 +302,7 @@ int main(int argc, char **argv)
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
-                    if (Rules_OP_ReadRules(*rulesfiles, &rulenode, &global_listnode) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists) < 0) {
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }
 
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
              * having to search thought the list of lists for the correct file
              * during rule evaluation.
              */
-            OS_ListLoadRules(&global_listnode);
+            OS_ListLoadRules(&os_analysisd_cdblists);
         }
     }
 
@@ -611,7 +611,7 @@ void OS_ReadMSG(char *ut_str)
                     }
                 }
 
-                OS_AddEvent(lf, last_events_list);
+                OS_AddEvent(lf, os_analysisd_last_events);
                 break;
 
             } while ((rulenode_pt = rulenode_pt->next) != NULL);

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -302,7 +302,7 @@ int main(int argc, char **argv)
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
-                    if (Rules_OP_ReadRules(*rulesfiles) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, rulenode, global_listnode) < 0) {
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }
 
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
              * having to search thought the list of lists for the correct file
              * during rule evaluation.
              */
-            OS_ListLoadRules();
+            OS_ListLoadRules(&global_listnode);
         }
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5341|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR modifies the respective functions to decoders, rules and CDBlist that will be necessary for the new wazuh-Logtest module. This way the function will act depending on if the thread that executes it is from Analisisd or from wazuh-Logtest.

## Tests
- [x] Scan-build on Linux
- [x] Valgrind
- [x] Ruleset test
- [x] Check CDB lists subsystem works

