### PR TITLE
Add restriction on endpoints with DELETE method

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -168,8 +168,10 @@ def check_token(username, token_nbf_time):
     -------
     Dict with the result
     """
+    with AuthenticationManager() as am:
+        user_id = am.get_user(username=username)['id']
     with TokenManager() as tm:
-        result = tm.is_token_valid(username=username, token_nbf_time=int(token_nbf_time))
+        result = tm.is_token_valid(user_id=user_id, token_nbf_time=int(token_nbf_time))
 
     return {'valid': result}
 

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -35,6 +35,8 @@ async def delete_agents(request, pretty=False, wait_for_complete=False, list_age
     ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the register date.
     :return: AllItemsResponseAgentIDs
     """
+    if 'all' in list_agents:
+        list_agents = None
     f_kwargs = {'agent_list': list_agents,
                 'purge': purge,
                 'status': status,
@@ -576,6 +578,8 @@ async def delete_groups(request, list_groups=None, pretty=False, wait_for_comple
     :param list_groups: Array of group's IDs.
     :return: AllItemsResponseGroupIDs + AgentGroupDeleted
     """
+    if 'all' in list_groups:
+        list_groups = None
     f_kwargs = {'group_list': list_groups}
 
     dapi = DistributedAPI(f=agent.delete_groups,

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -526,6 +526,8 @@ async def delete_multiple_agent_single_group(request, group_id, list_agents=None
     :param wait_for_complete: Disable timeout response
     :return: AllItemsResponseAgentIDs
     """
+    if 'all' in list_agents:
+        list_agents = None
     f_kwargs = {'agent_list': list_agents,
                 'group_list': [group_id]}
 

--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -18,7 +18,7 @@ from wazuh.core.cluster.dapi.dapi import DistributedAPI
 logger = logging.getLogger('wazuh')
 
 
-async def clear_syscheck_database(request, pretty=False, wait_for_complete=False, list_agents='*'):
+async def clear_syscheck_database(request, pretty=False, wait_for_complete=False, list_agents=None):
     """ Clear the syscheck database for all agents.
 
     :param pretty: Show results in human-readable format
@@ -26,6 +26,8 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
     :param list_agents: List of agent's IDs.
     :return: AllItemsResponseAgentIDs
     """
+    if 'all' in list_agents:
+        list_agents = '*'
     if not configuration.api_conf['experimental_features']:
         raise_if_exc(APIError(code=2008))
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1337,6 +1337,12 @@ components:
       description: "Agent ID"
       format: numbers
 
+    AgentID_DELETE:
+      type: string
+      minLength: 3
+      description: "Agent ID|All"
+      format: numbers_delete
+
     NodeID:
       type: string
       description: "Node ID"
@@ -1347,6 +1353,12 @@ components:
       minLength: 1
       description: "Group name"
       format: group_names
+
+    GroupID_DELETE:
+      type: string
+      minLength: 1
+      description: "Group name|All"
+      format: group_names_delete
 
     AgentConfiguration:
       type: object
@@ -1527,14 +1539,26 @@ components:
       type: string
       format: numbers
       description: "Role ID"
+    Role_id_DELETE:
+      type: string
+      description: "Role ID|All"
+      format: numbers_delete
     Policy_id:
       type: string
       format: numbers
       description: "Policy ID"
+    Policy_id_DELETE:
+      type: string
+      description: "Policy ID|All"
+      format: numbers_delete
     User_id:
       type: string
       format: numbers
       description: "User ID"
+    User_id_DELETE:
+      type: string
+      format: numbers_delete
+      description: "User ID|All"
     Username:
       type: string
       description: "Username of the user"
@@ -3681,6 +3705,15 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/AgentID'
+    list_agents_delete:
+      in: query
+      name: list_agents
+      description: "List of agent IDs (separated by comma), use the keyword 'all' to select all agents"
+      required: true
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/AgentID_DELETE'
     list_groups:
       in: query
       name: list_groups
@@ -3689,6 +3722,15 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/GroupID'
+    list_groups_delete:
+      in: query
+      name: list_groups
+      description: "List of group IDs (separated by comma), use the keyword 'all' to select all groups"
+      required: true
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/GroupID_DELETE'
     list_nodes:
       in: query
       name: list_nodes
@@ -3808,6 +3850,15 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/Policy_id'
+    policy_ids_rbac_delete:
+      in: query
+      name: 'policy_ids'
+      description: "List of policy IDs (separated by comma), use the keyword 'all' to select all policies"
+      required: true
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/Policy_id_DELETE'
     policy_ids_rbac_required:
       in: query
       name: 'policy_ids'
@@ -3893,20 +3944,29 @@ components:
     role_ids:
       in: query
       name: 'role_ids'
-      description: "List of role IDs"
+      description: "List of role IDs (separated by comma)"
       schema:
         type: array
         items:
           $ref: '#/components/schemas/Role_id'
+    role_ids_delete:
+      in: query
+      name: 'role_ids'
+      description: "List of role IDs (separated by comma), use the keyword 'all' to select all roles"
+      required: true
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/Role_id_DELETE'
     role_ids_required:
       in: query
       name: 'role_ids'
-      description: "List of role IDs"
+      description: "List of role IDs (separated by comma)"
       required: True
       schema:
         type: array
         items:
-          $ref: '#/components/schemas/Role_id'
+          $ref: '#/components/schemas/Role_id_DELETE'
     security_position:
       in: query
       name: 'position'
@@ -4038,20 +4098,27 @@ components:
     user_ids:
       in: query
       name: 'user_ids'
-      description: "List of user IDs"
+      description: "List of user IDs (separated by comma)"
       schema:
         type: array
         items:
           $ref: '#/components/schemas/User_id'
+    user_ids_delete:
+      in: query
+      name: 'user_ids'
+      description: "List of user IDs (separated by comma), use the keyword 'all' to select all users"
+      required: true
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/User_id_DELETE'
     user_id_required:
       in: path
       name: 'user_id'
       description: "User ID"
       required: True
       schema:
-        type: array
-        items:
-          $ref: '#/components/schemas/User_id'
+        $ref: '#/components/schemas/User_id'
     unknown:
       in: query
       name: unknown
@@ -4938,7 +5005,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/list_agents'
+        - $ref: '#/components/parameters/list_agents_delete'
         - $ref: '#/components/parameters/purge'
         - $ref: '#/components/parameters/statusAgentParam'
         - $ref: '#/components/parameters/older_than'
@@ -5726,7 +5793,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/list_groups'
+        - $ref: '#/components/parameters/list_groups_delete'
       responses:
         '200':
           description: "Remove multiple group of multiple agents"
@@ -10638,7 +10705,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/list_agents'
+        - $ref: '#/components/parameters/list_agents_delete'
       responses:
         '200':
           description: "Delete syscheck database"
@@ -12579,7 +12646,7 @@ paths:
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
       parameters:
-        - $ref: '#/components/parameters/role_ids'
+        - $ref: '#/components/parameters/role_ids_delete'
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
@@ -12827,7 +12894,7 @@ paths:
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
       parameters:
-        - $ref: '#/components/parameters/policy_ids_rbac'
+        - $ref: '#/components/parameters/policy_ids_rbac_delete'
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
@@ -13024,7 +13091,7 @@ paths:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
       parameters:
         - $ref: '#/components/parameters/role_id'
-        - $ref: '#/components/parameters/policy_ids_rbac_required'
+        - $ref: '#/components/parameters/policy_ids_rbac_delete'
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
@@ -13116,7 +13183,7 @@ paths:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
       parameters:
         - $ref: '#/components/parameters/user_id_required'
-        - $ref: '#/components/parameters/role_ids_required'
+        - $ref: '#/components/parameters/role_ids_delete'
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
@@ -13347,13 +13414,13 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a user"
-      description: "Delete a user by specifying their ID"
+      summary: "Delete a list of users"
+      description: "Delete a list of users by specifying their IDs"
       operationId: api.controllers.security_controller.delete_users
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
       parameters:
-        - $ref: '#/components/parameters/user_ids'
+        - $ref: '#/components/parameters/user_ids_delete'
       responses:
         '200':
           description: "User deleted successful"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1340,7 +1340,7 @@ components:
     AgentID_DELETE:
       type: string
       minLength: 3
-      description: "Agent ID|All"
+      description: "Agent ID|all"
       format: numbers_delete
 
     NodeID:
@@ -1357,7 +1357,7 @@ components:
     GroupID_DELETE:
       type: string
       minLength: 1
-      description: "Group name|All"
+      description: "Group name|all"
       format: group_names_delete
 
     AgentConfiguration:
@@ -1541,7 +1541,7 @@ components:
       description: "Role ID"
     Role_id_DELETE:
       type: string
-      description: "Role ID|All"
+      description: "Role ID|all"
       format: numbers_delete
     Policy_id:
       type: string
@@ -1549,7 +1549,7 @@ components:
       description: "Policy ID"
     Policy_id_DELETE:
       type: string
-      description: "Policy ID|All"
+      description: "Policy ID|all"
       format: numbers_delete
     User_id:
       type: string
@@ -1558,7 +1558,7 @@ components:
     User_id_DELETE:
       type: string
       format: numbers_delete
-      description: "User ID|All"
+      description: "User ID|all"
     Username:
       type: string
       description: "Username of the user"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5650,7 +5650,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/list_agents'
+        - $ref: '#/components/parameters/list_agents_delete'
         - $ref: '#/components/parameters/group_id_query'
       responses:
         '200':

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -20,7 +20,8 @@ _boolean = re.compile(r'^true$|^false$')
 _cdb_list = re.compile(r'^#?[\w\s-]+:{1}(#?[\w\s-]+|)$')
 _dates = re.compile(r'^\d{8}$')
 _empty_boolean = re.compile(r'^$|(^true$|^false$)')
-_group_names = re.compile(r'^[A-Za-z0-9.\-_]+$')
+_group_names = re.compile(r'^(?!.*(all))[A-Za-z0-9.\-_]+$')
+_group_names_delete = re.compile(r'^[A-Za-z0-9.\-_]+$')
 _hashes = re.compile(r'^(?:[\da-fA-F]{32})?$|(?:[\da-fA-F]{40})?$|(?:[\da-fA-F]{56})?$|(?:[\da-fA-F]{64})?$|(?:[\da-fA-F]{96})?$|(?:[\da-fA-F]{128})?$')
 _ips = re.compile(
     r'^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?:\/(?:[0-9]|[1-2][0-9]|3[0-2])){0,1}$|^any$|^ANY$')
@@ -29,6 +30,7 @@ _iso8601_date_time = (
     r'^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])[tT](2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?([zZ]|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])$')
 _names = re.compile(r'^[\w\-\.]+$')
 _numbers = re.compile(r'^\d+$')
+_numbers_delete = re.compile(r'^\d+|all$')
 _wazuh_key = re.compile(r'[a-zA-Z0-9]+$')
 _paths = re.compile(r'^[\w\-\.\\\/:]+$')
 _query_param = re.compile(r"^(?:[\w\.\-]+(?:=|!=|<|>|~)[\w\.\- ]+)(?:(?:;|,)[\w\.\-]+(?:=|!=|<|>|~)[\w\.\- ]+)*$")
@@ -183,6 +185,11 @@ def format_numbers(value):
     return check_exp(value, _numbers)
 
 
+@draft4_format_checker.checks("numbers_delete")
+def format_numbers(value):
+    return check_exp(value, _numbers_delete)
+
+
 @draft4_format_checker.checks("path")
 def format_path(value):
     return check_exp(value, _paths)
@@ -251,3 +258,7 @@ def format_datetime_or_empty(value):
 @draft4_format_checker.checks("group_names")
 def format_group_names(value):
     return check_exp(value, _group_names)
+
+@draft4_format_checker.checks("group_names_delete")
+def format_group_names(value):
+    return check_exp(value, _group_names_delete)

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -20,7 +20,7 @@ _boolean = re.compile(r'^true$|^false$')
 _cdb_list = re.compile(r'^#?[\w\s-]+:{1}(#?[\w\s-]+|)$')
 _dates = re.compile(r'^\d{8}$')
 _empty_boolean = re.compile(r'^$|(^true$|^false$)')
-_group_names = re.compile(r'^(?!.*(all))[A-Za-z0-9.\-_]+$')
+_group_names = re.compile(r'^[A-Za-z0-9.\-_]+\b(?<!\ball)$')
 _group_names_delete = re.compile(r'^[A-Za-z0-9.\-_]+$')
 _hashes = re.compile(r'^(?:[\da-fA-F]{32})?$|(?:[\da-fA-F]{40})?$|(?:[\da-fA-F]{56})?$|(?:[\da-fA-F]{64})?$|(?:[\da-fA-F]{96})?$|(?:[\da-fA-F]{128})?$')
 _ips = re.compile(
@@ -259,6 +259,7 @@ def format_datetime_or_empty(value):
 def format_group_names(value):
     return check_exp(value, _group_names)
 
+
 @draft4_format_checker.checks("group_names_delete")
-def format_group_names(value):
+def format_group_names_delete(value):
     return check_exp(value, _group_names_delete)

--- a/api/test/integration/test_agents_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_DELETE_endpoints.tavern.yaml
@@ -238,7 +238,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        list_agents: '000,002'
+        list_agents: 000,002
         group_id: group1
     response:
       status_code: 200
@@ -267,7 +267,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        list_agents: '998,999'
+        list_agents: 998,999
         group_id: group1
     response:
       strict: False
@@ -294,7 +294,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        list_agents: '006,010'
+        list_agents: 006,010
         group_id: group2
     response:
       status_code: 200
@@ -316,6 +316,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         group_id: group2
+        list_agents: all
     response:
       status_code: 200
       json:
@@ -324,6 +325,33 @@ stages:
             - '008'
           total_affected_items: 1
         message: !anystr
+
+  # DELETE /agents/group?group_id=group2
+  - name: Remove all agents from group2 (invalid list_agents)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        group_id: group2
+        list_agents: none
+    response:
+      status_code: 400
+
+  # DELETE /agents/group?group_id=group2
+  - name: Remove all agents from group2 (invalid list_agents)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        group_id: group2
+    response:
+      status_code: 400
 
 ---
 test_name: DELETE /groups (only one group)
@@ -404,6 +432,17 @@ stages:
           total_affected_items: 1
         message: !anystr
 
+  # DELETE /groups (invalid list_groups)
+  - name: Delete group3
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 400
+
 ---
 test_name: DELETE /groups (several groups)
 
@@ -472,6 +511,8 @@ stages:
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        list_groups: all
     response:
       status_code: 200
       json:
@@ -588,6 +629,20 @@ stages:
             - '010'
           total_affected_items: 1
         message: !anystr
+
+  # DELETE /agents?purge=True
+  - name: Delete an agent using purge
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        purge: True
+        older_than: '0s'
+    response:
+      status_code: 400
 
 ---
 test_name: DELETE /agents
@@ -812,6 +867,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         older_than: '0s'
+        list_agents: all
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -13,6 +13,8 @@ stages:
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        list_agents: all
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
@@ -796,6 +796,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         group_id: group2
+        list_agents: all
     response:
       status_code: 400
       json:
@@ -810,6 +811,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         group_id: group1
+        list_agents: all
     response:
       status_code: 200
       json:
@@ -932,6 +934,8 @@ stages:
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        list_groups: all
     response:
       status_code: 200
       json:
@@ -1109,6 +1113,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         older_than: '0s'
+        list_agents: all
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -13,6 +13,8 @@ stages:
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        list_agents: all
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -840,6 +840,8 @@ stages:
       url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        user_ids: all
       method: DELETE
     response:
       status_code: 200
@@ -874,6 +876,8 @@ stages:
       url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        user_ids: all
       method: DELETE
     response:
       status_code: 200
@@ -961,6 +965,8 @@ stages:
       url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        role_ids: all
       method: DELETE
     response:
       status_code: 200
@@ -1015,6 +1021,8 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
+      params:
+        policy_ids: all
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -844,6 +844,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         group_id: 'wrong_group'
+        list_agents: 'all'
     response:
       status_code: 400
       json:
@@ -858,6 +859,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         group_id: 'group1'
+        list_agents: 'all'
     response:
       status_code: 400
       json:
@@ -872,6 +874,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         group_id: 'group2'
+        list_agents: 'all'
     response:
       status_code: 200
       json:
@@ -1020,6 +1023,8 @@ stages:
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        list_groups: 'all'
     response:
       status_code: 200
       json:
@@ -1194,6 +1199,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         older_than: '0s'
+        list_agents: 'all'
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -13,6 +13,8 @@ stages:
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        list_agents: 'all'
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -957,6 +957,8 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
+      params:
+        user_ids: all
     response:
       status_code: 200
       json:
@@ -976,6 +978,8 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
+      params:
+        user_ids: all
     response:
       status_code: 200
       json:
@@ -1030,6 +1034,8 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
+      params:
+        role_ids: all
     response:
       status_code: 200
       json:
@@ -1066,6 +1072,8 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
+      params:
+        policy_ids: all
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -309,16 +309,16 @@ stages:
         <<: *error
 
   - name: Try to delete roles (invalid role_ids)
-  request: &delete_roles_request
-    verify: False
-    url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
-    headers:
-      Authorization: "Bearer {test_login_token}"
-    method: DELETE
-    params:
-      role_ids: invalid
-  response:
-    status_code: 400
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: DELETE
+      params:
+        role_ids: invalid
+    response:
+      status_code: 400
 
 ---
 test_name: DELETE /security/policies
@@ -374,7 +374,7 @@ stages:
         <<: *error
 
   - name: Try to delete policies (invalid policy_ids)
-    request: &delete_all_policies_request
+    request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
       headers:
@@ -616,6 +616,8 @@ stages:
       url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        policy_ids: all
       method: DELETE
     response:
       status_code: 200
@@ -632,6 +634,8 @@ stages:
       url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        role_ids: all
       method: DELETE
     response:
       status_code: 200

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -307,6 +307,19 @@ stages:
       status_code: 200
       json:
         <<: *error
+
+  - name: Try to delete roles (invalid role_ids)
+  request: &delete_roles_request
+    verify: False
+    url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+    headers:
+      Authorization: "Bearer {test_login_token}"
+    method: DELETE
+    params:
+      role_ids: invalid
+  response:
+    status_code: 400
+
 ---
 test_name: DELETE /security/policies
 
@@ -359,6 +372,18 @@ stages:
       status_code: 200
       json:
         <<: *error
+
+  - name: Try to delete policies (invalid policy_ids)
+    request: &delete_all_policies_request
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: DELETE
+      params:
+        policy_ids: none
+    response:
+      status_code: 400
 
 ---
 test_name: DELETE /security/users
@@ -484,6 +509,8 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
+      params:
+        user_ids: all
     response:
       status_code: 200
       json:
@@ -510,6 +537,18 @@ stages:
           total_failed_items: 0
           failed_items: []
         message: !anystr
+
+  - name: Delete all users in the system
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: DELETE
+      params:
+        user_ids: none
+    response:
+      status_code: 400
 
 ---
 test_name: PUT /security/config

--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -285,10 +285,7 @@ def _get_required_permissions(actions: list = None, resources: list = None, **kw
                     res_list.append("{0}:{1}".format(res_base, params))
             # If we don't find a regex match we obtain the static resource/s
             else:
-                if m.group(2) == '*':  # If resourceless
-                    target_params[m.group(1)] = m.group(2)
-                else:  # Static resource
-                    target_params[m.group(1)] = '*'
+                target_params[m.group(1)] = '*'
                 add_denied = not broadcast.get()
                 res_list.append(r)
     # Create dict of required policies with action: list(resources) pairs

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -114,9 +114,9 @@ class UserRoles(_Base):
 # Declare basic tables
 class TokenBlacklist(_Base):
     """
-    Table between Usernames and Policies, this table stores the relationship between the both entities
-    The information stored from Roles and Policies ais:
-        username: Affected username
+    This table contains the users with an invalid token and for how long
+    The information stored is:
+        user_id: Affected user id
         nbf_invalid_until: The tokens that has an nbf prior to this timestamp will be invalidated
         is_valid_until: Deadline for the rule's validity. To ensure that we can delete this rule,
         the deadline will be the time of token creation plus the time of token validity.
@@ -124,13 +124,13 @@ class TokenBlacklist(_Base):
     """
     __tablename__ = "token_blacklist"
 
-    username = Column('username', String(32), primary_key=True)
+    user_id = Column('user_id', Integer, primary_key=True)
     nbf_invalid_until = Column('nbf_invalid_until', Integer)
     is_valid_until = Column('is_valid_until', Integer)
-    __table_args__ = (UniqueConstraint('username', name='user_rule'),)
+    __table_args__ = (UniqueConstraint('user_id', name='user_rule'),)
 
-    def __init__(self, username):
-        self.username = username
+    def __init__(self, user_id):
+        self.user_id = user_id
         self.nbf_invalid_until = int(time())
         self.is_valid_until = self.nbf_invalid_until + security_conf['auth_token_exp_timeout']
 
@@ -139,7 +139,7 @@ class TokenBlacklist(_Base):
 
         :return: Dict with the information
         """
-        return {'username': self.username, 'nbf_invalid_until': self.nbf_invalid_until,
+        return {'user_id': self.user_id, 'nbf_invalid_until': self.nbf_invalid_until,
                 'is_valid_until': self.is_valid_until}
 
 
@@ -302,12 +302,12 @@ class TokenManager:
     all the methods needed for the token blacklist administration.
     """
 
-    def is_token_valid(self, username: str, token_nbf_time: int):
+    def is_token_valid(self, user_id: int, token_nbf_time: int):
         """Check if specified token is valid
 
         Parameters
         ----------
-        username : str
+        user_id : int
             Current token's username
         token_nbf_time : int
             Token's issue timestamp
@@ -317,13 +317,13 @@ class TokenManager:
         True if is valid, False if not
         """
         try:
-            rule = self.session.query(TokenBlacklist).filter_by(username=username).first()
+            rule = self.session.query(TokenBlacklist).filter_by(user_id=user_id).first()
             return not rule or (token_nbf_time > rule.nbf_invalid_until)
         except IntegrityError:
             return True
 
     def get_all_rules(self):
-        """Return a dictionary where keys are usernames and the value of each them is nbf_invalid_until
+        """Return a dictionary where keys are user_ids and the value of each them is nbf_invalid_until
 
         Returns
         -------
@@ -333,7 +333,7 @@ class TokenManager:
             rules = map(TokenBlacklist.to_dict, self.session.query(TokenBlacklist).all())
             format_rules = dict()
             for rule in list(rules):
-                format_rules[rule['username']] = rule['nbf_invalid_until']
+                format_rules[rule['user_id']] = rule['nbf_invalid_until']
             return format_rules
         except IntegrityError:
             return SecurityError.TOKEN_RULE_NOT_EXIST
@@ -352,29 +352,29 @@ class TokenManager:
         """
         try:
             self.delete_all_expired_rules()
-            for username in users:
-                self.delete_rule(username=username)
-                self.session.add(TokenBlacklist(username=username))
+            for user_id in users:
+                self.delete_rule(user_id=user_id)
+                self.session.add(TokenBlacklist(user_id=user_id))
                 self.session.commit()
             return True
         except IntegrityError:
             self.session.rollback()
             return SecurityError.ALREADY_EXIST
 
-    def delete_rule(self, username: str):
+    def delete_rule(self, user_id: str):
         """Remove the rule for the specified user
 
         Parameters
         ----------
-        username : str
-            Desired username
+        user_id : int
+            Desired user_id
 
         Returns
         -------
         True if success, SecurityError.TOKEN_RULE_NOT_EXIST if failed
         """
         try:
-            self.session.query(TokenBlacklist).filter_by(username=username).delete()
+            self.session.query(TokenBlacklist).filter_by(user_id=user_id).delete()
             self.session.commit()
             return True
         except IntegrityError:
@@ -393,7 +393,7 @@ class TokenManager:
             current_time = int(time())
             tokens_in_blacklist = self.session.query(TokenBlacklist).all()
             for user_token in tokens_in_blacklist:
-                token_rule = self.session.query(TokenBlacklist).filter_by(username=user_token.username)
+                token_rule = self.session.query(TokenBlacklist).filter_by(user_id=user_token.user_id)
                 if token_rule.first() and current_time > token_rule.first().is_valid_until:
                     token_rule.delete()
                     self.session.commit()
@@ -415,7 +415,7 @@ class TokenManager:
             tokens_in_blacklist = self.session.query(TokenBlacklist).all()
             for user_token in tokens_in_blacklist:
                 list_user.append(user_token.username)
-                self.session.query(TokenBlacklist).filter_by(username=user_token.username).delete()
+                self.session.query(TokenBlacklist).filter_by(user_id=user_token.user_id).delete()
                 self.session.commit()
             return list_user
         except IntegrityError:

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -414,7 +414,7 @@ class TokenManager:
             list_user = list()
             tokens_in_blacklist = self.session.query(TokenBlacklist).all()
             for user_token in tokens_in_blacklist:
-                list_user.append(user_token.username)
+                list_user.append(user_token.user_id)
                 self.session.query(TokenBlacklist).filter_by(user_id=user_token.user_id).delete()
                 self.session.commit()
             return list_user


### PR DESCRIPTION
Hi team,

This PR closes #5583. In this PR we have added the new keyword 'all' for all endpoints that has DELETE as method and accepts a list of resources. For example DELETE /agents.

```
curl -X DELETE "https://localhost:55040/v4/agents?list_agents=all&older_than=1s" -H  "accept: application/json" -H  "Authorization: Bearer TOKEN"

{
  "data": {
    "affected_items": [
      "001",
      "002",
      "003",
      "004",
      "005",
      "006",
      "007",
      "008",
      "009",
      "010",
      "011",
      "012",
    ],
    "total_affected_items": 12,
    "total_failed_items": 0,
    "failed_items": [],
    "older_than": "1s"
  },
  "message": "All selected agents were deleted"
}
```

These are the results of the updated integrated tests:

```
test_agents_DELETE_endpoints.tavern.yaml 
	 7 passed, 63 warnings

test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 523 warnings

test_agents_POST_endpoints.tavern.yaml 
	 4 passed, 40 warnings

test_agents_PUT_endpoints.tavern.yaml 
	 9 passed, 71 warnings

test_rbac_black_agents_endpoints.tavern.yaml 
	 39 passed, 162 warnings

test_rbac_white_agents_endpoints.tavern.yaml 
	 39 passed, 169 warnings

test_experimental_endpoints.tavern.yaml 
	 11 passed, 47 warnings

test_rbac_black_experimental_endpoints.tavern.yaml 
	 11 passed, 47 warnings

test_rbac_white_experimental_endpoints.tavern.yaml 
	 11 passed, 47 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 12 passed, 60 warnings

test_security_GET_endpoints.tavern.yaml 
	 14 passed, 87 warnings

test_security_POST_endpoints.tavern.yaml 
	 4 passed, 44 warnings

test_security_PUT_endpoints.tavern.yaml 
	 7 passed, 37 warnings

test_rbac_black_security_endpoints.tavern.yaml 
	 18 passed, 78 warnings

test_rbac_white_security_endpoints.tavern.yaml 
	 19 passed, 81 warnings
```