### PR TITLE
Improve registration response parsing

### DIFF
--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -304,6 +304,12 @@ cJSON *getClusterConfig(void) {
     os_calloc(OS_MAXSTR,sizeof(char),buffer);
 
     switch (length = OS_RecvSecureClusterTCP(sock, buffer, OS_MAXSTR), length) {
+    case -2:
+        merror("Cluster error detected");
+        free(buffer);
+        close(sock);
+        return NULL;
+                           
     case -1:
         merror("At wcom_main(): OS_RecvSecureClusterTCP(): %s", strerror(errno));
         free(buffer);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -748,9 +748,7 @@ int OS_SetSocketSize(int sock, int mode, int max_msg_size) {
 }
 
 
-/* Send secure TCP to Cluster message
- * Return 0 on success or OS_SOCKTERR on error.
- */
+/* Send secure TCP Cluster message */
 int OS_SendSecureTCPCluster(int sock, const void * command, const void * payload, size_t length) {
     const unsigned COMMAND_SIZE = 12;
     const unsigned HEADER_SIZE =  8;
@@ -795,9 +793,7 @@ int OS_SendSecureTCPCluster(int sock, const void * command, const void * payload
 }
 
 
-/* Receive secure TCP message
- * Return recvval on success or OS_SOCKTERR on error.
- */
+/* Receive secure TCP Cluster message */
 int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length) {
     int recvval;
     const unsigned CMD_SIZE = 12;
@@ -810,20 +806,21 @@ int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length) {
     switch(recvval){
         case -1:
             return recvval;
-            break;
 
         case 0:
             return recvval;
-            break;
 
         default:
             if ((uint32_t)recvval != HEADER_SIZE) {
                 return -1;
             }
     }
+   
+    if (strncmp(buffer+8, "err --------", CMD_SIZE) == 0) {
+        return -2;
+    }
 
     size = wnet_order_big(*(uint32_t*)(buffer + 4));
-
     if (size > length) {
         mwarn("Cluster message size (%u) exceeds buffer length (%u)", (unsigned)size, (unsigned)length);
         return -1;

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -114,19 +114,29 @@ int OS_SendSecureTCP(int sock, uint32_t size, const void * msg);
  */
 int OS_RecvSecureTCP(int sock, char * ret,uint32_t size);
 
-
-/* Send secure TCP Cluster message
- * Return 0 on success or OS_SOCKTERR on error.
- */
+/**
+ * @brief Send secure TCP Cluster message 
+ * @param sock Socket to write on
+ * @param command Command to send
+ * @param payload Payload of the command to send
+ * @param length Length of the message to send
+ * @return recvval on success
+ * @return OS_SOCKTERR on error
+ * */
 int OS_SendSecureTCPCluster(int sock, const void * command, const void * payload, size_t length);
 
-/* Receive secure TCP message
- * Return recvval on success or OS_SOCKTERR on error.
- */
-int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length);
+/**
+ * @brief Receive secure TCP Cluster message
+ * @param sock Socket to read from
+ * @param ret Response read
+ * @param length Max length to be read
+ * @return recvval on success
+ * @return -1 on socket errors
+ * @return -2 on cluster errors
+ * */
+int OS_RecvSecureClusterTCP(int sock, char* ret, size_t length);
 
-// Byte ordering
-
+/* Byte ordering */
 uint32_t wnet_order(uint32_t value);
 
 /* Set the maximum buffer size for the socket */

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -842,7 +842,7 @@ void delete_diff(const char *name)
     char tmp_folder[513];
     tmp_folder[512] = '\0';
     snprintf(tmp_folder, 512, "%s/%s",
-             DIFF_DIR,
+             DIFF_DIR_PATH,
              name);
     
     rmdir_ex(tmp_folder);

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -40,7 +40,7 @@ void __wrap__mdebug1(const char * file, int line, const char * func, const char 
   
 extern cJSON* w_create_agent_add_payload(const char *name, const char *ip, const char * groups, const char *key, const int force, const char *id);
 extern cJSON* w_create_agent_remove_payload(const char *id, const int purge);
-extern cJSON* w_create_send_sync_payload(const char *daemon_name, cJSON *message);
+extern cJSON* w_create_sendsync_payload(const char *daemon_name, cJSON *message);
 extern int w_parse_agent_add_response(const char* buffer, char *err_response, char* id, char* key, const int json_format, const int exit_on_error);
 extern int w_parse_agent_remove_response(const char* buffer, char *err_response, const int json_format, const int exit_on_error);
 
@@ -112,52 +112,38 @@ static void test_create_agent_remove_payload(void **state) {
     cJSON_Delete(payload); 
 }
 
-static void test_create_send_sync_payload(void **state) {   
+static void test_create_sendsync_payload(void **state) {   
     char* daemon = "daemon_test";
     char* id = "001";
     int purge = 1;
     cJSON* payload = NULL;
     cJSON* message = NULL;
-    cJSON* function = NULL;
-    cJSON* arguments = NULL;
     cJSON* item = NULL;   
     /* NULL message */ 
-    payload = w_create_send_sync_payload(daemon, message);    
+    payload = w_create_sendsync_payload(daemon, message);    
     
     assert_non_null(payload);
-    function = cJSON_GetObjectItem(payload, "function");
-    assert_non_null(function);
-    assert_string_equal(function->valuestring, "send_sync");
     
-    arguments = cJSON_GetObjectItem(payload, "arguments");
-    assert_non_null(arguments);
-    
-    item = cJSON_GetObjectItem(arguments, "daemon_name");
+    item = cJSON_GetObjectItem(payload, "daemon_name");
     assert_non_null(item);
     assert_string_equal(item->valuestring, daemon);    
     
-    item = cJSON_GetObjectItem(arguments, "message");
+    item = cJSON_GetObjectItem(payload, "message");
     assert_null(item);
 
     cJSON_Delete(payload); 
 
     /* non NULL message */
     message = w_create_agent_remove_payload(id,purge);
-    payload = w_create_send_sync_payload(daemon, message);    
+    payload = w_create_sendsync_payload(daemon, message);    
     
     assert_non_null(payload);
-    function = cJSON_GetObjectItem(payload, "function");
-    assert_non_null(function);
-    assert_string_equal(function->valuestring, "send_sync");
     
-    arguments = cJSON_GetObjectItem(payload, "arguments");
-    assert_non_null(arguments);
-    
-    item = cJSON_GetObjectItem(arguments, "daemon_name");
+    item = cJSON_GetObjectItem(payload, "daemon_name");
     assert_non_null(item);
     assert_string_equal(item->valuestring, daemon);    
     
-    item = cJSON_GetObjectItem(arguments, "message");
+    item = cJSON_GetObjectItem(payload, "message");
     assert_non_null(item);
 
     cJSON_Delete(payload);  
@@ -228,7 +214,7 @@ int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_create_agent_add_payload),
         cmocka_unit_test(test_create_agent_remove_payload),
-        cmocka_unit_test(test_create_send_sync_payload),
+        cmocka_unit_test(test_create_sendsync_payload),
         cmocka_unit_test(test_parse_agent_add_response),
         cmocka_unit_test(test_parse_agent_remove_response),
     };


### PR DESCRIPTION
|Related issue|
|---|
| #5546  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
**w_parse_agent_add_response()** and **w_parse_agent_remove_response()**, wasn't guaranteeing a valid **err_response** message if the received message has an invalid format. 
This scenario isn´t typical to reach, but when clusterd throws exceptions and answered the error exception, it shows up that this scenarios wasn't covered. 
Now, this functions handle this sceneario and provides a valid **err_response**. 


## Tests

Changes affect only Wazuh manager.
Minimal changes where implemented.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
- [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language
- [X] Unit tests for authd
- [X] Integration tests for authd 