### PR TITLE
Prevent the manager service from running Authd

### DIFF
--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -342,7 +342,19 @@ start()
                 fi
              else
                 continue
-             fi             
+             fi
+             # If it is a worker node, don't try to start authd.
+             start_config="$(grep -n "<cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
+             end_config="$(grep -n "</cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
+             if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
+                sed -n "${start_config},${end_config}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
+                if [ $? != 0 ]; then
+                    sed -n "${start_config},${end_config}p" ${DIR}/etc/ossec.conf | grep "<node_type>worker" >/dev/null 2>&1
+                    if [ $? = 0 ]; then
+                        continue
+                    fi
+                fi
+             fi
         fi
         if [ $USE_JSON = true ] && [ $first = false ]; then
             echo -n ','


### PR DESCRIPTION
|Related issue|
|---|
|#5454|

PR #5433 enabled Authd in worker nodes, but then disabled it provisionally (depends on #5435). However, we disabled it on _ossec-authd_ and not on _ossec-control_, which should skip running that daemon. Consequently:

- _ossec-control_ runs _ossec-authd_.
- _ossec-authd_ detects that is running on a worker node and exits successfully.
- _ossec-control_ detects that _ossec-authd_ was closed and it produces a failure.

## Fix

Revert commit 2002d6f55fda814f74529af9e9daff5dd14a95c7 completely.

## Artifacts affected

- _ossec-control_ script in a manager installation.

## Tests

- [x] Set up a cluster with a master and one worker node. Check that both nodes start correctly.
- [x] _ossec-authd_ should be running on the master node only.