### PR TITLE
ReadDecodeXML & Rules_OP_ReadRules - Remove error and warning

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -513,6 +513,9 @@ int main_analysisd(int argc, char **argv)
      */
     {
         {
+            /* Error and wargning msg */
+            char *msg = NULL;
+
             /* Initialize the decoders list */
             OS_CreateOSDecoderList();
 
@@ -531,7 +534,11 @@ int main_analysisd(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
-                    if (!ReadDecodeXML(*decodersfiles)) {
+                    if (!ReadDecodeXML(*decodersfiles, &msg)) {
+                        if(msg){
+                            printf("%s", msg);
+                            os_free(msg);
+                        }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
                     }
 
@@ -541,7 +548,11 @@ int main_analysisd(int argc, char **argv)
             }
 
             /* Load decoders */
-            SetDecodeXML();
+            SetDecodeXML(&msg);
+            if(msg){
+                printf("%s", msg);
+                os_free(msg);
+            }
         }
         {
             /* Load Lists */
@@ -579,20 +590,27 @@ int main_analysisd(int argc, char **argv)
 
             /* Read the rules */
             {
+                /* Error and wargning msg */
+                char *msg = NULL;
+
                 char **rulesfiles;
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     if (!test_config) {
                         mdebug1("Reading rules file: '%s'", *rulesfiles);
                     }
-                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, 
+                            &os_analysisd_cdblists, &msg) < 0) {
+                        if(msg){
+                            printf("%s", msg);
+                            os_free(msg);
+                        }
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }
 
                     free(*rulesfiles);
                     rulesfiles++;
                 }
-
                 free(Config.includes);
                 Config.includes = NULL;
             }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -513,7 +513,7 @@ int main_analysisd(int argc, char **argv)
      */
     {
         {
-            /* Error and wargning msg */
+            /* Error and warning msg */
             char *msg = NULL;
 
             /* Initialize the decoders list */
@@ -536,7 +536,7 @@ int main_analysisd(int argc, char **argv)
                     }
                     if (!ReadDecodeXML(*decodersfiles, &msg)) {
                         if (msg) {
-                            printf("%s", msg);
+                            minfo("Call ReadDecodeXML result in the following errors/warning:\n %s", msg);
                             os_free(msg);
                         }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
@@ -550,7 +550,7 @@ int main_analysisd(int argc, char **argv)
             /* Load decoders */
             SetDecodeXML(&msg);
             if (msg) {
-                printf("%s", msg);
+                minfo("Call SetDecodeXML result in the following errors/warning:\n %s", msg);
                 os_free(msg);
             }
         }
@@ -590,7 +590,7 @@ int main_analysisd(int argc, char **argv)
 
             /* Read the rules */
             {
-                /* Error and wargning msg */
+                /* Error and warning msg */
                 char *msg = NULL;
 
                 char **rulesfiles;
@@ -599,9 +599,10 @@ int main_analysisd(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading rules file: '%s'", *rulesfiles);
                     }
+                    
                     if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, &msg) < 0) {
                         if (msg) {
-                            printf("%s", msg);
+                            minfo("Call Rules_OP_ReadRules result in the following errors/warning:\n %s", msg);
                             os_free(msg);
                         }
                         merror_exit(RULES_ERROR, *rulesfiles);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -513,7 +513,9 @@ int main_analysisd(int argc, char **argv)
     {
         {
             /* Error and warning msg */
-            char *msg = NULL;
+            os_analysisd_list_log_msg_t*  list_msg = os_analysisd_create_list_log();
+            os_analysisd_log_msg_t* data_msg;
+            char* msg;
 
             /* Initialize the decoders list */
             OS_CreateOSDecoderList();
@@ -533,10 +535,17 @@ int main_analysisd(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
-                    if (!ReadDecodeXML(*decodersfiles, &msg)) {
-                        if (msg) {
-                            minfo("Call ReadDecodeXML result in the following errors/warning:\n%s", msg);
+                    if (!ReadDecodeXML(*decodersfiles, list_msg)) {
+                        while (data_msg = os_analysisd_pop_list_log(list_msg), data_msg) {
+                            msg = os_analysisd_string_log_msg(data_msg);
+                            if (data_msg->level == LOGLEVEL_WARNING) {
+                                mwarn("%s", msg);
+                            } else if (data_msg->level == LOGLEVEL_ERROR) {
+                                merror("%s", msg);
+                            }
                             os_free(msg);
+                            os_analysisd_free_log_msg(data_msg);
+                            os_free(data_msg);
                         }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
                     }
@@ -547,10 +556,17 @@ int main_analysisd(int argc, char **argv)
             }
 
             /* Load decoders */
-            SetDecodeXML(&msg);
-            if (msg) {
-                minfo("Call SetDecodeXML result in the following errors/warning:\n%s", msg);
+            SetDecodeXML(list_msg);
+            while (data_msg = os_analysisd_pop_list_log(list_msg), data_msg) {
+                msg = os_analysisd_string_log_msg(data_msg);
+                if (data_msg->level == LOGLEVEL_WARNING) {
+                    mwarn("%s", msg);
+                } else if (data_msg->level == LOGLEVEL_ERROR) {
+                    merror("%s", msg);
+                }
                 os_free(msg);
+                os_analysisd_free_log_msg(data_msg);
+                os_free(data_msg);
             }
         }
         {
@@ -590,7 +606,9 @@ int main_analysisd(int argc, char **argv)
             /* Read the rules */
             {
                 /* Error and warning msg */
-                char *msg = NULL;
+                os_analysisd_list_log_msg_t*  list_msg = os_analysisd_create_list_log();
+                os_analysisd_log_msg_t* data_msg;
+                char* msg;
 
                 char **rulesfiles;
                 rulesfiles = Config.includes;
@@ -599,10 +617,17 @@ int main_analysisd(int argc, char **argv)
                         mdebug1("Reading rules file: '%s'", *rulesfiles);
                     }
                     
-                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, &msg) < 0) {
-                        if (msg) {
-                            minfo("Call Rules_OP_ReadRules result in the following errors/warning:\n%s", msg);
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, list_msg) < 0) {
+                        while (data_msg = os_analysisd_pop_list_log(list_msg), data_msg) {
+                            msg = os_analysisd_string_log_msg(data_msg);
+                            if (data_msg->level == LOGLEVEL_WARNING) {
+                                mwarn("%s", msg);
+                            } else if (data_msg->level == LOGLEVEL_ERROR) {
+                                merror("%s", msg);
+                            }
                             os_free(msg);
+                            os_analysisd_free_log_msg(data_msg);
+                            os_free(data_msg);
                         }
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -535,7 +535,7 @@ int main_analysisd(int argc, char **argv)
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
                     if (!ReadDecodeXML(*decodersfiles, &msg)) {
-                        if(msg){
+                        if (msg) {
                             printf("%s", msg);
                             os_free(msg);
                         }
@@ -549,7 +549,7 @@ int main_analysisd(int argc, char **argv)
 
             /* Load decoders */
             SetDecodeXML(&msg);
-            if(msg){
+            if (msg) {
                 printf("%s", msg);
                 os_free(msg);
             }
@@ -599,9 +599,8 @@ int main_analysisd(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading rules file: '%s'", *rulesfiles);
                     }
-                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, 
-                            &os_analysisd_cdblists, &msg) < 0) {
-                        if(msg){
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, &msg) < 0) {
+                        if (msg) {
                             printf("%s", msg);
                             os_free(msg);
                         }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -535,7 +535,7 @@ int main_analysisd(int argc, char **argv)
                     }
                     if (!ReadDecodeXML(*decodersfiles, &msg)) {
                         if (msg) {
-                            minfo("Call ReadDecodeXML result in the following errors/warning:\n %s", msg);
+                            minfo("Call ReadDecodeXML result in the following errors/warning:\n%s", msg);
                             os_free(msg);
                         }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
@@ -549,7 +549,7 @@ int main_analysisd(int argc, char **argv)
             /* Load decoders */
             SetDecodeXML(&msg);
             if (msg) {
-                minfo("Call SetDecodeXML result in the following errors/warning:\n %s", msg);
+                minfo("Call SetDecodeXML result in the following errors/warning:\n%s", msg);
                 os_free(msg);
             }
         }
@@ -601,7 +601,7 @@ int main_analysisd(int argc, char **argv)
                     
                     if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, &msg) < 0) {
                         if (msg) {
-                            minfo("Call Rules_OP_ReadRules result in the following errors/warning:\n %s", msg);
+                            minfo("Call Rules_OP_ReadRules result in the following errors/warning:\n%s", msg);
                             os_free(msg);
                         }
                         merror_exit(RULES_ERROR, *rulesfiles);

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -23,13 +23,13 @@
  * @brief Appends a copy of *str to the *at string and return the new string
  * @details Allocate memory at "*at" and copy *str to it
  *          If *at already exist, realloc the memory and cat str on it.
- * @param[in] at original string (Null an acceptable Value).
- * @param[in] str source string to append at.
- * @param[in] log_msg list to save log messages.
+ * @param at original string (Null an acceptable Value).
+ * @param str source string to append at.
+ * @param log_msg list to save log messages.
  * @return char* The new string.
  * @warning This function assumes that "at" reserved memory is `OS_SIZE_1024`.
  */
-static char *_loadmemory(char *at, char* str, os_analysisd_list_log_msg_t* log_msg);
+static char *_loadmemory(char *at, char* str, OSList* log_msg);
 
 static int addDecoder2list(const char *name);
 static int os_setdecoderids(const char *p_name);
@@ -158,7 +158,7 @@ static int ReadDecodeAttrs(char *const *names, char *const *values)
     return (AFTER_ERROR | AFTER_ERR_NAME );
 }
 
-int ReadDecodeXML(const char *file, os_analysisd_list_log_msg_t* log_msg)
+int ReadDecodeXML(const char *file, OSList* log_msg)
 {
     OS_XML xml;
     XML_NODE node = NULL;
@@ -254,8 +254,8 @@ int ReadDecodeXML(const char *file, os_analysisd_list_log_msg_t* log_msg)
 
         /* Get name */
         if ((!node[i]->attributes) || (!node[i]->values) 
-                ||(!node[i]->values[0])  || (!node[i]->attributes[0]) 
-                ||(strcasecmp(node[i]->attributes[0], xml_decoder_name) != 0)) {
+                || (!node[i]->values[0]) || (!node[i]->attributes[0]) 
+                || (strcasecmp(node[i]->attributes[0], xml_decoder_name) != 0)) {
             log_emsg(log_msg, XML_INVELEM, node[i]->element);
             goto cleanup;
         }
@@ -804,7 +804,7 @@ cleanup:
     return retval;
 }
 
-int SetDecodeXML(os_analysisd_list_log_msg_t* log_msg)
+int SetDecodeXML(OSList* log_msg)
 {
     /* Add rootcheck decoder to list */
     addDecoder2list(ROOTCHECK_MOD);
@@ -831,7 +831,7 @@ int SetDecodeXML(os_analysisd_list_log_msg_t* log_msg)
     return (1);
 }
 
-char *_loadmemory(char *at, char *str, os_analysisd_list_log_msg_t* log_msg)
+char *_loadmemory(char *at, char *str, OSList* log_msg)
 {
     if (at == NULL) {
         size_t strsize = 0;

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -18,8 +18,8 @@
 #include "config.h"
 
 /* Internal functions */
-static char *_loadmemory(char *at, char *str);
-static int addDecoder2list(const char *name);
+static char *_loadmemory(char *at, char* str, char **smsg);
+static int addDecoder2list(const char *name, char **msg);
 static int os_setdecoderids(const char *p_name);
 static int ReadDecodeAttrs(char *const *names, char *const *values);
 static OSStore *os_decoder_store = NULL;
@@ -35,7 +35,7 @@ int getDecoderfromlist(const char *name)
     return (0);
 }
 
-static int addDecoder2list(const char *name)
+static int addDecoder2list(const char *name, char **msg)
 {
     if (os_decoder_store == NULL) {
         os_decoder_store = OSStore_Create();
@@ -47,7 +47,7 @@ static int addDecoder2list(const char *name)
 
     /* Store data */
     if (!OSStore_Put(os_decoder_store, name, NULL)) {
-        merror(LIST_ADD_ERROR);
+        smerror(msg, LIST_ADD_ERROR);
         return (0);
     }
 
@@ -136,23 +136,22 @@ static int ReadDecodeAttrs(char *const *names, char *const *values)
         } else if (strcmp(values[0], "after_regex") == 0) {
             offset |= AFTER_PREVREGEX;
         } else {
-            merror(INV_OFFSET, values[0]);
-            offset |= AFTER_ERROR;
+            offset |= AFTER_ERROR | AFTER_ERR_VAL;
         }
 
         return (offset);
     }
 
     /* Invalid attribute */
-    merror(INV_ATTR, names[0]);
-    return (AFTER_ERROR);
+    return (AFTER_ERROR | AFTER_ERR_NAME );
 }
 
-int ReadDecodeXML(const char *file)
+int ReadDecodeXML(const char *file, char **msg)
 {
     OS_XML xml;
     XML_NODE node = NULL;
     int retval = 0; // 0 means error
+    char* errmsg = NULL; // error description, valid if retval == 0
 
     /* XML variables */
     /* These are the available options for the rule configuration */
@@ -189,20 +188,19 @@ int ReadDecodeXML(const char *file)
             return (-2);
         }
 
-        merror(XML_ERROR, file, xml.err, xml.err_line);
+        smerror(&errmsg, XML_ERROR, file, xml.err, xml.err_line);
         goto cleanup;
     }
 
     /* Apply any variables found */
     if (OS_ApplyVariables(&xml) != 0) {
-        merror(XML_ERROR_VAR, file, xml.err);
+        smerror(&errmsg, XML_ERROR_VAR, file, xml.err);
         goto cleanup;
     }
 
     /* Check if the file is empty */
     if(FileSize(file) == 0){
         if (strcmp(file, XML_LDECODER) != 0) {
-            retval = 0;
             goto cleanup;
         }
     }
@@ -211,7 +209,7 @@ int ReadDecodeXML(const char *file)
     node = OS_GetElementsbyNode(&xml, NULL);
     if (!node) {
         if (strcmp(file, XML_LDECODER) != 0) {
-            merror(XML_ELEMNULL);
+            smerror(&errmsg, XML_ELEMNULL);
             goto cleanup;
         }
 
@@ -239,27 +237,28 @@ int ReadDecodeXML(const char *file)
         }
 
         if (strcasecmp(node[i]->element, xml_decoder) != 0) {
-            merror(XML_INVELEM, node[i]->element);
+            smerror(&errmsg, XML_INVELEM, node[i]->element);
             goto cleanup;
         }
 
         /* Get name */
-        if ((!node[i]->attributes) || (!node[i]->values) ||
-                (!node[i]->values[0])  || (!node[i]->attributes[0]) ||
-                (strcasecmp(node[i]->attributes[0], xml_decoder_name) != 0)) {
-            merror(XML_INVELEM, node[i]->element);
+        if ((!node[i]->attributes) || (!node[i]->values) 
+                ||(!node[i]->values[0])  || (!node[i]->attributes[0]) 
+                ||(strcasecmp(node[i]->attributes[0], xml_decoder_name) != 0)) {
+           
+            smerror(&errmsg, XML_INVELEM, node[i]->element);
             goto cleanup;
         }
 
         /* Check for additional entries */
         if (node[i]->attributes[1] && node[i]->values[1]) {
             if (strcasecmp(node[i]->attributes[1], xml_decoder_status) != 0) {
-                merror(XML_INVELEM, node[i]->element);
+                smerror(&errmsg, XML_INVELEM, node[i]->element);
                 goto cleanup;
             }
 
             if (node[i]->attributes[2]) {
-                merror(XML_INVELEM, node[i]->element);
+                smerror(&errmsg, XML_INVELEM, node[i]->element);
                 goto cleanup;
             }
         }
@@ -267,7 +266,7 @@ int ReadDecodeXML(const char *file)
         /* Get decoder options */
         elements = OS_GetElementsbyNode(&xml, node[i]);
         if (elements == NULL) {
-            merror(XML_ELEMNULL);
+            smerror(&errmsg, XML_ELEMNULL);
             goto cleanup;
         }
 
@@ -302,12 +301,12 @@ int ReadDecodeXML(const char *file)
 
         /* Check if strdup worked */
         if (!pi->name) {
-            merror(MEM_ERROR, errno, strerror(errno));
+             merror(MEM_ERROR, errno, strerror(errno));
             goto cleanup;
         }
 
         /* Add decoder */
-        if (!addDecoder2list(pi->name)) {
+        if (!addDecoder2list(pi->name, &errmsg)) {
             merror(MEM_ERROR, errno, strerror(errno));
             goto cleanup;
         }
@@ -315,16 +314,16 @@ int ReadDecodeXML(const char *file)
         /* Loop over all the elements */
         while (elements[j]) {
             if (!elements[j]->element) {
-                merror(XML_ELEMNULL);
+                smerror(&errmsg, XML_ELEMNULL);
                 goto cleanup;
             } else if (!elements[j]->content) {
-                merror(XML_VALUENULL, elements[j]->element);
+                smerror(&errmsg, XML_VALUENULL, elements[j]->element);
                 goto cleanup;
             }
 
             /* Check if it is a child of a rule */
             else if (strcasecmp(elements[j]->element, xml_parent) == 0) {
-                pi->parent = _loadmemory(pi->parent, elements[j]->content);
+                pi->parent = _loadmemory(pi->parent, elements[j]->content, &errmsg);
             }
 
             /* Get the regex */
@@ -334,14 +333,22 @@ int ReadDecodeXML(const char *file)
                                            elements[j]->values);
 
                 if (r_offset & AFTER_ERROR) {
-                    merror(DEC_REGEX_ERROR, pi->name);
+                    if(r_offset & AFTER_ERR_VAL){
+                        smerror(&errmsg, 
+                            INV_OFFSET, elements[j]->values[0]);
+                    } else if (r_offset & AFTER_ERR_NAME) {
+                        smerror(&errmsg,
+                            INV_ATTR, elements[j]->attributes[0]);
+                    }
+                    smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
+
                     goto cleanup;
                 }
 
                 /* Only the first regex entry may have an offset */
                 if (regex && r_offset) {
-                    merror(DUP_REGEX, pi->name);
-                    merror(DEC_REGEX_ERROR, pi->name);
+                    smerror(&errmsg, DUP_REGEX, pi->name);
+                    smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
                     goto cleanup;
                 }
 
@@ -351,9 +358,7 @@ int ReadDecodeXML(const char *file)
                 }
 
                 /* Assign regex */
-                regex =
-                    _loadmemory(regex,
-                                elements[j]->content);
+                regex = _loadmemory(regex, elements[j]->content, &errmsg);
             }
 
             /* Get the pre match */
@@ -370,7 +375,7 @@ int ReadDecodeXML(const char *file)
 
                 /* Only the first prematch entry may have an offset */
                 if (prematch && r_offset) {
-                    merror(DUP_REGEX, pi->name);
+                    merror(DUP_REGEX, pi->name); // not possible send through the socket
                     merror_exit(DEC_REGEX_ERROR, pi->name);
                 }
 
@@ -379,18 +384,17 @@ int ReadDecodeXML(const char *file)
                 }
 
                 prematch =
-                    _loadmemory(prematch,
-                                elements[j]->content);
+                    _loadmemory(prematch, elements[j]->content, &errmsg);
             }
 
             /* Get program name */
             else if (strcasecmp(elements[j]->element, xml_program_name) == 0) {
-                p_name = _loadmemory(p_name, elements[j]->content);
+                p_name = _loadmemory(p_name, elements[j]->content, &errmsg);
             }
 
             /* Get the FTS comment */
             else if (strcasecmp(elements[j]->element, xml_ftscomment) == 0) {
-                pi->ftscomment = _loadmemory(pi->ftscomment, elements[j]->content);
+                pi->ftscomment = _loadmemory(pi->ftscomment, elements[j]->content, &errmsg);
             }
 
             else if (strcasecmp(elements[j]->element, xml_usename) == 0) {
@@ -414,8 +418,8 @@ int ReadDecodeXML(const char *file)
 
                 /* Decoder not found */
                 if (pi->plugindecoder == NULL) {
-                    merror(INV_DECOPTION, elements[j]->element,
-                           elements[j]->content);
+                    smerror(&errmsg, INV_DECOPTION, 
+                        elements[j]->element, elements[j]->content);
                     goto cleanup;
                 }
 
@@ -434,7 +438,8 @@ int ReadDecodeXML(const char *file)
                 } else if (strcmp(elements[j]->content, "string") == 0) {
                     pi->flags |= SHOW_STRING;
                 } else {
-                    merror(INVALID_ELEMENT, elements[j]->element, elements[j]->content);
+                    smerror(&errmsg, INVALID_ELEMENT, 
+                        elements[j]->element, elements[j]->content);
                     goto cleanup;
                 }
             }
@@ -445,7 +450,8 @@ int ReadDecodeXML(const char *file)
                 } else if (strcmp(elements[j]->content, "array") == 0) {
                     pi->flags |= JSON_ARRAY;
                 } else {
-                    merror(INVALID_ELEMENT, elements[j]->element, elements[j]->content);
+                    smerror(&errmsg, INVALID_ELEMENT, 
+                        elements[j]->element, elements[j]->content);
                     goto cleanup;
                 }
             }
@@ -469,7 +475,8 @@ int ReadDecodeXML(const char *file)
                 } else if (strcmp(elements[j]->content, "ossec") == 0) {
                     pi->type = OSSEC_RL;
                 } else {
-                    merror("Invalid decoder type '%s'.", elements[j]->content);
+                    smerror(&errmsg, 
+                        "Invalid decoder type '%s'.", elements[j]->content);
                     goto cleanup;
                 }
             }
@@ -623,7 +630,8 @@ int ReadDecodeXML(const char *file)
                 /* Clear memory here */
                 free(s_norder);
             } else {
-                merror("Invalid element '%s' for decoder '%s'", elements[j]->element, node[i]->element);
+                smerror(&errmsg, "Invalid element '%s' for decoder '%s'", 
+                    elements[j]->element, node[i]->element);
                 goto cleanup;
             }
 
@@ -637,21 +645,21 @@ int ReadDecodeXML(const char *file)
 
         /* Prematch must be set */
         if (!prematch && !pi->parent && !p_name) {
-            merror(DECODE_NOPRE, pi->name);
-            merror(DEC_REGEX_ERROR, pi->name);
+            smerror(&errmsg, DECODE_NOPRE, pi->name);
+            smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
             goto cleanup;
         }
 
         /* If pi->regex is not set, fts must not be set too */
         if ((!regex && (pi->fts || pi->order)) || (regex && !pi->order)) {
-            merror(DEC_REGEX_ERROR, pi->name);
+            smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
             goto cleanup;
         }
 
         /* For the offsets */
         if ((pi->regex_offset & AFTER_PARENT) && !pi->parent) {
-            merror(INV_OFFSET, "after_parent");
-            merror(DEC_REGEX_ERROR, pi->name);
+            smerror(&errmsg, INV_OFFSET, "after_parent");
+            smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
             goto cleanup;
         }
 
@@ -664,8 +672,8 @@ int ReadDecodeXML(const char *file)
                 pi->regex_offset = 0;
                 pi->regex_offset |= AFTER_PARENT;
             } else if (!prematch) {
-                merror(INV_OFFSET, "after_prematch");
-                merror(DEC_REGEX_ERROR, pi->name);
+                smerror(&errmsg, INV_OFFSET, "after_prematch");
+                smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
                 goto cleanup;
             }
         }
@@ -673,8 +681,8 @@ int ReadDecodeXML(const char *file)
         /* For the after_regex offset */
         if (pi->regex_offset & AFTER_PREVREGEX) {
             if (!pi->parent || !regex) {
-                merror(INV_OFFSET, "after_regex");
-                merror(DEC_REGEX_ERROR, pi->name);
+                smerror(&errmsg, INV_OFFSET, "after_regex");
+                smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
                 goto cleanup;
             }
         }
@@ -684,26 +692,26 @@ int ReadDecodeXML(const char *file)
             /* Only the after parent is allowed */
             if (pi->prematch_offset & AFTER_PARENT) {
                 if (!pi->parent) {
-                    merror(INV_OFFSET, "after_parent");
-                    merror(DEC_REGEX_ERROR, pi->name);
+                    smerror(&errmsg, INV_OFFSET, "after_parent");
+                    smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
                     goto cleanup;
                 }
             } else {
-                merror(DEC_REGEX_ERROR, pi->name);
+                smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
                 goto cleanup;
             }
         }
 
         // Check the plugin offset
         if ((pi->plugin_offset & AFTER_PARENT) && !pi->parent) {
-            merror(INV_OFFSET, "after_parent");
-            merror(DEC_REGEX_ERROR, pi->name);
+            smerror(&errmsg, INV_OFFSET, "after_parent");
+            smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
             goto cleanup;
         }
 
         if (pi->plugin_offset & AFTER_PREMATCH && !prematch) {
-            merror(INV_OFFSET, "after_prematch");
-            merror(DEC_REGEX_ERROR, pi->name);
+            smerror(&errmsg, INV_OFFSET, "after_prematch");
+            smerror(&errmsg, DEC_REGEX_ERROR, pi->name);
             goto cleanup;
         }
 
@@ -711,7 +719,8 @@ int ReadDecodeXML(const char *file)
         if (prematch) {
             os_calloc(1, sizeof(OSRegex), pi->prematch);
             if (!OSRegex_Compile(prematch, pi->prematch, 0)) {
-                merror(REGEX_COMPILE, prematch, pi->prematch->error);
+                smerror(&errmsg, REGEX_COMPILE, 
+                    prematch, pi->prematch->error);
                 goto cleanup;
             }
 
@@ -723,7 +732,8 @@ int ReadDecodeXML(const char *file)
         if (p_name) {
             os_calloc(1, sizeof(OSMatch), pi->program_name);
             if (!OSMatch_Compile(p_name, pi->program_name, 0)) {
-                merror(REGEX_COMPILE, p_name, pi->program_name->error);
+                smerror(&errmsg, REGEX_COMPILE, 
+                    p_name, pi->program_name->error);
                 goto cleanup;
             }
 
@@ -735,13 +745,13 @@ int ReadDecodeXML(const char *file)
         if (regex) {
             os_calloc(1, sizeof(OSRegex), pi->regex);
             if (!OSRegex_Compile(regex, pi->regex, OS_RETURN_SUBSTRING)) {
-                merror(REGEX_COMPILE, regex, pi->regex->error);
+                smerror(&errmsg, REGEX_COMPILE, regex, pi->regex->error);
                 goto cleanup;
             }
 
             /* We must have the sub_strings to retrieve the nodes */
             if (!pi->regex->d_sub_strings) {
-                merror(REGEX_SUBS, regex);
+                smerror(&errmsg, REGEX_SUBS, regex);
                 goto cleanup;
             }
 
@@ -751,13 +761,14 @@ int ReadDecodeXML(const char *file)
 
         /* Validate arguments */
         if (pi->plugindecoder && (pi->regex || pi->order)) {
-            merror(DECODE_ADD, pi->name);
+            smerror(&errmsg, DECODE_ADD, pi->name);
             goto cleanup;
         }
 
         /* Add osdecoder to the list */
-        if (!OS_AddOSDecoder(pi, &os_analysisd_decoderlist_pn, &os_analysisd_decoderlist_nopn)) {
-            merror(DECODER_ERROR);
+        if (!OS_AddOSDecoder(pi, &os_analysisd_decoderlist_pn, 
+                            &os_analysisd_decoderlist_nopn, &errmsg)) {
+            smerror(&errmsg, DECODER_ERROR);
             goto cleanup;
         }
 
@@ -769,9 +780,14 @@ int ReadDecodeXML(const char *file)
 
 cleanup:
 
-    free(p_name);
-    free(prematch);
-    free(regex);
+    if(errmsg){
+        os_free(*msg);
+        *msg = errmsg;
+    }
+
+    os_free(p_name);
+    os_free(prematch);
+    os_free(regex);
 
     /* Clean node and XML structures */
     OS_ClearNode(elements);
@@ -783,27 +799,76 @@ cleanup:
     return retval;
 }
 
-int SetDecodeXML()
+int SetDecodeXML(char **msg)
 {
+    char* tmp_msg = NULL;
     /* Add rootcheck decoder to list */
-    addDecoder2list(ROOTCHECK_MOD);
-    addDecoder2list(SYSCHECK_MOD);
-    addDecoder2list(SYSCHECK_NEW);
-    addDecoder2list(SYSCHECK_DEL);
-    addDecoder2list(HOSTINFO_NEW);
-    addDecoder2list(HOSTINFO_MOD);
-    addDecoder2list(SYSCOLLECTOR_MOD);
-    addDecoder2list(CISCAT_MOD);
-    addDecoder2list(WINEVT_MOD);
-    addDecoder2list(SCA_MOD);
+    addDecoder2list(ROOTCHECK_MOD, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(SYSCHECK_MOD, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(SYSCHECK_NEW, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(SYSCHECK_DEL, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(HOSTINFO_NEW, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(HOSTINFO_MOD, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(SYSCOLLECTOR_MOD, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(CISCAT_MOD, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(WINEVT_MOD, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
+    addDecoder2list(SCA_MOD, &tmp_msg);
+    if(tmp_msg){
+        wm_strcat(msg, tmp_msg, 0);
+        os_free(tmp_msg);
+    }
 
     /* Set ids - for our two lists */
     if (!os_setdecoderids(NULL)) {
-        merror(DECODER_ERROR);
+        smerror(&tmp_msg, DECODER_ERROR);
+        if(tmp_msg){
+            wm_strcat(msg, tmp_msg, 0);
+            os_free(tmp_msg);
+        }
         return (0);
     }
     if (!os_setdecoderids(ARGV0)) {
-        merror(DECODER_ERROR);
+        smerror(&tmp_msg, DECODER_ERROR);
+        if(tmp_msg){
+            wm_strcat(msg, tmp_msg, 0);
+            os_free(tmp_msg);
+        }
         return (0);
     }
 
@@ -813,21 +878,18 @@ int SetDecodeXML()
 /* Allocate memory at "*at" and copy *str to it
  * If *at already exist, realloc the memory and cat str on it
  * Returns the new string
+ * If any error or warning occurs, your description will be stored in *smsg
  */
-char *_loadmemory(char *at, char *str)
+char *_loadmemory(char *at, char *str, char **msg)
 {
     if (at == NULL) {
         size_t strsize = 0;
         if ((strsize = strlen(str)) < OS_SIZE_1024) {
-            at = (char *) calloc(strsize + 1, sizeof(char));
-            if (at == NULL) {
-                merror(MEM_ERROR, errno, strerror(errno));
-                return (NULL);
-            }
+            os_calloc(strsize + 1, sizeof(char), at);
             strncpy(at, str, strsize);
             return (at);
         } else {
-            merror(SIZE_ERROR, str);
+            smerror(msg, SIZE_ERROR, str);
             return (NULL);
         }
     }
@@ -837,12 +899,12 @@ char *_loadmemory(char *at, char *str)
         size_t atsize = strlen(at);
         size_t finalsize = atsize + strsize + 1;
         if (finalsize > OS_SIZE_1024) {
-            merror(SIZE_ERROR, str);
+            smerror(msg,SIZE_ERROR, str);
             return (NULL);
         }
         at = (char *) realloc(at, (finalsize + 1) * sizeof(char));
         if (at == NULL) {
-            merror(MEM_ERROR, errno, strerror(errno));
+            smerror(msg, MEM_ERROR, errno, strerror(errno));
             return (NULL);
         }
         strncat(at, str, strsize);

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -18,6 +18,8 @@
 #define AFTER_PREMATCH  0x002   /* 2   */
 #define AFTER_PREVREGEX 0x004   /* 4   */
 #define AFTER_ERROR     0x010
+#define AFTER_ERR_VAL   (AFTER_ERROR << 1)
+#define AFTER_ERR_NAME  (AFTER_ERROR << 2)
 
 // JSON decoder flags
 // null treatment
@@ -79,11 +81,17 @@ typedef struct dbsync_context_t {
  * list and to get the first osdecoder
  */
 void OS_CreateOSDecoderList(void);
-int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode);
+int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode, char **msg);
 OSDecoderNode *OS_GetFirstOSDecoder(const char *pname);
 int getDecoderfromlist(const char *name);
 char *GetGeoInfobyIP(char *ip_addr);
-int SetDecodeXML(void);
+/**
+ * Add decoders of base modules to list
+ * @param [out] msg If any error occurs, your description will be stored in *msg
+ *              *msg can be null.
+ * @return  return 0 if an error adding decoder plugin.
+*/
+int SetDecodeXML(char **msg);
 void HostinfoInit(void);
 int fim_init(void);
 void RootcheckInit(void);
@@ -91,6 +99,13 @@ void SyscollectorInit(void);
 void CiscatInit(void);
 void WinevtInit(void);
 void SecurityConfigurationAssessmentInit(void);
-int ReadDecodeXML(const char *file);
+/**
+ * Add decoders to main list
+ * 
+ * @param [in] *file path of the decoder configuration xml file.
+ * @param [out] **msg If any error or warning occurs, your 
+ *                  description will be stored in *msg.
+*/
+int ReadDecodeXML(const char *file, char **msg);
 
 #endif /* DECODER_H */

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -110,7 +110,7 @@ void SecurityConfigurationAssessmentInit(void);
  * @return  1 Decoder was added to the list.
  *          0 in case of error.
  *         -2 File XML_LDECODER (localdecoderfile) not found or can't get root element of xmlfile.
- * @note If *msg==null, memory are allocate, otherwise memory are reallocate.
+ * @note If *msg==null, memory are allocate, otherwise memory are reallocate and concatenate the original content
 */
 int ReadDecodeXML(const char *file, char **msg);
 

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -91,7 +91,8 @@ char *GetGeoInfobyIP(char *ip_addr);
 /**
  * @brief Read decoder files and save them in the decoder list.
  * @param log_msg list to save log messages.
- * @return int 0 in case of error, 1 otherwise.
+ * @retval 0 in case of error.
+ * @retval 1 successful.
  */
 int SetDecodeXML(OSList* log_msg);
 
@@ -108,9 +109,9 @@ void SecurityConfigurationAssessmentInit(void);
  * 
  * @param file path of the decoder configuration xml file.
  * @param log_msg List to save log messages.
- * @return 1 Decoder was added to the list.
- *         0 in case of error.
- *        -2 File XML_LDECODER (localdecoderfile) not found or can't get root element of xmlfile.
+ * @retval -2 File XML_LDECODER (localdecoderfile) not found or can't get root element of xmlfile.
+ * @retval  0 in case of error.
+ * @retval  1 Decoder was added to the list.
  */
 int ReadDecodeXML(const char *file, OSList* log_msg);
 

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -82,17 +82,18 @@ typedef struct dbsync_context_t {
  * list and to get the first osdecoder
  */
 void OS_CreateOSDecoderList(void);
-int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode, os_analysisd_list_log_msg_t* log_msg);
+int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode,
+                    OSDecoderNode **npn_osdecodernode, OSList* log_msg);
 OSDecoderNode *OS_GetFirstOSDecoder(const char *pname);
 int getDecoderfromlist(const char *name);
 char *GetGeoInfobyIP(char *ip_addr);
 
 /**
  * @brief Read decoder files and save them in the decoder list.
- * @param[in] log_msg list to save log messages.
+ * @param log_msg list to save log messages.
  * @return int 0 in case of error, 1 otherwise.
  */
-int SetDecodeXML(os_analysisd_list_log_msg_t* log_msg);
+int SetDecodeXML(OSList* log_msg);
 
 void HostinfoInit(void);
 int fim_init(void);
@@ -105,12 +106,12 @@ void SecurityConfigurationAssessmentInit(void);
 /**
  * Add decoders to main list
  * 
- * @param[in]  *file path of the decoder configuration xml file.
- * @param[in]  log_msg List to save log messages.
- * @return  1 Decoder was added to the list.
- *          0 in case of error.
- *         -2 File XML_LDECODER (localdecoderfile) not found or can't get root element of xmlfile.
+ * @param file path of the decoder configuration xml file.
+ * @param log_msg List to save log messages.
+ * @return 1 Decoder was added to the list.
+ *         0 in case of error.
+ *        -2 File XML_LDECODER (localdecoderfile) not found or can't get root element of xmlfile.
  */
-int ReadDecodeXML(const char *file, os_analysisd_list_log_msg_t* log_msg);
+int ReadDecodeXML(const char *file, OSList* log_msg);
 
 #endif /* DECODER_H */

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -12,6 +12,7 @@
 #define DECODER_H
 
 #include "shared.h"
+#include "../list_log.h"
 #include "os_regex/os_regex.h"
 
 #define AFTER_PARENT    0x001   /* 1   */
@@ -81,18 +82,17 @@ typedef struct dbsync_context_t {
  * list and to get the first osdecoder
  */
 void OS_CreateOSDecoderList(void);
-int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode, char **msg);
+int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode, os_analysisd_list_log_msg_t* log_msg);
 OSDecoderNode *OS_GetFirstOSDecoder(const char *pname);
 int getDecoderfromlist(const char *name);
 char *GetGeoInfobyIP(char *ip_addr);
 
 /**
  * @brief Read decoder files and save them in the decoder list.
- * @param[out] msg Store warnings and error as result of call
+ * @param[in] log_msg list to save log messages.
  * @return int 0 in case of error, 1 otherwise.
- * @note If *msg==null, memory are allocate, otherwise memory are reallocate.
  */
-int SetDecodeXML(char **msg);
+int SetDecodeXML(os_analysisd_list_log_msg_t* log_msg);
 
 void HostinfoInit(void);
 int fim_init(void);
@@ -106,12 +106,11 @@ void SecurityConfigurationAssessmentInit(void);
  * Add decoders to main list
  * 
  * @param[in]  *file path of the decoder configuration xml file.
- * @param[out] **msg Store warnings and error as result of call
+ * @param[in]  log_msg List to save log messages.
  * @return  1 Decoder was added to the list.
  *          0 in case of error.
  *         -2 File XML_LDECODER (localdecoderfile) not found or can't get root element of xmlfile.
- * @note If *msg==null, memory are allocate, otherwise memory are reallocate and concatenate the original content
-*/
-int ReadDecodeXML(const char *file, char **msg);
+ */
+int ReadDecodeXML(const char *file, os_analysisd_list_log_msg_t* log_msg);
 
 #endif /* DECODER_H */

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -85,13 +85,15 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecod
 OSDecoderNode *OS_GetFirstOSDecoder(const char *pname);
 int getDecoderfromlist(const char *name);
 char *GetGeoInfobyIP(char *ip_addr);
+
 /**
- * Add decoders of base modules to list
- * @param [out] msg If any error occurs, your description will be stored in *msg
- *              *msg can be null.
- * @return  return 0 if an error adding decoder plugin.
-*/
+ * @brief Read decoder files and save them in the decoder list.
+ * @param[out] msg Store warnings and error as result of call
+ * @return int 0 in case of error, 1 otherwise.
+ * @note If *msg==null, memory are allocate, otherwise memory are reallocate.
+ */
 int SetDecodeXML(char **msg);
+
 void HostinfoInit(void);
 int fim_init(void);
 void RootcheckInit(void);
@@ -99,12 +101,16 @@ void SyscollectorInit(void);
 void CiscatInit(void);
 void WinevtInit(void);
 void SecurityConfigurationAssessmentInit(void);
+
 /**
  * Add decoders to main list
  * 
- * @param [in] *file path of the decoder configuration xml file.
- * @param [out] **msg If any error or warning occurs, your 
- *                  description will be stored in *msg.
+ * @param[in]  *file path of the decoder configuration xml file.
+ * @param[out] **msg Store warnings and error as result of call
+ * @return  1 Decoder was added to the list.
+ *          0 in case of error.
+ *         -2 File XML_LDECODER (localdecoderfile) not found or can't get root element of xmlfile.
+ * @note If *msg==null, memory are allocate, otherwise memory are reallocate.
 */
 int ReadDecodeXML(const char *file, char **msg);
 

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -18,7 +18,7 @@
 #include "error_messages/debug_messages.h"
 #include "analysisd.h"
 
-static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi);
+static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, char **msg);
 
 /* Create the Event List */
 void OS_CreateOSDecoderList()
@@ -41,18 +41,14 @@ OSDecoderNode *OS_GetFirstOSDecoder(const char *p_name)
 }
 
 /* Add an osdecoder to the list */
-static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi)
+static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, char **msg)
 {
     OSDecoderNode *tmp_node = s_node;
     OSDecoderNode *new_node;
     int rm_f = 0;
 
     if (tmp_node) {
-        new_node = (OSDecoderNode *)calloc(1, sizeof(OSDecoderNode));
-        if (new_node == NULL) {
-            merror(MEM_ERROR, errno, strerror(errno));
-            return (NULL);
-        }
+        os_calloc(1, sizeof(OSDecoderNode), new_node);
 
         /* Going to the last node */
         do {
@@ -66,20 +62,20 @@ static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi)
 
                 /* Multi-regexes patterns cannot have prematch */
                 if (pi->prematch) {
-                    merror(PDUP_INV, pi->name);
+                    smerror(msg, PDUP_INV, pi->name);
                     goto error;
                 }
 
                 /* Multi-regex patterns cannot have fts set */
                 if (pi->fts) {
-                    merror(PDUPFTS_INV, pi->name);
+                    smerror(msg, PDUPFTS_INV, pi->name);
                     goto error;
                 }
 
                 if ((tmp_node->osdecoder->regex || tmp_node->osdecoder->plugindecoder) && (pi->regex || pi->plugindecoder)) {
                     tmp_node->osdecoder->get_next = 1;
                 } else {
-                    merror(DUP_INV, pi->name);
+                    smerror(msg, DUP_INV, pi->name);
                     goto error;
                 }
             }
@@ -88,7 +84,7 @@ static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi)
 
         /* Must have a prematch set */
         if (!rm_f && (pi->regex_offset & AFTER_PREVREGEX)) {
-            merror(INV_OFFSET, pi->name);
+            smerror(msg, INV_OFFSET, pi->name);
             goto error;
         }
 
@@ -102,15 +98,11 @@ static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi)
     else {
         /* Must not have a previous regex set */
         if (pi->regex_offset & AFTER_PREVREGEX) {
-            merror(INV_OFFSET, pi->name);
+            smerror(msg, INV_OFFSET, pi->name);
             return (NULL);
         }
 
-        tmp_node = (OSDecoderNode *)calloc(1, sizeof(OSDecoderNode));
-
-        if (tmp_node == NULL) {
-            merror_exit(MEM_ERROR, errno, strerror(errno));
-        }
+        os_calloc(1, sizeof(OSDecoderNode), tmp_node);
 
         tmp_node->child = NULL;
         tmp_node->next = NULL;
@@ -122,13 +114,12 @@ static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi)
     return (s_node);
 
 error:
-    if (new_node) {
-        free(new_node);
-    }
+    os_free(new_node);
+
     return (NULL);
 }
 
-int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode)
+int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode, char **msg)
 {
     int added = 0;
     OSDecoderNode *osdecodernode;
@@ -149,9 +140,9 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecod
         /* List with p_name */
         while (tmp_node) {
             if (strcmp(tmp_node->osdecoder->name, pi->parent) == 0) {
-                tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi);
+                tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi, msg);
                 if (!tmp_node->child) {
-                    merror(DEC_PLUGIN_ERR);
+                    smerror(msg, DEC_PLUGIN_ERR);
                     return (0);
                 }
                 added = 1;
@@ -163,9 +154,9 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecod
         tmp_node = *npn_osdecodernode;
         while (tmp_node) {
             if (strcmp(tmp_node->osdecoder->name, pi->parent) == 0) {
-                tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi);
+                tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi, msg);
                 if (!tmp_node->child) {
-                    merror(DEC_PLUGIN_ERR);
+                    smerror(msg, DEC_PLUGIN_ERR);
                     return (0);
                 }
                 added = 1;
@@ -178,12 +169,12 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecod
             return (1);
         }
 
-        merror(PPLUGIN_INV, pi->parent);
+        smerror(msg, PPLUGIN_INV, pi->parent);
         return (0);
     } else {
-        osdecodernode = _OS_AddOSDecoder(osdecodernode, pi);
+        osdecodernode = _OS_AddOSDecoder(osdecodernode, pi, msg);
         if (!osdecodernode) {
-            merror(DEC_PLUGIN_ERR);
+            smerror(msg, DEC_PLUGIN_ERR);
             return (0);
         }
 

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -18,7 +18,7 @@
 #include "error_messages/debug_messages.h"
 #include "analysisd.h"
 
-static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, os_analysisd_list_log_msg_t* log_msg);
+static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, OSList* log_msg);
 
 /* Create the Event List */
 void OS_CreateOSDecoderList()
@@ -41,7 +41,7 @@ OSDecoderNode *OS_GetFirstOSDecoder(const char *p_name)
 }
 
 /* Add an osdecoder to the list */
-static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, os_analysisd_list_log_msg_t* log_msg)
+static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, OSList* log_msg)
 {
     OSDecoderNode *tmp_node = s_node;
     OSDecoderNode *new_node;
@@ -120,7 +120,8 @@ error:
     return (NULL);
 }
 
-int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode, OSDecoderNode **npn_osdecodernode, os_analysisd_list_log_msg_t* log_msg)
+int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode,
+                    OSDecoderNode **npn_osdecodernode, OSList* log_msg)
 {
     int added = 0;
     OSDecoderNode *osdecodernode;

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -72,7 +72,8 @@ static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi,
                     goto error;
                 }
 
-                if ((tmp_node->osdecoder->regex || tmp_node->osdecoder->plugindecoder) && (pi->regex || pi->plugindecoder)) {
+                if ((tmp_node->osdecoder->regex || tmp_node->osdecoder->plugindecoder) 
+                    && (pi->regex || pi->plugindecoder)) {
                     tmp_node->osdecoder->get_next = 1;
                 } else {
                     smerror(msg, DUP_INV, pi->name);

--- a/src/analysisd/list_log.c
+++ b/src/analysisd/list_log.c
@@ -1,0 +1,90 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "list_log.h"
+
+os_analysisd_list_log_msg_t* os_analysisd_create_list_log() {
+    os_analysisd_list_log_msg_t* list;
+    os_calloc(1, sizeof(os_analysisd_list_log_msg_t), list);
+    return list;
+}
+
+void _os_analysisd_add_list_log(os_analysisd_list_log_msg_t* list, int level, int line,
+                                const char* func, const char* file, char* msg, ...) {
+
+    va_list args;
+    os_analysisd_log_msg_t* new_msg;
+    os_malloc(sizeof(os_analysisd_log_msg_t), new_msg);
+    new_msg->next = NULL;
+
+    /* Debug information */
+    new_msg->line = line;
+    os_strdup(func, new_msg->func);
+    os_strdup(file, new_msg->file);
+
+    /* Generic message */
+    new_msg->level = level;
+    os_malloc(OS_BUFFER_SIZE, new_msg->msg);
+    va_start(args, msg);
+    (void)vsnprintf(new_msg->msg, OS_BUFFER_SIZE, msg, args);
+    va_end(args);
+    os_realloc(new_msg->msg, strlen(new_msg->msg) + 1, new_msg->msg);
+
+    if (list->head == NULL) {
+        list->head = new_msg;
+    } else {
+        os_analysisd_log_msg_t* current_node = list->head;
+
+        while (current_node->next) {
+            current_node = current_node->next;
+        }
+        current_node->next = new_msg;
+    }
+
+    return;
+}
+
+os_analysisd_log_msg_t* os_analysisd_pop_list_log(os_analysisd_list_log_msg_t* list) {
+
+    os_analysisd_log_msg_t* first_node = list->head;
+
+    if (!first_node) {
+        return NULL;
+    }
+    list->head = first_node->next;
+    first_node->next = NULL; // Prevents memory frees errors
+
+    return first_node;
+}
+
+char* os_analysisd_string_log_msg(os_analysisd_log_msg_t* log_msg) {
+    char* str;
+
+    if (isDebug()) {
+        os_malloc(OS_BUFFER_SIZE, str);
+        (void)snprintf(str, OS_BUFFER_SIZE, "%s:%d at %s(): %s", log_msg->file,
+                       log_msg->line, log_msg->func, log_msg->msg);
+        os_realloc(str, strlen(str) + 1, str);
+    } else {
+        os_strdup(log_msg->msg, str);
+    }
+
+    return str;
+}
+
+void os_analysisd_free_log_msg(os_analysisd_log_msg_t* log_msg) {
+    if(!log_msg){
+        return;
+    }
+
+    os_free(log_msg->file);
+    os_free(log_msg->func);
+    os_free(log_msg->msg);
+}

--- a/src/analysisd/list_log.c
+++ b/src/analysisd/list_log.c
@@ -10,19 +10,12 @@
 
 #include "list_log.h"
 
-os_analysisd_list_log_msg_t* os_analysisd_create_list_log() {
-    os_analysisd_list_log_msg_t* list;
-    os_calloc(1, sizeof(os_analysisd_list_log_msg_t), list);
-    return list;
-}
-
-void _os_analysisd_add_list_log(os_analysisd_list_log_msg_t* list, int level, int line,
-                                const char* func, const char* file, char* msg, ...) {
+void _os_analysisd_add_list_log(OSList * list, int level, int line, const char * func, 
+                                const char * file, char * msg, ...) {
 
     va_list args;
-    os_analysisd_log_msg_t* new_msg;
+    os_analysisd_log_msg_t * new_msg;
     os_malloc(sizeof(os_analysisd_log_msg_t), new_msg);
-    new_msg->next = NULL;
 
     /* Debug information */
     new_msg->line = line;
@@ -37,40 +30,21 @@ void _os_analysisd_add_list_log(os_analysisd_list_log_msg_t* list, int level, in
     va_end(args);
     os_realloc(new_msg->msg, strlen(new_msg->msg) + 1, new_msg->msg);
 
-    if (list->head == NULL) {
-        list->head = new_msg;
-    } else {
-        os_analysisd_log_msg_t* current_node = list->head;
-
-        while (current_node->next) {
-            current_node = current_node->next;
-        }
-        current_node->next = new_msg;
-    }
-
+    OSList_AddData(list, new_msg);
     return;
 }
 
-os_analysisd_log_msg_t* os_analysisd_pop_list_log(os_analysisd_list_log_msg_t* list) {
+char * os_analysisd_string_log_msg(os_analysisd_log_msg_t * log_msg) {
+    char * str;
 
-    os_analysisd_log_msg_t* first_node = list->head;
-
-    if (!first_node) {
+    if (log_msg == NULL) {
         return NULL;
     }
-    list->head = first_node->next;
-    first_node->next = NULL; // Prevents memory frees errors
-
-    return first_node;
-}
-
-char* os_analysisd_string_log_msg(os_analysisd_log_msg_t* log_msg) {
-    char* str;
 
     if (isDebug()) {
         os_malloc(OS_BUFFER_SIZE, str);
-        (void)snprintf(str, OS_BUFFER_SIZE, "%s:%d at %s(): %s", log_msg->file,
-                       log_msg->line, log_msg->func, log_msg->msg);
+        (void)snprintf(str, OS_BUFFER_SIZE, "%s:%d at %s(): %s", log_msg->file, log_msg->line, log_msg->func,
+                       log_msg->msg);
         os_realloc(str, strlen(str) + 1, str);
     } else {
         os_strdup(log_msg->msg, str);
@@ -79,12 +53,14 @@ char* os_analysisd_string_log_msg(os_analysisd_log_msg_t* log_msg) {
     return str;
 }
 
-void os_analysisd_free_log_msg(os_analysisd_log_msg_t* log_msg) {
-    if(!log_msg){
+void os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg) {
+
+    if (!*log_msg) {
         return;
     }
 
-    os_free(log_msg->file);
-    os_free(log_msg->func);
-    os_free(log_msg->msg);
+    os_free((*log_msg)->file);
+    os_free((*log_msg)->func);
+    os_free((*log_msg)->msg);
+    os_free(*log_msg);
 }

--- a/src/analysisd/list_log.h
+++ b/src/analysisd/list_log.h
@@ -1,0 +1,79 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef LIST_LOG_H
+#define LIST_LOG_H
+
+#include "shared.h"
+
+#define log_emsg(list, msg, ...) _os_analysisd_add_list_log(list, LOGLEVEL_ERROR, __LINE__, __func__, __FILE__, msg, ##__VA_ARGS__)
+#define log_wmsg(list, msg, ...) _os_analysisd_add_list_log(list, LOGLEVEL_WARNING, __LINE__, __func__, __FILE__, msg, ##__VA_ARGS__) 
+
+/**
+ * @brief  Structure to save information of log messages
+ */
+typedef struct os_analysisd_log_msg_t {
+    int level;    ///< Log level of message.
+    int line;     ///< Line number from where the function was called. the __LINE__ macro should be used.
+    char* func;   ///< Function name from where the function was called. the __func__ macro should be used.
+    char* file;   ///< File name from where the function was called. the __FILE__ macro should be used.
+    char* msg;    ///< Error/Warning message.
+    struct os_analysisd_log_msg_t* next;
+} os_analysisd_log_msg_t;
+
+/**
+ * @brief List of log mesagges
+ */
+typedef struct os_analysisd_list_log_msg_t {
+    os_analysisd_log_msg_t* head; ///< Top  of list
+} os_analysisd_list_log_msg_t;
+
+/**
+ * @brief Create and initialize list of \ref os_analysisd_list_log_msg_t
+ * @return os_analysisd_list_log_msg_t* 
+ */
+os_analysisd_list_log_msg_t*  os_analysisd_create_list_log();
+
+/**
+ * @brief Add a new message to list of \ref os_analysisd_list_log_msg_t.
+ * @param[in] list list to add.
+ * @param[in] level  Log level of message.
+ * @param[in] line   line number from where the function was called. the __LINE__ macro should be used.
+ * @param[in] func   function name from where the function was called. the __func__ macro should be used.
+ * @param[in] file   file name from where the function was called. the __FILE__ macro should be used.
+ * @param[in] msg    format includes format specifiers (subsequences beginning with %) for sprintf.
+ * @param[in] ...    additional arguments following format are formatted and inserted in the
+ *                   resulting string replacing their respective specifiers.
+ */
+void _os_analysisd_add_list_log(os_analysisd_list_log_msg_t* list, int level,
+                                int line, const char* func, const char* file, char* msg, ...) __attribute__((nonnull));
+
+/**
+ * @brief Remove the first element from the list and return it.
+ * @param[in] list list to remove item.
+ * @return os_analysisd_log_msg_t* First element of the list, NULL if the list is empty.
+ * @note The next element of the node is set to null before returning it.
+ */
+os_analysisd_log_msg_t* os_analysisd_pop_list_log(os_analysisd_list_log_msg_t* list) __attribute__((nonnull));
+
+/**
+ * @brief Create string message with the information from \ref os_analysisd_log_msg_t node.
+ * @param log_msg[in] Node with message information.
+ * @return char* string message, NULL if log_msg is NULL
+ */
+char* os_analysisd_string_log_msg(os_analysisd_log_msg_t* log_msg);
+
+/**
+ * @brief Free the elements of the \ref os_analysisd_log_msg_t
+ * @param log_msg 
+ */
+void os_analysisd_free_log_msg(os_analysisd_log_msg_t* log_msg);
+
+
+#endif

--- a/src/analysisd/list_log.h
+++ b/src/analysisd/list_log.h
@@ -13,67 +13,46 @@
 #include "shared.h"
 
 #define log_emsg(list, msg, ...) _os_analysisd_add_list_log(list, LOGLEVEL_ERROR, __LINE__, __func__, __FILE__, msg, ##__VA_ARGS__)
-#define log_wmsg(list, msg, ...) _os_analysisd_add_list_log(list, LOGLEVEL_WARNING, __LINE__, __func__, __FILE__, msg, ##__VA_ARGS__) 
+#define log_wmsg(list, msg, ...) _os_analysisd_add_list_log(list, LOGLEVEL_WARNING, __LINE__, __func__, __FILE__, msg, ##__VA_ARGS__)
+
+#define ERRORLIST_MAXSIZE   50 ///< Max size of log messages list
 
 /**
- * @brief  Structure to save information of log messages
+ * @brief Structure to save information of log messages
  */
 typedef struct os_analysisd_log_msg_t {
-    int level;    ///< Log level of message.
-    int line;     ///< Line number from where the function was called. the __LINE__ macro should be used.
-    char* func;   ///< Function name from where the function was called. the __func__ macro should be used.
-    char* file;   ///< File name from where the function was called. the __FILE__ macro should be used.
-    char* msg;    ///< Error/Warning message.
-    struct os_analysisd_log_msg_t* next;
+    int level;   ///< Log level of message.
+    int line;    ///< Line number from where the function was called. the __LINE__ macro should be used.
+    char * func; ///< Function name from where the function was called. the __func__ macro should be used.
+    char * file; ///< File name from where the function was called. the __FILE__ macro should be used.
+    char * msg;  ///< Generic message.
 } os_analysisd_log_msg_t;
 
 /**
- * @brief List of log mesagges
- */
-typedef struct os_analysisd_list_log_msg_t {
-    os_analysisd_log_msg_t* head; ///< Top  of list
-} os_analysisd_list_log_msg_t;
-
-/**
- * @brief Create and initialize list of \ref os_analysisd_list_log_msg_t
- * @return os_analysisd_list_log_msg_t* 
- */
-os_analysisd_list_log_msg_t*  os_analysisd_create_list_log();
-
-/**
- * @brief Add a new message to list of \ref os_analysisd_list_log_msg_t.
- * @param[in] list list to add.
- * @param[in] level  Log level of message.
- * @param[in] line   line number from where the function was called. the __LINE__ macro should be used.
- * @param[in] func   function name from where the function was called. the __func__ macro should be used.
- * @param[in] file   file name from where the function was called. the __FILE__ macro should be used.
- * @param[in] msg    format includes format specifiers (subsequences beginning with %) for sprintf.
- * @param[in] ...    additional arguments following format are formatted and inserted in the
+ * @brief Add a new message to list of \ref OSList*.
+ * @param list list to add.
+ * @param level  Log level of message.
+ * @param line   line number from where the function was called. the __LINE__ macro should be used.
+ * @param func   function name from where the function was called. the __func__ macro should be used.
+ * @param file   file name from where the function was called. the __FILE__ macro should be used.
+ * @param msg    format includes format specifiers (subsequences beginning with %) for sprintf.
+ * @param ...    additional arguments following format are formatted and inserted in the
  *                   resulting string replacing their respective specifiers.
  */
-void _os_analysisd_add_list_log(os_analysisd_list_log_msg_t* list, int level,
-                                int line, const char* func, const char* file, char* msg, ...) __attribute__((nonnull));
+void _os_analysisd_add_list_log(OSList * list, int level, int line, const char * func, 
+                                const char * file, char * msg, ...) __attribute__((nonnull));
 
 /**
- * @brief Remove the first element from the list and return it.
- * @param[in] list list to remove item.
- * @return os_analysisd_log_msg_t* First element of the list, NULL if the list is empty.
- * @note The next element of the node is set to null before returning it.
- */
-os_analysisd_log_msg_t* os_analysisd_pop_list_log(os_analysisd_list_log_msg_t* list) __attribute__((nonnull));
-
-/**
- * @brief Create string message with the information from \ref os_analysisd_log_msg_t node.
- * @param log_msg[in] Node with message information.
+ * @brief Create string message with the information from \ref os_analysisd_log_msg_t.
+ * @param log_msg Message information.
  * @return char* string message, NULL if log_msg is NULL
  */
-char* os_analysisd_string_log_msg(os_analysisd_log_msg_t* log_msg);
+char * os_analysisd_string_log_msg(os_analysisd_log_msg_t * log_msg);
 
 /**
- * @brief Free the elements of the \ref os_analysisd_log_msg_t
- * @param log_msg 
+ * @brief Free \ref os_analysisd_log_msg_t
+ * @param log_msg elements to free.
  */
-void os_analysisd_free_log_msg(os_analysisd_log_msg_t* log_msg);
-
+void os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg);
 
 #endif

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -78,7 +78,7 @@ void *w_logtest_main(w_logtest_connection *connection) {
     char msg_received[OS_MAXSTR];
     int size_msg_received;
 
-    while(1) {
+    while (1) {
 
         w_mutex_lock(&connection->mutex);
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1007,7 +1007,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_agent) == 0) {
-                        log_emsg(log_msg, "Detected a deprecated field option for rule, %s is not longer available.",
+                        log_wmsg(log_msg, "Detected a deprecated field option for rule, %s is not longer available.",
                             xml_same_agent);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_srcuser) == 0) {
@@ -1155,7 +1155,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_notsame_agent) == 0) {
-                        log_emsg(log_msg, "Detected a deprecated field option for rule, %s is not longer available.",
+                        log_wmsg(log_msg, "Detected a deprecated field option for rule, %s is not longer available.",
                             xml_notsame_agent);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_different_location) == 0) {
@@ -1354,7 +1354,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         mitre_opt = OS_GetElementsbyNode(&xml, rule_opt[k]);
 
                         if (mitre_opt == NULL) {
-                            log_emsg(log_msg, "Empty Mitre information for rule '%d'", config_ruleinfo->sigid);
+                            log_wmsg(log_msg, "Empty Mitre information for rule '%d'", config_ruleinfo->sigid);
                             k++;
                             continue;
                         }
@@ -1364,7 +1364,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                 break;
                             } else if (strcasecmp(mitre_opt[ind]->element, xml_mitre_id) == 0) {
                                 if (strlen(mitre_opt[ind]->content) == 0) {
-                                    log_emsg(log_msg, "No Mitre Technique ID found for rule '%d'",
+                                    log_wmsg(log_msg, "No Mitre Technique ID found for rule '%d'",
                                         config_ruleinfo->sigid);
                                 } else {
                                     int inarray = 0;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -256,14 +256,13 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
     while (node[i]) {
         if (node[i]->element) {
             if (strcasecmp(node[i]->element, xml_group) != 0) {
-                smerror(&tmp_msg, "rules_op: Invalid root element \"%s\"."
-                       "Only \"group\" is allowed", node[i]->element);
+                smerror(&tmp_msg, "rules_op: Invalid root element \"%s\".Only \"group\" is allowed", node[i]->element);
                 goto cleanup;
             }
-            if ((!node[i]->attributes) || (!node[i]->values) ||
-                    (!node[i]->values[0]) || (!node[i]->attributes[0]) ||
-                    (strcasecmp(node[i]->attributes[0], "name") != 0) ||
-                    (node[i]->attributes[1])) {
+            if ((!node[i]->attributes) || (!node[i]->values)
+                || (!node[i]->values[0]) || (!node[i]->attributes[0]) 
+                || (strcasecmp(node[i]->attributes[0], "name") != 0) 
+                || (node[i]->attributes[1])) {
                 smerror(&tmp_msg, "rules_op: Invalid root element '%s'."
                        "Only the group name is allowed", node[i]->element);
                 goto cleanup;
@@ -283,8 +282,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
         /* Get all rules for a global group */
         rule = OS_GetElementsbyNode(&xml, node[i]);
         if (rule == NULL) {
-            smerror(&tmp_msg, "Group '%s' without any rule.",
-                   node[i]->element);
+            smerror(&tmp_msg, "Group '%s' without any rule.", node[i]->element);
             goto cleanup;
         }
 
@@ -297,15 +295,13 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
             }
 
             if (strcasecmp(rule[j]->element, xml_rule) != 0) {
-                smerror(&tmp_msg, "Invalid configuration. '%s' is not "
-                       "a valid element.", rule[j]->element);
+                smerror(&tmp_msg, "Invalid configuration. '%s' is not a valid element.", rule[j]->element);
                 goto cleanup;
             }
 
             /* Check for the attributes of the rule */
             if ((!rule[j]->attributes) || (!rule[j]->values)) {
-                smerror(&tmp_msg, "Invalid rule '%d'. You must specify"
-                       " an ID and a level at least.", j);
+                smerror(&tmp_msg, "Invalid rule '%d'. You must specify an ID and a level at least.", j);
                 goto cleanup;
             }
 
@@ -327,8 +323,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
 
                 if ((id == -1) || (level == -1)) {
-                    smerror(&tmp_msg, "No rule id or level specified for "
-                           "rule '%d'.", j);
+                    smerror(&tmp_msg, "No rule id or level specified for rule '%d'.", j);
                     goto cleanup;
                 }
 
@@ -405,10 +400,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 XML_NODE rule_opt = NULL;
                 rule_opt =  OS_GetElementsbyNode(&xml, rule[j]);
                 if (rule_opt == NULL) {
-                    smerror(&tmp_msg, "Rule '%d' without any option. "
-                           "It may lead to false positives and some "
-                           "other problems for the system. Exiting.",
-                           config_ruleinfo->sigid);
+                    smerror(&tmp_msg, "Rule '%d' without any option. It may lead to false positives and some "
+                           "other problems for the system. Exiting.", config_ruleinfo->sigid);
                     goto cleanup;
                 }
 
@@ -428,8 +421,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             getDecoderfromlist(rule_opt[k]->content);
 
                         if (config_ruleinfo->decoded_as == 0) {
-                            smerror(&tmp_msg, "Invalid decoder name: '%s'.",
-                                   rule_opt[k]->content);
+                            smerror(&tmp_msg, "Invalid decoder name: '%s'.", rule_opt[k]->content);
                             goto cleanup;
                         }
                     } else if (strcasecmp(rule_opt[k]->element, xml_cve) == 0) {
@@ -483,9 +475,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         config_ruleinfo->day_time =
                             OS_IsValidTime(rule_opt[k]->content);
                         if (!config_ruleinfo->day_time) {
-                            smerror(&tmp_msg, INVALID_CONFIG,
-                                   rule_opt[k]->element,
-                                   rule_opt[k]->content);
+                            smerror(&tmp_msg, INVALID_CONFIG,rule_opt[k]->element,rule_opt[k]->content);
                             goto cleanup;
                         }
 
@@ -497,9 +487,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             OS_IsValidDay(rule_opt[k]->content, &tmp_msg);
 
                         if (!config_ruleinfo->week_day) {
-                            smerror(&tmp_msg, INVALID_CONFIG,
-                                   rule_opt[k]->element,
-                                   rule_opt[k]->content);
+                            smerror(&tmp_msg, INVALID_CONFIG,rule_opt[k]->element, rule_opt[k]->content);
                             goto cleanup;
                         }
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
@@ -712,7 +700,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         os_calloc(1, sizeof(OSRegex), config_ruleinfo->fields[ifield]->regex);
 
                         if (!OSRegex_Compile(rule_opt[k]->content, config_ruleinfo->fields[ifield]->regex, 0)) {
-                            smerror(&tmp_msg, REGEX_COMPILE, rule_opt[k]->content, config_ruleinfo->fields[ifield]->regex->error);
+                            smerror(&tmp_msg, REGEX_COMPILE, rule_opt[k]->content, 
+                                config_ruleinfo->fields[ifield]->regex->error);
                             goto cleanup;
                         }
 
@@ -740,11 +729,9 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_address_key_value) == 0) {
                                         lookup_type = LR_ADDRESS_MATCH_VALUE;
                                     } else {
-                                        smerror(&tmp_msg, INVALID_CONFIG,
-                                               rule_opt[k]->element,
-                                               rule_opt[k]->content);
-                                        smerror(&tmp_msg, "List match lookup=\"%s\" is not valid.",
-                                               rule_opt[k]->values[list_att_num]);
+                                        smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
+                                        smerror(&tmp_msg, "List match lookup=\"%s\" is not valid.", 
+                                                rule_opt[k]->values[list_att_num]);
                                         goto cleanup;
                                     }
                                 } else if (strcasecmp(rule_opt[k]->attributes[list_att_num], xml_list_field) == 0) {
@@ -789,27 +776,22 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                 } else if (strcasecmp(rule_opt[k]->attributes[list_att_num], xml_list_cvalue) == 0) {
                                     os_calloc(1, sizeof(OSMatch), matcher);
                                     if (!OSMatch_Compile(rule_opt[k]->values[list_att_num], matcher, 0)) {
-                                        smerror(&tmp_msg, INVALID_CONFIG,
-                                               rule_opt[k]->element,
-                                               rule_opt[k]->content);
-                                        smerror(&tmp_msg, REGEX_COMPILE,
-                                               rule_opt[k]->values[list_att_num],
-                                               matcher->error);
+                                        smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
+                                        smerror(&tmp_msg, REGEX_COMPILE, rule_opt[k]->values[list_att_num], 
+                                            matcher->error);
                                         goto cleanup;
                                     }
                                 } else {
                                     smerror(&tmp_msg, "List field=\"%s\" is not valid",
                                            rule_opt[k]->values[list_att_num]);
-                                    smerror(&tmp_msg, INVALID_CONFIG,
-                                           rule_opt[k]->element, rule_opt[k]->content);
+                                    smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                                     goto cleanup;
                                 }
                                 list_att_num++;
                             }
                             if (rule_type == 0) {
                                 smerror(&tmp_msg, "List requires the field=\"\" attribute");
-                                smerror(&tmp_msg, INVALID_CONFIG,
-                                       rule_opt[k]->element, rule_opt[k]->content);
+                                smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                                 goto cleanup;
                             }
 
@@ -827,16 +809,13 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             }
                         } else {
                             smerror(&tmp_msg, "List must have a correctly formatted field attribute");
-                            smerror(&tmp_msg, INVALID_CONFIG,
-                                   rule_opt[k]->element,
-                                   rule_opt[k]->content);
+                            smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                             goto cleanup;
                         }
                         /* xml_list eval is done */
                     } else if (strcasecmp(rule_opt[k]->element, xml_url) == 0) {
                         url =
-                            loadmemory(url,
-                                       rule_opt[k]->content, &tmp_msg);
+                            loadmemory(url, rule_opt[k]->content, &tmp_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_compiled) == 0) {
                         int it_id = 0;
 
@@ -850,10 +829,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                         /* Checking if the name is valid */
                         if (!compiled_rules_name[it_id]) {
-                            smerror(&tmp_msg, "Compiled rule not found: '%s'",
-                                   rule_opt[k]->content);
-                            smerror(&tmp_msg, INVALID_CONFIG,
-                                   rule_opt[k]->element, rule_opt[k]->content);
+                            smerror(&tmp_msg, "Compiled rule not found: '%s'", rule_opt[k]->content);
+                            smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                             goto cleanup;
 
                         }
@@ -889,9 +866,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                        rule_opt[k]->content, &tmp_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_if_level) == 0) {
                         if (!OS_StrIsNum(rule_opt[k]->content)) {
-                            smerror(&tmp_msg, INVALID_CONFIG,
-                                   "if_level",
-                                   rule_opt[k]->content);
+                            smerror(&tmp_msg, INVALID_CONFIG, "if_level", rule_opt[k]->content);
                             goto cleanup;
                         }
 
@@ -918,9 +893,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                           xml_if_matched_sid) == 0) {
                         config_ruleinfo->context = 1;
                         if (!OS_StrIsNum(rule_opt[k]->content)) {
-                            smerror(&tmp_msg, INVALID_CONFIG,
-                                   "if_matched_sid",
-                                   rule_opt[k]->content);
+                            smerror(&tmp_msg, INVALID_CONFIG, "if_matched_sid", rule_opt[k]->content);
                             goto cleanup;
                         }
                         config_ruleinfo->if_matched_sid =
@@ -1034,8 +1007,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_agent) == 0) {
-                        smwarn(&tmp_msg, 
-                            "Detected a deprecated field option for rule, %s is not longer available.",
+                        smwarn(&tmp_msg, "Detected a deprecated field option for rule, %s is not longer available.",
                             xml_same_agent);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_srcuser) == 0) {
@@ -1183,8 +1155,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_notsame_agent) == 0) {
-                        smwarn(&tmp_msg, 
-                            "Detected a deprecated field option for rule, %s is not longer available.",
+                        smwarn(&tmp_msg, "Detected a deprecated field option for rule, %s is not longer available.",
                             xml_notsame_agent);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_different_location) == 0) {
@@ -1269,11 +1240,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         } else if (strcmp("no_counter", rule_opt[k]->content) == 0) {
                             config_ruleinfo->alert_opts |= NO_COUNTER;
                         } else {
-                            smerror(&tmp_msg, XML_VALUEERR, xml_options,
-                                   rule_opt[k]->content);
-
-                            smerror(&tmp_msg, "Invalid option '%s' for "
-                                   "rule '%d'.", rule_opt[k]->element,
+                            smerror(&tmp_msg, XML_VALUEERR, xml_options, rule_opt[k]->content);
+                            smerror(&tmp_msg, "Invalid option '%s' for rule '%d'.", rule_opt[k]->element,
                                    config_ruleinfo->sigid);
                             goto cleanup;
                         }
@@ -1294,8 +1262,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             char *word = &(*norder)[strspn(*norder, " ")];
                             word[strcspn(word, " ")] = '\0';
 
-                            if (strlen(word) == 0)
-                                merror_exit("Wrong ignore option: '%s'", rule_opt[k]->content);
+                            if (strlen(word) == 0) {
+                                smerror(&tmp_msg, "Wrong ignore option: '%s'", rule_opt[k]->content);
+                                goto cleanup;
+                            }
 
                             if (!strcmp(word, "user")) {
                                 config_ruleinfo->ignore |= FTS_DSTUSER;
@@ -1312,8 +1282,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             } else if (!strcmp(word, "name")) {
                                 config_ruleinfo->ignore |= FTS_NAME;
                             } else {
-                                if (i >= Config.decoder_order_size)
-                                    merror_exit("Too many dynamic fields for ignore.");
+                                if (i >= Config.decoder_order_size) {
+                                    smerror(&tmp_msg, "Too many dynamic fields for ignore.");
+                                    goto cleanup;
+                                }
 
                                 config_ruleinfo->ignore |= FTS_DYNAMIC;
                                 config_ruleinfo->ignore_fields[i] = strdup(word);
@@ -1341,9 +1313,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             char *word = &(*norder)[strspn(*norder, " ")];
                             word[strcspn(word, " ")] = '\0';
 
-                            if (strlen(word) == 0)
-                                merror_exit("Wrong check_if_ignored option: '%s'", rule_opt[k]->content);
-
+                            if (strlen(word) == 0) {
+                                smerror(&tmp_msg, "Wrong check_if_ignored option: '%s'", rule_opt[k]->content);
+                                goto cleanup;
+                            }
 
                             if (!strcmp(word, "user")) {
                                 config_ruleinfo->ckignore |= FTS_DSTUSER;
@@ -1360,8 +1333,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             } else if (!strcmp(word, "name")) {
                                 config_ruleinfo->ckignore |= FTS_NAME;
                             } else {
-                                if (i >= Config.decoder_order_size)
-                                    merror_exit("Too many dynamic fields for check_if_ignored.");
+                                if (i >= Config.decoder_order_size) {
+                                     smerror(&tmp_msg, "Too many dynamic fields for check_if_ignored.");
+                                     goto cleanup;
+                                }
 
                                 config_ruleinfo->ckignore |= FTS_DYNAMIC;
                                 config_ruleinfo->ckignore_fields[i] = strdup(word);
@@ -1379,9 +1354,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         mitre_opt = OS_GetElementsbyNode(&xml, rule_opt[k]);
 
                         if (mitre_opt == NULL) {
-                            smwarn(&tmp_msg, 
-                                "Empty Mitre information for rule '%d'",
-                                config_ruleinfo->sigid);
+                            smwarn(&tmp_msg, "Empty Mitre information for rule '%d'", config_ruleinfo->sigid);
                             k++;
                             continue;
                         }
@@ -1391,8 +1364,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                 break;
                             } else if (strcasecmp(mitre_opt[ind]->element, xml_mitre_id) == 0) {
                                 if (strlen(mitre_opt[ind]->content) == 0) {
-                                    smwarn(&tmp_msg, 
-                                        "No Mitre Technique ID found for rule '%d'",
+                                    smwarn(&tmp_msg, "No Mitre Technique ID found for rule '%d'",
                                         config_ruleinfo->sigid);
                                 } else {
                                     int inarray = 0;
@@ -1410,9 +1382,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     }
                                 }
                             } else {
-                                smerror(&tmp_msg, "Invalid option '%s' for "
-                                "rule '%d'", mitre_opt[ind]->element,
-                                config_ruleinfo->sigid);
+                                smerror(&tmp_msg, "Invalid option '%s' for rule '%d'", mitre_opt[ind]->element,
+                                        config_ruleinfo->sigid);
                                 free_strarray(config_ruleinfo->mitre_id);
                                 OS_ClearNode(mitre_opt);
                                 goto cleanup;
@@ -1420,8 +1391,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                         OS_ClearNode(mitre_opt);
                     } else {
-                        smerror(&tmp_msg, "Invalid option '%s' for "
-                               "rule '%d'.", rule_opt[k]->element,
+                        smerror(&tmp_msg, "Invalid option '%s' for rule '%d'.", rule_opt[k]->element,
                                config_ruleinfo->sigid);
                         goto cleanup;
                     }
@@ -1436,13 +1406,11 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
 
                 /* Check for valid use of frequency */
-                if ((config_ruleinfo->context_opts || config_ruleinfo->same_field ||
-                        config_ruleinfo->different_field ||
-                        config_ruleinfo->frequency) &&
-                        !config_ruleinfo->context) {
+                if ((config_ruleinfo->context_opts || config_ruleinfo->same_field 
+                    || config_ruleinfo->different_field || config_ruleinfo->frequency) 
+                    && !config_ruleinfo->context) {
                     smerror(&tmp_msg, "Invalid use of frequency/context options. "
-                           "Missing if_matched on rule '%d'.",
-                           config_ruleinfo->sigid);
+                           "Missing if_matched on rule '%d'.", config_ruleinfo->sigid);
                     goto cleanup;
                 }
 
@@ -1467,8 +1435,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (regex) {
                     os_calloc(1, sizeof(OSRegex), config_ruleinfo->regex);
                     if (!OSRegex_Compile(regex, config_ruleinfo->regex, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, regex,
-                               config_ruleinfo->regex->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, regex, config_ruleinfo->regex->error);
                         goto cleanup;
                     }
                     free(regex);
@@ -1479,8 +1446,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (match) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->match);
                     if (!OSMatch_Compile(match, config_ruleinfo->match, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, match,
-                               config_ruleinfo->match->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, match, config_ruleinfo->match->error);
                         goto cleanup;
                     }
                     free(match);
@@ -1491,8 +1457,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (id) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->id);
                     if (!OSMatch_Compile(id, config_ruleinfo->id, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, id,
-                               config_ruleinfo->id->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, id, config_ruleinfo->id->error);
                         goto cleanup;
                     }
                     free(id);
@@ -1503,8 +1468,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (srcport) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->srcport);
                     if (!OSMatch_Compile(srcport, config_ruleinfo->srcport, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, srcport,
-                               config_ruleinfo->id->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, srcport, config_ruleinfo->id->error);
                         goto cleanup;
                     }
                     free(srcport);
@@ -1515,8 +1479,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (dstport) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->dstport);
                     if (!OSMatch_Compile(dstport, config_ruleinfo->dstport, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, dstport,
-                               config_ruleinfo->id->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, dstport, config_ruleinfo->id->error);
                         goto cleanup;
                     }
                     free(dstport);
@@ -1527,8 +1490,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (status) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->status);
                     if (!OSMatch_Compile(status, config_ruleinfo->status, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, status,
-                               config_ruleinfo->status->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, status, config_ruleinfo->status->error);
                         goto cleanup;
                     }
                     free(status);
@@ -1539,8 +1501,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (hostname) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->hostname);
                     if (!OSMatch_Compile(hostname, config_ruleinfo->hostname, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, hostname,
-                               config_ruleinfo->hostname->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, hostname, config_ruleinfo->hostname->error);
                         goto cleanup;
                     }
                     free(hostname);
@@ -1550,10 +1511,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 /* Add data */
                 if (data) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->data);
-                    if (!OSMatch_Compile(data,
-                                         config_ruleinfo->data, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, data,
-                               config_ruleinfo->data->error);
+                    if (!OSMatch_Compile(data, config_ruleinfo->data, 0)) {
+                        smerror(&tmp_msg, REGEX_COMPILE, data, config_ruleinfo->data->error);
                         goto cleanup;
                     }
                     free(data);
@@ -1563,10 +1522,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 /* Add extra data */
                 if (extra_data) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->extra_data);
-                    if (!OSMatch_Compile(extra_data,
-                                         config_ruleinfo->extra_data, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, extra_data,
-                               config_ruleinfo->extra_data->error);
+                    if (!OSMatch_Compile(extra_data, config_ruleinfo->extra_data, 0)) {
+                        smerror(&tmp_msg, REGEX_COMPILE, extra_data, config_ruleinfo->extra_data->error);
                         goto cleanup;
                     }
                     free(extra_data);
@@ -1576,10 +1533,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 /* Add in program name */
                 if (program_name) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->program_name);
-                    if (!OSMatch_Compile(program_name,
-                                         config_ruleinfo->program_name, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, program_name,
-                               config_ruleinfo->program_name->error);
+                    if (!OSMatch_Compile(program_name, config_ruleinfo->program_name, 0)) {
+                        smerror(&tmp_msg, REGEX_COMPILE, program_name, config_ruleinfo->program_name->error);
                         goto cleanup;
                     }
                     free(program_name);
@@ -1590,8 +1545,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (user) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->user);
                     if (!OSMatch_Compile(user, config_ruleinfo->user, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, user,
-                               config_ruleinfo->user->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, user, config_ruleinfo->user->error);
                         goto cleanup;
                     }
                     free(user);
@@ -1599,11 +1553,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
 
                 /* Adding in srcgeoip */
-                if(srcgeoip) {
+                if (srcgeoip) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->srcgeoip);
-                    if(!OSMatch_Compile(srcgeoip, config_ruleinfo->srcgeoip, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, srcgeoip,
-                                              config_ruleinfo->srcgeoip->error);
+                    if (!OSMatch_Compile(srcgeoip, config_ruleinfo->srcgeoip, 0)) {
+                        smerror(&tmp_msg, REGEX_COMPILE, srcgeoip, config_ruleinfo->srcgeoip->error);
                         return(-1);
                     }
                     free(srcgeoip);
@@ -1612,11 +1565,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
 
                 /* Adding in dstgeoip */
-                if(dstgeoip) {
+                if (dstgeoip) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->dstgeoip);
-                    if(!OSMatch_Compile(dstgeoip, config_ruleinfo->dstgeoip, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, dstgeoip,
-                                              config_ruleinfo->dstgeoip->error);
+                    if (!OSMatch_Compile(dstgeoip, config_ruleinfo->dstgeoip, 0)) {
+                        smerror(&tmp_msg, REGEX_COMPILE, dstgeoip, config_ruleinfo->dstgeoip->error);
                         return(-1);
                     }
                     free(dstgeoip);
@@ -1628,8 +1580,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (url) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->url);
                     if (!OSMatch_Compile(url, config_ruleinfo->url, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, url,
-                               config_ruleinfo->url->error);
+                        smerror(&tmp_msg, REGEX_COMPILE, url, config_ruleinfo->url->error);
                         goto cleanup;
                     }
                     free(url);
@@ -1653,11 +1604,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     os_calloc(1, sizeof(OSMatch),
                               config_ruleinfo->if_matched_group);
 
-                    if (!OSMatch_Compile(if_matched_group,
-                                         config_ruleinfo->if_matched_group,
-                                         0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, if_matched_group,
-                               config_ruleinfo->if_matched_group->error);
+                    if (!OSMatch_Compile(if_matched_group, config_ruleinfo->if_matched_group, 0)) {
+                        smerror(&tmp_msg, REGEX_COMPILE, if_matched_group, config_ruleinfo->if_matched_group->error);
                         goto cleanup;
                     }
                     free(if_matched_group);
@@ -1668,10 +1616,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (if_matched_regex) {
                     os_calloc(1, sizeof(OSRegex),
                               config_ruleinfo->if_matched_regex);
-                    if (!OSRegex_Compile(if_matched_regex,
-                                         config_ruleinfo->if_matched_regex, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, if_matched_regex,
-                               config_ruleinfo->if_matched_regex->error);
+                    if (!OSRegex_Compile(if_matched_regex, config_ruleinfo->if_matched_regex, 0)) {
+                        smerror(&tmp_msg, REGEX_COMPILE, if_matched_regex, config_ruleinfo->if_matched_regex->error);
                         goto cleanup;
                     }
                     free(if_matched_regex);
@@ -1716,10 +1662,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
             if (config_ruleinfo->sigid < 10) {
                 OS_AddRule(config_ruleinfo, r_node);
             } else if (config_ruleinfo->alert_opts & DO_OVERWRITE) {
-                if (!OS_AddRuleInfo(*r_node, config_ruleinfo,
-                                    config_ruleinfo->sigid)) {
-                    smerror(&tmp_msg, "Overwrite rule '%d' not found.",
-                           config_ruleinfo->sigid);
+                if (!OS_AddRuleInfo(*r_node, config_ruleinfo, config_ruleinfo->sigid)) {
+                    smerror(&tmp_msg, "Overwrite rule '%d' not found.", config_ruleinfo->sigid);
                     goto cleanup;
                 }
             } else {
@@ -1843,7 +1787,7 @@ static char *loadmemory(char *at, const char *str, char** msg)
         if ((strsize = strlen(str)) < OS_SIZE_2048) {
             at = (char *) calloc(strsize + 1, sizeof(char));
             if (at == NULL) {
-                smerror(msg, MEM_ERROR, errno, strerror(errno));
+                merror(MEM_ERROR, errno, strerror(errno));
                 return (NULL);
             }
             strncpy(at, str, strsize);
@@ -1866,7 +1810,7 @@ static char *loadmemory(char *at, const char *str, char** msg)
         at = (char *) realloc(at, (finalsize) * sizeof(char));
 
         if (at == NULL) {
-            smerror(msg, MEM_ERROR, errno, strerror(errno));
+            merror(MEM_ERROR, errno, strerror(errno));
             return (NULL);
         }
 
@@ -2020,8 +1964,7 @@ int get_info_attributes(char **attributes, char **values, char **msg)
     while (attributes[k]) {
         if (strcasecmp(attributes[k], xml_type) == 0) {
             if (!values[k]) {
-                smerror(msg, "rules_op: Element info attribute \"%s\" does not have a value",
-                       attributes[k]);
+                smerror(msg, "rules_op: Element info attribute \"%s\" does not have a value", attributes[k]);
                 return (-1);
             } else if (strcmp(values[k], "text") == 0) {
                 return (RULEINFODETAIL_TEXT);
@@ -2037,8 +1980,7 @@ int get_info_attributes(char **attributes, char **values, char **msg)
                 return (-1);
             }
         } else {
-            smerror(msg, "rules_op: Element info has invalid attribute \"%s\"",
-                   attributes[k]);
+            smerror(msg, "rules_op: Element info has invalid attribute \"%s\"", attributes[k]);
             return (-1);
         }
     }
@@ -2068,8 +2010,7 @@ static int getattributes(char **attributes, char **values,
     /* Get attributes */
     while (attributes[k]) {
         if (!values[k]) {
-            smerror(msg, "rules_op: Attribute \"%s\" without value."
-                   , attributes[k]);
+            smerror(msg, "rules_op: Attribute \"%s\" without value.", attributes[k]);
             return (-1);
         }
         /* Get rule id */
@@ -2077,10 +2018,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k]) && strlen(values[k]) <= 6) {
                 sscanf(values[k], "%6d", id);
             } else {
-                smerror(msg,
-                    "rules_op: Invalid rule id: %s. "
-                    "Must be integer (max 6 digits)" ,
-                    values[k]);
+                smerror(msg, "rules_op: Invalid rule id: %s. Must be integer (max 6 digits)", values[k]);
                 return (-1);
             }
         }
@@ -2089,9 +2027,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 *level = atoi(values[k]);
                 if (*level < 0 || *level > 16) {
-                    smerror(msg,
-                    "rules_op: Invalid level: %d. "
-                    "Must be an integer between 0 and 16.", *level);
+                    smerror(msg, "rules_op: Invalid level: %d. Must be an integer between 0 and 16.", *level);
                     return (-1);
                 }
             }
@@ -2101,10 +2037,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 sscanf(values[k], "%4d", maxsize);
             } else {
-                smerror(msg,
-                    "rules_op: Invalid maxsize: %s. "
-                    "Must be integer" ,
-                    values[k]);
+                smerror(msg, "rules_op: Invalid maxsize: %s. Must be integer", values[k]);
                 return (-1);
             }
         }
@@ -2113,10 +2046,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 sscanf(values[k], "%5d", timeframe);
             } else {
-                smerror(msg,
-                    "rules_op: Invalid timeframe: %s. "
-                    "Must be integer (max 5 digits)" ,
-                    values[k]);
+                smerror(msg, "rules_op: Invalid timeframe: %s. Must be integer (max 5 digits)", values[k]);
                 return (-1);
             }
         }
@@ -2125,16 +2055,13 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 *frequency = atoi(values[k]);
                 if (*frequency < 2 || *frequency > 9999) {
-                    smerror(msg,
-                    "rules_op: Invalid frequency: %d."
+                    smerror(msg, "rules_op: Invalid frequency: %d. "
                     "Must be higher than 1 and lower than 10000.", *frequency);
                     return (-1);
                 }
                 *frequency = *frequency - 2;
             } else {
-                smerror(msg,"rules_op: Invalid frequency: %s. "
-                       "Must be integer" ,
-                       values[k]);
+                smerror(msg,"rules_op: Invalid frequency: %s. Must be integer", values[k]);
                 return (-1);
             }
         }
@@ -2143,9 +2070,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 sscanf(values[k], "%4d", accuracy);
             } else {
-                smerror(msg, "rules_op: Invalid accuracy: %s. "
-                       "Must be integer" ,
-                       values[k]);
+                smerror(msg, "rules_op: Invalid accuracy: %s. Must be integer", values[k]);
                 return (-1);
             }
         }
@@ -2154,9 +2079,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 sscanf(values[k], "%6d", ignore_time);
             } else {
-                smerror(msg, "rules_op: Invalid ignore_time: %s. "
-                       "Must be integer (max 6 digits)" ,
-                       values[k]);
+                smerror(msg, "rules_op: Invalid ignore_time: %s. Must be integer (max 6 digits)", values[k]);
                 return (-1);
             }
         }
@@ -2169,14 +2092,12 @@ static int getattributes(char **attributes, char **values,
             } else if (strcmp(values[k], "no") == 0) {
                 *overwrite = 0;
             } else {
-                smerror(msg,"rules_op: Invalid overwrite: %s. "
-                       "Can only by 'yes' or 'no'.", values[k]);
+                smerror(msg,"rules_op: Invalid overwrite: %s. Can only by 'yes' or 'no'.", values[k]);
                 return (-1);
             }
         } else {
-            smerror(msg, "rules_op: Invalid attribute \"%s\". "
-                   "Only id, level, maxsize, accuracy, noalert, ignore, frequency and timeframe "
-                   "are allowed.", attributes[k]);
+            smerror(msg, "rules_op: Invalid attribute \"%s\". Only id, level, maxsize, accuracy,"
+                    " noalert, ignore, frequency and timeframe are allowed.", attributes[k]);
             return (-1);
         }
         k++;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -31,10 +31,10 @@ static int getattributes(char **attributes,
                   int *maxsize, int *timeframe,
                   int *frequency, int *accuracy,
                   int *noalert, int *ignore_time, int *overwrite,
-                  os_analysisd_list_log_msg_t* log_msg);
+                  OSList* log_msg);
 static int doesRuleExist(int sid, RuleNode *r_node);
 static void Rule_AddAR(RuleInfo *config_rule);
-static char *loadmemory(char *at, const char *str, os_analysisd_list_log_msg_t* log_msg);
+static char *loadmemory(char *at, const char *str, OSList* log_msg);
 static void printRuleinfo(const RuleInfo *rule, int node);
 
 /* Will initialize the rules list */
@@ -46,7 +46,7 @@ void Rules_OP_CreateRules()
     return;
 }
 
-int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, os_analysisd_list_log_msg_t* log_msg)
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, OSList* log_msg)
 {
     OS_XML xml;
     XML_NODE node = NULL;
@@ -474,7 +474,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         config_ruleinfo->day_time =
                             OS_IsValidTime(rule_opt[k]->content);
                         if (!config_ruleinfo->day_time) {
-                            log_emsg(log_msg, INVALID_CONFIG,rule_opt[k]->element,rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                             goto cleanup;
                         }
 
@@ -487,7 +487,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                         if (!config_ruleinfo->week_day) {
                             log_emsg(log_msg, INVALID_DAY, rule_opt[k]->content);
-                            log_emsg(log_msg, INVALID_CONFIG,rule_opt[k]->element, rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                             goto cleanup;
                         }
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
@@ -1777,7 +1777,7 @@ cleanup:
  * If *at already exist, realloc the memory and cat str on it.
  * Returns the new string
  */
-static char *loadmemory(char *at, const char *str, os_analysisd_list_log_msg_t* log_msg)
+static char *loadmemory(char *at, const char *str, OSList* log_msg)
 {
     if (at == NULL) {
         size_t strsize = 0;
@@ -1949,7 +1949,7 @@ RuleInfo *zerorulemember(int id, int level,
     return (ruleinfo_pt);
 }
 
-int get_info_attributes(char **attributes, char **values, os_analysisd_list_log_msg_t* log_msg)
+int get_info_attributes(char **attributes, char **values, OSList* log_msg)
 {
     const char *xml_type = "type";
     int k = 0;
@@ -1990,7 +1990,7 @@ static int getattributes(char **attributes, char **values,
                   int *maxsize, int *timeframe,
                   int *frequency, int *accuracy,
                   int *noalert, int *ignore_time, int *overwrite,
-                  os_analysisd_list_log_msg_t* log_msg)
+                  OSList* log_msg)
 {
     int k = 0;
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -494,7 +494,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                     } else if (strcasecmp(rule_opt[k]->element, xml_week_day) == 0) {
                         config_ruleinfo->week_day =
-                            OS_IsValidDay(rule_opt[k]->content);
+                            OS_IsValidDay(rule_opt[k]->content, &tmp_msg);
 
                         if (!config_ruleinfo->week_day) {
                             smerror(&tmp_msg, INVALID_CONFIG,

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1667,7 +1667,9 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     goto cleanup;
                 }
             } else {
-                OS_AddChild(config_ruleinfo, r_node);
+                if (OS_AddChild(config_ruleinfo, r_node, &tmp_msg) == -1) {
+                    goto cleanup;
+                }
             }
 
             /* Clean what we do not need */
@@ -1678,8 +1680,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
             /* Set the event_search pointer */
             if (config_ruleinfo->if_matched_sid) {
-                config_ruleinfo->event_search = (void *(*)(void *, void *, void *))
-                    Search_LastSids;
+                config_ruleinfo->event_search = (void *(*)(void *, void *, void *, void *)) Search_LastSids;
 
                 /* Mark rules that match this id */
                 OS_MarkID(NULL, config_ruleinfo);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -31,10 +31,10 @@ static int getattributes(char **attributes,
                   int *maxsize, int *timeframe,
                   int *frequency, int *accuracy,
                   int *noalert, int *ignore_time, int *overwrite,
-                  char** msg);
+                  os_analysisd_list_log_msg_t* log_msg);
 static int doesRuleExist(int sid, RuleNode *r_node);
 static void Rule_AddAR(RuleInfo *config_rule);
-static char *loadmemory(char *at, const char *str, char **msg);
+static char *loadmemory(char *at, const char *str, os_analysisd_list_log_msg_t* log_msg);
 static void printRuleinfo(const RuleInfo *rule, int node);
 
 /* Will initialize the rules list */
@@ -46,13 +46,12 @@ void Rules_OP_CreateRules()
     return;
 }
 
-int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, char** msg)
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, os_analysisd_list_log_msg_t* log_msg)
 {
     OS_XML xml;
     XML_NODE node = NULL;
     XML_NODE rule = NULL;
     int retval = -1;
-    char* tmp_msg = NULL;    
 
     /* XML variables */
     /* These are the available options for the rule configuration */
@@ -218,14 +217,14 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
     /* Read the XML */
     if (OS_ReadXML(rulepath, &xml) < 0) {
-        smerror(&tmp_msg, XML_ERROR, rulepath, xml.err, xml.err_line);
+        log_emsg(log_msg, XML_ERROR, rulepath, xml.err, xml.err_line);
         goto cleanup;
     }
     mdebug2("Read xml for rule.");
 
     /* Apply any variable found */
     if (OS_ApplyVariables(&xml) != 0) {
-        smerror(&tmp_msg, XML_ERROR_VAR, rulepath, xml.err);
+        log_emsg(log_msg, XML_ERROR_VAR, rulepath, xml.err);
         goto cleanup;
     }
     mdebug2("XML Variables applied.");
@@ -239,7 +238,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
     /* Get the root elements */
     node = OS_GetElementsbyNode(&xml, NULL);
     if (!node) {
-        smerror(&tmp_msg, CONFIG_ERROR, rulepath);
+        log_emsg(log_msg, CONFIG_ERROR, rulepath);
         goto cleanup;
     }
 
@@ -256,19 +255,19 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
     while (node[i]) {
         if (node[i]->element) {
             if (strcasecmp(node[i]->element, xml_group) != 0) {
-                smerror(&tmp_msg, "rules_op: Invalid root element \"%s\".Only \"group\" is allowed", node[i]->element);
+                log_emsg(log_msg, "rules_op: Invalid root element \"%s\".Only \"group\" is allowed", node[i]->element);
                 goto cleanup;
             }
             if ((!node[i]->attributes) || (!node[i]->values)
                 || (!node[i]->values[0]) || (!node[i]->attributes[0]) 
                 || (strcasecmp(node[i]->attributes[0], "name") != 0) 
                 || (node[i]->attributes[1])) {
-                smerror(&tmp_msg, "rules_op: Invalid root element '%s'."
+                log_emsg(log_msg, "rules_op: Invalid root element '%s'."
                        "Only the group name is allowed", node[i]->element);
                 goto cleanup;
             }
         } else {
-            smerror(&tmp_msg, XML_READ_ERROR);
+            log_emsg(log_msg, XML_READ_ERROR);
             goto cleanup;
         }
         i++;
@@ -282,7 +281,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
         /* Get all rules for a global group */
         rule = OS_GetElementsbyNode(&xml, node[i]);
         if (rule == NULL) {
-            smerror(&tmp_msg, "Group '%s' without any rule.", node[i]->element);
+            log_emsg(log_msg, "Group '%s' without any rule.", node[i]->element);
             goto cleanup;
         }
 
@@ -295,13 +294,13 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
             }
 
             if (strcasecmp(rule[j]->element, xml_rule) != 0) {
-                smerror(&tmp_msg, "Invalid configuration. '%s' is not a valid element.", rule[j]->element);
+                log_emsg(log_msg, "Invalid configuration. '%s' is not a valid element.", rule[j]->element);
                 goto cleanup;
             }
 
             /* Check for the attributes of the rule */
             if ((!rule[j]->attributes) || (!rule[j]->values)) {
-                smerror(&tmp_msg, "Invalid rule '%d'. You must specify an ID and a level at least.", j);
+                log_emsg(log_msg, "Invalid rule '%d'. You must specify an ID and a level at least.", j);
                 goto cleanup;
             }
 
@@ -317,18 +316,18 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (getattributes(rule[j]->attributes, rule[j]->values,
                                   &id, &level, &maxsize, &timeframe,
                                   &frequency, &accuracy, &noalert,
-                                  &ignore_time, &overwrite, &tmp_msg) < 0) {
-                    smerror(&tmp_msg, "Invalid attribute for rule.");
+                                  &ignore_time, &overwrite, log_msg) < 0) {
+                    log_emsg(log_msg, "Invalid attribute for rule.");
                     goto cleanup;
                 }
 
                 if ((id == -1) || (level == -1)) {
-                    smerror(&tmp_msg, "No rule id or level specified for rule '%d'.", j);
+                    log_emsg(log_msg, "No rule id or level specified for rule '%d'.", j);
                     goto cleanup;
                 }
 
                 if (overwrite != 1 && doesRuleExist(id, os_analysisd_rulelist)) {
-                    smerror(&tmp_msg, "Duplicate rule ID:%d", id);
+                    log_emsg(log_msg, "Duplicate rule ID:%d", id);
                     goto cleanup;
                 }
 
@@ -400,7 +399,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 XML_NODE rule_opt = NULL;
                 rule_opt =  OS_GetElementsbyNode(&xml, rule[j]);
                 if (rule_opt == NULL) {
-                    smerror(&tmp_msg, "Rule '%d' without any option. It may lead to false positives and some "
+                    log_emsg(log_msg, "Rule '%d' without any option. It may lead to false positives and some "
                            "other problems for the system. Exiting.", config_ruleinfo->sigid);
                     goto cleanup;
                 }
@@ -411,17 +410,17 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_opt[k]->element, xml_regex) == 0) {
                         regex =
                             loadmemory(regex,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_match) == 0) {
                         match =
                             loadmemory(match,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_decoded) == 0) {
                         config_ruleinfo->decoded_as =
                             getDecoderfromlist(rule_opt[k]->content);
 
                         if (config_ruleinfo->decoded_as == 0) {
-                            smerror(&tmp_msg, "Invalid decoder name: '%s'.", rule_opt[k]->content);
+                            log_emsg(log_msg, "Invalid decoder name: '%s'.", rule_opt[k]->content);
                             goto cleanup;
                         }
                     } else if (strcasecmp(rule_opt[k]->element, xml_cve) == 0) {
@@ -444,11 +443,11 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         /* keep old methods for now */
                         config_ruleinfo->cve =
                             loadmemory(config_ruleinfo->cve,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_info) == 0) {
 
                         info_type = get_info_attributes(rule_opt[k]->attributes,
-                                                        rule_opt[k]->values, &tmp_msg);
+                                                        rule_opt[k]->values, log_msg);
                         mdebug1("info_type = %d", info_type);
 
                         if (config_ruleinfo->info_details == NULL) {
@@ -470,12 +469,12 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         /* keep old methods for now */
                         config_ruleinfo->info =
                             loadmemory(config_ruleinfo->info,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_day_time) == 0) {
                         config_ruleinfo->day_time =
                             OS_IsValidTime(rule_opt[k]->content);
                         if (!config_ruleinfo->day_time) {
-                            smerror(&tmp_msg, INVALID_CONFIG,rule_opt[k]->element,rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_CONFIG,rule_opt[k]->element,rule_opt[k]->content);
                             goto cleanup;
                         }
 
@@ -484,10 +483,11 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                     } else if (strcasecmp(rule_opt[k]->element, xml_week_day) == 0) {
                         config_ruleinfo->week_day =
-                            OS_IsValidDay(rule_opt[k]->content, &tmp_msg);
+                            OS_IsValidDay(rule_opt[k]->content);
 
                         if (!config_ruleinfo->week_day) {
-                            smerror(&tmp_msg, INVALID_CONFIG,rule_opt[k]->element, rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_DAY, rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_CONFIG,rule_opt[k]->element, rule_opt[k]->content);
                             goto cleanup;
                         }
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
@@ -496,7 +496,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_opt[k]->element, xml_group) == 0) {
                         config_ruleinfo->group =
                             loadmemory(config_ruleinfo->group,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_comment) == 0) {
                         char *newline;
 
@@ -507,7 +507,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                         config_ruleinfo->comment =
                             loadmemory(config_ruleinfo->comment,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_srcip) == 0) {
                         unsigned int ip_s = 0;
 
@@ -531,7 +531,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         /* Checking if the ip is valid */
                         if (!OS_IsValidIP(rule_opt[k]->content,
                                           config_ruleinfo->srcip[ip_s])) {
-                            smerror(&tmp_msg, INVALID_IP, rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_IP, rule_opt[k]->content);
                             goto cleanup;
                         }
 
@@ -561,7 +561,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         /* Checking if the ip is valid */
                         if (!OS_IsValidIP(rule_opt[k]->content,
                                           config_ruleinfo->dstip[ip_s])) {
-                            smerror(&tmp_msg, INVALID_IP, rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_IP, rule_opt[k]->content);
                             goto cleanup;
                         }
 
@@ -571,7 +571,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_opt[k]->element, xml_user) == 0) {
                         user =
                             loadmemory(user,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -579,32 +579,32 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if(strcasecmp(rule_opt[k]->element,xml_srcgeoip)==0) {
                         srcgeoip =
                             loadmemory(srcgeoip,
-                                    rule_opt[k]->content, &tmp_msg);
+                                    rule_opt[k]->content, log_msg);
 
                         if(!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                     } else if(strcasecmp(rule_opt[k]->element,xml_dstgeoip)==0) {
                         dstgeoip =
                             loadmemory(dstgeoip,
-                                    rule_opt[k]->content, &tmp_msg);
+                                    rule_opt[k]->content, log_msg);
 
                         if(!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                     } else if (strcasecmp(rule_opt[k]->element, xml_id) == 0) {
                         id =
                             loadmemory(id,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_srcport) == 0) {
                         srcport =
                             loadmemory(srcport,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                         if (!(config_ruleinfo->alert_opts & DO_PACKETINFO)) {
                             config_ruleinfo->alert_opts |= DO_PACKETINFO;
                         }
                     } else if (strcasecmp(rule_opt[k]->element, xml_dstport) == 0) {
                         dstport =
                             loadmemory(dstport,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
 
                         if (!(config_ruleinfo->alert_opts & DO_PACKETINFO)) {
                             config_ruleinfo->alert_opts |= DO_PACKETINFO;
@@ -612,7 +612,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_opt[k]->element, xml_status) == 0) {
                         status =
                             loadmemory(status,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -620,7 +620,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_opt[k]->element, xml_hostname) == 0) {
                         hostname =
                             loadmemory(hostname,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -628,7 +628,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_opt[k]->element, xml_data) == 0) {
                         data =
                             loadmemory(data,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -636,7 +636,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_opt[k]->element, xml_extra_data) == 0) {
                         extra_data =
                             loadmemory(extra_data,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -645,21 +645,21 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                           xml_program_name) == 0) {
                         program_name =
                             loadmemory(program_name,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_action) == 0) {
                         config_ruleinfo->action =
                             loadmemory(config_ruleinfo->action,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if(strcasecmp(rule_opt[k]->element, xml_system_name) == 0){
                         system_name =
                             loadmemory(system_name,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if(strcasecmp(rule_opt[k]->element, xml_protocol) == 0){
                         protocol =
                             loadmemory(protocol,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_location) == 0) {
-                        location = loadmemory(location, rule_opt[k]->content, &tmp_msg);
+                        location = loadmemory(location, rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_field) == 0) {
                         if (rule_opt[k]->attributes && rule_opt[k]->attributes[0]) {
                             os_calloc(1, sizeof(FieldInfo), config_ruleinfo->fields[ifield]);
@@ -682,25 +682,25 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     strcasecmp(rule_opt[k]->values[0], xml_status) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_system_name))
                                     config_ruleinfo->fields[ifield]->name = loadmemory(config_ruleinfo->fields[ifield]->name,
-                                                                                        rule_opt[k]->values[0], &tmp_msg);
+                                                                                        rule_opt[k]->values[0], log_msg);
                                 else {
-                                    smerror(&tmp_msg, "Field '%s' is static.", rule_opt[k]->values[0]);
+                                    log_emsg(log_msg, "Field '%s' is static.", rule_opt[k]->values[0]);
                                     goto cleanup;
                                 }
 
                             } else {
-                                smerror(&tmp_msg, "Bad attribute '%s' for field.", rule_opt[k]->attributes[0]);
+                                log_emsg(log_msg, "Bad attribute '%s' for field.", rule_opt[k]->attributes[0]);
                                 goto cleanup;
                             }
                         } else {
-                            smerror(&tmp_msg, "No such attribute '%s' for field.", xml_name);
+                            log_emsg(log_msg, "No such attribute '%s' for field.", xml_name);
                             goto cleanup;
                         }
 
                         os_calloc(1, sizeof(OSRegex), config_ruleinfo->fields[ifield]->regex);
 
                         if (!OSRegex_Compile(rule_opt[k]->content, config_ruleinfo->fields[ifield]->regex, 0)) {
-                            smerror(&tmp_msg, REGEX_COMPILE, rule_opt[k]->content, 
+                            log_emsg(log_msg, REGEX_COMPILE, rule_opt[k]->content, 
                                 config_ruleinfo->fields[ifield]->regex->error);
                             goto cleanup;
                         }
@@ -729,8 +729,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     } else if (strcasecmp(rule_opt[k]->values[list_att_num], xml_address_key_value) == 0) {
                                         lookup_type = LR_ADDRESS_MATCH_VALUE;
                                     } else {
-                                        smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
-                                        smerror(&tmp_msg, "List match lookup=\"%s\" is not valid.", 
+                                        log_emsg(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
+                                        log_emsg(log_msg, "List match lookup=\"%s\" is not valid.", 
                                                 rule_opt[k]->values[list_att_num]);
                                         goto cleanup;
                                     }
@@ -776,22 +776,22 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                 } else if (strcasecmp(rule_opt[k]->attributes[list_att_num], xml_list_cvalue) == 0) {
                                     os_calloc(1, sizeof(OSMatch), matcher);
                                     if (!OSMatch_Compile(rule_opt[k]->values[list_att_num], matcher, 0)) {
-                                        smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
-                                        smerror(&tmp_msg, REGEX_COMPILE, rule_opt[k]->values[list_att_num], 
+                                        log_emsg(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
+                                        log_emsg(log_msg, REGEX_COMPILE, rule_opt[k]->values[list_att_num], 
                                             matcher->error);
                                         goto cleanup;
                                     }
                                 } else {
-                                    smerror(&tmp_msg, "List field=\"%s\" is not valid",
+                                    log_emsg(log_msg, "List field=\"%s\" is not valid",
                                            rule_opt[k]->values[list_att_num]);
-                                    smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
+                                    log_emsg(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                                     goto cleanup;
                                 }
                                 list_att_num++;
                             }
                             if (rule_type == 0) {
-                                smerror(&tmp_msg, "List requires the field=\"\" attribute");
-                                smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
+                                log_emsg(log_msg, "List requires the field=\"\" attribute");
+                                log_emsg(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                                 goto cleanup;
                             }
 
@@ -804,18 +804,18 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                                                     matcher,
                                                                     *l_node);
                             if (config_ruleinfo->lists == NULL) {
-                                smerror(&tmp_msg, "List error: Could not load %s", rule_opt[k]->content);
+                                log_emsg(log_msg, "List error: Could not load %s", rule_opt[k]->content);
                                 goto cleanup;
                             }
                         } else {
-                            smerror(&tmp_msg, "List must have a correctly formatted field attribute");
-                            smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
+                            log_emsg(log_msg, "List must have a correctly formatted field attribute");
+                            log_emsg(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                             goto cleanup;
                         }
                         /* xml_list eval is done */
                     } else if (strcasecmp(rule_opt[k]->element, xml_url) == 0) {
                         url =
-                            loadmemory(url, rule_opt[k]->content, &tmp_msg);
+                            loadmemory(url, rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_compiled) == 0) {
                         int it_id = 0;
 
@@ -829,8 +829,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                         /* Checking if the name is valid */
                         if (!compiled_rules_name[it_id]) {
-                            smerror(&tmp_msg, "Compiled rule not found: '%s'", rule_opt[k]->content);
-                            smerror(&tmp_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
+                            log_emsg(log_msg, "Compiled rule not found: '%s'", rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                             goto cleanup;
 
                         }
@@ -863,37 +863,37 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_opt[k]->element, xml_if_sid) == 0) {
                         config_ruleinfo->if_sid =
                             loadmemory(config_ruleinfo->if_sid,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_if_level) == 0) {
                         if (!OS_StrIsNum(rule_opt[k]->content)) {
-                            smerror(&tmp_msg, INVALID_CONFIG, "if_level", rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_CONFIG, "if_level", rule_opt[k]->content);
                             goto cleanup;
                         }
 
                         config_ruleinfo->if_level =
                             loadmemory(config_ruleinfo->if_level,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_if_group) == 0) {
                         config_ruleinfo->if_group =
                             loadmemory(config_ruleinfo->if_group,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_if_matched_regex) == 0) {
                         config_ruleinfo->context = 1;
                         if_matched_regex =
                             loadmemory(if_matched_regex,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_if_matched_group) == 0) {
                         config_ruleinfo->context = 1;
                         if_matched_group =
                             loadmemory(if_matched_group,
-                                       rule_opt[k]->content, &tmp_msg);
+                                       rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_if_matched_sid) == 0) {
                         config_ruleinfo->context = 1;
                         if (!OS_StrIsNum(rule_opt[k]->content)) {
-                            smerror(&tmp_msg, INVALID_CONFIG, "if_matched_sid", rule_opt[k]->content);
+                            log_emsg(log_msg, INVALID_CONFIG, "if_matched_sid", rule_opt[k]->content);
                             goto cleanup;
                         }
                         config_ruleinfo->if_matched_sid =
@@ -1007,7 +1007,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_agent) == 0) {
-                        smwarn(&tmp_msg, "Detected a deprecated field option for rule, %s is not longer available.",
+                        log_emsg(log_msg, "Detected a deprecated field option for rule, %s is not longer available.",
                             xml_same_agent);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_same_srcuser) == 0) {
@@ -1155,7 +1155,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_notsame_agent) == 0) {
-                        smwarn(&tmp_msg, "Detected a deprecated field option for rule, %s is not longer available.",
+                        log_emsg(log_msg, "Detected a deprecated field option for rule, %s is not longer available.",
                             xml_notsame_agent);
                     } else if (strcasecmp(rule_opt[k]->element,
                                           xml_different_location) == 0) {
@@ -1240,8 +1240,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         } else if (strcmp("no_counter", rule_opt[k]->content) == 0) {
                             config_ruleinfo->alert_opts |= NO_COUNTER;
                         } else {
-                            smerror(&tmp_msg, XML_VALUEERR, xml_options, rule_opt[k]->content);
-                            smerror(&tmp_msg, "Invalid option '%s' for rule '%d'.", rule_opt[k]->element,
+                            log_emsg(log_msg, XML_VALUEERR, xml_options, rule_opt[k]->content);
+                            log_emsg(log_msg, "Invalid option '%s' for rule '%d'.", rule_opt[k]->element,
                                    config_ruleinfo->sigid);
                             goto cleanup;
                         }
@@ -1263,7 +1263,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             word[strcspn(word, " ")] = '\0';
 
                             if (strlen(word) == 0) {
-                                smerror(&tmp_msg, "Wrong ignore option: '%s'", rule_opt[k]->content);
+                                log_emsg(log_msg, "Wrong ignore option: '%s'", rule_opt[k]->content);
                                 goto cleanup;
                             }
 
@@ -1283,7 +1283,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                 config_ruleinfo->ignore |= FTS_NAME;
                             } else {
                                 if (i >= Config.decoder_order_size) {
-                                    smerror(&tmp_msg, "Too many dynamic fields for ignore.");
+                                    log_emsg(log_msg, "Too many dynamic fields for ignore.");
                                     goto cleanup;
                                 }
 
@@ -1314,7 +1314,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             word[strcspn(word, " ")] = '\0';
 
                             if (strlen(word) == 0) {
-                                smerror(&tmp_msg, "Wrong check_if_ignored option: '%s'", rule_opt[k]->content);
+                                log_emsg(log_msg, "Wrong check_if_ignored option: '%s'", rule_opt[k]->content);
                                 goto cleanup;
                             }
 
@@ -1334,7 +1334,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                 config_ruleinfo->ckignore |= FTS_NAME;
                             } else {
                                 if (i >= Config.decoder_order_size) {
-                                     smerror(&tmp_msg, "Too many dynamic fields for check_if_ignored.");
+                                     log_emsg(log_msg, "Too many dynamic fields for check_if_ignored.");
                                      goto cleanup;
                                 }
 
@@ -1354,7 +1354,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         mitre_opt = OS_GetElementsbyNode(&xml, rule_opt[k]);
 
                         if (mitre_opt == NULL) {
-                            smwarn(&tmp_msg, "Empty Mitre information for rule '%d'", config_ruleinfo->sigid);
+                            log_emsg(log_msg, "Empty Mitre information for rule '%d'", config_ruleinfo->sigid);
                             k++;
                             continue;
                         }
@@ -1364,7 +1364,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                 break;
                             } else if (strcasecmp(mitre_opt[ind]->element, xml_mitre_id) == 0) {
                                 if (strlen(mitre_opt[ind]->content) == 0) {
-                                    smwarn(&tmp_msg, "No Mitre Technique ID found for rule '%d'",
+                                    log_emsg(log_msg, "No Mitre Technique ID found for rule '%d'",
                                         config_ruleinfo->sigid);
                                 } else {
                                     int inarray = 0;
@@ -1382,7 +1382,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     }
                                 }
                             } else {
-                                smerror(&tmp_msg, "Invalid option '%s' for rule '%d'", mitre_opt[ind]->element,
+                                log_emsg(log_msg, "Invalid option '%s' for rule '%d'", mitre_opt[ind]->element,
                                         config_ruleinfo->sigid);
                                 free_strarray(config_ruleinfo->mitre_id);
                                 OS_ClearNode(mitre_opt);
@@ -1391,7 +1391,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                         OS_ClearNode(mitre_opt);
                     } else {
-                        smerror(&tmp_msg, "Invalid option '%s' for rule '%d'.", rule_opt[k]->element,
+                        log_emsg(log_msg, "Invalid option '%s' for rule '%d'.", rule_opt[k]->element,
                                config_ruleinfo->sigid);
                         goto cleanup;
                     }
@@ -1401,7 +1401,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                 /* Check for a valid description */
                 if (!config_ruleinfo->comment) {
-                    smerror(&tmp_msg, "No such description at rule '%d'.", config_ruleinfo->sigid);
+                    log_emsg(log_msg, "No such description at rule '%d'.", config_ruleinfo->sigid);
                     goto cleanup;
                 }
 
@@ -1409,7 +1409,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if ((config_ruleinfo->context_opts || config_ruleinfo->same_field 
                     || config_ruleinfo->different_field || config_ruleinfo->frequency) 
                     && !config_ruleinfo->context) {
-                    smerror(&tmp_msg, "Invalid use of frequency/context options. "
+                    log_emsg(log_msg, "Invalid use of frequency/context options. "
                            "Missing if_matched on rule '%d'.", config_ruleinfo->sigid);
                     goto cleanup;
                 }
@@ -1435,7 +1435,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (regex) {
                     os_calloc(1, sizeof(OSRegex), config_ruleinfo->regex);
                     if (!OSRegex_Compile(regex, config_ruleinfo->regex, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, regex, config_ruleinfo->regex->error);
+                        log_emsg(log_msg, REGEX_COMPILE, regex, config_ruleinfo->regex->error);
                         goto cleanup;
                     }
                     free(regex);
@@ -1446,7 +1446,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (match) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->match);
                     if (!OSMatch_Compile(match, config_ruleinfo->match, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, match, config_ruleinfo->match->error);
+                        log_emsg(log_msg, REGEX_COMPILE, match, config_ruleinfo->match->error);
                         goto cleanup;
                     }
                     free(match);
@@ -1457,7 +1457,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (id) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->id);
                     if (!OSMatch_Compile(id, config_ruleinfo->id, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, id, config_ruleinfo->id->error);
+                        log_emsg(log_msg, REGEX_COMPILE, id, config_ruleinfo->id->error);
                         goto cleanup;
                     }
                     free(id);
@@ -1468,7 +1468,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (srcport) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->srcport);
                     if (!OSMatch_Compile(srcport, config_ruleinfo->srcport, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, srcport, config_ruleinfo->id->error);
+                        log_emsg(log_msg, REGEX_COMPILE, srcport, config_ruleinfo->id->error);
                         goto cleanup;
                     }
                     free(srcport);
@@ -1479,7 +1479,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (dstport) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->dstport);
                     if (!OSMatch_Compile(dstport, config_ruleinfo->dstport, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, dstport, config_ruleinfo->id->error);
+                        log_emsg(log_msg, REGEX_COMPILE, dstport, config_ruleinfo->id->error);
                         goto cleanup;
                     }
                     free(dstport);
@@ -1490,7 +1490,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (status) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->status);
                     if (!OSMatch_Compile(status, config_ruleinfo->status, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, status, config_ruleinfo->status->error);
+                        log_emsg(log_msg, REGEX_COMPILE, status, config_ruleinfo->status->error);
                         goto cleanup;
                     }
                     free(status);
@@ -1501,7 +1501,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (hostname) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->hostname);
                     if (!OSMatch_Compile(hostname, config_ruleinfo->hostname, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, hostname, config_ruleinfo->hostname->error);
+                        log_emsg(log_msg, REGEX_COMPILE, hostname, config_ruleinfo->hostname->error);
                         goto cleanup;
                     }
                     free(hostname);
@@ -1512,7 +1512,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (data) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->data);
                     if (!OSMatch_Compile(data, config_ruleinfo->data, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, data, config_ruleinfo->data->error);
+                        log_emsg(log_msg, REGEX_COMPILE, data, config_ruleinfo->data->error);
                         goto cleanup;
                     }
                     free(data);
@@ -1523,7 +1523,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (extra_data) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->extra_data);
                     if (!OSMatch_Compile(extra_data, config_ruleinfo->extra_data, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, extra_data, config_ruleinfo->extra_data->error);
+                        log_emsg(log_msg, REGEX_COMPILE, extra_data, config_ruleinfo->extra_data->error);
                         goto cleanup;
                     }
                     free(extra_data);
@@ -1534,7 +1534,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (program_name) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->program_name);
                     if (!OSMatch_Compile(program_name, config_ruleinfo->program_name, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, program_name, config_ruleinfo->program_name->error);
+                        log_emsg(log_msg, REGEX_COMPILE, program_name, config_ruleinfo->program_name->error);
                         goto cleanup;
                     }
                     free(program_name);
@@ -1545,7 +1545,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (user) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->user);
                     if (!OSMatch_Compile(user, config_ruleinfo->user, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, user, config_ruleinfo->user->error);
+                        log_emsg(log_msg, REGEX_COMPILE, user, config_ruleinfo->user->error);
                         goto cleanup;
                     }
                     free(user);
@@ -1556,7 +1556,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (srcgeoip) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->srcgeoip);
                     if (!OSMatch_Compile(srcgeoip, config_ruleinfo->srcgeoip, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, srcgeoip, config_ruleinfo->srcgeoip->error);
+                        log_emsg(log_msg, REGEX_COMPILE, srcgeoip, config_ruleinfo->srcgeoip->error);
                         return(-1);
                     }
                     free(srcgeoip);
@@ -1568,7 +1568,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (dstgeoip) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->dstgeoip);
                     if (!OSMatch_Compile(dstgeoip, config_ruleinfo->dstgeoip, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, dstgeoip, config_ruleinfo->dstgeoip->error);
+                        log_emsg(log_msg, REGEX_COMPILE, dstgeoip, config_ruleinfo->dstgeoip->error);
                         return(-1);
                     }
                     free(dstgeoip);
@@ -1580,7 +1580,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if (url) {
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->url);
                     if (!OSMatch_Compile(url, config_ruleinfo->url, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, url, config_ruleinfo->url->error);
+                        log_emsg(log_msg, REGEX_COMPILE, url, config_ruleinfo->url->error);
                         goto cleanup;
                     }
                     free(url);
@@ -1592,7 +1592,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->location);
 
                     if (!OSMatch_Compile(location, config_ruleinfo->location, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, location, config_ruleinfo->location->error);
+                        log_emsg(log_msg, REGEX_COMPILE, location, config_ruleinfo->location->error);
                         goto cleanup;
                     }
                     free(location);
@@ -1605,7 +1605,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                               config_ruleinfo->if_matched_group);
 
                     if (!OSMatch_Compile(if_matched_group, config_ruleinfo->if_matched_group, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, if_matched_group, config_ruleinfo->if_matched_group->error);
+                        log_emsg(log_msg, REGEX_COMPILE, if_matched_group, config_ruleinfo->if_matched_group->error);
                         goto cleanup;
                     }
                     free(if_matched_group);
@@ -1617,7 +1617,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     os_calloc(1, sizeof(OSRegex),
                               config_ruleinfo->if_matched_regex);
                     if (!OSRegex_Compile(if_matched_regex, config_ruleinfo->if_matched_regex, 0)) {
-                        smerror(&tmp_msg, REGEX_COMPILE, if_matched_regex, config_ruleinfo->if_matched_regex->error);
+                        log_emsg(log_msg, REGEX_COMPILE, if_matched_regex, config_ruleinfo->if_matched_regex->error);
                         goto cleanup;
                     }
                     free(if_matched_regex);
@@ -1628,7 +1628,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if(protocol){
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->protocol);
                     if(!OSMatch_Compile(protocol, config_ruleinfo->protocol, 0)){
-                        smerror(&tmp_msg, REGEX_COMPILE, protocol, config_ruleinfo->protocol->error);
+                        log_emsg(log_msg, REGEX_COMPILE, protocol, config_ruleinfo->protocol->error);
                         goto cleanup;
                     }
                     free(protocol);
@@ -1639,7 +1639,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 if(system_name){
                     os_calloc(1, sizeof(OSMatch), config_ruleinfo->system_name);
                     if(!OSMatch_Compile(system_name, config_ruleinfo->system_name, 0)){
-                        smerror(&tmp_msg, REGEX_COMPILE, system_name, config_ruleinfo->system_name->error);
+                        log_emsg(log_msg, REGEX_COMPILE, system_name, config_ruleinfo->system_name->error);
                         goto cleanup;
                     }
                     free(system_name);
@@ -1663,11 +1663,11 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 OS_AddRule(config_ruleinfo, r_node);
             } else if (config_ruleinfo->alert_opts & DO_OVERWRITE) {
                 if (!OS_AddRuleInfo(*r_node, config_ruleinfo, config_ruleinfo->sigid)) {
-                    smerror(&tmp_msg, "Overwrite rule '%d' not found.", config_ruleinfo->sigid);
+                    log_emsg(log_msg, "Overwrite rule '%d' not found.", config_ruleinfo->sigid);
                     goto cleanup;
                 }
             } else {
-                if (OS_AddChild(config_ruleinfo, r_node, &tmp_msg) == -1) {
+                if (OS_AddChild(config_ruleinfo, r_node, log_msg) == -1) {
                     goto cleanup;
                 }
             }
@@ -1765,11 +1765,6 @@ cleanup:
     if (retval) {
         free(config_ruleinfo);
     }
-    
-    if(tmp_msg){
-        os_free(*msg);
-        *msg = tmp_msg;
-    }
 
     /* Clean global node */
     OS_ClearNode(node);
@@ -1782,7 +1777,7 @@ cleanup:
  * If *at already exist, realloc the memory and cat str on it.
  * Returns the new string
  */
-static char *loadmemory(char *at, const char *str, char** msg)
+static char *loadmemory(char *at, const char *str, os_analysisd_list_log_msg_t* log_msg)
 {
     if (at == NULL) {
         size_t strsize = 0;
@@ -1795,7 +1790,7 @@ static char *loadmemory(char *at, const char *str, char** msg)
             strncpy(at, str, strsize);
             return (at);
         } else {
-            smerror(msg, SIZE_ERROR, str);
+            log_emsg(log_msg, SIZE_ERROR, str);
             return (NULL);
         }
     } else {
@@ -1805,7 +1800,7 @@ static char *loadmemory(char *at, const char *str, char** msg)
         size_t finalsize = atsize + strsize + 1;
 
         if ((atsize > OS_SIZE_2048) || (strsize > OS_SIZE_2048)) {
-            smerror(msg, SIZE_ERROR, str);
+            log_emsg(log_msg, SIZE_ERROR, str);
             return (NULL);
         }
 
@@ -1954,7 +1949,7 @@ RuleInfo *zerorulemember(int id, int level,
     return (ruleinfo_pt);
 }
 
-int get_info_attributes(char **attributes, char **values, char **msg)
+int get_info_attributes(char **attributes, char **values, os_analysisd_list_log_msg_t* log_msg)
 {
     const char *xml_type = "type";
     int k = 0;
@@ -1966,7 +1961,7 @@ int get_info_attributes(char **attributes, char **values, char **msg)
     while (attributes[k]) {
         if (strcasecmp(attributes[k], xml_type) == 0) {
             if (!values[k]) {
-                smerror(msg, "rules_op: Element info attribute \"%s\" does not have a value", attributes[k]);
+                log_emsg(log_msg, "rules_op: Element info attribute \"%s\" does not have a value", attributes[k]);
                 return (-1);
             } else if (strcmp(values[k], "text") == 0) {
                 return (RULEINFODETAIL_TEXT);
@@ -1977,12 +1972,12 @@ int get_info_attributes(char **attributes, char **values, char **msg)
             } else if (strcmp(values[k], "osvdb") == 0) {
                 return (RULEINFODETAIL_OSVDB);
             } else {
-                smerror(msg, "rules_op: Element info attribute \"%s\" has invalid value \"%s\"",
+                log_emsg(log_msg, "rules_op: Element info attribute \"%s\" has invalid value \"%s\"",
                        attributes[k], values[k]);
                 return (-1);
             }
         } else {
-            smerror(msg, "rules_op: Element info has invalid attribute \"%s\"", attributes[k]);
+            log_emsg(log_msg, "rules_op: Element info has invalid attribute \"%s\"", attributes[k]);
             return (-1);
         }
     }
@@ -1995,7 +1990,7 @@ static int getattributes(char **attributes, char **values,
                   int *maxsize, int *timeframe,
                   int *frequency, int *accuracy,
                   int *noalert, int *ignore_time, int *overwrite,
-                  char** msg)
+                  os_analysisd_list_log_msg_t* log_msg)
 {
     int k = 0;
 
@@ -2012,7 +2007,7 @@ static int getattributes(char **attributes, char **values,
     /* Get attributes */
     while (attributes[k]) {
         if (!values[k]) {
-            smerror(msg, "rules_op: Attribute \"%s\" without value.", attributes[k]);
+            log_emsg(log_msg, "rules_op: Attribute \"%s\" without value.", attributes[k]);
             return (-1);
         }
         /* Get rule id */
@@ -2020,7 +2015,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k]) && strlen(values[k]) <= 6) {
                 sscanf(values[k], "%6d", id);
             } else {
-                smerror(msg, "rules_op: Invalid rule id: %s. Must be integer (max 6 digits)", values[k]);
+                log_emsg(log_msg, "rules_op: Invalid rule id: %s. Must be integer (max 6 digits)", values[k]);
                 return (-1);
             }
         }
@@ -2029,7 +2024,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 *level = atoi(values[k]);
                 if (*level < 0 || *level > 16) {
-                    smerror(msg, "rules_op: Invalid level: %d. Must be an integer between 0 and 16.", *level);
+                    log_emsg(log_msg, "rules_op: Invalid level: %d. Must be an integer between 0 and 16.", *level);
                     return (-1);
                 }
             }
@@ -2039,7 +2034,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 sscanf(values[k], "%4d", maxsize);
             } else {
-                smerror(msg, "rules_op: Invalid maxsize: %s. Must be integer", values[k]);
+                log_emsg(log_msg, "rules_op: Invalid maxsize: %s. Must be integer", values[k]);
                 return (-1);
             }
         }
@@ -2048,7 +2043,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 sscanf(values[k], "%5d", timeframe);
             } else {
-                smerror(msg, "rules_op: Invalid timeframe: %s. Must be integer (max 5 digits)", values[k]);
+                log_emsg(log_msg, "rules_op: Invalid timeframe: %s. Must be integer (max 5 digits)", values[k]);
                 return (-1);
             }
         }
@@ -2057,13 +2052,13 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 *frequency = atoi(values[k]);
                 if (*frequency < 2 || *frequency > 9999) {
-                    smerror(msg, "rules_op: Invalid frequency: %d. "
+                    log_emsg(log_msg, "rules_op: Invalid frequency: %d. "
                     "Must be higher than 1 and lower than 10000.", *frequency);
                     return (-1);
                 }
                 *frequency = *frequency - 2;
             } else {
-                smerror(msg,"rules_op: Invalid frequency: %s. Must be integer", values[k]);
+                log_emsg(log_msg,"rules_op: Invalid frequency: %s. Must be integer", values[k]);
                 return (-1);
             }
         }
@@ -2072,7 +2067,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 sscanf(values[k], "%4d", accuracy);
             } else {
-                smerror(msg, "rules_op: Invalid accuracy: %s. Must be integer", values[k]);
+                log_emsg(log_msg, "rules_op: Invalid accuracy: %s. Must be integer", values[k]);
                 return (-1);
             }
         }
@@ -2081,7 +2076,7 @@ static int getattributes(char **attributes, char **values,
             if (OS_StrIsNum(values[k])) {
                 sscanf(values[k], "%6d", ignore_time);
             } else {
-                smerror(msg, "rules_op: Invalid ignore_time: %s. Must be integer (max 6 digits)", values[k]);
+                log_emsg(log_msg, "rules_op: Invalid ignore_time: %s. Must be integer (max 6 digits)", values[k]);
                 return (-1);
             }
         }
@@ -2094,11 +2089,11 @@ static int getattributes(char **attributes, char **values,
             } else if (strcmp(values[k], "no") == 0) {
                 *overwrite = 0;
             } else {
-                smerror(msg,"rules_op: Invalid overwrite: %s. Can only by 'yes' or 'no'.", values[k]);
+                log_emsg(log_msg,"rules_op: Invalid overwrite: %s. Can only by 'yes' or 'no'.", values[k]);
                 return (-1);
             }
         } else {
-            smerror(msg, "rules_op: Invalid attribute \"%s\". Only id, level, maxsize, accuracy,"
+            log_emsg(log_msg, "rules_op: Invalid attribute \"%s\". Only id, level, maxsize, accuracy,"
                     " noalert, ignore, frequency and timeframe are allowed.", attributes[k]);
             return (-1);
         }

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -213,7 +213,7 @@ typedef struct _RuleNode {
 
 
 RuleInfoDetail *zeroinfodetails(int type, const char *data);
-int get_info_attributes(char **attributes, char **values, os_analysisd_list_log_msg_t* log_msg);
+int get_info_attributes(char **attributes, char **values, OSList* log_msg);
 
 /* RuleInfo functions */
 RuleInfo *zerorulemember(int id,
@@ -235,13 +235,13 @@ void OS_CreateRuleList(void);
 int OS_AddRule(RuleInfo *read_rule, RuleNode **r_node);
 
 /**
- * @brief  Add rule information as a child.
- * @param[in]  read_rule rule information.
- * @param[in]  r_node node to add as a child rule information.
- * @param[in]  log_msg List to save log messages.
+ * @brief Add rule information as a child.
+ * @param read_rule rule information.
+ * @param r_node node to add as a child rule information.
+ * @param log_msg List to save log messages.
  * @return int -1 for critical errors, 1 for errors, 0 otherwise.
  */
-int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, os_analysisd_list_log_msg_t* log_msg);
+int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg);
 
 /* Add an overwrite rule */
 int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid);
@@ -259,12 +259,12 @@ void Rules_OP_CreateRules(void);
 
 /**
  * @brief Read the log rules of `rulefile` and add the `ruleNode` if the CDB list (l_node) allowed
- * @param[in]  rulefile path of the rule configuration xml file.
- * @param[in]  r_node Rules node to add.
- * @param[in]  l_node CDB list.
- * @param[in]  log_msg List to save log messages.
+ * @param rulefile path of the rule configuration xml file.
+ * @param r_node Rules node to add.
+ * @param l_node CDB list.
+ * @param log_msg List to save log messages.
 */ 
-int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, os_analysisd_list_log_msg_t* log_msg);
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, OSList* log_msg);
 
 int AddHash_Rule(RuleNode *node);
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -16,6 +16,7 @@
 #include "shared.h"
 #include "active-response.h"
 #include "lists.h"
+#include "list_log.h"
 
 /* Event fields - stored on a u_int32_t */
 #define FIELD_SRCIP      0x01
@@ -212,7 +213,7 @@ typedef struct _RuleNode {
 
 
 RuleInfoDetail *zeroinfodetails(int type, const char *data);
-int get_info_attributes(char **attributes, char **values, char **msg);
+int get_info_attributes(char **attributes, char **values, os_analysisd_list_log_msg_t* log_msg);
 
 /* RuleInfo functions */
 RuleInfo *zerorulemember(int id,
@@ -237,11 +238,10 @@ int OS_AddRule(RuleInfo *read_rule, RuleNode **r_node);
  * @brief  Add rule information as a child.
  * @param[in]  read_rule rule information.
  * @param[in]  r_node node to add as a child rule information.
- * @param[out] msg Store error as result of call.
+ * @param[in]  log_msg List to save log messages.
  * @return int -1 for critical errors, 1 for errors, 0 otherwise.
- * @note If *msg==null, memory are allocate, otherwise memory are reallocate and error are concatenate.
  */
-int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, char** msg);
+int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, os_analysisd_list_log_msg_t* log_msg);
 
 /* Add an overwrite rule */
 int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid);
@@ -260,13 +260,11 @@ void Rules_OP_CreateRules(void);
 /**
  * @brief Read the log rules of `rulefile` and add the `ruleNode` if the CDB list (l_node) allowed
  * @param[in]  rulefile path of the rule configuration xml file.
- * @param[in]  r_node Rules node to add
- * @param[in]  l_node CDB list
- * @param[out] **msg If any error or warning occurs, your description are stored in *msg.
- *                   If *msg==null, memory are allocate for messages, otherwise memory
- *                   are reallocate and error messages are stored here, replacing the original content.
+ * @param[in]  r_node Rules node to add.
+ * @param[in]  l_node CDB list.
+ * @param[in]  log_msg List to save log messages.
 */ 
-int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, char** msg);
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, os_analysisd_list_log_msg_t* log_msg);
 
 int AddHash_Rule(RuleNode *node);
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -212,7 +212,7 @@ typedef struct _RuleNode {
 
 
 RuleInfoDetail *zeroinfodetails(int type, const char *data);
-int get_info_attributes(char **attributes, char **values);
+int get_info_attributes(char **attributes, char **values, char **msg);
 
 /* RuleInfo functions */
 RuleInfo *zerorulemember(int id,
@@ -250,7 +250,16 @@ RuleNode *OS_GetFirstRule(void);
 
 void Rules_OP_CreateRules(void);
 
-int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node);
+/**
+ * Read the log rules
+ * 
+ * @param [in] rulefile
+ * @param [in] r_node
+ * @param [in] l_node
+ * @param [out] **msg If any error or warning occurs, your 
+ *                  description will be stored in *msg.
+*/ 
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, char** msg);
 
 int AddHash_Rule(RuleNode *node);
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -233,8 +233,15 @@ void OS_CreateRuleList(void);
 /* Add rule information to the list */
 int OS_AddRule(RuleInfo *read_rule, RuleNode **r_node);
 
-/* Add rule information as a child */
-int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node);
+/**
+ * @brief  Add rule information as a child.
+ * @param[in]  read_rule rule information.
+ * @param[in]  r_node node to add as a child rule information.
+ * @param[out] msg Store error as result of call.
+ * @return int -1 for critical errors, 1 for errors, 0 otherwise.
+ * @note If *msg==null, memory are allocate, otherwise memory are reallocate and error are concatenate.
+ */
+int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, char** msg);
 
 /* Add an overwrite rule */
 int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid);
@@ -251,7 +258,7 @@ RuleNode *OS_GetFirstRule(void);
 void Rules_OP_CreateRules(void);
 
 /**
- * @brief Read the log rules of `rulefile` and add the `ruleNode` if the bdb list (l_node) allowed
+ * @brief Read the log rules of `rulefile` and add the `ruleNode` if the CDB list (l_node) allowed
  * @param[in]  rulefile path of the rule configuration xml file.
  * @param[in]  r_node Rules node to add
  * @param[in]  l_node CDB list

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -251,13 +251,13 @@ RuleNode *OS_GetFirstRule(void);
 void Rules_OP_CreateRules(void);
 
 /**
- * Read the log rules
- * 
- * @param [in] rulefile
- * @param [in] r_node
- * @param [in] l_node
- * @param [out] **msg If any error or warning occurs, your 
- *                  description will be stored in *msg.
+ * @brief Read the log rules of `rulefile` and add the `ruleNode` if the bdb list (l_node) allowed
+ * @param[in]  rulefile path of the rule configuration xml file.
+ * @param[in]  r_node Rules node to add
+ * @param[in]  l_node CDB list
+ * @param[out] **msg If any error or warning occurs, your description are stored in *msg.
+ *                   If *msg==null, memory are allocate for messages, otherwise memory
+ *                   are reallocate and error messages are stored here, replacing the original content.
 */ 
 int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, char** msg);
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -239,7 +239,9 @@ int OS_AddRule(RuleInfo *read_rule, RuleNode **r_node);
  * @param read_rule rule information.
  * @param r_node node to add as a child rule information.
  * @param log_msg List to save log messages.
- * @return int -1 for critical errors, 1 for errors, 0 otherwise.
+ * @retval -1 Critical errors.
+ * @retval  0 successful.
+ * @retval  1 for errors.
  */
 int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg);
 

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -114,10 +114,10 @@ static int _AddtoRule(int sid, int level, int none, const char *group,
 }
 
 /* Add a child */
-int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, char** msg)
+int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, os_analysisd_list_log_msg_t* log_msg)
 {
     if (!read_rule) {
-        smerror(msg, "rules_list: Passing a NULL rule. Inconsistent state");
+        log_emsg(log_msg, "rules_list: Passing a NULL rule. Inconsistent state");
         return (1);
     }
 
@@ -138,13 +138,13 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, char** msg)
                 if (val == 0) {
                     rule_id = atoi(sid);
                     if (!_AddtoRule(rule_id, 0, 0, NULL, *r_node, read_rule)) {
-                        smerror(msg, "rules_list: Signature ID '%d' not found. Invalid 'if_sid'.", rule_id);
+                        log_emsg(log_msg, "rules_list: Signature ID '%d' not found. Invalid 'if_sid'.", rule_id);
                         return -1;
                     }
                     val = 1;
                 }
             } else {
-                smerror(msg, "rules_list: Signature ID must be an integer. Exiting...");
+                log_emsg(log_msg, "rules_list: Signature ID must be an integer. Exiting...");
                 return -1;
             }
         } while (*sid++ != '\0');
@@ -156,14 +156,14 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, char** msg)
 
         ilevel = atoi(read_rule->if_level);
         if (ilevel == 0) {
-            smerror(msg, "Invalid level (atoi)");
+            log_emsg(log_msg, "Invalid level (atoi)");
             return (1);
         }
 
         ilevel *= 100;
 
         if (!_AddtoRule(0, ilevel, 0, NULL, *r_node, read_rule)) {
-            smerror(msg, "rules_list: Level ID '%d' not found. Invalid 'if_level'.", ilevel);
+            log_emsg(log_msg, "rules_list: Level ID '%d' not found. Invalid 'if_level'.", ilevel);
             return -1;
         }
     }
@@ -171,7 +171,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, char** msg)
     /* Adding for if_group */
     else if (read_rule->if_group) {
         if (!_AddtoRule(0, 0, 0, read_rule->if_group, *r_node, read_rule)) {
-            smerror(msg, "rules_list: Group '%s' not found. Invalid 'if_group'.", read_rule->if_group);
+            log_emsg(log_msg, "rules_list: Group '%s' not found. Invalid 'if_group'.", read_rule->if_group);
             return -1;
         }
     }
@@ -179,7 +179,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, char** msg)
     /* Just add based on the category */
     else {
         if (!_AddtoRule(0, 0, 0, NULL, *r_node, read_rule)) {
-            smerror(msg, "rules_list: Category '%d' not found. Invalid 'category'.", read_rule->category);
+            log_emsg(log_msg, "rules_list: Category '%d' not found. Invalid 'category'.", read_rule->category);
             return -1;
         }
     }

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -114,7 +114,7 @@ static int _AddtoRule(int sid, int level, int none, const char *group,
 }
 
 /* Add a child */
-int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, os_analysisd_list_log_msg_t* log_msg)
+int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
 {
     if (!read_rule) {
         log_emsg(log_msg, "rules_list: Passing a NULL rule. Inconsistent state");
@@ -152,7 +152,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, os_analysisd_list_log_ms
 
     /* Adding for if_level */
     else if (read_rule->if_level) {
-        int  ilevel = 0;
+        int ilevel = 0;
 
         ilevel = atoi(read_rule->if_level);
         if (ilevel == 0) {

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -114,10 +114,10 @@ static int _AddtoRule(int sid, int level, int none, const char *group,
 }
 
 /* Add a child */
-int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node)
+int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, char** msg)
 {
     if (!read_rule) {
-        merror("rules_list: Passing a NULL rule. Inconsistent state");
+        smerror(msg, "rules_list: Passing a NULL rule. Inconsistent state");
         return (1);
     }
 
@@ -138,14 +138,14 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node)
                 if (val == 0) {
                     rule_id = atoi(sid);
                     if (!_AddtoRule(rule_id, 0, 0, NULL, *r_node, read_rule)) {
-                        merror_exit("rules_list: Signature ID '%d' not "
-                                  "found. Invalid 'if_sid'.", rule_id);
+                        smerror(msg, "rules_list: Signature ID '%d' not found. Invalid 'if_sid'.", rule_id);
+                        return -1;
                     }
                     val = 1;
                 }
             } else {
-                merror_exit("rules_list: Signature ID must be an integer. "
-                          "Exiting...");
+                smerror(msg, "rules_list: Signature ID must be an integer. Exiting...");
+                return -1;
             }
         } while (*sid++ != '\0');
     }
@@ -156,31 +156,31 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node)
 
         ilevel = atoi(read_rule->if_level);
         if (ilevel == 0) {
-            merror("Invalid level (atoi)");
+            smerror(msg, "Invalid level (atoi)");
             return (1);
         }
 
         ilevel *= 100;
 
         if (!_AddtoRule(0, ilevel, 0, NULL, *r_node, read_rule)) {
-            merror_exit("rules_list: Level ID '%d' not "
-                      "found. Invalid 'if_level'.", ilevel);
+            smerror(msg, "rules_list: Level ID '%d' not found. Invalid 'if_level'.", ilevel);
+            return -1;
         }
     }
 
     /* Adding for if_group */
     else if (read_rule->if_group) {
         if (!_AddtoRule(0, 0, 0, read_rule->if_group, *r_node, read_rule)) {
-            merror_exit("rules_list: Group '%s' not "
-                      "found. Invalid 'if_group'.", read_rule->if_group);
+            smerror(msg, "rules_list: Group '%s' not found. Invalid 'if_group'.", read_rule->if_group);
+            return -1;
         }
     }
 
     /* Just add based on the category */
     else {
         if (!_AddtoRule(0, 0, 0, NULL, *r_node, read_rule)) {
-            merror_exit("rules_list: Category '%d' not "
-                      "found. Invalid 'category'.", read_rule->category);
+            smerror(msg, "rules_list: Category '%d' not found. Invalid 'category'.", read_rule->category);
+            return -1;
         }
     }
 

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
                     if (!ReadDecodeXML(*decodersfiles, &msg)) {
-                        if(msg){
+                        if (msg) {
                             // [wazuh-logtest] This will be sent through the socket
                             printf("%s", msg);
                             os_free(msg);
@@ -249,14 +249,14 @@ int main(int argc, char **argv)
                 /* Read local ones */
 
                 c = ReadDecodeXML(XML_LDECODER, &msg);
-                if(msg){
+                if (msg) {
                     // [wazuh-logtest] This will be sent through the socket
                     printf("%s", msg);
                     os_free(msg);
                 }
                 if (!c) {
                     if ((c != -2)) {
-                        merror_exit(CONFIG_ERROR,  XML_LDECODER);
+                        merror_exit(CONFIG_ERROR, XML_LDECODER);
                     }
                 } else {
                     minfo("Reading local decoder file.");
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
                     if (!ReadDecodeXML(*decodersfiles, &msg)) {
-                        if(msg){
+                        if (msg) {
                             printf("%s", msg);
                             os_free(msg);
                         }
@@ -286,7 +286,7 @@ int main(int argc, char **argv)
 
             /* Load decoders */
             SetDecodeXML(&msg);
-            if(msg){
+            if (msg) {
                 // [wazuh-logtest] This will be sent through the socket
                 printf("%s", msg);
                 os_free(msg);
@@ -327,7 +327,7 @@ int main(int argc, char **argv)
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
                     if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, 
                                 &os_analysisd_cdblists, &msg) < 0) {
-                        if(msg){
+                        if (msg) {
                             printf("%s", msg);
                             os_free(msg);
                         }

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -218,6 +218,9 @@ int main(int argc, char **argv)
             /* Initialize the decoders list */
             OS_CreateOSDecoderList();
 
+            /* Error and wargning msg */
+            char* msg = NULL;
+
             if (!Config.decoders) {
                 /* Legacy loading */
                 /* Read decoders */
@@ -230,7 +233,12 @@ int main(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
-                    if (!ReadDecodeXML(*decodersfiles)) {
+                    if (!ReadDecodeXML(*decodersfiles, &msg)) {
+                        if(msg){
+                            // [wazuh-logtest] This will be sent through the socket
+                            printf("%s", msg);
+                            os_free(msg);
+                        }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
                     }
 
@@ -240,7 +248,12 @@ int main(int argc, char **argv)
 
                 /* Read local ones */
 
-                c = ReadDecodeXML(XML_LDECODER);
+                c = ReadDecodeXML(XML_LDECODER, &msg);
+                if(msg){
+                    // [wazuh-logtest] This will be sent through the socket
+                    printf("%s", msg);
+                    os_free(msg);
+                }
                 if (!c) {
                     if ((c != -2)) {
                         merror_exit(CONFIG_ERROR,  XML_LDECODER);
@@ -258,7 +271,11 @@ int main(int argc, char **argv)
                     if(!quiet) {
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
-                    if (!ReadDecodeXML(*decodersfiles)) {
+                    if (!ReadDecodeXML(*decodersfiles, &msg)) {
+                        if(msg){
+                            printf("%s", msg);
+                            os_free(msg);
+                        }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
                     }
 
@@ -268,7 +285,12 @@ int main(int argc, char **argv)
             }
 
             /* Load decoders */
-            SetDecodeXML();
+            SetDecodeXML(&msg);
+            if(msg){
+                // [wazuh-logtest] This will be sent through the socket
+                printf("%s", msg);
+                os_free(msg);
+            }
         }
         {
             /* Load Lists */
@@ -298,11 +320,17 @@ int main(int argc, char **argv)
 
             /* Read the rules */
             {
+                char*  msg = NULL;
                 char **rulesfiles;
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
-                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, 
+                                &os_analysisd_cdblists, &msg) < 0) {
+                        if(msg){
+                            printf("%s", msg);
+                            os_free(msg);
+                        }
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }
 

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
             /* Initialize the decoders list */
             OS_CreateOSDecoderList();
 
-            /* Error and wargning msg */
+            /* Error and warning msg */
             char* msg = NULL;
 
             if (!Config.decoders) {
@@ -236,7 +236,7 @@ int main(int argc, char **argv)
                     if (!ReadDecodeXML(*decodersfiles, &msg)) {
                         if (msg) {
                             // [wazuh-logtest] This will be sent through the socket
-                            printf("%s", msg);
+                            minfo("Call ReadDecodeXML result in the following errors/warning:\n %s", msg);
                             os_free(msg);
                         }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
@@ -251,7 +251,7 @@ int main(int argc, char **argv)
                 c = ReadDecodeXML(XML_LDECODER, &msg);
                 if (msg) {
                     // [wazuh-logtest] This will be sent through the socket
-                    printf("%s", msg);
+                    minfo("Call ReadDecodeXML result in the following errors/warning:\n %s", msg);
                     os_free(msg);
                 }
                 if (!c) {
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
                     }
                     if (!ReadDecodeXML(*decodersfiles, &msg)) {
                         if (msg) {
-                            printf("%s", msg);
+                            minfo("Call ReadDecodeXML result in the following errors/warning:\n %s", msg);
                             os_free(msg);
                         }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
@@ -288,7 +288,7 @@ int main(int argc, char **argv)
             SetDecodeXML(&msg);
             if (msg) {
                 // [wazuh-logtest] This will be sent through the socket
-                printf("%s", msg);
+                minfo("Call SetDecodeXML result in the following errors/warning:\n %s", msg);
                 os_free(msg);
             }
         }
@@ -325,10 +325,9 @@ int main(int argc, char **argv)
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
-                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, 
-                                &os_analysisd_cdblists, &msg) < 0) {
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, &msg) < 0) {
                         if (msg) {
-                            printf("%s", msg);
+                            minfo("Call Rules_OP_ReadRules result in the following errors/warning:\n %s", msg);
                             os_free(msg);
                         }
                         merror_exit(RULES_ERROR, *rulesfiles);

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -30,6 +30,7 @@
 #include "cleanevent.h"
 #include "lists_make.h"
 
+
 /** Internal Functions **/
 void OS_ReadMSG(char *ut_str);
 
@@ -216,7 +217,9 @@ int main(int argc, char **argv)
             OS_CreateOSDecoderList();
 
             /* Error and warning msg */
-            char* msg = NULL;
+            os_analysisd_list_log_msg_t* list_msg = os_analysisd_create_list_log();
+            os_analysisd_log_msg_t* data_msg;
+            char* msg;
 
             if (!Config.decoders) {
                 /* Legacy loading */
@@ -230,11 +233,17 @@ int main(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
-                    if (!ReadDecodeXML(*decodersfiles, &msg)) {
-                        if (msg) {
-                            // [wazuh-logtest] This will be sent through the socket
-                            minfo("Call ReadDecodeXML result in the following errors/warning:\n %s", msg);
+                    if (!ReadDecodeXML(*decodersfiles, list_msg)) {
+                        while (data_msg = os_analysisd_pop_list_log(list_msg), data_msg) {
+                            msg = os_analysisd_string_log_msg(data_msg);
+                            if (data_msg->level == LOGLEVEL_WARNING) {
+                                mwarn("%s", msg);
+                            } else if (data_msg->level == LOGLEVEL_ERROR) {
+                                merror("%s", msg);
+                            }
                             os_free(msg);
+                            os_analysisd_free_log_msg(data_msg);
+                            os_free(data_msg);
                         }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
                     }
@@ -245,11 +254,17 @@ int main(int argc, char **argv)
 
                 /* Read local ones */
 
-                c = ReadDecodeXML(XML_LDECODER, &msg);
-                if (msg) {
-                    // [wazuh-logtest] This will be sent through the socket
-                    minfo("Call ReadDecodeXML result in the following errors/warning:\n %s", msg);
+                c = ReadDecodeXML(XML_LDECODER, list_msg);
+                while (data_msg = os_analysisd_pop_list_log(list_msg), data_msg) {
+                    msg = os_analysisd_string_log_msg(data_msg);
+                    if (data_msg->level == LOGLEVEL_WARNING) {
+                        mwarn("%s", msg);
+                    } else if (data_msg->level == LOGLEVEL_ERROR) {
+                        merror("%s", msg);
+                    }
                     os_free(msg);
+                    os_analysisd_free_log_msg(data_msg);
+                    os_free(data_msg);
                 }
                 if (!c) {
                     if ((c != -2)) {
@@ -268,10 +283,17 @@ int main(int argc, char **argv)
                     if(!quiet) {
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
-                    if (!ReadDecodeXML(*decodersfiles, &msg)) {
-                        if (msg) {
-                            minfo("Call ReadDecodeXML result in the following errors/warning:\n %s", msg);
+                    if (!ReadDecodeXML(*decodersfiles, list_msg)) {
+                        while (data_msg = os_analysisd_pop_list_log(list_msg), data_msg) {
+                            msg = os_analysisd_string_log_msg(data_msg);
+                            if (data_msg->level == LOGLEVEL_WARNING) {
+                                mwarn("%s", msg);
+                            } else if (data_msg->level == LOGLEVEL_ERROR) {
+                                merror("%s", msg);
+                            }
                             os_free(msg);
+                            os_analysisd_free_log_msg(data_msg);
+                            os_free(data_msg);
                         }
                         merror_exit(CONFIG_ERROR, *decodersfiles);
                     }
@@ -282,11 +304,17 @@ int main(int argc, char **argv)
             }
 
             /* Load decoders */
-            SetDecodeXML(&msg);
-            if (msg) {
-                // [wazuh-logtest] This will be sent through the socket
-                minfo("Call SetDecodeXML result in the following errors/warning:\n %s", msg);
+            SetDecodeXML(list_msg);
+            while (data_msg = os_analysisd_pop_list_log(list_msg), data_msg) {
+                msg = os_analysisd_string_log_msg(data_msg);
+                if (data_msg->level == LOGLEVEL_WARNING) {
+                    mwarn("%s", msg);
+                } else if (data_msg->level == LOGLEVEL_ERROR) {
+                    merror("%s", msg);
+                }
                 os_free(msg);
+                os_analysisd_free_log_msg(data_msg);
+                os_free(data_msg);
             }
         }
         {
@@ -315,17 +343,28 @@ int main(int argc, char **argv)
             /* Create the rules list */
             Rules_OP_CreateRules();
 
+            /* Error and warning msg */
+            os_analysisd_list_log_msg_t* list_msg = os_analysisd_create_list_log();
+            os_analysisd_log_msg_t* data_msg;
+            char* msg;
+
             /* Read the rules */
             {
-                char*  msg = NULL;
                 char **rulesfiles;
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
-                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, &msg) < 0) {
-                        if (msg) {
-                            minfo("Call Rules_OP_ReadRules result in the following errors/warning:\n %s", msg);
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, list_msg) < 0) {
+                        while (data_msg = os_analysisd_pop_list_log(list_msg), data_msg) {
+                            msg = os_analysisd_string_log_msg(data_msg);
+                            if (data_msg->level == LOGLEVEL_WARNING) {
+                                mwarn("%s", msg);
+                            } else if (data_msg->level == LOGLEVEL_ERROR) {
+                                merror("%s", msg);
+                            }
                             os_free(msg);
+                            os_analysisd_free_log_msg(data_msg);
+                            os_free(data_msg);
                         }
                         merror_exit(RULES_ERROR, *rulesfiles);
                     }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1150,8 +1150,13 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
         /* Get scan day */
         else if (strcmp(node[i]->element, xml_scanday) == 0) {
-            syscheck->scan_day = OS_IsValidDay(node[i]->content);
+            char *err_msg = NULL;
+            syscheck->scan_day = OS_IsValidDay(node[i]->content, &err_msg);
             if (!syscheck->scan_day) {
+                if(err_msg){
+                    merror(INVALID_DAY, node[i]->content);
+                    os_free(err_msg);
+                }
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1150,13 +1150,9 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
         /* Get scan day */
         else if (strcmp(node[i]->element, xml_scanday) == 0) {
-            char *err_msg = NULL;
-            syscheck->scan_day = OS_IsValidDay(node[i]->content, &err_msg);
+            syscheck->scan_day = OS_IsValidDay(node[i]->content);
             if (!syscheck->scan_day) {
-                if (err_msg) {
-                    merror(INVALID_DAY, node[i]->content);
-                    os_free(err_msg);
-                }
+                merror(INVALID_DAY, node[i]->content);
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1153,7 +1153,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             char *err_msg = NULL;
             syscheck->scan_day = OS_IsValidDay(node[i]->content, &err_msg);
             if (!syscheck->scan_day) {
-                if(err_msg){
+                if (err_msg) {
                     merror(INVALID_DAY, node[i]->content);
                     os_free(err_msg);
                 }

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -74,13 +74,13 @@ void _mterror_exit(const char *tag, const char * file, int line, const char * fu
  * @brief Generate a new error string and concatenate to *msg
  * @details If in debug mode, then append line number,
  * function and file from where the call was made to msg
- * @param [in] file file name from where the function was called. the __FILE__ macro should be used
- * @param [in] line line number from where the function was called. the __LINE__ macro should be used
- * @param [in] func function name from where the function was called. the __func__ macro should be used
- * @param [out] msg Destination of error string, if *msg==null, memory are allocate, otherwise
+ * @param[in] file The file name which calls the function. Should use __FILE__ macro.
+ * @param[in] line line number from where the function was called. Should use __LINE__ macro.
+ * @param[in] func function name from where the function was called. Should use __func__ macro.
+ * @param[out] msg Destination of error string, if *msg==null, memory are allocate, otherwise
  *                  memory are reallocate and error messages are concatenated to the *msg string.
- * @param [in] format includes format specifiers (subsequences beginning with %) for printf
- * @param [in] ...  additional arguments following format are formatted and inserted in the
+ * @param[in] format includes format specifiers (subsequences beginning with %) for printf
+ * @param[in] ...  additional arguments following format are formatted and inserted in the
  *                  resulting string replacing their respective specifiers.
  */
 void _serror_join(const char * file, int line, const char * func, char** msg, const char *format, ...)  __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull (1, 3, 5)));
@@ -89,13 +89,13 @@ void _serror_join(const char * file, int line, const char * func, char** msg, co
  * @brief Generate a new warning string and concatenate to *msg
  * @details If in debug mode, then append line number,
  * function and file from where the call was made to msg
- * @param [in] file file name from where the function was called. the __FILE__ macro should be used
- * @param [in] line line number from where the function was called. the __LINE__ macro should be used
- * @param [in] func function name from where the function was called. the __func__ macro should be used
- * @param [out] msg Destination of error string, if *msg==null, memory are allocate, otherwise
+ * @param[in] file file name from where the function was called. the __FILE__ macro should be used
+ * @param[in] line line number from where the function was called. the __LINE__ macro should be used
+ * @param[in] func function name from where the function was called. the __func__ macro should be used
+ * @param[out] msg Destination of error string, if *msg==null, memory are allocate, otherwise
  *                  memory are reallocate and error messages are concatenated to the *msg string.
- * @param [in] format includes format specifiers (subsequences beginning with %) for printf
- * @param [in] ...  additional arguments following format are formatted and inserted in the
+ * @param[in] format includes format specifiers (subsequences beginning with %) for printf
+ * @param[in] ...  additional arguments following format are formatted and inserted in the
  *                  resulting string replacing their respective specifiers.
  */
 void _swarn_join(const char * file, int line, const char * func, char** msg, const char *format, ...)  __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull (1, 3, 5)));

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -43,10 +43,8 @@
 #define mtdebug2(tag, msg, ...) _mtdebug2(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define merror(msg, ...) _merror(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
-#define smerror(msg, format, ...) _serror_join(__FILE__, __LINE__, __func__, msg, format, ##__VA_ARGS__)
 #define mwarn(msg, ...) _mwarn(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mtwarn(tag, msg, ...) _mtwarn(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
-#define smwarn(msg, format, ...) _swarn_join(__FILE__, __LINE__, __func__, msg, format, ##__VA_ARGS__)
 #define minfo(msg, ...) _minfo(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mtinfo(tag, msg, ...) _mtinfo(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mferror(msg, ...) _mferror(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
@@ -69,36 +67,6 @@ void _mferror(const char * file, int line, const char * func, const char *msg, .
 void _mtferror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
 void _merror_exit(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull)) __attribute__ ((noreturn));
 void _mterror_exit(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull)) __attribute__ ((noreturn));
-
-/** 
- * @brief Generate a new error string and concatenate to *msg
- * @details If in debug mode, then append line number,
- * function and file from where the call was made to msg
- * @param[in] file The file name which calls the function. Should use __FILE__ macro.
- * @param[in] line line number from where the function was called. Should use __LINE__ macro.
- * @param[in] func function name from where the function was called. Should use __func__ macro.
- * @param[out] msg Destination of error string, if *msg==null, memory are allocate, otherwise
- *                  memory are reallocate and error messages are concatenated to the *msg string.
- * @param[in] format includes format specifiers (subsequences beginning with %) for printf
- * @param[in] ...  additional arguments following format are formatted and inserted in the
- *                  resulting string replacing their respective specifiers.
- */
-void _serror_join(const char * file, int line, const char * func, char** msg, const char *format, ...)  __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull (1, 3, 5)));
-
-/** 
- * @brief Generate a new warning string and concatenate to *msg
- * @details If in debug mode, then append line number,
- * function and file from where the call was made to msg
- * @param[in] file file name from where the function was called. the __FILE__ macro should be used
- * @param[in] line line number from where the function was called. the __LINE__ macro should be used
- * @param[in] func function name from where the function was called. the __func__ macro should be used
- * @param[out] msg Destination of error string, if *msg==null, memory are allocate, otherwise
- *                  memory are reallocate and error messages are concatenated to the *msg string.
- * @param[in] format includes format specifiers (subsequences beginning with %) for printf
- * @param[in] ...  additional arguments following format are formatted and inserted in the
- *                  resulting string replacing their respective specifiers.
- */
-void _swarn_join(const char * file, int line, const char * func, char** msg, const char *format, ...)  __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull (1, 3, 5)));
 
 /* Function to read the logging format configuration */
 void os_logging_config(void);

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -69,35 +69,33 @@ void _mferror(const char * file, int line, const char * func, const char *msg, .
 void _mtferror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
 void _merror_exit(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull)) __attribute__ ((noreturn));
 void _mterror_exit(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull)) __attribute__ ((noreturn));
+
 /** 
- * Generate a new error msg and concatenate to *msg
- * 
- * If *msg==NULL, alloc the memory and cat the error msg
- * If in debug mode, then append line number, 
- * function and file from where the call was made
- * 
- * @param [in] file
- * @param [in] line
- * @param [in] func
- * @param [out] msg
+ * @brief Generate a new error string and concatenate to *msg
+ * @details If in debug mode, then append line number,
+ * function and file from where the call was made to msg
+ * @param [in] file file name from where the function was called. the __FILE__ macro should be used
+ * @param [in] line line number from where the function was called. the __LINE__ macro should be used
+ * @param [in] func function name from where the function was called. the __func__ macro should be used
+ * @param [out] msg Destination of error string, if *msg==null, memory are allocate, otherwise
+ *                  memory are reallocate and error messages are concatenated to the *msg string.
  * @param [in] format includes format specifiers (subsequences beginning with %) for printf
- * @param [in] ...  additional arguments following format are formatted and inserted in the 
+ * @param [in] ...  additional arguments following format are formatted and inserted in the
  *                  resulting string replacing their respective specifiers.
  */
 void _serror_join(const char * file, int line, const char * func, char** msg, const char *format, ...)  __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull (1, 3, 5)));
+
 /** 
- * Generate a new warning msg and concatenate to *msg
- * 
- * If *msg==NULL, alloc the memory and cat the warning msg
- * If in debug mode, then append line number, 
- * function and file from where the call was made
- * 
- * @param [in] file
- * @param [in] line
- * @param [in] func
- * @param [out] msg
+ * @brief Generate a new warning string and concatenate to *msg
+ * @details If in debug mode, then append line number,
+ * function and file from where the call was made to msg
+ * @param [in] file file name from where the function was called. the __FILE__ macro should be used
+ * @param [in] line line number from where the function was called. the __LINE__ macro should be used
+ * @param [in] func function name from where the function was called. the __func__ macro should be used
+ * @param [out] msg Destination of error string, if *msg==null, memory are allocate, otherwise
+ *                  memory are reallocate and error messages are concatenated to the *msg string.
  * @param [in] format includes format specifiers (subsequences beginning with %) for printf
- * @param [in] ...  additional arguments following format are formatted and inserted in the 
+ * @param [in] ...  additional arguments following format are formatted and inserted in the
  *                  resulting string replacing their respective specifiers.
  */
 void _swarn_join(const char * file, int line, const char * func, char** msg, const char *format, ...)  __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull (1, 3, 5)));

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -43,8 +43,10 @@
 #define mtdebug2(tag, msg, ...) _mtdebug2(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define merror(msg, ...) _merror(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define smerror(msg, format, ...) _serror_join(__FILE__, __LINE__, __func__, msg, format, ##__VA_ARGS__)
 #define mwarn(msg, ...) _mwarn(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mtwarn(tag, msg, ...) _mtwarn(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define smwarn(msg, format, ...) _swarn_join(__FILE__, __LINE__, __func__, msg, format, ##__VA_ARGS__)
 #define minfo(msg, ...) _minfo(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mtinfo(tag, msg, ...) _mtinfo(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mferror(msg, ...) _mferror(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
@@ -67,6 +69,38 @@ void _mferror(const char * file, int line, const char * func, const char *msg, .
 void _mtferror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
 void _merror_exit(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull)) __attribute__ ((noreturn));
 void _mterror_exit(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull)) __attribute__ ((noreturn));
+/** 
+ * Generate a new error msg and concatenate to *msg
+ * 
+ * If *msg==NULL, alloc the memory and cat the error msg
+ * If in debug mode, then append line number, 
+ * function and file from where the call was made
+ * 
+ * @param [in] file
+ * @param [in] line
+ * @param [in] func
+ * @param [out] msg
+ * @param [in] format includes format specifiers (subsequences beginning with %) for printf
+ * @param [in] ...  additional arguments following format are formatted and inserted in the 
+ *                  resulting string replacing their respective specifiers.
+ */
+void _serror_join(const char * file, int line, const char * func, char** msg, const char *format, ...)  __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull (1, 3, 5)));
+/** 
+ * Generate a new warning msg and concatenate to *msg
+ * 
+ * If *msg==NULL, alloc the memory and cat the warning msg
+ * If in debug mode, then append line number, 
+ * function and file from where the call was made
+ * 
+ * @param [in] file
+ * @param [in] line
+ * @param [in] func
+ * @param [out] msg
+ * @param [in] format includes format specifiers (subsequences beginning with %) for printf
+ * @param [in] ...  additional arguments following format are formatted and inserted in the 
+ *                  resulting string replacing their respective specifiers.
+ */
+void _swarn_join(const char * file, int line, const char * func, char** msg, const char *format, ...)  __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull (1, 3, 5)));
 
 /* Function to read the logging format configuration */
 void os_logging_config(void);

--- a/src/headers/validate_op.h
+++ b/src/headers/validate_op.h
@@ -115,9 +115,10 @@ int OS_IsAfterTime(const char *time_str, const char *ossec_time) __attribute__((
  *      weekdays, weekends, monday, tuesday, thursday,..
  *      monday,tuesday
  *      mon,tue wed
- * @param day_str Day to be validated.
- * @param msg If an error occurs the msg will be stored in *msg
+ * @param[in] day_str Day to be validated.
+ * @param[out] **msg Store warnings and error as result of call
  * @return Returns 0 if doesn't match or a valid string in success.
+ * @note If *msg==null, memory are allocate, otherwise error messages are concatenated to the *msg string.
  */
 char *OS_IsValidDay(const char *day_str, char **msg);
 

--- a/src/headers/validate_op.h
+++ b/src/headers/validate_op.h
@@ -115,12 +115,10 @@ int OS_IsAfterTime(const char *time_str, const char *ossec_time) __attribute__((
  *      weekdays, weekends, monday, tuesday, thursday,..
  *      monday,tuesday
  *      mon,tue wed
- * @param[in] day_str Day to be validated.
- * @param[out] **msg Store warnings and error as result of call
+ * @param day_str Day to be validated.
  * @return Returns 0 if doesn't match or a valid string in success.
- * @note If *msg==null, memory are allocate, otherwise error messages are concatenated to the *msg string.
  */
-char *OS_IsValidDay(const char *day_str, char **msg);
+char *OS_IsValidDay(const char *day_str);
 
 
 /**

--- a/src/headers/validate_op.h
+++ b/src/headers/validate_op.h
@@ -116,9 +116,10 @@ int OS_IsAfterTime(const char *time_str, const char *ossec_time) __attribute__((
  *      monday,tuesday
  *      mon,tue wed
  * @param day_str Day to be validated.
+ * @param msg If an error occurs the msg will be stored in *msg
  * @return Returns 0 if doesn't match or a valid string in success.
  */
-char *OS_IsValidDay(const char *day_str);
+char *OS_IsValidDay(const char *day_str, char **msg);
 
 
 /**

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -354,11 +354,9 @@ static char* _smsg(int level, const char * file, int line, const char * func, co
       "CRITICAL",
     };
 
-    if (isDebug())
-    {
+    if (isDebug()) {
         (void) snprintf(str, OS_BUFFER_SIZE, "%s:%d at %s(): %s: ", file, line, func, strlevel[level]);
-    } else
-    {
+    } else {
         (void) snprintf(str, OS_BUFFER_SIZE, "%s: ", strlevel[level]);
     }
     

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -27,7 +27,6 @@ struct{
 } flags;
 
 static void _log(int level, const char *tag, const char * file, int line, const char * func, const char *msg, va_list args) __attribute__((format(printf, 5, 0))) __attribute__((nonnull));
-static char* _smsg(int level, const char * file, int line, const char * func, const char *msg, va_list args)  __attribute__((nonnull));
 
 
 #ifdef WIN32
@@ -339,73 +338,6 @@ void _merror(const char * file, int line, const char * func, const char *msg, ..
     _log(level, tag, file, line, func, msg, args);
     va_end(args);
 }
-
-static char* _smsg(int level, const char * file, int line, const char * func, const char *msg, va_list args){
-    
-    const char *tag = __local_name;
-    char* str = NULL;
-    os_malloc(OS_BUFFER_SIZE, str);
-    str[0] = '\0';
-    char *timestamp = w_get_timestamp(time(NULL));
-    
-    
-    const char *strlevel[5]={
-      "DEBUG",
-      "INFO",
-      "WARNING",
-      "ERROR",
-      "CRITICAL",
-    };
-
-    (void) snprintf(str, OS_BUFFER_SIZE, "%s ", timestamp);
-
-    if (isDebug()) {
-        (void) snprintf(str + strlen(str), OS_BUFFER_SIZE, "%s[%d] %s:%d at %s(): %s: ", tag, pid, file, line, func, strlevel[level]);
-    } else {
-        (void) snprintf(str + strlen(str), OS_BUFFER_SIZE, "%s: ", strlevel[level]);
-    }
-    
-    (void) vsnprintf(str + strlen(str), OS_BUFFER_SIZE - strlen(str), msg, args);
-    
-    os_realloc(str, strlen(str) + 1, str);
-    
-    return str;
-}
-
-
-void _serror_join(const char * file, int line, const char * func, char** msg, const char *format, ...)
-{
-    va_list args;
-    char* new_msg;
-    int level = LOGLEVEL_ERROR;
-
-    va_start(args, format);
-    new_msg = _smsg(level, file, line, func, format, args);
-    va_end(args);
-    if (*msg) {
-        wm_strcat(msg, "\n", 0);
-    }
-    wm_strcat(msg, new_msg, 0);
-    os_free(new_msg);
-    
-};
-
-
-void _swarn_join(const char * file, int line, const char * func, char** msg, const char *format, ...)
-{
-    va_list args;
-    char* new_msg;
-    int level = LOGLEVEL_WARNING;
-    
-    va_start(args, format);
-    new_msg = _smsg(level, file, line, func, format, args);
-    va_end(args);
-    if (*msg) {
-        wm_strcat(msg, "\n", 0);
-    }
-    wm_strcat(msg, new_msg, 0);
-    os_free(new_msg); 
-};
 
 void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -342,9 +342,12 @@ void _merror(const char * file, int line, const char * func, const char *msg, ..
 
 static char* _smsg(int level, const char * file, int line, const char * func, const char *msg, va_list args){
     
+    const char *tag = __local_name;
     char* str = NULL;
     os_malloc(OS_BUFFER_SIZE, str);
     str[0] = '\0';
+    char *timestamp = w_get_timestamp(time(NULL));
+    
     
     const char *strlevel[5]={
       "DEBUG",
@@ -354,14 +357,15 @@ static char* _smsg(int level, const char * file, int line, const char * func, co
       "CRITICAL",
     };
 
+    (void) snprintf(str, OS_BUFFER_SIZE, "%s ", timestamp);
+
     if (isDebug()) {
-        (void) snprintf(str, OS_BUFFER_SIZE, "%s:%d at %s(): %s: ", file, line, func, strlevel[level]);
+        (void) snprintf(str + strlen(str), OS_BUFFER_SIZE, "%s[%d] %s:%d at %s(): %s: ", tag, pid, file, line, func, strlevel[level]);
     } else {
-        (void) snprintf(str, OS_BUFFER_SIZE, "%s: ", strlevel[level]);
+        (void) snprintf(str + strlen(str), OS_BUFFER_SIZE, "%s: ", strlevel[level]);
     }
     
     (void) vsnprintf(str + strlen(str), OS_BUFFER_SIZE - strlen(str), msg, args);
-    (void) snprintf(str + strlen(str), OS_BUFFER_SIZE - strlen(str), "\n");
     
     os_realloc(str, strlen(str) + 1, str);
     
@@ -378,6 +382,9 @@ void _serror_join(const char * file, int line, const char * func, char** msg, co
     va_start(args, format);
     new_msg = _smsg(level, file, line, func, format, args);
     va_end(args);
+    if (*msg) {
+        wm_strcat(msg, "\n", 0);
+    }
     wm_strcat(msg, new_msg, 0);
     os_free(new_msg);
     
@@ -393,6 +400,9 @@ void _swarn_join(const char * file, int line, const char * func, char** msg, con
     va_start(args, format);
     new_msg = _smsg(level, file, line, func, format, args);
     va_end(args);
+    if (*msg) {
+        wm_strcat(msg, "\n", 0);
+    }
     wm_strcat(msg, new_msg, 0);
     os_free(new_msg); 
 };

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -27,6 +27,8 @@ struct{
 } flags;
 
 static void _log(int level, const char *tag, const char * file, int line, const char * func, const char *msg, va_list args) __attribute__((format(printf, 5, 0))) __attribute__((nonnull));
+static char* _smsg(int level, const char * file, int line, const char * func, const char *msg, va_list args)  __attribute__((nonnull));
+
 
 #ifdef WIN32
 void WinSetError();
@@ -337,6 +339,65 @@ void _merror(const char * file, int line, const char * func, const char *msg, ..
     _log(level, tag, file, line, func, msg, args);
     va_end(args);
 }
+
+static char* _smsg(int level, const char * file, int line, const char * func, const char *msg, va_list args){
+    
+    char* str = NULL;
+    os_malloc(OS_BUFFER_SIZE, str);
+    str[0] = '\0';
+    
+    const char *strlevel[5]={
+      "DEBUG",
+      "INFO",
+      "WARNING",
+      "ERROR",
+      "CRITICAL",
+    };
+
+    if (isDebug())
+    {
+        (void) snprintf(str, OS_BUFFER_SIZE, "%s:%d at %s(): %s: ", file, line, func, strlevel[level]);
+    } else
+    {
+        (void) snprintf(str, OS_BUFFER_SIZE, "%s: ", strlevel[level]);
+    }
+    
+    (void) vsnprintf(str + strlen(str), OS_BUFFER_SIZE - strlen(str), msg, args);
+    (void) snprintf(str + strlen(str), OS_BUFFER_SIZE - strlen(str), "\n");
+    
+    os_realloc(str, strlen(str) + 1, str);
+    
+    return str;
+}
+
+
+void _serror_join(const char * file, int line, const char * func, char** msg, const char *format, ...)
+{
+    va_list args;
+    char* new_msg;
+    int level = LOGLEVEL_ERROR;
+
+    va_start(args, format);
+    new_msg = _smsg(level, file, line, func, format, args);
+    va_end(args);
+    wm_strcat(msg, new_msg, 0);
+    os_free(new_msg);
+    
+};
+
+
+void _swarn_join(const char * file, int line, const char * func, char** msg, const char *format, ...)
+{
+    va_list args;
+    char* new_msg;
+    int level = LOGLEVEL_WARNING;
+    
+    va_start(args, format);
+    new_msg = _smsg(level, file, line, func, format, args);
+    va_end(args);
+    wm_strcat(msg, new_msg, 0);
+    os_free(new_msg); 
+};
 
 void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...)
 {

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -319,10 +319,15 @@ int OS_ReadXMLRules(const char *rulefile,
                         config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                     }
                 } else if (strcasecmp(rule_opt[k]->element, xml_week_day) == 0) {
+                    char *err_msg = NULL;
                     config_ruleinfo->week_day =
-                        OS_IsValidDay(rule_opt[k]->content);
+                        OS_IsValidDay(rule_opt[k]->content, &err_msg);
 
                     if (!config_ruleinfo->week_day) {
+                        if(err_msg){
+                            merror(INVALID_DAY, node[i]->content);
+                            os_free(err_msg);
+                        }
                         merror(INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                         retval = -1;
                         goto cleanup;

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -324,7 +324,7 @@ int OS_ReadXMLRules(const char *rulefile,
                         OS_IsValidDay(rule_opt[k]->content, &err_msg);
 
                     if (!config_ruleinfo->week_day) {
-                        if(err_msg){
+                        if (err_msg) {
                             merror(INVALID_DAY, node[i]->content);
                             os_free(err_msg);
                         }

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -319,15 +319,11 @@ int OS_ReadXMLRules(const char *rulefile,
                         config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                     }
                 } else if (strcasecmp(rule_opt[k]->element, xml_week_day) == 0) {
-                    char *err_msg = NULL;
                     config_ruleinfo->week_day =
-                        OS_IsValidDay(rule_opt[k]->content, &err_msg);
+                        OS_IsValidDay(rule_opt[k]->content);
 
                     if (!config_ruleinfo->week_day) {
-                        if (err_msg) {
-                            merror(INVALID_DAY, node[i]->content);
-                            os_free(err_msg);
-                        }
+                        merror(INVALID_DAY, rule_opt[k]->content);
                         merror(INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
                         retval = -1;
                         goto cleanup;

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -695,7 +695,7 @@ int OS_IsonDay(int week_day, const char *ossec_day)
 
 #define IS_SEP(x) (*x == ' ' || *x == ',')
 
-char *OS_IsValidDay(const char *day_str)
+char *OS_IsValidDay(const char *day_str, char **msg)
 {
     int i = 0, ng = 0;
     char *ret;
@@ -745,7 +745,7 @@ char *OS_IsValidDay(const char *day_str)
         }
 
         if (!days[i]) {
-            merror(INVALID_DAY, day_str);
+            smerror(msg,INVALID_DAY, day_str);
             return (NULL);
         }
 
@@ -757,7 +757,7 @@ char *OS_IsValidDay(const char *day_str)
         } else if (*day_str == '\0') {
             break;
         } else {
-            merror(INVALID_DAY, day_str);
+            smerror(msg,INVALID_DAY, day_str);
             return (NULL);
         }
     }
@@ -781,7 +781,7 @@ char *OS_IsValidDay(const char *day_str)
     /* At least one day must be checked */
     if (ng == 0) {
         free(ret);
-        merror(INVALID_DAY, day_str);
+        smerror(msg,INVALID_DAY, day_str);
         return (NULL);
     }
 

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -695,7 +695,7 @@ int OS_IsonDay(int week_day, const char *ossec_day)
 
 #define IS_SEP(x) (*x == ' ' || *x == ',')
 
-char *OS_IsValidDay(const char *day_str, char **msg)
+char *OS_IsValidDay(const char *day_str)
 {
     int i = 0, ng = 0;
     char *ret;
@@ -745,7 +745,6 @@ char *OS_IsValidDay(const char *day_str, char **msg)
         }
 
         if (!days[i]) {
-            smerror(msg,INVALID_DAY, day_str);
             return (NULL);
         }
 
@@ -757,7 +756,6 @@ char *OS_IsValidDay(const char *day_str, char **msg)
         } else if (*day_str == '\0') {
             break;
         } else {
-            smerror(msg,INVALID_DAY, day_str);
             return (NULL);
         }
     }
@@ -781,7 +779,6 @@ char *OS_IsValidDay(const char *day_str, char **msg)
     /* At least one day must be checked */
     if (ng == 0) {
         free(ret);
-        smerror(msg,INVALID_DAY, day_str);
         return (NULL);
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5363|

Hi team!

The following Analysisd's modifications are necessary to wazuh-logtest,
When analysisd call Rules_OP_ReadRules or ReadDecodeXML functions for read Ruleset and fails, will not write messages in log file instead they now accept a new parameter to store warnings and errors.
This will allow messages to be sent through the socket instead of being written to log

#### Warning
This PR contains a memory leak, whens fail to add a new rule, this will be fixed by[ PR:5543](https://github.com/wazuh/wazuh/pull/5543)

Best regards,
Julian

## Tests
- [x] Compilation without warnings Linux
- [x] Compilation without warnings Windows
- [x] Scan-build report
- [x] Valgrind
- [X] Single error msg
- [X] Multiples error msg
- [x] Doxygen
