### PR TITLE
Added set max rows action to testtool.

### DIFF
--- a/src/dbsync/testtool/action.h
+++ b/src/dbsync/testtool/action.h
@@ -115,4 +115,28 @@ struct CloseTransactionAction final : public IAction
     }
 };
 
+struct SetMaxRowsAction final : public IAction
+{
+    void execute(std::unique_ptr<TestContext>& ctx,
+                 const nlohmann::json& value) override
+    {
+        const auto table{value["body"]["table"].get<std::string>()};
+        const auto maxRows{value["body"]["max_rows"].get<unsigned int>()};
+        const auto retVal
+        {
+            dbsync_set_table_max_rows(ctx->handle,
+                                      table.c_str(),
+                                      maxRows)
+        };
+
+        std::stringstream oFileName;
+        oFileName << "action_" << ctx->currentId << ".json";
+        const auto outputFileName{ ctx->outputPath + "/" + oFileName.str() };
+
+        std::ofstream outputFile{ outputFileName };
+        const nlohmann::json jsonResult = { {"dbsync_set_table_max_rows", retVal } };
+        outputFile << jsonResult.dump() << std::endl;
+    }
+};
+
 #endif //_ACTION_H

--- a/src/dbsync/testtool/factoryAction.h
+++ b/src/dbsync/testtool/factoryAction.h
@@ -31,6 +31,10 @@ public:
         {
             return std::make_unique<CloseTransactionAction>();
         }
+        else if (0 == actionCode.compare("dbsync_set_table_max_rows"))
+        {
+            return std::make_unique<SetMaxRowsAction>();
+        }
         else
         {
             throw std::runtime_error { "Invalid action: " + actionCode };

--- a/src/dbsync/testtool/input/input6.json
+++ b/src/dbsync/testtool/input/input6.json
@@ -1,0 +1,7 @@
+{
+    "action": "dbsync_set_table_max_rows",
+    "body": {
+        "table": "processes",
+        "max_rows":100
+    }
+}


### PR DESCRIPTION
|Related issue|
|---|
|#5416|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR the dbsync_set_table_max_rows use was added to the dbsync test tool in order to extend the capabilities of the tool.
A json example was added with the action expected body.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
