### PR TITLE
Fix apostrophes in params. Fix reserved words (offset/count) in params.

### DIFF
--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -46,7 +46,6 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
                 'search': parse_api_param(search, 'search'),
                 'q': q,
                 'filters': filters}
-
     dapi = DistributedAPI(f=sca.get_sca_list,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
@@ -61,9 +60,9 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
 
 
 async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete=False, policy_id=None, title=None,
-                         description=None, rationale=None, remediation=None, file=None, process=None, directory=None,
-                         registry=None, references=None, result=None, condition=None, offset=0, limit=database_limit,
-                         sort=None, search=None, q=None):
+                         description=None, rationale=None, remediation=None, command=None, status=None, reason=None,
+                         file=None, process=None, directory=None, registry=None, references=None, result=None,
+                         condition=None, offset=0, limit=database_limit, sort=None, search=None, q=None):
     """Get policy monitoring alerts for a given policy
 
     :param agent_id: Agent ID. All possible values since 000 onwards
@@ -74,6 +73,9 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
     :param description: Filters by policy description
     :param rationale: Filters by rationale
     :param remediation: Filters by remediation
+    :param command: Filters by command
+    :param command: Filters by status
+    :param command: Filters by reason
     :param file: Filters by file
     :param process: Filters by process
     :param directory: Filters by directory
@@ -93,6 +95,9 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
                'description': description,
                'rationale': rationale,
                'remediation': remediation,
+               'command': command,
+               'status': status,
+               'reason': reason,
                'file': file,
                'process': process,
                'directory': directory,

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -74,8 +74,8 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
     :param rationale: Filters by rationale
     :param remediation: Filters by remediation
     :param command: Filters by command
-    :param command: Filters by status
-    :param command: Filters by reason
+    :param status: Filters by status
+    :param reason: Filters by reason
     :param file: Filters by file
     :param process: Filters by process
     :param directory: Filters by directory

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3180,6 +3180,13 @@ components:
       schema:
         type: string
         format: alphanumeric
+    command:
+      in: query
+      name: command
+      description: "Filter by command"
+      schema:
+        type: string
+        format: alphanumeric
     component:
       in: path
       name: component
@@ -3425,7 +3432,7 @@ components:
       description: "Filter by policy description"
       schema:
         type: string
-        format: alphanumeric
+        format: alphanumeric_symbols
     directory:
       in: query
       name: directory
@@ -3720,7 +3727,7 @@ components:
       description: "Filter by rationale"
       schema:
         type: string
-        format: alphanumeric
+        format: alphanumeric_symbols
     registry:
       in: query
       name: registry
@@ -3740,6 +3747,7 @@ components:
       description: "Filter by remediation"
       schema:
         type: string
+        format: alphanumeric_symbols
     rule_requirement:
       in: path
       name: requirement
@@ -3792,6 +3800,13 @@ components:
       schema:
         type: integer
         minimum: 0
+    reason:
+      in: query
+      name: reason
+      description: "Filter by reason"
+      schema:
+        type: string
+        format: alphanumeric_symbols
     rule_ids:
       in: query
       name: rule_ids
@@ -3839,6 +3854,13 @@ components:
       schema:
         type: string
         format: sort
+    status:
+      in: query
+      name: status
+      description: "Filter by status"
+      schema:
+        type: string
+        format: alphanumeric
     statusAgentParam:
       in: query
       name: status
@@ -3871,7 +3893,7 @@ components:
       description: "Filter by title"
       schema:
         type: string
-        format: alphanumeric
+        format: alphanumeric_symbols
     type_agents:
       in: query
       name: type
@@ -9548,6 +9570,9 @@ paths:
         - $ref: '#/components/parameters/description'
         - $ref: '#/components/parameters/rationale'
         - $ref: '#/components/parameters/remediation'
+        - $ref: '#/components/parameters/command'
+        - $ref: '#/components/parameters/status'
+        - $ref: '#/components/parameters/reason'
         - $ref: '#/components/parameters/full_path_filter'
         - $ref: '#/components/parameters/process'
         - $ref: '#/components/parameters/directory'

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -12,6 +12,7 @@ from jsonschema import draft4_format_checker
 from wazuh.core import common
 
 _alphanumeric_param = re.compile(r'^[\w,\-\.\+\s\:]+$')
+_symbols_alphanumeric_param = re.compile(r'^[a-zA-Z0-9_,<>!\-.+\s:/()\'"|=]+$')
 _array_numbers = re.compile(r'^\d+(,\d+)*$')
 _array_names = re.compile(r'^[\w\-\.]+(,[\w\-\.]+)*$')
 _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$')
@@ -116,6 +117,11 @@ def is_safe_path(path: str, basedir: str = common.ossec_path, follow_symlinks: b
 @draft4_format_checker.checks("alphanumeric")
 def format_alphanumeric(value):
     return check_exp(value, _alphanumeric_param)
+
+
+@draft4_format_checker.checks("alphanumeric_symbols")
+def format_alphanumeric_symbols(value):
+    return check_exp(value, _symbols_alphanumeric_param)
 
 
 @draft4_format_checker.checks("base64")

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -441,6 +441,66 @@ stages:
           failed_items: []
           total_failed_items: 0
 
+  - name: Parameters -> title="Ensure address space layout randomization (ASLR) is enabled"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        title: Ensure address space layout randomization (ASLR) is enabled
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - title: Ensure address space layout randomization (ASLR) is enabled
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> title="non-existent"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        title: non-existent
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: 0
+          affected_items: []
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> description="The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        description: The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root.
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - description: The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root.
+          failed_items: []
+          total_failed_items: 0
+        message: !anystr
+
   - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
     request:
       verify: False
@@ -459,6 +519,92 @@ stages:
           affected_items:
             - <<: *sca_check_result_001
               remediation: Remove any legacy + entries from /etc/group if they exist.
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> rationale with apostrophe and parenthesis"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        rationale: >-
+          Having no timeout value associated with a connection could allow an unauthorized user access to
+          another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a
+          timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5
+          minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0.
+          In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages
+          will be sent.
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - id: 3081
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> command="dpkg -s libpam-pwquality"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        command: dpkg -s libpam-pwquality
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - command: dpkg -s libpam-pwquality
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> status="Not applicable"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        status: Not applicable
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - status: Not applicable
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        reason: Invalid path or wrong permissions to run command 'ip6tables -L'
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - reason: Invalid path or wrong permissions to run command 'ip6tables -L'
           failed_items: []
           total_failed_items: 0
 
@@ -924,6 +1070,86 @@ stages:
           failed_items: []
           total_failed_items: 0
 
+  - name: Parameters -> rationale with apostrophe"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        rationale: With automounting enabled anyone with physical access could attach a USB drive or disc and have it's contents available in system even if they lacked permissions to mount it themselves.
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - rationale: With automounting enabled anyone with physical access could attach a USB drive or disc and have it's contents available in system even if they lacked permissions to mount it themselves.
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> command="systemctl is-enabled autofs"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        command: systemctl is-enabled autofs
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - command: systemctl is-enabled autofs
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> status="Not applicable"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        status: Not applicable
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - status: Not applicable
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> reason="Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        reason: Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - reason: Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'
+          failed_items: []
+          total_failed_items: 0
+
 ---
 test_name: GET /sca/003
 
@@ -1383,5 +1609,91 @@ stages:
           affected_items:
             - <<: *sca_check_result_003
               remediation: Remove any legacy + entries from /etc/group if they exist.
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> rationale with apostrophe and parenthesis"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        rationale: >-
+          Having no timeout value associated with a connection could allow an unauthorized user access to
+          another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a
+          timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5
+          minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0.
+          In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages
+          will be sent.
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - id: 3081
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> command="dpkg -s libpam-pwquality"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        command: dpkg -s libpam-pwquality
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - command: dpkg -s libpam-pwquality
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> status="Not applicable"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        status: Not applicable
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - status: Not applicable
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        reason: Invalid path or wrong permissions to run command 'ip6tables -L'
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - reason: Invalid path or wrong permissions to run command 'ip6tables -L'
           failed_items: []
           total_failed_items: 0

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -548,6 +548,53 @@ stages:
           failed_items: []
           total_failed_items: 0
 
+  - name: Parameters -> rationale with word "count"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        rationale: >-
+          Any users assigned to the shadow group would be granted read access to the /etc/shadow file.
+          If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking
+          program against the hashed passwords to break them. Other security information that is stored in
+          the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - rationale: >-
+                Any users assigned to the shadow group would be granted read access to the /etc/shadow file.
+                If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking
+                program against the hashed passwords to break them. Other security information that is stored in
+                the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> rationale with word "offset"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        rationale: offset
+    response:
+      status_code: 200
+      json:
+        data:
+          total_affected_items: 0
+          affected_items: []
+          failed_items: []
+          total_failed_items: 0
+
   - name: Parameters -> command="dpkg -s libpam-pwquality"
     request:
       verify: False

--- a/framework/wazuh/core/sca.py
+++ b/framework/wazuh/core/sca.py
@@ -2,9 +2,10 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
-from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
-from wazuh.core.agent import Agent
 from datetime import datetime
+
+from wazuh.core.agent import Agent
+from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
 
 # API field -> DB field
 fields_translation_sca = {'policy_id': 'policy_id',
@@ -66,6 +67,25 @@ class WazuhDBQuerySCA(WazuhDBQuery):
 
     def _default_count_query(self):
         return f"SELECT COUNT(DISTINCT {self.count_field})" + " FROM ({0})"
+
+    def _process_filter(self, field_name, field_filter, q_filter):
+        if field_name in self.date_fields and not isinstance(q_filter['value'], (int, float)):
+            # Filter a date, but only if it is in string (YYYY-MM-DD hh:mm:ss) format.
+            # If it matches the same format as DB (timestamp integer), filter directly by value (next if cond).
+            self._filter_date(q_filter, field_name)
+        else:
+            if q_filter['value'] is not None:
+                self.request[field_filter] = q_filter['value'] if field_name != "version" else re.sub(
+                    r'([a-zA-Z])([v])', r'\1 \2', q_filter['value'])
+                if q_filter['operator'] == 'LIKE' and q_filter['field'] not in self.wildcard_equal_fields:
+                    self.request[field_filter] = "%{}%".format(self.request[field_filter])
+                self.query += '{} {} :{}'.format(self.fields[field_name].split(' as ')[0], q_filter['operator'],
+                                                 field_filter)
+                if not field_filter.isdigit():
+                    # filtering without being uppercase/lowercase sensitive
+                    self.query += ' COLLATE NOCASE'
+            else:
+                self.query += '{} IS null'.format(self.fields[field_name])
 
     def _format_data_into_dictionary(self):
         def format_fields(field_name, value):

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -292,7 +292,7 @@ def test_WazuhDBQueryAgents_parse_legacy_filters(mock_socket_conn, mock_isfile, 
 @pytest.mark.parametrize('field_name, field_filter, q_filter', [
     ('group', 'field', {'value': '1', 'operator': 'LIKE'}),
     ('group', 'test', {'value': '1', 'operator': 'LIKE'}),
-    ('os.name', 'field', {'value': '1', 'operator': 'LIKE'}),
+    ('os.name', 'field', {'value': '1', 'operator': 'LIKE', 'field': 'status$0'}),
 ])
 @patch('wazuh.core.utils.glob.glob', return_value=True)
 @patch('sqlite3.connect')
@@ -820,65 +820,6 @@ def test_agent_remove_manual(grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, sa
             chmod_r_mock.assert_called_once_with(backup_path, 0o750)
 
 
-@pytest.mark.parametrize('agent_id, expected_exception', [
-    ('001', 1746),
-    ('006', 1701),
-    ('001', 1600),
-    ('001', 1748),
-    ('001', 1747)
-])
-@patch('wazuh.core.agent.WazuhDBBackend.connect_to_db')
-@patch('wazuh.core.agent.remove')
-@patch('wazuh.core.agent.rmtree')
-@patch('wazuh.core.agent.chown')
-@patch('wazuh.core.agent.chmod')
-@patch('wazuh.core.agent.stat')
-@patch('wazuh.core.agent.glob')
-@patch("wazuh.common.client_keys", new=os.path.join(test_data_path, 'etc', 'client.keys'))
-@patch('wazuh.core.agent.path.exists', side_effect=lambda x: not (common.backup_path in x))
-@patch('wazuh.core.database.isfile', return_value=True)
-@patch('wazuh.core.agent.path.isdir', return_value=True)
-@patch('wazuh.core.agent.safe_move')
-@patch('wazuh.core.agent.makedirs')
-@patch('wazuh.core.agent.chmod_r')
-@freeze_time('1975-01-01')
-@patch("wazuh.common.ossec_uid", return_value=getpwnam("root"))
-@patch("wazuh.common.ossec_gid", return_value=getgrnam("root"))
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path,  'global.db'))
-def test_agent_remove_manual_ko(grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, safe_move_mock, isdir_mock,
-                                isfile_mock,   exists_mock, glob_mock, stat_mock, chmod_mock, chown_mock, rmtree_mock,
-                                remove_mock, wdb_mock, agent_id, expected_exception):
-    """Test the _remove_manual function error cases.
-
-    Parameters
-    ----------
-    agent_id : str
-        Id of the agent to be searched.
-    expected_exception : int
-        Error code that is expected.
-    """
-    client_keys_text = '\n'.join([f'{str(row["id"]).zfill(3) if expected_exception != 1701 else "100"} '
-                                  f'{row["name"]} '
-                                  f'{row["register_ip"]} '
-                                  f'{row["internal_key"] + "" if expected_exception != 1746 else " random"}' for row in
-                                  test_data.global_db.execute(
-                                      'select id, name, register_ip, internal_key from agent where id > 0')])
-
-    glob_mock.return_value = ['/var/db/global.db'] if expected_exception != 1600 else []
-    rmtree_mock.side_effect = Exception("Boom!")
-
-    with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
-        with patch('sqlite3.connect') as mock_db:
-            mock_db.return_value = test_data.global_db
-            if expected_exception == 1747:
-                mock_db.return_value.execute("drop table belongs")
-            with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
-                Agent(agent_id)._remove_manual()
-
-    if expected_exception == 1746:
-        remove_mock.assert_any_call('{0}/etc/client.keys.tmp'.format(test_data_path))
-
-
 @pytest.mark.parametrize("authd_status", [
     'running',
     'stopped'
@@ -1170,13 +1111,13 @@ def test_agent_get_agents_overview_default():
     ({'id', 'dateAdd'}, 'all', None, 0),
     ({'id', 'ip', 'registerIP'}, 'all', None, 1),
     ({'id', 'registerIP'}, 'all', None, 1),
-    ({'id', 'ip', 'lastKeepAlive'}, 'active,pending', None, 0),
+    ({'id', 'ip', 'lastKeepAlive'}, 'active', None, 0),
     ({'id', 'ip', 'lastKeepAlive'}, 'disconnected', None, 1),
     ({'id', 'ip', 'lastKeepAlive'}, 'disconnected', '1s', 1),
     ({'id', 'ip', 'lastKeepAlive'}, 'disconnected', '2h', 0),
     ({'id', 'ip', 'lastKeepAlive'}, 'all', '15m', 2),
     ({'id', 'ip', 'lastKeepAlive'}, 'active', '15m', 0),
-    ({'id', 'ip', 'lastKeepAlive'}, 'active,pending', '15m', 1),
+    ({'id', 'ip', 'lastKeepAlive'}, 'pending', '15m', 1),
     ({'id', 'ip', 'lastKeepAlive'}, ['active', 'pending'], '15m', 1)
 ])
 @patch("wazuh.common.database_path_global", new=os.path.join(test_data_path,  'global.db'))
@@ -1255,7 +1196,7 @@ def test_agent_get_agents_overview_query(query, totalItems):
 @pytest.mark.parametrize("status, older_than, totalItems, exception", [
     ('active', '9m', 4, None),
     ('all', '1s', 8, None),
-    ('pending,never_connected', '30m', 1, None),
+    ('never_connected', '30m', 1, None),
     (55, '30m', 0, 1729)
 ])
 @patch("wazuh.common.database_path_global", new=os.path.join(test_data_path,  'global.db'))
@@ -2294,3 +2235,109 @@ def test_send_restart_command(mock_ossec_queue):
     """Test that restart_command calls send_msg_to_agent with correct params"""
     send_restart_command('001')
     mock_ossec_queue.return_value.send_msg_to_agent.assert_called_once_with(ANY, '001')
+
+
+@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path,  'global.db'))
+def test_get_agents_info():
+    """Test that get_agents_info() returns expected agent IDs"""
+    expected_result = {'005', '003', '008', '000', '004', '001', '006', '002', '007'}
+
+    with patch('sqlite3.connect') as mock_db:
+        mock_db.return_value = test_data.global_db
+
+        result = get_agents_info()
+        assert result == expected_result
+
+
+@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path,  'global.db'))
+def test_get_groups():
+    """Test that get_groups() returns expected agent groups"""
+    expected_result = {'group-1', 'group-2'}
+
+    with patch('sqlite3.connect') as mock_db:
+        mock_db.return_value = test_data.global_db
+
+        result = get_groups()
+        assert result == expected_result
+
+
+@pytest.mark.parametrize('group, expected_agents', [
+    ('group-1', {'000'}),
+    ('group-2', {'001'}),
+    ('*', {'006', '008', '000', '002', '005', '007', '001'})
+])
+@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path,  'global.db'))
+def test_expand_group(group, expected_agents):
+    """Test that expand_group() returns expected agent IDs
+
+    Parameters
+    ----------
+    group : str
+        Name of the group to be expanded
+    expected_agents : set
+        Expected agent IDs for the selected group
+    """
+    with patch('sqlite3.connect') as mock_db:
+        mock_db.return_value = test_data.global_db
+
+        result = expand_group(group)
+        assert result == expected_agents
+
+
+@pytest.mark.parametrize('agent_id, expected_exception', [
+    ('001', 1746),
+    ('006', 1701),
+    ('001', 1600),
+    ('001', 1748),
+    ('001', 1747)
+])
+@patch('wazuh.core.agent.WazuhDBBackend.connect_to_db')
+@patch('wazuh.core.agent.remove')
+@patch('wazuh.core.agent.rmtree')
+@patch('wazuh.core.agent.chown')
+@patch('wazuh.core.agent.chmod')
+@patch('wazuh.core.agent.stat')
+@patch('wazuh.core.agent.glob')
+@patch("wazuh.common.client_keys", new=os.path.join(test_data_path, 'etc', 'client.keys'))
+@patch('wazuh.core.agent.path.exists', side_effect=lambda x: not (common.backup_path in x))
+@patch('wazuh.core.database.isfile', return_value=True)
+@patch('wazuh.core.agent.path.isdir', return_value=True)
+@patch('wazuh.core.agent.safe_move')
+@patch('wazuh.core.agent.makedirs')
+@patch('wazuh.core.agent.chmod_r')
+@freeze_time('1975-01-01')
+@patch("wazuh.common.ossec_uid", return_value=getpwnam("root"))
+@patch("wazuh.common.ossec_gid", return_value=getgrnam("root"))
+@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path,  'global.db'))
+def test_agent_remove_manual_ko(grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, safe_move_mock, isdir_mock,
+                                isfile_mock,   exists_mock, glob_mock, stat_mock, chmod_mock, chown_mock, rmtree_mock,
+                                remove_mock, wdb_mock, agent_id, expected_exception):
+    """Test the _remove_manual function error cases.
+
+    Parameters
+    ----------
+    agent_id : str
+        Id of the agent to be searched.
+    expected_exception : int
+        Error code that is expected.
+    """
+    client_keys_text = '\n'.join([f'{str(row["id"]).zfill(3) if expected_exception != 1701 else "100"} '
+                                  f'{row["name"]} '
+                                  f'{row["register_ip"]} '
+                                  f'{row["internal_key"] + "" if expected_exception != 1746 else " random"}' for row in
+                                  test_data.global_db.execute(
+                                      'select id, name, register_ip, internal_key from agent where id > 0')])
+
+    glob_mock.return_value = ['/var/db/global.db'] if expected_exception != 1600 else []
+    rmtree_mock.side_effect = Exception("Boom!")
+
+    with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
+        with patch('sqlite3.connect') as mock_db:
+            mock_db.return_value = test_data.global_db
+            if expected_exception == 1747:
+                mock_db.return_value.execute("drop table belongs")
+            with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
+                Agent(agent_id)._remove_manual()
+
+    if expected_exception == 1746:
+        remove_mock.assert_any_call('{0}/etc/client.keys.tmp'.format(test_data_path))

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -169,13 +169,16 @@ class WazuhDBConnection:
                 raise WazuhError(2004, "Update query is wrong")
             return self._send(query_lower)
 
+        # Remove text inside 'where' clause to prevent finding reserved words (offset/count)
+        query_without_where = re.sub(r'where \(.*\)', 'where ()', query_lower)
+
         # if the query has already a parameter limit / offset, divide using it
         offset = 0
-        if 'offset' in query_lower:
+        if 'offset' in query_without_where:
             offset = int(re.compile(r".* offset (\d+)").match(query_lower).group(1))
             query_lower = query_lower.replace(" offset {}".format(offset), "")
 
-        if 'count' not in query_lower:
+        if not re.search(r'.?count\(.*\).?', query_without_where):
             lim = 0
             if 'limit' in query_lower:
                 lim = int(re.compile(r".* limit (\d+)").match(query_lower).group(1))


### PR DESCRIPTION
|Related issue|
|---|
|#5434|

# Description

Hello team. This PR add some different fixes/developments:

## Replace special characters before calling DB

When using special characters like apostrophe (`'`), several parameters stopped working fine, such as the `q` on most endpoints, multiple fields (title, description ...) in `GET /sca/{agent_id}/checks/{policy_id}`, etc. That behaviour was already reported and fixed on the issue https://github.com/wazuh/wazuh/issues/5312, but it was for version 3.13 of Wazuh. 

However, although the solution is similar (replacing special characters with a wildcard before performing the request to the database), in this PR it has been implemented inside WazuhDBQuery so it affects many more endpoints than the fix adopted for 3.13, in which only the WazuhDBQuerySCA class was modified.

Here you can see an example that looks for the following text with apostrophe and parentheses: 

> Ensure events that modify the system's Mandatory Access Controls are collected (SELinux)

```
curl -u foo:bar "https://localhost:55000/sca/000/checks/cis_debian9_L2?pretty&rationale=Changes%20to%20files%20in%20these%20directories%20could%20indicate%20that%20an%20unauthorized%20user%20is%20attempting%20to%20modify%20access%20controls%20and%20change%20security%20contexts%2C%20leading%20to%20a%20compromise%20of%20the%20system." -k
```
```JSON
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "directory": "/etc/audit",
            "remediation": "On systems using AppArmor add the following line to the /etc/audit/audit.rules file: -w /etc/apparmor/ -p wa -k MAC-policy | -w /etc/apparmor.d/ -p wa -k MAC-policy. Notes: Reloading the auditd config to set active settings may require a system reboot.",
            "result": "failed",
            "reason": "",
            "status": "",
            "condition": "all",
            "policy_id": "cis_debian9_L2",
            "description": "Monitor AppArmor mandatory access control. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/apparmor and /etc/apparmor.d directories.",
            "title": "Ensure events that modify the system's Mandatory Access Controls are collected (AppArmor)",
            "id": 3517,
            "rationale": "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system.",
         ...
         }
      ]
   }
}
```

## Fix wdb when offset or count inside query

When trying to filter by some strings, sometimes an error was returned. It was the case when trying to find, for instance, this text:

> ... (such as expiration) could also be useful to subvert additional user ac**count**s.

As you can see, it contains the word **count**. This when arriving at lines 178 (174 for the word **offset**) of wdb.py, caused unexpected behaviours. It has been corrected by removing everything that goes inside the _where_ clause.

https://github.com/wazuh/wazuh/blob/583bbc7dfc7e39b0e6842dade98cbfada45cf75c/framework/wazuh/core/wdb.py#L174-L178

## Add status, reason and command to /sca/{agent_id}/checks/{policy_id}

As was done in 3.13, `status`, `reason`, and `command` fields have been added to the endpoint `GET /sca/{agent_id}/checks/{policy_id}`. A new validator has also been created, which supports a greater variety of symbols.

## Update and add missing tests

Apart from adding and updating the unit tests corresponding to the changes explained in this PR, it has been necessary to add some extra tests for recently created functions that were not being tested, both in `wazuh/core/utils.py` and `wazuh/core/agents.py`.

Several new tests have also been added for the SCA endpoint, in order to test both the new parameters mentioned above, as well as strings that contain conflicting characters that previously would have caused failures.

# Tests
## Unit tests
### Core
```
PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest wazuh/core/tests/
=================================== test session starts ====================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: tavern-1.2.2, cov-2.10.0
collected 620 items                                                                        

wazuh/core/tests/test_active_response.py ............                                [  1%]
wazuh/core/tests/test_agent.py ..................................................... [ 10%]
.................................................................................... [ 24%]
.................................................                                    [ 31%]
wazuh/core/tests/test_cdb_list.py ......................                             [ 35%]
wazuh/core/tests/test_common.py .......                                              [ 36%]
wazuh/core/tests/test_configuration.py ................................              [ 41%]
wazuh/core/tests/test_decoder.py ...............                                     [ 44%]
wazuh/core/tests/test_input_validator.py ...                                         [ 44%]
wazuh/core/tests/test_manager.py ..........................                          [ 48%]
wazuh/core/tests/test_ossec_queue.py ...................                             [ 51%]
wazuh/core/tests/test_ossec_socket.py ..............                                 [ 54%]
wazuh/core/tests/test_pyDaemonModule.py ......                                       [ 55%]
wazuh/core/tests/test_results.py ........................................            [ 61%]
wazuh/core/tests/test_rule.py .....................                                  [ 65%]
wazuh/core/tests/test_syscollector.py ...                                            [ 65%]
wazuh/core/tests/test_utils.py ..................................................... [ 74%]
.................................................................................... [ 87%]
..........................................................                           [ 96%]
wazuh/core/tests/test_wdb.py ...................                                     [100%]

=================================== 620 passed in 2.12s ====================================
```

### SDK
The CDB lists tests already failed before, it would be necessary to study the reason and open an issue.
```
PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest wazuh/tests/
=================================== test session starts ====================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: tavern-1.2.2, cov-2.10.0
collected 585 items                                                                        

wazuh/tests/test_active_response.py .........                                        [  1%]
wazuh/tests/test_agent.py .......................................................... [ 11%]
....................................                                                 [ 17%]
wazuh/tests/test_cdb_list.py ..........................FFFFFFF.F.FF.FFFFFFFF         [ 25%]
wazuh/tests/test_ciscat.py ..                                                        [ 25%]
wazuh/tests/test_cluster.py .....ss                                                  [ 27%]
wazuh/tests/test_decoders.py ...............................                         [ 32%]
wazuh/tests/test_group.py ........                                                   [ 33%]
wazuh/tests/test_manager.py ........................................                 [ 40%]
wazuh/tests/test_mitre.py .......................................................... [ 50%]
.................................................................................... [ 64%]
......................................                                               [ 71%]
wazuh/tests/test_rule.py ....................................................        [ 80%]
wazuh/tests/test_sca.py .......                                                      [ 81%]
wazuh/tests/test_security.py ....................................................... [ 90%]
..........                                                                           [ 92%]
wazuh/tests/test_stats.py .............                                              [ 94%]
wazuh/tests/test_syscheck.py ..................                                      [ 97%]
wazuh/tests/test_syscollector.py ............                                        [100%]

========================================= FAILURES =========================================
```

## Integration tests
### SCA
```
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.2.2, cov-2.10.0
collecting ... collected 6 items

test_sca_endpoints.tavern.yaml::GET /sca/001 PASSED                      [ 16%]
test_sca_endpoints.tavern.yaml::GET /sca/001/checks/cis_debian9_L1 PASSED [ 33%]
test_sca_endpoints.tavern.yaml::GET /sca/002 PASSED                      [ 50%]
test_sca_endpoints.tavern.yaml::GET /sca/002/checks/cis_debian9_L1 PASSED [ 66%]
test_sca_endpoints.tavern.yaml::GET /sca/003 PASSED                      [ 83%]
test_sca_endpoints.tavern.yaml::GET /sca/003/checks/cis_debian9_L1 PASSED [100%]

=============================== warnings summary ===============================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 6 passed, 8 warnings in 88.96s (0:01:28) ===================
```

Although I am only attaching the result of the SCA tests, I have **successfully passed all the integration tests**, except for a failure in the `rules` test related to an incorrect rule.

Kind regards,
Selu.