### PR TITLE
Refactor check_experimental middleware

### DIFF
--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -9,6 +9,8 @@ from aiohttp import web
 import wazuh.ciscat as ciscat
 import wazuh.syscheck as syscheck
 import wazuh.syscollector as syscollector
+from api import configuration
+from api.api_exception import APIError
 from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -24,6 +26,9 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
     :param list_agents: List of agent's IDs.
     :return: AllItemsResponseAgentIDs
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     f_kwargs = {'agent_list': list_agents}
 
     dapi = DistributedAPI(f=syscheck.clear,
@@ -63,6 +68,9 @@ async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, li
     :param score: Filters by final score
     :return: AllItemsResponseCiscatResult
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -111,6 +119,9 @@ async def get_hardware_info(request, pretty=False, wait_for_complete=False, list
     :param board_serial: Filters by board_serial
     :return: AllItemsResponseSyscollectorHardware
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     filters = {
         'board_serial': board_serial
         }
@@ -163,6 +174,9 @@ async def get_network_address_info(request, pretty=False, wait_for_complete=Fals
     :param netmask: Filters by netmask
     :return: AllItemsResponseSyscollectorNetwork
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -212,6 +226,9 @@ async def get_network_interface_info(request, pretty=False, wait_for_complete=Fa
     :param mtu: Filters by mtu
     :return: AllItemsResponseSyscollectorInterface
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     filters = {
         'adapter': adapter,
         'type': request.query.get('type', None),
@@ -266,6 +283,9 @@ async def get_network_protocol_info(request, pretty=False, wait_for_complete=Fal
     :param dhcp: Filters by dhcp
     :return: AllItemsResponseSyscollectorProtocol
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -316,6 +336,9 @@ async def get_os_info(request, pretty=False, wait_for_complete=False, list_agent
     :param release: Filters by release
     :return: AllItemsResponseSyscollectorOS
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -365,6 +388,9 @@ async def get_packages_info(request, pretty=False, wait_for_complete=False, list
     :param version: Filters by format
     :return: AllItemsResponseSyscollectorPackages
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -416,6 +442,9 @@ async def get_ports_info(request, pretty=False, wait_for_complete=False, list_ag
     :param process: Filters by process
     :return: AllItemsResponseSyscollectorPorts
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     filters = {
         'pid': pid,
         'protocol': protocol,
@@ -483,6 +512,9 @@ async def get_processes_info(request, pretty=False, wait_for_complete=False, lis
     :param suser: Filters by process suser
     :return: AllItemsResponseSyscollectorProcesses
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -538,6 +570,8 @@ async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, list
     :param hotfix: Filters by hotfix in Windows agents
     :return:AllItemsResponseSyscollectorHotfixes
     """
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(APIError(code=2008))
 
     filters = {'hotfix': hotfix}
 

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -1,23 +1,10 @@
-from aiohttp import web
 
-from api import configuration
-from api.api_exception import APIError
-from api.util import raise_if_exc
+from aiohttp import web
 
 
 @web.middleware
 async def set_user_name(request, handler):
     if 'token_info' in request:
         request['user'] = request['token_info']['sub']
-    response = await handler(request)
-    return response
-
-
-@web.middleware
-async def check_experimental(request, handler):
-    if 'experimental' in request.path:
-        if not configuration.api_conf['experimental_features']:
-            raise_if_exc(APIError(code=2008))
-
     response = await handler(request)
     return response

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -25,7 +25,7 @@ from api import validator
 from api.api_exception import APIException
 from api.configuration import generate_self_signed_certificate, generate_private_key
 from api.constants import CONFIG_FILE_PATH, API_LOG_FILE_PATH
-from api.middlewares import set_user_name, check_experimental
+from api.middlewares import set_user_name
 from api.uri_parser import APIUriParser
 from api.util import to_relative_path
 from wazuh.core import pyDaemonModule, common
@@ -120,7 +120,7 @@ def start(foreground, root, config_file):
                 strict_validation=True,
                 validate_responses=True,
                 pass_context_arg_name='request',
-                options={"middlewares": [set_user_name, check_experimental]})
+                options={"middlewares": [set_user_name]})
 
     # Enable CORS
     if cors['enabled']:


### PR DESCRIPTION
|Related issue|
|--|
|#5460|

## Description

Hi team. Currently, when running any endpoint of the API, it checks if the endpoints belongs to `experimental` group. If it does, it checks whether experimental endpoints are allowed or not, so it raises an exception if needed. It works fine but it is adding some innecessary overhead since a substring is searched in all the requests performed to the API, as seen here:

https://github.com/wazuh/wazuh/blob/5e1ebb4e5ca5833a56eacd21244439597824831a/api/api/middlewares.py#L18-L24

Middlewares should be used only for those actions that affect (or may affect) every endpoint in the API. As this is not the case, we have moved the verification step to each experimental endpoint.

Best regards,
Selu.