### PR TITLE
Get deletions in transaction

### DIFF
--- a/src/dbsync/include/dbsync.h
+++ b/src/dbsync/include/dbsync.h
@@ -66,7 +66,8 @@ EXPORTED void dbsync_teardown(void);
  * @param thread_number  Number of worker threads for processing data. If 0 hardware concurrency
  *                       value will be used.
  * @param max_queue_size Max data number to hold/queue to be processed.
- * @param callback       This callback will be called for each result.
+ * @param callback_data  This struct contain the result callback will be called for each result
+ *                       and user data space returned in each callback call.
  *
  * @return Handle instance to be used in transacted operations.
  *
@@ -76,7 +77,7 @@ EXPORTED TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE handle,
                                       const cJSON*        tables,
                                       const unsigned int  thread_number,
                                       const unsigned int  max_queue_size,
-                                      result_callback_t   callback);
+                                      callback_data_t     callback_data);
 
 /**
  * @brief Closes the \p txn database transaction.
@@ -150,30 +151,32 @@ EXPORTED int dbsync_set_table_max_rows(const DBSYNC_HANDLE      handle,
 /**
  * @brief Inserts (or modifies) a database record.
  *
- * @param handle    Handle instance assigned as part of the \ref dbsync_create method().
- * @param input     JSON information used to add/modified a database record.
- * @param callback  This callback will be called for each result.
+ * @param handle         Handle instance assigned as part of the \ref dbsync_create method().
+ * @param input          JSON information used to add/modified a database record.
+ * @param callback_data  This struct contain the result callback will be called for each result
+ *                       and user data space returned in each callback call.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
  */
 EXPORTED int dbsync_sync_row(const DBSYNC_HANDLE handle,
                              const cJSON*        js_input,
-                             result_callback_t   callback);
+                             callback_data_t     callback_data);
 
 /**
  * @brief Select data, based in \p json_data_input data, from the database table.
  *
- * @param handle        Handle assigned as part of the \ref dbsync_create method().
- * @param js_data_input JSON with table name, fields and filters to apply in the query.
- * @param callback      This callback will be called for each result.
+ * @param handle          Handle assigned as part of the \ref dbsync_create method().
+ * @param js_data_input   JSON with table name, fields and filters to apply in the query.
+ * @param callback_data   This struct contain the result callback will be called for each result
+ *                        and user data space returned in each callback call.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
  */
 EXPORTED int dbsync_select_rows(const DBSYNC_HANDLE handle,
                                 const cJSON*        js_data_input,
-                                result_callback_t   callback);
+                                callback_data_t     callback_data);
 
 /**
  * @brief Deletes a database table record and its relationships based on \p js_key_values value.
@@ -190,14 +193,15 @@ EXPORTED int dbsync_delete_rows(const DBSYNC_HANDLE handle,
 /**
  * @brief Gets the deleted rows (diff) from the database.
  *
- * @param txn      Database transaction to be used.
- * @param callback This callback will be called for each result.
+ * @param txn             Database transaction to be used.
+ * @param callback_data   This struct contain the result callback will be called for each result
+ *                        and user data space returned in each callback call.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
  */
 EXPORTED int dbsync_get_deleted_rows(const TXN_HANDLE  txn,
-                                     result_callback_t callback);
+                                     callback_data_t   callback_data);
 
 /**
  * @brief Updates data table with \p js_snapshot information. \p js_result value will
@@ -219,16 +223,17 @@ EXPORTED int dbsync_update_with_snapshot(const DBSYNC_HANDLE handle,
 /**
  * @brief Update data table, based on json_raw_snapshot bulk data based on json string.
  *
- * @param handle      Handle assigned as part of the \ref dbsync_create method().
- * @param js_snapshot JSON with snapshot values.
- * @param callback    This callback will be called for each result.
+ * @param handle          Handle assigned as part of the \ref dbsync_create method().
+ * @param js_snapshot     JSON with snapshot values.
+ * @param callback_data   This struct contain the result callback will be called for each result
+ *                        and user data space returned in each callback call.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
  */
   EXPORTED int dbsync_update_with_snapshot_cb(const DBSYNC_HANDLE handle,
                                               const cJSON*        js_snapshot,
-                                              result_callback_t   callback);
+                                              callback_data_t     callback_data);
 
 /**
  * @brief Deallocate cJSON result data.

--- a/src/dbsync/include/typedef.h
+++ b/src/dbsync/include/typedef.h
@@ -62,7 +62,20 @@ typedef void* TXN_HANDLE;
  *
  * @details Callback called for each obtained result, after evaluating changes between two snapshots.
  */
-typedef void((*result_callback_t)(ReturnTypeCallback result_type, const cJSON* result_json));
+typedef void((*result_callback_t)(ReturnTypeCallback result_type, const cJSON* result_json, void* user_data));
+
+/** @struct CallbackData
+ *  This struct contain the result callback will be called for each result
+ *  and user data space returned in each callback call.
+ *  The instance of this structure lives in the library's consumer ecosystem.
+ */
+typedef struct 
+{
+    /*@{*/
+    result_callback_t callback;     /**< Result callback. */
+    void* user_data;                /**< User data space returned in each callback. */
+    /*@}*/
+} CallbackData, *callback_data_t;
 
 /**
  * @brief Callback function for user defined logging.

--- a/src/dbsync/src/db_exception.h
+++ b/src/dbsync/src/db_exception.h
@@ -20,6 +20,7 @@ constexpr auto SQLITE_CONNECTION_ERROR  { std::make_pair(4, "No connection avail
 constexpr auto EMPTY_DATABASE_PATH      { std::make_pair(5, "Empty database store path.") };
 constexpr auto EMPTY_TABLE_METADATA     { std::make_pair(6, "Empty table metadata.") };
 constexpr auto INVALID_PARAMETERS       { std::make_pair(7, "Invalid parameters.") };
+constexpr auto DATATYPE_NOT_IMPLEMENTED { std::make_pair(8, "Datatype not implemented.") };
 
 namespace DbSync
 {

--- a/src/dbsync/src/dbengine.h
+++ b/src/dbsync/src/dbengine.h
@@ -42,6 +42,9 @@ namespace DbSync
 
         virtual void deleteRowsByStatusField(const nlohmann::json& tableNames) = 0;
 
+        virtual void returnRowsMarkedForDelete(const nlohmann::json& tableNames, 
+                                               const DbSync::ResultCallback callback) = 0;
+
         virtual ~IDbEngine() = default;
 
     protected:

--- a/src/dbsync/src/dbsyncPipelineFactory.cpp
+++ b/src/dbsync/src/dbsyncPipelineFactory.cpp
@@ -69,13 +69,13 @@ namespace DbSync
                 dispatchResult(result);
             }
         }
-        void getDeleted(ResultCallback /*callback*/) override
+        void getDeleted(ResultCallback callback) override
         {
             if (m_spSyncNode)
             {
                 m_spSyncNode->rundown();
             }
-            // DBSyncImplementation::instance().getDeleted(m_handle, m_txnContext, calback);
+            DBSyncImplementation::instance().getDeleted(m_handle, m_txnContext, callback);
         }
     private:
         using SyncResult = std::tuple<ReturnTypeCallback, nlohmann::json>;

--- a/src/dbsync/src/dbsync_implementation.cpp
+++ b/src/dbsync/src/dbsync_implementation.cpp
@@ -106,3 +106,13 @@ void DBSyncImplementation::closeTransaction(const DBSYNC_HANDLE handle,
     ctx->m_dbEngine->deleteRowsByStatusField(tnxCtx->m_tables);
     ctx->deleteTransactionContext(txn);
 }
+
+void DBSyncImplementation::getDeleted(const DBSYNC_HANDLE   handle, 
+                                      const TXN_HANDLE      txnHandle,
+                                      const ResultCallback  callback)
+{
+    const auto& ctx{ dbEngineContext(handle) };
+    const auto& tnxCtx { ctx->transactionContext(txnHandle) };
+
+    ctx->m_dbEngine->returnRowsMarkedForDelete(tnxCtx->m_tables, callback);
+}

--- a/src/dbsync/src/dbsync_implementation.h
+++ b/src/dbsync/src/dbsync_implementation.h
@@ -21,7 +21,7 @@
 
 namespace DbSync
 {
-    class DBSyncImplementation
+    class DBSyncImplementation final
     {
     public:
         static DBSyncImplementation& instance()
@@ -56,17 +56,21 @@ namespace DbSync
         void closeTransaction(const DBSYNC_HANDLE handle,
                               const TXN_HANDLE txnHandle);
 
+        void getDeleted(const DBSYNC_HANDLE   handle, 
+                        const TXN_HANDLE      txnHandle,
+                        const ResultCallback  callback);
+
         void release();
     private:
 
-        struct TransactionContext
+        struct TransactionContext final
         {
             explicit TransactionContext(const nlohmann::json& tables) 
             : m_tables(std::move(tables))
             {}
             nlohmann::json m_tables;
         };
-        class DbEngineContext
+        class DbEngineContext final
         {
             public:
                 DbEngineContext(std::unique_ptr<IDbEngine>& dbEngine,

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -170,6 +170,48 @@ void SQLiteDBEngine::deleteRowsByStatusField(const nlohmann::json& tableNames)
     transaction->commit();
 }
 
+void SQLiteDBEngine::returnRowsMarkedForDelete(const nlohmann::json& tableNames, 
+                                               const DbSync::ResultCallback callback)
+{
+    for (const auto& tableValue : tableNames)
+    {
+        const auto& table { tableValue.get<std::string>() };
+
+        if (0 != loadTableData(table)) 
+        {
+            const auto& tableFields { m_tableFields[table] };
+            auto const& stmt { getStatement(getSelectAllQuery(table, tableFields)) };
+            
+            while (SQLITE_ROW == stmt->step())
+            {
+                Row registerFields;
+                for(const auto& field : tableFields)
+                {
+                    if (!std::get<TableHeader::TXNStatusField>(field))
+                    {
+                        getTableData(stmt, 
+                                 std::get<TableHeader::CID>(field), 
+                                 std::get<TableHeader::Type>(field),
+                                 std::get<TableHeader::Name>(field), 
+                                 registerFields);
+                    }
+                }
+                
+                nlohmann::json object {};
+                for (const auto& value : registerFields)
+                {
+                    getFieldValueFromTuple(value, object);
+                }
+                callback(ReturnTypeCallback::DELETED, object);
+            }
+        }
+        else
+        {
+            throw dbengine_error { EMPTY_TABLE_METADATA };
+        }
+    }
+}
+
 
 ///
 /// Private functions section
@@ -386,7 +428,7 @@ void SQLiteDBEngine::deleteTempTable(const std::string& table)
 { 
     try
     {
-        m_sqliteConnection->execute("DROP TABLE " + table + TEMP_TABLE_SUBFIX + ";");
+        m_sqliteConnection->execute("DROP TABLE IF EXISTS " + table + TEMP_TABLE_SUBFIX + ";");
     }
     //if the table doesn't exist we don't care.
     catch(...)
@@ -427,10 +469,7 @@ bool SQLiteDBEngine::removeNotExistsRows(const std::string& table,
                 nlohmann::json object;
                 for (const auto& value : row)
                 {
-                    if(!getFieldValueFromTuple(value, object))
-                    {
-                        std::cout << "not implemented "<< __LINE__ << " - " << __FILE__ << std::endl;
-                    }
+                    getFieldValueFromTuple(value, object);
                 }
                 if(callback)
                 {
@@ -711,10 +750,7 @@ bool SQLiteDBEngine::insertNewRows(const std::string& table,
             nlohmann::json object;
             for (const auto& value : row)
             {
-                if(!getFieldValueFromTuple(value, object))
-                {
-                    std::cout << "not implemented "<< __LINE__ << " - " << __FILE__ << std::endl;
-                }
+                getFieldValueFromTuple(value, object);
             }
             if(callback)
             {
@@ -770,10 +806,7 @@ int SQLiteDBEngine::changeModifiedRows(const std::string& table,
                 nlohmann::json object;
                 for (const auto& value : row)
                 {
-                    if(!getFieldValueFromTuple(value, object))
-                    {
-                        std::cout << "not implemented "<< __LINE__ << " - " << __FILE__ << std::endl;
-                    }
+                    getFieldValueFromTuple(value, object);
                 }
                 if(callback)
                 {
@@ -799,46 +832,38 @@ std::string SQLiteDBEngine::buildUpdateDataSqlQuery(const std::string& table,
     sql.append(" SET ");
     sql.append(field.first);
     sql.append("=");
-    if (getFieldValueFromTuple(field, sql, true))
+ 
+    getFieldValueFromTuple(field, sql, true);
+    sql.append(" WHERE ");
+    if (0 != primaryKeyList.size())
     {
-        sql.append(" WHERE ");
-        if (0 != primaryKeyList.size())
+        for (const auto& value : primaryKeyList)
         {
-            for (const auto& value : primaryKeyList)
+            const auto it { row.find("PK_"+value) };
+            if (it != row.end())
             {
-                const auto it { row.find("PK_"+value) };
-                if (it != row.end())
-                {
-                    sql.append(value);
-                    sql.append("=");  
-                    if (!getFieldValueFromTuple((*it), sql, true))
-                    {
-                        sql.clear();
-                        break;
-                    }
-                }
-                else
-                {
-                    sql.clear();
-                    break;
-                }
-                sql.append(" AND ");
+                sql.append(value);
+                sql.append("=");  
+                getFieldValueFromTuple((*it), sql, true);
             }
-            sql = sql.substr(0, sql.length()-5);
-            if (sql.length() > 0)
+            else
             {
-                sql.append(";");
+                sql.clear();
+                break;
             }
+            sql.append(" AND ");
         }
-        else
+        sql = sql.substr(0, sql.length()-5);
+        if (sql.length() > 0)
         {
-            sql.clear();
+            sql.append(";");
         }
     }
     else
     {
         sql.clear();
     }
+    
     return sql;
 }
 
@@ -974,10 +999,9 @@ bool SQLiteDBEngine::updateRows(const std::string& table,
     return true;
 }
 
-bool SQLiteDBEngine::getFieldValueFromTuple(const std::pair<const std::string, TableField> &value,
+void SQLiteDBEngine::getFieldValueFromTuple(const Field& value,
                                             nlohmann::json& object)
 {
-    auto ret { true };
     const auto rowType { std::get<GenericTupleIndex::GenType>(value.second) };
     if (ColumnType::BigInt == rowType)
     {
@@ -1001,18 +1025,14 @@ bool SQLiteDBEngine::getFieldValueFromTuple(const std::pair<const std::string, T
     }
     else
     {
-        std::cout << "not implemented "<< __LINE__ << " - " << __FILE__ << std::endl;
-        ret = false;
+        throw DATATYPE_NOT_IMPLEMENTED;
     }
-
-    return ret;
 }
 
-bool SQLiteDBEngine::getFieldValueFromTuple(const std::pair<const std::string, TableField> &value,
+void SQLiteDBEngine::getFieldValueFromTuple(const Field& value,
                                             std::string& resultValue,
                                             const bool quotationMarks)
 {
-    auto ret { true };
     const auto rowType { std::get<GenericTupleIndex::GenType>(value.second) };
     if (ColumnType::BigInt == rowType)
     {
@@ -1043,9 +1063,8 @@ bool SQLiteDBEngine::getFieldValueFromTuple(const std::pair<const std::string, T
     }
     else
     {
-        ret = false;
+        throw DATATYPE_NOT_IMPLEMENTED;
     }
-    return ret;
 }
 
 std::unique_ptr<SQLite::IStatement>const& SQLiteDBEngine::getStatement(const std::string& sql) 
@@ -1063,3 +1082,33 @@ std::unique_ptr<SQLite::IStatement>const& SQLiteDBEngine::getStatement(const std
     }
 }
 
+std::string SQLiteDBEngine::getSelectAllQuery(const std::string& table, 
+                                              const TableColumns& tableFields) const
+{
+    std::string retVal { "SELECT " };
+    
+    if (!tableFields.empty() && !table.empty())
+    {
+        for(const auto& field : tableFields)
+        {
+            if (!std::get<TableHeader::TXNStatusField>(field))
+            {
+                retVal.append(std::get<TableHeader::Name>(field));
+                retVal.append(",");
+            }
+            
+        }
+        retVal = retVal.substr(0, retVal.size()-1);
+        retVal.append(" FROM ");
+        retVal.append(table);
+        retVal.append(" WHERE ");
+        retVal.append(STATUS_FIELD_NAME);
+        retVal.append("=0;");
+    }
+    else 
+    {
+        throw EMPTY_TABLE_METADATA;
+    }
+    
+    return retVal;
+}

--- a/src/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.h
@@ -80,6 +80,8 @@ using TableField =
 
 using Row = std::map<std::string, TableField>;
 
+using Field = std::pair<const std::string, TableField>;
+
 enum ResponseType
 {
     RTJson = 0,
@@ -96,7 +98,7 @@ public:
     }
     {}
 };
-class SQLiteDBEngine : public DbSync::IDbEngine 
+class SQLiteDBEngine final : public DbSync::IDbEngine 
 {
     public:
         SQLiteDBEngine(const std::shared_ptr<ISQLiteFactory>& sqliteFactory,
@@ -120,6 +122,9 @@ class SQLiteDBEngine : public DbSync::IDbEngine
         void initializeStatusField(const nlohmann::json& tableNames) override;
 
         void deleteRowsByStatusField(const nlohmann::json& tableNames) override;
+
+        void returnRowsMarkedForDelete(const nlohmann::json& tableNames, 
+                                       const DbSync::ResultCallback callback) override;
 
     private:
         void initialize(const std::string& path,
@@ -212,11 +217,11 @@ class SQLiteDBEngine : public DbSync::IDbEngine
                         const std::vector<std::string>& primaryKeyList,
                         const std::vector<Row>& rowKeysValue);
 
-        bool getFieldValueFromTuple(const std::pair<const std::string, TableField> &value,
+        void getFieldValueFromTuple(const Field &value,
                                     std::string& resultValue,
                                     const bool quotationMarks = false);
 
-        bool getFieldValueFromTuple(const std::pair<const std::string, TableField> &value,
+        void getFieldValueFromTuple(const Field &value,
                                     nlohmann::json& object);
 
         SQLiteDBEngine(const SQLiteDBEngine&) = delete;
@@ -224,6 +229,9 @@ class SQLiteDBEngine : public DbSync::IDbEngine
         SQLiteDBEngine& operator=(const SQLiteDBEngine&) = delete;
 
         std::unique_ptr<SQLite::IStatement>const& getStatement(const std::string& sql);
+
+        std::string getSelectAllQuery(const std::string& table, 
+                                      const TableColumns& tableFields) const;
 
         std::map<std::string, TableColumns> m_tableFields;
         std::map<std::string, std::unique_ptr<SQLite::IStatement>> m_statementsCache;

--- a/src/dbsync/tests/dbengine/dbengine_test.cpp
+++ b/src/dbsync/tests/dbengine/dbengine_test.cpp
@@ -388,3 +388,127 @@ TEST_F(DBEngineTest, DeleteRowsByStatusFieldNoMetadata)
 
     EXPECT_THROW(spEngine->deleteRowsByStatusField(std::vector<std::string> {"dummy"}), dbengine_error);
 }
+
+TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusFieldNoMetadata)
+{
+    const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
+    const auto& mockConnection { std::make_shared<MockConnection>() };
+    
+    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
+    
+    auto mockStatement_1 { std::make_unique<MockStatement>() };
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockFactory, 
+        createStatement(_,"NNN"))
+        .WillOnce(Return(ByMove(std::move(mockStatement_1))));
+
+    
+    EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+
+    std::unique_ptr<SQLiteDBEngine> spEngine;
+    EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
+        mockFactory,
+        "1", 
+        "NNN"));
+
+    auto mockStatement_2 { std::make_unique<MockStatement>() };
+    EXPECT_CALL(*mockStatement_2, step())
+        .WillOnce(Return(SQLITE_DONE));     
+    EXPECT_CALL(*mockFactory, 
+        createStatement(_,"PRAGMA table_info(dummy);"))
+        .WillOnce(Return(ByMove(std::move(mockStatement_2))));
+
+    EXPECT_THROW(spEngine->returnRowsMarkedForDelete({"dummy"}, nullptr), dbengine_error);
+}
+
+TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
+{
+    const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
+    const auto& mockConnection { std::make_shared<MockConnection>() };
+    
+    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
+    
+    auto mockStatement_1 { std::make_unique<MockStatement>() };
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockFactory, 
+        createStatement(_,"NNN"))
+        .WillOnce(Return(ByMove(std::move(mockStatement_1))));
+
+    
+    EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+
+    std::unique_ptr<SQLiteDBEngine> spEngine;
+    EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
+        mockFactory,
+        "1", 
+        "NNN"));
+
+    auto mockColumn_1 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_1, value(An<const int32_t&>()))
+        .WillOnce(Return(0));
+    auto mockColumn_2 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_2, value(An<const std::string&>()))
+        .WillOnce(Return("PID"));
+    auto mockColumn_3 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_3, value(An<const std::string&>()))
+        .WillOnce(Return("INTEGER"));
+    auto mockColumn_4 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_4, value(An<const int32_t&>()))
+        .WillOnce(Return(1));
+
+    auto mockColumn_5 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_5, value(An<const int32_t&>()))
+        .WillOnce(Return(0));
+    auto mockColumn_6 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_6, value(An<const std::string&>()))
+        .WillOnce(Return(STATUS_FIELD_NAME));
+    auto mockColumn_7 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_7, value(An<const std::string&>()))
+        .WillOnce(Return(STATUS_FIELD_TYPE));
+    auto mockColumn_8 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_8, value(An<const int32_t&>()))
+        .WillOnce(Return(1));
+
+    auto mockStatement_2 { std::make_unique<MockStatement>() };
+    EXPECT_CALL(*mockStatement_2, step())
+        .WillOnce(Return(SQLITE_ROW))
+        .WillOnce(Return(SQLITE_ROW))
+        .WillOnce(Return(SQLITE_DONE));      
+    EXPECT_CALL(*mockStatement_2, column(0))
+        .WillOnce(Return(ByMove(std::move(mockColumn_1))))
+        .WillOnce(Return(ByMove(std::move(mockColumn_5))));
+    EXPECT_CALL(*mockStatement_2, column(1))
+        .WillOnce(Return(ByMove(std::move(mockColumn_2))))
+        .WillOnce(Return(ByMove(std::move(mockColumn_6))));
+    EXPECT_CALL(*mockStatement_2, column(2))
+        .WillOnce(Return(ByMove(std::move(mockColumn_3))))
+        .WillOnce(Return(ByMove(std::move(mockColumn_7))));
+    EXPECT_CALL(*mockStatement_2, column(5))
+        .WillOnce(Return(ByMove(std::move(mockColumn_4))))
+        .WillOnce(Return(ByMove(std::move(mockColumn_8))));
+    EXPECT_CALL(*mockFactory, 
+        createStatement(_,"PRAGMA table_info(dummy);"))
+        .WillOnce(Return(ByMove(std::move(mockStatement_2))));
+
+    auto mockStatement_3 { std::make_unique<MockStatement>() };
+    EXPECT_CALL(*mockStatement_3, 
+        step())
+        .WillOnce(Return(SQLITE_ROW))
+        .WillOnce(Return(SQLITE_DONE));  
+
+    auto mockColumn_9 { std::make_unique<MockColumn>() };
+    EXPECT_CALL(*mockColumn_9, value(An<const int32_t&>()))
+        .WillOnce(Return(1));
+
+    EXPECT_CALL(*mockStatement_3, column(0))
+        .WillOnce(Return(ByMove(std::move(mockColumn_9))));
+
+       
+    EXPECT_CALL(*mockFactory, 
+        createStatement(_,"SELECT PID FROM dummy WHERE db_status_field_dm=0;"))
+        .WillOnce(Return(ByMove(std::move(mockStatement_3))));
+
+    EXPECT_NO_THROW(spEngine->returnRowsMarkedForDelete({"dummy"}, [](ReturnTypeCallback, const nlohmann::json&){}));
+}

--- a/src/dbsync/testtool/action.h
+++ b/src/dbsync/testtool/action.h
@@ -11,7 +11,9 @@
 #ifndef _ACTION_H
 #define _ACTION_H
 #include <json.hpp>
+#include <mutex>
 #include "dbsync.h"
+#include "makeUnique.h"
 
 namespace TestDeleters
 {
@@ -68,7 +70,7 @@ struct UpdateWithSnapshotAction final : public IAction
     }
 };
 
-static void dummyCallback(ReturnTypeCallback, const cJSON*)
+static void dummyCallback(ReturnTypeCallback, const cJSON*, void*)
 {
 }
 
@@ -82,12 +84,14 @@ struct CreateTransactionAction final : public IAction
         { 
             cJSON_Parse(value["body"]["tables"].dump().c_str())
         };
+        
+        CallbackData callback_data { dummyCallback, nullptr };
 
         ctx->txnContext = dbsync_create_txn(ctx->handle,
                                      jsonTables.get(),
                                      0,
                                      100,
-                                     dummyCallback);
+                                     &callback_data);
 
         std::stringstream oFileName;
         oFileName << "action_" << ctx->currentId << ".json";
@@ -138,6 +142,63 @@ struct SetMaxRowsAction final : public IAction
 
         std::ofstream outputFile{ outputFileName };
         const nlohmann::json jsonResult = { {"dbsync_set_table_max_rows", retVal } };
+        outputFile << jsonResult.dump() << std::endl;
+    }
+};
+
+struct GetDeleteTxnCallbackLogger final 
+{
+    explicit GetDeleteTxnCallbackLogger(const std::string &fileName) 
+    : m_fileName(fileName)
+    {};
+    std::string m_fileName;
+    std::mutex m_mutex;
+
+};
+
+static void getDeleteTxnCallback(ReturnTypeCallback /*type*/,
+                                 const cJSON* json,
+                                 void* user_data)
+{
+    GetDeleteTxnCallbackLogger* loggerContext { reinterpret_cast<GetDeleteTxnCallbackLogger *>(user_data) };
+
+    std::lock_guard<std::mutex> lock(loggerContext->m_mutex);
+    std::ifstream inputFile{ loggerContext->m_fileName };
+    nlohmann::json jsonResult {};
+    if (inputFile.peek() != std::ifstream::traits_type::eof())
+    {
+        jsonResult = nlohmann::json::parse(inputFile);
+    }
+    const std::unique_ptr<char, TestDeleters::CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(json)};
+    const auto& newJson { nlohmann::json::parse(spJsonBytes.get()) };
+    jsonResult.push_back(newJson[0]);
+
+    std::ofstream outputFile{ loggerContext->m_fileName };
+    outputFile << jsonResult.dump() << std::endl;
+};
+
+
+struct GetDeletedRowsAction final : public IAction
+{
+    void execute(std::unique_ptr<TestContext>& ctx,
+                 const nlohmann::json& /*value*/) override
+    {
+        std::stringstream oFileName;
+        oFileName << "action_" << ctx->currentId << ".json";
+        const auto& outputFileName{ ctx->outputPath + "/" + oFileName.str() };
+        const auto& outputFileNameCallback{ ctx->outputPath + "/" + "callback." + oFileName.str() };
+
+        const auto& loggerContext { std::make_unique<GetDeleteTxnCallbackLogger>(outputFileNameCallback) };
+        CallbackData callback_data { getDeleteTxnCallback, loggerContext.get() } ;
+        
+        const auto retVal
+        {
+            dbsync_get_deleted_rows(ctx->txnContext,
+                                    &callback_data)
+        };
+        
+        std::ofstream outputFile{ outputFileName };
+        const nlohmann::json& jsonResult { {"dbsync_get_deleted_rows", retVal } };
         outputFile << jsonResult.dump() << std::endl;
     }
 };

--- a/src/dbsync/testtool/cmdArgsHelper.h
+++ b/src/dbsync/testtool/cmdArgsHelper.h
@@ -77,15 +77,15 @@ private:
 
     static std::vector<std::string> splitActions(const std::string& values)
     {
-        std::vector<std::string> actions;
+        std::vector<std::string> actionsList;
         std::stringstream ss{ values };
         while (ss.good())
         {
             std::string substr;
             getline(ss, substr, ','); // Getting each string between ',' character
-            actions.push_back(std::move(substr));
+            actionsList.push_back(std::move(substr));
         }
-        return actions;
+        return actionsList;
     }
 
     const std::string m_configFile;

--- a/src/dbsync/testtool/cmdArgsHelper.h
+++ b/src/dbsync/testtool/cmdArgsHelper.h
@@ -77,15 +77,15 @@ private:
 
     static std::vector<std::string> splitActions(const std::string& values)
     {
-        std::vector<std::string> actionsList;
+        std::vector<std::string> actionsValues;
         std::stringstream ss{ values };
         while (ss.good())
         {
             std::string substr;
             getline(ss, substr, ','); // Getting each string between ',' character
-            actionsList.push_back(std::move(substr));
+            actionsValues.push_back(std::move(substr));
         }
-        return actionsList;
+        return actionsValues;
     }
 
     const std::string m_configFile;

--- a/src/dbsync/testtool/factoryAction.h
+++ b/src/dbsync/testtool/factoryAction.h
@@ -35,6 +35,10 @@ public:
         {
             return std::make_unique<SetMaxRowsAction>();
         }
+        else if (0 == actionCode.compare("dbsync_get_deleted_rows"))
+        {
+            return std::make_unique<GetDeletedRowsAction>();
+        }
         else
         {
             throw std::runtime_error { "Invalid action: " + actionCode };

--- a/src/dbsync/testtool/input/input7.json
+++ b/src/dbsync/testtool/input/input7.json
@@ -1,0 +1,3 @@
+{
+    "action": "dbsync_get_deleted_rows"
+}

--- a/src/dbsync/utils/makeUnique.h
+++ b/src/dbsync/utils/makeUnique.h
@@ -12,6 +12,8 @@
 /* Taken from isocpp.org/files/papers/N3656.txt
  * Stephan T. Lavavej <stl@microsoft.com>
  */ 
+#ifndef _MAKE_UNIQUE_H
+#define _MAKE_UNIQUE_H
 
 #if __cplusplus < 201402L
 #include <cstddef>
@@ -50,3 +52,4 @@ namespace std {
         make_unique(Args&&...) = delete;
 }
 #endif
+#endif //_MAKE_UNIQUE_H


### PR DESCRIPTION
|Related issue|
|---|
|5292|

## Description
This aims to obtain the rows (one by one) that were left with the flag unchecked and that should be deleted when closing the virtual transaction.

## CPPCHECK
![image](https://user-images.githubusercontent.com/14300208/88451099-7f6cb380-ce2a-11ea-8684-d71128fa78ce.png)

## VALGRIND
![image](https://user-images.githubusercontent.com/14300208/88451127-a2976300-ce2a-11ea-8a1c-39a8d249f967.png)

## UNIT TEST
![image](https://user-images.githubusercontent.com/14300208/88451073-4fbdab80-ce2a-11ea-94f9-e29a56681662.png)
![image](https://user-images.githubusercontent.com/14300208/88451140-b3e06f80-ce2a-11ea-8327-19a4a78c5db8.png)
![image](https://user-images.githubusercontent.com/14300208/88451145-c65aa900-ce2a-11ea-9e96-727e227b850a.png)
![image](https://user-images.githubusercontent.com/14300208/88451151-d96d7900-ce2a-11ea-8533-73c8ec84bc81.png)
![image](https://user-images.githubusercontent.com/14300208/88451160-eee2a300-ce2a-11ea-8df2-4f1d7b7103f3.png)
![image](https://user-images.githubusercontent.com/14300208/88451172-fb66fb80-ce2a-11ea-9fab-f93d56d5f95a.png)
