### PR TITLE
Enhance wazuh_logtest_main

### DIFF
--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -83,9 +83,20 @@ void *w_logtest_main(w_logtest_connection_t *connection) {
     int client;
     char msg_received[OS_MAXSTR];
     int size_msg_received;
+    w_logtest_session_t* current_session;
+
+    /* input-ouput */
+    w_logtest_request req = {0};
+    cJSON* json_response;
+    cJSON* json_output;
+    char* str_response;
+    int error_code;
 
     while(1) {
+        error_code = 0;
+        json_response = cJSON_CreateObject();
 
+        /* Wait for client */
         w_mutex_lock(&connection->mutex);
 
         if (client = accept(connection->sock, (struct sockaddr *)NULL, NULL), client < 0) {
@@ -95,26 +106,88 @@ void *w_logtest_main(w_logtest_connection_t *connection) {
 
         w_mutex_unlock(&connection->mutex);
 
-        if (size_msg_received = recv(client, msg_received, OS_MAXSTR, 0), size_msg_received < 0) {
+        if (size_msg_received = recv(client, msg_received, OS_MAXSTR - 1, 0), size_msg_received < 0) {
             merror(LOGTEST_ERROR_RECV_MSG, strerror(errno));
             close(client);
             continue;
         }
+        msg_received[size_msg_received] = '\0';
 
+        /* Check msg and generate a request */
+        if (w_logtest_check_input(msg_received, &req) == -1) {
+            cJSON_AddStringToObject(json_response, W_LOGTEST_JSON_CODE,    "-1");
+            cJSON_AddStringToObject(json_response, W_LOGTEST_JSON_MESSAGE, "Error msg");
+            goto response;
+        }
+
+        /* Process */
+        current_session = w_logtest_get_session(&req);
+        json_output = w_logtest_process_log(&req, current_session);
+
+        /* Generate response */
+
+        if (cJSON_AddStringToObject(json_response, W_LOGTEST_JSON_TOKEN, req.token) == NULL) {
+            merror("(0000) %s error creating json response", W_LOGTEST_JSON_TOKEN);
+            goto cleanup;
+        }
+
+        // @TODO Check alert
+        if (cJSON_AddBoolToObject(json_response, W_LOGTEST_JSON_ALERT, 0) == NULL) {
+            merror("(0000) %s error creating json response", W_LOGTEST_JSON_TOKEN);
+            goto cleanup;
+        }
+
+        // @TODO Generate msg of info/warn/err
+        if (cJSON_AddStringToObject(json_response, W_LOGTEST_JSON_MESSAGE, "Maybe a msg") == NULL) {
+            merror("(0000) %s error creating json response", W_LOGTEST_JSON_TOKEN);
+            goto cleanup;
+        }
+
+        // @TODO Set code msg
+        if (cJSON_AddNumberToObject(json_response, W_LOGTEST_JSON_CODE, error_code) == NULL) {
+            merror("(0000) %s error creating json response", W_LOGTEST_JSON_TOKEN);
+            goto cleanup;
+        }
+
+        cJSON_AddItemToObject(json_response, W_LOGTEST_JSON_OUTPUT, json_output);
+
+  
+response:
+
+        if(isDebug()){
+            str_response = cJSON_Print(json_response);
+        }else{
+            str_response = cJSON_PrintUnformatted(json_response);
+        }
+
+        if (send(client, str_response, strlen(str_response) + 1, 0) == -1) {
+             merror(LOGTEST_ERROR_RESPONSE, req.token, errno, strerror(errno));
+        }
+
+cleanup:
+        w_logtest_free_request(&req);
+        os_free(str_response);
+        cJSON_Delete(json_response);
         close(client);
     }
 
     return NULL;
 }
 
+// Dummy init
+w_logtest_session_t *w_logtest_initialize_session(char *token) {
+    w_logtest_session_t *session;
+    os_calloc(1, sizeof(w_logtest_session_t), session);
+    if(OSHash_Add(w_logtest_sessions, token, session) != 2){
+        merror_exit("Error to add client");
+    }
 
-void w_logtest_initialize_session(const char *token) {
-
+    return session;
 }
 
 
-void w_logtest_process_log(const char *token) {
-
+cJSON* w_logtest_process_log(w_logtest_request* req, w_logtest_session_t* session) {
+    return NULL;
 }
 
 void w_logtest_remove_session(const char *token) {
@@ -177,4 +250,112 @@ int w_logtest_fts_init(OSList **fts_list, OSHash **fts_store) {
     }
 
     return 1;
+}
+
+int w_logtest_check_input(char* input_json, w_logtest_request* req) {
+    int ret = OS_INVALID; 
+
+    /* Parse raw JSON input */
+    cJSON* root;
+    cJSON* location;
+    cJSON* log_format;
+    cJSON* event;
+    cJSON* token;
+    const char* jsonErrPtr;
+
+    root = cJSON_ParseWithOpts(input_json, &jsonErrPtr, 0);
+    if (!root) {
+        mdebug1(LOGTEST_ERROR_JSON_PARSE);
+        mdebug1(LOGTEST_ERROR_JSON_PARSE_POS, (int)(jsonErrPtr - input_json),
+                (char*)(jsonErrPtr - 10 < input_json ? input_json : jsonErrPtr - 10));
+
+        goto cleanup;
+    }
+
+    /* Check JSON fields */
+    location = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_LOCATION);
+    if (!(cJSON_IsString(location) && (location->valuestring != NULL))) {
+        
+        mdebug1(LOGTEST_ERROR_JSON_REQUIRED_SFIELD, W_LOGTEST_JSON_LOCATION);
+        goto cleanup;
+    }
+
+    log_format = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_LOGFORMAT);
+    if (!(cJSON_IsString(log_format) && (log_format->valuestring != NULL))) {
+
+        mdebug1(LOGTEST_ERROR_JSON_REQUIRED_SFIELD, W_LOGTEST_JSON_LOGFORMAT);
+        goto cleanup;
+    }
+
+    event = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_EVENT);
+    if (!(cJSON_IsString(event) && (event->valuestring != NULL))) {
+        
+        mdebug1(LOGTEST_ERROR_JSON_REQUIRED_SFIELD, W_LOGTEST_JSON_EVENT);
+        goto cleanup;
+    }
+
+    token = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_TOKEN);
+    req->token = NULL;
+    if (cJSON_IsString(token) && (token->valuestring != NULL)) {
+
+        if (strlen(token->valuestring) != W_LOGTEST_TOKEN_LENGH) {
+            mdebug1(LOGTEST_ERROR_TOKEN_INVALID, token->valuestring);
+        } else {
+            os_strdup(token->valuestring, req->token);
+        }
+    }
+
+    os_strdup(location->valuestring, req->location);
+    os_strdup(log_format->valuestring, req->log_format);
+    os_strdup(event->valuestring, req->event);
+
+    ret = OS_SUCCESS;
+
+cleanup:
+    cJSON_Delete(root);
+    return ret;
+}
+
+void w_logtest_free_request(w_logtest_request* req) {
+
+    os_free(req->event);
+    os_free(req->token);
+    os_free(req->location);
+    os_free(req->log_format);
+}
+
+w_logtest_session_t* w_logtest_get_session(w_logtest_request* req){
+    
+    w_logtest_session_t* session = NULL;
+
+    /* Search an active session */
+    if (req->token) {
+        if (session = OSHash_Get(w_logtest_sessions, req->token), session) {
+            session->last_connection = time(NULL);
+            return session;
+        }
+        mdebug1("%s", LOGTEST_WARN_TOKEN_EXPIRED);
+    }
+
+    /* New session */
+    do {
+        os_free(req->token);
+        req->token = w_logtest_generate_token();
+    } while (OSHash_Get(w_logtest_sessions, req->token) != NULL);
+    mdebug1(LOGTEST_INFO_TOKEN_NEW, req->token);
+
+    session = w_logtest_initialize_session(req->token);
+    return session;
+}
+
+char* w_logtest_generate_token() {
+
+    char* str_token;
+    int32_t int_token;
+
+    os_malloc(W_LOGTEST_TOKEN_LENGH + 1, str_token);
+    randombytes((void*)&int_token, sizeof(int32_t));
+    snprintf(str_token, W_LOGTEST_TOKEN_LENGH + 1, "%08x", int_token);
+
+    return str_token;
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5373|

Hello team!

The following Analysisd's modifications are necessary to wazuh-logtest,

+ Enhance `wazuh_logtest_main`. When logtest receive messages:
    - Save message in the cJSON structure.
    - Check if messages have a correct format

## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows

- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Added unit tests (for new features)

