### PR TITLE
Avoid free of event log name in Windows so it persists on callbacks

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -166,8 +166,9 @@ void LogCollectorStart()
 
             /* Mutexes are not previously initialized under Windows*/
             w_mutex_init(&current->mutex, &win_el_mutex_attr);
-#endif
+#else
             free(current->file);
+#endif
             current->file = NULL;
             current->command = NULL;
             current->fp = NULL;
@@ -183,8 +184,9 @@ void LogCollectorStart()
 
             /* Mutexes are not previously initialized under Windows*/
             w_mutex_init(&current->mutex, &win_el_mutex_attr);
-#endif
+#else
             free(current->file);
+#endif
             current->file = NULL;
             current->command = NULL;
             current->fp = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|#5495|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

After some tests, the conclusion was reached that when restarting the Windows Event Log service, the eventchannel name being used to reconnect was stored in an invalid pointer. This PR aims at fixing this by duplicating the string into the context used by `event_channel_callback`

## Tests

Before applying this PR, after restarting the Windows Event Log, the following messages appeared in the log and the agent was never reconnected:
```
2020/07/17 12:22:36 ossec-agent[1612] read_win_event_channel.c:509 at event_channel_callback(): WARNING: The eventlog service is down. Unable to collect logs from 'ÿÿ_errors' channel.
2020/07/17 12:22:36 ossec-agent[1612] read_win_event_channel.c:93 at convert_unix_string(): ERROR: Could not MultiByteToWideChar() when determining size which returned (1113)
2020/07/17 12:22:36 ossec-agent[1612] read_win_event_channel.c:565 at win_start_event_channel(): ERROR: Could not convert_unix_string() evt_log for (ÿÿ_errors) which returned [(0)-(No error)]
2020/07/17 12:22:36 ossec-agent[1612] read_win_event_channel.c:513 at event_channel_callback(): DEBUG: Trying to reconnect ÿÿ_errors channel in 5 seconds.
```

After the change, the channel started to be properly showed as `Security` and the agent reconnected succesfully:
```
2020/07/17 12:49:47 ossec-agent[2772] read_win_event_channel.c:509 at event_channel_callback(): WARNING: The eventlog service is down. Unable to collect logs from 'Security' channel.
2020/07/17 12:49:47 ossec-agent[2772] read_win_event_channel.c:513 at event_channel_callback(): DEBUG: Trying to reconnect Security channel in 5 seconds.
...
2020/07/17 12:50:02 ossec-agent[2772] read_win_event_channel.c:516 at event_channel_callback(): INFO: 'Security' channel has been reconnected succesfully.
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Dr. Memory
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind