### PR TITLE
RTR build update

### DIFF
--- a/src/dbsync/build.sh
+++ b/src/dbsync/build.sh
@@ -107,7 +107,7 @@ runValgrind()
 configDbSync()
 {
     currentDir=$(pwd)
-    cmake -DEXTERNAL_LIB=$currentDir/../external/
+    cmake -DEXTERNAL_LIB=$currentDir/../external/ -DCMAKE_BUILD_TYPE=Debug -DUNIT_TEST=ON .
 }
 
 makeDbSync()


### PR DESCRIPTION
# Adding missing vars in the config method to avoid linker issues after cleaning all repo

## Related Issue
[5635](https://github.com/wazuh/wazuh/issues/5635)

## Description
Executing ./build --rtr should everything work after cleaning the entire dbsync repo.

* RTR Tool's Output:*
![image](https://user-images.githubusercontent.com/22640902/89312121-41069e00-d64d-11ea-8500-2c72748e30dd.png)

