### PR TITLE
Fix incorrect json merge for osquery and ciscat module

### DIFF
--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -43,8 +43,14 @@ conf_sections = {
     'alerts': {'type': 'merge', 'list_options': []},
     'client': {'type': 'merge', 'list_options': []},
     'database_output': {'type': 'merge', 'list_options': []},
-    'email_alerts': {'type': 'merge', 'list_options': []},
-    'reports': {'type': 'merge', 'list_options': []},
+    'email_alerts': {
+        'type': 'merge',
+        'list_options': ['email_to']
+    },
+    'reports': {
+        'type': 'merge',
+        'list_options': ['email_to']
+    },
     'global': {
         'type': 'merge',
         'list_options': ['white_list']

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -55,7 +55,7 @@ conf_sections = {
     },
     'cis-cat': {
         'type': 'merge',
-        'list_options': []
+        'list_options': ['content']
     },
     'syscollector': {
         'type': 'merge',
@@ -90,7 +90,7 @@ conf_sections = {
     },
     'osquery': {
         'type': 'merge',
-        'list_options': []
+        'list_options': ['pack']
     },
     'labels': {
         'type': 'duplicate',


### PR DESCRIPTION
|Related issue|
|---|
|#5490|

Hi team,

This PR closes #5490. In this PR, we have fixed the bug in the output for both modules. Both properties were not indicated as possible lists, this caused the bug.

```bash
curl -k -X GET "https://localhost:55040/v4/groups/group1/files/agent.conf/json?type=conf" -H  "accept: application/json" -H  "Authorization: Bearer TOKEN"
{
  "data": [
    {
      "filters": {},
      "config": {
        "osquery": {
          "disabled": "yes",
          "run_daemon": "yes",
          "log_path": "/var/log/osquery/osqueryd.results.log",
          "config_path": "/etc/osquery/osquery.conf",
          "add_labels": "yes",
          "pack": [
            {
              "name": "custom_pack",
              "item": "/path/to/custom_pack.conf"
            },
            {
              "name": "custom_pack2",
              "item": "/path/to/custom_pack2.conf"
            },
            {
              "name": "custom_pack3",
              "item": "/path/to/custom_pack3.conf"
            }
          ]
        }
      }
    }
  ]
}
```