### PR TITLE
Check NVD dependencies all the times the NVD detected a vulnerability

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1532,7 +1532,7 @@ void wm_vuldet_linux_rm_nvd_not_dependencies_met_packages(const char *cve, cve_v
     do {
         next = pkg->next;
 
-        if ((pkg->feed == VU_SRC_NVD) && !pkg->discard && pkg->nvd_cond) {
+        if ((pkg->feed & VU_SRC_NVD) && !pkg->discard && pkg->nvd_cond) {
 
             if (pkg->nvd_cond->parent == 0 && !strcmp(pkg->nvd_cond->operator, "AND")) { // Analyze children
                 int child = 0;
@@ -1598,7 +1598,7 @@ void wm_vuldet_linux_rm_nvd_not_vulnerable_packages(const char *cve, cve_vuln_pk
     do {
         next = pkg->next;
 
-        if ((pkg->feed == VU_SRC_NVD) && !pkg->discard && pkg->nvd_cond && !pkg->nvd_cond->vulnerable) {
+        if ((pkg->feed & VU_SRC_NVD) && !pkg->discard && pkg->nvd_cond && !pkg->nvd_cond->vulnerable) {
             // Some packages are dependencies of others but aren't vulnerable, so we won't alert those packages
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_DEP_NOT_VU, pkg->bin_name, cve);
             pkg->discard = 1;
@@ -1898,7 +1898,7 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
             os_strdup(condition, vuln_pkg->vuln_cond->condition);
         }
 
-        vuln_pkg->feed = VU_SRC_OVAL;
+        vuln_pkg->feed |= VU_SRC_OVAL;
         vuln_pkg->discard = 0;
         vuln_pkg->next = NULL;
 


### PR DESCRIPTION
## Description

The change introduced at this PR affects the filter to discard false positives after running the vulnerability scan for Linux agents. When detecting an affected package through the NVD scan, its dependencies and vulnerable flag are stored to be checked after the scan.

That check was only performed if the affected package is only detected by the NVD and not by the vendor feed. That check should be performed always there are dependencies to check.

## Testing results

- No changes in the vulnerabilities reported for Ubuntu and Debian agents.
- For RHEL6, 9 CVEs are now discarded
```
CVE-2010-1439
CVE-2014-8128
CVE-2014-8767
CVE-2014-9471
CVE-2015-1777
CVE-2015-4035
CVE-2016-4608
CVE-2016-4610
CVE-2016-9318
```
- For RHEL7, 6 CVEs are discarded
```
CVE-2014-8128
CVE-2014-9471
CVE-2015-1777
CVE-2016-4608
CVE-2016-4610
CVE-2016-9318
```
- No changes appeared for RHEL5 and RHEL8

Some of the removed CVEs:

*CVE-2014-9471*

- https://nvd.nist.gov/vuln/detail/CVE-2014-9471
- https://access.redhat.com/security/cve/CVE-2014-9471

Marked as vulnerable when running on Ubuntu by the NVD. The RedHat site classifies it as `Will not fix`.

*CVE-2016-4608*

- https://nvd.nist.gov/vuln/detail/CVE-2016-4608
- https://access.redhat.com/security/cve/CVE-2016-4608

The NVD marks the `libxslt` as vulnerable when running over Apple products.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
