### PR TITLE
5512 WPK  Agent id and version validation

### DIFF
--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -311,6 +311,9 @@ int wdb_update_agent_version(int id, const char *os_name, const char *os_version
 /* Update agent's last keepalive. It opens and closes the DB. Returns number of affected rows or -1 on error. */
 int wdb_update_agent_keepalive(int id, long keepalive);
 
+/* Get last_keepalive from agent. The string must be freed after using. Returns NULL on error. */
+int wdb_agent_last_keepalive(int id);
+
 /* Update agent group. It opens and closes the DB. Returns 0 on success or -1 on error. */
 int wdb_update_agent_group(int id,char *group);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -332,6 +332,9 @@ int wdb_remove_group_db(const char *name);
 /* Get name from agent. The string must be freed after using. Returns NULL on error. */
 char* wdb_agent_name(int id);
 
+/* Get version from agent. The string must be freed after using. Returns NULL on error. */
+char* wdb_agent_version(int id);
+
 /* Get group from agent. The string must be freed after using. Returns NULL on error. */
 char* wdb_agent_group(int id);
 

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -41,6 +41,7 @@ static const char *SQL_FIND_GROUP = "SELECT id FROM `group` WHERE name = ?;";
 static const char *SQL_SELECT_GROUPS = "SELECT name FROM `group`;";
 static const char *SQL_DELETE_GROUP = "DELETE FROM `group` WHERE name = ?;";
 static const char *SQL_SELECT_VERSION = "SELECT version FROM agent WHERE id = ?;";
+static const char *SQL_SELECT_LAST_KEEPALIVE = "SELECT last_keepalive FROM agent WHERE id = ?;";
 
 /* Insert agent. It opens and closes the DB. Returns 0 on success or -1 on error. */
 int wdb_insert_agent(int id, const char *name, const char *ip, const char *register_ip, const char *key, const char *group, int keep_date) {
@@ -178,6 +179,38 @@ int wdb_update_agent_keepalive(int id, long keepalive) {
     sqlite3_bind_int(stmt, 2, id);
 
     result = wdb_step(stmt) == SQLITE_DONE ? (int)sqlite3_changes(wdb_global) : -1;
+    sqlite3_finalize(stmt);
+
+    return result;
+}
+
+/* Get last_keepalive from agent. The string must be freed after using. Returns -1 on error. */
+int wdb_agent_last_keepalive(int id){
+    sqlite3_stmt *stmt = NULL;
+    int result = -1;
+
+    if (wdb_open_global() < 0)
+        return -1;
+
+    if (wdb_prepare(wdb_global, SQL_SELECT_LAST_KEEPALIVE, -1, &stmt, NULL)) {
+        mdebug1("SQLite: %s", sqlite3_errmsg(wdb_global));
+        return -1;
+    }
+
+    sqlite3_bind_int(stmt, 1, id);
+
+    switch (wdb_step(stmt)) {
+    case SQLITE_ROW:
+        result = sqlite3_column_int(stmt, 0);
+        break;
+    case SQLITE_DONE:
+        result = -1;
+        break;
+    default:
+        mdebug1("SQLite: %s", sqlite3_errmsg(wdb_global));
+        result = -1;
+    }
+
     sqlite3_finalize(stmt);
 
     return result;

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
@@ -45,7 +45,12 @@ const char* upgrade_error_codes[] = {
     [WM_UPGRADE_TASK_MANAGER_COMMUNICATION] ="Could not create task id for upgrade task",
     [WM_UPGRADE_TASK_MANAGER_FAILURE] = "", // Data string will be provided by task manager
     [WM_UPGRADE_UPGRADE_ALREADY_ON_PROGRESS] = "Upgrade procedure could not start. Agent already upgrading",
-    [WM_UPGRADE_UNKNOWN_ERROR] "Upgrade procedure could not start"
+    [WM_UPGRADE_UNKNOWN_ERROR] "Upgrade procedure could not start",
+    [WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED] = "Remote upgrade is not available for this agent version.",
+    [WM_UPGRADE_VERSION_SAME_MANAGER] = "Agent and manager have the same version. No need upgrade.",
+    [WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT] = "Current agent version is greater or equal.",
+    [WM_UPGRADE_NEW_VERSION_GREATER_MASTER] = "Upgrading an agent to a version higher than the manager requires the force flag.",
+    [WM_UPGRADE_NOT_AGENT_IN_DB] = "Not agent id found in database."
 };
 
 void wm_agent_upgrade_listen_messages(int sock, int timeout_sec) {

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
@@ -50,7 +50,8 @@ const char* upgrade_error_codes[] = {
     [WM_UPGRADE_VERSION_SAME_MANAGER] = "Agent and manager have the same version. No need upgrade.",
     [WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT] = "Current agent version is greater or equal.",
     [WM_UPGRADE_NEW_VERSION_GREATER_MASTER] = "Upgrading an agent to a version higher than the manager requires the force flag.",
-    [WM_UPGRADE_NOT_AGENT_IN_DB] = "Not agent id found in database."
+    [WM_UPGRADE_NOT_AGENT_IN_DB] = "Not agent id found in database.",
+    [WM_UPGRADE_AGENT_IS_NOT_ACTIVE] = "Agent is not active."
 };
 
 void wm_agent_upgrade_listen_messages(int sock, int timeout_sec) {

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
@@ -52,7 +52,8 @@ const char* upgrade_error_codes[] = {
     [WM_UPGRADE_NEW_VERSION_GREATER_MASTER] = "Upgrading an agent to a version higher than the manager requires the force flag.",
     [WM_UPGRADE_NOT_AGENT_IN_DB] = "Not agent id found in database.",
     [WM_UPGRADE_INVALID_ACTION_FOR_MANAGER] = "Action not available for Manager (agent 000)",
-    [WM_UPGRADE_AGENT_IS_NOT_ACTIVE] = "Agent is not active."
+    [WM_UPGRADE_AGENT_IS_NOT_ACTIVE] = "Agent is not active.",
+    [WM_UPGRADE_VERSION_QUERY_ERROR] = "Not agent version found in database."
 };
 
 void wm_agent_upgrade_listen_messages(int sock, int timeout_sec) {

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
@@ -51,6 +51,7 @@ const char* upgrade_error_codes[] = {
     [WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT] = "Current agent version is greater or equal.",
     [WM_UPGRADE_NEW_VERSION_GREATER_MASTER] = "Upgrading an agent to a version higher than the manager requires the force flag.",
     [WM_UPGRADE_NOT_AGENT_IN_DB] = "Not agent id found in database.",
+    [WM_UPGRADE_INVALID_ACTION_FOR_MANAGER] = "Action not available for Manager (agent 000)",
     [WM_UPGRADE_AGENT_IS_NOT_ACTIVE] = "Agent is not active."
 };
 

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
@@ -37,7 +37,8 @@ typedef enum _wm_upgrade_error_code {
     WM_UPGRADE_NEW_VERSION_GREATER_MASTER,
     WM_UPGRADE_NOT_AGENT_IN_DB,
     WM_UPGRADE_INVALID_ACTION_FOR_MANAGER,
-    WM_UPGRADE_AGENT_IS_NOT_ACTIVE
+    WM_UPGRADE_AGENT_IS_NOT_ACTIVE,
+    WM_UPGRADE_VERSION_QUERY_ERROR
 } wm_upgrade_error_code;
 
 typedef enum _wm_upgrade_state {
@@ -119,18 +120,22 @@ cJSON* wm_agent_upgrade_process_upgrade_result_command(const cJSON* agents);
  * @return return_code
  * @retval WM_UPGRADE_SUCCESS_VALIDATE
  * @retval WM_UPGRADE_NOT_AGENT_IN_DB
+ * @retval WM_UPGRADE_INVALID_ACTION_FOR_MANAGER
  * */
 int wm_agent_upgrade_validate_id(int agent_id);
 
 /**
  * Check if agent version is valid to upgrade
  * @param agent_id Id of agent to validate
+ * @param task pointer to task with the params
+ * @param command wm_upgrade_command with the selected upgrade type
  * @return return_code
  * @retval WM_UPGRADE_SUCCESS_VALIDATE
  * @retval WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED
  * @retval WM_UPGRADE_VERSION_SAME_MANAGER
  * @retval WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT
  * @retval WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
+ * @retval WM_UPGRADE_VERSION_QUERY_ERROR
  * */
 int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade_command command);
 

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
@@ -27,7 +27,12 @@ typedef enum _wm_upgrade_error_code {
     WM_UPGRADE_TASK_MANAGER_COMMUNICATION,
     WM_UPGRADE_TASK_MANAGER_FAILURE,
     WM_UPGRADE_UPGRADE_ALREADY_ON_PROGRESS,
-    WM_UPGRADE_UNKNOWN_ERROR
+    WM_UPGRADE_UNKNOWN_ERROR,
+    WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED,
+    WM_UPGRADE_VERSION_SAME_MANAGER,
+    WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT,
+    WM_UPGRADE_NEW_VERSION_GREATER_MASTER,
+    WM_UPGRADE_NOT_AGENT_IN_DB
 } wm_upgrade_error_code;
 
 typedef enum _wm_upgrade_state {
@@ -102,5 +107,22 @@ cJSON *wm_agent_upgrade_process_upgrade_custom_command(const cJSON* params, cons
  * @return json object with the response
  * */
 cJSON* wm_agent_upgrade_process_upgrade_result_command(const cJSON* agents);
+
+/**
+ * Check if agent exist
+ * @param agent_id Id of agent to validate
+ * @return error_code (0 = success, -1 = agent not exist)
+ * */
+int wm_agent_upgrade_validate_id(int agent_id);
+
+/**
+ * Check if agent version is valid to upgrade
+ * @param agent_id Id of agent to validate
+ * @return error_code (0 = not error,   WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED, 
+ *                                      WM_UPGRADE_VERSION_SAME_MANAGER, 
+ *                                      WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT,
+ *                                      WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
+ * */
+int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade_command command);
 
 #endif

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
@@ -14,6 +14,9 @@
 
 #define WM_AGENT_UPGRADE_LOGTAG ARGV0 ":" AGENT_UPGRADE_WM_NAME
 #define WM_AGENT_UPGRADE_MODULE_NAME "upgrade_module"
+#define WM_UPGRADE_MINIMAL_VERSION_SUPPORT "v3.0.0"
+#define WM_UPGRADE_SUCCESS_VALIDATE 0
+#define MANAGER_ID 0
 
 typedef struct _wm_agent_upgrade {
     int enabled:1;
@@ -33,6 +36,7 @@ typedef enum _wm_upgrade_error_code {
     WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT,
     WM_UPGRADE_NEW_VERSION_GREATER_MASTER,
     WM_UPGRADE_NOT_AGENT_IN_DB,
+    WM_UPGRADE_INVALID_ACTION_FOR_MANAGER,
     WM_UPGRADE_AGENT_IS_NOT_ACTIVE
 } wm_upgrade_error_code;
 
@@ -112,20 +116,31 @@ cJSON* wm_agent_upgrade_process_upgrade_result_command(const cJSON* agents);
 /**
  * Check if agent exist
  * @param agent_id Id of agent to validate
- * @return error_code (0 = success, -1 = agent not exist)
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS_VALIDATE
+ * @retval WM_UPGRADE_NOT_AGENT_IN_DB
  * */
 int wm_agent_upgrade_validate_id(int agent_id);
 
 /**
  * Check if agent version is valid to upgrade
  * @param agent_id Id of agent to validate
- * @return error_code (0 = not error,   WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED, 
- *                                      WM_UPGRADE_VERSION_SAME_MANAGER, 
- *                                      WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT,
- *                                      WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS_VALIDATE
+ * @retval WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED
+ * @retval WM_UPGRADE_VERSION_SAME_MANAGER
+ * @retval WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT
+ * @retval WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
  * */
 int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade_command command);
 
+/**
+ * Check if agent status is active
+ * @param agent_id Id of agent to validate
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS_VALIDATE
+ * @retval WM_UPGRADE_AGENT_IS_NOT_ACTIVE
+ * */
 int wm_agent_upgrade_validate_status(int agent_id);
 
 #endif

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
@@ -32,7 +32,8 @@ typedef enum _wm_upgrade_error_code {
     WM_UPGRADE_VERSION_SAME_MANAGER,
     WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT,
     WM_UPGRADE_NEW_VERSION_GREATER_MASTER,
-    WM_UPGRADE_NOT_AGENT_IN_DB
+    WM_UPGRADE_NOT_AGENT_IN_DB,
+    WM_UPGRADE_AGENT_IS_NOT_ACTIVE
 } wm_upgrade_error_code;
 
 typedef enum _wm_upgrade_state {
@@ -124,5 +125,7 @@ int wm_agent_upgrade_validate_id(int agent_id);
  *                                      WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
  * */
 int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade_command command);
+
+int wm_agent_upgrade_validate_status(int agent_id);
 
 #endif

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_tasks.c
@@ -175,8 +175,6 @@ cJSON* wm_agent_upgrade_create_agent_tasks(const cJSON *agents, void *task, wm_u
             cJSON_AddItemToArray(json_api, task_message);
             continue;
         }
-        
-        
 
         // Save task entry for agent
         int result = wm_agent_upgrade_create_task_entry(agent_id->valueint, agent_task);

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_tasks.c
@@ -74,6 +74,22 @@ static cJSON *wm_agent_upgrade_send_tasks_information(const cJSON *message_objec
 /* Hash table of current tasks based on agent_id */
 static OSHash *task_table_by_agent_id;
 
+/**
+ * Encloses calls to agent, status and version validation functions
+ * @param agent_id Id of agent to validate
+ * @param task pointer to task with the params
+ * @param command wm_upgrade_command with the selected upgrade type
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS_VALIDATE
+ * @retval WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED
+ * @retval WM_UPGRADE_VERSION_SAME_MANAGER
+ * @retval WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT
+ * @retval WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
+ * @retval WM_UPGRADE_NOT_AGENT_IN_DB
+ * @retval WM_UPGRADE_AGENT_IS_NOT_ACTIVE
+ * @retval WM_UPGRADE_INVALID_ACTION_FOR_MANAGER
+ * @retval WM_UPGRADE_VERSION_QUERY_ERROR
+ * */
 static int wm_agent_upgrade_validate_agent(int agent_id, void *task, wm_upgrade_command command);
 
 wm_upgrade_task* wm_agent_upgrade_init_upgrade_task() {

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_tasks.c
@@ -151,27 +151,23 @@ cJSON* wm_agent_upgrade_create_agent_tasks(const cJSON *agents, void *task, wm_u
         agent_task->command = command;
         agent_task->task = task;
 
-        if (wm_agent_upgrade_validate_id(agent_id->valueint) < 0){
-            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_NOT_AGENT_IN_DB, upgrade_error_codes[WM_UPGRADE_NOT_AGENT_IN_DB], &(agent_id->valueint), NULL, NULL);
+        int validate_result = wm_agent_upgrade_validate_id(agent_id->valueint);
+        if ( validate_result != WM_UPGRADE_SUCCESS){
+            cJSON *task_message = wm_agent_upgrade_parse_response_message(validate_result, upgrade_error_codes[validate_result], &(agent_id->valueint), NULL, NULL);
+            cJSON_AddItemToArray(json_api, task_message);
+            continue;
+        }
+
+        validate_result = wm_agent_upgrade_validate_status(agent_id->valueint);
+        if ( validate_result != WM_UPGRADE_SUCCESS){
+            cJSON *task_message = wm_agent_upgrade_parse_response_message(validate_result, upgrade_error_codes[validate_result], &(agent_id->valueint), NULL, NULL);
             cJSON_AddItemToArray(json_api, task_message);
             continue;
         }
         
-        int validate_ver_result = wm_agent_upgrade_validate_agent_version(agent_id->valueint, task, command);
-        if ( validate_ver_result == WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED){
-            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED, upgrade_error_codes[WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED], &(agent_id->valueint), NULL, NULL);
-            cJSON_AddItemToArray(json_api, task_message);
-            continue;
-        }else if ( validate_ver_result == WM_UPGRADE_NEW_VERSION_GREATER_MASTER){
-            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_NEW_VERSION_GREATER_MASTER, upgrade_error_codes[WM_UPGRADE_NEW_VERSION_GREATER_MASTER], &(agent_id->valueint), NULL, NULL);
-            cJSON_AddItemToArray(json_api, task_message);
-            continue;
-        }else if ( validate_ver_result == WM_UPGRADE_VERSION_SAME_MANAGER){
-            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_VERSION_SAME_MANAGER, upgrade_error_codes[WM_UPGRADE_VERSION_SAME_MANAGER], &(agent_id->valueint), NULL, NULL);
-            cJSON_AddItemToArray(json_api, task_message);
-            continue;
-        }else if ( validate_ver_result == WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT){
-            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT, upgrade_error_codes[WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT], &(agent_id->valueint), NULL, NULL);
+        validate_result = wm_agent_upgrade_validate_agent_version(agent_id->valueint, task, command);
+        if ( validate_result != WM_UPGRADE_SUCCESS){
+            cJSON *task_message = wm_agent_upgrade_parse_response_message(validate_result, upgrade_error_codes[validate_result], &(agent_id->valueint), NULL, NULL);
             cJSON_AddItemToArray(json_api, task_message);
             continue;
         }

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_tasks.c
@@ -151,6 +151,33 @@ cJSON* wm_agent_upgrade_create_agent_tasks(const cJSON *agents, void *task, wm_u
         agent_task->command = command;
         agent_task->task = task;
 
+        if (wm_agent_upgrade_validate_id(agent_id->valueint) < 0){
+            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_NOT_AGENT_IN_DB, upgrade_error_codes[WM_UPGRADE_NOT_AGENT_IN_DB], &(agent_id->valueint), NULL, NULL);
+            cJSON_AddItemToArray(json_api, task_message);
+            continue;
+        }
+        
+        int validate_ver_result = wm_agent_upgrade_validate_agent_version(agent_id->valueint, task, command);
+        if ( validate_ver_result == WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED){
+            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED, upgrade_error_codes[WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED], &(agent_id->valueint), NULL, NULL);
+            cJSON_AddItemToArray(json_api, task_message);
+            continue;
+        }else if ( validate_ver_result == WM_UPGRADE_NEW_VERSION_GREATER_MASTER){
+            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_NEW_VERSION_GREATER_MASTER, upgrade_error_codes[WM_UPGRADE_NEW_VERSION_GREATER_MASTER], &(agent_id->valueint), NULL, NULL);
+            cJSON_AddItemToArray(json_api, task_message);
+            continue;
+        }else if ( validate_ver_result == WM_UPGRADE_VERSION_SAME_MANAGER){
+            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_VERSION_SAME_MANAGER, upgrade_error_codes[WM_UPGRADE_VERSION_SAME_MANAGER], &(agent_id->valueint), NULL, NULL);
+            cJSON_AddItemToArray(json_api, task_message);
+            continue;
+        }else if ( validate_ver_result == WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT){
+            cJSON *task_message = wm_agent_upgrade_parse_response_message(WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT, upgrade_error_codes[WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT], &(agent_id->valueint), NULL, NULL);
+            cJSON_AddItemToArray(json_api, task_message);
+            continue;
+        }
+        
+        
+
         // Save task entry for agent
         int result = wm_agent_upgrade_create_task_entry(agent_id->valueint, agent_task);
 

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
@@ -21,12 +21,23 @@ static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_
  * */
 int wm_agent_upgrade_validate_id(int agent_id){
     char *name = NULL;
+    int return_code = WM_UPGRADE_SUCCESS;
     if (name = wdb_agent_name(agent_id), name) {
         // Agent found: OK
         free(name);
-        return 0;
+    } else {
+        return_code = WM_UPGRADE_NOT_AGENT_IN_DB;
     }
-    return -1;
+    return return_code;
+}
+
+int wm_agent_upgrade_validate_status(int agent_id){
+    int return_code = WM_UPGRADE_SUCCESS;
+    int last_keepalive = wdb_agent_last_keepalive(agent_id);
+    if (last_keepalive < 0 || last_keepalive < (time(0) - DISCON_TIME)) {
+        return_code = WM_UPGRADE_AGENT_IS_NOT_ACTIVE;
+    }
+    return return_code;
 }
 
 /**
@@ -40,7 +51,7 @@ int wm_agent_upgrade_validate_id(int agent_id){
 int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade_command command){
     char *agent_version = NULL;
     char *tmp_agent_version = NULL;
-    int return_code = 0;
+    int return_code = WM_UPGRADE_SUCCESS;
     if (agent_version = wdb_agent_version(agent_id), agent_version) {
         tmp_agent_version = strchr(agent_version, 'v');
         
@@ -60,7 +71,7 @@ static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_
     char *tmp_master_version = NULL;
     master_version = wdb_agent_version(0);
     tmp_master_version = strchr(master_version, 'v');
-    int return_code = 0;
+    int return_code = WM_UPGRADE_SUCCESS;
     if (task->custom_version && strcmp(agent_version, task->custom_version) >= 0 && task->force_upgrade == false){
         return_code = WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT;
     }else if (task->custom_version && strcmp(task->custom_version, tmp_master_version) > 0 && task->force_upgrade == false){

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
@@ -1,3 +1,14 @@
+/*
+ * Wazuh Module for Agent Upgrading
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * July 20, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
 #include "wazuh_db/wdb.h"
 #include "wazuh_modules/wmodules.h"
 

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
@@ -17,68 +17,98 @@ static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_
 /**
  * Check if agent exist
  * @param agent_id Id of agent to validate
- * @return error_code (0 = succes, -1 = agent not exist)
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS_VALIDATE
+ * @retval WM_UPGRADE_NOT_AGENT_IN_DB
  * */
-int wm_agent_upgrade_validate_id(int agent_id){
+int wm_agent_upgrade_validate_id(int agent_id) {
     char *name = NULL;
-    int return_code = WM_UPGRADE_SUCCESS;
-    if (name = wdb_agent_name(agent_id), name) {
+    int return_code = WM_UPGRADE_SUCCESS_VALIDATE;
+    if (agent_id == MANAGER_ID) {
+        return_code = WM_UPGRADE_INVALID_ACTION_FOR_MANAGER;
+    } else if (name = wdb_agent_name(agent_id), name) {
         // Agent found: OK
         free(name);
     } else {
         return_code = WM_UPGRADE_NOT_AGENT_IN_DB;
     }
+
     return return_code;
 }
 
-int wm_agent_upgrade_validate_status(int agent_id){
-    int return_code = WM_UPGRADE_SUCCESS;
+/**
+ * Check if agent status is active
+ * @param agent_id Id of agent to validate
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS_VALIDATE
+ * @retval WM_UPGRADE_AGENT_IS_NOT_ACTIVE
+ * */
+int wm_agent_upgrade_validate_status(int agent_id) {
+    int return_code = WM_UPGRADE_SUCCESS_VALIDATE;
     int last_keepalive = wdb_agent_last_keepalive(agent_id);
+
     if (last_keepalive < 0 || last_keepalive < (time(0) - DISCON_TIME)) {
         return_code = WM_UPGRADE_AGENT_IS_NOT_ACTIVE;
     }
+
     return return_code;
 }
 
 /**
  * Check if agent version is valid to upgrade
  * @param agent_id Id of agent to validate
- * @return error_code (0 = not error,   WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED, 
- *                                      WM_UPGRADE_VERSION_SAME_MANAGER, 
- *                                      WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT,
- *                                      WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS_VALIDATE
+ * @retval WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED
+ * @retval WM_UPGRADE_VERSION_SAME_MANAGER
+ * @retval WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT
+ * @retval WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
  * */
-int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade_command command){
+int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade_command command) {
     char *agent_version = NULL;
     char *tmp_agent_version = NULL;
-    int return_code = WM_UPGRADE_SUCCESS;
+    int return_code = WM_UPGRADE_SUCCESS_VALIDATE;
+
     if (agent_version = wdb_agent_version(agent_id), agent_version) {
         tmp_agent_version = strchr(agent_version, 'v');
         
-        if (strcmp(tmp_agent_version, "v3.0.0") < 0){
+        if (strcmp(tmp_agent_version, WM_UPGRADE_MINIMAL_VERSION_SUPPORT) < 0) {
             return_code = WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED;
-        }else if (WM_UPGRADE_UPGRADE == command){
+        } else if (WM_UPGRADE_UPGRADE == command) {
             task = (wm_upgrade_task *)task;
             return_code = wm_agent_upgrade_validate_non_custom_version(tmp_agent_version, task);
         }
+
         free(agent_version);
     }
+
     return return_code;
 }
 
-static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_upgrade_task *task){
+/**
+ * Check if agent version is valid to upgrade to a non-customized version
+ * @param agent_id Id of agent to validate
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS_VALIDATE
+ * @retval WM_UPGRADE_VERSION_SAME_MANAGER
+ * @retval WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT
+ * @retval WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
+ * */
+static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_upgrade_task *task) {
     char *master_version = NULL;
     char *tmp_master_version = NULL;
-    master_version = wdb_agent_version(0);
+    master_version = wdb_agent_version(MANAGER_ID);
     tmp_master_version = strchr(master_version, 'v');
-    int return_code = WM_UPGRADE_SUCCESS;
-    if (task->custom_version && strcmp(agent_version, task->custom_version) >= 0 && task->force_upgrade == false){
+    int return_code = WM_UPGRADE_SUCCESS_VALIDATE;
+
+    if (task->custom_version && strcmp(agent_version, task->custom_version) >= 0 && task->force_upgrade == false) {
         return_code = WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT;
-    }else if (task->custom_version && strcmp(task->custom_version, tmp_master_version) > 0 && task->force_upgrade == false){
+    } else if (task->custom_version && strcmp(task->custom_version, tmp_master_version) > 0 && task->force_upgrade == false) {
         return_code = WM_UPGRADE_NEW_VERSION_GREATER_MASTER;
-    }else if (strcmp(agent_version, tmp_master_version) == 0 && task->force_upgrade == false){
+    } else if (strcmp(agent_version, tmp_master_version) == 0 && task->force_upgrade == false) {
         return_code = WM_UPGRADE_VERSION_SAME_MANAGER;
     }
+
     free(master_version);
     return return_code;
 }

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
@@ -55,7 +55,6 @@ int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade
     return return_code;
 }
 
-
 static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_upgrade_task *task){
     char *master_version = NULL;
     char *tmp_master_version = NULL;
@@ -72,8 +71,3 @@ static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_
     free(master_version);
     return return_code;
 }
-
-
-            
-
-        

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade_validate.c
@@ -1,0 +1,68 @@
+#include "wazuh_db/wdb.h"
+#include "wazuh_modules/wmodules.h"
+
+static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_upgrade_task *task);
+
+/**
+ * Check if agent exist
+ * @param agent_id Id of agent to validate
+ * @return error_code (0 = succes, -1 = agent not exist)
+ * */
+int wm_agent_upgrade_validate_id(int agent_id){
+    char *name = NULL;
+    if (name = wdb_agent_name(agent_id), name) {
+        // Agent found: OK
+        free(name);
+        return 0;
+    }
+    return -1;
+}
+
+/**
+ * Check if agent version is valid to upgrade
+ * @param agent_id Id of agent to validate
+ * @return error_code (0 = not error,   WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED, 
+ *                                      WM_UPGRADE_VERSION_SAME_MANAGER, 
+ *                                      WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT,
+ *                                      WM_UPGRADE_NEW_VERSION_GREATER_MASTER)
+ * */
+int wm_agent_upgrade_validate_agent_version(int agent_id, void *task, wm_upgrade_command command){
+    char *agent_version = NULL;
+    char *tmp_agent_version = NULL;
+    int return_code = 0;
+    if (agent_version = wdb_agent_version(agent_id), agent_version) {
+        tmp_agent_version = strchr(agent_version, 'v');
+        
+        if (strcmp(tmp_agent_version, "v3.0.0") < 0){
+            return_code = WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED;
+        }else if (WM_UPGRADE_UPGRADE == command){
+            task = (wm_upgrade_task *)task;
+            return_code = wm_agent_upgrade_validate_non_custom_version(tmp_agent_version, task);
+        }
+        free(agent_version);
+    }
+    return return_code;
+}
+
+
+static int wm_agent_upgrade_validate_non_custom_version(char *agent_version, wm_upgrade_task *task){
+    char *master_version = NULL;
+    char *tmp_master_version = NULL;
+    master_version = wdb_agent_version(0);
+    tmp_master_version = strchr(master_version, 'v');
+    int return_code = 0;
+    if (task->custom_version && strcmp(agent_version, task->custom_version) >= 0 && task->force_upgrade == false){
+        return_code = WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT;
+    }else if (task->custom_version && strcmp(task->custom_version, tmp_master_version) > 0 && task->force_upgrade == false){
+        return_code = WM_UPGRADE_NEW_VERSION_GREATER_MASTER;
+    }else if (strcmp(agent_version, tmp_master_version) == 0 && task->force_upgrade == false){
+        return_code = WM_UPGRADE_VERSION_SAME_MANAGER;
+    }
+    free(master_version);
+    return return_code;
+}
+
+
+            
+
+        


### PR DESCRIPTION
|Related issue|
|---|
|#5512|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Before creating an upgrade task, the upgrade module must perform different validations:

1. Validate that agent_id is in the database
2. Validate that agent_id != 0 (manager)
3. Validate that agent is connected
4. Validate version to update
5. Validate Current  agent version

Upgrade:

- Current agent version = manager version
- Version you want to update> manager version
- Current agent version <3.0.0
- Version you want to update <= Current agent version

Upgrade_custom:

- Current agent version <3.0.0

## Logs/Alerts example

`2020/07/27 15:45:52 wazuh-modulesd:agent-upgrade[19767] wm_agent_upgrade.c:135 at wm_agent_upgrade_listen_messages(): DEBUG: (8157): Response message: '[{"error":12,"data":"Not agent id found in database.","agent":5}]'`


`2020/07/27 15:47:27 wazuh-modulesd:agent-upgrade[19767] wm_agent_upgrade.c:135 at wm_agent_upgrade_listen_messages(): DEBUG: (8157): Response message: '[{"error":10,"data":"Current agent version is greater or equal.","agent":1}]'`

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
 
