### PR TITLE
Fix deletion of the Modulesd PID file

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -51,11 +51,11 @@ char *get_agent_ip()
     for (i = SOCK_ATTEMPTS; i > 0; --i) {
         if (sock = control_check_connection(), sock >= 0) {
             if (OS_SendUnix(sock, agent_ip, IPSIZE) < 0) {
-                merror("Error sending msg to control socket (%d) %s", errno, strerror(errno));
+                mdebug1("Error sending msg to control socket (%d) %s", errno, strerror(errno));
             }
             else{
-                if(OS_RecvUnix(sock, IPSIZE, agent_ip) == 0){
-                    merror("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
+                if (OS_RecvUnix(sock, IPSIZE, agent_ip) <= 0) {
+                    mdebug1("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
                     *agent_ip = '\0';
                 }
             }

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -191,13 +191,14 @@ void wm_setup()
 
 void wm_cleanup()
 {
-    // Delete PID file
-
-    if (DeletePID(ARGV0) < 0)
-        merror("Couldn't delete PID file.");
-
     // Kill active child processes
     wm_kill_children();
+
+    // Delete PID file
+
+    if (DeletePID(ARGV0) < 0) {
+        merror("Couldn't delete PID file.");
+    }
 }
 
 // Action on signal


### PR DESCRIPTION
|Related issue|
|---|
|#5611|

This PR aims to switch the order of the Modulesd's clean up procedure:

1. Kill every child process.
2. Delete the PID file.

Deleting the PID file should be the very last operation by a module.

On the other hand, we're silencing an error produced by Agentd if Modulesd exists while executing the agent's IP query (as Logcollector already works).

## Tests

- [X] Compile manager for Linux.
- [X] Compile agent for Linux.
- [X] Compile agent for Windows.
- [X] Check that deleting the PID file is the very last operation in Modulesd.

### Tracing the process

We checked that Modulesd deletes the PID file before exiting, and no more operation is performed after erasing that file:

```
[pid 198533] --- SIGTERM {si_signo=SIGTERM, si_code=SI_USER, si_pid=198535, si_uid=0} ---
[pid 198528] <... futex resumed>)       = ? ERESTARTSYS (To be restarted if SA_RESTART is set)
[pid 198533] stat("/var/ossec/var/run/wazuh-modulesd-198528.pid", {st_mode=S_IFREG|0640, st_size=7, ...}) = 0
[pid 198528] futex(0x7fa8275dc9d0, FUTEX_WAIT, 198531, NULL <unfinished ...>
[pid 198533] unlink("/var/ossec/var/run/wazuh-modulesd-198528.pid") = 0
[pid 198533] exit_group(0)              = ?
[pid 198531] <... nanosleep resumed>)   = ? <unavailable>
[pid 198534] <... select resumed> <unfinished ...>) = ?
[pid 198532] <... nanosleep resumed> <unfinished ...>) = ?
[pid 198528] <... futex resumed>)       = ?
[pid 198534] +++ exited with 0 +++
[pid 198533] +++ exited with 0 +++
[pid 198532] +++ exited with 0 +++
[pid 198531] +++ exited with 0 +++
+++ exited with 0 +++
```