### PR TITLE
Feature/cluster messaging refactor

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -342,7 +342,7 @@ class Handler(asyncio.Protocol):
         Forwards a distributed API response from master node.
 
         :param data: Bytes containing local client name and string id separated by ' '
-        :return: sucess/error message
+        :return: success/error message
         """
         client, string_id = data.split(b' ', 1)
         client = client.decode()
@@ -363,7 +363,7 @@ class Handler(asyncio.Protocol):
         Forwards a sendsync response from master node.
 
         :param data: Bytes containing local client name and string id separated by ' '
-        :return: sucess/error message
+        :return: success/error message
         """
         client, string_id = data.split(b' ', 1)
         client = client.decode()

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -544,7 +544,7 @@ class DistributedAPI:
 
 
 class WazuhRequestQueue:
-
+    """Represents a queue of Wazuh requests"""
     def __init__(self, server):
         self.request_queue = asyncio.Queue()
         self.server = server

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -224,7 +224,8 @@ class LocalServerMaster(LocalServer):
         super().__init__(node=node, **kwargs)
         self.handler_class = LocalServerHandlerMaster
         self.dapi = dapi.APIRequestQueue(server=self)
-        self.tasks.append(self.dapi.run)
+        self.sendsync = dapi.SendSyncRequestQueue(server=self)
+        self.tasks.extend([self.dapi.run, self.sendsync.run])
 
 
 class LocalServerHandlerWorker(LocalServerHandler):
@@ -248,8 +249,11 @@ class LocalServerHandlerWorker(LocalServerHandler):
                 raise WazuhClusterError(3023)
             asyncio.create_task(self.server.node.client.send_request(b'dapi', self.name.encode() + b' ' + data))
             return b'ok', b'Added request to API requests queue'
-        elif command == b'send_sync':
-            return self.send_sync(data)
+        elif command == b'sendsync':
+            if self.server.node.client is None:
+                raise WazuhClusterError(3023)
+            asyncio.create_task(self.server.node.client.send_request(b'sendsync', self.name.encode() + b' ' + data))
+            return None, None
         else:
             return super().process_request(command, data)
 
@@ -293,18 +297,6 @@ class LocalServerHandlerWorker(LocalServerHandler):
         send_res = asyncio.create_task(self.send_request(command=b'dapi_res' if in_command == b'dapi' else b'control_res',
                                                          data=future.result()))
         send_res.add_done_callback(self.send_res_callback)
-
-    def send_sync(self, payload):
-        lc = local_client.LocalClient()
-        req = asyncio.create_task(lc.execute(command=b'dapi', data=payload, wait_for_complete=False))
-        req.add_done_callback(functools.partial(self.get_send_sync_response, self.name))
-
-        return None, None
-
-    def get_send_sync_response(self, name, future):
-        result = future.result()
-        msg_counter = self.next_counter()
-        self.server.clients[name].push(self.msg_build(b'send_sync', msg_counter, result.encode()))
 
     def send_file_request(self, path, node_name):
         """

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -154,13 +154,25 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         elif command == b'dapi_res':
             asyncio.create_task(self.forward_dapi_response(data))
             return b'ok', b'Response forwarded to worker'
+        elif command == b'sendsync_res':
+            asyncio.create_task(self.forward_sendsync_response(data))
+            return b'ok', b'Response forwarded to worker'
         elif command == b'dapi_err':
             dapi_client, error_msg = data.split(b' ', 1)
             try:
-                asyncio.create_task(self.manager.local_server.clients[dapi_client.decode()].send_request(command, error_msg))
+                asyncio.create_task(
+                    self.manager.local_server.clients[dapi_client.decode()].send_request(command, error_msg))
             except WazuhClusterError as e:
                 raise WazuhClusterError(3025)
             return b'ok', b'DAPI error forwarded to worker'
+        elif command == b'sendsync_err':
+            sendsync_client, error_msg = data.split(b' ', 1)
+            try:
+                asyncio.create_task(
+                    self.manager.local_server.clients[sendsync_client.decode()].send_request(command, error_msg))
+            except WazuhClusterError as e:
+                raise WazuhClusterError(3025)
+            return b'ok', b'SendSync error forwarded to worker'
         elif command == b'dapi':
             self.manager.dapi.add_request(b'master*' + data)
             return b'ok', b'Added request to API requests queue'


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh/issues/5545.

It adds a refactor to sendsync messaging service.

### Tests:

Successfull message: 
- `b'ok' `command
- Example: `b'H\xd5\xe9T\x00\x00\x00wok ---------{"id": "009", "name": "agent1", "ip": "any", "key": "9901cb51f698516d46e9c57d391e0b72c82ccf55b713b99124a97f0d43a40ca7"}'`

Cluster error/exception message: (master is not available)
- `b'err'` command
- Example: `b'\x00\x00\x00d\x00\x00\x00\xb2err --------{"__wazuh_exception__": {"__class__": "WazuhClusterError", "__object__": {"code": 3023, "extra_message": null, "extra_remediation": null, "cmd_error": false, "dapi_errors": {}}}}'`

SendSync error messages: (authd not available in the master node)
- `b'sendsync_err'` command
- Example: `b'\x99\xb8c3\x00\x00\x00]sendsync_errError in SendSync: Error 1013 - Unable to connect with socket: [Errno 111] Connection refused'`

