### PR TITLE
[5518] DBSync Code Coverage increase

### DIFF
--- a/src/dbsync/build.sh
+++ b/src/dbsync/build.sh
@@ -61,6 +61,8 @@ checkCoverageValues()
     if [[ coverageOk -eq 0 ]]; then
         return -1
     fi
+    echoGreen "Lines Coverage: $lines"
+    echoGreen "Functions Coverage: $functions"
     echoGreen [PASSED]
 }
 
@@ -74,7 +76,7 @@ getCoverage()
     folders="$folders --directory $Folder "
     done
     reportFolder=./coverage_report
-    lcov $folders --capture --output-file $reportFolder/code_coverage.info -rc lcov_branch_coverage=1 --exclude "*/tests/*" --include "*/dbsync/*" -q
+    lcov $folders --capture --output-file $reportFolder/code_coverage.info -rc lcov_branch_coverage=0 --exclude "*/tests/*" --include "*/dbsync/*" -q
     coverage=$(genhtml $reportFolder/code_coverage.info --branch-coverage --output-directory $reportFolder)
     echo "Report: $reportFolder/index.html"
     checkCoverageValues "$coverage"
@@ -161,7 +163,9 @@ readyToReview()
         echoRed "[FAILED]"
         return 5
     fi
-    echoGreen "RTR PASSED: code is ready to review"
+    echo ""
+    echoGreen "===> RTR PASSED: code is ready to review <==="
+    echo ""
 }
 
 showHelp()

--- a/src/dbsync/build.sh
+++ b/src/dbsync/build.sh
@@ -61,7 +61,7 @@ checkCoverageValues()
     if [[ coverageOk -eq 0 ]]; then
         return -1
     fi
-    echoGreen [PASSE]D
+    echoGreen [PASSED]
 }
 
 getCoverage()

--- a/src/dbsync/build.sh
+++ b/src/dbsync/build.sh
@@ -114,18 +114,20 @@ configDbSync()
 makeDbSync()
 {
     make
-    if [[ $? -eq 0 ]]; then
-        echoGreen "[PASSED]"
+    if [[ $? -ne 0 ]]; then
+        return -1
     fi
+    echoGreen "[PASSED]"
 }
 
 remakeDbSync()
 {
     make clean
     make
-    if [[ $? -eq 0 ]]; then
-        echoGreen "[PASSED]"
+    if [[ $? -ne 0 ]]; then
+        return -1
     fi
+    echoGreen "[PASSED]"
 }
 readyToReview()
 {

--- a/src/dbsync/build.sh
+++ b/src/dbsync/build.sh
@@ -34,7 +34,7 @@ runTest()
             return -1
         fi
     done
-    echoGreen "PASSED"
+    echoGreen "[PASSED]"
     return 0
 }
 
@@ -61,7 +61,7 @@ checkCoverageValues()
     if [[ coverageOk -eq 0 ]]; then
         return -1
     fi
-    echoGreen PASSED
+    echoGreen [PASSE]D
 }
 
 getCoverage()
@@ -89,7 +89,7 @@ runCppCheck()
         cppcheck --force --std=c++11 --quiet ./
         return -1
     fi
-    echoGreen "PASSED"
+    echoGreen "[PASSED]"
 }
 
 runValgrind()
@@ -102,6 +102,7 @@ runValgrind()
             return -1
         fi
     done
+    echoGreen "[PASSED]"
     return 0
 }
 configDbSync()
@@ -113,46 +114,52 @@ configDbSync()
 makeDbSync()
 {
     make
+    if [[ $? -eq 0 ]]; then
+        echoGreen "[PASSED]"
+    fi
 }
 
 remakeDbSync()
 {
     make clean
     make
+    if [[ $? -eq 0 ]]; then
+        echoGreen "[PASSED]"
+    fi
 }
 readyToReview()
 {
     echoYellow "====================== Compiling  ====================="
     makeDbSync
     if [[ $? -ne 0 ]]; then
-        echoRed "Compiling Failed"
+        echoRed "[FAILED]"
         return 1
     fi
     echoYellow "====================== Cppcheck  ====================="
     runCppCheck
     if [[ $? -ne 0 ]]; then
-        echoRed "cppcheck Failed"
+        echoRed "[FAILED]"
         return 2
     fi
     echoYellow "==================== Running Tests ===================="
     runTest
     if [[ $? -ne 0 ]]; then
-        echoRed "Tests Failed"
+        echoRed "[FAILED]"
         return 3
     fi
     echoYellow "====================== Valgrind  ====================="
     runValgrind
     if [[ $? -ne 0 ]]; then
-        echoRed "Valgrind Failed"
+        echoRed "[FAILED]"
         return 4
     fi
     echoYellow "==================== Running Coverage ================="
     getCoverage
     if [[ $? -ne 0 ]]; then
-        echoRed "Coverage Failed"
+        echoRed "[FAILED]"
         return 5
     fi
-    echoGreen "RTR PASSED: code is ready to review."
+    echoGreen "RTR PASSED: code is ready to review"
 }
 
 showHelp()

--- a/src/dbsync/cppcheckSuppress.txt
+++ b/src/dbsync/cppcheckSuppress.txt
@@ -1,1 +1,1 @@
-*:src/sqlite/sqlite_dbengine.cpp:115
+*:src/sqlite/sqlite_dbengine.cpp:122

--- a/src/dbsync/src/dbsync.cpp
+++ b/src/dbsync/src/dbsync.cpp
@@ -79,10 +79,12 @@ DBSYNC_HANDLE dbsync_create(const HostType     host_type,
         {
             errorMessage += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
     return retVal;
@@ -125,10 +127,12 @@ TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE handle,
         {
             errorMessage += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
     return txn;
@@ -154,10 +158,12 @@ int dbsync_close_txn(const TXN_HANDLE txn)
             errorMessage += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
             retVal = ex.id();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
     return retVal;
@@ -185,10 +191,12 @@ int dbsync_sync_txn_row(const TXN_HANDLE txn,
             error_message += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
             retVal = ex.id();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             error_message += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(error_message);
     return retVal;
@@ -236,10 +244,12 @@ int dbsync_insert_data(const DBSYNC_HANDLE handle,
             errorMessage += "DB error, ";
             errorMessage += ex.what();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
 
@@ -273,10 +283,12 @@ int dbsync_set_table_max_rows(const DBSYNC_HANDLE      handle,
             errorMessage += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
             retVal = ex.id();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
 
@@ -319,16 +331,12 @@ int dbsync_sync_row(const DBSYNC_HANDLE handle,
             errorMessage += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
             retVal = ex.id();
         }
-        catch(const DbSync::max_rows_error& ex)
-        {
-            errorMessage += "DB error, ";
-            errorMessage += ex.what();
-            callback_data.callback(ReturnTypeCallback::MAX_ROWS, js_input, callback_data.user_data);
-        }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
     return retVal;
@@ -370,10 +378,12 @@ int dbsync_select_rows(const DBSYNC_HANDLE handle,
             errorMessage += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
             retVal = ex.id();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
     return retVal;
@@ -406,10 +416,12 @@ int dbsync_delete_rows(const DBSYNC_HANDLE handle,
             errorMessage += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
             retVal = ex.id();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
     return retVal;
@@ -444,10 +456,12 @@ int dbsync_get_deleted_rows(const TXN_HANDLE  txn,
             error_message += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
             retVal = ex.id();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             error_message += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(error_message);
 
@@ -502,10 +516,12 @@ int dbsync_update_with_snapshot(const DBSYNC_HANDLE handle,
             errorMessage += "DB error, ";
             errorMessage += ex.what();
         }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
     return retVal;
@@ -547,16 +563,12 @@ int dbsync_update_with_snapshot_cb(const DBSYNC_HANDLE handle,
             errorMessage += "DB error, id: " + std::to_string(ex.id()) + ". " + ex.what();
             retVal = ex.id();
         }
-        catch(const DbSync::max_rows_error& ex)
-        {
-            errorMessage += "DB error, ";
-            errorMessage += ex.what();
-            callback_data.callback(ReturnTypeCallback::MAX_ROWS, js_snapshot, callback_data.user_data);
-        }
+        // LCOV_EXCL_START
         catch(...)
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
     log_message(errorMessage);
     return retVal;

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -28,17 +28,24 @@ SQLiteDBEngine::~SQLiteDBEngine()
 void SQLiteDBEngine::setMaxRows(const std::string& table,
                                 const unsigned long long maxRows)
 {
-    const constexpr auto ROW_COUNT_POSTFIX{"_row_count"};
-    const std::string sql
+    if (0 != loadTableData(table))
     {
-        maxRows ?
-        "CREATE TRIGGER " + table + ROW_COUNT_POSTFIX + " BEFORE INSERT ON " + table +
-        " WHEN (SELECT COUNT(*) FROM " + table + ") >= " + std::to_string(maxRows) +
-        " BEGIN SELECT RAISE(FAIL, '" + SQLite::MAX_ROWS_ERROR_STRING + "'); END;"
-        : "DROP TRIGGER " + table + ROW_COUNT_POSTFIX
+        const constexpr auto ROW_COUNT_POSTFIX{"_row_count"};
+        const std::string sql
+        {
+            maxRows ?
+            "CREATE TRIGGER " + table + ROW_COUNT_POSTFIX + " BEFORE INSERT ON " + table +
+            " WHEN (SELECT COUNT(*) FROM " + table + ") >= " + std::to_string(maxRows) +
+            " BEGIN SELECT RAISE(FAIL, '" + SQLite::MAX_ROWS_ERROR_STRING + "'); END;"
+            : "DROP TRIGGER " + table + ROW_COUNT_POSTFIX
 
-    };
-    m_sqliteConnection->execute(sql);
+        };
+        m_sqliteConnection->execute(sql);
+    }
+    else
+    {
+        throw dbengine_error { EMPTY_TABLE_METADATA };
+    }
 }
 
 void SQLiteDBEngine::bulkInsert(const std::string& table,

--- a/src/dbsync/tests/dbengine/dbengine_test.cpp
+++ b/src/dbsync/tests/dbengine/dbengine_test.cpp
@@ -21,6 +21,36 @@ using ::testing::Return;
 using ::testing::An;
 using ::testing::ByMove;
 
+static void initNoMetaDataMocks(std::unique_ptr<SQLiteDBEngine>& spEngine)
+{
+    const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
+    const auto& mockConnection { std::make_shared<MockConnection>() };
+
+    auto mockTransaction { std::make_unique<MockTransaction>() };
+
+    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
+
+    auto mockStatement_1 { std::make_unique<MockStatement>() };
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockFactory,
+        createStatement(_,"NNN"))
+        .WillOnce(Return(ByMove(std::move(mockStatement_1))));
+
+    EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+
+    EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
+        mockFactory,
+        "1",
+        "NNN"));
+
+    auto mockStatement_2 { std::make_unique<MockStatement>() };
+    EXPECT_CALL(*mockStatement_2, step())
+        .WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockFactory,
+        createStatement(_,"PRAGMA table_info(dummy);"))
+        .WillOnce(Return(ByMove(std::move(mockStatement_2))));
+}
 
 TEST_F(DBEngineTest, Initialization)
 {
@@ -62,7 +92,6 @@ TEST_F(DBEngineTest, InitializationEmptyFileName)
         "", 
         "NNN"), dbengine_error);
 }
-
 
 TEST_F(DBEngineTest, InitializeStatusField)
 {
@@ -260,10 +289,8 @@ TEST_F(DBEngineTest, InitializeStatusFieldPreExistent)
         createStatement(_,"UPDATE dummy SET db_status_field_dm=0;"))
         .WillOnce(Return(ByMove(std::move(mockStatement_4))));
  
-
     EXPECT_NO_THROW(spEngine->initializeStatusField(std::vector<std::string> {"dummy"}));
 }
-
 
 TEST_F(DBEngineTest, DeleteRowsByStatusField)
 {
@@ -282,7 +309,6 @@ TEST_F(DBEngineTest, DeleteRowsByStatusField)
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
-    
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
@@ -343,13 +369,11 @@ TEST_F(DBEngineTest, DeleteRowsByStatusField)
     EXPECT_CALL(*mockStatement_3, 
         step())
         .WillOnce(Return(0));
-
         
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"DELETE FROM dummy WHERE db_status_field_dm=0;"))
         .WillOnce(Return(ByMove(std::move(mockStatement_3))));
  
-
     EXPECT_NO_THROW(spEngine->deleteRowsByStatusField(std::vector<std::string> {"dummy"}));
 }
 
@@ -368,7 +392,6 @@ TEST_F(DBEngineTest, DeleteRowsByStatusFieldNoMetadata)
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
-
     
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
@@ -401,7 +424,6 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusFieldNoMetadata)
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
-
     
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
@@ -505,10 +527,36 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
     EXPECT_CALL(*mockStatement_3, column(0))
         .WillOnce(Return(ByMove(std::move(mockColumn_9))));
 
-       
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"SELECT PID FROM dummy WHERE db_status_field_dm=0;"))
         .WillOnce(Return(ByMove(std::move(mockStatement_3))));
 
     EXPECT_NO_THROW(spEngine->returnRowsMarkedForDelete({"dummy"}, [](ReturnTypeCallback, const nlohmann::json&){}));
+}
+
+TEST_F(DBEngineTest, syncTableRowDataWithoutMetadataShouldThrow)
+{
+    std::unique_ptr<SQLiteDBEngine> spEngine;
+    initNoMetaDataMocks(spEngine);
+
+    // Due to the no metadata this should throw
+    EXPECT_THROW(spEngine->syncTableRowData("dummy", {}, nullptr, false), dbengine_error);
+}
+
+TEST_F(DBEngineTest, deleteTableRowsDataWithoutMetadataShouldThrow)
+{
+    std::unique_ptr<SQLiteDBEngine> spEngine;
+    initNoMetaDataMocks(spEngine);
+
+    // Due to the no metadata this should throw
+    EXPECT_THROW(spEngine->deleteTableRowsData("dummy", {}), dbengine_error);
+}
+
+TEST_F(DBEngineTest, selectDataWithoutMetadataShouldThrow)
+{
+    std::unique_ptr<SQLiteDBEngine> spEngine;
+    initNoMetaDataMocks(spEngine);
+
+    // Due to the no metadata this should throw
+    EXPECT_THROW(spEngine->selectData("dummy", {}, nullptr), dbengine_error);
 }

--- a/src/dbsync/tests/dbengine/dbengine_test.cpp
+++ b/src/dbsync/tests/dbengine/dbengine_test.cpp
@@ -560,3 +560,12 @@ TEST_F(DBEngineTest, selectDataWithoutMetadataShouldThrow)
     // Due to the no metadata this should throw
     EXPECT_THROW(spEngine->selectData("dummy", {}, nullptr), dbengine_error);
 }
+
+TEST_F(DBEngineTest, bulkInsertWithoutMetadataShouldThrow)
+{
+    std::unique_ptr<SQLiteDBEngine> spEngine;
+    initNoMetaDataMocks(spEngine);
+
+    // Due to the no metadata this should throw
+    EXPECT_THROW(spEngine->bulkInsert("dummy", nullptr), dbengine_error);
+}

--- a/src/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/dbsync/tests/interface/dbsync_test.cpp
@@ -13,9 +13,6 @@
 #include "json.hpp"
 #include "dbsync_test.h"
 #include "dbsync.h"
-#include "../mocks/dbsyncImplementation_mock.h"
-
-using ::testing::_;
 
 constexpr auto DATABASE_TEMP {"TEMP.db"};
 
@@ -154,7 +151,6 @@ TEST_F(DBSyncTest, dbsyncAddTableRelationshipDummy)
 
 TEST_F(DBSyncTest, InsertData)
 {
-    //MockDBSyncImpl mockDBSyncImpl;
     const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
     const auto insertionSqlStmt{ R"({"table":"processes","data":[{"pid":4,"name":"System"}]})"};
     

--- a/src/dbsync/tests/interface/dbsync_test.h
+++ b/src/dbsync/tests/interface/dbsync_test.h
@@ -14,6 +14,7 @@
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "typedef.h"
 
 class DBSyncTest : public ::testing::Test 
 {
@@ -24,6 +25,12 @@ protected:
 
     void SetUp() override;
     void TearDown() override;
+};
+
+struct DummyContext
+{
+    DBSYNC_HANDLE handle;
+    TXN_HANDLE    txnContext;
 };
 
 #endif // _DBYSNC_TEST_H

--- a/src/dbsync/tests/pipelineFactory/CMakeLists.txt
+++ b/src/dbsync/tests/pipelineFactory/CMakeLists.txt
@@ -16,7 +16,8 @@ include_directories(${CMAKE_SOURCE_DIR}/include/)
 link_directories(${CMAKE_BINARY_DIR}/lib)
 
 file(GLOB PIPELINE_FACTORY_SRC
-    "${CMAKE_SOURCE_DIR}/src/dbsyncPipelineFactory.cpp")
+    "${CMAKE_SOURCE_DIR}/src/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/sqlite/*.cpp")
 
 add_executable(dbsyncPipelineFactory_unit_test 
     "${PIPELINE_FACTORY_UNITTEST_SRC}"


### PR DESCRIPTION
# DBSync Code coverage increase

## **Related issue**
[5518](https://github.com/wazuh/wazuh/issues/5518)

## **Description**
The main idea on these PR's changes is to exercise all the DBSync code methods deeper and expose them into different corner cases to double check that everything is working as expected. As a result of this more code coverage should be generated.
When this issue was created for dbengine module only we were like this:
![image](https://user-images.githubusercontent.com/22640902/89408057-33f1b980-d6f6-11ea-9a1d-78a6bf2ae92a.png)
And after some work done so far and consider this PR too, we are:
![image](https://user-images.githubusercontent.com/22640902/89460728-23b2fc00-d741-11ea-9047-78911bbd2009.png)

**Note**
I've disabled the branching code coverage checking due to the fact it gets erroneous values. Apparently, lcov does not work 100% with C++ branching coverage.
Evidence:
- [lcov-branch-coverage-weirdness](https://github.com/ghandmann/lcov-branch-coverage-weirdness)
- [FAQ](https://gcovr.com/en/stable/faq.html#why-does-c-code-have-so-many-uncovered-branches)



## **DoD:**
- [X] Development
- [X] RTR Tool execution
![image](https://user-images.githubusercontent.com/22640902/89460673-0a11b480-d741-11ea-95b9-e64b43895f50.png)


**- DBSync main branch code coverage:**
![image](https://user-images.githubusercontent.com/22640902/89371165-e9058100-d6b8-11ea-910b-8787f1cf4e75.png)

**- PR's changes code coverage:**
![image](https://user-images.githubusercontent.com/22640902/89460616-efd7d680-d740-11ea-954d-af5f8e7cdc20.png)




