### PR TITLE
Add authd.pass content to response in config endpoints

### DIFF
--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -759,6 +759,15 @@ def get_active_configuration(agent_id, component, configuration):
 
     if rec_msg_ok.startswith('ok'):
         msg = json.loads(rec_msg)
+
+        # Include password if auth->use_password enabled and authd.pass file exists
+        if msg.get('auth', {}).get('use_password') == 'yes':
+            try:
+                with open(os_path.join(common.ossec_path, "etc", "authd.pass"), 'r') as f:
+                    msg['authd.pass'] = f.read().rstrip()
+            except IOError:
+                pass
+
         return msg
     else:
         raise WazuhError(1117 if "No such file or directory" in rec_msg or "Cannot send request" in rec_msg else 1116,


### PR DESCRIPTION
Hello team! This PR closes #5572 

## Description

This PR adds the content of the auth password file (`authd.pass`) to the response of the following endpoints when requesting auth component:
- `GET {protocol}://{host}:{port}/v4/agents/{agent_id}/config/{component}/{configuration}` 
- `GET {protocol}://{host}:{port}/v4/manager/configuration/{component}/{configuration}` 

Auth.pass file only exists if the user creates it, so no extra information is added to the response in case the file does not exist or use_password is not enabled inside `<auth>` block. This is the response when the user does not set a password (so a random one is generated and shown inside ossec.log):

```JSON
{
  "data": {
    "affected_items": [
      {
        "auth": {
          "port": 1515,
          "force_time": "always",
          "disabled": "no",
          "use_source_ip": "no",
          "force_insert": "yes",
          "purge": "yes",
          "use_password": "yes",
          "limit_maxagents": "yes",
          "ssl_verify_host": "no",
          "ssl_auto_negotiate": "no",
          "ciphers": "HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH",
          "ssl_manager_cert": "/var/ossec/etc/sslmanager.cert",
          "ssl_manager_key": "/var/ossec/etc/sslmanager.key"
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration read successfully"
}
```

And this is when the file `/var/ossec/etc/authd.pass` exists:
```JSON
{
  "data": {
    "affected_items": [
      {
        "auth": {
          "port": 1515,
          "force_time": "always",
          "disabled": "no",
          "use_source_ip": "no",
          "force_insert": "yes",
          "purge": "yes",
          "use_password": "yes",
          "limit_maxagents": "yes",
          "ssl_verify_host": "no",
          "ssl_auto_negotiate": "no",
          "ciphers": "HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH",
          "ssl_manager_cert": "/var/ossec/etc/sslmanager.cert",
          "ssl_manager_key": "/var/ossec/etc/sslmanager.key"
        },
        "authd.pass": "test_password"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration read successfully"
}
```

It's outside the `auth` block to avoid confusing it with any of the auth options in `ossec.conf`


## Unit tests

Both endpoints share the same framework function, so it has needed only one new unit tests:
```
python3 -m pytest wazuh/core/tests/test_configuration.py 
=============================================== test session starts ===============================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, html-2.0.1
collected 34 items                                                                                                

wazuh/core/tests/test_configuration.py ..................................                                   [100%]

=============================================== 34 passed in 0.19s ================================================
```

## Integration tests
```
pytest test_manager_endpoints.tavern.yaml -vv
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-40-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, html-2.0.1
collected 35 items                                                                                                                                                                                           

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                         [  2%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                           [  5%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                                                                  [  8%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                                                               [ 11%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                                                               [ 14%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                                                               [ 17%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                                                                [ 20%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                                                             [ 22%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[open-scap] PASSED                                                                                                             [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                                                               [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                                                                [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                                                             [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                                                               [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                                                              [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                                                                          [ 42%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED                                                                                                [ 45%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                                                                   [ 48%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                                  [ 51%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                          [ 54%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                                   [ 57%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                                   [ 60%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                                [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                                  [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                           [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                                   [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/files PASSED                                                                                                                                          [ 74%]
test_manager_endpoints.tavern.yaml::PUT /manager/files PASSED                                                                                                                                          [ 77%]
test_manager_endpoints.tavern.yaml::DELETE /manager/files PASSED                                                                                                                                       [ 80%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                                                                  [ 82%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                                                                [ 85%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                      [ 88%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                                     [ 91%]
test_manager_endpoints.tavern.yaml::PUT /manager/api/config PASSED                                                                                                                                     [ 94%]
test_manager_endpoints.tavern.yaml::DELETE /manager/api/config PASSED                                                                                                                                  [ 97%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                        [100%]

============================================================================================== warnings summary ==============================================================================================

```

Best regards,
Selu.