### PR TITLE
Add sync_status column to global.db

### DIFF
--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -33,6 +33,7 @@ typedef struct _remoted {
     int nocmerged;
     socklen_t peer_size;
     long queue_size;
+    bool worker_node;
 } remoted;
 
 #endif /* CLOGREMOTE_H */

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -129,16 +129,14 @@ int main(int argc, char **argv)
 
     logr.nocmerged = nocmerged ? 1 : !getDefine_Int("remoted", "merge_shared", 0, 1);
 
-    // Don`t create the merged file in worker nodes of the cluster
-
     // Read the cluster status and the node type from the configuration file
-    int is_worker = w_is_worker();
-
-    switch (is_worker){
+    switch (w_is_worker()){
         case 0:
-            mdebug1("This is not a worker");
+            logr.worker_node = false;
+            mdebug1("This is not a worker");            
             break;
         case 1:
+            logr.worker_node = true;
             mdebug1("Cluster worker node: Disabling the merged.mg creation");
             logr.nocmerged = 1;
             break;

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -229,7 +229,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             // Updating version and keepalive in global.db
             result = wdb_update_agent_version(agent_id, os_name, os_version, os_major, os_minor, os_codename, os_platform,
                                               os_build, uname, os_arch, version, config_sum, merged_sum, manager_host,
-                                              node_name, agent_ip);
+                                              node_name, agent_ip, logr.worker_node?WDB_UNSYNCED:WDB_SYNCED);
             
             if (OS_INVALID == result)
                 mwarn("Unable to update information in global.db for agent: %s", key->id);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -163,7 +163,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
 
         agent_id = atoi(key->id);
 
-        result = wdb_update_agent_keepalive(agent_id);
+        result = wdb_update_agent_keepalive(agent_id, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED);
 
         if (OS_SUCCESS != result)
             mwarn("Unable to save agent last keepalive in global.db");
@@ -229,7 +229,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             // Updating version and keepalive in global.db
             result = wdb_update_agent_version(agent_id, os_name, os_version, os_major, os_minor, os_codename, os_platform,
                                               os_build, uname, os_arch, version, config_sum, merged_sum, manager_host,
-                                              node_name, agent_ip, logr.worker_node?WDB_UNSYNCED:WDB_SYNCED);
+                                              node_name, agent_ip, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED);
             
             if (OS_INVALID == result)
                 mwarn("Unable to update information in global.db for agent: %s", key->id);

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS agent (
     status TEXT NOT NULL CHECK (status IN ('empty', 'pending', 'updated')) DEFAULT 'empty',
     fim_offset INTEGER NOT NULL DEFAULT 0,
     reg_offset INTEGER NOT NULL DEFAULT 0,
-    `group` TEXT DEFAULT 'default'
+    `group` TEXT DEFAULT 'default',
+    sync_status INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -177,6 +177,12 @@ typedef enum {
     WDB_FIM         ///< File integrity monitoring.
 } wdb_component_t;
 
+/// Enumeration of sync-status.
+typedef enum {
+    WDB_UNSYNCED,
+    WDB_SYNCED    
+} wdb_sync_status_t;
+
 extern char *schema_global_sql;
 extern char *schema_agents_sql;
 extern char *schema_upgrade_v1_sql;
@@ -332,7 +338,23 @@ int wdb_insert_agent(int id, const char *name, const char *ip, const char *regis
 int wdb_update_agent_name(int id, const char *name);
 
 /* Update agent version. It opens and closes the DB. Returns number of affected rows or -1 on error. */
-int wdb_update_agent_version(int id, const char *os_name, const char *os_version, const char *os_major, const char *os_minor, const char *os_codename, const char *os_platform, const char *os_build, const char *os_uname, const char *os_arch, const char *version, const char *config_sum, const char *merged_sum, const char *manager_host, const char *node_name, const char *agent_ip);
+int wdb_update_agent_version(int id, 
+                             const char *os_name,
+                             const char *os_version,
+                             const char *os_major,
+                             const char *os_minor,
+                             const char *os_codename,
+                             const char *os_platform,
+                             const char *os_build,
+                             const char *os_uname,
+                             const char *os_arch,
+                             const char *version,
+                             const char *config_sum,
+                             const char *merged_sum,
+                             const char *manager_host,
+                             const char *node_name,
+                             const char *agent_ip,
+                             wdb_sync_status_t sync_status);
 
 /* Update agent's last keepalive. It opens and closes the DB. Returns number of affected rows or -1 on error. */
 int wdb_update_agent_keepalive(int id);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -179,8 +179,8 @@ typedef enum {
 
 /// Enumeration of sync-status.
 typedef enum {
-    WDB_UNSYNCED,
-    WDB_SYNCED    
+    WDB_SYNCED,
+    WDB_SYNC_REQ        
 } wdb_sync_status_t;
 
 extern char *schema_global_sql;
@@ -357,7 +357,7 @@ int wdb_update_agent_version(int id,
                              wdb_sync_status_t sync_status);
 
 /* Update agent's last keepalive. It opens and closes the DB. Returns number of affected rows or -1 on error. */
-int wdb_update_agent_keepalive(int id);
+int wdb_update_agent_keepalive(int id, wdb_sync_status_t sync_status);
 
 /* Update agent group. It opens and closes the DB. Returns 0 on success or -1 on error. */
 int wdb_update_agent_group(int id,char *group);

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -20,8 +20,8 @@
 static const char *global_db_queries[] = {
     [SQL_INSERT_AGENT] = "global sql INSERT INTO agent (id, name, ip, register_ip, internal_key, date_add, `group`) VALUES (%d, %Q, %Q, %Q, %Q, %lu, %Q);",
     [SQL_UPDATE_AGENT_NAME] = "global sql UPDATE agent SET name = %Q WHERE id = %d;",
-    [SQL_UPDATE_AGENT_VERSION] = "global sql UPDATE agent SET os_name = %Q, os_version = %Q, os_major = %Q, os_minor = %Q, os_codename = %Q, os_platform = %Q, os_build = %Q, os_uname = %s, os_arch = %Q, version = %Q, config_sum = %Q, merged_sum = %Q, manager_host = %Q, node_name = %Q, last_keepalive = STRFTIME('%s', 'NOW') WHERE id = %d;",
-    [SQL_UPDATE_AGENT_VERSION_IP] = "global sql UPDATE agent SET os_name = %Q, os_version = %Q, os_major = %Q, os_minor = %Q, os_codename = %Q, os_platform = %Q, os_build = %Q, os_uname = %s, os_arch = %Q, version = %Q, config_sum = %Q, merged_sum = %Q, manager_host = %Q, node_name = %Q, last_keepalive = STRFTIME('%s', 'NOW'), ip = %Q WHERE id = %d;",
+    [SQL_UPDATE_AGENT_VERSION] = "global sql UPDATE agent SET os_name = %Q, os_version = %Q, os_major = %Q, os_minor = %Q, os_codename = %Q, os_platform = %Q, os_build = %Q, os_uname = %s, os_arch = %Q, version = %Q, config_sum = %Q, merged_sum = %Q, manager_host = %Q, node_name = %Q, last_keepalive = STRFTIME('%s', 'NOW'),sync_status = %d WHERE id = %d;",
+    [SQL_UPDATE_AGENT_VERSION_IP] = "global sql UPDATE agent SET os_name = %Q, os_version = %Q, os_major = %Q, os_minor = %Q, os_codename = %Q, os_platform = %Q, os_build = %Q, os_uname = %s, os_arch = %Q, version = %Q, config_sum = %Q, merged_sum = %Q, manager_host = %Q, node_name = %Q, last_keepalive = STRFTIME('%s', 'NOW'), ip = %Q, sync_status = %d WHERE id = %d;",
     [SQL_UPDATE_AGENT_KEEPALIVE] = "global sql UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW') WHERE id = %d;",
     [SQL_DELETE_AGENT] = "global sql DELETE FROM agent WHERE id = %d;",
     [SQL_SELECT_AGENT] = "global sql SELECT name FROM agent WHERE id = %d;",
@@ -66,11 +66,11 @@ int wdb_insert_agent(int id, const char *name, const char *ip, const char *regis
             result = wdb_create_agent_db(id, name);
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             break;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             result = OS_INVALID;
     }
@@ -92,11 +92,11 @@ int wdb_update_agent_name(int id, const char *name) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             break;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             result = OS_INVALID;
     }
@@ -104,8 +104,25 @@ int wdb_update_agent_name(int id, const char *name) {
     return result;
 }
 
-/* Update agent version. It opens and closes the DB. Returns 1 or -1 on error. */
-int wdb_update_agent_version(int id, const char *os_name, const char *os_version, const char *os_major, const char *os_minor, const char *os_codename, const char *os_platform, const char *os_build, const char *os_uname, const char *os_arch, const char *version, const char *config_sum, const char *merged_sum, const char *manager_host, const char *node_name, const char *agent_ip) {
+/* Update agent version. Sends a request to Wazuh-DB. Returns 1 or -1 on error. */
+int wdb_update_agent_version(int id,
+                             const char *os_name,
+                             const char *os_version,
+                             const char *os_major,
+                             const char *os_minor,
+                             const char *os_codename,
+                             const char *os_platform,
+                             const char *os_build,
+                             const char *os_uname,
+                             const char *os_arch,
+                             const char *version,
+                             const char *config_sum,
+                             const char *merged_sum,
+                             const char *manager_host,
+                             const char *node_name,
+                             const char *agent_ip,
+                             wdb_sync_status_t sync_status) {
+
     int result = 0;
     char wdbquery[OS_BUFFER_SIZE] = "";
     char wdboutput[OS_BUFFER_SIZE] = "";
@@ -124,11 +141,11 @@ int wdb_update_agent_version(int id, const char *os_name, const char *os_version
     if(agent_ip) {
         sqlite3_snprintf(sizeof(wdbquery), wdbquery, global_db_queries[SQL_UPDATE_AGENT_VERSION_IP],
         os_name, os_version, os_major, os_minor, os_codename, os_platform, os_build, os_uname_format,
-        os_arch, version, config_sum, merged_sum, manager_host, node_name, keepalive_format, agent_ip , id );
+        os_arch, version, config_sum, merged_sum, manager_host, node_name, keepalive_format, agent_ip, sync_status, id);
     } else {
         sqlite3_snprintf(sizeof(wdbquery), wdbquery, global_db_queries[SQL_UPDATE_AGENT_VERSION],
         os_name, os_version, os_major, os_minor, os_codename, os_platform, os_build, os_uname_format,
-        os_arch, version, config_sum, merged_sum, manager_host, node_name, keepalive_format, id);
+        os_arch, version, config_sum, merged_sum, manager_host, node_name, keepalive_format, sync_status, id);
     }
 
     result = wdbc_query_ex(&wdb_sock, wdbquery, wdboutput, sizeof(wdboutput));
@@ -138,11 +155,11 @@ int wdb_update_agent_version(int id, const char *os_name, const char *os_version
             result = 1;
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             break;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             result = OS_INVALID;
     }
@@ -150,7 +167,7 @@ int wdb_update_agent_version(int id, const char *os_name, const char *os_version
     return result;
 }
 
-/* Update agent's last keepalive time. Returns OS_SUCCESS or -1 on error. */
+/* Update agent's last keepalive time. Sends a request to Wazuh-DB. Returns OS_SUCCESS or -1 on error. */
 int wdb_update_agent_keepalive(int id) {
     int result = 0;
     char wdbquery[OS_BUFFER_SIZE] = "";
@@ -166,11 +183,11 @@ int wdb_update_agent_keepalive(int id) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             break;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             result = OS_INVALID;
     }
@@ -199,11 +216,11 @@ int wdb_remove_agent(int id) {
             }
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             break;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             result = OS_INVALID;
     }
@@ -231,11 +248,11 @@ char* wdb_agent_name(int id) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return NULL;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return NULL;
     }
@@ -282,11 +299,11 @@ char* wdb_agent_group(int id) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return NULL;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return NULL;
     }
@@ -432,11 +449,11 @@ int* wdb_get_all_agents() {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return NULL;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return NULL;
     }
@@ -491,11 +508,11 @@ int wdb_find_agent(const char *name, const char *ip) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -553,11 +570,11 @@ long wdb_get_agent_offset(int id_agent, int type) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -608,11 +625,11 @@ int wdb_set_agent_offset(int id_agent, int type, long offset) {
             result = 1;
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -638,11 +655,11 @@ int wdb_get_agent_status(int id_agent) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -699,11 +716,11 @@ int wdb_set_agent_status(int id_agent, int status) {
             result = 1;
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -729,11 +746,11 @@ int wdb_update_agent_group(int id, char *group) {
             result = 1;
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -814,11 +831,11 @@ int wdb_find_group(const char *name) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -859,11 +876,11 @@ int wdb_insert_group(const char *name) {
             result = wdb_find_group(name);
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -886,11 +903,11 @@ int wdb_update_agent_belongs(int id_group, int id_agent) {
             result = 1;
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -913,11 +930,11 @@ int wdb_delete_agent_belongs(int id_agent) {
             result = 1;
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -945,11 +962,11 @@ int wdb_update_groups(const char *dirname) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -1047,11 +1064,11 @@ int wdb_remove_group_from_belongs_db(const char *name) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }
@@ -1078,11 +1095,11 @@ int wdb_remove_group_db(const char *name) {
         case OS_SUCCESS:
             break;
         case OS_INVALID:
-            mdebug1("GLobal DB Error in the response from socket");
+            mdebug1("Global DB Error in the response from socket");
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
         default:
-            mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB2_GLOB_NAME);
             mdebug2("Global DB SQL query: %s", wdbquery);
             return OS_INVALID;
     }

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -20,9 +20,9 @@
 static const char *global_db_queries[] = {
     [SQL_INSERT_AGENT] = "global sql INSERT INTO agent (id, name, ip, register_ip, internal_key, date_add, `group`) VALUES (%d, %Q, %Q, %Q, %Q, %lu, %Q);",
     [SQL_UPDATE_AGENT_NAME] = "global sql UPDATE agent SET name = %Q WHERE id = %d;",
-    [SQL_UPDATE_AGENT_VERSION] = "global sql UPDATE agent SET os_name = %Q, os_version = %Q, os_major = %Q, os_minor = %Q, os_codename = %Q, os_platform = %Q, os_build = %Q, os_uname = %s, os_arch = %Q, version = %Q, config_sum = %Q, merged_sum = %Q, manager_host = %Q, node_name = %Q, last_keepalive = STRFTIME('%s', 'NOW'),sync_status = %d WHERE id = %d;",
+    [SQL_UPDATE_AGENT_VERSION] = "global sql UPDATE agent SET os_name = %Q, os_version = %Q, os_major = %Q, os_minor = %Q, os_codename = %Q, os_platform = %Q, os_build = %Q, os_uname = %s, os_arch = %Q, version = %Q, config_sum = %Q, merged_sum = %Q, manager_host = %Q, node_name = %Q, last_keepalive = STRFTIME('%s', 'NOW'), sync_status = %d WHERE id = %d;",
     [SQL_UPDATE_AGENT_VERSION_IP] = "global sql UPDATE agent SET os_name = %Q, os_version = %Q, os_major = %Q, os_minor = %Q, os_codename = %Q, os_platform = %Q, os_build = %Q, os_uname = %s, os_arch = %Q, version = %Q, config_sum = %Q, merged_sum = %Q, manager_host = %Q, node_name = %Q, last_keepalive = STRFTIME('%s', 'NOW'), ip = %Q, sync_status = %d WHERE id = %d;",
-    [SQL_UPDATE_AGENT_KEEPALIVE] = "global sql UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW') WHERE id = %d;",
+    [SQL_UPDATE_AGENT_KEEPALIVE] = "global sql UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW'), sync_status = %d WHERE id = %d;",
     [SQL_DELETE_AGENT] = "global sql DELETE FROM agent WHERE id = %d;",
     [SQL_SELECT_AGENT] = "global sql SELECT name FROM agent WHERE id = %d;",
     [SQL_SELECT_AGENT_GROUP] = "global sql SELECT `group` FROM agent WHERE id = %d;",
@@ -168,14 +168,14 @@ int wdb_update_agent_version(int id,
 }
 
 /* Update agent's last keepalive time. Sends a request to Wazuh-DB. Returns OS_SUCCESS or -1 on error. */
-int wdb_update_agent_keepalive(int id) {
+int wdb_update_agent_keepalive(int id, wdb_sync_status_t sync_status) {
     int result = 0;
     char wdbquery[OS_BUFFER_SIZE] = "";
     char wdboutput[OS_BUFFER_SIZE] = "";
     char *keepalive_format = "%s";
     int wdb_sock = -1;
 
-    sqlite3_snprintf(sizeof(wdbquery), wdbquery, global_db_queries[SQL_UPDATE_AGENT_KEEPALIVE], keepalive_format, id);
+    sqlite3_snprintf(sizeof(wdbquery), wdbquery, global_db_queries[SQL_UPDATE_AGENT_KEEPALIVE], keepalive_format, sync_status, id);
     
     result = wdbc_query_ex(&wdb_sock, wdbquery, wdboutput, sizeof(wdboutput));
 

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -286,7 +286,7 @@ void wm_sync_manager() {
             }
         }
 
-        wdb_update_agent_version(0, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_build, os_uname, os_arch, __ossec_name " " __ossec_version, NULL, NULL, hostname, node_name, NULL);
+        wdb_update_agent_version(0, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_build, os_uname, os_arch, __ossec_name " " __ossec_version, NULL, NULL, hostname, node_name, NULL, WDB_SYNCED);
 
         free(node_name);
         free(os_major);


### PR DESCRIPTION
|Related issue|
|---|
| [Issue 5582](https://github.com/wazuh/wazuh/issues/5582) |

## Description
This PR adds a new column **sync_status** to **agent** table in **global.db**.
Adds this column to WazuhDB update queries.
Defines wdb_sync_status_t, possible values of send_sync.
Moves worker flag to remoted config struct.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
