### PR TITLE
Update and fix older_than parameter behaviour in DELETE /agents API endpoint

### DIFF
--- a/api/test/integration/test_agents_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_DELETE_endpoints.tavern.yaml
@@ -690,7 +690,7 @@ stages:
           total_failed_items: 1
         message: !anystr
 
-    # DELETE /agents?list_agents=004&status=active&older_than=1s
+    # DELETE /agents?list_agents=004&status=active&older_than=0s
   - name: Delete agent with a proper status
     request:
       verify: False
@@ -698,14 +698,14 @@ stages:
       params:
         list_agents: '004'
         status: 'active'
-        older_than: '1s'
+        older_than: '0s'
     response:
       status_code: 200
       json:
         data:
           affected_items:
             - '004'
-          older_than: 1s
+          older_than: 0s
           total_affected_items: 1
         message: !anystr
 
@@ -745,50 +745,50 @@ stages:
           total_failed_items: 1
         message: !anystr
 
-    # DELETE /agents?list_agents=007&older_than=1s
+    # DELETE /agents?list_agents=009&older_than=1s
   - name: Delete agent older_than 1s
     request:
       verify: False
       <<: *delete_agents
       params:
-        list_agents: '007'
+        list_agents: '009'
         older_than: '1s'
     response:
       status_code: 200
       json:
         data:
           affected_items:
-            - '007'
+            - '009'
           older_than: '1s'
           total_affected_items: 1
         message: !anystr
 
-    # DELETE /agents?list_agents=008,009&older_than=1s
+    # DELETE /agents?list_agents=001,011&older_than=1s
   - name: Delete several agents
     request:
       verify: False
       <<: *delete_agents
       params:
-        list_agents: '008,009'
-        older_than: '1s'
+        list_agents: '001,011'
+        older_than: '0s'
     response:
       status_code: 200
       json:
         data:
           affected_items:
-            - "008"
-            - "009"
-          older_than: '1s'
+            - "001"
+            - "011"
+          older_than: '0s'
           total_affected_items: 2
         message: !anystr
 
-    # DELETE /agents?list_agents=011&older_than=1s&purge=True
+    # DELETE /agents?list_agents=012&older_than=1s&purge=True
   - name: Delete agent older_than 1s with purge
     request:
       verify: False
       <<: *delete_agents
       params:
-        list_agents: '011'
+        list_agents: '012'
         older_than: '1s'
         purge: True
     response:
@@ -796,13 +796,13 @@ stages:
       json:
         data:
           affected_items:
-            - '011'
+            - '012'
           older_than: '1s'
           total_affected_items: 1
         message: !anystr
 
     # DELETE /agents
-  - name: Delete all agents (001,002,003,005,012)
+  - name: Delete all agents (001,002,003,005)
     delay_before: 12
     request:
       verify: False
@@ -817,11 +817,9 @@ stages:
       json:
         data:
           affected_items:
-            - "001"
             - "002"
             - "003"
             - "005"
-            - "012"
           older_than: '0s'
           total_affected_items: 5
         message: !anystr

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -104,7 +104,7 @@ class WazuhDBQueryAgents(WazuhDBQuery):
         return super()._format_data_into_dictionary()
 
     def _parse_legacy_filters(self):
-        if 'older_than' in self.legacy_filters:
+        if 'older_than' in self.legacy_filters and self.legacy_filters['older_than'] != '0s':
             if self.legacy_filters['older_than']:
                 self.q = (self.q + ';' if self.q else '') + \
                           "(lastKeepAlive>{0};status!=never_connected,dateAdd>{0};status=never_connected)".format(

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1063,6 +1063,7 @@ class WazuhDBQuery(object):
     def _parse_legacy_filters(self):
         """Parses legacy filters."""
         # some legacy filters can contain multiple values to filter separated by commas. That must split in a list.
+        self.legacy_filters.get('older_than', None) == '0s' and self.legacy_filters.pop('older_than')
         legacy_filters_as_list = {
             name: value if isinstance(value, list) else [value] for name, value in self.legacy_filters.items()
         }


### PR DESCRIPTION
|Related issue|
|---|
|#5470|

Hi team,

This PR closes #5470. In this PR we have fixed a race condition that affected the `older_than` parameter when its value was `0s`.
We have also improved and tested several times in a row the integration tests affected by this change.

### Test results
```bash
adriiiprodri@wazuh python3 run_tests.py -rbac both -k agent           
Collected tests [6]:
test_agents_DELETE_endpoints.tavern.yaml, test_agents_GET_endpoints.tavern.yaml, test_agents_POST_endpoints.tavern.yaml, test_agents_PUT_endpoints.tavern.yaml, test_rbac_black_agents_endpoints.tavern.yaml, test_rbac_white_agents_endpoints.tavern.yaml


test_agents_DELETE_endpoints.tavern.yaml 
	 7 passed, 59 warnings

test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 533 warnings

test_agents_POST_endpoints.tavern.yaml 
	 4 passed, 40 warnings

test_agents_PUT_endpoints.tavern.yaml 
	 8 passed, 66 warnings

test_rbac_black_agents_endpoints.tavern.yaml 
	 38 passed, 157 warnings

test_rbac_white_agents_endpoints.tavern.yaml 
	 38 passed, 166 warnings
```