### PR TITLE
Fixing bugs reported by Coverity for Vulnerability Detector

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -471,11 +471,15 @@ void wm_vuldet_enable_rhel_json_feed(update_node **updates) {
             mwarn(VU_OFFLINE_CONFLICT, updates[rhel_enabled]->dist);
         }
         // As soon as a valid RedHat O.S. is detected, enable the RedHat JSON feed
-        wm_vuldet_set_feed_version("jredhat", NULL, updates);
+        int retval;
+        if (retval = wm_vuldet_set_feed_version("jredhat", NULL, updates), retval == OS_INVALID) {
+            mwarn("Unable to load the RedHat JSON feed at module '%s'", WM_VULNDETECTOR_CONTEXT.name);
+        }
     }
 }
 
 int wm_vuldet_read_deprecated_config(const OS_XML *xml, xml_node *node, update_node **updates, long unsigned int *update) {
+
     mwarn("'%s' option at module '%s' is deprecated. Use '%s' instead.", node->element, WM_VULNDETECTOR_CONTEXT.name, XML_PROVIDER);
 
     if (!strcmp(node->element, XML_FEED)) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1433,7 +1433,7 @@ int wm_vuldet_send_cve_report(vu_report *report) {
             report->cve,
             report->condition ? report->condition : "Hotfix is not installed.");
     } else {
-        if (report && report->software && report->version && report->agent_id && report->cve) {
+        if (report->software && report->version && report->agent_id && report->cve) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACK_VER_VULN, report->software,
             report->version, atoi(report->agent_id), report->cve,
             report->condition && *report->condition != '\0' ? report->condition :
@@ -6079,13 +6079,14 @@ end:
 }
 
 int wm_vuldet_index_json(wm_vuldet_db *parsed_vulnerabilities, update_node *update, char *path, char multi_path) {
+
     int retval = OS_INVALID;
-    char *directory;
     DIR *upd_dir = NULL;
     struct dirent *entry;
     char *path_cpy = NULL;
 
     if (multi_path) {
+        char *directory = NULL;
         char generated_path[PATH_MAX + 1];
         char *pattern;
         regex_t path_pattern;
@@ -6098,9 +6099,10 @@ int wm_vuldet_index_json(wm_vuldet_db *parsed_vulnerabilities, update_node *upda
             goto end;
         }
 
-        directory = strrchr(path_cpy, '/');
-
-        assert(directory != NULL);
+        if (directory = strrchr(path_cpy, '/'), !directory) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_MULTIPATH_ERROR, path_cpy, "corrupted");
+            goto end;
+        }
 
         *directory = '\0';
         pattern = directory + 1;


### PR DESCRIPTION
## Description

Fixing three errors reported by Coverity:

- Null pointer dereferences

```
*** CID 211521:  Null pointer dereferences  (REVERSE_INULL)
/wazuh_modules/vulnerability_detector/wm_vuln_detector.c: 1436 in wm_vuldet_send_cve_report()
1430         if (report->is_hotfix) {
1431             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_HOTFIX_VUL,
1432                 atoi(report->agent_id),
1433                 report->cve,
1434                 report->condition ? report->condition : "Hotfix is not installed.");
1435         } else {
>>>     CID 211521:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "report" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
1436             if (report && report->software && report->version && report->agent_id && report->cve) {
1437             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACK_VER_VULN, report->software,
1438                 report->version, atoi(report->agent_id), report->cve,
1439                 report->condition && *report->condition != '\0' ? report->condition :
1440                 "exists");
1441             }
```

- Error handling issues (not checking a return value)

```
*** CID 211351:  Error handling issues  (CHECKED_RETURN)
/config/wmodules-vuln-detector.c: 474 in wm_vuldet_enable_rhel_json_feed()
468         } else {
469             // Online JSON but Offline OVALs
470             if (updates[rhel_enabled]->path || updates[rhel_enabled]->url) {
471                 mwarn(VU_OFFLINE_CONFLICT, updates[rhel_enabled]->dist);
472             }
473             // As soon as a valid RedHat O.S. is detected, enable the RedHat JSON feed
>>>     CID 211351:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "wm_vuldet_set_feed_version" without checking return value (as is done elsewhere 4 out of 5 times).
474             wm_vuldet_set_feed_version("jredhat", NULL, updates);
475         }
476     }
477     
478     int wm_vuldet_read_deprecated_config(const OS_XML *xml, xml_node *node, update_node **updates, long unsigned int *update) {
479         mwarn("'%s' option at module '%s' is deprecated. Use '%s' instead.", node->element, WM_VULNDETECTOR_CONTEXT.name, XML_PROVIDER);
```

- Dereference null return value

```
CID 204340 (#1 of 1): Dereference null return value (NULL_RETURNS)
6. dereference: Dereferencing directory, which is known to be NULL.
6152        *directory = '\0';
6153        pattern = directory + 1;
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
