### PR TITLE
Setting keepalive from SQL query

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -110,7 +110,6 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
     pending_data_t *data = NULL;
     int is_startup = 0;
     int agent_id = 0;
-    time_t keepalive = 0;
     int result = 0;
 
     if (strncmp(r_msg, HC_REQUEST, strlen(HC_REQUEST)) == 0) {
@@ -163,8 +162,8 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
         w_mutex_unlock(&lastmsg_mutex);
 
         agent_id = atoi(key->id);
-        keepalive = time(NULL);
-        result = wdb_update_agent_keepalive(agent_id, keepalive);
+
+        result = wdb_update_agent_keepalive(agent_id);
 
         if (OS_SUCCESS != result)
             mwarn("Unable to save agent last keepalive in global.db");
@@ -226,7 +225,6 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             }
 
             agent_id = atoi(key->id);
-            keepalive = time(NULL);
 
             // Updating version and keepalive in global.db
             result = wdb_update_agent_version(agent_id, os_name, os_version, os_major, os_minor, os_codename, os_platform,
@@ -235,11 +233,6 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             
             if (OS_INVALID == result)
                 mwarn("Unable to update information in global.db for agent: %s", key->id);
-            
-            result = wdb_update_agent_keepalive(agent_id, keepalive);
-
-            if (OS_INVALID == result)
-                mwarn("Unable to save last keepalive in global.db for agent: %s", key->id);
 
             os_free(version);
             os_free(os_name);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -311,7 +311,7 @@ int wdb_update_agent_name(int id, const char *name);
 int wdb_update_agent_version(int id, const char *os_name, const char *os_version, const char *os_major, const char *os_minor, const char *os_codename, const char *os_platform, const char *os_build, const char *os_uname, const char *os_arch, const char *version, const char *config_sum, const char *merged_sum, const char *manager_host, const char *node_name, const char *agent_ip);
 
 /* Update agent's last keepalive. It opens and closes the DB. Returns number of affected rows or -1 on error. */
-int wdb_update_agent_keepalive(int id, long keepalive);
+int wdb_update_agent_keepalive(int id);
 
 /* Update agent group. It opens and closes the DB. Returns 0 on success or -1 on error. */
 int wdb_update_agent_group(int id,char *group);

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -18,9 +18,9 @@
 
 static const char *SQL_INSERT_AGENT = "INSERT INTO agent (id, name, ip, register_ip, internal_key, date_add, `group`) VALUES (?, ?, ?, ?, ?, ?, ?);";
 static const char *SQL_UPDATE_AGENT_NAME = "UPDATE agent SET name = ? WHERE id = ?;";
-static const char *SQL_UPDATE_AGENT_VERSION = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ? WHERE id = ?;";
-static const char *SQL_UPDATE_AGENT_VERSION_IP = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ? , ip = ? WHERE id = ?;";
-static const char *SQL_UPDATE_AGENT_KEEPALIVE = "UPDATE agent SET last_keepalive = ? WHERE id = ?;";
+static const char *SQL_UPDATE_AGENT_VERSION = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ?, last_keepalive = STRFTIME('%s', 'NOW') WHERE id = ?;";
+static const char *SQL_UPDATE_AGENT_VERSION_IP = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ?, last_keepalive = STRFTIME('%s', 'NOW'), ip = ? WHERE id = ?;";
+static const char *SQL_UPDATE_AGENT_KEEPALIVE = "UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW') WHERE id = ?;";
 static const char *SQL_SELECT_AGENT_STATUS = "SELECT status FROM agent WHERE id = ?;";
 static const char *SQL_UPDATE_AGENT_STATUS = "UPDATE agent SET status = ? WHERE id = ?;";
 static const char *SQL_UPDATE_AGENT_GROUP = "UPDATE agent SET `group` = ? WHERE id = ?;";
@@ -161,7 +161,7 @@ int wdb_update_agent_version(int id, const char *os_name, const char *os_version
 }
 
 /* Update agent's last keepalive time. It opens and closes the DB. Returns number of affected rows or -1 on error. */
-int wdb_update_agent_keepalive(int id, long keepalive) {
+int wdb_update_agent_keepalive(int id) {
     int result = 0;
     sqlite3_stmt *stmt;
 
@@ -173,8 +173,7 @@ int wdb_update_agent_keepalive(int id, long keepalive) {
         return -1;
     }
 
-    sqlite3_bind_int64(stmt, 1, keepalive);
-    sqlite3_bind_int(stmt, 2, id);
+    sqlite3_bind_int(stmt, 1, id);
 
     result = wdb_step(stmt) == SQLITE_DONE ? (int)sqlite3_changes(wdb_global) : -1;
     sqlite3_finalize(stmt);


### PR DESCRIPTION
|Related issue|
|---|
| [Issue 5566](https://github.com/wazuh/wazuh/issues/5566) |

## Description

This PR improves the way that we were using to set the `last_keepalive` field in the `global.db`. The change avoid using the `time()` **C** function to instead make use of the `STRFTIME()` **SQL** function directly in the **SQL** query.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade