### PR TITLE
Changing location og global.db to the Wazuh DB folder

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -117,7 +117,7 @@ int wdb_open_global() {
 
     if (!wdb_global) {
         // Database dir
-        snprintf(dir, OS_FLSIZE, "%s%s/%s", isChroot() ? "/" : "", WDB_DIR, WDB_GLOB_NAME);
+        snprintf(dir, OS_FLSIZE, "%s%s/%s", isChroot() ? "/" : "", WDB2_DIR, WDB_GLOB_NAME);
 
         // Connect to the database
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4463,7 +4463,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
     vu_feed agent_dist_ver;
     vu_feed agent_dist;
 
-    snprintf(global_db, OS_FLSIZE, "%s%s/%s", isChroot() ? "/" : "", WDB_DIR, WDB_GLOB_NAME);
+    snprintf(global_db, OS_FLSIZE, "%s%s/%s", isChroot() ? "/" : "", WDB2_DIR, WDB_GLOB_NAME);
 
     if (sqlite3_open_v2(global_db, &db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GLOBALDB_ERROR " SQL Error: '%s'", sqlite3_errmsg(db));


### PR DESCRIPTION
|Related issue|
|---|
|[Issue 5422](https://github.com/wazuh/wazuh/issues/5422)|

## Description

This PR changes the location of the `global.db` database from the legacy database folder **var/db/** to the **Wazuh DB** folder in **queue/db/**.

## Configuration options

No new configurations were added.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade