### PR TITLE
Added path or url options to update the Debian Security Tracker feed locally.

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -32,7 +32,7 @@
 #define VU_INS_CPES_DIC       "(5417): Inserting Wazuh's CPE dictonary."
 #define VU_INS_MSU            "(5418): Inserting Microsoft Security Update dictonary."
 #define VU_INS_VUL_SEC        "(5419): Inserting %s vulnerabilities section."
-/* ID 5420 is available */
+#define VU_DEB_STATUS_FEED    "(5420): Indexing vulnerabilities from the Debian Security Tracker."
 #define VU_INDEX_TIME         "(5421): It took '%ld' seconds to '%s' vulnerabilities."
 #define VU_INS_TEST_SEC       "(5422): Inserting '%s' vulnerabilities references."
 #define VU_UPDATE_VU_CO       "(5423): Inserting '%s' vulnerabilities conditions."
@@ -48,7 +48,7 @@
 #define VU_AGENT_UNSOPPORTED  "(5433): Agent '%.3d' has an unsupported Wazuh version: '%s'"
 #define VU_UNS_OS_VERSION     "(5434): Agent '%.3d' has an unsupported OS version: '%s'"
 #define VU_AG_NO_TARGET       "(5435): The analysis can not be launched because there are no target agents."
-/* ID 5436 is available */
+#define VU_DEB_STATUS_FETCH   "(5436): Fetching Debian Security Tracker from '%s'"
 #define VU_AGENT_SOFTWARE_REQ "(5437): Collecting agent '%.3d' software."
 #define VU_AG_FULL_SCAN       "(5438): A full scan will be run on agent '%.3d'"
 #define VU_AG_PART_SCAN       "(5439): A partial scan will be run on agent '%.3d'"

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -372,7 +372,7 @@
 #define VU_REPORT_NVD_SCORE_ERROR   "(5580): Could not fill the report with the CVE score from the NVD for agent '%.3d'"
 #define VU_REPORT_OVAL_ERROR        "(5581): Could not fill the report with the CVE info from the Vendor feed for agent '%.3d'"
 #define VU_NVD_EMPTY                "(5582): Unavailable vulnerabilities at the NVD database. The scan is aborted."
-#define VU_GET_DEB_STATUS_FEED      "(5583): Couldn't get the Debian feed '%s' to check the status of the packages. This can lead to many false positives."
+#define VU_DEB_STATUS_FEED_ERROR    "(5583): Couldn't get the Debian feed '%s' to check the vulnerable packages."
 #define VU_FILTER_VULN_NVD_ERROR    "(5584): Couldn't verify if the vulnerability '%s' is reported in the NVD feed."
 #define VU_GET_NVD_YEAR_ERROR       "(5585): Couldn't get the NVD configured year."
 #define VU_NO_ENABLED_FEEDS         "(5586): No feeds specified for '%s' provider. Enabling all the available ones."

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -105,19 +105,19 @@ STATIC bool wm_vuldet_set_feed_update_url(update_node *update);
 
 /**
  * @brief Get the Debian status feed to check the status of the vulnerabilities.
- * @param timeout Timeout for the download request
+ * @param update Update structure of the feed being analyzed.
  * @return Parsed JSON on success, NULL otherwise.
  */
-STATIC cJSON *wm_vuldet_get_debian_status_feed(const long timeout);
+STATIC cJSON *wm_vuldet_get_debian_status_feed(update_node *update);
 
 /**
  * @brief Insert the Debian vulnerable packages into the DB.
  * @param db Pointer to the CVE DB.
  * @param target Debian OS target.
- * @param timeout Timeout for the download request
+ * @param update Update structure of the feed being analyzed.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_index_debian(sqlite3 *db, const char *target, const long timeout);
+STATIC int wm_vuldet_index_debian(sqlite3 *db, const char *target, update_node *update);
 
 /**
  * @brief For an specific agent, copy all installed packages' information from SYS_PROGRAM to the AGENTS table.
@@ -1433,10 +1433,12 @@ int wm_vuldet_send_cve_report(vu_report *report) {
             report->cve,
             report->condition ? report->condition : "Hotfix is not installed.");
     } else {
+        if (report && report->software && report->version && report->agent_id && report->cve) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACK_VER_VULN, report->software,
             report->version, atoi(report->agent_id), report->cve,
             report->condition && *report->condition != '\0' ? report->condition :
             "exists");
+        }
     }
 
     if (wm_sendmsg(usec, *vu_queue, alert_msg, header, send_queue) < 0) {
@@ -2165,7 +2167,7 @@ int wm_vuldet_update_feed(update_node *upd, int8_t *updated) {
     return 0;
 }
 
-int wm_vuldet_index_debian(sqlite3 *db, const char *target, const long timeout) {
+int wm_vuldet_index_debian(sqlite3 *db, const char *target, update_node *update) {
     sqlite3_stmt *stmt = NULL;
     cJSON *deb_json = NULL;
     cJSON *package_json = NULL;
@@ -2182,8 +2184,10 @@ int wm_vuldet_index_debian(sqlite3 *db, const char *target, const long timeout) 
     char *version = NULL;
     int ignore = 0;
 
-    if (deb_json = wm_vuldet_get_debian_status_feed(timeout), !deb_json) {
-        mtwarn(WM_VULNDETECTOR_LOGTAG, VU_GET_DEB_STATUS_FEED, DEBIAN_REPO_STATUS);
+    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FEED);
+
+    if (deb_json = wm_vuldet_get_debian_status_feed(update), !deb_json) {
+        mtwarn(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FEED_ERROR, DEBIAN_REPO_STATUS);
         return 0;
     }
 
@@ -2427,6 +2431,10 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     }
 
     // Adds the vulnerabilities
+    if (vul_it) {
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_VUL_SEC, update->dist_ext);
+    }
+
     while (vul_it) {
         // If you do not have this field, it has been discarded by the preparser and the OS is not affected
         if (vul_it->state_id) {
@@ -2463,8 +2471,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
 
     // Adds Debian vulnerabilities
     if (update->dist_ref == FEED_DEBIAN) {
-        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_VUL_SEC, update->dist_ext);
-        if (wm_vuldet_index_debian(db, vu_feed_tag[update->dist_tag_ref], update->timeout) == OS_INVALID) {
+        if (wm_vuldet_index_debian(db, vu_feed_tag[update->dist_tag_ref], update) == OS_INVALID) {
             return wm_vuldet_sql_error(db, stmt);
         }
     }
@@ -3733,7 +3740,7 @@ int wm_vuldet_fetch_feed(update_node *update, int8_t *need_update) {
     int result;
     *need_update = 1;
 
-    if (!update->url && (update->path || update->multi_path)) {
+    if (!update->url && (update->path || (update->multi_path && update->dist_ref != FEED_DEBIAN))) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_LOCAL_FETCH, update->path ? update->path : update->multi_path);
         return 0;
     }
@@ -3844,15 +3851,34 @@ int wm_vuldet_check_feed(update_node *upd, int8_t *updated) {
     return 0;
 }
 
-cJSON *wm_vuldet_get_debian_status_feed(const long timeout) {
+cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
     FILE *deb_file = NULL;
     int attempts;
     int res_url_request;
+    char * path = NULL;
+    char * url = DEBIAN_REPO_STATUS;
+    cJSON * json_file = NULL;
 
-    if (deb_file = fopen(VU_DEB_TEMP_FILE, "r"), !deb_file) {
+    if (update->multi_path) {
+        path = update->multi_path;
+    }
+
+    if (update->multi_url) {
+        url = update->multi_url;
+    }
+
+    if (path) {
+        // Fetch Debian Security Tracker feed locally
+        if (w_is_file(path)) {
+            mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, path);
+            json_file = wm_vuldet_json_fread(path);
+        }
+        return json_file;
+    } else if (deb_file = fopen(VU_DEB_TEMP_FILE, "r"), !deb_file) {
         // Download Debian status feed
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, url);
         for (attempts = 0;; attempts++) {
-            if (res_url_request = wurl_request(DEBIAN_REPO_STATUS, VU_DEB_TEMP_FILE, NULL, NULL, timeout), !res_url_request) {
+            if (res_url_request = wurl_request(url, VU_DEB_TEMP_FILE, NULL, NULL, update->timeout), !res_url_request) {
                 break;
             } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
                 return NULL;
@@ -3861,6 +3887,7 @@ cJSON *wm_vuldet_get_debian_status_feed(const long timeout) {
             sleep(attempts);
         }
     } else {
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, VU_DEB_TEMP_FILE);
         fclose(deb_file);
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3872,9 +3872,13 @@ cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
         if (w_is_file(path)) {
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, path);
             json_file = wm_vuldet_json_fread(path);
+            return json_file;
+        } else {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Unable to read file '%s'", path);
         }
-        return json_file;
-    } else if (deb_file = fopen(VU_DEB_TEMP_FILE, "r"), !deb_file) {
+    }
+
+    if (deb_file = fopen(VU_DEB_TEMP_FILE, "r"), !deb_file) {
         // Download Debian status feed
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, url);
         for (attempts = 0;; attempts++) {


### PR DESCRIPTION
## Description
Added the possibility to set a custom location for the Debian Security Tracker feed, which provide us the affected packages for all the Debian vulnerabilities.

To achieve it, the tags `url` and `path` are now available for this feed, generic to all the Debian distributions.

## Configuration options and log examples

**Path**

```xml
<path>/root/vulnerability-detector/feeds/security_tracker_local.json</path>
```

```
2020/07/24 04:31:27 wazuh-modulesd:vulnerability-detector[85998] wm_vuln_detector.c:2187 at wm_vuldet_index_debian(): DEBUG: (5420): Indexing vulnerabilities from the Debian Security Tracker.
2020/07/24 04:31:27 wazuh-modulesd:vulnerability-detector[85998] wm_vuln_detector.c:3873 at wm_vuldet_get_debian_status_feed(): DEBUG: (5436): Fetching Debian Security Tracker from '/root/vulnerability-detector/feeds/security_tracker_local.json'
```

**URL**

```xml
<url>http://192.168.1.38/security_tracker_url.json</url>
```

```
2020/07/24 04:36:23 wazuh-modulesd:vulnerability-detector[86899] wm_vuln_detector.c:2187 at wm_vuldet_index_debian(): DEBUG: (5420): Indexing vulnerabilities from the Debian Security Tracker.
2020/07/24 04:36:23 wazuh-modulesd:vulnerability-detector[86899] wm_vuln_detector.c:3879 at wm_vuldet_get_debian_status_feed(): DEBUG: (5436): Fetching Debian Security Tracker from 'http://192.168.1.38/security_tracker_url.json'
2020/07/24 04:36:23 wazuh-modulesd:download[86899] wm_download.c:226 at wm_download_dispatch(): DEBUG: Downloading 'http://192.168.1.38/security_tracker_url.json' to '/var/ossec/tmp/vuln-temp-deb'
2020/07/24 04:36:23 wazuh-modulesd:download[86899] wm_download.c:246 at wm_download_dispatch(): DEBUG: Download of 'http://192.168.1.38/security_tracker_url.json' finished.
```

**URL + port**

```xml
<url port="80">http://192.168.1.38/security_tracker_url.json</url>
```

```
2020/07/24 04:38:15 wazuh-modulesd:vulnerability-detector[87327] wm_vuln_detector.c:3879 at wm_vuldet_get_debian_status_feed(): DEBUG: (5436): Fetching Debian Security Tracker from 'http://192.168.1.38:80/security_tracker_url.json'
```

After the first time the feed is downloaded, it is stored in the `tmp/` directory, so it is read from there directly for the rest of the Debian OVAL feeds.

```
2020/07/24 04:36:30 wazuh-modulesd:vulnerability-detector[86899] wm_vuln_detector.c:3890 at wm_vuldet_get_debian_status_feed(): DEBUG: (5436): Fetching Debian Security Tracker from 'tmp/vuln-temp-deb'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] Tested use cases described above

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
