### PR TITLE
Fix default gateway data gathering in Syscollector on Linux 2.6

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -1396,18 +1396,24 @@ char* get_default_gateway(char *ifa_name){
     struct in_addr address;
     int destination, gateway, flags, ref, use, metric;
     char * def_gateway;
+    bool is_first_line = true;
+    bool starts_with_default_gw = false;
     os_calloc(V_LENGTH, sizeof(char) + 1, def_gateway);
 
     strncpy(interface, ifa_name, sizeof(interface) - 1);
     snprintf(file_location, PATH_LENGTH, "%s%s", WM_SYS_NET_DIR, "route");
     snprintf(def_gateway, V_LENGTH, "%s", "unknown");
 
-    if ((fp = fopen(file_location, "r"))){
+    if ((fp = fopen(file_location, "r"))) {
 
-        while (fgets(string, OS_MAXSTR, fp) != NULL){
+        while (fgets(string, OS_MAXSTR, fp) != NULL) {
+            if (sscanf(string, "%s %8x %8x %d %d %d %d", if_name, &destination, &gateway, &flags, &ref, &use, &metric) == 7) {
+                if (is_first_line) {
+                    is_first_line = false;
+                    starts_with_default_gw = (destination == 0);
+                }
 
-            if (sscanf(string, "%s %8x %8x %d %d %d %d", if_name, &destination, &gateway, &flags, &ref, &use, &metric) == 7){
-                if (destination != 00000000) {
+                if (starts_with_default_gw && destination != 0) {
                     break;
                 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#5479|

This PR fixes a regression by #5088, which assumed that the kernel routing table always starts with the default gateway. This happens as of Linux 3.0.

## Proposed fix

Apply the optimization only if the routing table starts with the default gateway (_destination = 0_).

## API query

### Agent data

```json
{
   "error": 0,
   "data": {
      "os": {
         "arch": "x86_64",
         "major": "6",
         "minor": "10",
         "name": "CentOS Linux",
         "platform": "centos",
         "uname": "Linux |centos6 |2.6.32-754.29.1.el6.x86_64 |#1 SMP Mon Apr 27 15:30:33 UTC 2020 |x86_64",
         "version": "6.10"
      },
      "mergedSum": "fd756ba04d9c32c8848d4608bec41251",
      "status": "Active",
      "id": "002",
      "node_name": "node01",
      "manager": "focal",
      "version": "Wazuh v4.0.0",
      "dateAdd": "1970-01-01 00:00:00",
      "ip": "10.0.2.15",
      "registerIP": "any",
      "name": "centos6",
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "lastKeepAlive": "2020-07-24 14:54:31"
   }
}
```

### Network protocol

```json
{
   "error": 0,
   "data": {
      "items": [
         {
            "scan": {
               "id": 2013751560
            },
            "iface": "eth0",
            "type": "ipv4",
            "gateway": "0.0.0.0",
            "dhcp": "enabled"
         },
         {
            "scan": {
               "id": 2013751560
            },
            "iface": "eth0",
            "type": "ipv6",
            "dhcp": "enabled"
         },
         {
            "scan": {
               "id": 2013751560
            },
            "iface": "eth1",
            "type": "ipv4",
            "gateway": "0.0.0.0",
            "dhcp": "disabled"
         },
         {
            "scan": {
               "id": 2013751560
            },
            "iface": "eth1",
            "type": "ipv6",
            "dhcp": "enabled"
         }
      ],
      "totalItems": 4
   }
}
```

## Affects

### Artifacts

- wazuh-modulesd

### Components

- Syscollector (network inventory)
- Agentd (primary IP report)

### Platforms

- Linux exclusively

## Tests

### Features

- [X] The algorithm flow is correct on CentOS 6.
- [X] The algorithm flow is correct on Ubuntu 20.04.
- [X] The API reports the primary CentOS 6 agent's IP.

### Building

- [X] Agent on CentOS 6.
- [x] Agent on CentOS 7.
- [x] Agent on CentOS 8.
- [X] Manager on Ubuntu 20.04.

### Code analysis

- [x] Coverity scan.

### Memory analysis

- [x] Valgrind.