### PR TITLE
Modify FTS functions and variables for wazuh-logtest

### DIFF
--- a/src/analysisd/accumulator.c
+++ b/src/analysisd/accumulator.c
@@ -27,7 +27,7 @@
 #define OS_ACM_MAXELM 81
 
 /**
- * @brief Struct to save related data by ID
+ * @brief Struct to save data from events sharing the same ID
  */
 typedef struct _OS_ACM_Store {
     time_t timestamp;
@@ -42,7 +42,6 @@ typedef struct _OS_ACM_Store {
 
 /**
  * @brief Copies the C string pointed by src into the array pointed by dst
- *
  * @param dst destination
  * @param src source
  */
@@ -55,7 +54,6 @@ static OS_ACM_Store *InitACMStore(void);
 
 /**
  * @brief Remove OS_ACM_Store objetct
- *
  * @param obj object to remove
  */
 static void FreeACMStore(OS_ACM_Store *obj);
@@ -99,19 +97,19 @@ Eventinfo *Accumulate(Eventinfo *lf, OSHash **acm_store, int *acm_lookups, time_
     time_t  current_ts;
     struct timeval tp;
 
-    if ( lf == NULL ) {
+    if (lf == NULL) {
         mdebug1("accumulator: DEBUG: Received NULL EventInfo");
         return lf;
     }
-    if ( lf->id == NULL ) {
+    if (lf->id == NULL) {
         mdebug2("accumulator: DEBUG: No id available");
         return lf;
     }
-    if ( lf->decoder_info == NULL ) {
+    if (lf->decoder_info == NULL) {
         mdebug1("accumulator: DEBUG: No decoder_info available");
         return lf;
     }
-    if ( lf->decoder_info->name == NULL ) {
+    if (lf->decoder_info->name == NULL) {
         mdebug1("accumulator: DEBUG: No decoder name available");
         return lf;
     }
@@ -138,7 +136,7 @@ Eventinfo *Accumulate(Eventinfo *lf, OSHash **acm_store, int *acm_lookups, time_
         mdebug2("accumulator: DEBUG: Lookup for '%s' found a stored value!", _key);
 
         if ( stored_data->timestamp > 0 && stored_data->timestamp < current_ts - OS_ACM_EXPIRE_ELM ) {
-            if ( OSHash_Delete_ex(*acm_store, _key) != NULL ) {
+            if (OSHash_Delete_ex(*acm_store, _key) != NULL) {
                 mdebug1("accumulator: DEBUG: Deleted expired hash entry for '%s'", _key);
                 /* Clear this memory */
                 FreeACMStore(stored_data);
@@ -211,15 +209,15 @@ Eventinfo *Accumulate(Eventinfo *lf, OSHash **acm_store, int *acm_lookups, time_
     }
 
     /* Update or Add to the hash */
-    if ( do_update == 1 ) {
+    if (do_update == 1) {
         /* Update the hash entry */
-        if ( (result = OSHash_Update_ex(*acm_store, _key, stored_data)) != 1) {
+        if (result = OSHash_Update_ex(*acm_store, _key, stored_data), result != 1) {
             merror("accumulator: ERROR: Update of stored data for %s failed (%d).", _key, result);
         } else {
             mdebug1("accumulator: DEBUG: Updated stored data for %s", _key);
         }
     } else {
-        if ((result = OSHash_Add_ex(*acm_store, _key, stored_data)) != 2 ) {
+        if (result = OSHash_Add_ex(*acm_store, _key, stored_data), result != 2) {
             FreeACMStore(stored_data);
             merror("accumulator: ERROR: Addition of stored data for %s failed (%d).", _key, result);
         } else {
@@ -242,13 +240,13 @@ void Accumulate_CleanUp(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_
     unsigned int ti;
 
     /* Keep track of how many times we're called */
-    *acm_lookups++;
+    (*acm_lookups)++;
 
     gettimeofday(&tp, NULL);
     current_ts = tp.tv_sec;
 
     /* Do we really need to purge? */
-    if ( *acm_lookups < OS_ACM_PURGE_COUNT && *acm_purge_ts < current_ts + OS_ACM_PURGE_INTERVAL ) {
+    if (*acm_lookups < OS_ACM_PURGE_COUNT && *acm_purge_ts < current_ts + OS_ACM_PURGE_INTERVAL) {
         return;
     }
     mdebug1("accumulator: DEBUG: Accumulator_CleanUp() running .. ");
@@ -258,8 +256,8 @@ void Accumulate_CleanUp(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_
     *acm_purge_ts = current_ts;
 
     /* Loop through the hash */
-    for ( ti = 0; ti < acm_store[0]->rows; ti++ ) {
-        curr = acm_store[0]->table[ti];
+    for (ti = 0; ti < (*acm_store)->rows; ti++) {
+        curr = (*acm_store)->table[ti];
         while ( curr != NULL ) {
             /* Get the Key and Data */
             key  = (char *) curr->key;
@@ -274,7 +272,7 @@ void Accumulate_CleanUp(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_
                 mdebug2("accumulator: DEBUG: CleanUp() elm:%ld, curr:%ld", (long int)stored_data->timestamp, (long int)current_ts);
                 if ( stored_data->timestamp < current_ts - OS_ACM_EXPIRE_ELM ) {
                     mdebug2("accumulator: DEBUG: CleanUp() Expiring '%s'", key);
-                    if ( OSHash_Delete_ex(*acm_store, key) != NULL ) {
+                    if (OSHash_Delete_ex(*acm_store, key) != NULL) {
                         FreeACMStore(stored_data);
                         expired++;
                     } else {

--- a/src/analysisd/accumulator.h
+++ b/src/analysisd/accumulator.h
@@ -15,14 +15,14 @@
 
 
 /**
- * @brief Hash where save data which have same id
+ * @brief Hash to save data which have the same id
  *
  * Only for Analysisd use
  */
 OSHash *os_analysisd_acm_store;
 
 /**
- * @brief Counter of the number of times purge
+ * @brief Counter of the number of times purged
  *
  * Only for Analysisd use
  */
@@ -37,30 +37,28 @@ time_t os_analysisd_acm_purge_ts;
 
 /**
  * @brief Initialize accumulator engine
- *
- * @param acm_store
- * @param acm_purge_ts
+ * @param acm_store Hash to save data which have the same id
+ * @param acm_lookups counter of the number of times purged
+ * @param acm_purge_ts counter of interval time since the last purge
  * @return 1 on succes, otherwise 0
  */
 int Accumulate_Init(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts);
 
 /**
  * @brief Accumulate data from events sharing the same ID
- *
  * @param lf EventInfo to proccess
- * @param acm_store Hash where save data which have same ID
- * @param acm_lookups
- * @param acm_purge_ts
+ * @param acm_store Hash to save data which have the same id
+ * @param acm_lookups counter of the number of times purged
+ * @param acm_purge_ts counter of interval time since the last purge
  * @return EventInfo passed from input
  */
 Eventinfo *Accumulate(Eventinfo *lf, OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts);
 
 /**
  * @brief Purge the cache as needed
- *
- * @param acm_store
- * @param acm_lookups
- * @param acm_purge_ts
+ * @param acm_store Hash to save data which have the same id
+ * @param acm_lookups counter of the number of times purged
+ * @param acm_purge_ts counter of interval time since the last purge
  */
 void Accumulate_CleanUp(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts);
 

--- a/src/analysisd/accumulator.h
+++ b/src/analysisd/accumulator.h
@@ -13,9 +13,55 @@
 
 #include "eventinfo.h"
 
-/* Accumulator Functions */
-int Accumulate_Init(void);
-Eventinfo *Accumulate(Eventinfo *lf);
-void Accumulate_CleanUp(void);
+
+/**
+ * @brief Hash where save data which have same id
+ *
+ * Only for Analysisd use
+ */
+OSHash *os_analysisd_acm_store;
+
+/**
+ * @brief Counter of the number of times purge
+ *
+ * Only for Analysisd use
+ */
+int os_analysisd_acm_lookups;
+
+/**
+ * @brief Counter of interval time since the last purge
+ *
+ * Only for Analysisd use
+ */
+time_t os_analysisd_acm_purge_ts;
+
+/**
+ * @brief Initialize accumulator engine
+ *
+ * @param acm_store
+ * @param acm_purge_ts
+ * @return 1 on succes, otherwise 0
+ */
+int Accumulate_Init(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts);
+
+/**
+ * @brief Accumulate data from events sharing the same ID
+ *
+ * @param lf EventInfo to proccess
+ * @param acm_store Hash where save data which have same ID
+ * @param acm_lookups
+ * @param acm_purge_ts
+ * @return EventInfo passed from input
+ */
+Eventinfo *Accumulate(Eventinfo *lf, OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts);
+
+/**
+ * @brief Purge the cache as needed
+ *
+ * @param acm_store
+ * @param acm_lookups
+ * @param acm_purge_ts
+ */
+void Accumulate_CleanUp(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts);
 
 #endif /* ACCUMULATOR_H */

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -897,7 +897,7 @@ void OS_ReadMSG_analysisd(int m_queue)
         merror_exit(FTS_LIST_ERROR);
     }
 
-    mdebug1("FTSInit completed.");
+    mdebug1("FTS_Init completed.");
 
     /* Create message handler thread */
     w_create_thread(ad_input_main, &m_queue);
@@ -2456,8 +2456,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
 
             /* Check each rule */
             else if (t_currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists,
-                     rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store),
-                     t_currently_rule == NULL) {
+                     rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store), !t_currently_rule) {
 
                 continue;
             }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -758,7 +758,7 @@ void OS_ReadMSG_analysisd(int m_queue)
     SecurityConfigurationAssessmentInit();
 
     /* Initialize the Accumulator */
-    if (!Accumulate_Init()) {
+    if (!Accumulate_Init(&os_analysisd_acm_store, &os_analysisd_acm_lookups, &os_analysisd_acm_purge_ts)) {
         merror("accumulator: ERROR: Initialization failed");
         exit(1);
     }
@@ -2366,7 +2366,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
         /* Run accumulator */
         if ( lf->decoder_info->accumulate == 1 ) {
             w_mutex_lock(&accumulate_mutex);
-            lf = Accumulate(lf);
+            lf = Accumulate(lf, &os_analysisd_acm_store, &os_analysisd_acm_lookups, &os_analysisd_acm_purge_ts);
             w_mutex_unlock(&accumulate_mutex);
         }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -893,9 +893,11 @@ void OS_ReadMSG_analysisd(int m_queue)
     num_dispatch_dbsync_threads = (num_dispatch_dbsync_threads > 0) ? num_dispatch_dbsync_threads : cpu_cores;
 
     /* Initiate the FTS list */
-    if (!FTS_Init(num_rule_matching_threads)) {
+    if (!FTS_Init(num_rule_matching_threads, &os_analysisd_fts_list, &os_analysisd_fts_store)) {
         merror_exit(FTS_LIST_ERROR);
     }
+
+    mdebug1("FTSInit completed.");
 
     /* Create message handler thread */
     w_create_thread(ad_input_main, &m_queue);
@@ -974,8 +976,9 @@ void OS_ReadMSG_analysisd(int m_queue)
 }
 
 /* Checks if the current_rule matches the event information */
-RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *cdblists, RuleNode *curr_node, regex_matching *rule_match)
-{
+RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *cdblists, RuleNode *curr_node,
+                              regex_matching *rule_match, OSList **fts_list, OSHash **fts_store) {
+
     /* We check for:
      * decoded_as,
      * fts,
@@ -1316,7 +1319,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *c
             char * _line_cpy;
             if ((lf->decoder_info->fts & FTS_DONE) || (lf->rootcheck_fts & FTS_DONE))  {
                 /* We already did the fts in here */
-            } else if (_line = FTS(lf),_line == NULL) {
+            } else if (_line = FTS(lf, fts_list, fts_store),_line == NULL) {
                 return (NULL);
             }
 
@@ -1507,7 +1510,8 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *c
 #endif
 
         while (child_node) {
-            child_rule = OS_CheckIfRuleMatch(lf, last_events, cdblists, child_node, rule_match);
+            child_rule = OS_CheckIfRuleMatch(lf, last_events, cdblists, child_node, rule_match,
+                                             &os_analysisd_fts_list, &os_analysisd_fts_store);
             if (child_rule != NULL) {
                 if (!child_rule->prev_rule) {
                     child_rule->prev_rule = rule;
@@ -2451,8 +2455,10 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
             }
 
             /* Check each rule */
-            else if ((t_currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists, rulenode_pt, &rule_match))
-                        == NULL) {
+            else if (t_currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists,
+                     rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store),
+                     t_currently_rule == NULL) {
+
                 continue;
             }
 

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -120,8 +120,9 @@ void w_get_queues_size();
 void w_get_initial_queues_size();
 
 /**
- * @brief Initialize decoded event queues, log writer queues, database
- * synchronization message queue, and archives writer queue.
+ * @brief Initialize queues
+ *
+ * Queues: decoded event, log writer, database synchronization message and archives writer
  */
 void w_init_queues();
 

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -100,24 +100,31 @@ size_t asyscom_getconfig(const char * section, char ** output);
  * @param rule_match stores the regex of the rule
  * @return the rule information if it matches, otherwise null
  */
-RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *cdblists, RuleNode *curr_node, regex_matching *rule_match);
+RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *cdblists, RuleNode *curr_node,
+                              regex_matching *rule_match, OSList **fts_list, OSHash **fts_store);
 
 #define WM_ANALYSISD_LOGTAG ARGV0 "" // Tag for log messages
 
-typedef struct cpu_info {
-    char *cpu_name;
-    int cpu_cores;
-    double cpu_MHz;
-} cpu_info;
-
-/* CPU info */
-cpu_info *get_cpu_info();
-cpu_info *get_cpu_info_bsd();
-cpu_info *get_cpu_info_linux();
-
+/**
+ * @brief Get the number of elements divided by the size of queues
+ * 
+ * Values are save in state's variables
+ */
 void w_get_queues_size();
+
+/**
+ * @brief Obtains analysisd's queues sizes
+ * 
+ * Values are save in state's variables
+ */
 void w_get_initial_queues_size();
+
+/**
+ * @brief Initialize decoded event queues, log writer queues, database
+ * synchronization message queue, and archives writer queue.
+ */
 void w_init_queues();
+
 
 #define OSSEC_SERVER    "ossec-server"
 #define MAX_DECODER_ORDER_SIZE  1024

--- a/src/analysisd/fts.c
+++ b/src/analysisd/fts.c
@@ -51,11 +51,11 @@ int FTS_Init(int threads, OSList **fts_list, OSHash **fts_store)
     /* Create store data */
     *fts_store = OSHash_Create();
     if (!(*fts_store)) {
-        merror(LIST_ERROR);
+        merror(HASH_ERROR);
         return (0);
     }
     if (!OSHash_setSize(*fts_store, 2048)) {
-        merror(LIST_ERROR);
+        merror(LIST_SIZE_ERROR);
         return (0);
     }
 

--- a/src/analysisd/fts.c
+++ b/src/analysisd/fts.c
@@ -18,9 +18,6 @@
 unsigned int fts_minsize_for_str = 0;
 int fts_list_size;
 
-static OSList *fts_list = NULL;
-static OSHash *fts_store = NULL;
-
 static FILE *fp_list = NULL;
 static FILE **fp_ignore = NULL;
 
@@ -29,15 +26,15 @@ static pthread_rwlock_t file_update_rwlock;
 static pthread_mutex_t fts_write_lock;
 
 /* Start the FTS module */
-int FTS_Init(int threads)
+int FTS_Init(int threads, OSList **fts_list, OSHash **fts_store)
 {
     char _line[OS_FLSIZE + 1];
     int i;
 
     _line[OS_FLSIZE] = '\0';
 
-    fts_list = OSList_Create();
-    if (!fts_list) {
+    *fts_list = OSList_Create();
+    if (!(*fts_list)) {
         merror(LIST_ERROR);
         return (0);
     }
@@ -52,12 +49,12 @@ int FTS_Init(int threads)
     }
 
     /* Create store data */
-    fts_store = OSHash_Create();
-    if (!fts_store) {
+    *fts_store = OSHash_Create();
+    if (!(*fts_store)) {
         merror(LIST_ERROR);
         return (0);
     }
-    if (!OSHash_setSize(fts_store, 2048)) {
+    if (!OSHash_setSize(*fts_store, 2048)) {
         merror(LIST_ERROR);
         return (0);
     }
@@ -72,7 +69,7 @@ int FTS_Init(int threads)
                           "fts_min_size_for_str",
                           6, 128);
 
-    if (!OSList_SetMaxSize(fts_list, fts_list_size)) {
+    if (!OSList_SetMaxSize(*fts_list, fts_list_size)) {
         merror(LIST_SIZE_ERROR);
         return (0);
     }
@@ -119,7 +116,7 @@ int FTS_Init(int threads)
         }
 
         os_strdup(_line, tmp_s);
-        if (OSHash_Add(fts_store, tmp_s, tmp_s) != 2) {
+        if (OSHash_Add(*fts_store, tmp_s, tmp_s) != 2) {
             free(tmp_s);
             merror(LIST_ADD_ERROR);
         }
@@ -162,8 +159,6 @@ int FTS_Init(int threads)
     for (i = 1; i < threads; i++) {
         fp_ignore[i] = fopen(IG_QUEUE, "r+");
     }
-
-    mdebug1("FTSInit completed.");
 
     return (1);
 }
@@ -276,7 +271,7 @@ int IGnore(Eventinfo *lf, int pos)
 /*  Check if the word "msg" is present on the "queue".
  *  If it is not, write it there.
  */
-char * FTS(Eventinfo *lf)
+char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store)
 {
     int i;
     int number_of_matches = 0;
@@ -309,7 +304,7 @@ char * FTS(Eventinfo *lf)
     }
 
     /** Check if FTS is already present **/
-    if (OSHash_Get_ex(fts_store, _line)) {
+    if (OSHash_Get_ex(*fts_store, _line)) {
         free(_line);
         return NULL;
     }
@@ -318,7 +313,7 @@ char * FTS(Eventinfo *lf)
      * If yes, we just ignore it.
      */
     if (lf->decoder_info->type == IDS) {
-        fts_node = OSList_GetLastNode(fts_list);
+        fts_node = OSList_GetLastNode(*fts_list);
         while (fts_node) {
             if (OS_StrHowClosedMatch((char *)fts_node->data, _line) >
                     fts_minsize_for_str) {
@@ -331,7 +326,7 @@ char * FTS(Eventinfo *lf)
                 }
             }
 
-            fts_node = OSList_GetPrevNode(fts_list);
+            fts_node = OSList_GetPrevNode(*fts_list);
         }
 
         fts_node = NULL;
@@ -343,7 +338,7 @@ char * FTS(Eventinfo *lf)
             return NULL;
         }
 
-        fts_node = OSList_AddData(fts_list, line_for_list);
+        fts_node = OSList_AddData(*fts_list, line_for_list);
         if (!fts_node) {
             free(line_for_list);
             free(_line);
@@ -361,18 +356,14 @@ char * FTS(Eventinfo *lf)
         }
     }
 
-    if (OSHash_Add_ex(fts_store, line_for_list, line_for_list) != 2) {
-        if (fts_node) OSList_DeleteThisNode(fts_list, fts_node);
+    if (OSHash_Add_ex(*fts_store, line_for_list, line_for_list) != 2) {
+        if (fts_node) OSList_DeleteThisNode(*fts_list, fts_node);
         free(line_for_list);
         free(_line);
         return NULL;
     }
 
     return _line;
-}
-
-FILE **w_get_fp_ignore(){
-    return fp_ignore;
 }
 
 void FTS_Fprintf(char * _line){

--- a/src/analysisd/fts.h
+++ b/src/analysisd/fts.h
@@ -35,7 +35,6 @@ OSHash *os_analysisd_fts_store;
 
 /**
  * @brief Initialize FTS engine
- *
  * @param threads number of analysisd threads
  * @param fts_list List which save fts previous events
  * @param fts_store Hash table which save fts values processed previously
@@ -55,26 +54,23 @@ void AddtoIGnore(Eventinfo *lf, int pos);
 
 /**
  * @brief Check if the event is to be ignored
- *
  * @param lf Event to check if must be ignored
  * @param pos Position of ignore file in fp_ignore
- * @return if must be ignored return 1,  otherwise return 0
+ * @return if must be ignored return 1, otherwise return 0
  */
 int IGnore(Eventinfo *lf, int pos);
 
 /**
  * @brief Check if fts value was present in previous events
- *
  * @param lf Event to process
  * @param fts_list List which save fts previous events
- * @param fts_store Hash table which save fts values processed previously
+ * @param fts_store hash table which save fts values processed previously
  * @return Null if FTS is already present or in case of failure, otherwise return value
  */
 char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store);
 
 /**
  * @brief Save value in fts-queue
- *
  * @param _line Value to print in fts-queue
  */
 void FTS_Fprintf(char * _line);

--- a/src/analysisd/fts.h
+++ b/src/analysisd/fts.h
@@ -22,13 +22,68 @@
 #define IG_QUEUE  "/queue/fts/ig-queue"
 #endif
 
-int FTS_Init(int threads);
+/**
+ * @brief Structure to save previous fts events
+ */
+OSList *os_analysisd_fts_list;
+
+/**
+ * @brief Structure to save fts values processed
+ */
+OSHash *os_analysisd_fts_store;
+
+
+/**
+ * @brief Initialize FTS engine
+ *
+ * @param threads number of analysisd threads
+ * @param fts_list List which save fts previous events
+ * @param fts_store Hash table which save fts values processed previously
+ * @return 1 on success, 0 on failure
+ */
+int FTS_Init(int threads, OSList **fts_list, OSHash **fts_store);
+
+/**
+ * @brief Save fts value in queue/fts/ig-queue to ignore it next time
+ *
+ * It only use for Analysisd
+ *
+ * @param lf Event to add to ignore
+ * @param pos Position of ignore file in fp_ignore
+ */
 void AddtoIGnore(Eventinfo *lf, int pos);
+
+/**
+ * @brief Check if the event is to be ignored
+ *
+ * @param lf Event to check if must be ignored
+ * @param pos Position of ignore file in fp_ignore
+ * @return if must be ignored return 1,  otherwise return 0
+ */
 int IGnore(Eventinfo *lf, int pos);
-char * FTS(Eventinfo *lf);
-FILE **w_get_fp_ignore();
+
+/**
+ * @brief Check if fts value was present in previous events
+ *
+ * @param lf Event to process
+ * @param fts_list List which save fts previous events
+ * @param fts_store Hash table which save fts values processed previously
+ * @return Null if FTS is already present or in case of failure, otherwise return value
+ */
+char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store);
+
+/**
+ * @brief Save value in fts-queue
+ *
+ * @param _line Value to print in fts-queue
+ */
 void FTS_Fprintf(char * _line);
+
+/**
+ * @brief Flush file fts-queue
+ */
 void FTS_Flush();
+
 
 /* Global variables */
 extern unsigned int fts_minsize_for_str;

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -120,3 +120,30 @@ void w_logtest_remove_session(int token) {
 void w_logtest_check_active_sessions() {
 
 }
+
+
+int w_logtest_fts_init(OSList **fts_list, OSHash **fts_store) {
+
+    int list_size = getDefine_Int("analysisd", "fts_list_size", 12, 512);
+
+    if (*fts_list = OSList_Create(), *fts_list == NULL) {
+        merror(LIST_ERROR);
+        return 0;
+    }
+
+    if (!OSList_SetMaxSize(*fts_list, list_size)) {
+        merror(LIST_SIZE_ERROR);
+        return 0;
+    }
+
+    if (*fts_store = OSHash_Create(), *fts_store == NULL) {
+        merror(HASH_ERROR);
+        return 0;
+    }
+    if (!OSHash_setSize(*fts_store, 2048)) {
+        merror(LIST_SIZE_ERROR);
+        return 0;
+    }
+
+    return 1;
+}

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -32,9 +32,9 @@ typedef struct w_logtest_session_t {
     OSHash *g_rules_hash;                   ///< Hash table of rules
     OSList *fts_list;                       ///< Save FTS previous events
     OSHash *fts_store;                      ///< Save FTS values processed
-    OSHash *acm_store;                      ///< Hash where save data which have same id
-    int acm_lookups;                        ///< Counter of the number of times purge accumulate option
-    time_t acm_purge_ts;                    ///< Counter of the number of times purge accumulate option
+    OSHash *acm_store;                      ///< Hash to save data which have the same id
+    int acm_lookups;                        ///< Counter of the number of times purged. Option accumulate
+    time_t acm_purge_ts;                    ///< Counter of the time interval of last purge. Option accumulate
 
 } w_logtest_session_t;
 
@@ -62,6 +62,8 @@ void *w_logtest_init();
 
 /**
  * @brief Initialize logtest configuration. Then, call ReadConfig
+ *
+ * @return OS_SUCCESS on success, otherwise OS_INVALID
  */
 int w_logtest_init_parameters();
 
@@ -99,3 +101,11 @@ void w_logtest_remove_session(int token);
  * for more than 15 minutes, remove it.
  */
 void w_logtest_check_active_sessions();
+
+/**
+ * @brief Initialize FTS engine for a client session
+ * @param fts_list list which save fts previous events
+ * @param fts_store hash table which save fts values processed previously
+ * @return 1 on success, otherwise return 0
+ */
+int w_logtest_fts_init(OSList **fts_list, OSHash **fts_store);

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -30,6 +30,8 @@ typedef struct w_logtest_session_t {
     ListRule *cdblistrule;                  ///< List to attach rules and CDB lists
     EventList *eventlist;                   ///< Previous events list
     OSHash *g_rules_hash;                   ///< Hash table of rules
+    OSList *fts_list;                       ///< Save FTS previous events
+    OSHash *fts_store;                      ///< Save FTS values processed
 
 } w_logtest_session_t;
 

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -32,6 +32,9 @@ typedef struct w_logtest_session_t {
     OSHash *g_rules_hash;                   ///< Hash table of rules
     OSList *fts_list;                       ///< Save FTS previous events
     OSHash *fts_store;                      ///< Save FTS values processed
+    OSHash *acm_store;                      ///< Hash where save data which have same id
+    int acm_lookups;                        ///< Counter of the number of times purge accumulate option
+    time_t acm_purge_ts;                    ///< Counter of the number of times purge accumulate option
 
 } w_logtest_session_t;
 

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -413,7 +413,7 @@ void OS_ReadMSG(char *ut_str)
         merror_exit(FTS_LIST_ERROR);
     }
 
-    mdebug1("FTSInit completed.");
+    mdebug1("FTS_Init completed.");
 
     /* Initialize the Accumulator */
     if (!Accumulate_Init(&os_analysisd_acm_store, &os_analysisd_acm_lookups, &os_analysisd_acm_purge_ts)) {

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -409,9 +409,11 @@ void OS_ReadMSG(char *ut_str)
     currently_rule = NULL;
 
     /* Initiate the FTS list */
-    if (!FTS_Init(1)) {
+    if (!FTS_Init(1, &os_analysisd_fts_list, &os_analysisd_fts_store)) {
         merror_exit(FTS_LIST_ERROR);
     }
+
+    mdebug1("FTSInit completed.");
 
     /* Initialize the Accumulator */
     if (!Accumulate_Init()) {
@@ -520,7 +522,8 @@ void OS_ReadMSG(char *ut_str)
                 }
 
                 /* Check each rule */
-                else if (currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists, rulenode_pt, &rule_match), !currently_rule) {
+                else if (currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists,
+                         rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store), !currently_rule) {
                     continue;
                 }
 

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -416,7 +416,7 @@ void OS_ReadMSG(char *ut_str)
     mdebug1("FTSInit completed.");
 
     /* Initialize the Accumulator */
-    if (!Accumulate_Init()) {
+    if (!Accumulate_Init(&os_analysisd_acm_store, &os_analysisd_acm_lookups, &os_analysisd_acm_purge_ts)) {
         merror("accumulator: ERROR: Initialization failed");
         exit(1);
     }
@@ -490,7 +490,7 @@ void OS_ReadMSG(char *ut_str)
             /* Run accumulator */
             if ( lf->decoder_info->accumulate == 1 ) {
                 print_out("\n**ACCUMULATOR: LEVEL UP!!**\n");
-                lf = Accumulate(lf);
+                lf = Accumulate(lf, &os_analysisd_acm_store, &os_analysisd_acm_lookups, &os_analysisd_acm_purge_ts);
             }
 
             /* Loop over all the rules */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -167,6 +167,9 @@
 #define LIST_SIZE_ERROR "(1292): Error setting error size."
 #define LIST_FREE_ERROR "(1293): Error setting data free pointer."
 
+/* Hash operation */
+#define HASH_ERROR      "(1295): Unable to create a new hash (calloc)."
+
 /* Log collector messages */
 #define MISS_LOG_FORMAT "(1901): Missing 'log_format' element."
 #define MISS_FILE       "(1902): Missing 'location' element."

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -41,7 +41,8 @@ LIST(APPEND analysisd_flags "-W")
 LIST(APPEND analysisd_names "test_logtest")
 LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap,OS_BindUnixDomain -Wl,--wrap,OSHash_Create \
                              -Wl,--wrap,pthread_mutex_init -Wl,--wrap,_minfo -Wl,--wrap,_w_mutex_init -Wl,--wrap,w_create_thread \
-                             -Wl,--wrap,mutex_destroy -Wl,--wrap,close")
+                             -Wl,--wrap,mutex_destroy -Wl,--wrap,close -Wl,--wrap,getDefine_Int -Wl,--wrap,OSList_Create \
+                             -Wl,--wrap,OSList_SetMaxSize -Wl,--wrap,OSHash_setSize")
 
 LIST(APPEND analysisd_names "test_logtest-config")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \


### PR DESCRIPTION
|Related issue|
|---|
| [5384](https://github.com/wazuh/wazuh/issues/5384) |

## Description

FTS and accumulator flow have changed to use different variables. When it is called by Analysisd threads variables used are:

```c
OSList *os_analysisd_fts_list;
OSHash *os_analysisd_fts_store;

OSHash *os_analysisd_acm_store;
int os_analysisd_acm_lookups;
time_t os_analysisd_acm_purge_ts;
```

When Logtest threads call functions variables used are:

```c
typedef struct w_logtest_session_t {

    int token;
    // ...
    OSList *fts_list;
    OSHash *fts_store;
    OSHash *acm_store; 
    int acm_lookups;
    time_t acm_purge_ts; 

} w_logtest_session_t;
```


## Tests
 - [x] Compilation without warnings Linux
 - [x] Compilation without warnings Windows
- [x] Scan-build report
- [x] Valgrind
- [x] Rules and decoders with FTS option works
- [x] Rules and decoders with accumulator option works
