### PR TITLE
Disable perpetual connection attempts to modules

### DIFF
--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -60,7 +60,7 @@ static int send_intcheck_msg(const char *script, const char *host, const char *m
     if (SendMSG(lessdc.queue, msg, sys_location, SYSCHECK_MQ) < 0) {
         merror(QUEUE_SEND);
 
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             merror_exit(QUEUE_FATAL, DEFAULTQPATH);
         }
 
@@ -81,7 +81,7 @@ static int send_log_msg(const char *script, const char *host, const char *msg)
 
     if (SendMSG(lessdc.queue, msg, sys_location, LOCALFILE_MQ) < 0) {
         merror(QUEUE_SEND);
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             merror_exit(QUEUE_FATAL, DEFAULTQPATH);
         }
 
@@ -137,7 +137,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
     if (SendMSG(lessdc.queue, diff_alert, buf, LOCALFILE_MQ) < 0) {
         merror(QUEUE_SEND);
 
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             merror_exit(QUEUE_FATAL, DEFAULTQPATH);
         }
 
@@ -455,7 +455,7 @@ void Agentlessd()
     today = tm_result.tm_mday;
 
     /* Connect to the message queue. Exit if it fails. */
-    if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -658,7 +658,7 @@ int main_analysisd(int argc, char **argv)
     }
 
     /* Set the queue */
-    if ((m_queue = StartMQ(DEFAULTQUEUE, READ, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((m_queue = StartMQ(DEFAULTQUEUE, READ, 0)) < 0) {
         merror_exit(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
     }
 

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -147,7 +147,7 @@ end:
 
 static int ConnectToSecurityConfigurationAssessmentSocket() {
 
-    if ((cfga_socket = StartMQ(CFGAQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((cfga_socket = StartMQ(CFGAQUEUE, WRITE, 1)) < 0) {
         merror(QUEUE_ERROR, CFGAQUEUE, strerror(errno));
         return -1;
     }
@@ -157,7 +157,7 @@ static int ConnectToSecurityConfigurationAssessmentSocket() {
 
 static int ConnectToSecurityConfigurationAssessmentSocketRemoted() {
 
-    if ((cfgar_socket = StartMQ(CFGARQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((cfgar_socket = StartMQ(CFGARQUEUE, WRITE, 1)) < 0) {
         merror(QUEUE_ERROR, CFGARQUEUE, strerror(errno));
         return -1;
     }

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -80,7 +80,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     os_setwait();
 
     /* Create the queue and read from it. Exit if fails. */
-    if ((agt->m_queue = StartMQ(DEFAULTQPATH, READ, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((agt->m_queue = StartMQ(DEFAULTQPATH, READ, 0)) < 0) {
         merror_exit(QUEUE_ERROR, DEFAULTQPATH, strerror(errno));
     }
 

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -141,7 +141,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 
     /* Connect to the execd queue */
     if (agt->execdq == 0) {
-        if ((agt->execdq = StartMQ(EXECQUEUEPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((agt->execdq = StartMQ(EXECQUEUEPATH, WRITE, 1)) < 0) {
             minfo("Unable to connect to the active response "
                    "queue (disabled).");
             agt->execdq = -1;

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -151,7 +151,7 @@ int receive_msg()
                         merror("Error communicating with Security configuration assessment");
                         close(agt->cfgadq);
 
-                        if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+                        if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, 1)) < 0) {
                             merror("Unable to connect to the Security configuration assessment "
                                     "queue (disabled).");
                             agt->cfgadq = -1;
@@ -162,7 +162,7 @@ int receive_msg()
                         }
                     }
                 } else {
-                    if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+                    if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, 1)) < 0) {
                         merror("Unable to connect to the Security configuration assessment "
                             "queue (disabled).");
                         agt->cfgadq = -1;

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -31,7 +31,7 @@
 #define CISCAT_MQ        'e'
 #define WIN_EVT_MQ       'f'
 
-#define MAX_OPENQ_ATTEMPS 0
+#define INFINITE_OPENQ_ATTEMPTS 0
 
 extern int sock_fail_time;
 /**

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1832,7 +1832,7 @@ void * w_output_thread(void * args){
                 #endif
 
                 // Retry to connect infinitely.
-                logr_queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+                logr_queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
                 minfo("Successfully reconnected to '%s'", DEFAULTQPATH);
 

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
     mdebug1(STARTED_MSG);
 
     /* Start the queue */
-    if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQPATH);
     }
 

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -84,7 +84,7 @@ void Monitord()
         if (mond.monitor_agents && counter >= 120) {
             if (mond.a_queue < 0) {
                 /* Connect to the message queue */
-                if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE, 1)) > 0) {
+                if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) > 0) {
                     /* Send startup message */
                     snprintf(str, OS_SIZE_1024 - 1, OS_AD_STARTED);
                     if (SendMSG(mond.a_queue, str, ARGV0,

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -59,7 +59,7 @@ void Monitord()
 #endif
 
     /* Connect to the message queue or exit */
-    if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
@@ -84,7 +84,7 @@ void Monitord()
         if (mond.monitor_agents && counter >= 120) {
             if (mond.a_queue < 0) {
                 /* Connect to the message queue */
-                if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) > 0) {
+                if ((mond.a_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) > 0) {
                     /* Send startup message */
                     snprintf(str, OS_SIZE_1024 - 1, OS_AD_STARTED);
                     if (SendMSG(mond.a_queue, str, ARGV0,

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
     }
 
     /* Start exec queue */
-    if ((m_queue = StartMQ(EXECQUEUEPATH, READ, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((m_queue = StartMQ(EXECQUEUEPATH, READ, 0)) < 0) {
         merror_exit(QUEUE_ERROR, EXECQUEUEPATH, strerror(errno));
     }
 

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -409,7 +409,7 @@ static void ExecdStart(int q)
             int rc;
             /* Start api socket */
             int api_sock;
-            if ((api_sock = StartMQ(EXECQUEUEPATHAPI, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+            if ((api_sock = StartMQ(EXECQUEUEPATHAPI, WRITE, 1)) < 0) {
                 merror(QUEUE_ERROR, EXECQUEUEPATHAPI, strerror(errno));
                 os_free(output);
                 continue;

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -33,7 +33,7 @@ void *AR_Forward(__attribute__((unused)) void *arg)
     char agent_id[KEYSIZE + 1] = "";
 
     /* Create the unix queue */
-    if ((arq = StartMQ(path, READ, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((arq = StartMQ(path, READ, 0)) < 0) {
         merror_exit(QUEUE_ERROR, path, strerror(errno));
     }
 

--- a/src/remoted/cfga-forward.c
+++ b/src/remoted/cfga-forward.c
@@ -25,7 +25,7 @@ void *SCFGA_Forward(__attribute__((unused)) void *arg)
     char msg[OS_SIZE_4096 + 1];
 
     /* Create the unix queue */
-    if ((cfgarq = StartMQ(path, READ, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((cfgarq = StartMQ(path, READ, 0)) < 0) {
         merror_exit(QUEUE_ERROR, path, strerror(errno));
     }
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -118,7 +118,7 @@ void HandleSecure()
     /* Connect to the message queue
      * Exit if it fails.
      */
-    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
@@ -426,7 +426,7 @@ static void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
         merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
         // Try to reconnect infinitely
-        logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS);
+        logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
         minfo("Successfully reconnected to '%s'", DEFAULTQUEUE);
 

--- a/src/remoted/syslog.c
+++ b/src/remoted/syslog.c
@@ -52,7 +52,7 @@ void HandleSyslog()
     memset(&peer_info, 0, sizeof(struct sockaddr_in));
 
     /* Connect to the message queue infinitely */
-    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
@@ -101,7 +101,7 @@ void HandleSyslog()
             merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
             // Try to reconnect infinitely
-            logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS);
+            logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
             minfo("Successfully reconnected to '%s'", DEFAULTQUEUE);
 

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -49,7 +49,7 @@ void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
         if (SendMSG(logr.m_queue, data_pt, srcip, SYSLOG_MQ) < 0) {
             merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
-            if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+            if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
                 merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
             }
         }
@@ -111,7 +111,7 @@ void HandleSyslogTCP()
     /* Connecting to the message queue
      * Exit if it fails.
      */
-    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -247,7 +247,7 @@ void rootcheck_connect() {
         mtdebug1(ARGV0, "Starting queue ...");
 
         /* Start the queue */
-        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQPATH);
         }
     }

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -43,7 +43,7 @@ int notify_rk(int rk_type, const char *msg)
     if (SendMSG(rootcheck.queue, msg, ROOTCHECK, ROOTCHECK_MQ) < 0) {
         mterror(ARGV0, QUEUE_SEND);
 
-        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQPATH);
         }
 

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -33,7 +33,7 @@ int StartMQ(const char *path, short int type, short int n_attempts)
         while ((rc = OS_ConnectUnixDomain(path, SOCK_DGRAM, OS_MAXSTR + 256)), rc < 0){
             attempt++;
             mdebug1("Can't connect to queue. attempt: %d", attempt);
-            if (n_attempts != 0 && attempt == n_attempts) {
+            if (n_attempts != INFINITE_OPENQ_ATTEMPTS && attempt == n_attempts) {
                 break;
             }
             sleep(sleep_time += 5);

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -32,7 +32,7 @@ int StartMQ(const char *path, short int type, short int n_attempts)
         // If n_attempts is 0, trying to reconnect infinitely
         while ((rc = OS_ConnectUnixDomain(path, SOCK_DGRAM, OS_MAXSTR + 256)), rc < 0){
             attempt++;
-            mdebug1("Can't connect to queue. attempt: %d", attempt);
+            mdebug1("Can't connect to '%s': %s (%d). Attempt: %d", path, strerror(errno), errno, attempt);
             if (n_attempts != INFINITE_OPENQ_ATTEMPTS && attempt == n_attempts) {
                 break;
             }
@@ -43,8 +43,8 @@ int StartMQ(const char *path, short int type, short int n_attempts)
             merror(QUEUE_ERROR, path, strerror(errno));
             return OS_INVALID;
         }
-        mdebug1 ("Connected succesfully to %s after %d attempts", path, attempt);
 
+        mdebug1("Connected succesfully to '%s' after %d attempts", path, attempt);
         mdebug1(MSG_SOCKET_SIZE, OS_getsocketsize(rc));
         return (rc);
     }

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -943,7 +943,7 @@ int connect_to_remoted()
 {
     int arq = -1;
 
-    if ((arq = StartMQ(ARQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((arq = StartMQ(ARQUEUE, WRITE, 1)) < 0) {
         merror(ARQ_ERROR);
         return (-1);
     }

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
 
     /* Connect to the queue */
 
-    if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQPATH);
     }
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -78,7 +78,7 @@ STATIC void fim_send_msg(char mq, const char * location, const char * msg) {
     if (SendMSG(syscheck.queue, msg, location, mq) < 0) {
         merror(QUEUE_SEND);
 
-        if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             merror_exit(QUEUE_FATAL, DEFAULTQPATH);
         }
 

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -38,11 +38,11 @@ void __wrap__merror(const char * file, int line, const char * func, const char *
 }
 
 void __wrap__mdebug1(const char * file, int line, const char * func, const char * msg, ...){
-    char formatted_msg[OS_SIZE_64];
+    char formatted_msg[OS_SIZE_1024];
     va_list args;
 
     va_start(args, msg);
-    vsnprintf(formatted_msg, OS_SIZE_64, msg, args);
+    vsnprintf(formatted_msg, sizeof(formatted_msg), msg, args);
     va_end(args);
 
     check_expected(formatted_msg);
@@ -110,7 +110,7 @@ void test_start_mq_write_simple_success(void ** state){
 
     will_return(__wrap_OS_ConnectUnixDomain, 0);
     
-    snprintf(messages[0], OS_SIZE_64,"Connected succesfully to %s after %d attempts", path, 0);
+    snprintf(messages[0], OS_SIZE_64,"Connected succesfully to '%s' after %d attempts", path, 0);
     expect_string(__wrap__mdebug1, formatted_msg, messages[0]);
 
     snprintf(messages[1], OS_SIZE_64, "(unix_domain) Maximum send buffer set to: '%d'.",SOCKET_SIZE);
@@ -133,7 +133,7 @@ void test_start_mq_write_simple_fail(void ** state){
     errno = ERRNO;
 
     will_return(__wrap_OS_ConnectUnixDomain, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "Can't connect to queue. attempt: 1");
+    expect_string(__wrap__mdebug1, formatted_msg, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: 1");
     
     snprintf(expected_str, OS_SIZE_64, "(1210): Queue '%s' not accessible: '%s'", path,strerror(errno));
     expect_string(__wrap__merror, formatted_msg, expected_str);
@@ -151,21 +151,21 @@ void test_start_mq_write_multiple_success(void ** state){
     char * path = "/test";
 
     int ret = 0;
-    char messages[n_attempts+1][OS_SIZE_64];
+    char messages[n_attempts+1][OS_SIZE_1024];
 
     errno = ERRNO;
 
     for (int i = 0; i < n_attempts - 1; i++) {
         will_return(__wrap_OS_ConnectUnixDomain, -1);
-        snprintf(messages[i], OS_SIZE_64, "Can't connect to queue. attempt: %d", i + 1);
+        snprintf(messages[i], OS_SIZE_1024, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
     }
     will_return(__wrap_OS_ConnectUnixDomain, 0);
 
-    snprintf(messages[n_attempts - 1], OS_SIZE_64,"Connected succesfully to %s after %d attempts", path, n_attempts - 1);
+    snprintf(messages[n_attempts - 1], OS_SIZE_1024,"Connected succesfully to '%s' after %d attempts", path, n_attempts - 1);
     expect_string(__wrap__mdebug1, formatted_msg, messages[n_attempts - 1]);
 
-    snprintf(messages[n_attempts], OS_SIZE_64,"(unix_domain) Maximum send buffer set to: '%d'.", SOCKET_SIZE);
+    snprintf(messages[n_attempts], OS_SIZE_1024,"(unix_domain) Maximum send buffer set to: '%d'.", SOCKET_SIZE);
     expect_string(__wrap__mdebug1, formatted_msg, messages[n_attempts]);
 
     ret = StartMQ(path, type, n_attempts);
@@ -181,12 +181,12 @@ void test_start_mq_write_multiple_fail(void ** state){
     char * path = "/test";
 
     int ret = 0;
-    char messages[n_attempts][OS_SIZE_64];
+    char messages[n_attempts][OS_SIZE_1024];
     char expected_str[OS_SIZE_64];
 
     for (int i = 0; i <= n_attempts - 1; i++) {
         will_return(__wrap_OS_ConnectUnixDomain, -1);
-        snprintf(messages[i], OS_SIZE_64, "Can't connect to queue. attempt: %d", i + 1);
+        snprintf(messages[i], OS_SIZE_1024, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
     }
 
@@ -206,19 +206,19 @@ void test_start_mq_write_inf_success(void ** state){
     char * path = "/test";
     
     int ret = 0;
-    char messages[MAX_ATTEMPTS + 1][OS_SIZE_64];
+    char messages[MAX_ATTEMPTS + 1][OS_SIZE_1024];
 
     for (int i = 0; i < MAX_ATTEMPTS - 1; i++) {
         will_return(__wrap_OS_ConnectUnixDomain, -1);
-        sprintf(messages[i], "Can't connect to queue. attempt: %d", i + 1);
+        sprintf(messages[i], "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
     }
     will_return(__wrap_OS_ConnectUnixDomain, 0);
 
-    snprintf(messages[MAX_ATTEMPTS - 1], OS_SIZE_64,"Connected succesfully to %s after %d attempts", path, MAX_ATTEMPTS - 1);
+    snprintf(messages[MAX_ATTEMPTS - 1], OS_SIZE_1024,"Connected succesfully to '%s' after %d attempts", path, MAX_ATTEMPTS - 1);
     expect_string(__wrap__mdebug1, formatted_msg, messages[MAX_ATTEMPTS - 1]);
 
-    snprintf(messages[MAX_ATTEMPTS], OS_SIZE_64,"(unix_domain) Maximum send buffer set to: '%d'.", SOCKET_SIZE);
+    snprintf(messages[MAX_ATTEMPTS], OS_SIZE_1024,"(unix_domain) Maximum send buffer set to: '%d'.", SOCKET_SIZE);
     expect_string(__wrap__mdebug1, formatted_msg, messages[MAX_ATTEMPTS]);
 
     ret = StartMQ(path, type, n_attempts);
@@ -234,11 +234,11 @@ void test_start_mq_write_inf_fail(void ** state){
     char * path = "/test";
 
     int ret = 0;
-    char messages[MAX_ATTEMPTS][OS_SIZE_64];
+    char messages[MAX_ATTEMPTS][OS_SIZE_1024];
 
     for (int i = 0; i <= MAX_ATTEMPTS - 1; i++) {
         will_return(__wrap_OS_ConnectUnixDomain, -1);
-        snprintf(messages[i], OS_SIZE_64, "Can't connect to queue. attempt: %d", i + 1);
+        snprintf(messages[i], OS_SIZE_1024, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
     }
     /* Breaking the infinite loop */

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -200,7 +200,7 @@ static void wm_sys_setup(wm_sys_t *_sys) {
     #ifndef WIN32
 
     // Connect to socket
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (queue_fd < 0) {
         mterror(WM_SYS_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1406,7 +1406,7 @@ int wm_vuldet_send_cve_report(vu_report *report) {
 
     if (wm_sendmsg(usec, *vu_queue, alert_msg, header, send_queue) < 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-        if ((*vu_queue = StartMQ(DEFAULTQUEUE, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((*vu_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             mterror_exit(WM_VULNDETECTOR_LOGTAG, QUEUE_FATAL, DEFAULTQUEUE);
         }
     }
@@ -6774,7 +6774,7 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
         pthread_exit(NULL);
     }
 
-    vuldet->queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    vuldet->queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (vuldet->queue_fd < 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -249,7 +249,7 @@ void wm_aws_setup(wm_aws *_aws_config) {
 
     // Connect to socket
 
-    aws_config->queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    aws_config->queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (aws_config->queue_fd < 0) {
         mterror(WM_AWS_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -343,7 +343,7 @@ void wm_azure_setup(wm_azure_t *_azure_config) {
 
     // Connect to socket
 
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (queue_fd < 0) {
         mterror(WM_AZURE_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -230,7 +230,7 @@ void wm_ciscat_setup(wm_ciscat *_ciscat) {
 
 #ifndef WIN32
 
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (queue_fd < 0) {
         mterror(WM_CISCAT_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -153,7 +153,7 @@ void * wm_command_main(wm_command_t * command) {
 #ifndef WIN32
     if (!command->ignore_output) {
 
-        command->queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+        command->queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
         if (command->queue_fd < 0) {
             mterror(WM_COMMAND_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -86,7 +86,7 @@ void * wm_key_request_main(wm_krequest_t * data) {
     /* Init the queue input */
     request_queue = queue_init(data->queue_size);
 
-    if ((sock = StartMQ(WM_KEY_REQUEST_SOCK_PATH, READ, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((sock = StartMQ(WM_KEY_REQUEST_SOCK_PATH, READ, 0)) < 0) {
         merror(QUEUE_ERROR, WM_KEY_REQUEST_SOCK_PATH, strerror(errno));
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -97,7 +97,7 @@ void wm_oscap_setup(wm_oscap *_oscap) {
 
     // Connect to socket
 
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (queue_fd < 0) {
         mterror(WM_OSCAP_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -587,7 +587,7 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
 #ifndef WIN32
     // Connect to queue
 
-    osquery->queue_fd = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    osquery->queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
     if (osquery->queue_fd < 0) {
         mterror(WM_OSQUERYMONITOR_LOGTAG, "Can't connect to queue. Closing module.");
         return NULL;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -208,7 +208,7 @@ void * wm_sca_main(wm_sca_t * data) {
 
 #ifndef WIN32
 
-    data->queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS);
+    data->queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (data->queue < 0) {
         merror("Can't connect to queue.");
@@ -256,7 +256,7 @@ static int wm_sca_send_alert(wm_sca_t * data,cJSON *json_alert)
             close(data->queue);
         }
 
-        if ((data->queue = StartMQ(DEFAULTQPATH, WRITE, MAX_OPENQ_ATTEMPS)) < 0) {
+        if ((data->queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             mwarn("Can't connect to queue.");
         } else {
             if(wm_sendmsg(data->msg_delay, data->queue, msg,WM_SCA_STAMP, SCA_MQ) < 0) {
@@ -2951,7 +2951,7 @@ static void * wm_sca_request_thread(wm_sca_t * data) {
 
     /* Create request socket */
     int cfga_queue;
-    if ((cfga_queue = StartMQ(CFGASSESSMENTQUEUEPATH, READ, MAX_OPENQ_ATTEMPS)) < 0) {
+    if ((cfga_queue = StartMQ(CFGASSESSMENTQUEUEPATH, READ, 0)) < 0) {
         merror(QUEUE_ERROR, CFGASSESSMENTQUEUEPATH, strerror(errno));
         pthread_exit(NULL);
     }


### PR DESCRIPTION
|Related issue|Related PR|
|---|---|
|#5621|#4510|

This PR aims to ensure that only connection attempts to the system's queue (Analysisd or Agentd) are perpetual. The rest shall perform one attempt only.

On the other hand, we're refactoring `MAX_OPENQ_ATTEMPS` to:
- `INFINITE_OPENQ_ATTEMPTS` where calling `StartMQ` in `WRITE` mode.
- `0` where calling `StartMQ` in `READ` mode (as that parameter does not apply here).

## Tests

- [X] Compile agent for Linux.
- [X] Compile manager for Linux.
- [x] Compile agent for Windows.
- [X] Unit tests for manager on Linux.
- [X] Unit tests for agent on Linux.