### PR TITLE
Remove inactive client session in Logtest

### DIFF
--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -20,7 +20,7 @@
  */
 typedef struct w_logtest_session_t {
 
-    int token;                              ///< Client ID
+    char *token;                            ///< Client ID
     time_t last_connection;                 ///< Timestamp of the last query
 
     RuleNode *rule_list;                    ///< Rule list
@@ -46,12 +46,12 @@ OSHash *w_logtest_sessions;
 /**
  * @brief An instance of w_logtest_connection allow managing the connections with the logtest socket
  */
-typedef struct w_logtest_connection {
+typedef struct w_logtest_connection_t {
 
     pthread_mutex_t mutex;      ///< Mutex to prevent race condition in accept syscall
     int sock;                   ///< The open connection with logtest queue
 
-} w_logtest_connection;
+} w_logtest_connection_t;
 
 
 /**
@@ -74,33 +74,33 @@ int w_logtest_init_parameters();
  *
  * @param connection The listener where clients connect
  */
-void *w_logtest_main(w_logtest_connection * connection);
+void *w_logtest_main(w_logtest_connection_t * connection);
 
 /**
  * @brief Create resources necessary to service client
  * @param fd File descriptor which represents the client
  */
-void w_logtest_initialize_session(int token);
+void w_logtest_initialize_session(const char * token);
 
 /**
  * @brief Process client's request
  * @param fd File descriptor which represents the client
  */
-void w_logtest_process_log(int token);
+void w_logtest_process_log(const char * token);
 
 /**
  * @brief Free resources after client closes connection
  * @param fd File descriptor which represents the client
  */
-void w_logtest_remove_session(int token);
+void w_logtest_remove_session(const char * token);
 
 /**
- * @brief Check the active log-test sessions
+ * @brief Check the inactive logtest sessions
  *
- * Check all sessions. If a session is created and the client has been offline
- * for more than 15 minutes, remove it.
+ * Check all the sessions. If a session has been inactive longer than session_timeout,
+ * call w_logtest_remove_session to remove it.
  */
-void w_logtest_check_active_sessions();
+void * w_logtest_check_inactive_sessions(__attribute__((unused)) void * arg);
 
 /**
  * @brief Initialize FTS engine for a client session

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -498,6 +498,7 @@
 #define LOGTEST_ERROR_RECV_MSG                      "(7302): Failure to receive message. Errno: %s"
 #define LOGTEST_ERROR_INIT_HASH                     "(7303): Failure to initialize all_sesssions hash"
 #define LOGTEST_ERROR_INV_CONF                      "(7304): Invalid wazuh-logtest configuration"
+#define LOGTEST_ERROR_SIZE_HASH                     "(7305): Failure to resize all_sesssions hash"
 
 /* Verbose messages */
 #define STARTUP_MSG "Started (pid: %d)."


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5375|


## Description
To prevent memory growth due to the number of sessions, the function `w_logtest_check_inactive_sessions` will be implemented which will check the Hash table of sessions and remove those that have been inactive for `session_timeout` time.

This scan will be done by an `analysisd` thread that will be executed every `session_timeout` time.

## Tests
- [x] Compilation without warnings Linux
- [x] Compilation without warnings Windows
- [x] Scan-build report
- [x] Valgrind
- [x] Check the correct working of analysisd
- [x] Check the correct working of logtest
- [x] Running runtest.py successfully