### PR TITLE
Modify EventList and Rules hash table for wazuh-logtest

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -53,7 +53,6 @@
 
 /** Prototypes **/
 void OS_ReadMSG(int m_queue);
-RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching *rule_match);
 static void LoopRule(RuleNode *curr_node, FILE *flog);
 
 /* For decoders */
@@ -975,7 +974,7 @@ void OS_ReadMSG_analysisd(int m_queue)
 }
 
 /* Checks if the current_rule matches the event information */
-RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching *rule_match)
+RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *cdblists, RuleNode *curr_node, regex_matching *rule_match)
 {
     /* We check for:
      * decoded_as,
@@ -1342,7 +1341,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->srcip) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->srcip, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->srcip, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1350,7 +1349,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->srcport) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->srcport, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->srcport, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1358,7 +1357,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->dstip) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->dstip, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->dstip, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1366,17 +1365,17 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->dstport) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->dstport, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->dstport, cdblists)) {
                         return (NULL);
                     }
                     break;
                 case RULE_USER:
                     if (lf->srcuser) {
-                        if (!OS_DBSearch(list_holder, lf->srcuser, os_analysisd_cdblists)) {
+                        if (!OS_DBSearch(list_holder, lf->srcuser,cdblists)) {
                             return (NULL);
                         }
                     } else if (lf->dstuser) {
-                        if (!OS_DBSearch(list_holder, lf->dstuser, os_analysisd_cdblists)) {
+                        if (!OS_DBSearch(list_holder, lf->dstuser, cdblists)) {
                             return (NULL);
                         }
                     } else {
@@ -1387,7 +1386,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->url) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->url, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->url, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1395,7 +1394,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->id) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->id, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->id, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1403,7 +1402,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->hostname) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->hostname, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->hostname, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1411,7 +1410,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->program_name) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->program_name, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->program_name, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1419,7 +1418,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->status) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->status, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->status, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1427,7 +1426,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->action) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->action, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->action, cdblists)) {
                         return (NULL);
                     }
                     break;
@@ -1435,7 +1434,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->systemname) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->systemname, os_analysisd_cdblists)){
+                    if (!OS_DBSearch(list_holder, lf->systemname, cdblists)){
                         return (NULL);
                     }
                     break;
@@ -1443,7 +1442,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->protocol) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->protocol, os_analysisd_cdblists)){
+                    if (!OS_DBSearch(list_holder, lf->protocol, cdblists)){
                         return (NULL);
                     }
                     break;
@@ -1451,7 +1450,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->data) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->data, os_analysisd_cdblists)){
+                    if (!OS_DBSearch(list_holder, lf->data, cdblists)){
                         return (NULL);
                     }
                     break;
@@ -1459,14 +1458,14 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                     if (!lf->extra_data) {
                         return (NULL);
                     }
-                    if (!OS_DBSearch(list_holder, lf->extra_data, os_analysisd_cdblists)) {
+                    if (!OS_DBSearch(list_holder, lf->extra_data, cdblists)) {
                         return (NULL);
                     }
                     break;
                 case RULE_DYNAMIC:
                     field = FindField(lf, list_holder->dfield);
 
-                    if (!(field &&OS_DBSearch(list_holder, (char*)field, os_analysisd_cdblists)))
+                    if (!(field &&OS_DBSearch(list_holder, (char*)field, cdblists)))
                         return NULL;
 
                     break;
@@ -1482,7 +1481,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
     if (rule->context == 1) {
         if (!(rule->context_opts & FIELD_DODIFF)) {
             if (rule->event_search) {
-                if (!rule->event_search(lf, rule, rule_match)) {
+                if (!rule->event_search(lf, last_events, rule, rule_match)) {
                     w_FreeArray(lf->last_events);
                     return (NULL);
                 }
@@ -1508,7 +1507,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
 #endif
 
         while (child_node) {
-            child_rule = OS_CheckIfRuleMatch(lf, child_node, rule_match);
+            child_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists, child_node, rule_match);
             if (child_rule != NULL) {
                 if (!child_rule->prev_rule) {
                     child_rule->prev_rule = rule;
@@ -2452,7 +2451,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
             }
 
             /* Check each rule */
-            else if ((t_currently_rule = OS_CheckIfRuleMatch(lf, rulenode_pt, &rule_match))
+            else if ((t_currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists,rulenode_pt, &rule_match))
                         == NULL) {
                 continue;
             }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -56,7 +56,7 @@ void OS_ReadMSG(int m_queue);
 static void LoopRule(RuleNode *curr_node, FILE *flog);
 
 /* For decoders */
-void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *node);
+void DecodeEvent(Eventinfo *lf, OSHash *rules_hash, regex_matching *decoder_match, OSDecoderNode *node);
 int DecodeSyscheck(Eventinfo *lf, _sdb *sdb);
 // Decode events in json format
 int decode_fim_event(_sdb *sdb, Eventinfo *lf);
@@ -1507,7 +1507,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *c
 #endif
 
         while (child_node) {
-            child_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists, child_node, rule_match);
+            child_rule = OS_CheckIfRuleMatch(lf, last_events, cdblists, child_node, rule_match);
             if (child_rule != NULL) {
                 if (!child_rule->prev_rule) {
                     child_rule->prev_rule = rule;
@@ -2227,7 +2227,7 @@ void * w_decode_event_thread(__attribute__((unused)) void * args){
                 }
             } else {
                 node = OS_GetFirstOSDecoder(lf->program_name);
-                DecodeEvent(lf, &decoder_match, node);
+                DecodeEvent(lf, Config.g_rules_hash, &decoder_match, node);
             }
 
             free(msg);
@@ -2451,7 +2451,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
             }
 
             /* Check each rule */
-            else if ((t_currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists,rulenode_pt, &rule_match))
+            else if ((t_currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists, rulenode_pt, &rule_match))
                         == NULL) {
                 continue;
             }

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -79,6 +79,7 @@ void * asyscom_main(__attribute__((unused)) void * arg) ;
  * @brief Check that request is to get a configuration
  * @param command message received from api
  * @param output the configuration to send
+ * @return the size of the string "output" containing the configuration
  */
 size_t asyscom_dispatch(char * command, char ** output);
 
@@ -86,9 +87,20 @@ size_t asyscom_dispatch(char * command, char ** output);
  * @brief Process the message received to send the configuration requested
  * @param section contains the name of configuration requested
  * @param output the configuration to send
+ * @return the size of the string "output" containing the configuration
  */
 size_t asyscom_getconfig(const char * section, char ** output);
 
+/**
+ * @brief Check if a rule matches the event
+ * @param lf event to be processed
+ * @param last_events list of previous events processed
+ * @param cdblists list of cdbs
+ * @param curr_node rule to compare with the event "lf"
+ * @param rule_match stores the regex of the rule
+ * @return the rule information if it matches, otherwise null
+ */
+RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, EventList *last_events, ListNode *cdblists, RuleNode *curr_node, regex_matching *rule_match);
 
 #define WM_ANALYSISD_LOGTAG ARGV0 "" // Tag for log messages
 

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -407,7 +407,7 @@ int ReadDecodeXML(const char *file)
                         /* Initialize plugin */
                         void (*dec_init)(void) = (void (*)(void)) plugin_decoders_init[ed_c];
                         dec_init();
-                        pi->plugindecoder = (void (*)(void *, void *)) plugin_decoders_exec[ed_c];
+                        pi->plugindecoder = (void (*)(void *, void *, void *)) plugin_decoders_exec[ed_c];
                         break;
                     }
                 }

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -17,7 +17,7 @@
 
 
 /* Use the osdecoders to decode the received event */
-void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *node)
+void DecodeEvent(Eventinfo *lf, OSHash *rules_hash, regex_matching *decoder_match, OSDecoderNode *node)
 {
     OSDecoderNode *child_node;
     OSDecoderInfo *nnode;
@@ -144,7 +144,7 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *no
         while (child_node) {
             /* If we have an external decoder, execute it */
             if (nnode->plugindecoder) {
-                nnode->plugindecoder(lf, decoder_match);
+                nnode->plugindecoder(lf, rules_hash, decoder_match);
             } else if (nnode->regex) {
                 int i;
 

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -54,7 +54,7 @@ typedef struct {
     OSRegex *prematch;
     OSMatch *program_name;
 
-    void (*plugindecoder)(void *lf, void *decoder_match);
+    void (*plugindecoder)(void *lf, void *rule_hash, void *decoder_match);
     void* (**order)(struct _Eventinfo *, char *, const char *);
 } OSDecoderInfo;
 

--- a/src/analysisd/decoders/plugin_decoders.h
+++ b/src/analysisd/decoders/plugin_decoders.h
@@ -27,7 +27,7 @@ void *SonicWall_Decoder_Exec(Eventinfo *lf, regex_matching *decoder_match);
 
 /* Plugin for OSSEC alert */
 void *OSSECAlert_Decoder_Init(void);
-void *OSSECAlert_Decoder_Exec(Eventinfo *lf, regex_matching *decoder_match);
+void *OSSECAlert_Decoder_Exec(Eventinfo *lf, OSHash *rules_hash, regex_matching *decoder_match);
 
 /* Plugin for JSON */
 void *JSON_Decoder_Init(void);

--- a/src/analysisd/decoders/plugins/ossecalert_decoder.c
+++ b/src/analysisd/decoders/plugins/ossecalert_decoder.c
@@ -30,7 +30,7 @@ void *OSSECAlert_Decoder_Init()
  * Examples:
  *
  */
-void *OSSECAlert_Decoder_Exec(Eventinfo *lf, __attribute__((unused)) regex_matching *decoder_match)
+void *OSSECAlert_Decoder_Exec(Eventinfo *lf, OSHash *rules_hash, __attribute__((unused)) regex_matching *decoder_match)
 {
     char *oa_id = 0;
     char *oa_location;
@@ -68,7 +68,7 @@ void *OSSECAlert_Decoder_Exec(Eventinfo *lf, __attribute__((unused)) regex_match
     *tmp_str = '\0';
 
     /* Get rule structure */
-    rule_pointer = (RuleInfo *) OSHash_Get(Config.g_rules_hash, oa_id);
+    rule_pointer = (RuleInfo *) OSHash_Get(rules_hash, oa_id);
     if (!rule_pointer) {
         mwarn("Rule id '%s' not found internally: %s", oa_id, lf->log);
         *tmp_str = ' ';

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -86,7 +86,7 @@ bool different_loop(RuleInfo *rule, Eventinfo *lf, Eventinfo *my_lf) {
 /* Search last times a signature fired
  * Will look for only that specific signature.
  */
-Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unused)) regex_matching *rule_match)
+Eventinfo *Search_LastSids(Eventinfo *my_lf, __attribute__((unused)) EventList *last_events, RuleInfo *rule, __attribute__((unused)) regex_matching *rule_match)
 {
     Eventinfo *lf = NULL;
     Eventinfo *first_matched = NULL;
@@ -259,7 +259,7 @@ end:
 /* Search last times a group fired
  * Will look for only that specific group on that rule.
  */
-Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule, __attribute__((unused)) regex_matching *rule_match)
+Eventinfo *Search_LastGroups(Eventinfo *my_lf, __attribute__((unused)) EventList *last_events, RuleInfo *rule, __attribute__((unused)) regex_matching *rule_match)
 {
     Eventinfo *lf = NULL;
     OSListNode *lf_node;
@@ -443,7 +443,7 @@ end:
 /* Look if any of the last events (inside the timeframe)
  * match the specified rule
  */
-Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *rule_match)
+Eventinfo *Search_LastEvents(Eventinfo *my_lf, EventList *last_events, RuleInfo *rule, regex_matching *rule_match)
 {
     EventNode *eventnode_pt = NULL;
     EventNode *first_pt;
@@ -458,7 +458,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule, regex_matching *r
     w_mutex_lock(&rule->mutex);
 
     /* Get the first event */
-    if (first_pt = OS_GetFirstEvent(os_analysisd_last_events), !first_pt) {
+    if (first_pt = OS_GetFirstEvent(last_events), !first_pt) {
         /* Nothing found */
         goto end;
     }

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -187,9 +187,9 @@ extern int alert_only;
 /** Functions for events **/
 
 /* Search for matches in the last events */
-Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule, regex_matching *rule_match);
-Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule, regex_matching *rule_match);
-Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule, regex_matching *rule_match);
+Eventinfo *Search_LastEvents(Eventinfo *my_lf, EventList *last_events, RuleInfo *currently_rule, regex_matching *rule_match);
+Eventinfo *Search_LastSids(Eventinfo *my_lf, EventList *last_events, RuleInfo *currently_rule, regex_matching *rule_match);
+Eventinfo *Search_LastGroups(Eventinfo *my_lf, EventList *last_events, RuleInfo *currently_rule, regex_matching *rule_match);
 
 /* Zero the eventinfo structure */
 void Zero_Eventinfo(Eventinfo *lf);

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -29,6 +29,7 @@ typedef struct w_logtest_session_t {
     ListNode *cdblistnode;                  ///< List of CDB lists
     ListRule *cdblistrule;                  ///< List to attach rules and CDB lists
     EventList *eventlist;                   ///< Previous events list
+    OSHash *g_rules_hash;                   ///< Hash table of rules
 
 } w_logtest_session_t;
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1726,7 +1726,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
             /* Set the event_search pointer */
             if (config_ruleinfo->if_matched_sid) {
-                config_ruleinfo->event_search = (void *(*)(void *, void *, void *))
+                config_ruleinfo->event_search = (void *(*)(void *, void *, void *, void *))
                     Search_LastSids;
 
                 /* Mark rules that match this id */
@@ -1745,14 +1745,14 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 OS_MarkGroup(NULL, config_ruleinfo);
 
                 /* Set function pointer */
-                config_ruleinfo->event_search = (void *(*)(void *, void *, void *))
+                config_ruleinfo->event_search = (void *(*)(void *, void *, void *, void *))
                     Search_LastGroups;
             } else if (config_ruleinfo->context) {
                 if ((config_ruleinfo->context == 1) &&
                         (config_ruleinfo->context_opts & FIELD_DODIFF)) {
                     config_ruleinfo->context = 0;
                 } else {
-                    config_ruleinfo->event_search = (void *(*)(void *, void *, void *))
+                    config_ruleinfo->event_search = (void *(*)(void *, void *, void *, void *))
                         Search_LastEvents;
                 }
             }

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -142,7 +142,7 @@ typedef struct _RuleInfo {
     OSList *group_search;
 
     /* Function pointer to the event_search */
-    void *(*event_search)(void *lf, void *rule, void *rule_match);
+    void *(*event_search)(void *lf, void *os_analysisd_last_events, void *rule, void *rule_match);
 
     char *group;
     OSMatch *match;

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -33,7 +33,7 @@
 /** Internal Functions **/
 void OS_ReadMSG(char *ut_str);
 
-void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *node);
+void DecodeEvent(Eventinfo *lf, OSHash *rules_hash, regex_matching *decoder_match, OSDecoderNode *node);
 
 // Cleanup at exit
 static void onexit();
@@ -483,7 +483,7 @@ void OS_ReadMSG(char *ut_str)
 
             /* Decode event */
             node = OS_GetFirstOSDecoder(lf->program_name);
-            DecodeEvent(lf, &decoder_match, node);
+            DecodeEvent(lf, Config.g_rules_hash, &decoder_match, node);
 
             /* Run accumulator */
             if ( lf->decoder_info->accumulate == 1 ) {

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -33,9 +33,6 @@
 /** Internal Functions **/
 void OS_ReadMSG(char *ut_str);
 
-/* Analysisd function */
-RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching *rule_match);
-
 void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match, OSDecoderNode *node);
 
 // Cleanup at exit
@@ -523,7 +520,7 @@ void OS_ReadMSG(char *ut_str)
                 }
 
                 /* Check each rule */
-                else if (currently_rule = OS_CheckIfRuleMatch(lf, rulenode_pt, &rule_match), !currently_rule) {
+                else if (currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, os_analysisd_cdblists, rulenode_pt, &rule_match), !currently_rule) {
                     continue;
                 }
 

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -123,7 +123,7 @@ typedef struct _RuleInfo {
     OSList *group_search;
 
     /* Function pointer to the event_search */
-    void *(*event_search)(void *lf, void *rule, void *rule_match);
+    void *(*event_search)(void *lf, void *os_analysisd_last_events, void *rule, void *rule_match);
 
     char *group;
     OSMatch *match;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5382|

## Description
This PR makes modifications in `analysisd` to make it work properly, adapting the Eventlist structure and the rule hash table for the new `wazuh-logtest` design.

## Tests
- [x] Compilation without warnings Linux
- [x] Compilation without warnings Windows
- [x] Scan-build report
- [x] Valgrind
- [x] Check the correct working of analysisd
- [x] Check the correct working of logtest
- [x] Running runtest.py successfully


